### PR TITLE
test(ff-filter): add integration test for VideoToolbox hardware filter

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -411,3 +411,36 @@ fn push_video_through_cuda_scale_should_return_resized_frame_or_skip() {
     assert_eq!(out.width(), 32, "width should be scaled to 32");
     assert_eq!(out.height(), 32, "height should be scaled to 32");
 }
+
+#[test]
+fn push_video_through_videotoolbox_scale_should_return_resized_frame_or_skip() {
+    // VideoToolbox is macOS-only; on other platforms av_hwdevice_ctx_create
+    // will fail and the test skips gracefully.  On macOS the hwupload filter
+    // uploads frames to the VideoToolbox device and hwdownload brings them
+    // back; avfilter_graph_config failure is also treated as a skip.
+    let mut graph = match FilterGraph::builder()
+        .hardware(HwAccel::VideoToolbox)
+        .scale(32, 32)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping (build): {e}");
+            return;
+        }
+    };
+
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping (push): {e}");
+            return;
+        }
+    }
+
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after videotoolbox scale push");
+    assert_eq!(out.width(), 32, "width should be scaled to 32");
+    assert_eq!(out.height(), 32, "height should be scaled to 32");
+}


### PR DESCRIPTION
## Summary

The VideoToolbox backend was fully implemented as part of #147 (issue #34) — `HwAccel::VideoToolbox` already maps to `AV_HWDEVICE_TYPE_VIDEOTOOLBOX` and uses the `hwupload`/`hwdownload` filter pair. This PR adds the missing integration test that exercises the VideoToolbox code path, following the same graceful-skip pattern as the CUDA test.

## Changes

- Added `push_video_through_videotoolbox_scale_should_return_resized_frame_or_skip` to `crates/ff-filter/tests/push_pull_tests.rs`; skips gracefully on non-macOS platforms where `av_hwdevice_ctx_create` returns an error

## Related Issues

Closes #35

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes