### PR TITLE
feat(ff-pipeline): implement Pipeline::run() for single-input transcode

### DIFF
--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -6,7 +6,10 @@
 //! - [`PipelineBuilder`] — consuming builder that validates configuration
 //! - [`Pipeline`] — the configured pipeline, executed by calling [`run`](Pipeline::run)
 
-use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
+use std::time::Instant;
+
+use ff_decode::{AudioDecoder, VideoDecoder};
+use ff_encode::{AudioCodec, BitrateMode, HardwareEncoder, VideoCodec, VideoEncoder};
 use ff_filter::{FilterGraph, HwAccel};
 
 use crate::error::PipelineError;
@@ -49,7 +52,6 @@ pub struct Pipeline {
     inputs: Vec<String>,
     filter: Option<FilterGraph>,
     output: Option<(String, EncoderConfig)>,
-    #[allow(dead_code)]
     callback: Option<ProgressCallback>,
 }
 
@@ -82,14 +84,125 @@ impl Pipeline {
     ///
     /// Returns [`PipelineError`] on decode, filter, encode, or cancellation failures.
     pub fn run(self) -> Result<(), PipelineError> {
-        log::debug!(
-            "pipeline run called inputs={} has_filter={} has_output={}",
-            self.inputs.len(),
-            self.filter.is_some(),
-            self.output.is_some(),
+        // Invariants guaranteed by build(): inputs is non-empty, output is Some.
+        let input = &self.inputs[0];
+        let (out_path, enc_config) = self.output.ok_or(PipelineError::NoOutput)?;
+        let mut filter = self.filter;
+
+        // Open video decoder and read source properties.
+        let mut vdec = VideoDecoder::open(input).build()?;
+        let total_frames = vdec.stream_info().frame_count();
+        let (out_width, out_height) = enc_config
+            .resolution
+            .unwrap_or_else(|| (vdec.width(), vdec.height()));
+        let fps = enc_config.framerate.unwrap_or_else(|| vdec.frame_rate());
+
+        log::info!(
+            "pipeline starting input={input} output={out_path} \
+             width={out_width} height={out_height} fps={fps} total_frames={total_frames:?}"
         );
-        // TODO(#55): implement decode → filter → encode loop
-        Err(PipelineError::Cancelled)
+
+        // Try to open an audio decoder; silently skip if the stream is absent.
+        let mut adec_opt: Option<AudioDecoder> = match AudioDecoder::open(input).build() {
+            Ok(adec) => Some(adec),
+            Err(e) => {
+                log::warn!("audio stream unavailable, encoding video only path={input} reason={e}");
+                None
+            }
+        };
+
+        // Build video encoder, adding audio track only when a decoder was opened.
+        let hw = hwaccel_to_hardware_encoder(enc_config.hardware);
+        let mut enc_builder = VideoEncoder::create(&out_path)
+            .video(out_width, out_height, fps)
+            .video_codec(enc_config.video_codec)
+            .bitrate_mode(enc_config.bitrate_mode)
+            .hardware_encoder(hw);
+
+        if let Some(ref adec) = adec_opt {
+            enc_builder = enc_builder
+                .audio(
+                    adec.stream_info().sample_rate(),
+                    adec.stream_info().channels(),
+                )
+                .audio_codec(enc_config.audio_codec);
+        }
+
+        let mut encoder = enc_builder.build()?;
+        log::debug!(
+            "encoder opened codec={} hardware={hw:?}",
+            encoder.actual_video_codec()
+        );
+
+        let start = Instant::now();
+        let mut frames_processed: u64 = 0;
+        let mut cancelled = false;
+
+        // Video decode → optional filter → encode loop.
+        loop {
+            let Some(raw_frame) = vdec.decode_one()? else {
+                break;
+            };
+
+            let frame = if let Some(ref mut fg) = filter {
+                fg.push_video(0, &raw_frame)?;
+                match fg.pull_video()? {
+                    Some(f) => f,
+                    None => continue, // filter is buffering; feed more input
+                }
+            } else {
+                raw_frame
+            };
+
+            encoder.push_video(&frame)?;
+            frames_processed += 1;
+
+            if let Some(ref cb) = self.callback {
+                let progress = Progress {
+                    frames_processed,
+                    total_frames,
+                    elapsed: start.elapsed(),
+                };
+                if !cb(&progress) {
+                    log::info!(
+                        "pipeline cancelled by callback frames_processed={frames_processed}"
+                    );
+                    cancelled = true;
+                    break;
+                }
+            }
+        }
+
+        // Audio pass-through: decode and encode all audio frames.
+        if !cancelled && let Some(ref mut adec) = adec_opt {
+            while let Some(aframe) = adec.decode_one()? {
+                encoder.push_audio(&aframe)?;
+            }
+        }
+
+        // Flush encoder and write trailer regardless of cancellation.
+        encoder.finish()?;
+
+        let elapsed = start.elapsed();
+        log::info!("pipeline finished frames_processed={frames_processed} elapsed={elapsed:?}");
+
+        if cancelled {
+            return Err(PipelineError::Cancelled);
+        }
+        Ok(())
+    }
+}
+
+/// Converts a filter-graph hardware backend into an encoder hardware backend.
+///
+/// `HwAccel` (ff-filter) and `HardwareEncoder` (ff-encode) are separate types
+/// to avoid a cross-crate dependency.  This function maps between them.
+fn hwaccel_to_hardware_encoder(hw: Option<HwAccel>) -> HardwareEncoder {
+    match hw {
+        None => HardwareEncoder::None,
+        Some(HwAccel::Cuda) => HardwareEncoder::Nvenc,
+        Some(HwAccel::VideoToolbox) => HardwareEncoder::VideoToolbox,
+        Some(HwAccel::Vaapi) => HardwareEncoder::Vaapi,
     }
 }
 

--- a/crates/ff-pipeline/tests/fixtures/mod.rs
+++ b/crates/ff-pipeline/tests/fixtures/mod.rs
@@ -1,0 +1,56 @@
+//! Test fixtures and helpers for ff-pipeline integration tests.
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+/// Returns the path to the shared test assets directory.
+pub fn assets_dir() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(format!("{}/../../assets", manifest_dir))
+}
+
+/// Returns the path to the test video file (contains both video and audio).
+pub fn test_video_path() -> PathBuf {
+    assets_dir().join("video/gameplay.mp4")
+}
+
+/// Returns the directory used for test output files.
+pub fn test_output_dir() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(format!("{}/target/test-output", manifest_dir))
+}
+
+/// Creates a path inside the test output directory.
+///
+/// The directory is created automatically if it does not exist.
+pub fn test_output_path(filename: &str) -> PathBuf {
+    let dir = test_output_dir();
+    std::fs::create_dir_all(&dir).ok();
+    dir.join(filename)
+}
+
+/// RAII guard that deletes a file when dropped.
+///
+/// Ensures test output files are cleaned up even when tests panic.
+pub struct FileGuard {
+    path: PathBuf,
+}
+
+impl FileGuard {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+
+impl Drop for FileGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}

--- a/crates/ff-pipeline/tests/pipeline_run_tests.rs
+++ b/crates/ff-pipeline/tests/pipeline_run_tests.rs
@@ -1,0 +1,192 @@
+//! Integration tests for `Pipeline::run()`.
+//!
+//! These tests call the real FFmpeg API and are skipped gracefully when the
+//! required codecs or decoders are unavailable.
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use std::sync::{Arc, Mutex};
+
+use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
+use ff_filter::FilterGraph;
+use ff_pipeline::{EncoderConfig, Pipeline, PipelineError};
+use fixtures::{FileGuard, test_output_path, test_video_path};
+
+fn basic_config() -> EncoderConfig {
+    EncoderConfig {
+        video_codec: VideoCodec::Mpeg4,
+        audio_codec: AudioCodec::Aac,
+        bitrate_mode: BitrateMode::Cbr(1_000_000),
+        resolution: Some((320, 240)),
+        framerate: Some(24.0),
+        hardware: None,
+    }
+}
+
+#[test]
+fn transcode_single_input_should_produce_valid_output_file() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let output = test_output_path("pipeline_run_basic.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let pipeline = match Pipeline::builder()
+        .input(input.to_str().unwrap())
+        .output(output.to_str().unwrap(), basic_config())
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Ok(()) => {
+            assert!(output.exists(), "output file must exist after run");
+            assert!(
+                std::fs::metadata(&output).unwrap().len() > 0,
+                "output file must be non-empty"
+            );
+        }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn transcode_cancelled_by_callback_should_return_cancelled() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let output = test_output_path("pipeline_run_cancel.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let pipeline = match Pipeline::builder()
+        .input(input.to_str().unwrap())
+        .output(output.to_str().unwrap(), basic_config())
+        .on_progress(|_p| false) // cancel on first frame
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Err(PipelineError::Cancelled) => { /* expected */ }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Ok(()) => panic!("expected Cancelled but got Ok"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn transcode_progress_callback_should_receive_increasing_frame_counts() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let output = test_output_path("pipeline_run_progress.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let counts: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+    let counts_clone = Arc::clone(&counts);
+
+    let pipeline = match Pipeline::builder()
+        .input(input.to_str().unwrap())
+        .output(output.to_str().unwrap(), basic_config())
+        .on_progress(move |p| {
+            counts_clone.lock().unwrap().push(p.frames_processed);
+            true
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Ok(()) => {
+            let c = counts.lock().unwrap();
+            assert!(
+                !c.is_empty(),
+                "progress callback must be called at least once"
+            );
+            for w in c.windows(2) {
+                assert!(w[1] > w[0], "frame count must increase monotonically");
+            }
+        }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn transcode_with_scale_filter_should_produce_valid_output() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let output = test_output_path("pipeline_run_filter.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let filter = match FilterGraph::builder().scale(160, 120).build() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: filter build failed: {e}");
+            return;
+        }
+    };
+
+    // Resolution matches filter output; no override needed.
+    let config = EncoderConfig {
+        video_codec: VideoCodec::Mpeg4,
+        audio_codec: AudioCodec::Aac,
+        bitrate_mode: BitrateMode::Cbr(500_000),
+        resolution: Some((160, 120)),
+        framerate: Some(24.0),
+        hardware: None,
+    };
+
+    let pipeline = match Pipeline::builder()
+        .input(input.to_str().unwrap())
+        .filter(filter)
+        .output(output.to_str().unwrap(), config)
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Ok(()) => {
+            assert!(output.exists(), "output file must exist after run");
+        }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(PipelineError::Filter(e)) => println!("Skipping: filter unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements `Pipeline::run()` for the single-input transcode case, replacing the TODO stub with a full decode → (optional filter) → encode loop. Video frames are decoded one at a time, passed through the `FilterGraph` if one is attached, then pushed to `VideoEncoder`. A second sequential pass handles audio. The progress callback is called after each video frame and cancellation is supported.

## Changes

- `pipeline.rs`: full `run()` implementation — video decode loop, filter branch, progress/cancel logic, sequential audio pass, encoder flush
- `pipeline.rs`: added `hwaccel_to_hardware_encoder()` to convert `ff_filter::HwAccel` → `ff_encode::HardwareEncoder`
- `pipeline.rs`: removed `#[allow(dead_code)]` from the `callback` field (now consumed in `run()`)
- `tests/fixtures/mod.rs`: new test helper module (`assets_dir`, `test_video_path`, `test_output_path`, `FileGuard`)
- `tests/pipeline_run_tests.rs`: 4 integration tests — basic transcode, callback cancellation, monotonically increasing frame counts, transcode with scale filter

## Related Issues

Closes #58

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes