### PR TITLE
feat(ff-encode): add chapter write support to VideoEncoderBuilder

### DIFF
--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -46,6 +46,7 @@ pub struct VideoEncoderBuilder {
     pub(crate) progress_callback: Option<Box<dyn ProgressCallback>>,
     pub(crate) two_pass: bool,
     pub(crate) metadata: Vec<(String, String)>,
+    pub(crate) chapters: Vec<ff_format::chapter::ChapterInfo>,
 }
 
 impl std::fmt::Debug for VideoEncoderBuilder {
@@ -70,6 +71,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             )
             .field("two_pass", &self.two_pass)
             .field("metadata", &self.metadata)
+            .field("chapters", &self.chapters)
             .finish()
     }
 }
@@ -93,6 +95,7 @@ impl VideoEncoderBuilder {
             progress_callback: None,
             two_pass: false,
             metadata: Vec::new(),
+            chapters: Vec::new(),
         }
     }
 
@@ -208,6 +211,18 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn metadata(mut self, key: &str, value: &str) -> Self {
         self.metadata.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    // === Chapters ===
+
+    /// Add a chapter to the output container.
+    ///
+    /// Allocates an `AVChapter` entry on `AVFormatContext` before the header
+    /// is written. Multiple calls accumulate chapters in the order added.
+    #[must_use]
+    pub fn chapter(mut self, chapter: ff_format::chapter::ChapterInfo) -> Self {
+        self.chapters.push(chapter);
         self
     }
 
@@ -360,6 +375,7 @@ impl VideoEncoder {
             _progress_callback: builder.progress_callback.is_some(),
             two_pass: builder.two_pass,
             metadata: builder.metadata,
+            chapters: builder.chapters,
         };
 
         let inner = if config.video_width.is_some() {
@@ -599,6 +615,7 @@ mod tests {
                 _progress_callback: false,
                 two_pass: false,
                 metadata: Vec::new(),
+                chapters: Vec::new(),
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -12,15 +12,16 @@
 use crate::{AudioCodec, EncodeError, VideoCodec};
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVChannelLayout, AVCodecContext, AVCodecID, AVCodecID_AV_CODEC_ID_AAC,
+    AV_TIME_BASE, AVChannelLayout, AVChapter, AVCodecContext, AVCodecID, AVCodecID_AV_CODEC_ID_AAC,
     AVCodecID_AV_CODEC_ID_AV1, AVCodecID_AV_CODEC_ID_DNXHD, AVCodecID_AV_CODEC_ID_FLAC,
     AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC, AVCodecID_AV_CODEC_ID_MP3,
     AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
     AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP9,
     AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext,
-    SwsContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc,
-    av_packet_free, av_packet_unref, av_write_trailer, avcodec, avformat_alloc_output_context2,
-    avformat_free_context, avformat_new_stream, avformat_write_header, swresample, swscale,
+    SwsContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_mallocz,
+    av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer, avcodec,
+    avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat_write_header, swresample, swscale,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -141,6 +142,7 @@ pub(super) struct VideoEncoderConfig {
     pub(super) _progress_callback: bool,
     pub(super) two_pass: bool,
     pub(super) metadata: Vec<(String, String)>,
+    pub(super) chapters: Vec<ff_format::chapter::ChapterInfo>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -176,6 +178,82 @@ impl VideoEncoderInner {
                     ff_sys::av_error_string(ret)
                 );
             }
+        }
+    }
+
+    /// Allocate `AVChapter` entries on the format context before `avformat_write_header`.
+    ///
+    /// # Safety
+    /// `format_ctx` must be a valid non-null pointer to an allocated `AVFormatContext`.
+    /// Must be called before `avformat_write_header`.
+    unsafe fn apply_chapters(
+        format_ctx: *mut ff_sys::AVFormatContext,
+        chapters: &[ff_format::chapter::ChapterInfo],
+    ) {
+        if chapters.is_empty() {
+            return;
+        }
+        let n = chapters.len();
+        // SAFETY: allocating an array of n pointers for the chapters field.
+        let chapters_arr =
+            av_mallocz(std::mem::size_of::<*mut AVChapter>() * n) as *mut *mut AVChapter;
+        if chapters_arr.is_null() {
+            log::warn!("av_mallocz failed for chapters array, skipping chapters");
+            return;
+        }
+        (*format_ctx).chapters = chapters_arr;
+        (*format_ctx).nb_chapters = 0;
+
+        for (i, chapter) in chapters.iter().enumerate() {
+            // SAFETY: allocating a zeroed AVChapter struct.
+            let chap = av_mallocz(std::mem::size_of::<AVChapter>()) as *mut AVChapter;
+            if chap.is_null() {
+                log::warn!(
+                    "av_mallocz failed for AVChapter, skipping chapter id={}",
+                    chapter.id()
+                );
+                continue;
+            }
+            // SAFETY: chap is freshly allocated, non-null, and zeroed.
+            (*chap).id = chapter.id();
+            (*chap).time_base = ff_sys::AVRational {
+                num: 1,
+                den: AV_TIME_BASE as i32,
+            };
+            (*chap).start = chapter.start().as_micros() as i64;
+            (*chap).end = chapter.end().as_micros() as i64;
+            (*chap).metadata = std::ptr::null_mut();
+
+            if let Some(title) = chapter.title() {
+                let Ok(c_title) = std::ffi::CString::new(title) else {
+                    log::warn!(
+                        "chapter title contains null byte, skipping title id={}",
+                        chapter.id()
+                    );
+                    // SAFETY: chapters_arr is valid with capacity n.
+                    *chapters_arr.add(i) = chap;
+                    (*format_ctx).nb_chapters += 1;
+                    continue;
+                };
+                // SAFETY: chap->metadata is null; av_dict_set allocates and copies.
+                let ret = ff_sys::av_dict_set(
+                    &mut (*chap).metadata,
+                    b"title\0".as_ptr() as *const _,
+                    c_title.as_ptr(),
+                    0,
+                );
+                if ret < 0 {
+                    log::warn!(
+                        "av_dict_set failed for chapter title, skipping title \
+                         id={} error={}",
+                        chapter.id(),
+                        ff_sys::av_error_string(ret)
+                    );
+                }
+            }
+            // SAFETY: i < n so the write is in bounds.
+            *chapters_arr.add(i) = chap;
+            (*format_ctx).nb_chapters += 1;
         }
     }
 
@@ -282,6 +360,7 @@ impl VideoEncoderInner {
                 }
 
                 Self::apply_metadata(format_ctx, &config.metadata);
+                Self::apply_chapters(format_ctx, &config.chapters);
                 let ret = avformat_write_header(format_ctx, ptr::null_mut());
                 if ret < 0 {
                     encoder.cleanup();
@@ -1512,6 +1591,7 @@ impl VideoEncoderInner {
         }
 
         Self::apply_metadata(self.format_ctx, &config.metadata);
+        Self::apply_chapters(self.format_ctx, &config.chapters);
         let ret = avformat_write_header(self.format_ctx, ptr::null_mut());
         if ret < 0 {
             return Err(EncodeError::Ffmpeg(format!(

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -520,3 +520,51 @@ fn metadata_mpeg4_should_produce_valid_output() {
     encoder.finish().expect("Failed to finish encoding");
     assert_valid_output_file(&output_path);
 }
+
+#[test]
+fn chapter_mpeg4_should_produce_valid_output() {
+    use ff_format::chapter::ChapterInfo;
+    use std::time::Duration;
+
+    let output_path = test_output_path("chapter_mpeg4.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let chapter1 = ChapterInfo::builder()
+        .id(0)
+        .title("Intro")
+        .start(Duration::ZERO)
+        .end(Duration::from_secs(5))
+        .build();
+    let chapter2 = ChapterInfo::builder()
+        .id(1)
+        .title("Main")
+        .start(Duration::from_secs(5))
+        .end(Duration::from_secs(10))
+        .build();
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .chapter(chapter1)
+        .chapter(chapter2)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping chapter_mpeg4 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+}

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -183,6 +183,7 @@ pub struct AVCodecContext {
 
 pub const AV_DICT_IGNORE_SUFFIX: u32 = 2;
 pub const AV_NUM_DATA_POINTERS: usize = 8;
+pub const AV_TIME_BASE: u32 = 1_000_000;
 
 pub const AVMediaType_AVMEDIA_TYPE_VIDEO: AVMediaType = 0;
 pub const AVMediaType_AVMEDIA_TYPE_AUDIO: AVMediaType = 1;
@@ -471,6 +472,10 @@ pub unsafe fn swr_init(_s: *mut SwrContext) -> c_int {
 pub unsafe fn av_channel_layout_default(_ch_layout: *mut AVChannelLayout, _nb_channels: c_int) {}
 
 pub unsafe fn av_channel_layout_uninit(_ch_layout: *mut AVChannelLayout) {}
+
+pub unsafe fn av_mallocz(_size: usize) -> *mut c_void {
+    std::ptr::null_mut()
+}
 
 // ── Wrapper module stubs ──────────────────────────────────────────────────────
 //


### PR DESCRIPTION
## Summary

Adds a `.chapter(ChapterInfo)` method to `VideoEncoderBuilder` that embeds chapter markers into output containers. Internally, it allocates `AVChapter` entries on `AVFormatContext` before `avformat_write_header`, setting the chapter id, start/end timestamps (as microseconds against `AV_TIME_BASE`), and title metadata. Both the single-pass and two-pass encoding paths are covered.

## Changes

- `ff-sys`: Added `AV_TIME_BASE` constant and `av_mallocz` stub to `docsrs_stubs.rs`
- `ff-encode/video/encoder_inner.rs`: Added `chapters: Vec<ChapterInfo>` field to `VideoEncoderConfig`; added private `apply_chapters()` helper that allocates `AVChapter` structs via `av_mallocz` and populates them; called before both `avformat_write_header` invocations (single-pass and two-pass)
- `ff-encode/video/builder.rs`: Added `chapters` field, `chapter()` setter, `Debug` impl entry, wired into `from_builder()`, and updated unit test mock
- `ff-encode/tests/video_encoder_tests.rs`: Added `chapter_mpeg4_should_produce_valid_output` integration test with two chapters

## Related Issues

Closes #47

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes