### PR TITLE
test(ff-encode): add VBR encode integration test

### DIFF
--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -260,6 +260,40 @@ fn test_builder_with_quality() {
 }
 
 #[test]
+fn vbr_mpeg4_should_produce_valid_output() {
+    let output_path = test_output_path("vbr_mpeg4.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Vbr {
+            target: 1_000_000,
+            max: 2_000_000,
+        })
+        .preset(Preset::Ultrafast)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping vbr_mpeg4 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
 fn crf_h264_should_produce_valid_output() {
     let output_path = test_output_path("crf_h264.mp4");
     let _guard = FileGuard::new(output_path.clone());


### PR DESCRIPTION
## Summary

Adds an integration test `vbr_mpeg4_should_produce_valid_output` that confirms the `BitrateMode::Vbr { target, max }` path produces a valid encoded output file end-to-end. The AVCodecContext wiring (`bit_rate`, `rc_max_rate`, `rc_buffer_size`) was implemented in #160; this PR closes the testing gap identified in issue #46.

## Changes

- Added `vbr_mpeg4_should_produce_valid_output` integration test in `crates/ff-encode/tests/video_encoder_tests.rs`
- Follows the standard pattern: skip-on-failure, `FileGuard` cleanup, `assert_valid_output_file` assertion
- Total integration tests in `video_encoder_tests`: 14 (13 existing + 1 new)

## Related Issues

Closes #46

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes