### PR TITLE
test(ff-decode): ignore flaky thumbnail performance test in CI

### DIFF
--- a/crates/ff-decode/tests/performance_validation_tests.rs
+++ b/crates/ff-decode/tests/performance_validation_tests.rs
@@ -240,6 +240,7 @@ fn test_scrubbing_workflow_performance() {
 }
 
 #[test]
+#[ignore = "performance thresholds are environment-dependent; run explicitly with -- --include-ignored"]
 fn test_thumbnail_generation_performance() {
     let mut decoder = create_decoder();
 


### PR DESCRIPTION
## Summary

`test_thumbnail_generation_performance` used a hard 100ms threshold that is environment-dependent and fails intermittently on shared CI runners (e.g. 109ms on macos-latest). The other four performance tests in the same file were already marked `#[ignore]` for the same reason; this test was simply missed.

## Changes

- Add `#[ignore = "performance thresholds are environment-dependent; run explicitly with -- --include-ignored"]` to `test_thumbnail_generation_performance`

## Related Issues

N/A — CI flake fix

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes