### PR TITLE
feat(ff-filter): implement trim video filter with timestamp reset

### DIFF
--- a/crates/ff-filter/src/filter_inner.rs
+++ b/crates/ff-filter/src/filter_inner.rs
@@ -273,6 +273,12 @@ impl FilterGraphInner {
         for (i, step) in steps.iter().enumerate() {
             prev_ctx = add_and_link_step(graph, prev_ctx, step, i, "step")?;
 
+            // After trim, insert setpts=PTS-STARTPTS so the output timestamps
+            // are reset to start at zero.
+            if matches!(step, FilterStep::Trim { .. }) {
+                prev_ctx = add_setpts_after_trim(graph, prev_ctx, i)?;
+            }
+
             // Overlay consumes a second input on pad 1.
             if matches!(step, FilterStep::Overlay { .. })
                 && let Some(Some(extra_src)) = src_ctxs.get(1)
@@ -758,6 +764,49 @@ unsafe fn add_and_link_step(
         return Err(FilterError::BuildFailed);
     }
     Ok(step_ctx)
+}
+
+/// Insert a `setpts=PTS-STARTPTS` filter immediately after a `trim` step so
+/// that the output stream's timestamps start at zero.
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+unsafe fn add_setpts_after_trim(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    trim_index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let setpts = ff_sys::avfilter_get_by_name(c"setpts".as_ptr());
+    if setpts.is_null() {
+        log::warn!("filter not found name=setpts");
+        return Err(FilterError::BuildFailed);
+    }
+
+    let name = std::ffi::CString::new(format!("setpts{trim_index}"))
+        .map_err(|_| FilterError::BuildFailed)?;
+
+    let mut ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut ctx,
+        setpts,
+        name.as_ptr(),
+        c"PTS-STARTPTS".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=setpts args=PTS-STARTPTS");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=setpts args=PTS-STARTPTS");
+
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+    Ok(ctx)
 }
 
 // ── buffersrc / buffersink arg-string helpers ──────────────────────────────────

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -139,3 +139,26 @@ fn push_audio_and_pull_through_volume_should_return_frame() {
     assert_eq!(out.channels(), 2);
     assert_eq!(out.samples(), 1024);
 }
+
+#[test]
+fn push_video_through_trim_should_return_frame_within_range() {
+    let mut graph = match FilterGraph::builder().trim(0.0, 5.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after trim push within range");
+    assert_eq!(out.width(), 64, "width should be unchanged after trim");
+    assert_eq!(out.height(), 64, "height should be unchanged after trim");
+}


### PR DESCRIPTION
## Summary

Completes Issue #24 by wiring the already-present `trim` filter step to automatically append `setpts=PTS-STARTPTS` in the video filter graph, so that output timestamps are reset to start at zero after trimming. The `FilterGraphBuilder::trim()` method and `FilterStep::Trim` were already scaffolded; this PR adds the runtime behaviour and a covering integration test.

## Changes

- `filter_inner.rs`: added `add_setpts_after_trim` helper that creates a `setpts=PTS-STARTPTS` AVFilterContext and links it immediately after every `trim` step in `build_video_graph`
- `push_pull_tests.rs`: added `push_video_through_trim_should_return_frame_within_range` — pushes a 64×64 Yuv420p frame through `trim(0.0, 5.0)` and asserts the pulled frame has the correct dimensions

## Related Issues

Closes #24

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes