### PR TITLE
test(ff-filter): add integration test for amix audio filter

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -322,3 +322,35 @@ fn push_video_through_tone_map_should_return_frame() {
     let result = graph.pull_video().expect("pull_video must not fail");
     assert!(result.is_some(), "expected Some(frame) after tone_map push");
 }
+
+#[test]
+fn push_audio_through_amix_should_return_mixed_frame() {
+    let mut graph = match FilterGraph::builder().amix(2).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    // Push to slot 0 — this also initialises the audio graph.
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    // Push to slot 1 so amix has data on both inputs and can produce output.
+    match graph.push_audio(1, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    let out = result.expect("expected Some(frame) after amix push to both slots");
+    assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+    assert_eq!(out.channels(), 2, "channel count should be unchanged");
+}


### PR DESCRIPTION
## Summary

The `amix` filter was already fully implemented (`FilterStep::Amix`, `audio_input_count()`, multi-slot `build_audio_graph`, builder method, and unit test) as part of the filtergraph builder scaffolding in PR #136. This PR adds the missing push/pull integration test exercising the real FFmpeg `amix` filter with two input slots.

## Changes

- `push_pull_tests.rs`: added `push_audio_through_amix_should_return_mixed_frame` — builds an `amix(2)` graph, pushes identical stereo F32 frames (1024 samples @ 48 kHz) to both input slots, and asserts the mixed output has the correct sample rate (48000) and channel count (2). Both slots must have data before amix produces output, mirroring the overlay two-slot pattern on the video path.

## Related Issues

Closes #32

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes