### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2026-03-14
+
+### Added
+
+#### ff-encode
+- `ImageEncoder`: encodes a single `VideoFrame` to JPEG, PNG, or BMP using the FFmpeg image2 muxer ([#152](https://github.com/itsakeyfut/avio/issues/152))
+- `ImageEncoderBuilder` options: `width`, `height`, `quality`, and `pixel_format` ([#153](https://github.com/itsakeyfut/avio/issues/153))
+- `ImageEncoderInner` with RAII `Drop` for safe cleanup of FFmpeg resources ([#154](https://github.com/itsakeyfut/avio/issues/154))
+- `BitrateMode` enum (`Cbr` / `Vbr`) for video bitrate control; `Vbr` wired to `AVCodecContext` ([#44](https://github.com/itsakeyfut/avio/issues/44), [#46](https://github.com/itsakeyfut/avio/issues/46))
+- Two-pass video encoding via `VideoEncoderBuilder::two_pass()` ([#43](https://github.com/itsakeyfut/avio/issues/43))
+- Metadata write support via `VideoEncoderBuilder::metadata()` ([#45](https://github.com/itsakeyfut/avio/issues/45))
+- Chapter write support via `VideoEncoderBuilder::chapters()` ([#47](https://github.com/itsakeyfut/avio/issues/47))
+- Subtitle passthrough via `VideoEncoderBuilder::subtitle_passthrough()` ([#48](https://github.com/itsakeyfut/avio/issues/48))
+- Integration tests: `ImageEncoder` file creation, round-trip decode, quality, and drop-without-encode ([#155](https://github.com/itsakeyfut/avio/issues/155))
+- Integration tests: chapter round-trip ([#52](https://github.com/itsakeyfut/avio/issues/52)) and subtitle passthrough round-trip ([#53](https://github.com/itsakeyfut/avio/issues/53))
+
+#### ff-probe
+- `SubtitleCodec` enum covering common subtitle codecs (ASS, SRT, WebVTT, HDMV PGS, DVB, MOV text, TTML) ([#49](https://github.com/itsakeyfut/avio/issues/49))
+- `SubtitleStreamInfo` struct with `codec`, `language`, `title`, and `default_stream` accessors ([#50](https://github.com/itsakeyfut/avio/issues/50))
+- `subtitle_streams()`, `has_subtitles()`, and `subtitle_stream_count()` on `MediaInfo` ([#51](https://github.com/itsakeyfut/avio/issues/51))
+- Integration tests for subtitle stream probing
+
+### Changed
+
+#### ff-encode
+- Module structure restructured to match the `ff-decode` pattern (`video/`, `audio/`, `image/`) ([#151](https://github.com/itsakeyfut/avio/issues/151))
+
+### Fixed
+
+#### ff-encode
+- Subtitle packets with `AV_NOPTS_VALUE` DTS now have DTS mirrored from PTS before `av_interleaved_write_frame`; prevents silent packet drops by the Matroska muxer
+
+---
+
 ## [0.2.0] - 2026-03-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.2.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.2.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.2.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.2.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.2.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.2.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.2.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.2.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.2.0" }
-avio        = { path = "crates/avio",        version = "0.2.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.3.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.3.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.3.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.3.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.3.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.3.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.3.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.3.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.3.0" }
+avio        = { path = "crates/avio",        version = "0.3.0" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.2.0 to 0.3.0 and documents all changes in CHANGELOG.md. This release completes milestone v0.3.0 (Encoding Enhancements + Metadata Write).

## Changes

- `Cargo.toml`: workspace version `0.2.0` → `0.3.0`; all intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.3.0]` entry covering ImageEncoder, BitrateMode, two-pass encoding, metadata/chapter/subtitle write in ff-encode, and SubtitleCodec/SubtitleStreamInfo in ff-probe

## Related Issues

Closes #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #151, #152, #153, #154, #155

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes