### PR TITLE
chore: ignore Cargo.lock for library crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/Cargo.lock


### PR DESCRIPTION
## Changes

- Add `Cargo.lock` to `.gitignore`

Library crates should not commit `Cargo.lock`. Downstream users manage their own lock file, so the one in this repository has no effect on their builds.

See: [Cargo FAQ — Why do binaries have Cargo.lock in version control, but not libraries?](https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --all` passes
