### PR TITLE
test(ff-stream): add From conversion and Display tests for StreamError

### DIFF
--- a/crates/ff-stream/src/error.rs
+++ b/crates/ff-stream/src/error.rs
@@ -55,4 +55,25 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("missing input path"), "got: {msg}");
     }
+
+    #[test]
+    fn io_error_should_convert_via_from() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
+        let err: StreamError = io.into();
+        assert!(matches!(err, StreamError::Io(_)));
+    }
+
+    #[test]
+    fn encode_error_should_convert_via_from() {
+        let enc = ff_encode::EncodeError::Cancelled;
+        let err: StreamError = enc.into();
+        assert!(matches!(err, StreamError::Encode(_)));
+    }
+
+    #[test]
+    fn display_io_should_contain_message() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied");
+        let err: StreamError = io.into();
+        assert!(err.to_string().contains("access denied"), "got: {err}");
+    }
 }


### PR DESCRIPTION
## Summary

Adds the missing test coverage for `StreamError`'s `From` trait implementations and `Display` formatting. The variant definitions and `#[from]` attributes were already correct from the scaffold; this PR closes the gap by verifying that `std::io::Error` and `ff_encode::EncodeError` convert correctly and that the `Io` variant surfaces the underlying message through `Display`.

## Changes

- Added `io_error_should_convert_via_from`: asserts `std::io::Error → StreamError::Io` via `Into`
- Added `encode_error_should_convert_via_from`: asserts `EncodeError::Cancelled → StreamError::Encode` via `Into`
- Added `display_io_should_contain_message`: asserts the wrapped I/O message is visible in the formatted output

## Related Issues

Closes #69

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes