### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.2] - 2026-03-12
+
+### Added
+
+#### ff-format
+- New `ChapterInfo` and `ChapterInfoBuilder` types for representing chapter markers within a media container (MKV, MP4, M4A, etc.). Fields: `id`, `title`, `start`, `end`, `time_base`, `metadata` ([#12](https://github.com/itsakeyfut/avio/pull/123))
+- `MediaInfo` now exposes `chapters()`, `has_chapters()`, and `chapter_count()` accessors, plus corresponding builder methods `.chapter()` / `.chapters()` ([#13](https://github.com/itsakeyfut/avio/pull/123))
+
+#### ff-probe
+- Chapter extraction from `AVFormatContext`: iterates `nb_chapters`, converts each `AVChapter` (including `AVRational`-based timestamps) into `ChapterInfo` and populates `MediaInfo::chapters()` ([#14](https://github.com/itsakeyfut/avio/pull/123))
+- Re-exports `ChapterInfo` and `ChapterInfoBuilder` from the public API and prelude
+
+### Fixed
+
+#### ff-encode
+- `av_opt_set` return values for CRF and preset options are now checked; a `log::warn!` is emitted and the encode continues with the encoder default when an option is unsupported ([#10](https://github.com/itsakeyfut/avio/pull/122))
+
+#### ff-decode
+- Channel layout detection now reads `AVChannelLayout.u.mask` when `order == AV_CHANNEL_ORDER_NATIVE`, correctly distinguishing layouts that share a channel count (e.g. `Stereo2_1` vs `Surround3_0`). Falls back to channel-count heuristic with a `log::warn!` for unrecognised masks or non-native order ([#11](https://github.com/itsakeyfut/avio/pull/119))
+
+### Changed
+
+#### ff-decode, ff-encode, ff-probe, ff-format
+- Silent fallbacks that previously discarded unsupported values without notice now emit `log::warn!` with `key=value` diagnostics ([#5–#9](https://github.com/itsakeyfut/avio/pull/116))
+
+---
+
 ## [0.1.1] - 2026-03-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.1.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.1.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.1.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.1.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.1.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.1.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.1.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.1.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.1.0" }
-avio        = { path = "crates/avio",        version = "0.1.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.1.2" }
+ff-common   = { path = "crates/ff-common",   version = "0.1.2" }
+ff-format   = { path = "crates/ff-format",   version = "0.1.2" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.1.2" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.1.2" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.1.2" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.1.2" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.1.2" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.1.2" }
+avio        = { path = "crates/avio",        version = "0.1.2" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.1.1 to 0.1.2 and documents all changes in CHANGELOG.md. This release closes the v0.1.x milestone (issues #10, #12, #13, #14).

## Changes

- `Cargo.toml`: workspace version 0.1.1 → 0.1.2; intra-workspace dependency pins updated to 0.1.2
- `CHANGELOG.md`: add `[0.1.2]` entry covering all merged changes since 0.1.1

## Related Issues

Closes milestone: v0.1.x (Stabilization & Quality)

Fixes #10
Fixes #11
Fixes #12
Fixes #13
Fixes #14

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes