### PR TITLE
test(ff-filter): add integration test for crop video filter

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -162,3 +162,26 @@ fn push_video_through_trim_should_return_frame_within_range() {
     assert_eq!(out.width(), 64, "width should be unchanged after trim");
     assert_eq!(out.height(), 64, "height should be unchanged after trim");
 }
+
+#[test]
+fn push_video_through_crop_should_return_cropped_frame() {
+    let mut graph = match FilterGraph::builder().crop(0, 0, 32, 32).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after crop push");
+    assert_eq!(out.width(), 32, "width should be cropped to 32");
+    assert_eq!(out.height(), 32, "height should be cropped to 32");
+}


### PR DESCRIPTION
## Summary

The `crop` filter was already fully implemented (builder method, `FilterStep::Crop`, `filter_name()`, `args()`, and unit test) as part of the filtergraph builder scaffolding in PR #136. The only missing piece was a push/pull integration test exercising the real FFmpeg `crop` filter. This PR adds it.

## Changes

- `push_pull_tests.rs`: added `push_video_through_crop_should_return_cropped_frame` — pushes a 64×64 Yuv420p frame through `crop(0, 0, 32, 32)` and asserts the output frame is 32×32

## Related Issues

Closes #26

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes