### PR TITLE
test(ff-filter): add integration test for rotate video filter

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -276,3 +276,25 @@ fn push_video_through_fade_out_should_return_frame_with_same_dimensions() {
         "height should be unchanged after fade_out"
     );
 }
+
+#[test]
+fn push_video_through_rotate_should_return_frame() {
+    let mut graph = match FilterGraph::builder().rotate(90.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    // Use a square frame so output dimensions are unambiguous after 90° rotation.
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    assert!(result.is_some(), "expected Some(frame) after rotate push");
+}


### PR DESCRIPTION
## Summary

The `rotate` filter was already fully implemented (builder method, `FilterStep::Rotate`, `filter_name()`, `args()` converting degrees to radians, and unit test) as part of the filtergraph builder scaffolding in PR #136. This PR adds the missing push/pull integration test exercising the real FFmpeg `rotate` filter.

## Changes

- `push_pull_tests.rs`: added `push_video_through_rotate_should_return_frame` — pushes a 64×64 Yuv420p square frame through `rotate(90°)` and asserts the filter graph produces a frame. A square input is used so the output dimensions are unambiguous regardless of FFmpeg's default padding behaviour for the `rotate` filter.

## Related Issues

Closes #29

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes