### PR TITLE
feat(ff-encode): add width, height, quality, pixel_format options to ImageEncoder

### DIFF
--- a/crates/ff-encode/src/image/builder.rs
+++ b/crates/ff-encode/src/image/builder.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use ff_format::VideoFrame;
+use ff_format::{PixelFormat, VideoFrame};
 
 use crate::EncodeError;
 
@@ -10,26 +10,97 @@ use super::encoder_inner;
 
 /// Builder for [`ImageEncoder`].
 ///
-/// Created via [`ImageEncoder::create`]. Validates the output path extension
-/// at [`build`](ImageEncoderBuilder::build) time so errors surface early.
+/// Created via [`ImageEncoder::create`] or [`ImageEncoder::new`]. Extension
+/// validation and zero-dimension checks happen in [`build`](ImageEncoderBuilder::build).
 #[derive(Debug)]
 pub struct ImageEncoderBuilder {
     path: PathBuf,
+    width: Option<u32>,
+    height: Option<u32>,
+    quality: Option<u32>,
+    pixel_format: Option<PixelFormat>,
 }
 
 impl ImageEncoderBuilder {
     pub(crate) fn new(path: PathBuf) -> Self {
-        Self { path }
+        Self {
+            path,
+            width: None,
+            height: None,
+            quality: None,
+            pixel_format: None,
+        }
     }
 
-    /// Validate the file extension and return an [`ImageEncoder`].
+    /// Override the output width in pixels.
     ///
-    /// Returns [`EncodeError::InvalidConfig`] when the path has no extension
-    /// and [`EncodeError::UnsupportedCodec`] for unrecognised extensions.
+    /// If not set, the source frame's width is used. If only `width` is set
+    /// (without `height`), the source frame's height is preserved unchanged.
+    #[must_use]
+    pub fn width(mut self, w: u32) -> Self {
+        self.width = Some(w);
+        self
+    }
+
+    /// Override the output height in pixels.
+    ///
+    /// If not set, the source frame's height is used. If only `height` is set
+    /// (without `width`), the source frame's width is preserved unchanged.
+    #[must_use]
+    pub fn height(mut self, h: u32) -> Self {
+        self.height = Some(h);
+        self
+    }
+
+    /// Set encoder quality on a 0–100 scale (100 = best quality).
+    ///
+    /// The value is mapped per codec:
+    /// - **JPEG**: qscale 1–31 (100 → 1 = best, 0 → 31 = worst)
+    /// - **PNG**: compression level 0–9 (100 → 9 = maximum compression)
+    /// - **WebP**: quality 0–100 (direct mapping)
+    /// - **BMP / TIFF**: no quality concept; the value is ignored with a warning
+    #[must_use]
+    pub fn quality(mut self, q: u32) -> Self {
+        self.quality = Some(q);
+        self
+    }
+
+    /// Override the output pixel format.
+    ///
+    /// If not set, a codec-native default is used (e.g. `YUVJ420P` for JPEG,
+    /// `RGB24` for PNG). Setting an incompatible format may cause encoding to
+    /// fail with an FFmpeg error.
+    #[must_use]
+    pub fn pixel_format(mut self, fmt: PixelFormat) -> Self {
+        self.pixel_format = Some(fmt);
+        self
+    }
+
+    /// Validate settings and return an [`ImageEncoder`].
+    ///
+    /// # Errors
+    ///
+    /// - [`EncodeError::InvalidConfig`] — path has no extension, or width/height is zero
+    /// - [`EncodeError::UnsupportedCodec`] — extension is not a supported image format
     pub fn build(self) -> Result<ImageEncoder, EncodeError> {
-        // Validate at build time — fail fast before touching the filesystem.
         encoder_inner::codec_from_extension(&self.path)?;
-        Ok(ImageEncoder { path: self.path })
+        if let Some(0) = self.width {
+            return Err(EncodeError::InvalidConfig {
+                reason: "width must be non-zero".to_string(),
+            });
+        }
+        if let Some(0) = self.height {
+            return Err(EncodeError::InvalidConfig {
+                reason: "height must be non-zero".to_string(),
+            });
+        }
+        Ok(ImageEncoder {
+            path: self.path,
+            width: self.width,
+            height: self.height,
+            quality: self.quality,
+            pixel_format: self.pixel_format,
+        })
     }
 }
 
@@ -42,13 +113,22 @@ impl ImageEncoderBuilder {
 ///
 /// ```ignore
 /// use ff_encode::ImageEncoder;
+/// use ff_format::PixelFormat;
 ///
-/// let encoder = ImageEncoder::create("thumbnail.png").build()?;
+/// let encoder = ImageEncoder::create("thumbnail.jpg")
+///     .width(320)
+///     .height(240)
+///     .quality(85)
+///     .build()?;
 /// encoder.encode(&frame)?;
 /// ```
 #[derive(Debug)]
 pub struct ImageEncoder {
     path: PathBuf,
+    width: Option<u32>,
+    height: Option<u32>,
+    quality: Option<u32>,
+    pixel_format: Option<PixelFormat>,
 }
 
 impl ImageEncoder {
@@ -60,16 +140,32 @@ impl ImageEncoder {
         ImageEncoderBuilder::new(path.as_ref().to_path_buf())
     }
 
+    /// Alias for [`create`](ImageEncoder::create).
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(path: impl AsRef<Path>) -> ImageEncoderBuilder {
+        ImageEncoderBuilder::new(path.as_ref().to_path_buf())
+    }
+
     /// Encode `frame` and write it to the output file.
+    ///
+    /// If `width` or `height` were set on the builder and differ from the
+    /// source frame dimensions, swscale is used to resize. If `pixel_format`
+    /// was set and differs from the frame format, swscale performs conversion.
     ///
     /// # Errors
     ///
     /// Returns an error if the FFmpeg encoder is unavailable, the output file
     /// cannot be created, or encoding fails.
     pub fn encode(self, frame: &VideoFrame) -> Result<(), EncodeError> {
+        let opts = encoder_inner::ImageEncodeOptions {
+            width: self.width,
+            height: self.height,
+            quality: self.quality,
+            pixel_format: self.pixel_format,
+        };
         // SAFETY: encode_image manages all FFmpeg resources internally and
         // frees them before returning, whether on success or error.
-        unsafe { encoder_inner::encode_image(&self.path, frame) }
+        unsafe { encoder_inner::encode_image(&self.path, frame, &opts) }
     }
 }
 
@@ -79,8 +175,12 @@ mod tests {
 
     #[test]
     fn create_should_return_builder() {
-        // ImageEncoder::create is infallible
         let _builder = ImageEncoder::create("out.png");
+    }
+
+    #[test]
+    fn new_should_return_builder() {
+        let _builder = ImageEncoder::new("out.png");
     }
 
     #[test]
@@ -99,5 +199,68 @@ mod tests {
             matches!(result, Err(EncodeError::InvalidConfig { .. })),
             "expected InvalidConfig, got {result:?}"
         );
+    }
+
+    #[test]
+    fn build_with_zero_width_should_return_error() {
+        let result = ImageEncoder::create("out.png").width(0).build();
+        assert!(
+            matches!(result, Err(EncodeError::InvalidConfig { .. })),
+            "expected InvalidConfig for zero width, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn build_with_zero_height_should_return_error() {
+        let result = ImageEncoder::create("out.png").height(0).build();
+        assert!(
+            matches!(result, Err(EncodeError::InvalidConfig { .. })),
+            "expected InvalidConfig for zero height, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn width_setter_should_store_value() {
+        let encoder = ImageEncoder::create("out.png").width(320).build().unwrap();
+        assert_eq!(encoder.width, Some(320));
+    }
+
+    #[test]
+    fn height_setter_should_store_value() {
+        let encoder = ImageEncoder::create("out.png").height(240).build().unwrap();
+        assert_eq!(encoder.height, Some(240));
+    }
+
+    #[test]
+    fn quality_setter_should_store_value() {
+        let encoder = ImageEncoder::create("out.png").quality(75).build().unwrap();
+        assert_eq!(encoder.quality, Some(75));
+    }
+
+    #[test]
+    fn pixel_format_setter_should_store_value() {
+        let encoder = ImageEncoder::create("out.png")
+            .pixel_format(PixelFormat::Rgb24)
+            .build()
+            .unwrap();
+        assert_eq!(encoder.pixel_format, Some(PixelFormat::Rgb24));
+    }
+
+    #[test]
+    fn build_with_only_width_should_succeed() {
+        // Partial dimensions are valid — height falls back to frame dimension.
+        let result = ImageEncoder::create("out.png").width(128).build();
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn build_with_all_options_should_succeed() {
+        let result = ImageEncoder::create("out.jpg")
+            .width(320)
+            .height(240)
+            .quality(80)
+            .pixel_format(PixelFormat::Yuv420p)
+            .build();
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 }

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -28,6 +28,18 @@ use crate::EncodeError;
 /// Maximum number of planes in AVFrame data/linesize arrays.
 const MAX_PLANES: usize = 8;
 
+/// Options forwarded from the builder to the encoder.
+pub(super) struct ImageEncodeOptions {
+    /// Override output width (pixels). `None` → use source frame width.
+    pub(super) width: Option<u32>,
+    /// Override output height (pixels). `None` → use source frame height.
+    pub(super) height: Option<u32>,
+    /// Quality 0–100 (100 = best). `None` → codec default.
+    pub(super) quality: Option<u32>,
+    /// Output pixel format override. `None` → codec-native default.
+    pub(super) pixel_format: Option<PixelFormat>,
+}
+
 /// Return the `AVCodecID` for the given file extension.
 ///
 /// This is `pub(super)` so `builder.rs` can call it for early validation.
@@ -84,17 +96,103 @@ fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
     }
 }
 
+/// Apply a quality value (0–100, 100 = best) to the codec context.
+///
+/// Must be called after the codec context fields are set but before
+/// `avcodec_open2`.
+///
+/// # Safety
+///
+/// `codec_ctx` must be a valid, non-null pointer to an allocated
+/// `AVCodecContext` whose `priv_data` is valid (guaranteed after
+/// `avcodec_alloc_context3`).
+unsafe fn apply_quality(codec_ctx: *mut ff_sys::AVCodecContext, codec_id: AVCodecID, quality: u32) {
+    let q = quality.min(100);
+
+    if codec_id == AVCodecID_AV_CODEC_ID_MJPEG {
+        // Map 0–100 (100 = best) → MJPEG qscale 1–31 (1 = best, 31 = worst).
+        let qscale = (1 + (100 - q) * 30 / 100) as i32;
+        (*codec_ctx).qmin = qscale;
+        (*codec_ctx).qmax = qscale;
+        log::info!("MJPEG quality applied quality={q} qscale={qscale}");
+    } else if codec_id == AVCodecID_AV_CODEC_ID_PNG {
+        // Map 0–100 → compression_level 0–9 (9 = maximum compression).
+        let level = q * 9 / 100;
+        if (*codec_ctx).priv_data.is_null() {
+            log::warn!("PNG compression_level: priv_data is null, skipping quality={q}");
+            return;
+        }
+        let Ok(key) = CString::new("compression_level") else {
+            return;
+        };
+        let Ok(val) = CString::new(level.to_string()) else {
+            return;
+        };
+        // SAFETY: priv_data is non-null; key/val are valid NUL-terminated strings.
+        let ret = ff_sys::av_opt_set((*codec_ctx).priv_data, key.as_ptr(), val.as_ptr(), 0);
+        if ret < 0 {
+            log::warn!(
+                "av_opt_set compression_level failed, ignoring \
+                 quality={q} error={}",
+                ff_sys::av_error_string(ret)
+            );
+        } else {
+            log::info!("PNG compression_level applied quality={q} level={level}");
+        }
+    } else if codec_id == AVCodecID_AV_CODEC_ID_WEBP {
+        // Direct 0–100 mapping for WebP quality.
+        if (*codec_ctx).priv_data.is_null() {
+            log::warn!("WebP quality: priv_data is null, skipping quality={q}");
+            return;
+        }
+        let Ok(key) = CString::new("quality") else {
+            return;
+        };
+        let Ok(val) = CString::new(q.to_string()) else {
+            return;
+        };
+        // SAFETY: priv_data is non-null; key/val are valid NUL-terminated strings.
+        let ret = ff_sys::av_opt_set((*codec_ctx).priv_data, key.as_ptr(), val.as_ptr(), 0);
+        if ret < 0 {
+            log::warn!(
+                "av_opt_set quality failed for WebP, ignoring \
+                 quality={q} error={}",
+                ff_sys::av_error_string(ret)
+            );
+        } else {
+            log::info!("WebP quality applied quality={q}");
+        }
+    } else {
+        log::warn!(
+            "quality option has no effect for this codec \
+             codec_id={codec_id} quality={q}"
+        );
+    }
+}
+
 /// Encode a single `VideoFrame` and write it to `path`.
 ///
 /// # Safety
 ///
 /// Caller must ensure `path` is a valid file path. All FFmpeg resources
 /// allocated inside this function are freed before returning.
-pub(super) unsafe fn encode_image(path: &Path, frame: &VideoFrame) -> Result<(), EncodeError> {
+pub(super) unsafe fn encode_image(
+    path: &Path,
+    frame: &VideoFrame,
+    opts: &ImageEncodeOptions,
+) -> Result<(), EncodeError> {
     ff_sys::ensure_initialized();
 
     let codec_id = codec_from_extension(path)?;
-    let pix_fmt = preferred_pix_fmt(codec_id);
+
+    // Resolve output dimensions — fall back to source frame dimensions if unset.
+    let dst_width = opts.width.unwrap_or_else(|| frame.width());
+    let dst_height = opts.height.unwrap_or_else(|| frame.height());
+
+    // Resolve output pixel format — fall back to codec-native default if unset.
+    let pix_fmt = opts
+        .pixel_format
+        .map_or_else(|| preferred_pix_fmt(codec_id), pixel_format_to_av);
 
     // ── Step 1: Build the output format context ───────────────────────────────
     let c_path = CString::new(path.to_str().ok_or_else(|| EncodeError::CannotCreateFile {
@@ -142,10 +240,16 @@ pub(super) unsafe fn encode_image(path: &Path, frame: &VideoFrame) -> Result<(),
     })?;
 
     // ── Step 5: Set codec context fields ─────────────────────────────────────
-    (*codec_ctx).width = frame.width() as i32;
-    (*codec_ctx).height = frame.height() as i32;
+    (*codec_ctx).width = dst_width as i32;
+    (*codec_ctx).height = dst_height as i32;
     (*codec_ctx).time_base = AVRational { num: 1, den: 1 };
     (*codec_ctx).pix_fmt = pix_fmt;
+
+    // ── Step 5b: Apply quality (before open2) ────────────────────────────────
+    if let Some(q) = opts.quality {
+        // SAFETY: codec_ctx is non-null and was just allocated with alloc_context3.
+        apply_quality(codec_ctx, codec_id, q);
+    }
 
     // ── Step 6: Open the codec ────────────────────────────────────────────────
     if let Err(e) = avcodec::open2(codec_ctx, codec, ptr::null_mut()) {
@@ -192,8 +296,8 @@ pub(super) unsafe fn encode_image(path: &Path, frame: &VideoFrame) -> Result<(),
     }
 
     (*dst_frame).format = pix_fmt;
-    (*dst_frame).width = frame.width() as i32;
-    (*dst_frame).height = frame.height() as i32;
+    (*dst_frame).width = dst_width as i32;
+    (*dst_frame).height = dst_height as i32;
 
     let ret = ff_sys::av_frame_get_buffer(dst_frame, 0);
     if ret < 0 {
@@ -204,18 +308,19 @@ pub(super) unsafe fn encode_image(path: &Path, frame: &VideoFrame) -> Result<(),
         return Err(EncodeError::from_ffmpeg_error(ret));
     }
 
-    // ── Step 11: Fill dst_frame (convert if needed) ───────────────────────────
+    // ── Step 11: Fill dst_frame (convert / resize if needed) ─────────────────
     let src_fmt = pixel_format_to_av(frame.format());
-    let needs_conversion = src_fmt != pix_fmt;
+    let needs_conversion =
+        src_fmt != pix_fmt || frame.width() != dst_width || frame.height() != dst_height;
 
     if needs_conversion {
-        // Use swscale for pixel format conversion.
+        // Use swscale for pixel format conversion and/or resize.
         let sws_ctx = swscale::get_context(
             frame.width() as i32,
             frame.height() as i32,
             src_fmt,
-            frame.width() as i32,
-            frame.height() as i32,
+            dst_width as i32,
+            dst_height as i32,
             pix_fmt,
             swscale::scale_flags::BILINEAR,
         )
@@ -256,7 +361,7 @@ pub(super) unsafe fn encode_image(path: &Path, frame: &VideoFrame) -> Result<(),
             return Err(EncodeError::from_ffmpeg_error(e));
         }
     } else {
-        // Direct plane copy — same format.
+        // Direct plane copy — same format and dimensions.
         for (i, plane) in frame.planes().iter().enumerate() {
             if i >= MAX_PLANES || (*dst_frame).data[i].is_null() {
                 break;
@@ -362,10 +467,7 @@ pub(super) unsafe fn encode_image(path: &Path, frame: &VideoFrame) -> Result<(),
                     return Err(EncodeError::from_ffmpeg_error(ret));
                 }
             }
-            Err(e) if e == ff_sys::error_codes::EOF => {
-                break;
-            }
-            Err(e) if e == ff_sys::error_codes::EAGAIN => {
+            Err(e) if e == ff_sys::error_codes::EOF || e == ff_sys::error_codes::EAGAIN => {
                 break;
             }
             Err(e) => {
@@ -388,10 +490,12 @@ pub(super) unsafe fn encode_image(path: &Path, frame: &VideoFrame) -> Result<(),
     avformat_free_context(format_ctx);
 
     log::info!(
-        "Image encoded successfully path={} width={} height={}",
+        "Image encoded successfully path={} src={}x{} dst={}x{}",
         path.display(),
         frame.width(),
-        frame.height()
+        frame.height(),
+        dst_width,
+        dst_height,
     );
 
     Ok(())

--- a/crates/ff-encode/tests/image_encoder_tests.rs
+++ b/crates/ff-encode/tests/image_encoder_tests.rs
@@ -5,7 +5,12 @@
 mod fixtures;
 
 use ff_encode::ImageEncoder;
-use fixtures::{FileGuard, assert_valid_output_file, create_black_frame, test_output_path};
+use ff_format::PixelFormat;
+use fixtures::{
+    FileGuard, assert_valid_output_file, create_black_frame, get_file_size, test_output_path,
+};
+
+// ── Baseline tests ────────────────────────────────────────────────────────────
 
 #[test]
 fn encode_jpeg_should_produce_valid_output() {
@@ -86,4 +91,245 @@ fn encode_bmp_should_produce_valid_output() {
 fn build_with_unsupported_extension_should_return_error() {
     let result = ImageEncoder::create("out.avi").build();
     assert!(result.is_err(), "expected error for unsupported extension");
+}
+
+// ── Dimension tests ───────────────────────────────────────────────────────────
+
+#[test]
+fn encode_jpeg_with_explicit_dimensions_should_produce_valid_output() {
+    let output_path = test_output_path("test_image_resize.jpg");
+    let _guard = FileGuard::new(output_path.clone());
+
+    // Encode a 64×64 source frame but request 128×128 output.
+    let encoder = match ImageEncoder::create(&output_path)
+        .width(128)
+        .height(128)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    match encoder.encode(&frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
+fn encode_png_with_explicit_dimensions_should_produce_valid_output() {
+    let output_path = test_output_path("test_image_resize.png");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let encoder = match ImageEncoder::create(&output_path)
+        .width(32)
+        .height(32)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    match encoder.encode(&frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
+fn encode_jpeg_with_only_width_should_produce_valid_output() {
+    let output_path = test_output_path("test_image_width_only.jpg");
+    let _guard = FileGuard::new(output_path.clone());
+
+    // Height is not set → falls back to the source frame's height (64).
+    let encoder = match ImageEncoder::create(&output_path).width(128).build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    match encoder.encode(&frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}
+
+// ── Quality tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn encode_jpeg_with_quality_should_produce_valid_output() {
+    let output_path = test_output_path("test_image_quality.jpg");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let encoder = match ImageEncoder::create(&output_path).quality(75).build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    match encoder.encode(&frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
+fn encode_jpeg_high_quality_should_be_larger_than_low_quality() {
+    let path_lo = test_output_path("test_image_quality_lo.jpg");
+    let path_hi = test_output_path("test_image_quality_hi.jpg");
+    let _guard_lo = FileGuard::new(path_lo.clone());
+    let _guard_hi = FileGuard::new(path_hi.clone());
+
+    // Use a non-trivial frame so quality differences are visible.
+    let frame = create_black_frame(128, 128);
+
+    let enc_lo = match ImageEncoder::create(&path_lo).quality(5).build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    if let Err(e) = enc_lo.encode(&frame) {
+        println!("Skipping: {e}");
+        return;
+    }
+
+    let frame = create_black_frame(128, 128);
+    let enc_hi = match ImageEncoder::create(&path_hi).quality(95).build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    if let Err(e) = enc_hi.encode(&frame) {
+        println!("Skipping: {e}");
+        return;
+    }
+
+    let size_lo = get_file_size(&path_lo);
+    let size_hi = get_file_size(&path_hi);
+    println!("JPEG quality=5 size={size_lo}  quality=95 size={size_hi}");
+    assert!(
+        size_hi >= size_lo,
+        "high-quality JPEG should be >= low-quality JPEG in size"
+    );
+}
+
+#[test]
+fn encode_png_with_quality_should_produce_valid_output() {
+    let output_path = test_output_path("test_image_quality.png");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let encoder = match ImageEncoder::create(&output_path).quality(60).build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    match encoder.encode(&frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}
+
+// ── Pixel format tests ────────────────────────────────────────────────────────
+
+#[test]
+fn encode_jpeg_with_pixel_format_should_produce_valid_output() {
+    let output_path = test_output_path("test_image_pixfmt.jpg");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let encoder = match ImageEncoder::create(&output_path)
+        .pixel_format(PixelFormat::Yuv420p)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    match encoder.encode(&frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
+fn encode_png_with_rgb24_pixel_format_should_produce_valid_output() {
+    let output_path = test_output_path("test_image_rgb24.png");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let encoder = match ImageEncoder::create(&output_path)
+        .pixel_format(PixelFormat::Rgb24)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    match encoder.encode(&frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
 }


### PR DESCRIPTION
## Summary

Extends `ImageEncoderBuilder` with four new optional builder setters —
`width`, `height`, `quality`, and `pixel_format` — giving callers control
over output dimensions, encode quality, and pixel format without changing the
`encode(&frame)` call site. Unset options fall back to source-frame values or
codec-native defaults, so existing code continues to work unchanged.

Also adds `ImageEncoder::new()` as an alias for `create()` per the issue spec.

## Changes

- `ImageEncoderBuilder`: added `width: Option<u32>`, `height: Option<u32>`, `quality: Option<u32>`, `pixel_format: Option<PixelFormat>` fields with consuming setter methods (`#[must_use]`)
- `build()`: rejects `width = 0` or `height = 0` with `InvalidConfig`; partial dimension sets (only width or only height) are valid and fall back to the frame's natural dimension
- `ImageEncoder::new()`: alias for `create()` matching issue specification
- `ImageEncodeOptions`: new `pub(super)` struct forwarding builder options into `encode_image`
- `encode_image()`: resolves `dst_width`/`dst_height` and `pix_fmt` from options or frame; passes dst dimensions to swscale for resize support; calls `apply_quality()` before `avcodec_open2`
- `apply_quality()`: per-codec quality mapping — MJPEG via `qmin`/`qmax` (0–100 → qscale 1–31), PNG via `av_opt_set("compression_level", …)` (0–100 → 0–9), WebP via `av_opt_set("quality", …)` (direct 0–100), BMP/TIFF log warn and skip
- Integration tests: expanded from 4 to 12 tests covering resize, partial dimension, quality (including file-size comparison), and pixel format override

## Related Issues

Closes #153

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes