### PR TITLE
feat(ff-stream): implement DashOutput::write() with FFmpeg DASH muxer

### DIFF
--- a/crates/ff-stream/src/dash.rs
+++ b/crates/ff-stream/src/dash.rs
@@ -114,12 +114,18 @@ impl DashOutput {
     ///
     /// # Errors
     ///
-    /// Returns [`StreamError::InvalidConfig`] with `"not yet implemented"` until
-    /// `FFmpeg` DASH muxing integration is complete.
+    /// Returns [`StreamError::InvalidConfig`] when the builder is not fully
+    /// configured, or [`StreamError::Ffmpeg`] when an `FFmpeg` operation fails.
     pub fn write(self) -> Result<(), StreamError> {
-        Err(StreamError::InvalidConfig {
-            reason: "not yet implemented".into(),
-        })
+        let input_path = self.input_path.ok_or_else(|| StreamError::InvalidConfig {
+            reason: "input path missing after build (internal error)".into(),
+        })?;
+        let seg_secs = self.segment_duration.as_secs_f64();
+        log::info!(
+            "dash write starting input={input_path} output_dir={} segment_duration={seg_secs:.1}s",
+            self.output_dir
+        );
+        crate::dash_inner::write_dash(&input_path, &self.output_dir, seg_secs)
     }
 }
 
@@ -143,5 +149,11 @@ mod tests {
     fn build_with_valid_config_should_succeed() {
         let result = DashOutput::new("/tmp/dash").input("/src/video.mp4").build();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn write_without_build_should_return_invalid_config() {
+        let result = DashOutput::new("/tmp/dash").write();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
     }
 }

--- a/crates/ff-stream/src/dash_inner.rs
+++ b/crates/ff-stream/src/dash_inner.rs
@@ -1,0 +1,809 @@
+//! Internal DASH muxing implementation using `FFmpeg` directly.
+//!
+//! This module implements the decode → encode → DASH-mux loop that powers
+//! [`DashOutput::write`](crate::dash::DashOutput::write).  All `unsafe` code is
+//! isolated here; `dash.rs` is purely safe Rust.
+
+// This module is intentionally unsafe — it drives the FFmpeg C API directly.
+#![allow(unsafe_code)]
+// Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
+#![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg C API frequently requires raw pointer casting and borrows-as-ptr
+#![allow(clippy::ptr_as_ptr)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_lossless)]
+#![allow(clippy::too_many_lines)]
+// `&mut ptr` to get `*mut *mut T` is the standard FFmpeg double-pointer pattern
+#![allow(clippy::borrow_as_ptr)]
+// `&mut foo as *mut *mut _` is the standard way to pass double-pointers in FFmpeg
+#![allow(clippy::ref_as_ptr)]
+
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr;
+
+use ff_sys::{
+    AVCodecContext, AVFormatContext, AVFrame, AVPictureType_AV_PICTURE_TYPE_I,
+    AVPictureType_AV_PICTURE_TYPE_NONE, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P,
+    SwrContext, SwsContext, av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref,
+    av_interleaved_write_frame, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref,
+    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat_write_header,
+};
+
+use crate::error::StreamError;
+
+// ============================================================================
+// Helper: map an FFmpeg error code to StreamError::Ffmpeg
+// ============================================================================
+
+fn ffmpeg_err(code: i32) -> StreamError {
+    StreamError::Ffmpeg {
+        code,
+        message: ff_sys::av_error_string(code),
+    }
+}
+
+fn ffmpeg_err_msg(msg: &str) -> StreamError {
+    StreamError::Ffmpeg {
+        code: 0,
+        message: msg.to_owned(),
+    }
+}
+
+// ============================================================================
+// Public entry point (safe wrapper)
+// ============================================================================
+
+/// Write a DASH segmented stream for the given input file.
+///
+/// Creates `output_dir/manifest.mpd` and initialization/media segment files
+/// (`init-stream0.m4s`, `chunk-stream0-NNNNN.m4s`, …).
+///
+/// # Errors
+///
+/// Returns [`StreamError::Ffmpeg`] when any `FFmpeg` operation fails, or
+/// [`StreamError::Io`] when directory creation fails.
+pub(crate) fn write_dash(
+    input_path: &str,
+    output_dir: &str,
+    segment_duration_secs: f64,
+) -> Result<(), StreamError> {
+    std::fs::create_dir_all(output_dir)?;
+    // SAFETY: All FFmpeg resources are allocated and freed within this call.
+    unsafe { write_dash_unsafe(input_path, output_dir, segment_duration_secs) }
+}
+
+// ============================================================================
+// Unsafe implementation
+// ============================================================================
+
+unsafe fn write_dash_unsafe(
+    input_path: &str,
+    output_dir: &str,
+    segment_duration_secs: f64,
+) -> Result<(), StreamError> {
+    ff_sys::ensure_initialized();
+
+    // ── 1. Open input ─────────────────────────────────────────────────────────
+    let mut input_ctx = ff_sys::avformat::open_input(Path::new(input_path)).map_err(ffmpeg_err)?;
+
+    ff_sys::avformat::find_stream_info(input_ctx).map_err(|e| {
+        ff_sys::avformat::close_input(&mut input_ctx);
+        ffmpeg_err(e)
+    })?;
+
+    // ── 2. Locate video and audio streams ─────────────────────────────────────
+    let nb_streams = (*input_ctx).nb_streams as usize;
+    let mut video_stream_idx: i32 = -1;
+    let mut audio_stream_idx: i32 = -1;
+
+    for i in 0..nb_streams {
+        let stream = *(*input_ctx).streams.add(i);
+        let codec_type = (*(*stream).codecpar).codec_type;
+        if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO && video_stream_idx < 0 {
+            video_stream_idx = i as i32;
+        } else if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO && audio_stream_idx < 0 {
+            audio_stream_idx = i as i32;
+        }
+    }
+
+    if video_stream_idx < 0 {
+        ff_sys::avformat::close_input(&mut input_ctx);
+        return Err(StreamError::InvalidConfig {
+            reason: "input file contains no video stream".into(),
+        });
+    }
+
+    // ── 3. Read video stream properties ──────────────────────────────────────
+    let video_stream = *(*input_ctx).streams.add(video_stream_idx as usize);
+    let video_codecpar = (*video_stream).codecpar;
+    let enc_width = (*video_codecpar).width;
+    let enc_height = (*video_codecpar).height;
+    let video_fps = {
+        let r = (*video_stream).avg_frame_rate;
+        if r.den > 0 && r.num > 0 {
+            r.num as f64 / r.den as f64
+        } else {
+            30.0
+        }
+    };
+    let fps_int = video_fps.round().max(1.0) as i32;
+
+    // Compute keyframe interval from segment duration and fps
+    let keyframe_interval = (segment_duration_secs * fps_int as f64).round().max(1.0) as u32;
+
+    // ── 4. Open input video decoder ────────────────────────────────────────────
+    let vid_codec_id = (*video_codecpar).codec_id;
+    let vid_decoder = ff_sys::avcodec::find_decoder(vid_codec_id)
+        .ok_or_else(|| ffmpeg_err_msg("no video decoder available for input stream"))?;
+
+    let mut vid_dec_ctx = ff_sys::avcodec::alloc_context3(vid_decoder).map_err(ffmpeg_err)?;
+
+    ff_sys::avcodec::parameters_to_context(vid_dec_ctx, video_codecpar).map_err(|e| {
+        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
+        ff_sys::avformat::close_input(&mut input_ctx);
+        ffmpeg_err(e)
+    })?;
+
+    ff_sys::avcodec::open2(vid_dec_ctx, vid_decoder, ptr::null_mut()).map_err(|e| {
+        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
+        ff_sys::avformat::close_input(&mut input_ctx);
+        ffmpeg_err(e)
+    })?;
+
+    // ── 5. Open input audio decoder (optional) ────────────────────────────────
+    let mut aud_dec_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_sample_rate: i32 = 44100;
+    let mut aud_nb_channels: i32 = 2;
+
+    if audio_stream_idx >= 0 {
+        let audio_stream = *(*input_ctx).streams.add(audio_stream_idx as usize);
+        let audio_codecpar = (*audio_stream).codecpar;
+        let aud_codec_id = (*audio_codecpar).codec_id;
+
+        if let Some(aud_decoder) = ff_sys::avcodec::find_decoder(aud_codec_id) {
+            if let Ok(ctx) = ff_sys::avcodec::alloc_context3(aud_decoder) {
+                aud_dec_ctx = ctx;
+                if ff_sys::avcodec::parameters_to_context(aud_dec_ctx, audio_codecpar).is_ok()
+                    && ff_sys::avcodec::open2(aud_dec_ctx, aud_decoder, ptr::null_mut()).is_ok()
+                {
+                    aud_sample_rate = (*aud_dec_ctx).sample_rate;
+                    aud_nb_channels = (*aud_dec_ctx).ch_layout.nb_channels;
+                    log::info!(
+                        "dash audio decoder opened sample_rate={aud_sample_rate} \
+                         channels={aud_nb_channels}"
+                    );
+                } else {
+                    ff_sys::avcodec::free_context(&mut aud_dec_ctx as *mut *mut _);
+                    aud_dec_ctx = ptr::null_mut();
+                    audio_stream_idx = -1;
+                    log::warn!("dash audio decoder open failed, skipping audio");
+                }
+            } else {
+                audio_stream_idx = -1;
+                log::warn!("dash audio decoder alloc failed, skipping audio");
+            }
+        } else {
+            audio_stream_idx = -1;
+            log::warn!("dash no audio decoder found, skipping audio");
+        }
+    }
+
+    // ── 6. Allocate DASH output context ───────────────────────────────────────
+    let manifest_path = format!("{output_dir}/manifest.mpd");
+    let c_manifest = CString::new(manifest_path.as_str())
+        .map_err(|_| ffmpeg_err_msg("manifest path contains null byte"))?;
+    let c_dash = c"dash";
+
+    let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
+    let ret = avformat_alloc_output_context2(
+        &mut out_ctx,
+        ptr::null_mut(),
+        c_dash.as_ptr(),
+        c_manifest.as_ptr(),
+    );
+    if ret < 0 || out_ctx.is_null() {
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        return Err(ffmpeg_err(ret));
+    }
+
+    // ── 7. Set DASH muxer options ──────────────────────────────────────────────
+    let seg_duration_str = format!("{}", segment_duration_secs as u32);
+    if let Ok(c_seg_dur) = CString::new(seg_duration_str.as_str()) {
+        let ret = av_opt_set(
+            (*out_ctx).priv_data,
+            c"seg_duration".as_ptr(),
+            c_seg_dur.as_ptr(),
+            0,
+        );
+        if ret < 0 {
+            log::warn!(
+                "dash seg_duration option not supported, using default \
+                 requested={seg_duration_str} error={}",
+                ff_sys::av_error_string(ret)
+            );
+        }
+    }
+
+    // ── 8. Open H.264 video encoder ───────────────────────────────────────────
+    let vid_enc_codec = select_h264_encoder().ok_or_else(|| {
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ffmpeg_err_msg("no H.264 encoder available (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)")
+    })?;
+
+    let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ffmpeg_err(e)
+    })?;
+
+    (*vid_enc_ctx).width = enc_width;
+    (*vid_enc_ctx).height = enc_height;
+    (*vid_enc_ctx).time_base.num = 1;
+    (*vid_enc_ctx).time_base.den = fps_int;
+    (*vid_enc_ctx).framerate.num = fps_int;
+    (*vid_enc_ctx).framerate.den = 1;
+    (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+    (*vid_enc_ctx).bit_rate = 2_000_000;
+
+    ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
+        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ffmpeg_err(e)
+    })?;
+
+    // ── 9. Add video output stream ────────────────────────────────────────────
+    let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+    if vid_out_stream.is_null() {
+        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        return Err(ffmpeg_err_msg("cannot create video output stream"));
+    }
+    (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+    let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+
+    if !(*vid_out_stream).codecpar.is_null() {
+        (*(*vid_out_stream).codecpar).codec_id = (*vid_enc_ctx).codec_id;
+        (*(*vid_out_stream).codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
+        (*(*vid_out_stream).codecpar).width = (*vid_enc_ctx).width;
+        (*(*vid_out_stream).codecpar).height = (*vid_enc_ctx).height;
+        (*(*vid_out_stream).codecpar).format = (*vid_enc_ctx).pix_fmt;
+    }
+
+    // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
+    let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_out_stream_idx: i32 = -1;
+    let mut swr_ctx: *mut SwrContext = ptr::null_mut();
+
+    if audio_stream_idx >= 0 {
+        match open_aac_encoder(aud_sample_rate, aud_nb_channels) {
+            Ok(ctx) => {
+                aud_enc_ctx = ctx;
+                let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+                if aud_out_stream.is_null() {
+                    ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                    log::warn!("dash cannot create audio output stream, skipping audio");
+                    audio_stream_idx = -1;
+                } else {
+                    (*aud_out_stream).time_base.num = 1;
+                    (*aud_out_stream).time_base.den = aud_sample_rate;
+                    aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+
+                    if !(*aud_out_stream).codecpar.is_null() {
+                        (*(*aud_out_stream).codecpar).codec_id = (*aud_enc_ctx).codec_id;
+                        (*(*aud_out_stream).codecpar).codec_type =
+                            ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO;
+                        (*(*aud_out_stream).codecpar).sample_rate = (*aud_enc_ctx).sample_rate;
+                        (*(*aud_out_stream).codecpar).format = (*aud_enc_ctx).sample_fmt;
+                        let _ = ff_sys::swresample::channel_layout::copy(
+                            &mut (*(*aud_out_stream).codecpar).ch_layout,
+                            &(*aud_enc_ctx).ch_layout,
+                        );
+                    }
+
+                    // Set up resampler: decoded audio → FLTP at aud_sample_rate
+                    let enc_ch_layout = &(*aud_enc_ctx).ch_layout;
+                    let enc_sample_fmt = (*aud_enc_ctx).sample_fmt;
+                    let enc_sample_rate = (*aud_enc_ctx).sample_rate;
+                    let dec_ch_layout = &(*aud_dec_ctx).ch_layout;
+                    let dec_sample_fmt = (*aud_dec_ctx).sample_fmt;
+                    let dec_sample_rate = (*aud_dec_ctx).sample_rate;
+
+                    if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
+                        enc_ch_layout,
+                        enc_sample_fmt,
+                        enc_sample_rate,
+                        dec_ch_layout,
+                        dec_sample_fmt,
+                        dec_sample_rate,
+                    ) {
+                        if ff_sys::swresample::init(ctx).is_ok() {
+                            swr_ctx = ctx;
+                        } else {
+                            let mut swr_tmp = ctx;
+                            ff_sys::swresample::free(&mut swr_tmp);
+                            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                            log::warn!("dash swr init failed, skipping audio");
+                            audio_stream_idx = -1;
+                        }
+                    } else {
+                        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                        log::warn!("dash swr alloc failed, skipping audio");
+                        audio_stream_idx = -1;
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("dash aac encoder unavailable: {e}, skipping audio");
+                audio_stream_idx = -1;
+            }
+        }
+    }
+
+    // ── 11. Open output file and write header ─────────────────────────────────
+    let pb = ff_sys::avformat::open_output(
+        Path::new(&manifest_path),
+        ff_sys::avformat::avio_flags::WRITE,
+    )
+    .map_err(|e| {
+        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ffmpeg_err(e)
+    })?;
+    (*out_ctx).pb = pb;
+
+    let ret = avformat_write_header(out_ctx, ptr::null_mut());
+    if ret < 0 {
+        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        return Err(ffmpeg_err(ret));
+    }
+
+    // Close pb now so the DASH muxer can manage its own avio handles for
+    // segment files without hitting a locked-file error on Windows.
+    ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+
+    log::info!(
+        "dash output context ready width={enc_width} height={enc_height} fps={video_fps:.1} \
+         audio={}",
+        audio_stream_idx >= 0
+    );
+
+    // ── 12. Allocate frame and packet buffers ──────────────────────────────────
+    let mut pkt = av_packet_alloc();
+    if pkt.is_null() {
+        av_write_trailer(out_ctx);
+        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        return Err(ffmpeg_err_msg("cannot allocate packet"));
+    }
+
+    let vid_dec_frame = av_frame_alloc();
+    let vid_enc_frame = av_frame_alloc();
+    let aud_dec_frame = av_frame_alloc();
+    let aud_enc_frame = av_frame_alloc();
+
+    if vid_dec_frame.is_null()
+        || vid_enc_frame.is_null()
+        || aud_dec_frame.is_null()
+        || aud_enc_frame.is_null()
+    {
+        free_frames(vid_dec_frame, vid_enc_frame, aud_dec_frame, aud_enc_frame);
+        av_packet_free(&mut pkt);
+        av_write_trailer(out_ctx);
+        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
+        cleanup_output_ctx(out_ctx);
+        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        return Err(ffmpeg_err_msg("cannot allocate frame"));
+    }
+
+    // ── 13. Decode–encode loop ─────────────────────────────────────────────────
+    let mut video_frame_count: u64 = 0;
+    let mut audio_sample_count: i64 = 0;
+    let mut sws_ctx: *mut SwsContext = ptr::null_mut();
+    let mut last_src_fmt: Option<AVPixelFormat> = None;
+    let mut last_src_w: Option<i32> = None;
+    let mut last_src_h: Option<i32> = None;
+
+    loop {
+        match ff_sys::avformat::read_frame(input_ctx, pkt) {
+            Err(e) if e == ff_sys::error_codes::EOF => break,
+            Err(_e) => {
+                // Non-EOF read errors: continue to try next packet
+                av_packet_unref(pkt);
+                continue;
+            }
+            Ok(()) => {}
+        }
+
+        let stream_idx = (*pkt).stream_index;
+
+        if stream_idx == video_stream_idx {
+            // ── Video path ────────────────────────────────────────────────────
+            if ff_sys::avcodec::send_packet(vid_dec_ctx, pkt).is_err() {
+                av_packet_unref(pkt);
+                continue;
+            }
+            av_packet_unref(pkt);
+
+            loop {
+                match ff_sys::avcodec::receive_frame(vid_dec_ctx, vid_dec_frame) {
+                    Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                        break;
+                    }
+                    Err(_) => break,
+                    Ok(()) => {}
+                }
+
+                // Force keyframe at intervals
+                (*vid_dec_frame).pict_type =
+                    if video_frame_count.is_multiple_of(u64::from(keyframe_interval)) {
+                        AVPictureType_AV_PICTURE_TYPE_I
+                    } else {
+                        AVPictureType_AV_PICTURE_TYPE_NONE
+                    };
+
+                // Convert decoded frame to YUV420P at encoder dimensions
+                let src_fmt = (*vid_dec_frame).format;
+                let src_w = (*vid_dec_frame).width;
+                let src_h = (*vid_dec_frame).height;
+
+                // Recreate SwsContext when source properties change
+                if last_src_fmt != Some(src_fmt)
+                    || last_src_w != Some(src_w)
+                    || last_src_h != Some(src_h)
+                {
+                    if !sws_ctx.is_null() {
+                        ff_sys::swscale::free_context(sws_ctx);
+                        sws_ctx = ptr::null_mut();
+                    }
+                    if let Ok(ctx) = ff_sys::swscale::get_context(
+                        src_w,
+                        src_h,
+                        src_fmt,
+                        enc_width,
+                        enc_height,
+                        AVPixelFormat_AV_PIX_FMT_YUV420P,
+                        ff_sys::swscale::scale_flags::BILINEAR,
+                    ) {
+                        sws_ctx = ctx;
+                        last_src_fmt = Some(src_fmt);
+                        last_src_w = Some(src_w);
+                        last_src_h = Some(src_h);
+                    } else {
+                        av_frame_unref(vid_dec_frame);
+                        continue;
+                    }
+                }
+
+                // Prepare encoder frame
+                (*vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
+                (*vid_enc_frame).width = enc_width;
+                (*vid_enc_frame).height = enc_height;
+                (*vid_enc_frame).pts = video_frame_count as i64;
+
+                let buf_ret = av_frame_get_buffer(vid_enc_frame, 0);
+                if buf_ret < 0 {
+                    av_frame_unref(vid_dec_frame);
+                    continue;
+                }
+
+                // Scale decoded frame into encoder frame
+                let scale_ok = ff_sys::swscale::scale(
+                    sws_ctx,
+                    (*vid_dec_frame).data.as_ptr() as *const *const u8,
+                    (*vid_dec_frame).linesize.as_ptr(),
+                    0,
+                    src_h,
+                    (*vid_enc_frame).data.as_mut_ptr().cast_const(),
+                    (*vid_enc_frame).linesize.as_mut_ptr(),
+                );
+
+                if scale_ok.is_ok()
+                    && ff_sys::avcodec::send_frame(vid_enc_ctx, vid_enc_frame).is_ok()
+                {
+                    drain_encoder(vid_enc_ctx, out_ctx, vid_out_stream_idx);
+                }
+
+                av_frame_unref(vid_enc_frame);
+                av_frame_unref(vid_dec_frame);
+                video_frame_count += 1;
+            }
+        } else if stream_idx == audio_stream_idx && !aud_dec_ctx.is_null() {
+            // ── Audio path ────────────────────────────────────────────────────
+            if ff_sys::avcodec::send_packet(aud_dec_ctx, pkt).is_err() {
+                av_packet_unref(pkt);
+                continue;
+            }
+            av_packet_unref(pkt);
+
+            loop {
+                match ff_sys::avcodec::receive_frame(aud_dec_ctx, aud_dec_frame) {
+                    Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                        break;
+                    }
+                    Err(_) => break,
+                    Ok(()) => {}
+                }
+
+                let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
+                    (*aud_enc_ctx).frame_size
+                } else {
+                    (*aud_dec_frame).nb_samples
+                };
+
+                (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
+                (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+                (*aud_enc_frame).nb_samples = enc_frame_size;
+                let _ = ff_sys::swresample::channel_layout::copy(
+                    &mut (*aud_enc_frame).ch_layout,
+                    &(*aud_enc_ctx).ch_layout,
+                );
+
+                let buf_ret = av_frame_get_buffer(aud_enc_frame, 0);
+                if buf_ret < 0 {
+                    av_frame_unref(aud_dec_frame);
+                    continue;
+                }
+
+                let in_data = (*aud_dec_frame).data.as_ptr() as *const *const u8;
+                let in_samples = (*aud_dec_frame).nb_samples;
+
+                let samples_out = ff_sys::swresample::convert(
+                    swr_ctx,
+                    (*aud_enc_frame).data.as_mut_ptr(),
+                    enc_frame_size,
+                    in_data,
+                    in_samples,
+                );
+
+                if let Ok(n) = samples_out
+                    && n > 0
+                {
+                    (*aud_enc_frame).nb_samples = n;
+                    (*aud_enc_frame).pts = audio_sample_count;
+                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                    }
+                    audio_sample_count += i64::from(n);
+                }
+
+                av_frame_unref(aud_enc_frame);
+                av_frame_unref(aud_dec_frame);
+            }
+        } else {
+            av_packet_unref(pkt);
+        }
+    }
+
+    // ── 14. Flush encoders ────────────────────────────────────────────────────
+    let _ = ff_sys::avcodec::send_frame(vid_enc_ctx, ptr::null());
+    drain_encoder(vid_enc_ctx, out_ctx, vid_out_stream_idx);
+
+    if !aud_enc_ctx.is_null() {
+        // Flush resampler
+        if !swr_ctx.is_null() {
+            let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
+                (*aud_enc_ctx).frame_size
+            } else {
+                1024
+            };
+            (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
+            (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+            (*aud_enc_frame).nb_samples = enc_frame_size;
+            let _ = ff_sys::swresample::channel_layout::copy(
+                &mut (*aud_enc_frame).ch_layout,
+                &(*aud_enc_ctx).ch_layout,
+            );
+            if av_frame_get_buffer(aud_enc_frame, 0) == 0 {
+                if let Ok(n) = ff_sys::swresample::convert(
+                    swr_ctx,
+                    (*aud_enc_frame).data.as_mut_ptr(),
+                    enc_frame_size,
+                    ptr::null(),
+                    0,
+                ) && n > 0
+                {
+                    (*aud_enc_frame).nb_samples = n;
+                    (*aud_enc_frame).pts = audio_sample_count;
+                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                    }
+                }
+                av_frame_unref(aud_enc_frame);
+            }
+        }
+        let _ = ff_sys::avcodec::send_frame(aud_enc_ctx, ptr::null());
+        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+    }
+
+    // ── 15. Finalize ──────────────────────────────────────────────────────────
+    av_write_trailer(out_ctx);
+    // pb was already closed after avformat_write_header; skip double-close.
+
+    // ── Cleanup ───────────────────────────────────────────────────────────────
+    free_frames(vid_dec_frame, vid_enc_frame, aud_dec_frame, aud_enc_frame);
+    av_packet_free(&mut pkt);
+
+    if !sws_ctx.is_null() {
+        ff_sys::swscale::free_context(sws_ctx);
+    }
+
+    cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
+    cleanup_output_ctx(out_ctx);
+    cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+
+    log::info!(
+        "dash write complete video_frames={video_frame_count} \
+         audio_samples={audio_sample_count}"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Helper: drain all available encoded packets into the output muxer
+// ============================================================================
+
+unsafe fn drain_encoder(
+    enc_ctx: *mut AVCodecContext,
+    out_ctx: *mut AVFormatContext,
+    stream_idx: i32,
+) {
+    let mut pkt = av_packet_alloc();
+    if pkt.is_null() {
+        return;
+    }
+
+    loop {
+        match ff_sys::avcodec::receive_packet(enc_ctx, pkt) {
+            Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                break;
+            }
+            Err(_) => break,
+            Ok(()) => {}
+        }
+
+        (*pkt).stream_index = stream_idx;
+        let ret = av_interleaved_write_frame(out_ctx, pkt);
+        av_packet_unref(pkt);
+        if ret < 0 {
+            log::warn!(
+                "dash av_interleaved_write_frame failed \
+                 stream_index={stream_idx} error={}",
+                ff_sys::av_error_string(ret)
+            );
+            break;
+        }
+    }
+
+    av_packet_free(&mut pkt);
+}
+
+// ============================================================================
+// Helper: select best available H.264 encoder
+// ============================================================================
+
+unsafe fn select_h264_encoder() -> Option<*const ff_sys::AVCodec> {
+    let candidates = [
+        "h264_nvenc",
+        "h264_qsv",
+        "h264_amf",
+        "h264_videotoolbox",
+        "libx264",
+        "mpeg4",
+    ];
+    for name in candidates {
+        if let Ok(c_name) = CString::new(name)
+            && let Some(codec) = ff_sys::avcodec::find_encoder_by_name(c_name.as_ptr())
+        {
+            log::info!("dash selected video encoder encoder={name}");
+            return Some(codec);
+        }
+    }
+    None
+}
+
+// ============================================================================
+// Helper: open AAC encoder
+// ============================================================================
+
+unsafe fn open_aac_encoder(
+    sample_rate: i32,
+    nb_channels: i32,
+) -> Result<*mut AVCodecContext, StreamError> {
+    let codec = ff_sys::avcodec::find_encoder_by_name(c"aac".as_ptr())
+        .or_else(|| ff_sys::avcodec::find_encoder_by_name(c"libfdk_aac".as_ptr()))
+        .ok_or_else(|| ffmpeg_err_msg("no AAC encoder available"))?;
+
+    let mut ctx = ff_sys::avcodec::alloc_context3(codec).map_err(ffmpeg_err)?;
+
+    (*ctx).sample_rate = sample_rate;
+    (*ctx).sample_fmt = ff_sys::swresample::sample_format::FLTP;
+    (*ctx).bit_rate = 192_000;
+    (*ctx).time_base.num = 1;
+    (*ctx).time_base.den = sample_rate;
+    ff_sys::swresample::channel_layout::set_default(&mut (*ctx).ch_layout, nb_channels);
+
+    ff_sys::avcodec::open2(ctx, codec, ptr::null_mut()).map_err(|e| {
+        ff_sys::avcodec::free_context(&mut ctx as *mut *mut _);
+        ffmpeg_err(e)
+    })?;
+
+    log::info!("dash aac encoder opened sample_rate={sample_rate} channels={nb_channels}");
+    Ok(ctx)
+}
+
+// ============================================================================
+// Cleanup helpers (safe to call with null pointers)
+// ============================================================================
+
+unsafe fn cleanup_decoders(
+    mut vid_dec_ctx: *mut AVCodecContext,
+    mut aud_dec_ctx: *mut AVCodecContext,
+    input_ctx: *mut *mut AVFormatContext,
+) {
+    if !vid_dec_ctx.is_null() {
+        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
+    }
+    if !aud_dec_ctx.is_null() {
+        ff_sys::avcodec::free_context(&mut aud_dec_ctx as *mut *mut _);
+    }
+    ff_sys::avformat::close_input(input_ctx);
+}
+
+unsafe fn cleanup_encoders(
+    mut vid_enc_ctx: *mut AVCodecContext,
+    mut aud_enc_ctx: *mut AVCodecContext,
+    mut swr_ctx: *mut SwrContext,
+) {
+    if !vid_enc_ctx.is_null() {
+        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+    }
+    if !aud_enc_ctx.is_null() {
+        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+    }
+    if !swr_ctx.is_null() {
+        ff_sys::swresample::free(&mut swr_ctx);
+    }
+}
+
+unsafe fn cleanup_output_ctx(mut out_ctx: *mut AVFormatContext) {
+    if !out_ctx.is_null() {
+        avformat_free_context(out_ctx);
+        out_ctx = ptr::null_mut();
+        let _ = out_ctx; // suppress unused warning
+    }
+}
+
+unsafe fn free_frames(
+    mut vid_dec: *mut AVFrame,
+    mut vid_enc: *mut AVFrame,
+    mut aud_dec: *mut AVFrame,
+    mut aud_enc: *mut AVFrame,
+) {
+    if !vid_dec.is_null() {
+        av_frame_free(&mut vid_dec as *mut *mut _);
+    }
+    if !vid_enc.is_null() {
+        av_frame_free(&mut vid_enc as *mut *mut _);
+    }
+    if !aud_dec.is_null() {
+        av_frame_free(&mut aud_dec as *mut *mut _);
+    }
+    if !aud_enc.is_null() {
+        av_frame_free(&mut aud_enc as *mut *mut _);
+    }
+}

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -72,6 +72,7 @@
 
 pub mod abr;
 pub mod dash;
+pub(crate) mod dash_inner;
 /// Unified error type for the `ff-stream` crate.
 pub mod error;
 pub mod hls;

--- a/crates/ff-stream/tests/dash_output_tests.rs
+++ b/crates/ff-stream/tests/dash_output_tests.rs
@@ -1,0 +1,107 @@
+//! Integration tests for DashOutput::write().
+//!
+//! These tests exercise the full FFmpeg DASH muxing pipeline:
+//! 1. Create a short synthetic input video via `ff_encode`.
+//! 2. Call `DashOutput::write()` on it.
+//! 3. Verify that `manifest.mpd` and at least one segment file are created.
+//!
+//! All tests skip gracefully when the required encoder/decoder is unavailable.
+
+// Tests are allowed to use unwrap() for simplicity.
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
+mod fixtures;
+
+use ff_stream::{DashOutput, StreamError};
+use fixtures::{DirGuard, create_test_video, tmp_dir};
+use std::path::PathBuf;
+use std::time::Duration;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Runs the full DASH pipeline and returns the output dir + guard if successful.
+/// Returns `None` when encoder/decoder is unavailable (test should skip).
+fn run_dash_write(test_name: &str, segment_secs: u64) -> Option<(PathBuf, DirGuard)> {
+    let out_dir = tmp_dir(test_name);
+    let guard = DirGuard(out_dir.clone());
+    let input_path = out_dir.join("input.mp4");
+
+    if !create_test_video(&input_path) {
+        return None;
+    }
+
+    let result = DashOutput::new(out_dir.to_str().unwrap())
+        .input(input_path.to_str().unwrap())
+        .segment_duration(Duration::from_secs(segment_secs))
+        .build()
+        .expect("build should succeed")
+        .write();
+
+    match result {
+        Err(StreamError::Ffmpeg { code, message }) => {
+            println!("Skipping: DASH write failed: {message} (code={code})");
+            None
+        }
+        Err(e) => panic!("Unexpected error: {e}"),
+        Ok(()) => Some((out_dir, guard)),
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn write_should_produce_manifest_and_segments() {
+    let Some((out_dir, _guard)) = run_dash_write("dash_write_test", 1) else {
+        return;
+    };
+
+    let manifest = out_dir.join("manifest.mpd");
+    assert!(manifest.exists(), "manifest.mpd should exist");
+    assert!(
+        std::fs::metadata(&manifest).unwrap().len() > 0,
+        "manifest.mpd should be non-empty"
+    );
+
+    let segments: Vec<_> = std::fs::read_dir(&out_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.ends_with(".m4s") || name.ends_with(".mp4")
+        })
+        .filter(|e| e.file_name().to_string_lossy() != "manifest.mpd")
+        .collect();
+    assert!(
+        !segments.is_empty(),
+        "at least one segment file (.m4s or .mp4) should be present"
+    );
+
+    println!(
+        "DASH output: {} segments, manifest {} bytes",
+        segments.len(),
+        std::fs::metadata(&manifest).unwrap().len(),
+    );
+}
+
+#[test]
+fn manifest_should_contain_required_dash_tags() {
+    let Some((out_dir, _guard)) = run_dash_write("dash_tags_test", 1) else {
+        return;
+    };
+
+    let content = std::fs::read_to_string(out_dir.join("manifest.mpd")).unwrap();
+    assert!(
+        content.contains("<?xml"),
+        "missing <?xml declaration in manifest"
+    );
+    assert!(content.contains("MPD"), "missing MPD element in manifest");
+    assert!(
+        content.contains("AdaptationSet"),
+        "missing AdaptationSet in manifest"
+    );
+}

--- a/crates/ff-stream/tests/fixtures/mod.rs
+++ b/crates/ff-stream/tests/fixtures/mod.rs
@@ -1,0 +1,107 @@
+//! Test fixtures and helpers for ff-stream integration tests.
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+// ============================================================================
+// Output Path Helpers
+// ============================================================================
+
+/// Returns the path to the shared test output directory.
+pub fn test_output_dir() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(format!("{manifest_dir}/target/test-output"))
+}
+
+/// Creates a unique temporary subdirectory under `target/test-output/`.
+pub fn tmp_dir(name: &str) -> PathBuf {
+    let dir = test_output_dir().join(name);
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+// ============================================================================
+// Cleanup Helpers
+// ============================================================================
+
+/// Guard that removes a directory tree when dropped.
+///
+/// After removing the named subdirectory, it also attempts to remove the
+/// parent `target/test-output` directory; the removal is a no-op when other
+/// tests have left their own subdirectories behind.
+pub struct DirGuard(pub PathBuf);
+
+impl Drop for DirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+        // Walk up and remove each ancestor only if it is now empty.
+        let mut dir = self.0.as_path();
+        while let Some(parent) = dir.parent() {
+            if std::fs::remove_dir(parent).is_err() {
+                break;
+            }
+            dir = parent;
+        }
+    }
+}
+
+// ============================================================================
+// Video Fixture Helper
+// ============================================================================
+
+/// Create a minimal synthetic video file at `path` using ff_encode.
+///
+/// Returns `false` and prints a skip message if the encoder is unavailable.
+pub fn create_test_video(path: &PathBuf) -> bool {
+    use ff_encode::{VideoCodec, VideoEncoder};
+    use ff_format::{PixelFormat, PooledBuffer, Timestamp, VideoFrame};
+
+    let mut encoder = match VideoEncoder::create(path.to_str().unwrap())
+        .video(320, 240, 25.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping test: cannot create encoder: {e}");
+            return false;
+        }
+    };
+
+    // 50 frames = 2 s at 25 fps
+    for _ in 0..50 {
+        let y_size = 320 * 240;
+        let uv_size = (320 / 2) * (240 / 2);
+        let frame = match VideoFrame::new(
+            vec![
+                PooledBuffer::standalone(vec![0u8; y_size]),
+                PooledBuffer::standalone(vec![128u8; uv_size]),
+                PooledBuffer::standalone(vec![128u8; uv_size]),
+            ],
+            vec![320, 160, 160],
+            320,
+            240,
+            PixelFormat::Yuv420p,
+            Timestamp::default(),
+            true,
+        ) {
+            Ok(f) => f,
+            Err(_) => {
+                println!("Skipping test: frame creation failed");
+                return false;
+            }
+        };
+        if encoder.push_video(&frame).is_err() {
+            println!("Skipping test: frame push failed");
+            return false;
+        }
+    }
+
+    if encoder.finish().is_err() {
+        println!("Skipping test: encoder finish failed");
+        return false;
+    }
+
+    true
+}

--- a/crates/ff-stream/tests/hls_output_tests.rs
+++ b/crates/ff-stream/tests/hls_output_tests.rs
@@ -11,80 +11,16 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
+mod fixtures;
+
 use ff_stream::{HlsOutput, StreamError};
+use fixtures::{DirGuard, create_test_video, tmp_dir};
 use std::path::PathBuf;
 use std::time::Duration;
 
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/// Create a unique temporary output directory under the crate's target/.
-fn tmp_dir(name: &str) -> PathBuf {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let dir = PathBuf::from(format!("{manifest_dir}/target/test-output/{name}"));
-    std::fs::create_dir_all(&dir).ok();
-    dir
-}
-
-/// Guard that removes a directory tree when dropped.
-struct DirGuard(PathBuf);
-impl Drop for DirGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.0);
-    }
-}
-
-/// Create a minimal synthetic video file at `path` using ff_encode.
-///
-/// Returns `false` and prints a skip message if the encoder is unavailable.
-fn create_test_video(path: &PathBuf) -> bool {
-    use ff_encode::{VideoCodec, VideoEncoder};
-    use ff_format::{PixelFormat, PooledBuffer, Timestamp, VideoFrame};
-
-    let mut encoder = match VideoEncoder::create(path.to_str().unwrap())
-        .video(320, 240, 25.0)
-        .video_codec(VideoCodec::Mpeg4)
-        .build()
-    {
-        Ok(enc) => enc,
-        Err(e) => {
-            println!("Skipping test: cannot create encoder: {e}");
-            return false;
-        }
-    };
-
-    // 50 frames = 2 s at 25 fps
-    for _ in 0..50 {
-        let y_size = 320 * 240;
-        let uv_size = (320 / 2) * (240 / 2);
-        let frame = VideoFrame::new(
-            vec![
-                PooledBuffer::standalone(vec![0u8; y_size]),
-                PooledBuffer::standalone(vec![128u8; uv_size]),
-                PooledBuffer::standalone(vec![128u8; uv_size]),
-            ],
-            vec![320, 160, 160],
-            320,
-            240,
-            PixelFormat::Yuv420p,
-            Timestamp::default(),
-            true,
-        )
-        .expect("frame creation failed");
-        if encoder.push_video(&frame).is_err() {
-            println!("Skipping test: frame push failed");
-            return false;
-        }
-    }
-
-    if encoder.finish().is_err() {
-        println!("Skipping test: encoder finish failed");
-        return false;
-    }
-
-    true
-}
 
 /// Runs the full HLS pipeline and returns the output dir + guard if successful.
 /// Returns `None` when encoder/decoder is unavailable (test should skip).


### PR DESCRIPTION
## Summary

Implements `DashOutput::write()` using FFmpeg's DASH muxer, replacing the previous stub. The implementation follows the same decode→encode→mux pipeline established by `hls_inner.rs`, with DASH-specific options: `manifest.mpd` output path, `seg_duration` muxer option, and keyframe interval computed internally from segment duration × fps. The Windows pb-close-after-write-header pattern is carried over to avoid file-locking conflicts.

Also extracts shared test helpers into `tests/fixtures/mod.rs` and extends `DirGuard::drop()` to walk up the directory tree removing empty ancestors, so `target/test-output/` and `target/` are cleaned up automatically after all tests complete.

## Changes

- `src/dash_inner.rs` (new): full unsafe DASH muxing implementation (`write_dash`)
- `src/dash.rs`: wire `write()` to `dash_inner::write_dash`; add `write_without_build_should_return_invalid_config` unit test
- `src/lib.rs`: register `pub(crate) mod dash_inner`
- `tests/fixtures/mod.rs` (new): shared `DirGuard`, `tmp_dir`, `create_test_video` helpers with cascading empty-directory cleanup on drop
- `tests/dash_output_tests.rs` (new): 2 integration tests — manifest + segment existence, required MPD XML tags
- `tests/hls_output_tests.rs`: migrated to shared fixtures module

## Related Issues

Closes #72

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes