### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-03-16
+
+### Added
+
+#### ff-pipeline
+- `Pipeline::run()` for single-input transcode: decode → optional filter graph → encode with progress tracking ([#58](https://github.com/itsakeyfut/avio/issues/58))
+- Multi-input concatenation in `Pipeline::run()`: sequential inputs with PTS offset stitching ([#59](https://github.com/itsakeyfut/avio/issues/59))
+- Audio stream handling in `Pipeline::run()`: audio decoded and encoded in parallel with video; silently skipped when no audio stream is present ([#60](https://github.com/itsakeyfut/avio/issues/60))
+- Cancellation via `ProgressCallback`: returning `false` from the callback aborts the pipeline and returns `PipelineError::Cancelled` ([#61](https://github.com/itsakeyfut/avio/issues/61))
+- `ThumbnailPipeline`: extracts a `VideoFrame` at each caller-specified timestamp using `VideoDecoder::seek` + `decode_one` ([#62](https://github.com/itsakeyfut/avio/issues/62))
+- `parallel` Cargo feature for `ThumbnailPipeline`: when enabled, each timestamp is decoded in its own rayon thread; results are returned in ascending timestamp order ([#63](https://github.com/itsakeyfut/avio/issues/63))
+- Integration tests: single-input transcode verifying non-zero output duration and progress callback invocation ([#64](https://github.com/itsakeyfut/avio/issues/64))
+- Integration tests: multi-input concatenation verifying output duration ≈ sum of input durations ([#65](https://github.com/itsakeyfut/avio/issues/65))
+- Integration tests: cancellation after first progress callback ([#66](https://github.com/itsakeyfut/avio/issues/66))
+- Integration tests: `ThumbnailPipeline` frame count and dimension verification, sequential and parallel ([#67](https://github.com/itsakeyfut/avio/issues/67))
+
+---
+
 ## [0.3.0] - 2026-03-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.3.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.3.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.3.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.3.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.3.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.3.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.3.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.3.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.3.0" }
-avio        = { path = "crates/avio",        version = "0.3.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.4.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.4.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.4.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.4.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.4.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.4.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.4.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.4.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.4.0" }
+avio        = { path = "crates/avio",        version = "0.4.0" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.3.0 to 0.4.0 and documents all changes in CHANGELOG.md. This release delivers the complete ff-pipeline implementation including Pipeline::run(), ThumbnailPipeline, the parallel rayon feature, and a full integration test suite.

## Changes

- `Cargo.toml`: workspace version 0.3.0 → 0.4.0; all intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.4.0]` entry covering issues #58–#67

## Related Issues

Closes #54
Closes #55
Closes #56
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
Closes #67

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes