### PR TITLE
test(ff-stream): add HLS playlist content and segment naming tests

### DIFF
--- a/crates/ff-stream/tests/hls_output_tests.rs
+++ b/crates/ff-stream/tests/hls_output_tests.rs
@@ -86,40 +86,49 @@ fn create_test_video(path: &PathBuf) -> bool {
     true
 }
 
-// ============================================================================
-// Tests
-// ============================================================================
-
-#[test]
-fn write_should_produce_playlist_and_segments() {
-    let out_dir = tmp_dir("hls_write_test");
-    let _guard = DirGuard(out_dir.clone());
+/// Runs the full HLS pipeline and returns the output dir + guard if successful.
+/// Returns `None` when encoder/decoder is unavailable (test should skip).
+fn run_hls_write(
+    test_name: &str,
+    segment_secs: u64,
+    keyframe_interval: u32,
+) -> Option<(PathBuf, DirGuard)> {
+    let out_dir = tmp_dir(test_name);
+    let guard = DirGuard(out_dir.clone());
     let input_path = out_dir.join("input.mp4");
 
-    // Step 1: create a small test video
     if !create_test_video(&input_path) {
-        return; // skip
+        return None;
     }
 
-    // Step 2: run HLS output
     let result = HlsOutput::new(out_dir.to_str().unwrap())
         .input(input_path.to_str().unwrap())
-        .segment_duration(Duration::from_secs(1))
-        .keyframe_interval(25)
+        .segment_duration(Duration::from_secs(segment_secs))
+        .keyframe_interval(keyframe_interval)
         .build()
         .expect("build should succeed")
         .write();
 
     match result {
         Err(StreamError::Ffmpeg { code, message }) => {
-            println!("Skipping: HLS write failed (no suitable encoder): {message} (code={code})");
-            return;
+            println!("Skipping: HLS write failed: {message} (code={code})");
+            None
         }
         Err(e) => panic!("Unexpected error: {e}"),
-        Ok(()) => {}
+        Ok(()) => Some((out_dir, guard)),
     }
+}
 
-    // Step 3: verify outputs
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn write_should_produce_playlist_and_segments() {
+    let Some((out_dir, _guard)) = run_hls_write("hls_write_test", 1, 25) else {
+        return;
+    };
+
     let playlist = out_dir.join("playlist.m3u8");
     assert!(playlist.exists(), "playlist.m3u8 should exist");
     assert!(
@@ -127,7 +136,6 @@ fn write_should_produce_playlist_and_segments() {
         "playlist.m3u8 should be non-empty"
     );
 
-    // At least one segment file should be present
     let segments: Vec<_> = std::fs::read_dir(&out_dir)
         .unwrap()
         .filter_map(|e| e.ok())
@@ -142,5 +150,70 @@ fn write_should_produce_playlist_and_segments() {
         "HLS output: {} segments, playlist {} bytes",
         segments.len(),
         std::fs::metadata(&playlist).unwrap().len(),
+    );
+}
+
+#[test]
+fn playlist_should_contain_required_hls_tags() {
+    let Some((out_dir, _guard)) = run_hls_write("hls_tags_test", 1, 25) else {
+        return;
+    };
+
+    let content = std::fs::read_to_string(out_dir.join("playlist.m3u8")).unwrap();
+    assert!(content.contains("#EXTM3U"), "missing #EXTM3U in playlist");
+    assert!(
+        content.contains("#EXT-X-TARGETDURATION"),
+        "missing #EXT-X-TARGETDURATION in playlist"
+    );
+    assert!(content.contains("#EXTINF:"), "missing #EXTINF in playlist");
+    assert!(
+        content.contains("#EXT-X-ENDLIST"),
+        "missing #EXT-X-ENDLIST in playlist"
+    );
+}
+
+#[test]
+fn segments_should_follow_numbered_filename_pattern() {
+    let Some((out_dir, _guard)) = run_hls_write("hls_naming_test", 1, 25) else {
+        return;
+    };
+
+    let mut names: Vec<String> = std::fs::read_dir(&out_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.ends_with(".ts"))
+        .collect();
+    names.sort();
+
+    assert!(!names.is_empty(), "no .ts segments found");
+    assert_eq!(
+        names[0], "segment000.ts",
+        "first segment should be segment000.ts"
+    );
+    for name in &names {
+        assert!(
+            name.starts_with("segment") && name.ends_with(".ts") && name.len() == 13,
+            "unexpected segment filename: {name}"
+        );
+    }
+}
+
+#[test]
+fn segment_duration_should_be_respected_in_playlist() {
+    let Some((out_dir, _guard)) = run_hls_write("hls_duration_test", 1, 25) else {
+        return;
+    };
+
+    let content = std::fs::read_to_string(out_dir.join("playlist.m3u8")).unwrap();
+    let target_dur: u32 = content
+        .lines()
+        .find(|l| l.starts_with("#EXT-X-TARGETDURATION:"))
+        .and_then(|l| l.trim_start_matches("#EXT-X-TARGETDURATION:").parse().ok())
+        .expect("#EXT-X-TARGETDURATION not found or not an integer");
+
+    assert!(
+        target_dur <= 2,
+        "#EXT-X-TARGETDURATION={target_dur} expected ≤2 for 1s configured segment duration"
     );
 }


### PR DESCRIPTION
## Summary

Extends the HLS integration test suite to verify that `HlsOutput::write()` produces spec-compliant output. The existing test only checked file existence; these additions assert playlist tag correctness, segment filename pattern, and `#EXT-X-TARGETDURATION` accuracy.

## Changes

- Extract shared `run_hls_write()` helper to eliminate setup duplication across tests
- Refactor `write_should_produce_playlist_and_segments` to use the helper
- Add `playlist_should_contain_required_hls_tags`: asserts `#EXTM3U`, `#EXT-X-TARGETDURATION`, `#EXTINF:`, `#EXT-X-ENDLIST` are present
- Add `segments_should_follow_numbered_filename_pattern`: asserts first segment is `segment000.ts` and all names match `segment\d{3}.ts`
- Add `segment_duration_should_be_respected_in_playlist`: asserts `#EXT-X-TARGETDURATION ≤ 2` when configured for 1 s segments

## Related Issues

Closes #71

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes