### PR TITLE
feat(ff-filter): propagate avfilter_graph_config error code and message

### DIFF
--- a/crates/ff-filter/src/filter_inner.rs
+++ b/crates/ff-filter/src/filter_inner.rs
@@ -42,6 +42,16 @@ const AUDIO_TIME_BASE_NUM: i32 = 1;
 type FilterCtxVec = Vec<Option<NonNull<ff_sys::AVFilterContext>>>;
 type BuildResult = Result<(FilterCtxVec, NonNull<ff_sys::AVFilterContext>), FilterError>;
 
+// ── FFmpeg error helper ───────────────────────────────────────────────────────
+
+/// Convert a negative `FFmpeg` return code into a [`FilterError::Ffmpeg`].
+fn ffmpeg_err(code: i32) -> FilterError {
+    FilterError::Ffmpeg {
+        code,
+        message: ff_sys::av_error_string(code),
+    }
+}
+
 // ── FilterGraphInner ──────────────────────────────────────────────────────────
 
 /// Low-level filter graph wrapper.
@@ -245,7 +255,8 @@ impl FilterGraphInner {
         // 6. Configure the graph.
         let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
         if ret < 0 {
-            return Err(FilterError::BuildFailed);
+            log::warn!("avfilter_graph_config failed code={ret}");
+            return Err(ffmpeg_err(ret));
         }
 
         // SAFETY: `avfilter_graph_create_filter` with ret >= 0 guarantees
@@ -527,7 +538,8 @@ impl FilterGraphInner {
         // 6. Configure the graph.
         let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
         if ret < 0 {
-            return Err(FilterError::BuildFailed);
+            log::warn!("avfilter_graph_config failed code={ret}");
+            return Err(ffmpeg_err(ret));
         }
 
         // SAFETY: sink_ctx is non-null (ret >= 0 above).
@@ -1105,6 +1117,32 @@ mod tests {
             None,
         );
         assert_eq!(inner.video_input_count(), 1);
+    }
+
+    // ── ffmpeg_err helper ──────────────────────────────────────────────────────
+
+    /// `ffmpeg_err` must return the `Ffmpeg` variant carrying the original code.
+    #[test]
+    fn ffmpeg_err_should_return_ffmpeg_variant_with_code() {
+        let err = ffmpeg_err(-22);
+        assert!(
+            matches!(err, FilterError::Ffmpeg { code: -22, .. }),
+            "expected Ffmpeg variant with code -22, got {err:?}"
+        );
+    }
+
+    /// `ffmpeg_err` must populate a non-empty message string for a known error code.
+    #[test]
+    fn ffmpeg_err_should_populate_non_empty_message() {
+        let err = ffmpeg_err(-22);
+        if let FilterError::Ffmpeg { message, .. } = err {
+            assert!(
+                !message.is_empty(),
+                "message must not be empty for a known error code"
+            );
+        } else {
+            panic!("expected Ffmpeg variant");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

When `avfilter_graph_config` fails, the graph builder previously returned the opaque `FilterError::BuildFailed` which discarded the FFmpeg error code and message. This PR surfaces that information via `FilterError::Ffmpeg { code, message }` and logs a `warn!` so failures are visible without needing a debugger.

## Changes

- Add private `ffmpeg_err(code: i32) -> FilterError` helper that wraps an FFmpeg return code into `FilterError::Ffmpeg` using `ff_sys::av_error_string`
- In `build_video_graph`: replace `FilterError::BuildFailed` on `avfilter_graph_config` failure with `ffmpeg_err(ret)` + `log::warn!`
- In `build_audio_graph`: same treatment
- Add 2 unit tests: `ffmpeg_err_should_return_ffmpeg_variant_with_code` and `ffmpeg_err_should_populate_non_empty_message`

## Related Issues

Closes #23

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes