### PR TITLE
feat(ff-stream): propagate bit_rate to DASH codecpar and add manifest tests

### DIFF
--- a/crates/ff-stream/src/dash_inner.rs
+++ b/crates/ff-stream/src/dash_inner.rs
@@ -274,6 +274,7 @@ unsafe fn write_dash_unsafe(
         (*(*vid_out_stream).codecpar).width = (*vid_enc_ctx).width;
         (*(*vid_out_stream).codecpar).height = (*vid_enc_ctx).height;
         (*(*vid_out_stream).codecpar).format = (*vid_enc_ctx).pix_fmt;
+        (*(*vid_out_stream).codecpar).bit_rate = (*vid_enc_ctx).bit_rate;
     }
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────

--- a/crates/ff-stream/tests/dash_output_tests.rs
+++ b/crates/ff-stream/tests/dash_output_tests.rs
@@ -105,3 +105,46 @@ fn manifest_should_contain_required_dash_tags() {
         "missing AdaptationSet in manifest"
     );
 }
+
+#[test]
+fn representation_should_match_encoder_dimensions() {
+    let Some((out_dir, _guard)) = run_dash_write("dash_repr_test", 1) else {
+        return;
+    };
+    let content = std::fs::read_to_string(out_dir.join("manifest.mpd")).unwrap();
+    assert!(
+        content.contains("Representation"),
+        "missing Representation element"
+    );
+    assert!(
+        content.contains("width=\"320\""),
+        "Representation missing width=\"320\""
+    );
+    assert!(
+        content.contains("height=\"240\""),
+        "Representation missing height=\"240\""
+    );
+}
+
+#[test]
+fn manifest_should_contain_single_adaptation_set() {
+    let Some((out_dir, _guard)) = run_dash_write("dash_single_as_test", 1) else {
+        return;
+    };
+    let content = std::fs::read_to_string(out_dir.join("manifest.mpd")).unwrap();
+    let count = content.matches("<AdaptationSet").count();
+    assert_eq!(count, 1, "expected exactly 1 AdaptationSet, got {count}");
+}
+
+#[test]
+fn init_segment_should_be_present() {
+    let Some((out_dir, _guard)) = run_dash_write("dash_init_test", 1) else {
+        return;
+    };
+    let init = out_dir.join("init-stream0.m4s");
+    assert!(init.exists(), "init-stream0.m4s should exist");
+    assert!(
+        std::fs::metadata(&init).unwrap().len() > 0,
+        "init-stream0.m4s should be non-empty"
+    );
+}


### PR DESCRIPTION
## Summary

FFmpeg's `dash` muxer reads `AVStream.codecpar.bit_rate` to populate the `bandwidth` attribute on each `<Representation>` element in the MPD manifest. This value was not being set, causing the warning `[dash] No bit rate set for stream 0` and an incomplete manifest. This PR propagates the encoder's bit rate to the output stream's `codecpar` and adds integration tests that verify manifest correctness.

## Changes

- `dash_inner.rs`: Add `(*(*vid_out_stream).codecpar).bit_rate = (*vid_enc_ctx).bit_rate;` in step 9 (output stream setup), immediately after the existing `format` field assignment
- `dash_output_tests.rs`: Add three integration tests:
  - `representation_should_match_encoder_dimensions` — asserts `<Representation>` contains `width="320"` and `height="240"`
  - `manifest_should_contain_single_adaptation_set` — asserts exactly one `<AdaptationSet>` is present
  - `init_segment_should_be_present` — asserts `init-stream0.m4s` exists and is non-empty

## Related Issues

Closes #73

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes