### PR TITLE
feat(ff-stream): add derives and unit tests to Rendition struct

### DIFF
--- a/crates/ff-stream/src/abr.rs
+++ b/crates/ff-stream/src/abr.rs
@@ -20,6 +20,7 @@ use crate::error::StreamError;
 /// let r = Rendition { width: 1280, height: 720, bitrate: 3_000_000 };
 /// assert_eq!(r.width, 1280);
 /// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rendition {
     /// Output width in pixels.
     pub width: u32,
@@ -146,6 +147,74 @@ impl AbrLadder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rendition_should_store_all_fields() {
+        let r = Rendition {
+            width: 1920,
+            height: 1080,
+            bitrate: 6_000_000,
+        };
+        assert_eq!(r.width, 1920);
+        assert_eq!(r.height, 1080);
+        assert_eq!(r.bitrate, 6_000_000);
+    }
+
+    #[test]
+    fn rendition_should_be_equal_when_fields_match() {
+        let a = Rendition {
+            width: 854,
+            height: 480,
+            bitrate: 1_500_000,
+        };
+        let b = Rendition {
+            width: 854,
+            height: 480,
+            bitrate: 1_500_000,
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn rendition_should_not_be_equal_when_fields_differ() {
+        let a = Rendition {
+            width: 1280,
+            height: 720,
+            bitrate: 3_000_000,
+        };
+        let b = Rendition {
+            width: 1280,
+            height: 720,
+            bitrate: 2_000_000,
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn rendition_should_implement_debug() {
+        let r = Rendition {
+            width: 640,
+            height: 360,
+            bitrate: 800_000,
+        };
+        let s = format!("{r:?}");
+        assert!(s.contains("640"));
+        assert!(s.contains("360"));
+        assert!(s.contains("800000"));
+    }
+
+    #[test]
+    fn rendition_should_be_copyable() {
+        let original = Rendition {
+            width: 1280,
+            height: 720,
+            bitrate: 3_000_000,
+        };
+        let copy = original;
+        assert_eq!(copy.width, original.width);
+        assert_eq!(copy.height, original.height);
+        assert_eq!(copy.bitrate, original.bitrate);
+    }
 
     #[test]
     fn new_should_store_input_path() {


### PR DESCRIPTION
## Summary

`Rendition` was defined with the correct fields but lacked standard derives, making it impossible to print, clone, copy, or compare values in user code and tests. This PR adds `Debug`, `Clone`, `Copy`, and `PartialEq` derives (all fields are `Copy` primitives so all four are zero-cost) and adds five focused unit tests that exercise each derived capability directly.

## Changes

- `abr.rs`: Add `#[derive(Debug, Clone, Copy, PartialEq)]` to `Rendition`
- `abr.rs`: Add unit tests:
  - `rendition_should_store_all_fields` — verifies all three fields (`width`, `height`, `bitrate`)
  - `rendition_should_be_equal_when_fields_match` — exercises `PartialEq` equality
  - `rendition_should_not_be_equal_when_fields_differ` — exercises `PartialEq` inequality
  - `rendition_should_implement_debug` — verifies `Debug` output contains all field values
  - `rendition_should_be_copyable` — verifies `Copy` by assigning without a borrow

## Related Issues

Closes #74

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes