### PR TITLE
feat(ff-encode): add metadata write support to VideoEncoderBuilder

### DIFF
--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -45,6 +45,7 @@ pub struct VideoEncoderBuilder {
     pub(crate) audio_bitrate: Option<u64>,
     pub(crate) progress_callback: Option<Box<dyn ProgressCallback>>,
     pub(crate) two_pass: bool,
+    pub(crate) metadata: Vec<(String, String)>,
 }
 
 impl std::fmt::Debug for VideoEncoderBuilder {
@@ -68,6 +69,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
                 &self.progress_callback.as_ref().map(|_| "<callback>"),
             )
             .field("two_pass", &self.two_pass)
+            .field("metadata", &self.metadata)
             .finish()
     }
 }
@@ -90,6 +92,7 @@ impl VideoEncoderBuilder {
             audio_bitrate: None,
             progress_callback: None,
             two_pass: false,
+            metadata: Vec::new(),
         }
     }
 
@@ -192,6 +195,19 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn two_pass(mut self) -> Self {
         self.two_pass = true;
+        self
+    }
+
+    // === Metadata ===
+
+    /// Embed a metadata tag in the output container.
+    ///
+    /// Calls `av_dict_set` on `AVFormatContext->metadata` before the header
+    /// is written. Multiple calls accumulate entries; duplicate keys use the
+    /// last value.
+    #[must_use]
+    pub fn metadata(mut self, key: &str, value: &str) -> Self {
+        self.metadata.push((key.to_string(), value.to_string()));
         self
     }
 
@@ -343,6 +359,7 @@ impl VideoEncoder {
             audio_bitrate: builder.audio_bitrate,
             _progress_callback: builder.progress_callback.is_some(),
             two_pass: builder.two_pass,
+            metadata: builder.metadata,
         };
 
         let inner = if config.video_width.is_some() {
@@ -581,6 +598,7 @@ mod tests {
                 audio_bitrate: None,
                 _progress_callback: false,
                 two_pass: false,
+                metadata: Vec::new(),
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -140,8 +140,45 @@ pub(super) struct VideoEncoderConfig {
     pub(super) audio_bitrate: Option<u64>,
     pub(super) _progress_callback: bool,
     pub(super) two_pass: bool,
+    pub(super) metadata: Vec<(String, String)>,
 }
 impl VideoEncoderInner {
+    /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
+    ///
+    /// # Safety
+    /// `format_ctx` must be a valid non-null pointer to an allocated `AVFormatContext`.
+    /// Must be called before `avformat_write_header`.
+    unsafe fn apply_metadata(
+        format_ctx: *mut ff_sys::AVFormatContext,
+        metadata: &[(String, String)],
+    ) {
+        for (key, value) in metadata {
+            let Ok(c_key) = std::ffi::CString::new(key.as_str()) else {
+                log::warn!("metadata key contains null byte, skipping key={key}");
+                continue;
+            };
+            let Ok(c_value) = std::ffi::CString::new(value.as_str()) else {
+                log::warn!("metadata value contains null byte, skipping key={key}");
+                continue;
+            };
+            // SAFETY: format_ctx is valid and non-null. c_key/c_value are valid
+            // CStrings covering this call. av_dict_set copies both strings.
+            let ret = ff_sys::av_dict_set(
+                &mut (*format_ctx).metadata,
+                c_key.as_ptr(),
+                c_value.as_ptr(),
+                0,
+            );
+            if ret < 0 {
+                log::warn!(
+                    "av_dict_set failed for metadata entry, skipping \
+                     key={key} error={}",
+                    ff_sys::av_error_string(ret)
+                );
+            }
+        }
+    }
+
     /// Create a new encoder with the given configuration.
     pub(super) fn new(config: &VideoEncoderConfig) -> Result<Self, EncodeError> {
         unsafe {
@@ -244,6 +281,7 @@ impl VideoEncoderInner {
                     }
                 }
 
+                Self::apply_metadata(format_ctx, &config.metadata);
                 let ret = avformat_write_header(format_ctx, ptr::null_mut());
                 if ret < 0 {
                     encoder.cleanup();
@@ -1473,6 +1511,7 @@ impl VideoEncoderInner {
             }
         }
 
+        Self::apply_metadata(self.format_ctx, &config.metadata);
         let ret = avformat_write_header(self.format_ctx, ptr::null_mut());
         if ret < 0 {
             return Err(EncodeError::Ffmpeg(format!(

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -488,3 +488,35 @@ fn two_pass_encode_should_produce_valid_output() {
     println!("Two-pass output: {} bytes", file_size);
     assert!(file_size > 1000, "File too small, might be corrupted");
 }
+
+#[test]
+fn metadata_mpeg4_should_produce_valid_output() {
+    let output_path = test_output_path("metadata_mpeg4.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .metadata("title", "Test Video")
+        .metadata("artist", "ff-encode integration test")
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping metadata_mpeg4 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+}

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -315,6 +315,15 @@ pub unsafe fn av_dict_get(
     std::ptr::null_mut()
 }
 
+pub unsafe fn av_dict_set(
+    _pm: *mut *mut AVDictionary,
+    _key: *const c_char,
+    _value: *const c_char,
+    _flags: c_int,
+) -> c_int {
+    0
+}
+
 pub unsafe fn avcodec_get_name(_id: AVCodecID) -> *const c_char {
     std::ptr::null()
 }


### PR DESCRIPTION
## Summary

Adds a `.metadata(key, value)` method to `VideoEncoderBuilder` that embeds container-level metadata tags (e.g. title, artist) into output files. Internally, it calls `av_dict_set` on `AVFormatContext->metadata` before `avformat_write_header`, covering both the single-pass and two-pass encoding paths.

## Changes

- `ff-sys`: Added `av_dict_set` stub to `docsrs_stubs.rs` for docs.rs builds
- `ff-encode/video/encoder_inner.rs`: Added `metadata: Vec<(String, String)>` field to `VideoEncoderConfig`; added private `apply_metadata()` helper; called before both `avformat_write_header` invocations (single-pass and two-pass)
- `ff-encode/video/builder.rs`: Added `metadata` field, `Debug` impl entry, `new()` initializer, `.metadata(key, value)` setter, wired into `from_builder()`, and updated mock in unit tests
- `ff-encode/tests/video_encoder_tests.rs`: Added `metadata_mpeg4_should_produce_valid_output` integration test

## Related Issues

Closes #45

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes