### PR TITLE
test(ff-pipeline): verify nonzero duration and progress callback on transcode

### DIFF
--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -26,5 +26,8 @@ log        = { workspace = true }
 thiserror  = { workspace = true }
 rayon      = { version = "1.11.0", optional = true }
 
+[dev-dependencies]
+ff-probe = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/ff-pipeline/src/thumbnail.rs
+++ b/crates/ff-pipeline/src/thumbnail.rs
@@ -129,14 +129,15 @@ mod tests {
 
     #[test]
     fn timestamps_should_sort_ascending_before_run() {
-        let mut ts = vec![3.0_f64, 1.0, 2.0];
+        let mut ts = [3.0_f64, 1.0, 2.0];
         ts.sort_by(f64::total_cmp);
-        assert_eq!(ts, vec![1.0, 2.0, 3.0]);
+        assert_eq!(ts, [1.0, 2.0, 3.0]);
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn timestamps_nan_should_sort_after_finite_values() {
-        let mut ts = vec![2.0_f64, f64::NAN, 1.0];
+        let mut ts = [2.0_f64, f64::NAN, 1.0];
         ts.sort_by(f64::total_cmp);
         assert_eq!(ts[0], 1.0);
         assert_eq!(ts[1], 2.0);

--- a/crates/ff-pipeline/tests/pipeline_run_tests.rs
+++ b/crates/ff-pipeline/tests/pipeline_run_tests.rs
@@ -7,6 +7,7 @@
 
 mod fixtures;
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
@@ -281,6 +282,63 @@ fn transcode_two_inputs_should_produce_larger_output_than_single_input() {
             println!("Skipping: decoder unavailable: {e}");
         }
         (Err(e), _) | (_, Err(e)) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn transcode_single_input_should_produce_nonzero_duration_and_call_progress() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let output = test_output_path("pipeline_duration_progress.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let call_count = Arc::new(AtomicU64::new(0));
+    let call_count_clone = Arc::clone(&call_count);
+
+    let pipeline = match Pipeline::builder()
+        .input(input.to_str().unwrap())
+        .output(output.to_str().unwrap(), basic_config())
+        .on_progress(move |_p| {
+            call_count_clone.fetch_add(1, Ordering::Relaxed);
+            true
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Ok(()) => {
+            assert!(output.exists(), "output file must exist after run");
+
+            let info = match ff_probe::open(&output) {
+                Ok(i) => i,
+                Err(e) => {
+                    println!("Skipping duration check: probe failed: {e}");
+                    return;
+                }
+            };
+            assert!(
+                info.duration() > std::time::Duration::ZERO,
+                "output must have non-zero duration, got {:?}",
+                info.duration()
+            );
+
+            assert!(
+                call_count.load(Ordering::Relaxed) >= 1,
+                "progress callback must be called at least once"
+            );
+        }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an integration test that covers three requirements in a single run: transcode a short video through `Pipeline`, probe the output with `ff-probe` to assert a non-zero container duration, and confirm the progress callback was invoked at least once. Also adds `ff-probe` as a dev-dependency so test binaries can probe output files.

## Changes

- `crates/ff-pipeline/Cargo.toml` — added `[dev-dependencies]` with `ff-probe = { workspace = true }`
- `crates/ff-pipeline/tests/pipeline_run_tests.rs` — added `transcode_single_input_should_produce_nonzero_duration_and_call_progress`; uses an `AtomicU64` counter in the progress callback and probes the output with `ff_probe::open` after `run()` succeeds
- `crates/ff-pipeline/src/thumbnail.rs` — fixed two clippy lints in unit tests added in #63: `useless_vec` (use arrays instead) and `float_cmp` (`#[allow]` on the NaN-sort test)

## Related Issues

Closes #64

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes