### PR TITLE
feat(ff-decode): implement ImageDecoder with builder pattern and iterator

### DIFF
--- a/crates/ff-decode/src/image/builder.rs
+++ b/crates/ff-decode/src/image/builder.rs
@@ -1,0 +1,205 @@
+//! Image decoder builder for constructing image decoders.
+//!
+//! This module provides the [`ImageDecoderBuilder`] type which enables fluent
+//! configuration of image decoders. Use [`ImageDecoder::open()`] to start building.
+
+use std::path::{Path, PathBuf};
+
+use ff_format::VideoFrame;
+
+use crate::error::DecodeError;
+use crate::image::decoder_inner::ImageDecoderInner;
+
+/// Builder for configuring and constructing an [`ImageDecoder`].
+///
+/// Created by calling [`ImageDecoder::open()`]. Call [`build()`](Self::build)
+/// to open the file and prepare for decoding.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::ImageDecoder;
+///
+/// let frame = ImageDecoder::open("photo.png").build()?.decode()?;
+/// println!("{}x{}", frame.width(), frame.height());
+/// ```
+#[derive(Debug)]
+pub struct ImageDecoderBuilder {
+    path: PathBuf,
+}
+
+impl ImageDecoderBuilder {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Opens the image file and returns an [`ImageDecoder`] ready to decode.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if the file cannot be opened, contains no
+    /// video stream, or uses an unsupported codec.
+    pub fn build(self) -> Result<ImageDecoder, DecodeError> {
+        if !self.path.exists() {
+            return Err(DecodeError::FileNotFound {
+                path: self.path.clone(),
+            });
+        }
+        let inner = ImageDecoderInner::new(&self.path)?;
+        let width = inner.width();
+        let height = inner.height();
+        Ok(ImageDecoder {
+            inner: Some(inner),
+            width,
+            height,
+        })
+    }
+}
+
+/// Decodes a single still image into a [`VideoFrame`].
+///
+/// Supports common image formats: JPEG, PNG, BMP, TIFF, WebP.
+///
+/// # Construction
+///
+/// Use [`ImageDecoder::open()`] to create a builder, then call
+/// [`ImageDecoderBuilder::build()`]:
+///
+/// ```ignore
+/// use ff_decode::ImageDecoder;
+///
+/// let frame = ImageDecoder::open("photo.png").build()?.decode()?;
+/// println!("{}x{}", frame.width(), frame.height());
+/// ```
+///
+/// # Frame Decoding
+///
+/// The image can be decoded as a single frame or via an iterator:
+///
+/// ```ignore
+/// // Single frame (consuming)
+/// let frame = decoder.decode()?;
+///
+/// // Via iterator (for API consistency with VideoDecoder / AudioDecoder)
+/// for frame in decoder.frames() {
+///     let frame = frame?;
+/// }
+/// ```
+pub struct ImageDecoder {
+    /// Inner `FFmpeg` state; `None` after the frame has been decoded.
+    inner: Option<ImageDecoderInner>,
+    /// Cached width so it remains accessible after `decode_one` consumes `inner`.
+    width: u32,
+    /// Cached height so it remains accessible after `decode_one` consumes `inner`.
+    height: u32,
+}
+
+impl ImageDecoder {
+    /// Creates a builder for the specified image file path.
+    ///
+    /// # Note
+    ///
+    /// This method does not validate that the file exists or is a valid image.
+    /// Validation occurs when [`ImageDecoderBuilder::build()`] is called.
+    pub fn open(path: impl AsRef<Path>) -> ImageDecoderBuilder {
+        ImageDecoderBuilder::new(path.as_ref().to_path_buf())
+    }
+
+    /// Returns the image width in pixels.
+    #[must_use]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Returns the image height in pixels.
+    #[must_use]
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Decodes the image frame.
+    ///
+    /// Returns `Ok(Some(frame))` on the first call, then `Ok(None)` on
+    /// subsequent calls (the underlying `FFmpeg` context is consumed on first
+    /// decode).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if `FFmpeg` fails to decode the image.
+    pub fn decode_one(&mut self) -> Result<Option<VideoFrame>, DecodeError> {
+        let Some(inner) = self.inner.take() else {
+            return Ok(None);
+        };
+        Ok(Some(inner.decode()?))
+    }
+
+    /// Returns an iterator that yields the single decoded image frame.
+    ///
+    /// This method exists for API consistency with [`VideoDecoder`] and
+    /// [`AudioDecoder`].  The iterator yields at most one item.
+    ///
+    /// [`VideoDecoder`]: crate::VideoDecoder
+    /// [`AudioDecoder`]: crate::AudioDecoder
+    pub fn frames(&mut self) -> ImageFrameIterator<'_> {
+        ImageFrameIterator { decoder: self }
+    }
+
+    /// Decodes the image, consuming `self` and returning the [`VideoFrame`].
+    ///
+    /// This is a convenience wrapper around [`decode_one`](Self::decode_one)
+    /// for the common single-frame use-case.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if the image cannot be decoded or was already
+    /// decoded.
+    pub fn decode(mut self) -> Result<VideoFrame, DecodeError> {
+        self.decode_one()?
+            .ok_or_else(|| DecodeError::Ffmpeg("Image already decoded".to_string()))
+    }
+}
+
+/// Iterator over the decoded image frame.
+///
+/// Created by calling [`ImageDecoder::frames()`]. Yields exactly one item —
+/// the decoded [`VideoFrame`] — then returns `None`.
+///
+/// This type exists for API consistency with [`VideoFrameIterator`] and
+/// [`AudioFrameIterator`].
+///
+/// [`VideoFrameIterator`]: crate::VideoFrameIterator
+/// [`AudioFrameIterator`]: crate::AudioFrameIterator
+pub struct ImageFrameIterator<'a> {
+    decoder: &'a mut ImageDecoder,
+}
+
+impl Iterator for ImageFrameIterator<'_> {
+    type Item = Result<VideoFrame, DecodeError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.decoder.decode_one() {
+            Ok(Some(frame)) => Some(Ok(frame)),
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn open_nonexistent_file_should_return_file_not_found() {
+        let result = ImageDecoder::open("nonexistent_image_12345.png").build();
+        assert!(result.is_err());
+        assert!(matches!(result, Err(DecodeError::FileNotFound { .. })));
+    }
+
+    #[test]
+    fn builder_new_should_store_path() {
+        let builder = ImageDecoderBuilder::new(PathBuf::from("photo.png"));
+        assert_eq!(builder.path, PathBuf::from("photo.png"));
+    }
+}

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -1,0 +1,636 @@
+//! Internal image decoder implementation using FFmpeg.
+//!
+//! This module contains the low-level decoder logic that directly interacts
+//! with FFmpeg's C API through the ff-sys crate. It is not exposed publicly.
+
+// Allow unsafe code in this module as it's necessary for FFmpeg FFI
+#![allow(unsafe_code)]
+// Allow specific clippy lints for FFmpeg FFI code
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::ptr_as_ptr)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
+use std::path::Path;
+use std::ptr;
+
+use ff_format::time::{Rational, Timestamp};
+use ff_format::{PixelFormat, PooledBuffer, VideoFrame};
+use ff_sys::{
+    AVCodecContext, AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket,
+    AVPixelFormat,
+};
+
+use crate::error::DecodeError;
+
+// ── RAII guards ────────────────────────────────────────────────────────────────
+
+/// RAII guard for `AVFormatContext` to ensure proper cleanup.
+struct AvFormatContextGuard(*mut AVFormatContext);
+
+impl AvFormatContextGuard {
+    unsafe fn new(path: &Path) -> Result<Self, DecodeError> {
+        // SAFETY: Caller ensures FFmpeg is initialized and path is valid
+        let format_ctx = unsafe {
+            ff_sys::avformat::open_input(path).map_err(|e| {
+                DecodeError::Ffmpeg(format!(
+                    "Failed to open file: {}",
+                    ff_sys::av_error_string(e)
+                ))
+            })?
+        };
+        Ok(Self(format_ctx))
+    }
+
+    const fn as_ptr(&self) -> *mut AVFormatContext {
+        self.0
+    }
+
+    fn into_raw(self) -> *mut AVFormatContext {
+        let ptr = self.0;
+        std::mem::forget(self);
+        ptr
+    }
+}
+
+impl Drop for AvFormatContextGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: self.0 is valid and owned by this guard
+            unsafe {
+                ff_sys::avformat::close_input(&mut (self.0 as *mut _));
+            }
+        }
+    }
+}
+
+/// RAII guard for `AVCodecContext` to ensure proper cleanup.
+struct AvCodecContextGuard(*mut AVCodecContext);
+
+impl AvCodecContextGuard {
+    unsafe fn new(codec: *const ff_sys::AVCodec) -> Result<Self, DecodeError> {
+        // SAFETY: Caller ensures codec pointer is valid
+        let codec_ctx = unsafe {
+            ff_sys::avcodec::alloc_context3(codec).map_err(|e| {
+                DecodeError::Ffmpeg(format!("Failed to allocate codec context: {e}"))
+            })?
+        };
+        Ok(Self(codec_ctx))
+    }
+
+    const fn as_ptr(&self) -> *mut AVCodecContext {
+        self.0
+    }
+
+    fn into_raw(self) -> *mut AVCodecContext {
+        let ptr = self.0;
+        std::mem::forget(self);
+        ptr
+    }
+}
+
+impl Drop for AvCodecContextGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: self.0 is valid and owned by this guard
+            unsafe {
+                ff_sys::avcodec::free_context(&mut (self.0 as *mut _));
+            }
+        }
+    }
+}
+
+// ── ImageDecoderInner ─────────────────────────────────────────────────────────
+
+/// Internal state for the image decoder.
+///
+/// Holds raw FFmpeg pointers and is responsible for proper cleanup in `Drop`.
+pub(crate) struct ImageDecoderInner {
+    /// Format context for reading the image file.
+    format_ctx: *mut AVFormatContext,
+    /// Codec context for decoding the image.
+    codec_ctx: *mut AVCodecContext,
+    /// Video stream index in the format context.
+    stream_index: usize,
+    /// Reusable packet for reading from file.
+    packet: *mut AVPacket,
+    /// Reusable frame for decoding.
+    frame: *mut AVFrame,
+}
+
+// SAFETY: `ImageDecoderInner` owns all FFmpeg contexts exclusively.
+//         FFmpeg contexts are not safe for concurrent access (not Sync),
+//         but ownership transfer between threads is safe.
+unsafe impl Send for ImageDecoderInner {}
+
+impl ImageDecoderInner {
+    /// Opens an image file and prepares the decoder.
+    ///
+    /// Performs the full FFmpeg initialization sequence:
+    /// 1. `avformat_open_input`
+    /// 2. `avformat_find_stream_info`
+    /// 3. `av_find_best_stream(AVMEDIA_TYPE_VIDEO)`
+    /// 4. `avcodec_find_decoder`
+    /// 5. `avcodec_alloc_context3`
+    /// 6. `avcodec_parameters_to_context`
+    /// 7. `avcodec_open2`
+    pub(crate) fn new(path: &Path) -> Result<Self, DecodeError> {
+        ff_sys::ensure_initialized();
+
+        // 1. avformat_open_input
+        // SAFETY: Path is valid; AvFormatContextGuard ensures cleanup on error.
+        let format_ctx_guard = unsafe { AvFormatContextGuard::new(path)? };
+        let format_ctx = format_ctx_guard.as_ptr();
+
+        // 2. avformat_find_stream_info
+        // SAFETY: format_ctx is valid and owned by the guard.
+        unsafe {
+            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| {
+                DecodeError::Ffmpeg(format!(
+                    "Failed to find stream info: {}",
+                    ff_sys::av_error_string(e)
+                ))
+            })?;
+        }
+
+        // 3. Find the video stream.
+        // SAFETY: format_ctx is valid.
+        let (stream_index, codec_id) =
+            unsafe { Self::find_video_stream(format_ctx) }.ok_or_else(|| {
+                DecodeError::NoVideoStream {
+                    path: path.to_path_buf(),
+                }
+            })?;
+
+        // 4. avcodec_find_decoder
+        // SAFETY: codec_id comes from FFmpeg.
+        let codec = unsafe {
+            ff_sys::avcodec::find_decoder(codec_id).ok_or_else(|| {
+                DecodeError::UnsupportedCodec {
+                    codec: format!("codec_id={codec_id:?}"),
+                }
+            })?
+        };
+
+        // 5. avcodec_alloc_context3
+        // SAFETY: codec pointer is valid; AvCodecContextGuard ensures cleanup.
+        let codec_ctx_guard = unsafe { AvCodecContextGuard::new(codec)? };
+        let codec_ctx = codec_ctx_guard.as_ptr();
+
+        // 6. avcodec_parameters_to_context
+        // SAFETY: All pointers are valid; stream_index was validated above.
+        unsafe {
+            let stream = (*format_ctx).streams.add(stream_index);
+            let codecpar = (*(*stream)).codecpar;
+            ff_sys::avcodec::parameters_to_context(codec_ctx, codecpar).map_err(|e| {
+                DecodeError::Ffmpeg(format!(
+                    "Failed to copy codec parameters: {}",
+                    ff_sys::av_error_string(e)
+                ))
+            })?;
+        }
+
+        // 7. avcodec_open2
+        // SAFETY: codec_ctx and codec are valid; no hardware acceleration for images.
+        unsafe {
+            ff_sys::avcodec::open2(codec_ctx, codec, ptr::null_mut()).map_err(|e| {
+                DecodeError::Ffmpeg(format!(
+                    "Failed to open codec: {}",
+                    ff_sys::av_error_string(e)
+                ))
+            })?;
+        }
+
+        // Allocate packet and frame.
+        // SAFETY: FFmpeg is initialized.
+        let packet = unsafe { ff_sys::av_packet_alloc() };
+        if packet.is_null() {
+            return Err(DecodeError::Ffmpeg("Failed to allocate packet".to_string()));
+        }
+        let frame = unsafe { ff_sys::av_frame_alloc() };
+        if frame.is_null() {
+            unsafe { ff_sys::av_packet_free(&mut (packet as *mut _)) };
+            return Err(DecodeError::Ffmpeg("Failed to allocate frame".to_string()));
+        }
+
+        Ok(Self {
+            format_ctx: format_ctx_guard.into_raw(),
+            codec_ctx: codec_ctx_guard.into_raw(),
+            stream_index,
+            packet,
+            frame,
+        })
+    }
+
+    /// Returns the image width in pixels.
+    pub(crate) fn width(&self) -> u32 {
+        // SAFETY: codec_ctx is valid for the lifetime of `self`.
+        unsafe { (*self.codec_ctx).width as u32 }
+    }
+
+    /// Returns the image height in pixels.
+    pub(crate) fn height(&self) -> u32 {
+        // SAFETY: codec_ctx is valid for the lifetime of `self`.
+        unsafe { (*self.codec_ctx).height as u32 }
+    }
+
+    /// Decodes the image, consuming `self` and returning a [`VideoFrame`].
+    ///
+    /// Follows the sequence:
+    /// 1. `av_read_frame`
+    /// 2. `avcodec_send_packet`
+    /// 3. `avcodec_receive_frame`
+    /// 4. Convert to [`VideoFrame`]
+    pub(crate) fn decode(self) -> Result<VideoFrame, DecodeError> {
+        // 1. av_read_frame
+        // SAFETY: format_ctx and packet are valid.
+        let ret = unsafe { ff_sys::av_read_frame(self.format_ctx, self.packet) };
+        if ret < 0 {
+            return Err(DecodeError::Ffmpeg(format!(
+                "Failed to read frame: {}",
+                ff_sys::av_error_string(ret)
+            )));
+        }
+
+        // 2. avcodec_send_packet
+        // SAFETY: codec_ctx and packet are valid; packet contains image data.
+        let ret = unsafe { ff_sys::avcodec_send_packet(self.codec_ctx, self.packet) };
+        unsafe { ff_sys::av_packet_unref(self.packet) };
+        if ret < 0 {
+            return Err(DecodeError::Ffmpeg(format!(
+                "Failed to send packet to decoder: {}",
+                ff_sys::av_error_string(ret)
+            )));
+        }
+
+        // 3. avcodec_receive_frame
+        // SAFETY: codec_ctx and frame are valid.
+        let ret = unsafe { ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame) };
+        if ret < 0 {
+            return Err(DecodeError::Ffmpeg(format!(
+                "Failed to receive decoded frame: {}",
+                ff_sys::av_error_string(ret)
+            )));
+        }
+
+        // 4. Convert to VideoFrame.
+        // SAFETY: frame is valid and contains decoded image data.
+        let video_frame = unsafe { self.av_frame_to_video_frame(self.frame)? };
+        Ok(video_frame)
+    }
+
+    /// Finds the first video stream in the format context.
+    ///
+    /// # Safety
+    ///
+    /// `format_ctx` must be a valid, fully initialized `AVFormatContext`.
+    unsafe fn find_video_stream(format_ctx: *mut AVFormatContext) -> Option<(usize, AVCodecID)> {
+        // SAFETY: Caller ensures format_ctx is valid.
+        unsafe {
+            let nb_streams = (*format_ctx).nb_streams as usize;
+            for i in 0..nb_streams {
+                let stream = (*format_ctx).streams.add(i);
+                let codecpar = (*(*stream)).codecpar;
+                if (*codecpar).codec_type == AVMediaType_AVMEDIA_TYPE_VIDEO {
+                    return Some((i, (*codecpar).codec_id));
+                }
+            }
+        }
+        None
+    }
+
+    /// Maps an `AVPixelFormat` value to our [`PixelFormat`] enum.
+    ///
+    /// Image decoders commonly produce YUVJ formats (full-range YUV), which
+    /// have the same plane layout as the corresponding YUV formats but with a
+    /// different color range flag.  We map them to their YUV equivalents here
+    /// and rely on the colour-range metadata to distinguish them if needed.
+    fn convert_pixel_format(fmt: AVPixelFormat) -> PixelFormat {
+        if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P
+            || fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUVJ420P
+        {
+            PixelFormat::Yuv420p
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P
+            || fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUVJ422P
+        {
+            PixelFormat::Yuv422p
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P
+            || fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUVJ444P
+        {
+            PixelFormat::Yuv444p
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24 {
+            PixelFormat::Rgb24
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24 {
+            PixelFormat::Bgr24
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA {
+            PixelFormat::Rgba
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA {
+            PixelFormat::Bgra
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8 {
+            PixelFormat::Gray8
+        } else {
+            log::warn!(
+                "pixel_format unsupported, falling back to Rgb24 requested={fmt} fallback=Rgb24"
+            );
+            PixelFormat::Rgb24
+        }
+    }
+
+    /// Converts a decoded `AVFrame` to a [`VideoFrame`].
+    ///
+    /// # Safety
+    ///
+    /// `frame` must be a valid, fully decoded `AVFrame` owned by `self`.
+    unsafe fn av_frame_to_video_frame(
+        &self,
+        frame: *const AVFrame,
+    ) -> Result<VideoFrame, DecodeError> {
+        // SAFETY: Caller ensures frame is valid.
+        unsafe {
+            let width = (*frame).width as u32;
+            let height = (*frame).height as u32;
+            let format = Self::convert_pixel_format((*frame).format);
+
+            // Extract timestamp (images often have no meaningful PTS).
+            let pts = (*frame).pts;
+            let timestamp = if pts == ff_sys::AV_NOPTS_VALUE {
+                Timestamp::default()
+            } else {
+                let stream = (*self.format_ctx).streams.add(self.stream_index);
+                let time_base = (*(*stream)).time_base;
+                Timestamp::new(
+                    pts as i64,
+                    Rational::new(time_base.num as i32, time_base.den as i32),
+                )
+            };
+
+            let (planes, strides) = Self::extract_planes_and_strides(frame, width, height, format)?;
+
+            // Images are always key frames.
+            VideoFrame::new(planes, strides, width, height, format, timestamp, true)
+                .map_err(|e| DecodeError::Ffmpeg(format!("Failed to create VideoFrame: {e}")))
+        }
+    }
+
+    /// Extracts pixel data from an `AVFrame` into [`PooledBuffer`] planes.
+    ///
+    /// Copies data row-by-row to strip any FFmpeg padding from line strides.
+    ///
+    /// # Safety
+    ///
+    /// `frame` must be a valid, fully decoded `AVFrame` with `format` matching
+    /// the actual pixel format of the frame.
+    unsafe fn extract_planes_and_strides(
+        frame: *const AVFrame,
+        width: u32,
+        height: u32,
+        format: PixelFormat,
+    ) -> Result<(Vec<PooledBuffer>, Vec<usize>), DecodeError> {
+        // SAFETY: Caller ensures frame is valid and format matches.
+        unsafe {
+            let w = width as usize;
+            let h = height as usize;
+            let mut planes: Vec<PooledBuffer> = Vec::new();
+            let mut strides: Vec<usize> = Vec::new();
+
+            match format {
+                PixelFormat::Rgba | PixelFormat::Bgra => {
+                    let bytes_per_pixel = 4_usize;
+                    let stride = (*frame).linesize[0] as usize;
+                    let row_w = w * bytes_per_pixel;
+                    let mut buf = vec![0u8; row_w * h];
+                    let src = (*frame).data[0];
+                    if src.is_null() {
+                        return Err(DecodeError::Ffmpeg(
+                            "Null plane data for packed format".to_string(),
+                        ));
+                    }
+                    for row in 0..h {
+                        ptr::copy_nonoverlapping(
+                            src.add(row * stride),
+                            buf[row * row_w..].as_mut_ptr(),
+                            row_w,
+                        );
+                    }
+                    planes.push(PooledBuffer::standalone(buf));
+                    strides.push(row_w);
+                }
+                PixelFormat::Rgb24 | PixelFormat::Bgr24 => {
+                    let bytes_per_pixel = 3_usize;
+                    let stride = (*frame).linesize[0] as usize;
+                    let row_w = w * bytes_per_pixel;
+                    let mut buf = vec![0u8; row_w * h];
+                    let src = (*frame).data[0];
+                    if src.is_null() {
+                        return Err(DecodeError::Ffmpeg(
+                            "Null plane data for packed format".to_string(),
+                        ));
+                    }
+                    for row in 0..h {
+                        ptr::copy_nonoverlapping(
+                            src.add(row * stride),
+                            buf[row * row_w..].as_mut_ptr(),
+                            row_w,
+                        );
+                    }
+                    planes.push(PooledBuffer::standalone(buf));
+                    strides.push(row_w);
+                }
+                PixelFormat::Gray8 => {
+                    let stride = (*frame).linesize[0] as usize;
+                    let mut buf = vec![0u8; w * h];
+                    let src = (*frame).data[0];
+                    if src.is_null() {
+                        return Err(DecodeError::Ffmpeg("Null plane data for Gray8".to_string()));
+                    }
+                    for row in 0..h {
+                        ptr::copy_nonoverlapping(
+                            src.add(row * stride),
+                            buf[row * w..].as_mut_ptr(),
+                            w,
+                        );
+                    }
+                    planes.push(PooledBuffer::standalone(buf));
+                    strides.push(w);
+                }
+                PixelFormat::Yuv420p | PixelFormat::Nv12 | PixelFormat::Nv21 => {
+                    // Y plane (full size).
+                    let y_stride = (*frame).linesize[0] as usize;
+                    let mut y_buf = vec![0u8; w * h];
+                    let y_src = (*frame).data[0];
+                    if y_src.is_null() {
+                        return Err(DecodeError::Ffmpeg("Null Y plane".to_string()));
+                    }
+                    for row in 0..h {
+                        ptr::copy_nonoverlapping(
+                            y_src.add(row * y_stride),
+                            y_buf[row * w..].as_mut_ptr(),
+                            w,
+                        );
+                    }
+                    planes.push(PooledBuffer::standalone(y_buf));
+                    strides.push(w);
+
+                    if matches!(format, PixelFormat::Nv12 | PixelFormat::Nv21) {
+                        // Interleaved UV plane (half height).
+                        let uv_h = h / 2;
+                        let uv_stride = (*frame).linesize[1] as usize;
+                        let mut uv_buf = vec![0u8; w * uv_h];
+                        let uv_src = (*frame).data[1];
+                        if !uv_src.is_null() {
+                            for row in 0..uv_h {
+                                ptr::copy_nonoverlapping(
+                                    uv_src.add(row * uv_stride),
+                                    uv_buf[row * w..].as_mut_ptr(),
+                                    w,
+                                );
+                            }
+                        }
+                        planes.push(PooledBuffer::standalone(uv_buf));
+                        strides.push(w);
+                    } else {
+                        // YUV 4:2:0 — separate U and V planes (half width, half height).
+                        let uv_w = w / 2;
+                        let uv_h = h / 2;
+                        for plane_idx in 1..=2usize {
+                            let uv_stride = (*frame).linesize[plane_idx] as usize;
+                            let mut uv_buf = vec![0u8; uv_w * uv_h];
+                            let uv_src = (*frame).data[plane_idx];
+                            if !uv_src.is_null() {
+                                for row in 0..uv_h {
+                                    ptr::copy_nonoverlapping(
+                                        uv_src.add(row * uv_stride),
+                                        uv_buf[row * uv_w..].as_mut_ptr(),
+                                        uv_w,
+                                    );
+                                }
+                            }
+                            planes.push(PooledBuffer::standalone(uv_buf));
+                            strides.push(uv_w);
+                        }
+                    }
+                }
+                PixelFormat::Yuv422p => {
+                    // Y plane (full size), U and V planes (half width, full height).
+                    let uv_w = w / 2;
+                    let plane_dims = [(w, h), (uv_w, h), (uv_w, h)];
+                    for (plane_idx, (pw, ph)) in plane_dims.iter().enumerate() {
+                        let stride = (*frame).linesize[plane_idx] as usize;
+                        let mut buf = vec![0u8; pw * ph];
+                        let src = (*frame).data[plane_idx];
+                        if !src.is_null() {
+                            for row in 0..*ph {
+                                ptr::copy_nonoverlapping(
+                                    src.add(row * stride),
+                                    buf[row * pw..].as_mut_ptr(),
+                                    *pw,
+                                );
+                            }
+                        }
+                        planes.push(PooledBuffer::standalone(buf));
+                        strides.push(*pw);
+                    }
+                }
+                PixelFormat::Yuv444p => {
+                    // All three planes are full size.
+                    for plane_idx in 0..3usize {
+                        let stride = (*frame).linesize[plane_idx] as usize;
+                        let mut buf = vec![0u8; w * h];
+                        let src = (*frame).data[plane_idx];
+                        if !src.is_null() {
+                            for row in 0..h {
+                                ptr::copy_nonoverlapping(
+                                    src.add(row * stride),
+                                    buf[row * w..].as_mut_ptr(),
+                                    w,
+                                );
+                            }
+                        }
+                        planes.push(PooledBuffer::standalone(buf));
+                        strides.push(w);
+                    }
+                }
+                _ => {
+                    return Err(DecodeError::Ffmpeg(format!(
+                        "Unsupported pixel format for image decoding: {format:?}"
+                    )));
+                }
+            }
+
+            Ok((planes, strides))
+        }
+    }
+}
+
+impl Drop for ImageDecoderInner {
+    fn drop(&mut self) {
+        // SAFETY: All pointers are exclusively owned by this struct and were
+        // allocated by the corresponding FFmpeg alloc functions.
+        unsafe {
+            if !self.frame.is_null() {
+                ff_sys::av_frame_free(&mut (self.frame as *mut _));
+            }
+            if !self.packet.is_null() {
+                ff_sys::av_packet_free(&mut (self.packet as *mut _));
+            }
+            if !self.codec_ctx.is_null() {
+                ff_sys::avcodec::free_context(&mut (self.codec_ctx as *mut _));
+            }
+            if !self.format_ctx.is_null() {
+                ff_sys::avformat::close_input(&mut (self.format_ctx as *mut _));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convert_pixel_format_yuv420p_should_map_to_yuv420p() {
+        assert_eq!(
+            ImageDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P),
+            PixelFormat::Yuv420p
+        );
+    }
+
+    #[test]
+    fn convert_pixel_format_yuvj420p_should_map_to_yuv420p() {
+        assert_eq!(
+            ImageDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUVJ420P),
+            PixelFormat::Yuv420p
+        );
+    }
+
+    #[test]
+    fn convert_pixel_format_rgb24_should_map_to_rgb24() {
+        assert_eq!(
+            ImageDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24),
+            PixelFormat::Rgb24
+        );
+    }
+
+    #[test]
+    fn convert_pixel_format_rgba_should_map_to_rgba() {
+        assert_eq!(
+            ImageDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA),
+            PixelFormat::Rgba
+        );
+    }
+
+    #[test]
+    fn convert_pixel_format_gray8_should_map_to_gray8() {
+        assert_eq!(
+            ImageDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8),
+            PixelFormat::Gray8
+        );
+    }
+}

--- a/crates/ff-decode/src/image/mod.rs
+++ b/crates/ff-decode/src/image/mod.rs
@@ -1,0 +1,9 @@
+//! Image decoding module.
+//!
+//! This module provides the image decoder implementation for decoding still
+//! images (JPEG, PNG, BMP, TIFF, WebP) into [`VideoFrame`](ff_format::VideoFrame)s.
+
+pub mod builder;
+pub mod decoder_inner;
+
+pub use builder::{ImageDecoder, ImageDecoderBuilder, ImageFrameIterator};

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -102,12 +102,14 @@
 // Module declarations
 pub mod audio;
 pub mod error;
+pub mod image;
 pub mod pool;
 pub mod video;
 
 // Re-exports for convenience
 pub use audio::{AudioDecoder, AudioDecoderBuilder, AudioFrameIterator};
 pub use error::DecodeError;
+pub use image::{ImageDecoder, ImageDecoderBuilder, ImageFrameIterator};
 pub use pool::{FramePool, PooledBuffer, SimpleFramePool};
 pub use video::{VideoDecoder, VideoDecoderBuilder, VideoFrameIterator};
 
@@ -287,8 +289,8 @@ impl HardwareAccel {
 pub mod prelude {
     pub use crate::{
         AudioDecoder, AudioDecoderBuilder, AudioFrameIterator, DecodeError, FramePool,
-        HardwareAccel, PooledBuffer, SeekMode, SimpleFramePool, VideoDecoder, VideoDecoderBuilder,
-        VideoFrameIterator,
+        HardwareAccel, ImageDecoder, ImageDecoderBuilder, ImageFrameIterator, PooledBuffer,
+        SeekMode, SimpleFramePool, VideoDecoder, VideoDecoderBuilder, VideoFrameIterator,
     };
 }
 

--- a/crates/ff-decode/tests/image_decoder_tests.rs
+++ b/crates/ff-decode/tests/image_decoder_tests.rs
@@ -1,0 +1,460 @@
+//! Integration tests for [`ImageDecoder`], [`ImageDecoderBuilder`], and
+//! [`ImageFrameIterator`].
+//!
+//! The real asset `assets/img/hello-triangle.png` is used for happy-path tests.
+//! If FFmpeg is unavailable or the file cannot be opened the tests skip
+//! gracefully via `println!("Skipping: …"); return;`.
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use std::path::PathBuf;
+
+use ff_decode::{ImageDecoder, ImageDecoderBuilder, ImageFrameIterator};
+
+fn png_path() -> PathBuf {
+    fixtures::assets_dir().join("img/hello-triangle.png")
+}
+
+// ── crate-root exports ────────────────────────────────────────────────────────
+
+/// `ImageDecoder`, `ImageDecoderBuilder`, and `ImageFrameIterator` must all be
+/// importable from the crate root without any extra path segments.
+#[test]
+fn crate_root_should_export_image_decoder_types() {
+    // If these types are not re-exported the test won't compile.
+    let _: fn(&str) -> ImageDecoderBuilder = |p| ImageDecoder::open(p);
+    let _: std::marker::PhantomData<ImageFrameIterator> = std::marker::PhantomData;
+}
+
+// ── open() / build() — error cases ───────────────────────────────────────────
+
+#[test]
+fn open_missing_file_should_return_file_not_found_error() {
+    let path = PathBuf::from("/nonexistent/path/does_not_exist.png");
+    let result = ImageDecoder::open(&path).build();
+    assert!(
+        matches!(result, Err(ff_decode::DecodeError::FileNotFound { .. })),
+        "expected FileNotFound"
+    );
+}
+
+#[test]
+fn open_audio_only_file_should_return_error() {
+    // An audio-only file has no video stream — open must not succeed silently.
+    let path = fixtures::test_audio_path();
+    if !path.exists() {
+        println!("Skipping: audio asset not found");
+        return;
+    }
+    let result = ImageDecoder::open(&path).build();
+    assert!(
+        result.is_err(),
+        "opening an audio-only file should fail, got Ok"
+    );
+}
+
+// ── open() / build() — happy path ────────────────────────────────────────────
+
+#[test]
+fn open_png_should_succeed() {
+    match ImageDecoder::open(png_path()).build() {
+        Ok(_) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+        }
+    }
+}
+
+#[test]
+fn open_png_should_report_positive_width() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert!(decoder.width() > 0, "width must be positive after open");
+}
+
+#[test]
+fn open_png_should_report_positive_height() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert!(decoder.height() > 0, "height must be positive after open");
+}
+
+#[test]
+fn open_returns_builder_then_build_opens_file() {
+    // Verify the two-step builder API: open() → builder, build() → decoder.
+    let builder = ImageDecoder::open(png_path());
+    match builder.build() {
+        Ok(decoder) => assert!(decoder.width() > 0),
+        Err(e) => println!("Skipping: {e}"),
+    }
+}
+
+// ── decode() — consuming convenience API ──────────────────────────────────────
+
+#[test]
+fn decode_png_should_return_video_frame() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    match decoder.decode() {
+        Ok(_) => {}
+        Err(e) => println!("Skipping: {e}"),
+    }
+}
+
+#[test]
+fn decode_png_frame_width_should_match_open_width() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let expected = decoder.width();
+    let frame = match decoder.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert_eq!(
+        frame.width(),
+        expected,
+        "frame width must match reported width"
+    );
+}
+
+#[test]
+fn decode_png_frame_height_should_match_open_height() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let expected = decoder.height();
+    let frame = match decoder.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert_eq!(
+        frame.height(),
+        expected,
+        "frame height must match reported height"
+    );
+}
+
+#[test]
+fn decode_png_frame_should_be_key_frame() {
+    // Images are always key frames — decoder_inner hard-codes `true`.
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = match decoder.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert!(
+        frame.is_key_frame(),
+        "decoded image must be marked as a key frame"
+    );
+}
+
+#[test]
+fn decode_png_frame_should_have_at_least_one_plane() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = match decoder.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert!(
+        frame.num_planes() > 0,
+        "decoded frame must have at least one plane"
+    );
+}
+
+#[test]
+fn decode_png_frame_planes_should_be_non_empty() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = match decoder.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    for (i, plane) in frame.planes().iter().enumerate() {
+        assert!(!plane.is_empty(), "plane {i} must contain pixel data");
+    }
+}
+
+#[test]
+fn decode_png_frame_total_size_should_be_positive() {
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = match decoder.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert!(
+        frame.total_size() > 0,
+        "decoded frame must have a positive total byte size"
+    );
+}
+
+#[test]
+fn decode_png_frame_pixel_format_should_be_supported() {
+    use ff_format::PixelFormat;
+    let supported = [
+        PixelFormat::Yuv420p,
+        PixelFormat::Yuv422p,
+        PixelFormat::Yuv444p,
+        PixelFormat::Rgb24,
+        PixelFormat::Bgr24,
+        PixelFormat::Rgba,
+        PixelFormat::Bgra,
+        PixelFormat::Gray8,
+    ];
+    let decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = match decoder.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert!(
+        supported.contains(&frame.format()),
+        "pixel format {:?} must be one of the supported formats",
+        frame.format()
+    );
+}
+
+// ── decode_one() — mutable incremental API ────────────────────────────────────
+
+#[test]
+fn decode_one_first_call_should_return_some_frame() {
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let result = decoder.decode_one();
+    assert!(
+        matches!(result, Ok(Some(_))),
+        "first decode_one must return Ok(Some(frame)), got {result:?}"
+    );
+}
+
+#[test]
+fn decode_one_second_call_should_return_none() {
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let _ = decoder.decode_one();
+    let result = decoder.decode_one();
+    assert!(
+        matches!(result, Ok(None)),
+        "second decode_one must return Ok(None), got {result:?}"
+    );
+}
+
+#[test]
+fn decode_one_frame_dimensions_should_match_reported_dimensions() {
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let w = decoder.width();
+    let h = decoder.height();
+    let frame = match decoder.decode_one() {
+        Ok(Some(f)) => f,
+        Ok(None) => {
+            println!("Skipping: no frame returned");
+            return;
+        }
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    assert_eq!(frame.width(), w);
+    assert_eq!(frame.height(), h);
+}
+
+// ── frames() — iterator API ───────────────────────────────────────────────────
+
+#[test]
+fn frames_iterator_should_yield_exactly_one_frame() {
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frames: Vec<_> = decoder.frames().collect();
+    assert_eq!(
+        frames.len(),
+        1,
+        "frames() must yield exactly one frame for a still image"
+    );
+    assert!(frames[0].is_ok(), "the single frame must be Ok");
+}
+
+#[test]
+fn frames_iterator_second_call_should_yield_nothing() {
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let _ = decoder.frames().collect::<Vec<_>>();
+    let second: Vec<_> = decoder.frames().collect();
+    assert!(
+        second.is_empty(),
+        "frames() after image already decoded must yield nothing"
+    );
+}
+
+#[test]
+fn frames_iterator_frame_should_be_key_frame() {
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    for result in decoder.frames() {
+        let frame = match result {
+            Ok(f) => f,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        assert!(
+            frame.is_key_frame(),
+            "frame from iterator must be a key frame"
+        );
+    }
+}
+
+#[test]
+fn frames_iterator_frame_should_have_correct_dimensions() {
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let w = decoder.width();
+    let h = decoder.height();
+    for result in decoder.frames() {
+        let frame = match result {
+            Ok(f) => f,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        assert_eq!(frame.width(), w, "iterator frame width must match");
+        assert_eq!(frame.height(), h, "iterator frame height must match");
+    }
+}
+
+// ── Drop safety ───────────────────────────────────────────────────────────────
+
+#[test]
+fn decoder_drop_after_decode_should_not_panic() {
+    // Drop must handle `inner == None` gracefully after decode_one consumes it.
+    let mut decoder = match ImageDecoder::open(png_path()).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let _ = decoder.decode_one();
+    // decoder is dropped here
+}
+
+#[test]
+fn decoder_drop_without_decode_should_not_panic() {
+    // Drop must free FFmpeg resources even when decode was never called.
+    match ImageDecoder::open(png_path()).build() {
+        Ok(_decoder) => {} // dropped here without decoding
+        Err(e) => println!("Skipping: {e}"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `ImageDecoder` module in `ff-decode` for decoding still images (JPEG, PNG, BMP, TIFF, WebP) into `VideoFrame`. The module structure mirrors `AudioDecoder` and `VideoDecoder` — a builder returned by `open()`, a `decode_one()` / `frames()` incremental API, and a `decode()` convenience wrapper for single-frame use.

## Changes

- `image/decoder_inner.rs` — unsafe FFmpeg pipeline: `avformat_open_input` → `avcodec_open2` → `avcodec_receive_frame`; RAII guards for `AVFormatContext` and `AVCodecContext`; plane extraction for packed (RGBA, RGB24) and planar (YUV420p/422p/444p, NV12, Gray8) formats; YUVJ* formats mapped to their YUV equivalents
- `image/builder.rs` — `ImageDecoderBuilder`, `ImageDecoder`, `ImageFrameIterator`; `inner` stored as `Option` so `decode_one` can consume the FFmpeg context while `width`/`height` remain accessible afterwards
- `image/mod.rs` — re-exports matching the `audio/` and `video/` layout
- `lib.rs` — `ImageDecoder`, `ImageDecoderBuilder`, `ImageFrameIterator` exported from crate root and `prelude`
- `tests/image_decoder_tests.rs` — 24 integration tests covering: crate-root exports, `open()` error cases (missing file, audio-only file), dimensions after open, `decode()` frame content (`is_key_frame`, `num_planes`, plane data, `total_size`, pixel format), `decode_one()` idempotency, `frames()` iterator count and second-call behaviour, Drop safety with and without decoding

## Related Issues

Closes #37
Closes #38
Closes #39

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes