### PR TITLE
test(ff-filter): add unit tests for FilterError

### DIFF
--- a/crates/ff-filter/src/error.rs
+++ b/crates/ff-filter/src/error.rs
@@ -32,3 +32,57 @@ pub enum FilterError {
         message: String,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FilterError;
+    use std::error::Error;
+
+    #[test]
+    fn build_failed_should_display_correct_message() {
+        let err = FilterError::BuildFailed;
+        assert_eq!(err.to_string(), "failed to build filter graph");
+    }
+
+    #[test]
+    fn process_failed_should_display_correct_message() {
+        let err = FilterError::ProcessFailed;
+        assert_eq!(err.to_string(), "failed to process frame");
+    }
+
+    #[test]
+    fn invalid_input_should_display_slot_and_reason() {
+        let err = FilterError::InvalidInput {
+            slot: 2,
+            reason: "slot out of range".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid input: slot=2 reason=slot out of range"
+        );
+    }
+
+    #[test]
+    fn ffmpeg_should_display_code_and_message() {
+        let err = FilterError::Ffmpeg {
+            code: -22,
+            message: "Invalid argument".to_string(),
+        };
+        assert_eq!(err.to_string(), "ffmpeg error: Invalid argument (code=-22)");
+    }
+
+    #[test]
+    fn filter_error_should_implement_std_error() {
+        fn assert_error<E: Error>(_: &E) {}
+        assert_error(&FilterError::BuildFailed);
+        assert_error(&FilterError::ProcessFailed);
+        assert_error(&FilterError::InvalidInput {
+            slot: 0,
+            reason: String::new(),
+        });
+        assert_error(&FilterError::Ffmpeg {
+            code: 0,
+            message: String::new(),
+        });
+    }
+}


### PR DESCRIPTION
## Summary

`FilterError` was already fully defined in `crates/ff-filter/src/error.rs` with all four required variants and `thiserror`-derived `Display` / `Error` implementations. This PR closes the issue by adding the missing unit tests that verify the type's contract.

## Changes

- Added `#[cfg(test)] mod tests` to `error.rs` with five test functions:
  - `build_failed_should_display_correct_message` — verifies Display output for `BuildFailed`
  - `process_failed_should_display_correct_message` — verifies Display output for `ProcessFailed`
  - `invalid_input_should_display_slot_and_reason` — verifies Display with named fields
  - `ffmpeg_should_display_code_and_message` — verifies Display with code and message
  - `filter_error_should_implement_std_error` — compile-time check that all variants satisfy `std::error::Error`

## Related Issues

Closes #20

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes