### PR TITLE
test(ff-decode): add unit tests for pure conversion functions in vide…

### DIFF
--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -1990,9 +1990,7 @@ mod tests {
     #[test]
     fn color_primaries_bt470bg_yields_bt601() {
         assert_eq!(
-            VideoDecoderInner::convert_color_primaries(
-                ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG
-            ),
+            VideoDecoderInner::convert_color_primaries(ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG),
             ColorPrimaries::Bt601
         );
     }
@@ -2099,12 +2097,18 @@ mod tests {
 
     #[test]
     fn hw_accel_auto_yields_none() {
-        assert_eq!(VideoDecoderInner::hw_accel_to_device_type(HardwareAccel::Auto), None);
+        assert_eq!(
+            VideoDecoderInner::hw_accel_to_device_type(HardwareAccel::Auto),
+            None
+        );
     }
 
     #[test]
     fn hw_accel_none_yields_none() {
-        assert_eq!(VideoDecoderInner::hw_accel_to_device_type(HardwareAccel::None), None);
+        assert_eq!(
+            VideoDecoderInner::hw_accel_to_device_type(HardwareAccel::None),
+            None
+        );
     }
 
     #[test]
@@ -2154,61 +2158,91 @@ mod tests {
     #[test]
     fn pixel_format_to_av_round_trip_yuv420p() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Yuv420p);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Yuv420p);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Yuv420p
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_yuv422p() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Yuv422p);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Yuv422p);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Yuv422p
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_yuv444p() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Yuv444p);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Yuv444p);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Yuv444p
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_rgb24() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Rgb24);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Rgb24);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Rgb24
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_bgr24() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Bgr24);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Bgr24);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Bgr24
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_rgba() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Rgba);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Rgba);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Rgba
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_bgra() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Bgra);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Bgra);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Bgra
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_gray8() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Gray8);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Gray8);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Gray8
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_nv12() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Nv12);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Nv12);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Nv12
+        );
     }
 
     #[test]
     fn pixel_format_to_av_round_trip_nv21() {
         let av = VideoDecoderInner::pixel_format_to_av(PixelFormat::Nv21);
-        assert_eq!(VideoDecoderInner::convert_pixel_format(av), PixelFormat::Nv21);
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(av),
+            PixelFormat::Nv21
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add 50 unit tests for the 7 pure-Rust conversion functions in `crates/ff-decode/src/video/decoder_inner.rs`
- No FFmpeg runtime, no media files required — all tests run in pure Rust
- Follows the same pattern established for the audio decoder in #11

## Background

`video/decoder_inner.rs` (1,802 lines) contained the entire video decoding engine with **zero unit tests**.
While most of the file requires real FFmpeg contexts and media files, the conversion functions are pure
integer comparisons and match statements that can be tested in complete isolation.

## Tests added (50 total)

### `convert_pixel_format` — 11 tests

| Test | Input | Expected |
|------|-------|----------|
| `pixel_format_yuv420p` … `pixel_format_nv21` | 10 known `AVPixelFormat` constants | Corresponding `PixelFormat` variant |
| `pixel_format_unknown_falls_back_to_yuv420p` | `AV_PIX_FMT_NONE` | `PixelFormat::Yuv420p` (fallback) |

### `convert_color_space` — 5 tests

| Test | Input | Expected |
|------|-------|----------|
| `color_space_bt709` | `AVCOL_SPC_BT709` | `ColorSpace::Bt709` |
| `color_space_bt470bg_yields_bt601` | `AVCOL_SPC_BT470BG` | `ColorSpace::Bt601` |
| `color_space_smpte170m_yields_bt601` | `AVCOL_SPC_SMPTE170M` | `ColorSpace::Bt601` (same arm, explicit coverage) |
| `color_space_bt2020_ncl` | `AVCOL_SPC_BT2020_NCL` | `ColorSpace::Bt2020` |
| `color_space_unknown_falls_back_to_bt709` | `AVCOL_SPC_UNSPECIFIED` | `ColorSpace::Bt709` (fallback) |

### `convert_color_range` — 3 tests

| Test | Input | Expected |
|------|-------|----------|
| `color_range_jpeg_yields_full` | `AVCOL_RANGE_JPEG` | `ColorRange::Full` |
| `color_range_mpeg_yields_limited` | `AVCOL_RANGE_MPEG` | `ColorRange::Limited` |
| `color_range_unknown_falls_back_to_limited` | `AVCOL_RANGE_UNSPECIFIED` | `ColorRange::Limited` (fallback) |

### `convert_color_primaries` — 5 tests

| Test | Input | Expected |
|------|-------|----------|
| `color_primaries_bt709` | `AVCOL_PRI_BT709` | `ColorPrimaries::Bt709` |
| `color_primaries_bt470bg_yields_bt601` | `AVCOL_PRI_BT470BG` | `ColorPrimaries::Bt601` |
| `color_primaries_smpte170m_yields_bt601` | `AVCOL_PRI_SMPTE170M` | `ColorPrimaries::Bt601` (same arm, explicit coverage) |
| `color_primaries_bt2020` | `AVCOL_PRI_BT2020` | `ColorPrimaries::Bt2020` |
| `color_primaries_unknown_falls_back_to_bt709` | `AVCOL_PRI_UNSPECIFIED` | `ColorPrimaries::Bt709` (fallback) |

### `convert_codec` — 8 tests

| Test | Input | Expected |
|------|-------|----------|
| `codec_h264` … `codec_prores` | 7 known `AVCodecID` constants | Corresponding `VideoCodec` variant |
| `codec_unknown_falls_back_to_h264` | `AV_CODEC_ID_NONE` | `VideoCodec::H264` (fallback) |

### `hw_accel_to_device_type` — 7 tests

| Test | Input | Expected |
|------|-------|----------|
| `hw_accel_auto_yields_none` | `HardwareAccel::Auto` | `None` |
| `hw_accel_none_yields_none` | `HardwareAccel::None` | `None` |
| `hw_accel_nvdec_yields_cuda` | `HardwareAccel::Nvdec` | `Some(AV_HWDEVICE_TYPE_CUDA)` |
| `hw_accel_qsv_yields_qsv` | `HardwareAccel::Qsv` | `Some(AV_HWDEVICE_TYPE_QSV)` |
| `hw_accel_amf_yields_d3d11va` | `HardwareAccel::Amf` | `Some(AV_HWDEVICE_TYPE_D3D11VA)` |
| `hw_accel_videotoolbox` | `HardwareAccel::VideoToolbox` | `Some(AV_HWDEVICE_TYPE_VIDEOTOOLBOX)` |
| `hw_accel_vaapi` | `HardwareAccel::Vaapi` | `Some(AV_HWDEVICE_TYPE_VAAPI)` |

### `pixel_format_to_av` — 11 tests

| Test | Verifies |
|------|----------|
| `pixel_format_to_av_round_trip_yuv420p` … `_nv21` | `convert_pixel_format(pixel_format_to_av(fmt)) == fmt` for all 10 known formats |
| `pixel_format_to_av_unknown_falls_back_to_yuv420p_av` | `pixel_format_to_av(Yuv420p10le)` hits the `_` arm and returns `AV_PIX_FMT_YUV420P` |

## Checklist

- [x] `cargo build -p ff-decode` passes
- [x] `cargo clippy -p ff-decode` passes with no warnings
- [x] All 50 new unit tests pass

Closes #117