### PR TITLE
feat(ff-probe): add SubtitleCodec enum and subtitle stream detection

### DIFF
--- a/crates/ff-format/src/codec.rs
+++ b/crates/ff-format/src/codec.rs
@@ -383,6 +383,128 @@ impl fmt::Display for AudioCodec {
     }
 }
 
+/// Subtitle codec identifier.
+///
+/// This enum represents common subtitle codecs used in media files.
+/// It covers text-based and bitmap-based formats while remaining extensible
+/// via the `Other` variant.
+///
+/// Note: No `Copy` or `Default` derive because `Other(String)` is not `Copy`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SubtitleCodec {
+    /// `SubRip` / SRT — text-based timed subtitles
+    Srt,
+    /// ASS/SSA (Advanced `SubStation` Alpha) — styled text subtitles
+    Ass,
+    /// DVB bitmap subtitles (digital broadcast)
+    Dvb,
+    /// HDMV/PGS — Blu-ray bitmap subtitles
+    Hdmv,
+    /// `WebVTT` — web-standard text subtitles
+    Webvtt,
+    /// Unrecognized codec; raw codec name stored for transparency
+    Other(String),
+}
+
+impl SubtitleCodec {
+    /// Returns the codec name as a short string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::codec::SubtitleCodec;
+    ///
+    /// assert_eq!(SubtitleCodec::Srt.name(), "srt");
+    /// assert_eq!(SubtitleCodec::Ass.name(), "ass");
+    /// ```
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Srt => "srt",
+            Self::Ass => "ass",
+            Self::Dvb => "dvb_subtitle",
+            Self::Hdmv => "hdmv_pgs_subtitle",
+            Self::Webvtt => "webvtt",
+            Self::Other(name) => name.as_str(),
+        }
+    }
+
+    /// Returns the human-readable display name for the codec.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::codec::SubtitleCodec;
+    ///
+    /// assert_eq!(SubtitleCodec::Srt.display_name(), "SubRip (SRT)");
+    /// assert_eq!(SubtitleCodec::Hdmv.display_name(), "HDMV/PGS");
+    /// ```
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::Srt => "SubRip (SRT)",
+            Self::Ass => "ASS/SSA",
+            Self::Dvb => "DVB Subtitle",
+            Self::Hdmv => "HDMV/PGS",
+            Self::Webvtt => "WebVTT",
+            Self::Other(name) => name.as_str(),
+        }
+    }
+
+    /// Returns `true` if this is a text-based subtitle codec.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::codec::SubtitleCodec;
+    ///
+    /// assert!(SubtitleCodec::Srt.is_text_based());
+    /// assert!(SubtitleCodec::Ass.is_text_based());
+    /// assert!(!SubtitleCodec::Dvb.is_text_based());
+    /// ```
+    #[must_use]
+    pub fn is_text_based(&self) -> bool {
+        matches!(self, Self::Srt | Self::Ass | Self::Webvtt)
+    }
+
+    /// Returns `true` if this is a bitmap-based subtitle codec.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::codec::SubtitleCodec;
+    ///
+    /// assert!(SubtitleCodec::Dvb.is_bitmap_based());
+    /// assert!(SubtitleCodec::Hdmv.is_bitmap_based());
+    /// assert!(!SubtitleCodec::Srt.is_bitmap_based());
+    /// ```
+    #[must_use]
+    pub fn is_bitmap_based(&self) -> bool {
+        matches!(self, Self::Dvb | Self::Hdmv)
+    }
+
+    /// Returns `true` if the codec is unrecognized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::codec::SubtitleCodec;
+    ///
+    /// assert!(SubtitleCodec::Other("dvd_subtitle".to_string()).is_unknown());
+    /// assert!(!SubtitleCodec::Srt.is_unknown());
+    /// ```
+    #[must_use]
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Other(_))
+    }
+}
+
+impl fmt::Display for SubtitleCodec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display_name())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -483,6 +605,84 @@ mod tests {
             let codec = VideoCodec::H264;
             let copied = codec;
             assert_eq!(codec, copied);
+        }
+    }
+
+    mod subtitle_codec_tests {
+        use super::*;
+
+        #[test]
+        fn name_should_return_short_codec_name() {
+            assert_eq!(SubtitleCodec::Srt.name(), "srt");
+            assert_eq!(SubtitleCodec::Ass.name(), "ass");
+            assert_eq!(SubtitleCodec::Dvb.name(), "dvb_subtitle");
+            assert_eq!(SubtitleCodec::Hdmv.name(), "hdmv_pgs_subtitle");
+            assert_eq!(SubtitleCodec::Webvtt.name(), "webvtt");
+            assert_eq!(
+                SubtitleCodec::Other("dvd_subtitle".to_string()).name(),
+                "dvd_subtitle"
+            );
+        }
+
+        #[test]
+        fn display_name_should_return_human_readable_name() {
+            assert_eq!(SubtitleCodec::Srt.display_name(), "SubRip (SRT)");
+            assert_eq!(SubtitleCodec::Ass.display_name(), "ASS/SSA");
+            assert_eq!(SubtitleCodec::Dvb.display_name(), "DVB Subtitle");
+            assert_eq!(SubtitleCodec::Hdmv.display_name(), "HDMV/PGS");
+            assert_eq!(SubtitleCodec::Webvtt.display_name(), "WebVTT");
+        }
+
+        #[test]
+        fn display_should_use_display_name() {
+            assert_eq!(format!("{}", SubtitleCodec::Srt), "SubRip (SRT)");
+            assert_eq!(format!("{}", SubtitleCodec::Hdmv), "HDMV/PGS");
+        }
+
+        #[test]
+        fn is_text_based_should_return_true_for_text_codecs() {
+            assert!(SubtitleCodec::Srt.is_text_based());
+            assert!(SubtitleCodec::Ass.is_text_based());
+            assert!(SubtitleCodec::Webvtt.is_text_based());
+            assert!(!SubtitleCodec::Dvb.is_text_based());
+            assert!(!SubtitleCodec::Hdmv.is_text_based());
+        }
+
+        #[test]
+        fn is_bitmap_based_should_return_true_for_bitmap_codecs() {
+            assert!(SubtitleCodec::Dvb.is_bitmap_based());
+            assert!(SubtitleCodec::Hdmv.is_bitmap_based());
+            assert!(!SubtitleCodec::Srt.is_bitmap_based());
+            assert!(!SubtitleCodec::Ass.is_bitmap_based());
+            assert!(!SubtitleCodec::Webvtt.is_bitmap_based());
+        }
+
+        #[test]
+        fn is_unknown_should_return_true_only_for_other_variant() {
+            assert!(SubtitleCodec::Other("dvd_subtitle".to_string()).is_unknown());
+            assert!(!SubtitleCodec::Srt.is_unknown());
+            assert!(!SubtitleCodec::Dvb.is_unknown());
+        }
+
+        #[test]
+        fn equality_should_compare_by_value() {
+            assert_eq!(SubtitleCodec::Srt, SubtitleCodec::Srt);
+            assert_ne!(SubtitleCodec::Srt, SubtitleCodec::Ass);
+            assert_eq!(
+                SubtitleCodec::Other("foo".to_string()),
+                SubtitleCodec::Other("foo".to_string())
+            );
+            assert_ne!(
+                SubtitleCodec::Other("foo".to_string()),
+                SubtitleCodec::Other("bar".to_string())
+            );
+        }
+
+        #[test]
+        fn clone_should_produce_equal_value() {
+            let codec = SubtitleCodec::Other("test".to_string());
+            let cloned = codec.clone();
+            assert_eq!(codec, cloned);
         }
     }
 

--- a/crates/ff-format/src/lib.rs
+++ b/crates/ff-format/src/lib.rs
@@ -64,7 +64,7 @@ pub mod time;
 
 pub use channel::ChannelLayout;
 pub use chapter::{ChapterInfo, ChapterInfoBuilder};
-pub use codec::{AudioCodec, VideoCodec};
+pub use codec::{AudioCodec, SubtitleCodec, VideoCodec};
 pub use color::{ColorPrimaries, ColorRange, ColorSpace};
 pub use error::{FormatError, FrameError};
 pub use ff_common::PooledBuffer;
@@ -73,7 +73,8 @@ pub use media::{MediaInfo, MediaInfoBuilder};
 pub use pixel::PixelFormat;
 pub use sample::SampleFormat;
 pub use stream::{
-    AudioStreamInfo, AudioStreamInfoBuilder, VideoStreamInfo, VideoStreamInfoBuilder,
+    AudioStreamInfo, AudioStreamInfoBuilder, SubtitleStreamInfo, SubtitleStreamInfoBuilder,
+    VideoStreamInfo, VideoStreamInfoBuilder,
 };
 pub use time::{Rational, Timestamp};
 

--- a/crates/ff-format/src/media.rs
+++ b/crates/ff-format/src/media.rs
@@ -56,7 +56,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::chapter::ChapterInfo;
-use crate::stream::{AudioStreamInfo, VideoStreamInfo};
+use crate::stream::{AudioStreamInfo, SubtitleStreamInfo, VideoStreamInfo};
 
 /// Information about a media file.
 ///
@@ -96,6 +96,8 @@ pub struct MediaInfo {
     video_streams: Vec<VideoStreamInfo>,
     /// Audio streams in the file
     audio_streams: Vec<AudioStreamInfo>,
+    /// Subtitle streams in the file
+    subtitle_streams: Vec<SubtitleStreamInfo>,
     /// Chapter markers in the file
     chapters: Vec<ChapterInfo>,
     /// File metadata (title, artist, etc.)
@@ -179,6 +181,13 @@ impl MediaInfo {
         &self.audio_streams
     }
 
+    /// Returns all subtitle streams in the file.
+    #[must_use]
+    #[inline]
+    pub fn subtitle_streams(&self) -> &[SubtitleStreamInfo] {
+        &self.subtitle_streams
+    }
+
     /// Returns all chapters in the file.
     #[must_use]
     #[inline]
@@ -230,6 +239,13 @@ impl MediaInfo {
         !self.audio_streams.is_empty()
     }
 
+    /// Returns `true` if the file contains at least one subtitle stream.
+    #[must_use]
+    #[inline]
+    pub fn has_subtitles(&self) -> bool {
+        !self.subtitle_streams.is_empty()
+    }
+
     /// Returns the number of video streams.
     #[must_use]
     #[inline]
@@ -244,11 +260,18 @@ impl MediaInfo {
         self.audio_streams.len()
     }
 
-    /// Returns the total number of streams (video + audio).
+    /// Returns the number of subtitle streams.
+    #[must_use]
+    #[inline]
+    pub fn subtitle_stream_count(&self) -> usize {
+        self.subtitle_streams.len()
+    }
+
+    /// Returns the total number of streams (video + audio + subtitle).
     #[must_use]
     #[inline]
     pub fn stream_count(&self) -> usize {
-        self.video_streams.len() + self.audio_streams.len()
+        self.video_streams.len() + self.audio_streams.len() + self.subtitle_streams.len()
     }
 
     // === Primary Stream Selection ===
@@ -285,6 +308,13 @@ impl MediaInfo {
     #[inline]
     pub fn audio_stream(&self, index: usize) -> Option<&AudioStreamInfo> {
         self.audio_streams.get(index)
+    }
+
+    /// Returns a subtitle stream by index within the subtitle streams list.
+    #[must_use]
+    #[inline]
+    pub fn subtitle_stream(&self, index: usize) -> Option<&SubtitleStreamInfo> {
+        self.subtitle_streams.get(index)
     }
 
     // === Convenience Methods ===
@@ -434,6 +464,7 @@ impl Default for MediaInfo {
             bitrate: None,
             video_streams: Vec::new(),
             audio_streams: Vec::new(),
+            subtitle_streams: Vec::new(),
             chapters: Vec::new(),
             metadata: HashMap::new(),
         }
@@ -468,6 +499,7 @@ pub struct MediaInfoBuilder {
     bitrate: Option<u64>,
     video_streams: Vec<VideoStreamInfo>,
     audio_streams: Vec<AudioStreamInfo>,
+    subtitle_streams: Vec<SubtitleStreamInfo>,
     chapters: Vec<ChapterInfo>,
     metadata: HashMap<String, String>,
 }
@@ -543,6 +575,20 @@ impl MediaInfoBuilder {
         self
     }
 
+    /// Adds a subtitle stream.
+    #[must_use]
+    pub fn subtitle_stream(mut self, stream: SubtitleStreamInfo) -> Self {
+        self.subtitle_streams.push(stream);
+        self
+    }
+
+    /// Sets all subtitle streams at once, replacing any existing streams.
+    #[must_use]
+    pub fn subtitle_streams(mut self, streams: Vec<SubtitleStreamInfo>) -> Self {
+        self.subtitle_streams = streams;
+        self
+    }
+
     /// Adds a chapter.
     #[must_use]
     pub fn chapter(mut self, chapter: ChapterInfo) -> Self {
@@ -583,6 +629,7 @@ impl MediaInfoBuilder {
             bitrate: self.bitrate,
             video_streams: self.video_streams,
             audio_streams: self.audio_streams,
+            subtitle_streams: self.subtitle_streams,
             chapters: self.chapters,
             metadata: self.metadata,
         }
@@ -592,7 +639,7 @@ impl MediaInfoBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::{AudioCodec, VideoCodec};
+    use crate::codec::{AudioCodec, SubtitleCodec, VideoCodec};
     use crate::time::Rational;
     use crate::{PixelFormat, SampleFormat};
 
@@ -618,6 +665,15 @@ mod tests {
             .channels(2)
             .sample_format(SampleFormat::F32)
             .duration(Duration::from_secs(120))
+            .build()
+    }
+
+    fn sample_subtitle_stream() -> SubtitleStreamInfo {
+        SubtitleStreamInfo::builder()
+            .index(2)
+            .codec(SubtitleCodec::Srt)
+            .codec_name("srt")
+            .language("eng")
             .build()
     }
 
@@ -816,6 +872,53 @@ mod tests {
             assert_eq!(info.video_stream_count(), 2);
             assert_eq!(info.audio_stream_count(), 3);
             assert_eq!(info.stream_count(), 5);
+        }
+
+        #[test]
+        fn has_subtitles_should_return_true_when_subtitle_streams_present() {
+            let no_subs = MediaInfo::default();
+            assert!(!no_subs.has_subtitles());
+            assert_eq!(no_subs.subtitle_stream_count(), 0);
+
+            let with_subs = MediaInfo::builder()
+                .subtitle_stream(sample_subtitle_stream())
+                .subtitle_stream(sample_subtitle_stream())
+                .build();
+            assert!(with_subs.has_subtitles());
+            assert_eq!(with_subs.subtitle_stream_count(), 2);
+        }
+
+        #[test]
+        fn subtitle_stream_count_should_be_included_in_stream_count() {
+            let info = MediaInfo::builder()
+                .video_stream(sample_video_stream())
+                .audio_stream(sample_audio_stream())
+                .subtitle_stream(sample_subtitle_stream())
+                .build();
+            assert_eq!(info.stream_count(), 3);
+        }
+
+        #[test]
+        fn subtitle_stream_by_index_should_return_correct_stream() {
+            let sub1 = SubtitleStreamInfo::builder()
+                .index(2)
+                .codec(SubtitleCodec::Srt)
+                .language("eng")
+                .build();
+            let sub2 = SubtitleStreamInfo::builder()
+                .index(3)
+                .codec(SubtitleCodec::Ass)
+                .language("jpn")
+                .build();
+
+            let info = MediaInfo::builder()
+                .subtitle_stream(sub1)
+                .subtitle_stream(sub2)
+                .build();
+
+            assert_eq!(info.subtitle_stream(0).unwrap().language(), Some("eng"));
+            assert_eq!(info.subtitle_stream(1).unwrap().language(), Some("jpn"));
+            assert!(info.subtitle_stream(2).is_none());
         }
 
         #[test]

--- a/crates/ff-format/src/stream.rs
+++ b/crates/ff-format/src/stream.rs
@@ -42,7 +42,7 @@
 use std::time::Duration;
 
 use crate::channel::ChannelLayout;
-use crate::codec::{AudioCodec, VideoCodec};
+use crate::codec::{AudioCodec, SubtitleCodec, VideoCodec};
 use crate::color::{ColorPrimaries, ColorRange, ColorSpace};
 use crate::pixel::PixelFormat;
 use crate::sample::SampleFormat;
@@ -746,6 +746,199 @@ impl AudioStreamInfoBuilder {
     }
 }
 
+/// Information about a subtitle stream within a media file.
+///
+/// This struct contains all metadata needed to identify and categorize
+/// a subtitle stream, including codec, language, and forced flag.
+///
+/// # Construction
+///
+/// Use [`SubtitleStreamInfo::builder()`] for fluent construction:
+///
+/// ```
+/// use ff_format::stream::SubtitleStreamInfo;
+/// use ff_format::codec::SubtitleCodec;
+///
+/// let info = SubtitleStreamInfo::builder()
+///     .index(2)
+///     .codec(SubtitleCodec::Srt)
+///     .codec_name("srt")
+///     .language("eng")
+///     .build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct SubtitleStreamInfo {
+    /// Stream index within the container
+    index: u32,
+    /// Subtitle codec
+    codec: SubtitleCodec,
+    /// Codec name as reported by the demuxer
+    codec_name: String,
+    /// Language code (e.g., "eng", "jpn")
+    language: Option<String>,
+    /// Stream title (e.g., "English (Forced)")
+    title: Option<String>,
+    /// Stream duration (if known)
+    duration: Option<Duration>,
+    /// Whether this is a forced subtitle track
+    forced: bool,
+}
+
+impl SubtitleStreamInfo {
+    /// Creates a new builder for constructing `SubtitleStreamInfo`.
+    #[must_use]
+    pub fn builder() -> SubtitleStreamInfoBuilder {
+        SubtitleStreamInfoBuilder::default()
+    }
+
+    /// Returns the stream index within the container.
+    #[must_use]
+    #[inline]
+    pub const fn index(&self) -> u32 {
+        self.index
+    }
+
+    /// Returns the subtitle codec.
+    #[must_use]
+    #[inline]
+    pub fn codec(&self) -> &SubtitleCodec {
+        &self.codec
+    }
+
+    /// Returns the codec name as reported by the demuxer.
+    #[must_use]
+    #[inline]
+    pub fn codec_name(&self) -> &str {
+        &self.codec_name
+    }
+
+    /// Returns the language code, if specified.
+    #[must_use]
+    #[inline]
+    pub fn language(&self) -> Option<&str> {
+        self.language.as_deref()
+    }
+
+    /// Returns the stream title, if specified.
+    #[must_use]
+    #[inline]
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Returns the stream duration, if known.
+    #[must_use]
+    #[inline]
+    pub const fn duration(&self) -> Option<Duration> {
+        self.duration
+    }
+
+    /// Returns `true` if this is a forced subtitle track.
+    #[must_use]
+    #[inline]
+    pub const fn is_forced(&self) -> bool {
+        self.forced
+    }
+
+    /// Returns `true` if the codec is text-based.
+    #[must_use]
+    #[inline]
+    pub fn is_text_based(&self) -> bool {
+        self.codec.is_text_based()
+    }
+}
+
+/// Builder for constructing `SubtitleStreamInfo`.
+#[derive(Debug, Clone)]
+pub struct SubtitleStreamInfoBuilder {
+    index: u32,
+    codec: SubtitleCodec,
+    codec_name: String,
+    language: Option<String>,
+    title: Option<String>,
+    duration: Option<Duration>,
+    forced: bool,
+}
+
+impl Default for SubtitleStreamInfoBuilder {
+    fn default() -> Self {
+        Self {
+            index: 0,
+            codec: SubtitleCodec::Other(String::new()),
+            codec_name: String::new(),
+            language: None,
+            title: None,
+            duration: None,
+            forced: false,
+        }
+    }
+}
+
+impl SubtitleStreamInfoBuilder {
+    /// Sets the stream index.
+    #[must_use]
+    pub fn index(mut self, index: u32) -> Self {
+        self.index = index;
+        self
+    }
+
+    /// Sets the subtitle codec.
+    #[must_use]
+    pub fn codec(mut self, codec: SubtitleCodec) -> Self {
+        self.codec = codec;
+        self
+    }
+
+    /// Sets the codec name string.
+    #[must_use]
+    pub fn codec_name(mut self, name: impl Into<String>) -> Self {
+        self.codec_name = name.into();
+        self
+    }
+
+    /// Sets the language code.
+    #[must_use]
+    pub fn language(mut self, lang: impl Into<String>) -> Self {
+        self.language = Some(lang.into());
+        self
+    }
+
+    /// Sets the stream title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Sets the stream duration.
+    #[must_use]
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = Some(duration);
+        self
+    }
+
+    /// Sets the forced flag.
+    #[must_use]
+    pub fn forced(mut self, forced: bool) -> Self {
+        self.forced = forced;
+        self
+    }
+
+    /// Builds the `SubtitleStreamInfo`.
+    #[must_use]
+    pub fn build(self) -> SubtitleStreamInfo {
+        SubtitleStreamInfo {
+            index: self.index,
+            codec: self.codec,
+            codec_name: self.codec_name,
+            language: self.language,
+            title: self.title,
+            duration: self.duration,
+            forced: self.forced,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1058,6 +1251,60 @@ mod tests {
             assert_eq!(info.channels(), cloned.channels());
             assert_eq!(info.language(), cloned.language());
             assert_eq!(info.codec_name(), cloned.codec_name());
+        }
+    }
+
+    mod subtitle_stream_info_tests {
+        use super::*;
+
+        #[test]
+        fn builder_should_store_all_fields() {
+            let info = SubtitleStreamInfo::builder()
+                .index(2)
+                .codec(SubtitleCodec::Srt)
+                .codec_name("srt")
+                .language("eng")
+                .title("English")
+                .duration(Duration::from_secs(120))
+                .forced(true)
+                .build();
+
+            assert_eq!(info.index(), 2);
+            assert_eq!(info.codec(), &SubtitleCodec::Srt);
+            assert_eq!(info.codec_name(), "srt");
+            assert_eq!(info.language(), Some("eng"));
+            assert_eq!(info.title(), Some("English"));
+            assert_eq!(info.duration(), Some(Duration::from_secs(120)));
+            assert!(info.is_forced());
+        }
+
+        #[test]
+        fn is_forced_should_default_to_false() {
+            let info = SubtitleStreamInfo::builder()
+                .codec(SubtitleCodec::Ass)
+                .build();
+            assert!(!info.is_forced());
+        }
+
+        #[test]
+        fn is_text_based_should_delegate_to_codec() {
+            let text = SubtitleStreamInfo::builder()
+                .codec(SubtitleCodec::Srt)
+                .build();
+            assert!(text.is_text_based());
+
+            let bitmap = SubtitleStreamInfo::builder()
+                .codec(SubtitleCodec::Hdmv)
+                .build();
+            assert!(!bitmap.is_text_based());
+        }
+
+        #[test]
+        fn optional_fields_should_default_to_none() {
+            let info = SubtitleStreamInfo::builder().build();
+            assert!(info.language().is_none());
+            assert!(info.title().is_none());
+            assert!(info.duration().is_none());
         }
     }
 }

--- a/crates/ff-probe/src/info.rs
+++ b/crates/ff-probe/src/info.rs
@@ -59,9 +59,9 @@ use std::time::Duration;
 
 use ff_format::channel::ChannelLayout;
 use ff_format::chapter::ChapterInfo;
-use ff_format::codec::{AudioCodec, VideoCodec};
+use ff_format::codec::{AudioCodec, SubtitleCodec, VideoCodec};
 use ff_format::color::{ColorPrimaries, ColorRange, ColorSpace};
-use ff_format::stream::{AudioStreamInfo, VideoStreamInfo};
+use ff_format::stream::{AudioStreamInfo, SubtitleStreamInfo, VideoStreamInfo};
 use ff_format::{MediaInfo, PixelFormat, Rational, SampleFormat};
 
 use crate::error::ProbeError;
@@ -180,6 +180,10 @@ pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
     // SAFETY: ctx is valid and find_stream_info succeeded
     let audio_streams = unsafe { extract_audio_streams(ctx) };
 
+    // Extract subtitle streams
+    // SAFETY: ctx is valid and find_stream_info succeeded
+    let subtitle_streams = unsafe { extract_subtitle_streams(ctx) };
+
     // Extract chapter info
     // SAFETY: ctx is valid and find_stream_info succeeded
     let chapters = unsafe { extract_chapters(ctx) };
@@ -199,6 +203,7 @@ pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
         .file_size(file_size)
         .video_streams(video_streams)
         .audio_streams(audio_streams)
+        .subtitle_streams(subtitle_streams)
         .chapters(chapters)
         .metadata_map(metadata);
 
@@ -1020,6 +1025,150 @@ unsafe fn extract_language(stream: *mut ff_sys::AVStream) -> Option<String> {
 // ============================================================================
 // Audio Type Mapping Functions
 // ============================================================================
+
+// ============================================================================
+// Subtitle Stream Extraction
+// ============================================================================
+
+/// Extracts all subtitle streams from an `AVFormatContext`.
+///
+/// This function iterates through all streams in the container and extracts
+/// detailed information for each subtitle stream.
+///
+/// # Safety
+///
+/// The `ctx` pointer must be valid and `avformat_find_stream_info` must have been called.
+unsafe fn extract_subtitle_streams(ctx: *mut ff_sys::AVFormatContext) -> Vec<SubtitleStreamInfo> {
+    // SAFETY: Caller guarantees ctx is valid and find_stream_info was called
+    unsafe {
+        let nb_streams = (*ctx).nb_streams;
+        let streams_ptr = (*ctx).streams;
+
+        if streams_ptr.is_null() || nb_streams == 0 {
+            return Vec::new();
+        }
+
+        let mut subtitle_streams = Vec::new();
+
+        for i in 0..nb_streams {
+            // SAFETY: i < nb_streams, so this is within bounds
+            let stream = *streams_ptr.add(i as usize);
+            if stream.is_null() {
+                continue;
+            }
+
+            let codecpar = (*stream).codecpar;
+            if codecpar.is_null() {
+                continue;
+            }
+
+            // Check if this is a subtitle stream
+            if (*codecpar).codec_type != ff_sys::AVMediaType_AVMEDIA_TYPE_SUBTITLE {
+                continue;
+            }
+
+            let stream_info = extract_single_subtitle_stream(stream, codecpar, i);
+            subtitle_streams.push(stream_info);
+        }
+
+        subtitle_streams
+    }
+}
+
+/// Extracts information from a single subtitle stream.
+///
+/// # Safety
+///
+/// Both `stream` and `codecpar` pointers must be valid.
+unsafe fn extract_single_subtitle_stream(
+    stream: *mut ff_sys::AVStream,
+    codecpar: *mut ff_sys::AVCodecParameters,
+    index: u32,
+) -> SubtitleStreamInfo {
+    // SAFETY: Caller guarantees pointers are valid
+    unsafe {
+        let codec_id = (*codecpar).codec_id;
+        let codec = map_subtitle_codec(codec_id);
+        let codec_name = extract_codec_name(codec_id);
+
+        // disposition is a c_int bitmask; cast to u32 for bitwise AND with the u32 constant
+        #[expect(
+            clippy::cast_sign_loss,
+            reason = "disposition is a non-negative bitmask"
+        )]
+        let forced = ((*stream).disposition as u32 & ff_sys::AV_DISPOSITION_FORCED) != 0;
+
+        let duration = extract_stream_duration(stream);
+        let language = extract_language(stream);
+        let title = extract_stream_title(stream);
+
+        let mut builder = SubtitleStreamInfo::builder()
+            .index(index)
+            .codec(codec)
+            .codec_name(codec_name)
+            .forced(forced);
+
+        if let Some(d) = duration {
+            builder = builder.duration(d);
+        }
+        if let Some(lang) = language {
+            builder = builder.language(lang);
+        }
+        if let Some(t) = title {
+            builder = builder.title(t);
+        }
+
+        builder.build()
+    }
+}
+
+/// Extracts the "title" metadata tag from a stream's `AVDictionary`.
+///
+/// # Safety
+///
+/// The `stream` pointer must be valid.
+unsafe fn extract_stream_title(stream: *mut ff_sys::AVStream) -> Option<String> {
+    // SAFETY: Caller guarantees stream is valid
+    unsafe {
+        let metadata = (*stream).metadata;
+        if metadata.is_null() {
+            return None;
+        }
+
+        let key = c"title";
+        let entry = ff_sys::av_dict_get(metadata, key.as_ptr(), std::ptr::null(), 0);
+
+        if entry.is_null() {
+            return None;
+        }
+
+        let value_ptr = (*entry).value;
+        if value_ptr.is_null() {
+            return None;
+        }
+
+        Some(CStr::from_ptr(value_ptr).to_string_lossy().into_owned())
+    }
+}
+
+/// Maps an `FFmpeg` `AVCodecID` to our [`SubtitleCodec`] enum.
+fn map_subtitle_codec(codec_id: ff_sys::AVCodecID) -> SubtitleCodec {
+    match codec_id {
+        ff_sys::AVCodecID_AV_CODEC_ID_SRT | ff_sys::AVCodecID_AV_CODEC_ID_SUBRIP => {
+            SubtitleCodec::Srt
+        }
+        ff_sys::AVCodecID_AV_CODEC_ID_SSA | ff_sys::AVCodecID_AV_CODEC_ID_ASS => SubtitleCodec::Ass,
+        ff_sys::AVCodecID_AV_CODEC_ID_DVB_SUBTITLE => SubtitleCodec::Dvb,
+        ff_sys::AVCodecID_AV_CODEC_ID_HDMV_PGS_SUBTITLE => SubtitleCodec::Hdmv,
+        ff_sys::AVCodecID_AV_CODEC_ID_WEBVTT => SubtitleCodec::Webvtt,
+        _ => {
+            // SAFETY: avcodec_get_name is safe for any codec ID
+            let name = unsafe { extract_codec_name(codec_id) };
+            log::warn!("unknown subtitle codec codec_id={codec_id}");
+            SubtitleCodec::Other(name)
+        }
+    }
+}
 
 /// Maps an `FFmpeg` `AVCodecID` to our [`AudioCodec`] enum.
 fn map_audio_codec(codec_id: ff_sys::AVCodecID) -> AudioCodec {

--- a/crates/ff-probe/src/lib.rs
+++ b/crates/ff-probe/src/lib.rs
@@ -133,8 +133,8 @@ mod info;
 // Re-export types from ff-format for convenience
 pub use ff_format::{
     AudioCodec, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder, ColorPrimaries,
-    ColorRange, ColorSpace, MediaInfo, PixelFormat, Rational, SampleFormat, Timestamp, VideoCodec,
-    VideoStreamInfo,
+    ColorRange, ColorSpace, MediaInfo, PixelFormat, Rational, SampleFormat, SubtitleCodec,
+    SubtitleStreamInfo, SubtitleStreamInfoBuilder, Timestamp, VideoCodec, VideoStreamInfo,
 };
 
 pub use error::ProbeError;
@@ -165,7 +165,8 @@ pub mod prelude {
     pub use crate::{
         AudioCodec, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder,
         ColorPrimaries, ColorRange, ColorSpace, MediaInfo, PixelFormat, ProbeError, Rational,
-        SampleFormat, Timestamp, VideoCodec, VideoStreamInfo, open,
+        SampleFormat, SubtitleCodec, SubtitleStreamInfo, SubtitleStreamInfoBuilder, Timestamp,
+        VideoCodec, VideoStreamInfo, open,
     };
 }
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -115,6 +115,7 @@ pub struct AVStream {
     pub avg_frame_rate: AVRational,
     pub r_frame_rate: AVRational,
     pub start_time: i64,
+    pub disposition: c_int,
     pub metadata: *mut AVDictionary,
 }
 
@@ -189,6 +190,8 @@ pub const AVMediaType_AVMEDIA_TYPE_VIDEO: AVMediaType = 0;
 pub const AVMediaType_AVMEDIA_TYPE_AUDIO: AVMediaType = 1;
 pub const AVMediaType_AVMEDIA_TYPE_SUBTITLE: AVMediaType = 3;
 
+pub const AV_DISPOSITION_FORCED: u32 = 0x0040;
+
 pub const AVChannelOrder_AV_CHANNEL_ORDER_UNSPEC: AVChannelOrder = 0;
 pub const AVChannelOrder_AV_CHANNEL_ORDER_NATIVE: AVChannelOrder = 1;
 
@@ -211,6 +214,15 @@ pub const AVCodecID_AV_CODEC_ID_PNG: AVCodecID = 61;
 pub const AVCodecID_AV_CODEC_ID_BMP: AVCodecID = 76;
 pub const AVCodecID_AV_CODEC_ID_TIFF: AVCodecID = 90;
 pub const AVCodecID_AV_CODEC_ID_WEBP: AVCodecID = 219;
+
+// AVCodecID — subtitle
+pub const AVCodecID_AV_CODEC_ID_DVB_SUBTITLE: AVCodecID = 94209;
+pub const AVCodecID_AV_CODEC_ID_SSA: AVCodecID = 94212;
+pub const AVCodecID_AV_CODEC_ID_HDMV_PGS_SUBTITLE: AVCodecID = 94214;
+pub const AVCodecID_AV_CODEC_ID_SRT: AVCodecID = 94216;
+pub const AVCodecID_AV_CODEC_ID_SUBRIP: AVCodecID = 94248;
+pub const AVCodecID_AV_CODEC_ID_WEBVTT: AVCodecID = 94249;
+pub const AVCodecID_AV_CODEC_ID_ASS: AVCodecID = 94253;
 
 // AVCodecID — audio
 pub const AVCodecID_AV_CODEC_ID_PCM_S16LE: AVCodecID = 65536;


### PR DESCRIPTION
## Summary

Implements subtitle stream detection in `ff-probe` as specified in issue #49. Adds the `SubtitleCodec` enum and `SubtitleStreamInfo`/`SubtitleStreamInfoBuilder` types to `ff-format`, extends `MediaInfo` with a `subtitle_streams` field, and wires up FFmpeg extraction logic in `ff-probe` to populate those fields at probe time.

## Changes

- **`ff-sys/docsrs_stubs.rs`**: added `disposition` field to `AVStream`, `AV_DISPOSITION_FORCED` constant, and 7 subtitle `AVCodecID` constants (`SRT`, `SUBRIP`, `SSA`, `ASS`, `DVB_SUBTITLE`, `HDMV_PGS_SUBTITLE`, `WEBVTT`)
- **`ff-format/codec.rs`**: new `SubtitleCodec` enum with `Srt`, `Ass`, `Dvb`, `Hdmv`, `Webvtt`, `Other(String)` variants; `name()`, `display_name()`, `is_text_based()`, `is_bitmap_based()`, `is_unknown()` methods; `Display` impl; unit tests
- **`ff-format/stream.rs`**: new `SubtitleStreamInfo` struct and `SubtitleStreamInfoBuilder` (index, codec, codec_name, language, title, duration, forced); unit tests
- **`ff-format/media.rs`**: added `subtitle_streams` field; `subtitle_streams()`, `has_subtitles()`, `subtitle_stream_count()`, `subtitle_stream()` accessors; `stream_count()` now includes subtitle streams; builder methods `subtitle_stream()` / `subtitle_streams()`; unit tests
- **`ff-format/lib.rs`**, **`ff-probe/lib.rs`**: re-export `SubtitleCodec`, `SubtitleStreamInfo`, `SubtitleStreamInfoBuilder` (including in prelude)
- **`ff-probe/info.rs`**: added `extract_subtitle_streams()`, `extract_single_subtitle_stream()`, `extract_stream_title()`, and `map_subtitle_codec()`; forced-flag detection via `AV_DISPOSITION_FORCED`; wired into `open()`

## Related Issues

Closes #49
Closes #51

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes