### PR TITLE
feat(ff-pipeline): add parallel thumbnail extraction via rayon feature

### DIFF
--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["multimedia::video", "multimedia::audio"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+parallel = ["dep:rayon"]
+
 [dependencies]
 ff-common  = { workspace = true }
 ff-format  = { workspace = true }
@@ -21,6 +24,7 @@ ff-filter  = { workspace = true }
 ff-encode  = { workspace = true }
 log        = { workspace = true }
 thiserror  = { workspace = true }
+rayon      = { version = "1.11.0", optional = true }
 
 [lints]
 workspace = true

--- a/crates/ff-pipeline/src/thumbnail.rs
+++ b/crates/ff-pipeline/src/thumbnail.rs
@@ -50,6 +50,11 @@ impl ThumbnailPipeline {
     /// Timestamps are processed in ascending order. If `timestamps` is empty,
     /// the file is never opened and `Ok(vec![])` is returned immediately.
     ///
+    /// When the `parallel` feature is enabled, each timestamp is decoded in its
+    /// own thread via `rayon`. Each thread opens an independent [`VideoDecoder`];
+    /// no decoder context is shared. The output order matches the ascending
+    /// timestamp order regardless of which thread finishes first.
+    ///
     /// # Errors
     ///
     /// Propagates [`PipelineError::Decode`] for any decoding or seek failure.
@@ -60,17 +65,43 @@ impl ThumbnailPipeline {
 
         self.timestamps.sort_by(f64::total_cmp);
 
-        let mut decoder = VideoDecoder::open(&self.path).build()?;
-        log::info!("thumbnail pipeline opened file path={}", self.path);
+        #[cfg(feature = "parallel")]
+        {
+            use rayon::prelude::*;
 
-        let mut frames = Vec::with_capacity(self.timestamps.len());
-        for ts in &self.timestamps {
-            decoder.seek(Duration::from_secs_f64(*ts), SeekMode::Keyframe)?;
-            let frame = decoder.decode_one()?.ok_or(DecodeError::EndOfStream)?;
-            frames.push(frame);
+            log::info!(
+                "thumbnail pipeline starting parallel extraction path={} count={}",
+                self.path,
+                self.timestamps.len()
+            );
+
+            // par_iter on a slice is an IndexedParallelIterator: collect() preserves
+            // the original index order, so the output is already timestamp-sorted.
+            self.timestamps
+                .par_iter()
+                .map(|ts| {
+                    let mut decoder = VideoDecoder::open(&self.path).build()?;
+                    decoder.seek(Duration::from_secs_f64(*ts), SeekMode::Keyframe)?;
+                    let frame = decoder.decode_one()?.ok_or(DecodeError::EndOfStream)?;
+                    Ok(frame)
+                })
+                .collect()
         }
 
-        Ok(frames)
+        #[cfg(not(feature = "parallel"))]
+        {
+            let mut decoder = VideoDecoder::open(&self.path).build()?;
+            log::info!("thumbnail pipeline opened file path={}", self.path);
+
+            let mut frames = Vec::with_capacity(self.timestamps.len());
+            for ts in &self.timestamps {
+                decoder.seek(Duration::from_secs_f64(*ts), SeekMode::Keyframe)?;
+                let frame = decoder.decode_one()?.ok_or(DecodeError::EndOfStream)?;
+                frames.push(frame);
+            }
+
+            Ok(frames)
+        }
     }
 }
 
@@ -92,6 +123,29 @@ mod tests {
 
     #[test]
     fn run_with_no_timestamps_should_return_empty_vec() {
+        let result = ThumbnailPipeline::new("nonexistent.mp4").run();
+        assert!(matches!(result, Ok(ref v) if v.is_empty()));
+    }
+
+    #[test]
+    fn timestamps_should_sort_ascending_before_run() {
+        let mut ts = vec![3.0_f64, 1.0, 2.0];
+        ts.sort_by(f64::total_cmp);
+        assert_eq!(ts, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn timestamps_nan_should_sort_after_finite_values() {
+        let mut ts = vec![2.0_f64, f64::NAN, 1.0];
+        ts.sort_by(f64::total_cmp);
+        assert_eq!(ts[0], 1.0);
+        assert_eq!(ts[1], 2.0);
+        assert!(ts[2].is_nan());
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn parallel_run_with_no_timestamps_should_return_empty_vec() {
         let result = ThumbnailPipeline::new("nonexistent.mp4").run();
         assert!(matches!(result, Ok(ref v) if v.is_empty()));
     }

--- a/crates/ff-pipeline/tests/thumbnail_pipeline_tests.rs
+++ b/crates/ff-pipeline/tests/thumbnail_pipeline_tests.rs
@@ -56,3 +56,76 @@ fn thumbnail_with_no_timestamps_should_return_empty_vec() {
         "expected Ok([]) for empty timestamps"
     );
 }
+
+#[cfg(feature = "parallel")]
+#[test]
+fn parallel_thumbnail_at_valid_timestamp_should_return_single_frame() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+
+    let result = ThumbnailPipeline::new(input.to_str().unwrap())
+        .timestamps(vec![0.0])
+        .run();
+
+    match result {
+        Ok(frames) => assert_eq!(frames.len(), 1, "expected exactly one frame"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn parallel_thumbnails_should_return_one_frame_per_timestamp() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+
+    let timestamps = vec![2.0, 0.0, 1.0]; // intentionally unsorted
+    let expected = timestamps.len();
+
+    let result = ThumbnailPipeline::new(input.to_str().unwrap())
+        .timestamps(timestamps)
+        .run();
+
+    match result {
+        Ok(frames) => assert_eq!(frames.len(), expected, "expected one frame per timestamp"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn parallel_thumbnails_unsorted_input_should_return_frames_in_ascending_order() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+
+    let result = ThumbnailPipeline::new(input.to_str().unwrap())
+        .timestamps(vec![2.0, 0.0, 1.0]) // intentionally unsorted
+        .run();
+
+    match result {
+        Ok(frames) => {
+            assert_eq!(frames.len(), 3, "expected three frames");
+            let timestamps: Vec<_> = frames.iter().map(|f| f.timestamp()).collect();
+            for w in timestamps.windows(2) {
+                assert!(
+                    w[0] <= w[1],
+                    "frames must be in non-decreasing timestamp order, got {:?}",
+                    timestamps
+                );
+            }
+        }
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `parallel` Cargo feature to `ff-pipeline`. When the feature is enabled, `ThumbnailPipeline::run()` dispatches each timestamp concurrently using `rayon::par_iter`, with each thread opening an independent `VideoDecoder`. Timestamps are sorted ascending before dispatch; `rayon`'s `IndexedParallelIterator` guarantees `collect()` preserves that order, so no secondary sort is required.

## Changes

- `crates/ff-pipeline/Cargo.toml` — added `[features] parallel = ["dep:rayon"]` and `rayon = { version = "1", optional = true }`
- `crates/ff-pipeline/src/thumbnail.rs` — `run()` split into `#[cfg(feature = "parallel")]` and `#[cfg(not(feature = "parallel"))]` branches; added 3 unit tests (ascending sort, NaN placement, parallel empty-timestamps short-circuit)
- `crates/ff-pipeline/tests/thumbnail_pipeline_tests.rs` — added 3 `#[cfg(feature = "parallel")]` integration tests: single frame, frame count per timestamp, and ascending PTS order assertion on unsorted input

## Related Issues

Closes #63

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes