### PR TITLE
feat(ff-stream): implement crate scaffold with HLS, DASH, and ABR modules

### DIFF
--- a/crates/ff-stream/Cargo.toml
+++ b/crates/ff-stream/Cargo.toml
@@ -14,9 +14,13 @@ categories = ["multimedia::video", "multimedia::encoding"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ff-common = { workspace = true }
-ff-format = { workspace = true }
-thiserror = { workspace = true }
+ff-common   = { workspace = true }
+ff-format   = { workspace = true }
+ff-encode   = { workspace = true }
+ff-decode   = { workspace = true }
+ff-pipeline = { workspace = true }
+thiserror   = { workspace = true }
+log         = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ff-stream/src/abr.rs
+++ b/crates/ff-stream/src/abr.rs
@@ -1,0 +1,182 @@
+//! Adaptive bitrate (ABR) ladder for multi-rendition HLS / DASH output.
+//!
+//! This module provides [`AbrLadder`] and [`Rendition`]. An `AbrLadder` holds
+//! an ordered list of [`Rendition`]s (resolution + bitrate pairs) and produces
+//! multi-variant HLS or multi-representation DASH output from a single input
+//! file in one call.
+
+use crate::error::StreamError;
+
+/// A single resolution/bitrate rendition in an ABR ladder.
+///
+/// Each `Rendition` describes one quality level that the player can switch
+/// between based on available bandwidth.
+///
+/// # Examples
+///
+/// ```
+/// use ff_stream::Rendition;
+///
+/// let r = Rendition { width: 1280, height: 720, bitrate: 3_000_000 };
+/// assert_eq!(r.width, 1280);
+/// ```
+pub struct Rendition {
+    /// Output width in pixels.
+    pub width: u32,
+    /// Output height in pixels.
+    pub height: u32,
+    /// Target bitrate in bits per second.
+    pub bitrate: u64,
+}
+
+/// Produces multi-rendition HLS or DASH output from a single input.
+///
+/// `AbrLadder` accepts one or more [`Rendition`]s and encodes the input at
+/// each quality level, writing the results into a directory structure that a
+/// player can consume with a single master playlist or MPD manifest.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_stream::{AbrLadder, Rendition};
+///
+/// AbrLadder::new("source.mp4")
+///     .add_rendition(Rendition { width: 1920, height: 1080, bitrate: 6_000_000 })
+///     .add_rendition(Rendition { width: 1280, height:  720, bitrate: 3_000_000 })
+///     .hls("/var/www/hls")?;
+/// ```
+pub struct AbrLadder {
+    // Stored for use by the future `FFmpeg` muxing implementation.
+    #[allow(dead_code)]
+    input_path: String,
+    renditions: Vec<Rendition>,
+}
+
+impl AbrLadder {
+    /// Create a new ladder for the given input file.
+    ///
+    /// No renditions are added at construction time; use
+    /// [`add_rendition`](Self::add_rendition) to populate the ladder before
+    /// calling [`hls`](Self::hls) or [`dash`](Self::dash).
+    #[must_use]
+    pub fn new(input_path: &str) -> Self {
+        Self {
+            input_path: input_path.to_owned(),
+            renditions: Vec::new(),
+        }
+    }
+
+    /// Append a rendition to the ladder.
+    ///
+    /// Renditions are encoded in the order they are added. By convention,
+    /// list them from highest to lowest quality so that the master playlist
+    /// presents them in that order.
+    #[must_use]
+    pub fn add_rendition(mut self, r: Rendition) -> Self {
+        self.renditions.push(r);
+        self
+    }
+
+    /// Write a multi-variant HLS output to `output_dir`.
+    ///
+    /// Each rendition is written to a numbered sub-directory
+    /// (`output_dir/0/`, `output_dir/1/`, …) containing its own
+    /// `playlist.m3u8`. A master playlist at `output_dir/master.m3u8`
+    /// references all renditions.
+    ///
+    /// # Errors
+    ///
+    /// - [`StreamError::InvalidConfig`] with `"no renditions added"` when the
+    ///   ladder is empty.
+    /// - [`StreamError::InvalidConfig`] with `"not yet implemented"` until
+    ///   `FFmpeg` HLS muxing integration is complete.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_stream::{AbrLadder, Rendition};
+    ///
+    /// // Empty ladder → error
+    /// assert!(AbrLadder::new("src.mp4").hls("/tmp/hls").is_err());
+    /// ```
+    pub fn hls(self, _output_dir: &str) -> Result<(), StreamError> {
+        if self.renditions.is_empty() {
+            return Err(StreamError::InvalidConfig {
+                reason: "no renditions added".into(),
+            });
+        }
+        Err(StreamError::InvalidConfig {
+            reason: "not yet implemented".into(),
+        })
+    }
+
+    /// Write a multi-representation DASH output to `output_dir`.
+    ///
+    /// All renditions are muxed into a single DASH presentation. `FFmpeg`'s
+    /// DASH muxer generates the `manifest.mpd` and the per-representation
+    /// initialization and media segments automatically.
+    ///
+    /// # Errors
+    ///
+    /// - [`StreamError::InvalidConfig`] with `"no renditions added"` when the
+    ///   ladder is empty.
+    /// - [`StreamError::InvalidConfig`] with `"not yet implemented"` until
+    ///   `FFmpeg` DASH muxing integration is complete.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_stream::{AbrLadder, Rendition};
+    ///
+    /// // Empty ladder → error
+    /// assert!(AbrLadder::new("src.mp4").dash("/tmp/dash").is_err());
+    /// ```
+    pub fn dash(self, _output_dir: &str) -> Result<(), StreamError> {
+        if self.renditions.is_empty() {
+            return Err(StreamError::InvalidConfig {
+                reason: "no renditions added".into(),
+            });
+        }
+        Err(StreamError::InvalidConfig {
+            reason: "not yet implemented".into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_should_store_input_path() {
+        let ladder = AbrLadder::new("/src/video.mp4");
+        assert_eq!(ladder.input_path, "/src/video.mp4");
+    }
+
+    #[test]
+    fn add_rendition_should_store_rendition() {
+        let ladder = AbrLadder::new("/src/video.mp4").add_rendition(Rendition {
+            width: 1280,
+            height: 720,
+            bitrate: 3_000_000,
+        });
+        assert_eq!(ladder.renditions.len(), 1);
+        assert_eq!(ladder.renditions[0].width, 1280);
+    }
+
+    #[test]
+    fn hls_with_no_renditions_should_return_invalid_config() {
+        let result = AbrLadder::new("/src/video.mp4").hls("/tmp/hls");
+        assert!(
+            matches!(result, Err(StreamError::InvalidConfig { reason }) if reason == "no renditions added")
+        );
+    }
+
+    #[test]
+    fn dash_with_no_renditions_should_return_invalid_config() {
+        let result = AbrLadder::new("/src/video.mp4").dash("/tmp/dash");
+        assert!(
+            matches!(result, Err(StreamError::InvalidConfig { reason }) if reason == "no renditions added")
+        );
+    }
+}

--- a/crates/ff-stream/src/dash.rs
+++ b/crates/ff-stream/src/dash.rs
@@ -1,0 +1,147 @@
+//! DASH segmented output builder.
+//!
+//! This module exposes [`DashOutput`], a consuming builder that configures and
+//! writes a DASH segmented stream. Validation is deferred to
+//! [`DashOutput::build`] so setter calls are infallible.
+
+use std::time::Duration;
+
+use crate::error::StreamError;
+
+/// Builds and writes a DASH segmented output.
+///
+/// `DashOutput` follows the consuming-builder pattern: each setter takes `self`
+/// and returns a new `Self`, and the final [`build`](Self::build) call validates
+/// the configuration before returning a ready-to-write instance.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_stream::DashOutput;
+/// use std::time::Duration;
+///
+/// DashOutput::new("/var/www/dash")
+///     .input("source.mp4")
+///     .segment_duration(Duration::from_secs(4))
+///     .build()?
+///     .write()?;
+/// ```
+pub struct DashOutput {
+    output_dir: String,
+    input_path: Option<String>,
+    segment_duration: Duration,
+}
+
+impl DashOutput {
+    /// Create a new builder targeting `output_dir`.
+    ///
+    /// The directory does not need to exist at construction time; it will be
+    /// created (if absent) by the `FFmpeg` DASH muxer when [`write`](Self::write)
+    /// is called.
+    ///
+    /// Default: segment duration = 4 s.
+    #[must_use]
+    pub fn new(output_dir: &str) -> Self {
+        Self {
+            output_dir: output_dir.to_owned(),
+            input_path: None,
+            segment_duration: Duration::from_secs(4),
+        }
+    }
+
+    /// Set the input media file path.
+    ///
+    /// This is required; [`build`](Self::build) will return
+    /// [`StreamError::InvalidConfig`] if no input is supplied.
+    #[must_use]
+    pub fn input(mut self, path: &str) -> Self {
+        self.input_path = Some(path.to_owned());
+        self
+    }
+
+    /// Override the DASH segment duration (default: 4 s).
+    ///
+    /// MPEG-DASH recommends 2–10 s segments; 4 s is a common default that
+    /// balances latency against the overhead of many small files.
+    #[must_use]
+    pub fn segment_duration(mut self, d: Duration) -> Self {
+        self.segment_duration = d;
+        self
+    }
+
+    /// Validate the configuration and return a ready-to-write `DashOutput`.
+    ///
+    /// # Errors
+    ///
+    /// - [`StreamError::InvalidConfig`] when `output_dir` is empty.
+    /// - [`StreamError::InvalidConfig`] when no input path has been set via
+    ///   [`input`](Self::input).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_stream::DashOutput;
+    ///
+    /// // Missing input → error
+    /// assert!(DashOutput::new("/tmp/dash").build().is_err());
+    ///
+    /// // Valid configuration → ok
+    /// assert!(DashOutput::new("/tmp/dash").input("src.mp4").build().is_ok());
+    /// ```
+    pub fn build(self) -> Result<Self, StreamError> {
+        if self.output_dir.is_empty() {
+            return Err(StreamError::InvalidConfig {
+                reason: "output_dir must not be empty".into(),
+            });
+        }
+        if self.input_path.is_none() {
+            return Err(StreamError::InvalidConfig {
+                reason: "input path is required".into(),
+            });
+        }
+        log::info!(
+            "dash output configured output_dir={} segment_duration={:.1}s",
+            self.output_dir,
+            self.segment_duration.as_secs_f64(),
+        );
+        Ok(self)
+    }
+
+    /// Write DASH segments to the output directory.
+    ///
+    /// On success the output directory will contain a `manifest.mpd` file and
+    /// the corresponding initialization and media segments.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StreamError::InvalidConfig`] with `"not yet implemented"` until
+    /// `FFmpeg` DASH muxing integration is complete.
+    pub fn write(self) -> Result<(), StreamError> {
+        Err(StreamError::InvalidConfig {
+            reason: "not yet implemented".into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_should_store_output_dir() {
+        let d = DashOutput::new("/tmp/dash");
+        assert_eq!(d.output_dir, "/tmp/dash");
+    }
+
+    #[test]
+    fn build_without_input_should_return_invalid_config() {
+        let result = DashOutput::new("/tmp/dash").build();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn build_with_valid_config_should_succeed() {
+        let result = DashOutput::new("/tmp/dash").input("/src/video.mp4").build();
+        assert!(result.is_ok());
+    }
+}

--- a/crates/ff-stream/src/error.rs
+++ b/crates/ff-stream/src/error.rs
@@ -1,0 +1,58 @@
+//! Error types for streaming operations.
+//!
+//! This module provides the [`StreamError`] enum which represents all
+//! possible errors that can occur during HLS / DASH output and ABR ladder
+//! generation.
+
+/// Errors that can occur during streaming output operations.
+///
+/// This enum covers all error conditions that may arise when configuring,
+/// building, or writing HLS / DASH output.
+///
+/// # Error Categories
+///
+/// - **Encoding errors**: [`Encode`](Self::Encode) — wraps errors from `ff-encode`
+/// - **I/O errors**: [`Io`](Self::Io) — file system errors during segment writing
+/// - **Configuration errors**: [`InvalidConfig`](Self::InvalidConfig) — missing or
+///   invalid builder options, or not-yet-implemented stubs
+#[derive(Debug, thiserror::Error)]
+pub enum StreamError {
+    /// An encoding operation in the underlying `ff-encode` crate failed.
+    ///
+    /// This error propagates from [`ff_encode::EncodeError`] when the encoder
+    /// cannot open a codec or write frames.
+    #[error("encode failed: {0}")]
+    Encode(#[from] ff_encode::EncodeError),
+
+    /// An I/O operation failed during segment or playlist writing.
+    ///
+    /// Typical causes include missing output directories, permission errors,
+    /// or a full disk.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A configuration value is missing or invalid, or the feature is not yet
+    /// implemented.
+    ///
+    /// This variant is also used as a stub return value for `write()` / `hls()`
+    /// / `dash()` methods that await `FFmpeg` muxing integration.
+    #[error("invalid config: {reason}")]
+    InvalidConfig {
+        /// Human-readable description of the configuration problem.
+        reason: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_config_should_display_reason() {
+        let err = StreamError::InvalidConfig {
+            reason: "missing input path".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("missing input path"), "got: {msg}");
+    }
+}

--- a/crates/ff-stream/src/hls.rs
+++ b/crates/ff-stream/src/hls.rs
@@ -1,0 +1,188 @@
+//! HLS segmented output builder.
+//!
+//! This module exposes [`HlsOutput`], a consuming builder that configures and
+//! writes an HLS segmented stream. Validation is deferred to [`HlsOutput::build`]
+//! so setter calls are infallible.
+
+use std::time::Duration;
+
+use crate::error::StreamError;
+
+/// Builds and writes an HLS segmented output.
+///
+/// `HlsOutput` follows the consuming-builder pattern: each setter takes `self`
+/// and returns a new `Self`, and the final [`build`](Self::build) call validates
+/// the configuration before returning a ready-to-write instance.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_stream::HlsOutput;
+/// use std::time::Duration;
+///
+/// HlsOutput::new("/var/www/hls")
+///     .input("source.mp4")
+///     .segment_duration(Duration::from_secs(6))
+///     .keyframe_interval(48)
+///     .build()?
+///     .write()?;
+/// ```
+pub struct HlsOutput {
+    output_dir: String,
+    input_path: Option<String>,
+    segment_duration: Duration,
+    keyframe_interval: u32,
+}
+
+impl HlsOutput {
+    /// Create a new builder targeting `output_dir`.
+    ///
+    /// The directory does not need to exist at construction time; it will be
+    /// created (if absent) by the `FFmpeg` HLS muxer when [`write`](Self::write)
+    /// is called.
+    ///
+    /// Defaults: segment duration = 6 s, keyframe interval = 48 frames.
+    #[must_use]
+    pub fn new(output_dir: &str) -> Self {
+        Self {
+            output_dir: output_dir.to_owned(),
+            input_path: None,
+            segment_duration: Duration::from_secs(6),
+            keyframe_interval: 48,
+        }
+    }
+
+    /// Set the input media file path.
+    ///
+    /// This is required; [`build`](Self::build) will return
+    /// [`StreamError::InvalidConfig`] if no input is supplied.
+    #[must_use]
+    pub fn input(mut self, path: &str) -> Self {
+        self.input_path = Some(path.to_owned());
+        self
+    }
+
+    /// Override the HLS segment duration (default: 6 s).
+    ///
+    /// Apple's HLS recommendation is 6 s for live streams and up to 10 s for
+    /// VOD. Smaller values reduce latency but increase the number of segment
+    /// files and playlist entries.
+    #[must_use]
+    pub fn segment_duration(mut self, d: Duration) -> Self {
+        self.segment_duration = d;
+        self
+    }
+
+    /// Override the keyframe interval in frames (default: 48).
+    ///
+    /// HLS requires segment boundaries to align with keyframes. Setting this to
+    /// `fps × segment_duration` (e.g. 24 fps × 2 s = 48) ensures clean cuts
+    /// without decoding artefacts at the start of each segment.
+    #[must_use]
+    pub fn keyframe_interval(mut self, frames: u32) -> Self {
+        self.keyframe_interval = frames;
+        self
+    }
+
+    /// Validate the configuration and return a ready-to-write `HlsOutput`.
+    ///
+    /// # Errors
+    ///
+    /// - [`StreamError::InvalidConfig`] when `output_dir` is empty.
+    /// - [`StreamError::InvalidConfig`] when no input path has been set via
+    ///   [`input`](Self::input).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_stream::HlsOutput;
+    ///
+    /// // Missing input → error
+    /// assert!(HlsOutput::new("/tmp/hls").build().is_err());
+    ///
+    /// // Valid configuration → ok
+    /// assert!(HlsOutput::new("/tmp/hls").input("src.mp4").build().is_ok());
+    /// ```
+    pub fn build(self) -> Result<Self, StreamError> {
+        if self.output_dir.is_empty() {
+            return Err(StreamError::InvalidConfig {
+                reason: "output_dir must not be empty".into(),
+            });
+        }
+        if self.input_path.is_none() {
+            return Err(StreamError::InvalidConfig {
+                reason: "input path is required".into(),
+            });
+        }
+        log::info!(
+            "hls output configured output_dir={} segment_duration={:.1}s keyframe_interval={}",
+            self.output_dir,
+            self.segment_duration.as_secs_f64(),
+            self.keyframe_interval,
+        );
+        Ok(self)
+    }
+
+    /// Write HLS segments to the output directory.
+    ///
+    /// On success the output directory will contain a `playlist.m3u8` file and
+    /// numbered segment files (`segment000.ts`, `segment001.ts`, …).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StreamError::InvalidConfig`] with `"not yet implemented"` until
+    /// `FFmpeg` HLS muxing integration is complete.
+    pub fn write(self) -> Result<(), StreamError> {
+        Err(StreamError::InvalidConfig {
+            reason: "not yet implemented".into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_should_store_output_dir() {
+        let h = HlsOutput::new("/tmp/hls");
+        assert_eq!(h.output_dir, "/tmp/hls");
+    }
+
+    #[test]
+    fn input_should_store_input_path() {
+        let h = HlsOutput::new("/tmp/hls").input("/src/video.mp4");
+        assert_eq!(h.input_path.as_deref(), Some("/src/video.mp4"));
+    }
+
+    #[test]
+    fn segment_duration_should_store_duration() {
+        let d = Duration::from_secs(10);
+        let h = HlsOutput::new("/tmp/hls").segment_duration(d);
+        assert_eq!(h.segment_duration, d);
+    }
+
+    #[test]
+    fn keyframe_interval_should_store_interval() {
+        let h = HlsOutput::new("/tmp/hls").keyframe_interval(24);
+        assert_eq!(h.keyframe_interval, 24);
+    }
+
+    #[test]
+    fn build_without_input_should_return_invalid_config() {
+        let result = HlsOutput::new("/tmp/hls").build();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn build_with_empty_output_dir_should_return_invalid_config() {
+        let result = HlsOutput::new("").input("/src/video.mp4").build();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn build_with_valid_config_should_succeed() {
+        let result = HlsOutput::new("/tmp/hls").input("/src/video.mp4").build();
+        assert!(result.is_ok());
+    }
+}

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -1,19 +1,82 @@
-//! HLS and DASH adaptive streaming output for the ff-* crate family.
+//! # ff-stream
 //!
-//! # Status
+//! HLS and DASH adaptive streaming output - the Rust way.
 //!
-//! **This crate is not yet implemented.** It is a placeholder for future development.
+//! This crate provides segmented HLS and DASH output along with ABR (Adaptive
+//! Bitrate) ladder generation. It exposes a safe, ergonomic Builder API and
+//! completely hides `FFmpeg` muxer internals.
 //!
-//! # Design Principles
+//! ## Features
 //!
-//! All public APIs in this crate are **safe**. Users never need to write `unsafe` code.
-//! Unsafe `FFmpeg` internals are encapsulated within the underlying ff-encode crate.
+//! - **HLS Output**: Segmented HLS with configurable segment duration and keyframe interval
+//! - **DASH Output**: Segmented DASH with configurable segment duration
+//! - **ABR Ladder**: Multi-rendition HLS / DASH from a single input in one call
+//! - **Builder Pattern**: Consuming builders with validation in `build()`
 //!
-//! # Planned Features
+//! ## Usage
 //!
-//! - HLS output via `HlsOutput` with configurable segment duration
-//! - DASH output via `DashOutput`
-//! - ABR ladder generation via `AbrLadder` (multiple renditions in one pass)
-//! - Keyframe interval control for optimal segment boundaries
+//! ### HLS Output
+//!
+//! ```ignore
+//! use ff_stream::HlsOutput;
+//! use std::time::Duration;
+//!
+//! HlsOutput::new("/var/www/hls")
+//!     .input("source.mp4")
+//!     .segment_duration(Duration::from_secs(6))
+//!     .keyframe_interval(48)
+//!     .build()?
+//!     .write()?;
+//! ```
+//!
+//! ### DASH Output
+//!
+//! ```ignore
+//! use ff_stream::DashOutput;
+//! use std::time::Duration;
+//!
+//! DashOutput::new("/var/www/dash")
+//!     .input("source.mp4")
+//!     .segment_duration(Duration::from_secs(4))
+//!     .build()?
+//!     .write()?;
+//! ```
+//!
+//! ### ABR Ladder
+//!
+//! ```ignore
+//! use ff_stream::{AbrLadder, Rendition};
+//!
+//! AbrLadder::new("source.mp4")
+//!     .add_rendition(Rendition { width: 1920, height: 1080, bitrate: 6_000_000 })
+//!     .add_rendition(Rendition { width: 1280, height:  720, bitrate: 3_000_000 })
+//!     .add_rendition(Rendition { width:  854, height:  480, bitrate: 1_500_000 })
+//!     .hls("/var/www/hls")?;
+//! ```
+//!
+//! ## Module Structure
+//!
+//! - [`hls`] — [`HlsOutput`]: segmented HLS output builder
+//! - [`dash`] — [`DashOutput`]: segmented DASH output builder
+//! - [`abr`] — [`AbrLadder`] + [`Rendition`]: multi-rendition ABR ladder
+//! - [`error`] — [`StreamError`]: unified error type for this crate
+//!
+//! ## Status
+//!
+//! The public API is stable. The `write()` / `hls()` / `dash()` methods that
+//! perform actual `FFmpeg` muxing are stubs and will return
+//! [`StreamError::InvalidConfig`] with `"not yet implemented"` until the
+//! `FFmpeg` HLS/DASH integration is complete.
 
-// This crate is a placeholder. No public API is available yet.
+#![warn(missing_docs)]
+
+pub mod abr;
+pub mod dash;
+/// Unified error type for the `ff-stream` crate.
+pub mod error;
+pub mod hls;
+
+pub use abr::{AbrLadder, Rendition};
+pub use dash::DashOutput;
+pub use error::StreamError;
+pub use hls::HlsOutput;


### PR DESCRIPTION
## Summary

Fills in the `ff-stream` crate, which previously existed as an empty placeholder. Adds the full module structure (`error`, `hls`, `dash`, `abr`) with consuming-builder APIs for `HlsOutput`, `DashOutput`, and `AbrLadder`. All `write()` / `hls()` / `dash()` methods that require actual `FFmpeg` HLS/DASH muxing are stubs returning `Err(InvalidConfig { "not yet implemented" })` so the crate compiles and the API is usable without `todo!()`/`unimplemented!()`.

## Changes

- `crates/ff-stream/Cargo.toml` — add `ff-encode`, `ff-decode`, `ff-pipeline`, `log` dependencies
- `src/error.rs` — `StreamError` enum with `Encode`, `Io`, and `InvalidConfig` variants
- `src/hls.rs` — `HlsOutput` consuming builder (segment duration, keyframe interval, validation in `build()`)
- `src/dash.rs` — `DashOutput` consuming builder (segment duration, validation in `build()`)
- `src/abr.rs` — `Rendition` struct and `AbrLadder` consuming builder with `hls()` / `dash()` stubs
- `src/lib.rs` — replace placeholder with module declarations, public re-exports, and full crate-level docs (Features, Usage examples, Module Structure)
- 15 unit tests across all modules covering builder setters, validation errors, and `Display` output

## Related Issues

Closes #68

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes