### PR TITLE
test(ff-filter): add integration test for overlay video filter

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -185,3 +185,36 @@ fn push_video_through_crop_should_return_cropped_frame() {
     assert_eq!(out.width(), 32, "width should be cropped to 32");
     assert_eq!(out.height(), 32, "height should be cropped to 32");
 }
+
+#[test]
+fn push_video_through_overlay_should_return_composited_frame() {
+    let mut graph = match FilterGraph::builder().overlay(0, 0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let base = make_yuv420p_frame(64, 64);
+    let overlay = make_yuv420p_frame(64, 64);
+    // Push base video to slot 0 first; this also initialises the graph.
+    match graph.push_video(0, &base) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    // Push overlay video to slot 1.
+    match graph.push_video(1, &overlay) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after overlay push");
+    assert_eq!(out.width(), 64, "output width should match base video");
+    assert_eq!(out.height(), 64, "output height should match base video");
+}


### PR DESCRIPTION
## Summary

The `overlay` filter was already fully implemented (builder method, `FilterStep::Overlay`, `video_input_count()` returning 2, extra-pad linking in `build_video_graph`, and unit test) as part of the filtergraph builder scaffolding in PR #136. The only missing piece was a push/pull integration test exercising the real FFmpeg `overlay` filter with two input slots.

## Changes

- `push_pull_tests.rs`: added `push_video_through_overlay_should_return_composited_frame` — pushes a 64×64 base frame to slot 0 and a 64×64 overlay frame to slot 1, then asserts the output frame is 64×64

## Related Issues

Closes #27

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes