### PR TITLE
test(avio): add unit tests verifying filter feature re-exports

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -187,4 +187,35 @@ mod tests {
     fn encode_error_should_be_accessible() {
         let _: EncodeError = EncodeError::Cancelled;
     }
+
+    // ── filter feature ────────────────────────────────────────────────────────
+
+    #[cfg(feature = "filter")]
+    #[test]
+    fn filter_graph_builder_should_be_accessible() {
+        // FilterGraphBuilder::new() is the public entry point.
+        let _builder: FilterGraphBuilder = FilterGraphBuilder::new();
+    }
+
+    #[cfg(feature = "filter")]
+    #[test]
+    fn filter_tone_map_should_be_accessible() {
+        let _: ToneMap = ToneMap::Hable;
+        let _: ToneMap = ToneMap::Reinhard;
+        let _: ToneMap = ToneMap::Mobius;
+    }
+
+    #[cfg(feature = "filter")]
+    #[test]
+    fn filter_hw_accel_should_be_accessible() {
+        let _: HwAccel = HwAccel::Cuda;
+        let _: HwAccel = HwAccel::VideoToolbox;
+    }
+
+    #[cfg(feature = "filter")]
+    #[test]
+    fn filter_error_should_be_accessible() {
+        let _: FilterError = FilterError::BuildFailed;
+        let _: FilterError = FilterError::ProcessFailed;
+    }
 }


### PR DESCRIPTION
## Summary

The `ff-filter` re-exports under the `filter` feature were already wired up in #494 (issue #78). This PR closes issue #80 by adding four `#[cfg(feature = "filter")]` unit tests to `avio/src/lib.rs` that verify every `ff-filter` public type is accessible from the `avio` namespace when the feature is enabled.

## Changes

- `crates/avio/src/lib.rs`: add 4 filter-feature unit tests:
  - `filter_graph_builder_should_be_accessible` — `FilterGraphBuilder::new()` resolves without qualification
  - `filter_tone_map_should_be_accessible` — `ToneMap::Hable`, `Reinhard`, `Mobius` variants are in scope
  - `filter_hw_accel_should_be_accessible` — `HwAccel::Cuda`, `VideoToolbox` variants are in scope
  - `filter_error_should_be_accessible` — `FilterError::BuildFailed`, `ProcessFailed` are in scope

## Related Issues

Closes #80

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes