### PR TITLE
feat(ff-pipeline): route audio frames through filter graph

### DIFF
--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -234,6 +234,16 @@ impl Pipeline {
                                 new_pts_secs,
                                 ts.time_base(),
                             ));
+
+                            let aframe = if let Some(ref mut fg) = filter {
+                                fg.push_audio(0, &aframe)?;
+                                match fg.pull_audio()? {
+                                    Some(f) => f,
+                                    None => continue,
+                                }
+                            } else {
+                                aframe
+                            };
                             encoder.push_audio(&aframe)?;
                         }
                         audio_offset_secs = last_audio_end_secs;


### PR DESCRIPTION
## Summary

Routes audio frames through the attached `FilterGraph` in `Pipeline::run()` when one is present, using `push_audio` / `pull_audio` — matching the existing video filter routing pattern. Without this, audio frames bypassed any audio filters and went directly to the encoder.

## Changes

- In the audio pass of `Pipeline::run()`, wrap each decoded audio frame through `FilterGraph::push_audio(0, &aframe)` / `pull_audio()` when a filter graph is attached; continue buffering if `pull_audio` returns `None`
- No-audio-stream graceful handling is unchanged

## Related Issues

Closes #60

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes