### PR TITLE
feat(ff-probe): add ChapterInfo type and chapter extraction

### DIFF
--- a/crates/ff-format/src/chapter.rs
+++ b/crates/ff-format/src/chapter.rs
@@ -1,0 +1,337 @@
+//! Chapter information.
+//!
+//! This module provides the [`ChapterInfo`] struct for representing chapter
+//! markers within a media container (e.g., MKV, MP4, M4A).
+//!
+//! # Examples
+//!
+//! ```
+//! use ff_format::chapter::ChapterInfo;
+//! use ff_format::Rational;
+//! use std::time::Duration;
+//!
+//! let chapter = ChapterInfo::builder()
+//!     .id(1)
+//!     .title("Opening")
+//!     .start(Duration::from_secs(0))
+//!     .end(Duration::from_secs(120))
+//!     .time_base(Rational::new(1, 1000))
+//!     .build();
+//!
+//! assert_eq!(chapter.id(), 1);
+//! assert_eq!(chapter.title(), Some("Opening"));
+//! assert_eq!(chapter.duration(), Duration::from_secs(120));
+//! ```
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::time::Rational;
+
+/// Information about a chapter within a media file.
+///
+/// Chapters are discrete, named segments within a container (e.g., a chapter in
+/// an audiobook or a scene in a movie). Each chapter has a start and end time,
+/// and optionally a title and other metadata tags.
+///
+/// # Construction
+///
+/// Use [`ChapterInfo::builder()`] for fluent construction:
+///
+/// ```
+/// use ff_format::chapter::ChapterInfo;
+/// use std::time::Duration;
+///
+/// let chapter = ChapterInfo::builder()
+///     .id(0)
+///     .title("Intro")
+///     .start(Duration::ZERO)
+///     .end(Duration::from_secs(30))
+///     .build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct ChapterInfo {
+    /// Chapter ID as reported by the container (`AVChapter.id`).
+    id: i64,
+    /// Chapter title from the "title" metadata tag, if present.
+    title: Option<String>,
+    /// Chapter start time.
+    start: Duration,
+    /// Chapter end time.
+    end: Duration,
+    /// Container time base for this chapter.
+    ///
+    /// Useful when sub-`Duration` precision is required. `None` if the
+    /// time base had a zero denominator (invalid/unset).
+    time_base: Option<Rational>,
+    /// All metadata tags except "title" (which is surfaced via [`ChapterInfo::title`]).
+    ///
+    /// `None` if the chapter had no metadata dictionary or all tags were filtered out.
+    metadata: Option<HashMap<String, String>>,
+}
+
+impl ChapterInfo {
+    /// Creates a new builder for constructing `ChapterInfo`.
+    #[must_use]
+    pub fn builder() -> ChapterInfoBuilder {
+        ChapterInfoBuilder::default()
+    }
+
+    /// Returns the chapter ID.
+    #[must_use]
+    #[inline]
+    pub fn id(&self) -> i64 {
+        self.id
+    }
+
+    /// Returns the chapter title, if available.
+    #[must_use]
+    #[inline]
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Returns the chapter start time.
+    #[must_use]
+    #[inline]
+    pub fn start(&self) -> Duration {
+        self.start
+    }
+
+    /// Returns the chapter end time.
+    #[must_use]
+    #[inline]
+    pub fn end(&self) -> Duration {
+        self.end
+    }
+
+    /// Returns the chapter time base, if available.
+    #[must_use]
+    #[inline]
+    pub fn time_base(&self) -> Option<Rational> {
+        self.time_base
+    }
+
+    /// Returns the chapter metadata tags (excluding "title"), if any.
+    #[must_use]
+    #[inline]
+    pub fn metadata(&self) -> Option<&HashMap<String, String>> {
+        self.metadata.as_ref()
+    }
+
+    /// Returns `true` if the chapter has a title.
+    #[must_use]
+    #[inline]
+    pub fn has_title(&self) -> bool {
+        self.title.is_some()
+    }
+
+    /// Returns the chapter duration (`end − start`).
+    ///
+    /// Uses saturating subtraction so that malformed chapters where `end < start`
+    /// return [`Duration::ZERO`] instead of panicking.
+    #[must_use]
+    #[inline]
+    pub fn duration(&self) -> Duration {
+        self.end.saturating_sub(self.start)
+    }
+}
+
+impl Default for ChapterInfo {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            title: None,
+            start: Duration::ZERO,
+            end: Duration::ZERO,
+            time_base: None,
+            metadata: None,
+        }
+    }
+}
+
+/// Builder for constructing [`ChapterInfo`].
+///
+/// # Examples
+///
+/// ```
+/// use ff_format::chapter::ChapterInfo;
+/// use ff_format::Rational;
+/// use std::time::Duration;
+///
+/// let chapter = ChapterInfo::builder()
+///     .id(2)
+///     .title("Act I")
+///     .start(Duration::from_secs(120))
+///     .end(Duration::from_secs(480))
+///     .time_base(Rational::new(1, 1000))
+///     .build();
+///
+/// assert_eq!(chapter.title(), Some("Act I"));
+/// assert_eq!(chapter.duration(), Duration::from_secs(360));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ChapterInfoBuilder {
+    id: i64,
+    title: Option<String>,
+    start: Duration,
+    end: Duration,
+    time_base: Option<Rational>,
+    metadata: Option<HashMap<String, String>>,
+}
+
+impl ChapterInfoBuilder {
+    /// Sets the chapter ID.
+    #[must_use]
+    pub fn id(mut self, id: i64) -> Self {
+        self.id = id;
+        self
+    }
+
+    /// Sets the chapter title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Sets the chapter start time.
+    #[must_use]
+    pub fn start(mut self, start: Duration) -> Self {
+        self.start = start;
+        self
+    }
+
+    /// Sets the chapter end time.
+    #[must_use]
+    pub fn end(mut self, end: Duration) -> Self {
+        self.end = end;
+        self
+    }
+
+    /// Sets the chapter time base.
+    #[must_use]
+    pub fn time_base(mut self, time_base: Rational) -> Self {
+        self.time_base = Some(time_base);
+        self
+    }
+
+    /// Sets the chapter metadata (tags other than "title").
+    #[must_use]
+    pub fn metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    /// Builds the [`ChapterInfo`].
+    #[must_use]
+    pub fn build(self) -> ChapterInfo {
+        ChapterInfo {
+            id: self.id,
+            title: self.title,
+            start: self.start,
+            end: self.end,
+            time_base: self.time_base,
+            metadata: self.metadata,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chapter_info_builder_should_set_all_fields() {
+        let mut meta = HashMap::new();
+        meta.insert("language".to_string(), "eng".to_string());
+
+        let info = ChapterInfo::builder()
+            .id(3)
+            .title("Intro")
+            .start(Duration::from_secs(0))
+            .end(Duration::from_secs(60))
+            .time_base(Rational::new(1, 1000))
+            .metadata(meta)
+            .build();
+
+        assert_eq!(info.id(), 3);
+        assert_eq!(info.title(), Some("Intro"));
+        assert_eq!(info.start(), Duration::ZERO);
+        assert_eq!(info.end(), Duration::from_secs(60));
+        assert_eq!(info.time_base(), Some(Rational::new(1, 1000)));
+        assert_eq!(info.metadata().unwrap()["language"], "eng");
+    }
+
+    #[test]
+    fn chapter_info_duration_should_return_end_minus_start() {
+        let info = ChapterInfo::builder()
+            .start(Duration::from_secs(10))
+            .end(Duration::from_secs(70))
+            .build();
+
+        assert_eq!(info.duration(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn chapter_info_duration_should_return_zero_when_end_before_start() {
+        let info = ChapterInfo::builder()
+            .start(Duration::from_secs(70))
+            .end(Duration::from_secs(10))
+            .build();
+
+        assert_eq!(info.duration(), Duration::ZERO);
+    }
+
+    #[test]
+    fn chapter_info_with_no_title_should_return_none() {
+        let info = ChapterInfo::builder().id(1).build();
+
+        assert_eq!(info.title(), None);
+        assert!(!info.has_title());
+    }
+
+    #[test]
+    fn chapter_info_with_title_should_have_title() {
+        let info = ChapterInfo::builder().title("Chapter One").build();
+
+        assert_eq!(info.title(), Some("Chapter One"));
+        assert!(info.has_title());
+    }
+
+    #[test]
+    fn chapter_info_default_should_have_zero_times() {
+        let info = ChapterInfo::default();
+
+        assert_eq!(info.id(), 0);
+        assert_eq!(info.start(), Duration::ZERO);
+        assert_eq!(info.end(), Duration::ZERO);
+        assert!(info.title().is_none());
+        assert!(info.time_base().is_none());
+        assert!(info.metadata().is_none());
+    }
+
+    #[test]
+    fn chapter_info_builder_without_metadata_should_return_none() {
+        let info = ChapterInfo::builder().id(1).title("Test").build();
+
+        assert!(info.metadata().is_none());
+    }
+
+    #[test]
+    fn chapter_info_builder_clone_should_produce_equal_instance() {
+        let builder = ChapterInfo::builder()
+            .id(5)
+            .title("Cloned")
+            .start(Duration::from_secs(100))
+            .end(Duration::from_secs(200));
+
+        let info1 = builder.clone().build();
+        let info2 = builder.build();
+
+        assert_eq!(info1.id(), info2.id());
+        assert_eq!(info1.title(), info2.title());
+        assert_eq!(info1.start(), info2.start());
+        assert_eq!(info1.end(), info2.end());
+    }
+}

--- a/crates/ff-format/src/lib.rs
+++ b/crates/ff-format/src/lib.rs
@@ -16,6 +16,7 @@
 //! - `color` - Color space definitions ([`ColorSpace`], [`ColorRange`], [`ColorPrimaries`])
 //! - `codec` - Codec definitions ([`VideoCodec`], [`AudioCodec`])
 //! - `channel` - Channel layout definitions ([`ChannelLayout`])
+//! - `chapter` - Chapter information ([`ChapterInfo`])
 //! - `error` - Error types ([`FormatError`])
 //!
 //! ## Usage
@@ -50,6 +51,7 @@
 
 // Module declarations
 pub mod channel;
+pub mod chapter;
 pub mod codec;
 pub mod color;
 pub mod error;
@@ -61,6 +63,7 @@ pub mod stream;
 pub mod time;
 
 pub use channel::ChannelLayout;
+pub use chapter::{ChapterInfo, ChapterInfoBuilder};
 pub use codec::{AudioCodec, VideoCodec};
 pub use color::{ColorPrimaries, ColorRange, ColorSpace};
 pub use error::{FormatError, FrameError};
@@ -83,9 +86,9 @@ pub use time::{Rational, Timestamp};
 /// ```
 pub mod prelude {
     pub use crate::{
-        AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ColorPrimaries, ColorRange,
-        ColorSpace, FormatError, FrameError, MediaInfo, PixelFormat, PooledBuffer, Rational,
-        SampleFormat, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
+        AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ChapterInfo, ColorPrimaries,
+        ColorRange, ColorSpace, FormatError, FrameError, MediaInfo, PixelFormat, PooledBuffer,
+        Rational, SampleFormat, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
     };
 }
 

--- a/crates/ff-format/src/media.rs
+++ b/crates/ff-format/src/media.rs
@@ -55,6 +55,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::chapter::ChapterInfo;
 use crate::stream::{AudioStreamInfo, VideoStreamInfo};
 
 /// Information about a media file.
@@ -95,6 +96,8 @@ pub struct MediaInfo {
     video_streams: Vec<VideoStreamInfo>,
     /// Audio streams in the file
     audio_streams: Vec<AudioStreamInfo>,
+    /// Chapter markers in the file
+    chapters: Vec<ChapterInfo>,
     /// File metadata (title, artist, etc.)
     metadata: HashMap<String, String>,
 }
@@ -174,6 +177,27 @@ impl MediaInfo {
     #[inline]
     pub fn audio_streams(&self) -> &[AudioStreamInfo] {
         &self.audio_streams
+    }
+
+    /// Returns all chapters in the file.
+    #[must_use]
+    #[inline]
+    pub fn chapters(&self) -> &[ChapterInfo] {
+        &self.chapters
+    }
+
+    /// Returns `true` if the file contains at least one chapter marker.
+    #[must_use]
+    #[inline]
+    pub fn has_chapters(&self) -> bool {
+        !self.chapters.is_empty()
+    }
+
+    /// Returns the number of chapters.
+    #[must_use]
+    #[inline]
+    pub fn chapter_count(&self) -> usize {
+        self.chapters.len()
     }
 
     /// Returns the file metadata.
@@ -410,6 +434,7 @@ impl Default for MediaInfo {
             bitrate: None,
             video_streams: Vec::new(),
             audio_streams: Vec::new(),
+            chapters: Vec::new(),
             metadata: HashMap::new(),
         }
     }
@@ -443,6 +468,7 @@ pub struct MediaInfoBuilder {
     bitrate: Option<u64>,
     video_streams: Vec<VideoStreamInfo>,
     audio_streams: Vec<AudioStreamInfo>,
+    chapters: Vec<ChapterInfo>,
     metadata: HashMap<String, String>,
 }
 
@@ -517,6 +543,20 @@ impl MediaInfoBuilder {
         self
     }
 
+    /// Adds a chapter.
+    #[must_use]
+    pub fn chapter(mut self, chapter: ChapterInfo) -> Self {
+        self.chapters.push(chapter);
+        self
+    }
+
+    /// Sets all chapters at once, replacing any existing chapters.
+    #[must_use]
+    pub fn chapters(mut self, chapters: Vec<ChapterInfo>) -> Self {
+        self.chapters = chapters;
+        self
+    }
+
     /// Adds a metadata key-value pair.
     #[must_use]
     pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
@@ -543,6 +583,7 @@ impl MediaInfoBuilder {
             bitrate: self.bitrate,
             video_streams: self.video_streams,
             audio_streams: self.audio_streams,
+            chapters: self.chapters,
             metadata: self.metadata,
         }
     }

--- a/crates/ff-probe/src/info.rs
+++ b/crates/ff-probe/src/info.rs
@@ -58,6 +58,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use ff_format::channel::ChannelLayout;
+use ff_format::chapter::ChapterInfo;
 use ff_format::codec::{AudioCodec, VideoCodec};
 use ff_format::color::{ColorPrimaries, ColorRange, ColorSpace};
 use ff_format::stream::{AudioStreamInfo, VideoStreamInfo};
@@ -179,6 +180,10 @@ pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
     // SAFETY: ctx is valid and find_stream_info succeeded
     let audio_streams = unsafe { extract_audio_streams(ctx) };
 
+    // Extract chapter info
+    // SAFETY: ctx is valid and find_stream_info succeeded
+    let chapters = unsafe { extract_chapters(ctx) };
+
     // Close the format context
     // SAFETY: ctx is valid
     unsafe {
@@ -194,6 +199,7 @@ pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
         .file_size(file_size)
         .video_streams(video_streams)
         .audio_streams(audio_streams)
+        .chapters(chapters)
         .metadata_map(metadata);
 
     if let Some(name) = format_long_name {
@@ -1078,6 +1084,179 @@ fn map_sample_format(format: i32) -> SampleFormat {
     }
 }
 
+// ============================================================================
+// Chapter Extraction
+// ============================================================================
+
+/// Extracts all chapters from an `AVFormatContext`.
+///
+/// # Safety
+///
+/// The `ctx` pointer must be valid and `avformat_find_stream_info` must have been called.
+unsafe fn extract_chapters(ctx: *mut ff_sys::AVFormatContext) -> Vec<ChapterInfo> {
+    // SAFETY: Caller guarantees ctx is valid
+    unsafe {
+        let nb_chapters = (*ctx).nb_chapters;
+        let chapters_ptr = (*ctx).chapters;
+
+        if chapters_ptr.is_null() || nb_chapters == 0 {
+            return Vec::new();
+        }
+
+        let mut chapters = Vec::with_capacity(nb_chapters as usize);
+
+        for i in 0..nb_chapters {
+            // SAFETY: i < nb_chapters, so this is within bounds
+            let chapter = *chapters_ptr.add(i as usize);
+            if chapter.is_null() {
+                continue;
+            }
+
+            chapters.push(extract_single_chapter(chapter));
+        }
+
+        chapters
+    }
+}
+
+/// Extracts information from a single `AVChapter`.
+///
+/// # Safety
+///
+/// The `chapter` pointer must be valid.
+unsafe fn extract_single_chapter(chapter: *mut ff_sys::AVChapter) -> ChapterInfo {
+    // SAFETY: Caller guarantees chapter is valid
+    unsafe {
+        let id = (*chapter).id;
+
+        let av_tb = (*chapter).time_base;
+        let time_base = if av_tb.den != 0 {
+            Some(Rational::new(av_tb.num, av_tb.den))
+        } else {
+            log::warn!(
+                "chapter time_base has zero denominator, treating as unknown \
+                 chapter_id={id} time_base_num={num} time_base_den=0",
+                num = av_tb.num
+            );
+            None
+        };
+
+        let (start, end) = if let Some(tb) = time_base {
+            (
+                pts_to_duration((*chapter).start, tb),
+                pts_to_duration((*chapter).end, tb),
+            )
+        } else {
+            (std::time::Duration::ZERO, std::time::Duration::ZERO)
+        };
+
+        let title = extract_chapter_title((*chapter).metadata);
+        let metadata = extract_chapter_metadata((*chapter).metadata);
+
+        let mut builder = ChapterInfo::builder().id(id).start(start).end(end);
+
+        if let Some(t) = title {
+            builder = builder.title(t);
+        }
+        if let Some(tb) = time_base {
+            builder = builder.time_base(tb);
+        }
+        if let Some(m) = metadata {
+            builder = builder.metadata(m);
+        }
+
+        builder.build()
+    }
+}
+
+/// Converts a PTS value to a [`Duration`] using the given time base.
+///
+/// Returns [`Duration::ZERO`] for non-positive PTS values.
+fn pts_to_duration(pts: i64, time_base: Rational) -> std::time::Duration {
+    if pts <= 0 {
+        return std::time::Duration::ZERO;
+    }
+    // secs = pts * num / den
+    // Note: precision loss from i64/i32 to f64 is acceptable for media timestamps
+    #[expect(clippy::cast_precision_loss, reason = "media timestamps are bounded")]
+    let secs = (pts as f64) * f64::from(time_base.num()) / f64::from(time_base.den());
+    if secs > 0.0 {
+        std::time::Duration::from_secs_f64(secs)
+    } else {
+        std::time::Duration::ZERO
+    }
+}
+
+/// Extracts the "title" metadata tag from a chapter's `AVDictionary`.
+///
+/// Returns `None` if the dict is null or the tag is absent.
+///
+/// # Safety
+///
+/// `dict` may be null (returns `None`) or a valid `AVDictionary` pointer.
+unsafe fn extract_chapter_title(dict: *mut ff_sys::AVDictionary) -> Option<String> {
+    // SAFETY: av_dict_get handles null dict by returning null
+    unsafe {
+        if dict.is_null() {
+            return None;
+        }
+        let entry = ff_sys::av_dict_get(dict, c"title".as_ptr(), std::ptr::null(), 0);
+        if entry.is_null() {
+            return None;
+        }
+        let value_ptr = (*entry).value;
+        if value_ptr.is_null() {
+            return None;
+        }
+        Some(CStr::from_ptr(value_ptr).to_string_lossy().into_owned())
+    }
+}
+
+/// Extracts all metadata tags except "title" from a chapter's `AVDictionary`.
+///
+/// Returns `None` if the dict is null or all tags are filtered out.
+///
+/// # Safety
+///
+/// `dict` may be null (returns `None`) or a valid `AVDictionary` pointer.
+unsafe fn extract_chapter_metadata(
+    dict: *mut ff_sys::AVDictionary,
+) -> Option<HashMap<String, String>> {
+    // SAFETY: av_dict_get handles null dict by returning null
+    unsafe {
+        if dict.is_null() {
+            return None;
+        }
+
+        let mut map = HashMap::new();
+        let mut entry: *const ff_sys::AVDictionaryEntry = std::ptr::null();
+        let flags = ff_sys::AV_DICT_IGNORE_SUFFIX.cast_signed();
+
+        loop {
+            entry = ff_sys::av_dict_get(dict, c"".as_ptr(), entry, flags);
+            if entry.is_null() {
+                break;
+            }
+
+            let key_ptr = (*entry).key;
+            let value_ptr = (*entry).value;
+
+            if key_ptr.is_null() || value_ptr.is_null() {
+                continue;
+            }
+
+            let key = CStr::from_ptr(key_ptr).to_string_lossy().into_owned();
+            if key == "title" {
+                continue;
+            }
+            let value = CStr::from_ptr(value_ptr).to_string_lossy().into_owned();
+            map.insert(key, value);
+        }
+
+        if map.is_empty() { None } else { Some(map) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1118,6 +1297,38 @@ mod tests {
     fn test_av_time_base_constant() {
         // Verify our constant matches the expected value
         assert_eq!(AV_TIME_BASE, 1_000_000);
+    }
+
+    // ========================================================================
+    // pts_to_duration Tests
+    // ========================================================================
+
+    #[test]
+    fn pts_to_duration_should_convert_millisecond_timebase_correctly() {
+        // 1/1000 timebase: 5000 pts = 5 seconds
+        let tb = Rational::new(1, 1000);
+        let dur = pts_to_duration(5000, tb);
+        assert_eq!(dur, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn pts_to_duration_should_convert_mpeg_ts_timebase_correctly() {
+        // 1/90000 timebase: 90000 pts = 1 second
+        let tb = Rational::new(1, 90000);
+        let dur = pts_to_duration(90000, tb);
+        assert!((dur.as_secs_f64() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn pts_to_duration_should_return_zero_for_zero_pts() {
+        let tb = Rational::new(1, 1000);
+        assert_eq!(pts_to_duration(0, tb), Duration::ZERO);
+    }
+
+    #[test]
+    fn pts_to_duration_should_return_zero_for_negative_pts() {
+        let tb = Rational::new(1, 1000);
+        assert_eq!(pts_to_duration(-1, tb), Duration::ZERO);
     }
 
     #[test]

--- a/crates/ff-probe/src/lib.rs
+++ b/crates/ff-probe/src/lib.rs
@@ -132,8 +132,9 @@ mod info;
 
 // Re-export types from ff-format for convenience
 pub use ff_format::{
-    AudioCodec, AudioStreamInfo, ChannelLayout, ColorPrimaries, ColorRange, ColorSpace, MediaInfo,
-    PixelFormat, Rational, SampleFormat, Timestamp, VideoCodec, VideoStreamInfo,
+    AudioCodec, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder, ColorPrimaries,
+    ColorRange, ColorSpace, MediaInfo, PixelFormat, Rational, SampleFormat, Timestamp, VideoCodec,
+    VideoStreamInfo,
 };
 
 pub use error::ProbeError;
@@ -162,9 +163,9 @@ pub use info::open;
 /// ```
 pub mod prelude {
     pub use crate::{
-        AudioCodec, AudioStreamInfo, ChannelLayout, ColorPrimaries, ColorRange, ColorSpace,
-        MediaInfo, PixelFormat, ProbeError, Rational, SampleFormat, Timestamp, VideoCodec,
-        VideoStreamInfo, open,
+        AudioCodec, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder,
+        ColorPrimaries, ColorRange, ColorSpace, MediaInfo, PixelFormat, ProbeError, Rational,
+        SampleFormat, Timestamp, VideoCodec, VideoStreamInfo, open,
     };
 }
 


### PR DESCRIPTION
## Summary

Adds `ChapterInfo` to the type system and wires chapter extraction into `ff-probe`'s `open()` function. Chapter markers from the container (e.g., MKV, MP4) are now surfaced via `MediaInfo::chapters()`. `ChapterInfo` is defined in `ff-format` (alongside `VideoStreamInfo` and `AudioStreamInfo`) so that `MediaInfo` can reference it without inverting the dependency graph.

## Changes

- Add `ff-format/src/chapter.rs` — new `ChapterInfo` and `ChapterInfoBuilder` with 6 fields (`id`, `title`, `start`, `end`, `time_base`, `metadata`) and 8 unit tests
- Add `chapters: Vec<ChapterInfo>` to `MediaInfo` with `chapters()`, `has_chapters()`, and `chapter_count()` accessors and corresponding builder methods
- Add chapter extraction to `ff-probe/src/info.rs` — `extract_chapters()`, `extract_single_chapter()`, `pts_to_duration()`, `extract_chapter_title()`, `extract_chapter_metadata()`; 4 unit tests for `pts_to_duration`
- Re-export `ChapterInfo` and `ChapterInfoBuilder` from `ff-probe`'s public API and prelude

The design doc specifies 6 fields; the extra two over the issue minimum (`time_base`, `metadata`) are included now to avoid a follow-up churn PR.

## Related Issues

Fixes #12
Fixes #13
Fixes #14

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes