### PR TITLE
feat(ff-pipeline): add crate scaffold (#54)

### DIFF
--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -14,9 +14,13 @@ categories = ["multimedia::video", "multimedia::audio"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ff-common = { workspace = true }
-ff-format = { workspace = true }
-thiserror = { workspace = true }
+ff-common  = { workspace = true }
+ff-format  = { workspace = true }
+ff-decode  = { workspace = true }
+ff-filter  = { workspace = true }
+ff-encode  = { workspace = true }
+log        = { workspace = true }
+thiserror  = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ff-pipeline/src/error.rs
+++ b/crates/ff-pipeline/src/error.rs
@@ -1,0 +1,59 @@
+//! Error types for pipeline operations.
+//!
+//! This module provides [`PipelineError`], which covers all failure modes that
+//! can arise when building or running a [`Pipeline`](crate::Pipeline).
+
+/// Errors that can occur while building or running a pipeline.
+///
+/// # Error Categories
+///
+/// - **Downstream errors**: [`Decode`](Self::Decode), [`Filter`](Self::Filter),
+///   [`Encode`](Self::Encode) — propagated from the underlying crates via `#[from]`
+/// - **Configuration errors**: [`NoInput`](Self::NoInput), [`NoOutput`](Self::NoOutput)
+///   — returned by [`PipelineBuilder::build`](crate::PipelineBuilder::build)
+/// - **Runtime control**: [`Cancelled`](Self::Cancelled) — returned by
+///   [`Pipeline::run`](crate::Pipeline::run) when the progress callback returns `false`
+#[derive(Debug, thiserror::Error)]
+pub enum PipelineError {
+    /// A decoding step failed.
+    ///
+    /// Wraps [`ff_decode::DecodeError`] and is produced automatically via `#[from]`
+    /// when a decode operation inside the pipeline returns an error.
+    #[error("decode failed: {0}")]
+    Decode(#[from] ff_decode::DecodeError),
+
+    /// A filter graph step failed.
+    ///
+    /// Wraps [`ff_filter::FilterError`] and is produced automatically via `#[from]`
+    /// when the filter graph inside the pipeline returns an error.
+    #[error("filter failed: {0}")]
+    Filter(#[from] ff_filter::FilterError),
+
+    /// An encoding step failed.
+    ///
+    /// Wraps [`ff_encode::EncodeError`] and is produced automatically via `#[from]`
+    /// when an encode operation inside the pipeline returns an error.
+    #[error("encode failed: {0}")]
+    Encode(#[from] ff_encode::EncodeError),
+
+    /// No input path was provided to the builder.
+    ///
+    /// At least one call to [`PipelineBuilder::input`](crate::PipelineBuilder::input)
+    /// is required before [`PipelineBuilder::build`](crate::PipelineBuilder::build).
+    #[error("no input specified")]
+    NoInput,
+
+    /// No output path and config were provided to the builder.
+    ///
+    /// A call to [`PipelineBuilder::output`](crate::PipelineBuilder::output) is
+    /// required before [`PipelineBuilder::build`](crate::PipelineBuilder::build).
+    #[error("no output specified")]
+    NoOutput,
+
+    /// The pipeline was cancelled by the progress callback.
+    ///
+    /// Returned by [`Pipeline::run`](crate::Pipeline::run) when the
+    /// [`ProgressCallback`](crate::ProgressCallback) returns `false`.
+    #[error("pipeline cancelled by caller")]
+    Cancelled,
+}

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -1,21 +1,56 @@
-//! Unified decode-filter-encode pipeline for the ff-* crate family.
+//! # ff-pipeline
 //!
-//! # Status
+//! Unified decode → filter → encode pipeline for the ff-* crate family.
 //!
-//! **This crate is not yet implemented.** It is a placeholder for future development.
+//! This crate wires together `ff-decode`, `ff-filter`, and `ff-encode` into a
+//! single high-level API. All `unsafe` `FFmpeg` internals remain encapsulated in
+//! the underlying crates; users of `ff-pipeline` never need to write `unsafe` code.
 //!
-//! # Design Principles
+//! ## Features
 //!
-//! All public APIs in this crate are **safe**. Users never need to write `unsafe` code.
-//! Unsafe `FFmpeg` internals are encapsulated within the underlying ff-decode, ff-filter,
-//! and ff-encode crates.
+//! - **Single-call transcode**: open → filter → encode in one `Pipeline::run()`
+//! - **Progress callbacks**: real-time frame-count and elapsed-time updates
+//! - **Cancellation**: returning `false` from the progress callback aborts the pipeline
+//! - **Multi-input concatenation**: pass multiple input paths to concatenate clips
 //!
-//! # Planned Features
+//! ## Usage
 //!
-//! - Unified `Pipeline` type connecting decode → filter → encode in a single call
-//! - Progress tracking via callback (`on_progress`)
-//! - Cancellation support
-//! - Multi-input concatenation
-//! - Parallel thumbnail generation via optional `rayon` feature
+//! ```ignore
+//! use ff_pipeline::{Pipeline, EncoderConfig};
+//! use ff_encode::{VideoCodec, AudioCodec, BitrateMode};
+//!
+//! let config = EncoderConfig {
+//!     video_codec:  VideoCodec::H264,
+//!     audio_codec:  AudioCodec::Aac,
+//!     bitrate_mode: BitrateMode::Cbr(4_000_000),
+//!     resolution:   Some((1280, 720)),
+//!     framerate:    Some(30.0),
+//!     hardware:     None,
+//! };
+//!
+//! Pipeline::builder()
+//!     .input("input.mp4")
+//!     .output("output.mp4", config)
+//!     .on_progress(|p| {
+//!         println!("frame={} elapsed={:?}", p.frames_processed, p.elapsed);
+//!         true // return false to cancel
+//!     })
+//!     .build()?
+//!     .run()?;
+//! ```
+//!
+//! ## Module Structure
+//!
+//! - [`error`] — [`PipelineError`]
+//! - [`pipeline`] — [`Pipeline`], [`PipelineBuilder`], [`EncoderConfig`]
+//! - [`progress`] — [`Progress`], [`ProgressCallback`]
 
-// This crate is a placeholder. No public API is available yet.
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod pipeline;
+pub mod progress;
+
+pub use error::PipelineError;
+pub use pipeline::{EncoderConfig, Pipeline, PipelineBuilder};
+pub use progress::{Progress, ProgressCallback};

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -1,0 +1,221 @@
+//! Pipeline builder and runner.
+//!
+//! This module provides:
+//!
+//! - [`EncoderConfig`] — codec and quality settings for the output file
+//! - [`PipelineBuilder`] — consuming builder that validates configuration
+//! - [`Pipeline`] — the configured pipeline, executed by calling [`run`](Pipeline::run)
+
+use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
+use ff_filter::{FilterGraph, HwAccel};
+
+use crate::error::PipelineError;
+use crate::progress::{Progress, ProgressCallback};
+
+/// Codec and quality configuration for the pipeline output.
+///
+/// Passed to [`PipelineBuilder::output`] alongside the output path.
+pub struct EncoderConfig {
+    /// Video codec to use for the output stream.
+    pub video_codec: VideoCodec,
+
+    /// Audio codec to use for the output stream.
+    pub audio_codec: AudioCodec,
+
+    /// Bitrate control mode (CBR, VBR, or CRF).
+    pub bitrate_mode: BitrateMode,
+
+    /// Output resolution as `(width, height)` in pixels.
+    ///
+    /// `None` preserves the source resolution.
+    pub resolution: Option<(u32, u32)>,
+
+    /// Output frame rate in frames per second.
+    ///
+    /// `None` preserves the source frame rate.
+    pub framerate: Option<f64>,
+
+    /// Hardware acceleration device to use during encoding.
+    ///
+    /// `None` uses software (CPU) encoding.
+    pub hardware: Option<HwAccel>,
+}
+
+/// A configured, ready-to-run transcode pipeline.
+///
+/// Construct via [`Pipeline::builder`] → [`PipelineBuilder::build`].
+/// Execute by calling [`run`](Self::run).
+pub struct Pipeline {
+    inputs: Vec<String>,
+    filter: Option<FilterGraph>,
+    output: Option<(String, EncoderConfig)>,
+    #[allow(dead_code)]
+    callback: Option<ProgressCallback>,
+}
+
+impl Pipeline {
+    /// Returns a new [`PipelineBuilder`].
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_pipeline::{Pipeline, EncoderConfig};
+    /// use ff_encode::{VideoCodec, AudioCodec, BitrateMode};
+    ///
+    /// let pipeline = Pipeline::builder()
+    ///     .input("input.mp4")
+    ///     .output("output.mp4", config)
+    ///     .build()?;
+    /// ```
+    #[must_use]
+    pub fn builder() -> PipelineBuilder {
+        PipelineBuilder::new()
+    }
+
+    /// Runs the pipeline to completion.
+    ///
+    /// Executes the decode → (optional) filter → encode loop, calling the
+    /// progress callback after each frame.  Returns
+    /// [`PipelineError::Cancelled`] if the callback returns `false`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PipelineError`] on decode, filter, encode, or cancellation failures.
+    pub fn run(self) -> Result<(), PipelineError> {
+        log::debug!(
+            "pipeline run called inputs={} has_filter={} has_output={}",
+            self.inputs.len(),
+            self.filter.is_some(),
+            self.output.is_some(),
+        );
+        // TODO(#55): implement decode → filter → encode loop
+        Err(PipelineError::Cancelled)
+    }
+}
+
+/// Consuming builder for [`Pipeline`].
+///
+/// Validation is performed only in [`build`](Self::build), not in setters.
+/// All setter methods take `self` by value and return `Self` for chaining.
+pub struct PipelineBuilder {
+    inputs: Vec<String>,
+    filter: Option<FilterGraph>,
+    output: Option<(String, EncoderConfig)>,
+    callback: Option<ProgressCallback>,
+}
+
+impl PipelineBuilder {
+    /// Creates an empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inputs: Vec::new(),
+            filter: None,
+            output: None,
+            callback: None,
+        }
+    }
+
+    /// Adds an input file path.
+    ///
+    /// Multiple calls append to the input list; clips are concatenated in order.
+    #[must_use]
+    pub fn input(mut self, path: &str) -> Self {
+        self.inputs.push(path.to_owned());
+        self
+    }
+
+    /// Sets the filter graph to apply between decode and encode.
+    ///
+    /// If not called, decoded frames are passed directly to the encoder.
+    #[must_use]
+    pub fn filter(mut self, graph: FilterGraph) -> Self {
+        self.filter = Some(graph);
+        self
+    }
+
+    /// Sets the output file path and encoder configuration.
+    #[must_use]
+    pub fn output(mut self, path: &str, config: EncoderConfig) -> Self {
+        self.output = Some((path.to_owned(), config));
+        self
+    }
+
+    /// Registers a progress callback.
+    ///
+    /// The closure is called after each frame is encoded.  Returning `false`
+    /// cancels the pipeline and causes [`Pipeline::run`] to return
+    /// [`PipelineError::Cancelled`].
+    #[must_use]
+    pub fn on_progress(mut self, cb: impl Fn(&Progress) -> bool + Send + 'static) -> Self {
+        self.callback = Some(Box::new(cb));
+        self
+    }
+
+    /// Validates the configuration and returns a [`Pipeline`].
+    ///
+    /// # Errors
+    ///
+    /// - [`PipelineError::NoInput`] — no input was added via [`input`](Self::input)
+    /// - [`PipelineError::NoOutput`] — [`output`](Self::output) was not called
+    pub fn build(self) -> Result<Pipeline, PipelineError> {
+        if self.inputs.is_empty() {
+            return Err(PipelineError::NoInput);
+        }
+        if self.output.is_none() {
+            return Err(PipelineError::NoOutput);
+        }
+        Ok(Pipeline {
+            inputs: self.inputs,
+            filter: self.filter,
+            output: self.output,
+            callback: self.callback,
+        })
+    }
+}
+
+impl Default for PipelineBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
+
+    fn dummy_config() -> EncoderConfig {
+        EncoderConfig {
+            video_codec: VideoCodec::H264,
+            audio_codec: AudioCodec::Aac,
+            bitrate_mode: BitrateMode::Cbr(4_000_000),
+            resolution: None,
+            framerate: None,
+            hardware: None,
+        }
+    }
+
+    #[test]
+    fn build_should_return_error_when_no_input() {
+        let result = Pipeline::builder()
+            .output("/tmp/out.mp4", dummy_config())
+            .build();
+        assert!(matches!(result, Err(PipelineError::NoInput)));
+    }
+
+    #[test]
+    fn build_should_return_error_when_no_output() {
+        let result = Pipeline::builder().input("/tmp/in.mp4").build();
+        assert!(matches!(result, Err(PipelineError::NoOutput)));
+    }
+
+    #[test]
+    fn build_should_succeed_with_valid_input_and_output() {
+        let pipeline = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .output("/tmp/out.mp4", dummy_config())
+            .build();
+        assert!(pipeline.is_ok());
+    }
+}

--- a/crates/ff-pipeline/src/progress.rs
+++ b/crates/ff-pipeline/src/progress.rs
@@ -1,0 +1,92 @@
+//! Pipeline progress tracking.
+//!
+//! This module provides [`Progress`], which is passed to the
+//! [`ProgressCallback`] on every processed frame, and the
+//! [`ProgressCallback`] type alias itself.
+
+/// Progress information delivered to the caller on each processed frame.
+///
+/// An instance of this struct is passed by reference to the
+/// [`ProgressCallback`] registered via
+/// [`PipelineBuilder::on_progress`](crate::PipelineBuilder::on_progress).
+/// The callback returns `true` to continue or `false` to cancel the pipeline.
+#[derive(Debug, Clone)]
+pub struct Progress {
+    /// Number of frames processed so far.
+    pub frames_processed: u64,
+
+    /// Total number of frames in the source, or `None` if the container
+    /// does not report a frame count.
+    pub total_frames: Option<u64>,
+
+    /// Wall-clock time elapsed since [`Pipeline::run`](crate::Pipeline::run) was called.
+    pub elapsed: std::time::Duration,
+}
+
+impl Progress {
+    /// Returns the completion percentage in the range `0.0..=100.0`, or `None`
+    /// when [`total_frames`](Self::total_frames) is unknown.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_pipeline::Progress;
+    /// use std::time::Duration;
+    ///
+    /// let p = Progress { frames_processed: 25, total_frames: Some(100), elapsed: Duration::ZERO };
+    /// assert_eq!(p.percent(), Some(25.0));
+    ///
+    /// let p = Progress { frames_processed: 5, total_frames: None, elapsed: Duration::ZERO };
+    /// assert_eq!(p.percent(), None);
+    /// ```
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn percent(&self) -> Option<f64> {
+        self.total_frames
+            .map(|total| (self.frames_processed as f64 / total as f64) * 100.0)
+    }
+}
+
+/// Callback invoked on every processed frame to report progress.
+///
+/// The closure receives a [`Progress`] reference and must return `true` to
+/// continue processing or `false` to request cancellation.  When `false` is
+/// returned, [`Pipeline::run`](crate::Pipeline::run) stops at the next frame
+/// boundary and returns [`PipelineError::Cancelled`](crate::PipelineError::Cancelled).
+pub type ProgressCallback = Box<dyn Fn(&Progress) -> bool + Send>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn percent_should_return_none_when_total_frames_unknown() {
+        let p = Progress {
+            frames_processed: 10,
+            total_frames: None,
+            elapsed: Duration::from_secs(1),
+        };
+        assert_eq!(p.percent(), None);
+    }
+
+    #[test]
+    fn percent_should_return_correct_value_when_total_known() {
+        let p = Progress {
+            frames_processed: 50,
+            total_frames: Some(200),
+            elapsed: Duration::from_secs(1),
+        };
+        assert!((p.percent().unwrap() - 25.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn percent_should_return_100_when_complete() {
+        let p = Progress {
+            frames_processed: 100,
+            total_frames: Some(100),
+            elapsed: Duration::from_secs(5),
+        };
+        assert!((p.percent().unwrap() - 100.0).abs() < f64::EPSILON);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the ff-pipeline crate scaffold defined in `docs/crates/ff-pipeline/design.md` (issue #54). The crate wires together `ff-decode`, `ff-filter`, and `ff-encode` under a single high-level `Pipeline` API with progress tracking and cancellation support. `Pipeline::run()` is left as a stub with a `TODO(#55)` comment; full decode → filter → encode implementation is out of scope for this issue.

## Changes

- **`Cargo.toml`**: add `ff-decode`, `ff-filter`, `ff-encode`, and `log` dependencies
- **`error.rs`**: `PipelineError` with six variants — `Decode`, `Filter`, `Encode` (each `#[from]` the corresponding downstream error), `NoInput`, `NoOutput`, `Cancelled`
- **`progress.rs`**: `Progress` struct (`frames_processed`, `total_frames`, `elapsed`, `percent()`) and `ProgressCallback` type alias; 3 unit tests
- **`pipeline.rs`**: `EncoderConfig`, `PipelineBuilder` (consuming builder, validation only in `build()`), and `Pipeline` with stub `run()`; 3 unit tests
- **`lib.rs`**: module declarations, public re-exports, crate-level doc with Features/Usage/Module Structure sections, and `#![warn(missing_docs)]`

## Related Issues

Closes #54

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes