### PR TITLE
fix(ff-sys): raise minimum FFmpeg version from 6.0 to 7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"

--- a/ff-sys/build.rs
+++ b/ff-sys/build.rs
@@ -274,7 +274,9 @@ fn configure_linux() -> Vec<String> {
 }
 
 /// Minimum required FFmpeg version for pkg-config detection.
-const FFMPEG_MIN_VERSION: &str = "6.0";
+/// FFmpeg 7.x introduced enum-based SwsFlags (SwsFlags_SWS_*), which is
+/// incompatible with the #define macros used in 6.x. Only 7.x is supported.
+const FFMPEG_MIN_VERSION: &str = "7.0";
 
 /// pkg-config library names for FFmpeg components.
 const PKGCONFIG_LIBS: &[&str] = &[


### PR DESCRIPTION
## Changes
- Raise minimum FFmpeg version
  - 6.0 to 7.0
- Raise crate minor version
  -  0.1.0 to 0.1.1