### PR TITLE
test(ff-filter): add integration test for equalizer audio filter

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -354,3 +354,27 @@ fn push_audio_through_amix_should_return_mixed_frame() {
     assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
     assert_eq!(out.channels(), 2, "channel count should be unchanged");
 }
+
+#[test]
+fn push_audio_through_equalizer_should_return_frame_with_same_properties() {
+    let mut graph = match FilterGraph::builder().equalizer(1000.0, 3.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    let out = result.expect("expected Some(frame) after equalizer push");
+    assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+    assert_eq!(out.channels(), 2, "channel count should be unchanged");
+    assert_eq!(out.samples(), 1024, "sample count should be unchanged");
+}


### PR DESCRIPTION
## Summary

The `equalizer` filter was already fully implemented (builder method, `FilterStep::Equalizer`, `filter_name()`, `args()`, and unit test) as part of the filtergraph builder scaffolding in PR #136. This PR adds the missing push/pull integration test exercising the real FFmpeg `equalizer` filter.

## Changes

- `push_pull_tests.rs`: added `push_audio_through_equalizer_should_return_frame_with_same_properties` — pushes a 1024-sample stereo F32 frame at 48 kHz through `equalizer(1000Hz, +3dB)` and asserts sample rate (48000), channel count (2), and sample count (1024) are all unchanged after the filter pass

## Related Issues

Closes #33

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes