### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.3] - 2026-03-13
+
+### Fixed
+
+#### ff-sys
+- docs.rs builds now succeed for all crates. `build.rs` detects the `DOCS_RS`
+  environment variable and writes empty bindings, emitting `cfg(docsrs)`.
+  A new `docsrs_stubs.rs` file provides shape-compatible stub types, constants,
+  functions, and wrapper modules so that `ff-probe`, `ff-decode`, and `ff-encode`
+  compile on docs.rs without any changes to those crates ([#125](https://github.com/itsakeyfut/avio/pull/125))
+- All crates now carry `[package.metadata.docs.rs]` with
+  `rustdoc-args = ["--cfg", "docsrs"]` ([#125](https://github.com/itsakeyfut/avio/pull/125))
+
+---
+
 ## [0.1.2] - 2026-03-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.1.2" }
-ff-common   = { path = "crates/ff-common",   version = "0.1.2" }
-ff-format   = { path = "crates/ff-format",   version = "0.1.2" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.1.2" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.1.2" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.1.2" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.1.2" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.1.2" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.1.2" }
-avio        = { path = "crates/avio",        version = "0.1.2" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.1.3" }
+ff-common   = { path = "crates/ff-common",   version = "0.1.3" }
+ff-format   = { path = "crates/ff-format",   version = "0.1.3" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.1.3" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.1.3" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.1.3" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.1.3" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.1.3" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.1.3" }
+avio        = { path = "crates/avio",        version = "0.1.3" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.1.2 to 0.1.3 and documents the docs.rs fix in CHANGELOG.md.

## Changes

- `Cargo.toml`: workspace version 0.1.2 → 0.1.3; intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.1.3]` entry

## Related Issues

Fixes docs.rs build failures for ff-sys, ff-decode, ff-encode, ff-filter, ff-probe, and avio.

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes