### PR TITLE
test(ff-pipeline): integration tests for concat duration, cancellation, and thumbnails

### DIFF
--- a/crates/ff-pipeline/tests/pipeline_run_tests.rs
+++ b/crates/ff-pipeline/tests/pipeline_run_tests.rs
@@ -412,3 +412,115 @@ fn transcode_multi_input_frames_processed_should_be_sum_of_single_runs() {
         "two-input pipeline must process exactly 2× the frames of a single-input run"
     );
 }
+
+#[test]
+fn transcode_cancelled_after_first_callback_should_return_cancelled() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let output = test_output_path("pipeline_cancel_after_first.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let call_count = Arc::new(AtomicU64::new(0));
+    let call_count_clone = Arc::clone(&call_count);
+
+    let pipeline = match Pipeline::builder()
+        .input(input.to_str().unwrap())
+        .output(output.to_str().unwrap(), basic_config())
+        .on_progress(move |_p| {
+            // Allow the first call (return true), cancel on the second.
+            call_count_clone.fetch_add(1, Ordering::Relaxed) == 0
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Err(PipelineError::Cancelled) => {
+            assert!(
+                call_count.load(Ordering::Relaxed) >= 2,
+                "callback must have been invoked at least twice before cancellation"
+            );
+        }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Ok(()) => panic!("expected Cancelled but got Ok"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn concat_two_inputs_should_produce_output_with_approx_sum_duration() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let input_str = input.to_str().unwrap();
+
+    // Probe the input to determine its duration.
+    let input_info = match ff_probe::open(&input) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping: failed to probe input: {e}");
+            return;
+        }
+    };
+    let input_duration = input_info.duration();
+    if input_duration == std::time::Duration::ZERO {
+        println!("Skipping: input has zero duration");
+        return;
+    }
+
+    let output = test_output_path("pipeline_concat_duration.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let pipeline = match Pipeline::builder()
+        .input(input_str)
+        .input(input_str)
+        .output(output.to_str().unwrap(), basic_config())
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Ok(()) => {
+            let output_info = match ff_probe::open(&output) {
+                Ok(i) => i,
+                Err(e) => {
+                    println!("Skipping duration check: probe failed: {e}");
+                    return;
+                }
+            };
+            let output_duration = output_info.duration();
+            let expected = input_duration * 2;
+            // Allow ±20% to account for encoding/muxing overhead.
+            let tolerance = input_duration.mul_f64(0.4);
+            assert!(
+                output_duration >= expected.saturating_sub(tolerance),
+                "output duration {output_duration:?} shorter than expected \
+                 ~{expected:?} (tolerance ±{tolerance:?})"
+            );
+            assert!(
+                output_duration <= expected + tolerance,
+                "output duration {output_duration:?} longer than expected \
+                 ~{expected:?} (tolerance ±{tolerance:?})"
+            );
+        }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}

--- a/crates/ff-pipeline/tests/thumbnail_pipeline_tests.rs
+++ b/crates/ff-pipeline/tests/thumbnail_pipeline_tests.rs
@@ -10,6 +10,51 @@ mod fixtures;
 use ff_pipeline::{PipelineError, ThumbnailPipeline};
 use fixtures::test_video_path;
 
+/// Extracts 3 frames and verifies count + dimensions match the source video.
+/// Shared by the sequential and parallel variants of the dimension test.
+fn assert_thumbnails_have_expected_dimensions(path: &str) {
+    let source_info = match ff_probe::open(path) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping dimension check: probe failed: {e}");
+            return;
+        }
+    };
+    let (expected_w, expected_h) = match source_info.primary_video() {
+        Some(v) => (v.width(), v.height()),
+        None => {
+            println!("Skipping dimension check: no video stream found");
+            return;
+        }
+    };
+
+    let result = ThumbnailPipeline::new(path)
+        .timestamps(vec![0.0, 1.0, 2.0])
+        .run();
+
+    match result {
+        Ok(frames) => {
+            assert_eq!(frames.len(), 3, "expected 3 frames");
+            for (i, frame) in frames.iter().enumerate() {
+                assert_eq!(
+                    frame.width(),
+                    expected_w,
+                    "frame {i} width mismatch: got {} expected {expected_w}",
+                    frame.width()
+                );
+                assert_eq!(
+                    frame.height(),
+                    expected_h,
+                    "frame {i} height mismatch: got {} expected {expected_h}",
+                    frame.height()
+                );
+            }
+        }
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
 #[test]
 fn thumbnail_at_valid_timestamp_should_return_single_frame() {
     let input = test_video_path();
@@ -98,6 +143,27 @@ fn parallel_thumbnails_should_return_one_frame_per_timestamp() {
         Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
         Err(e) => panic!("unexpected error: {e}"),
     }
+}
+
+#[test]
+fn thumbnails_at_three_timestamps_should_have_source_dimensions() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    assert_thumbnails_have_expected_dimensions(input.to_str().unwrap());
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn parallel_thumbnails_at_three_timestamps_should_have_source_dimensions() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    assert_thumbnails_have_expected_dimensions(input.to_str().unwrap());
 }
 
 #[cfg(feature = "parallel")]


### PR DESCRIPTION
## Summary

Adds four integration tests across `pipeline_run_tests.rs` and `thumbnail_pipeline_tests.rs` to cover multi-input duration verification, cancellation after a successful first callback, and thumbnail frame dimension validation (sequential and parallel paths).

## Changes

- `crates/ff-pipeline/tests/pipeline_run_tests.rs`
  - `concat_two_inputs_should_produce_output_with_approx_sum_duration` — probes the input with `ff_probe`, runs a two-input pipeline, and asserts the output duration is within ±20% of `2 × input_duration`
  - `transcode_cancelled_after_first_callback_should_return_cancelled` — allows the first progress callback (returns `true`), cancels on the second (returns `false`), and asserts `PipelineError::Cancelled` with callback count ≥ 2

- `crates/ff-pipeline/tests/thumbnail_pipeline_tests.rs`
  - `assert_thumbnails_have_expected_dimensions` — shared helper that probes source dimensions and verifies all 3 extracted frames match
  - `thumbnails_at_three_timestamps_should_have_source_dimensions` — sequential path
  - `parallel_thumbnails_at_three_timestamps_should_have_source_dimensions` — rayon path via `#[cfg(feature = "parallel")]`

## Related Issues

Closes #65
Closes #66
Closes #67

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes