### PR TITLE
test(ff-filter): add integration test for tone_map video filter

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use ff_filter::{FilterError, FilterGraph};
+use ff_filter::{FilterError, FilterGraph, ToneMap};
 use ff_format::{AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame};
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
@@ -297,4 +297,28 @@ fn push_video_through_rotate_should_return_frame() {
     }
     let result = graph.pull_video().expect("pull_video must not fail");
     assert!(result.is_some(), "expected Some(frame) after rotate push");
+}
+
+#[test]
+fn push_video_through_tone_map_should_return_frame() {
+    // The tonemap filter is HDR-specific and may not be available in all
+    // FFmpeg builds, or may reject non-HDR input. All failure paths are
+    // treated as graceful skips.
+    let mut graph = match FilterGraph::builder().tone_map(ToneMap::Hable).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    assert!(result.is_some(), "expected Some(frame) after tone_map push");
 }


### PR DESCRIPTION
## Summary

The `tone_map` filter and `ToneMap` enum were already fully implemented (builder method, `FilterStep::ToneMap`, `filter_name()`, `args()`, `ToneMap::as_str()`, and unit tests) as part of the filtergraph builder scaffolding in PR #136. This PR adds the missing push/pull integration test exercising the real FFmpeg `tonemap` filter.

## Changes

- `push_pull_tests.rs`: import `ToneMap` from `ff_filter`
- `push_pull_tests.rs`: added `push_video_through_tone_map_should_return_frame` — builds a `tonemap(Hable)` graph, pushes a 64×64 Yuv420p frame, and asserts the filter produces output. The `tonemap` filter is HDR-specific; non-HDR input causes FFmpeg to log a warning (`"Untagged transfer, assuming linear light"`) but still produces a frame. All hard-failure paths (filter unavailable, graph config failure) are treated as graceful skips.

## Related Issues

Closes #30

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes