### PR TITLE
feat(ff-stream): wire rendition bitrate and dimensions into HlsOutput

### DIFF
--- a/crates/ff-stream/src/abr.rs
+++ b/crates/ff-stream/src/abr.rs
@@ -106,11 +106,13 @@ impl AbrLadder {
                 reason: "no renditions added".into(),
             });
         }
-        for (i, _rendition) in self.renditions.iter().enumerate() {
+        for (i, rendition) in self.renditions.iter().enumerate() {
             let subdir = format!("{output_dir}/{i}");
             crate::hls::HlsOutput::new(&subdir)
                 .input(&self.input_path)
                 .segment_duration(Duration::from_secs(6))
+                .bitrate(rendition.bitrate)
+                .video_size(rendition.width, rendition.height)
                 .build()?
                 .write()?;
         }

--- a/crates/ff-stream/src/hls.rs
+++ b/crates/ff-stream/src/hls.rs
@@ -32,6 +32,8 @@ pub struct HlsOutput {
     input_path: Option<String>,
     segment_duration: Duration,
     keyframe_interval: u32,
+    target_bitrate: Option<u64>,
+    target_video_size: Option<(u32, u32)>,
 }
 
 impl HlsOutput {
@@ -49,6 +51,8 @@ impl HlsOutput {
             input_path: None,
             segment_duration: Duration::from_secs(6),
             keyframe_interval: 48,
+            target_bitrate: None,
+            target_video_size: None,
         }
     }
 
@@ -70,6 +74,24 @@ impl HlsOutput {
     #[must_use]
     pub fn segment_duration(mut self, d: Duration) -> Self {
         self.segment_duration = d;
+        self
+    }
+
+    /// Override the target video bitrate in bits per second.
+    ///
+    /// When not set, the encoder uses a default of 2 Mbit/s.
+    #[must_use]
+    pub fn bitrate(mut self, bps: u64) -> Self {
+        self.target_bitrate = Some(bps);
+        self
+    }
+
+    /// Override the output video dimensions.
+    ///
+    /// When not set, the encoder uses the input stream's dimensions.
+    #[must_use]
+    pub fn video_size(mut self, width: u32, height: u32) -> Self {
+        self.target_video_size = Some((width, height));
         self
     }
 
@@ -115,10 +137,13 @@ impl HlsOutput {
             });
         }
         log::info!(
-            "hls output configured output_dir={} segment_duration={:.1}s keyframe_interval={}",
+            "hls output configured output_dir={} segment_duration={:.1}s keyframe_interval={} \
+             bitrate={:?} video_size={:?}",
             self.output_dir,
             self.segment_duration.as_secs_f64(),
             self.keyframe_interval,
+            self.target_bitrate,
+            self.target_video_size,
         );
         Ok(self)
     }
@@ -145,11 +170,18 @@ impl HlsOutput {
             self.output_dir,
             self.keyframe_interval
         );
+        let target_bitrate = self.target_bitrate.map_or(0i64, |b| b.cast_signed());
+        let (target_width, target_height) = self
+            .target_video_size
+            .map_or((0i32, 0i32), |(w, h)| (w.cast_signed(), h.cast_signed()));
         crate::hls_inner::write_hls(
             &input_path,
             &self.output_dir,
             seg_secs,
             self.keyframe_interval,
+            target_bitrate,
+            target_width,
+            target_height,
         )
     }
 }
@@ -206,5 +238,42 @@ mod tests {
         // input_path is None because build() was not called
         let result = HlsOutput::new("/tmp/hls").write();
         assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn bitrate_should_store_bitrate() {
+        let h = HlsOutput::new("/tmp/hls").bitrate(3_000_000);
+        assert_eq!(h.target_bitrate, Some(3_000_000));
+    }
+
+    #[test]
+    fn video_size_should_store_dimensions() {
+        let h = HlsOutput::new("/tmp/hls").video_size(1280, 720);
+        assert_eq!(h.target_video_size, Some((1280, 720)));
+    }
+
+    #[test]
+    fn bitrate_default_should_be_none() {
+        let h = HlsOutput::new("/tmp/hls");
+        assert_eq!(h.target_bitrate, None);
+    }
+
+    #[test]
+    fn video_size_default_should_be_none() {
+        let h = HlsOutput::new("/tmp/hls");
+        assert_eq!(h.target_video_size, None);
+    }
+
+    #[test]
+    fn build_with_bitrate_and_video_size_should_succeed() {
+        let result = HlsOutput::new("/tmp/hls")
+            .input("/src/video.mp4")
+            .bitrate(4_000_000)
+            .video_size(1920, 1080)
+            .build();
+        assert!(result.is_ok());
+        let h = result.unwrap();
+        assert_eq!(h.target_bitrate, Some(4_000_000));
+        assert_eq!(h.target_video_size, Some((1920, 1080)));
     }
 }

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -71,6 +71,9 @@ pub(crate) fn write_hls(
     output_dir: &str,
     segment_duration_secs: f64,
     keyframe_interval: u32,
+    target_bitrate: i64,
+    target_width: i32,
+    target_height: i32,
 ) -> Result<(), StreamError> {
     std::fs::create_dir_all(output_dir)?;
     // SAFETY: All FFmpeg resources are allocated and freed within this call.
@@ -80,6 +83,9 @@ pub(crate) fn write_hls(
             output_dir,
             segment_duration_secs,
             keyframe_interval,
+            target_bitrate,
+            target_width,
+            target_height,
         )
     }
 }
@@ -93,6 +99,9 @@ unsafe fn write_hls_unsafe(
     output_dir: &str,
     segment_duration_secs: f64,
     keyframe_interval: u32,
+    target_bitrate: i64,
+    target_width: i32,
+    target_height: i32,
 ) -> Result<(), StreamError> {
     ff_sys::ensure_initialized();
 
@@ -129,8 +138,16 @@ unsafe fn write_hls_unsafe(
     // ── 3. Read video stream properties ──────────────────────────────────────
     let video_stream = *(*input_ctx).streams.add(video_stream_idx as usize);
     let video_codecpar = (*video_stream).codecpar;
-    let enc_width = (*video_codecpar).width;
-    let enc_height = (*video_codecpar).height;
+    let enc_width = if target_width > 0 {
+        target_width
+    } else {
+        (*video_codecpar).width
+    };
+    let enc_height = if target_height > 0 {
+        target_height
+    } else {
+        (*video_codecpar).height
+    };
     let video_fps = {
         let r = (*video_stream).avg_frame_rate;
         if r.den > 0 && r.num > 0 {
@@ -271,7 +288,11 @@ unsafe fn write_hls_unsafe(
     (*vid_enc_ctx).framerate.num = fps_int;
     (*vid_enc_ctx).framerate.den = 1;
     (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-    (*vid_enc_ctx).bit_rate = 2_000_000;
+    (*vid_enc_ctx).bit_rate = if target_bitrate > 0 {
+        target_bitrate
+    } else {
+        2_000_000
+    };
 
     ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
         ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
@@ -398,7 +419,8 @@ unsafe fn write_hls_unsafe(
 
     log::info!(
         "hls output context ready width={enc_width} height={enc_height} fps={video_fps:.1} \
-         audio={}",
+         bit_rate={} audio={}",
+        (*vid_enc_ctx).bit_rate,
         audio_stream_idx >= 0
     );
 


### PR DESCRIPTION
## Summary

Each `AbrLadder` rendition now encodes at its declared `bitrate` and `(width, height)` instead of the hardcoded 2 Mbit/s and input dimensions. `HlsOutput` gains `bitrate()` and `video_size()` setters that are forwarded through `write_hls` to the FFmpeg video encoder context; zero sentinels fall back to the previous defaults so existing callers are unaffected.

## Changes

- `hls_inner.rs`: added `target_bitrate: i64`, `target_width: i32`, `target_height: i32` parameters to `write_hls` and `write_hls_unsafe`; applied in encoder context setup; updated `log::info!` to include `bit_rate`
- `hls.rs`: added `target_bitrate: Option<u64>` and `target_video_size: Option<(u32, u32)>` fields; added `bitrate()` and `video_size()` setters; updated `build()` log line; updated `write()` call-site; added 5 unit tests (31 total)
- `abr.rs`: changed `_rendition` → `rendition`; chained `.bitrate(rendition.bitrate).video_size(rendition.width, rendition.height)` so each rendition encodes at its declared parameters

## Related Issues

Closes #76

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes