### PR TITLE
test(ff-encode): add unit tests for pure conversion functions in audi…

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -566,3 +566,119 @@ fn sample_format_to_av(format: ff_format::SampleFormat) -> ff_sys::AVSampleForma
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ff_format::SampleFormat;
+    use ff_sys::swresample::sample_format;
+    use ff_sys::{
+        AVCodecID_AV_CODEC_ID_AAC, AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3,
+        AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_VORBIS,
+    };
+
+    use crate::AudioCodec;
+
+    use super::{codec_to_id, sample_format_to_av};
+
+    // -------------------------------------------------------------------------
+    // codec_to_id
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn codec_to_id_aac() {
+        assert_eq!(codec_to_id(AudioCodec::Aac), AVCodecID_AV_CODEC_ID_AAC);
+    }
+
+    #[test]
+    fn codec_to_id_opus() {
+        assert_eq!(codec_to_id(AudioCodec::Opus), AVCodecID_AV_CODEC_ID_OPUS);
+    }
+
+    #[test]
+    fn codec_to_id_mp3() {
+        assert_eq!(codec_to_id(AudioCodec::Mp3), AVCodecID_AV_CODEC_ID_MP3);
+    }
+
+    #[test]
+    fn codec_to_id_flac() {
+        assert_eq!(codec_to_id(AudioCodec::Flac), AVCodecID_AV_CODEC_ID_FLAC);
+    }
+
+    #[test]
+    fn codec_to_id_pcm() {
+        assert_eq!(
+            codec_to_id(AudioCodec::Pcm),
+            AVCodecID_AV_CODEC_ID_PCM_S16LE
+        );
+    }
+
+    #[test]
+    fn codec_to_id_vorbis() {
+        assert_eq!(
+            codec_to_id(AudioCodec::Vorbis),
+            AVCodecID_AV_CODEC_ID_VORBIS
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // sample_format_to_av
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn sample_format_u8() {
+        assert_eq!(sample_format_to_av(SampleFormat::U8), sample_format::U8);
+    }
+
+    #[test]
+    fn sample_format_i16() {
+        assert_eq!(sample_format_to_av(SampleFormat::I16), sample_format::S16);
+    }
+
+    #[test]
+    fn sample_format_i32() {
+        assert_eq!(sample_format_to_av(SampleFormat::I32), sample_format::S32);
+    }
+
+    #[test]
+    fn sample_format_f32() {
+        assert_eq!(sample_format_to_av(SampleFormat::F32), sample_format::FLT);
+    }
+
+    #[test]
+    fn sample_format_f64() {
+        assert_eq!(sample_format_to_av(SampleFormat::F64), sample_format::DBL);
+    }
+
+    #[test]
+    fn sample_format_u8p() {
+        assert_eq!(sample_format_to_av(SampleFormat::U8p), sample_format::U8P);
+    }
+
+    #[test]
+    fn sample_format_i16p() {
+        assert_eq!(sample_format_to_av(SampleFormat::I16p), sample_format::S16P);
+    }
+
+    #[test]
+    fn sample_format_i32p() {
+        assert_eq!(sample_format_to_av(SampleFormat::I32p), sample_format::S32P);
+    }
+
+    #[test]
+    fn sample_format_f32p() {
+        assert_eq!(sample_format_to_av(SampleFormat::F32p), sample_format::FLTP);
+    }
+
+    #[test]
+    fn sample_format_f64p() {
+        assert_eq!(sample_format_to_av(SampleFormat::F64p), sample_format::DBLP);
+    }
+
+    #[test]
+    fn sample_format_unknown_falls_back_to_fltp() {
+        assert_eq!(
+            sample_format_to_av(SampleFormat::Other(99)),
+            sample_format::FLTP
+        );
+    }
+}

--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -83,3 +83,35 @@ impl EncodeError {
         EncodeError::Ffmpeg(format!("{} (code: {})", error_msg, errnum))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EncodeError;
+
+    #[test]
+    fn from_ffmpeg_error_returns_ffmpeg_variant() {
+        let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::EINVAL);
+        assert!(matches!(err, EncodeError::Ffmpeg(_)));
+    }
+
+    #[test]
+    fn from_ffmpeg_error_message_contains_code() {
+        let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::EINVAL);
+        let msg = err.to_string();
+        assert!(msg.contains("code: -22"), "expected 'code: -22' in '{msg}'");
+    }
+
+    #[test]
+    fn from_ffmpeg_error_message_nonempty() {
+        let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::ENOMEM);
+        let msg = err.to_string();
+        assert!(!msg.is_empty());
+    }
+
+    #[test]
+    fn from_ffmpeg_error_eof() {
+        let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::EOF);
+        assert!(matches!(err, EncodeError::Ffmpeg(_)));
+        assert!(!err.to_string().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add 17 unit tests for `codec_to_id` and `sample_format_to_av` in `crates/ff-encode/src/audio/encoder_inner.rs`
- Add 4 unit tests for `EncodeError::from_ffmpeg_error` in `crates/ff-encode/src/error.rs`
- No FFmpeg runtime, no media files required — all tests run in pure Rust
- Follows the same pattern established in `ff-decode/src/audio/decoder_inner.rs` after #11

## Background

Two files in `crates/ff-encode/` contained testable pure Rust logic but had no unit tests:

- `src/audio/encoder_inner.rs` — `codec_to_id` and `sample_format_to_av` are free-standing
  conversion functions with no FFmpeg context dependency
- `src/error.rs` — `EncodeError::from_ffmpeg_error` wraps `ff_sys::av_error_string` and can be
  exercised with any `i32` error code constant

## Tests added (21 total)

### `codec_to_id` — 6 tests (`encoder_inner.rs`)

All 6 `AudioCodec` variants are explicitly covered. The match is exhaustive within the crate
(no `_` fallback arm), so one test per variant is sufficient.

| Test | Input | Expected |
|------|-------|----------|
| `codec_to_id_aac` | `AudioCodec::Aac` | `AV_CODEC_ID_AAC` |
| `codec_to_id_opus` | `AudioCodec::Opus` | `AV_CODEC_ID_OPUS` |
| `codec_to_id_mp3` | `AudioCodec::Mp3` | `AV_CODEC_ID_MP3` |
| `codec_to_id_flac` | `AudioCodec::Flac` | `AV_CODEC_ID_FLAC` |
| `codec_to_id_pcm` | `AudioCodec::Pcm` | `AV_CODEC_ID_PCM_S16LE` |
| `codec_to_id_vorbis` | `AudioCodec::Vorbis` | `AV_CODEC_ID_VORBIS` |

### `sample_format_to_av` — 11 tests (`encoder_inner.rs`)

| Test | Input | Expected |
|------|-------|----------|
| `sample_format_u8` | `SampleFormat::U8` | `sample_format::U8` |
| `sample_format_i16` | `SampleFormat::I16` | `sample_format::S16` |
| `sample_format_i32` | `SampleFormat::I32` | `sample_format::S32` |
| `sample_format_f32` | `SampleFormat::F32` | `sample_format::FLT` |
| `sample_format_f64` | `SampleFormat::F64` | `sample_format::DBL` |
| `sample_format_u8p` | `SampleFormat::U8p` | `sample_format::U8P` |
| `sample_format_i16p` | `SampleFormat::I16p` | `sample_format::S16P` |
| `sample_format_i32p` | `SampleFormat::I32p` | `sample_format::S32P` |
| `sample_format_f32p` | `SampleFormat::F32p` | `sample_format::FLTP` |
| `sample_format_f64p` | `SampleFormat::F64p` | `sample_format::DBLP` |
| `sample_format_unknown_falls_back_to_fltp` | `SampleFormat::Other(99)` | `sample_format::FLTP` (fallback) |

### `EncodeError::from_ffmpeg_error` — 4 tests (`error.rs`)

The function always produces `EncodeError::Ffmpeg(String)` with the format
`"{av_error_string} (code: {errnum})"`.

| Test | Verifies |
|------|----------|
| `from_ffmpeg_error_returns_ffmpeg_variant` | Result is `EncodeError::Ffmpeg(_)` variant |
| `from_ffmpeg_error_message_contains_code` | Message contains `"code: -22"` for `EINVAL` |
| `from_ffmpeg_error_message_nonempty` | Message is non-empty for `ENOMEM` |
| `from_ffmpeg_error_eof` | `EncodeError::Ffmpeg(_)` with non-empty message for `EOF` |

## Checklist

- [x] `cargo build -p ff-encode` passes
- [x] `cargo clippy -p ff-encode` passes with no warnings
- [x] All 21 new unit tests pass (65 total in crate, all green)

Closes #118