### PR TITLE
feat(ff-probe): add probe logging and subtitle stream integration tests

### DIFF
--- a/crates/ff-probe/src/info.rs
+++ b/crates/ff-probe/src/info.rs
@@ -127,6 +127,8 @@ const AV_TIME_BASE: i64 = 1_000_000;
 pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
     let path = path.as_ref();
 
+    log::debug!("probing media file path={}", path.display());
+
     // Check if file exists
     if !path.exists() {
         return Err(ProbeError::FileNotFound {
@@ -194,6 +196,14 @@ pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
         let mut ctx_ptr = ctx;
         ff_sys::avformat::close_input(&raw mut ctx_ptr);
     }
+
+    log::debug!(
+        "probe complete video_streams={} audio_streams={} subtitle_streams={} chapters={}",
+        video_streams.len(),
+        audio_streams.len(),
+        subtitle_streams.len(),
+        chapters.len()
+    );
 
     // Build MediaInfo
     let mut builder = MediaInfo::builder()

--- a/crates/ff-probe/tests/integration_tests.rs
+++ b/crates/ff-probe/tests/integration_tests.rs
@@ -770,3 +770,41 @@ fn test_probe_bitrate_consistency() {
         }
     }
 }
+
+// ============================================================================
+// Subtitle Stream Tests
+// ============================================================================
+
+#[test]
+fn test_probe_video_file_has_no_subtitle_streams() {
+    let path = test_video_path();
+    let info = open(&path).expect("Failed to open video file");
+
+    assert!(
+        info.subtitle_streams().is_empty(),
+        "Video file without subtitles should have empty subtitle_streams()"
+    );
+}
+
+#[test]
+fn test_probe_video_file_has_subtitles_returns_false() {
+    let path = test_video_path();
+    let info = open(&path).expect("Failed to open video file");
+
+    assert!(
+        !info.has_subtitles(),
+        "has_subtitles() should return false for a video file without subtitle streams"
+    );
+}
+
+#[test]
+fn test_probe_video_file_subtitle_stream_count_is_zero() {
+    let path = test_video_path();
+    let info = open(&path).expect("Failed to open video file");
+
+    assert_eq!(
+        info.subtitle_stream_count(),
+        0,
+        "subtitle_stream_count() should be 0 for a video file without subtitle streams"
+    );
+}


### PR DESCRIPTION
## Summary

The \`SubtitleStreamInfo\` struct was implemented in PR #168, but two gaps remained: the \`open()\` function was missing the debug log calls specified in the ff-probe design doc, and no integration tests covered the subtitle stream API. This PR fills both gaps.

## Changes

- **\`ff-probe/src/info.rs\`**: added \`log::debug!\` at the entry of \`open()\` (logs the target path) and at completion (logs the count of video, audio, subtitle streams and chapters) as specified in \`docs/crates/ff-probe/design.md\`
- **\`ff-probe/tests/integration_tests.rs\`**: added three integration tests for the subtitle API —
  - \`test_probe_video_file_has_no_subtitle_streams\` — verifies \`subtitle_streams()\` returns an empty slice for a video file without subtitles
  - \`test_probe_video_file_has_subtitles_returns_false\` — verifies \`has_subtitles()\` returns \`false\`
  - \`test_probe_video_file_subtitle_stream_count_is_zero\` — verifies \`subtitle_stream_count()\` returns \`0\`

## Related Issues

Closes #50

## Test Plan

- [x] \`cargo test --all --all-features\` passes
- [x] \`cargo clippy --all --all-features -- -D warnings\` passes
- [x] \`cargo fmt --all -- --check\` passes
- [x] \`cargo doc --all-features --no-deps\` passes