### PR TITLE
refactor(ff-encode): remove duplicate VideoCodec/AudioCodec; re-export from ff-format

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -13,11 +13,13 @@ use crate::{AudioCodec, EncodeError};
 use ff_format::AudioFrame;
 use ff_sys::{
     AVChannelLayout, AVCodecContext, AVCodecID, AVCodecID_AV_CODEC_ID_AAC,
-    AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_OPUS,
-    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame,
-    SwrContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc,
-    av_packet_free, av_packet_unref, av_write_trailer, avcodec, avformat_alloc_output_context2,
-    avformat_free_context, avformat_new_stream, avformat_write_header, swresample,
+    AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_DTS,
+    AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3,
+    AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
+    AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame, SwrContext, av_frame_alloc,
+    av_frame_free, av_interleaved_write_frame, av_packet_alloc, av_packet_free, av_packet_unref,
+    av_write_trailer, avcodec, avformat_alloc_output_context2, avformat_free_context,
+    avformat_new_stream, avformat_write_header, swresample,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -176,6 +178,11 @@ impl AudioEncoderInner {
                 AudioCodec::Flac => 0, // Lossless
                 AudioCodec::Pcm => 0,  // Uncompressed
                 AudioCodec::Vorbis => 192_000,
+                AudioCodec::Ac3 => 192_000,
+                AudioCodec::Eac3 => 192_000,
+                AudioCodec::Dts => 0,  // Lossless/variable
+                AudioCodec::Alac => 0, // Lossless
+                _ => 192_000,
             };
         }
 
@@ -225,6 +232,11 @@ impl AudioEncoderInner {
             AudioCodec::Flac => vec!["flac"],
             AudioCodec::Pcm => vec!["pcm_s16le"],
             AudioCodec::Vorbis => vec!["libvorbis", "vorbis"],
+            AudioCodec::Ac3 => vec!["ac3"],
+            AudioCodec::Eac3 => vec!["eac3"],
+            AudioCodec::Dts => vec![],
+            AudioCodec::Alac => vec!["alac"],
+            _ => vec![],
         };
 
         // Try each candidate
@@ -538,6 +550,11 @@ fn codec_to_id(codec: AudioCodec) -> AVCodecID {
         AudioCodec::Flac => AVCodecID_AV_CODEC_ID_FLAC,
         AudioCodec::Pcm => AVCodecID_AV_CODEC_ID_PCM_S16LE,
         AudioCodec::Vorbis => AVCodecID_AV_CODEC_ID_VORBIS,
+        AudioCodec::Ac3 => AVCodecID_AV_CODEC_ID_AC3,
+        AudioCodec::Eac3 => AVCodecID_AV_CODEC_ID_EAC3,
+        AudioCodec::Dts => AVCodecID_AV_CODEC_ID_DTS,
+        AudioCodec::Alac => AVCodecID_AV_CODEC_ID_ALAC,
+        _ => AVCodecID_AV_CODEC_ID_NONE,
     }
 }
 

--- a/crates/ff-encode/src/codec.rs
+++ b/crates/ff-encode/src/codec.rs
@@ -1,98 +1,62 @@
-//! Codec definitions for encoding.
+//! Codec type re-exports and encode-specific extensions.
+//!
+//! `VideoCodec` and `AudioCodec` are the canonical types defined in
+//! `ff-format` and re-exported here so callers can import them from a
+//! single crate.  Encode-specific behaviour (LGPL licensing, default
+//! file extension) is provided via the [`VideoCodecEncodeExt`] trait.
 
-/// Video codec for encoding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[non_exhaustive]
-pub enum VideoCodec {
-    /// H.264 / AVC (most compatible)
-    #[default]
-    H264,
+pub use ff_format::{AudioCodec, VideoCodec};
 
-    /// H.265 / HEVC (high compression)
-    H265,
+/// Encode-specific methods for [`VideoCodec`].
+///
+/// This trait adds encoding-oriented helpers to the shared `VideoCodec` type.
+/// Import it to call [`is_lgpl_compatible`](Self::is_lgpl_compatible) or
+/// [`default_extension`](Self::default_extension) on a codec value.
+///
+/// # Examples
+///
+/// ```
+/// use ff_encode::{VideoCodec, VideoCodecEncodeExt};
+///
+/// assert!(VideoCodec::Vp9.is_lgpl_compatible());
+/// assert_eq!(VideoCodec::H264.default_extension(), "mp4");
+/// ```
+pub trait VideoCodecEncodeExt {
+    /// Returns `true` if the *software* encoder for this codec is
+    /// LGPL-compatible (i.e. does not require a GPL or proprietary licence).
+    ///
+    /// **Important**: This reflects the codec family's typical software
+    /// encoder licensing, not the actual encoder chosen at runtime.
+    /// H.264 and H.265 return `false` because their software encoders
+    /// (libx264/libx265) are GPL; hardware encoders (NVENC, QSV, etc.)
+    /// are LGPL-compatible regardless.
+    ///
+    /// Use [`VideoEncoder::is_lgpl_compliant`](crate::VideoEncoder) to
+    /// query the actual encoder selected at runtime.
+    fn is_lgpl_compatible(&self) -> bool;
 
-    /// VP9 (`WebM`, royalty-free)
-    Vp9,
-
-    /// AV1 (latest, high compression, LGPL compatible)
-    Av1,
-
-    /// `ProRes` (Apple, editing)
-    ProRes,
-
-    /// `DNxHD`/`DNxHR` (Avid, editing)
-    DnxHd,
-
-    /// MPEG-4
-    Mpeg4,
+    /// Returns the default output file extension for this codec.
+    fn default_extension(&self) -> &'static str;
 }
 
-impl VideoCodec {
-    /// Check if this codec specification is LGPL compatible.
-    ///
-    /// Returns `true` for codecs that can be used without GPL licensing.
-    ///
-    /// **Important**: This indicates the codec family's licensing, not the actual encoder used.
-    /// H.264 and H.265 return `false` because their software encoders (libx264/libx265) are GPL,
-    /// but hardware encoders (NVENC, QSV, etc.) are LGPL-compatible.
-    ///
-    /// Use [`VideoEncoder::is_lgpl_compliant()`](crate::VideoEncoder::is_lgpl_compliant) to check
-    /// the actual encoder selected at runtime.
-    ///
-    /// # LGPL-Compatible Codecs
-    ///
-    /// - `VP9` - Google's royalty-free codec (libvpx-vp9)
-    /// - `AV1` - Next-gen royalty-free codec (libaom-av1)
-    /// - `ProRes` - Apple's professional codec
-    /// - `DNxHD` - Avid's professional codec
-    /// - `MPEG4` - ISO MPEG-4 Part 2
-    ///
-    /// # GPL Codecs (require licensing for commercial use)
-    ///
-    /// - `H264` - Requires MPEG LA license (when using libx264)
-    /// - `H265` - Requires MPEG LA license (when using libx265)
-    ///
-    /// Note: Hardware H.264/H.265 encoders are LGPL-compatible and don't require licensing fees.
-    #[must_use]
-    pub const fn is_lgpl_compatible(self) -> bool {
-        match self {
-            Self::Vp9 | Self::Av1 | Self::Mpeg4 | Self::ProRes | Self::DnxHd => true,
-            Self::H264 | Self::H265 => false, // libx264/libx265 are GPL
-        }
+impl VideoCodecEncodeExt for VideoCodec {
+    fn is_lgpl_compatible(&self) -> bool {
+        matches!(
+            self,
+            VideoCodec::Vp9
+                | VideoCodec::Av1
+                | VideoCodec::Mpeg4
+                | VideoCodec::ProRes
+                | VideoCodec::DnxHd
+        )
     }
 
-    /// Get default file extension for this codec.
-    #[must_use]
-    pub const fn default_extension(self) -> &'static str {
+    fn default_extension(&self) -> &'static str {
         match self {
-            Self::Vp9 | Self::Av1 => "webm",
+            VideoCodec::Vp9 | VideoCodec::Av1 => "webm",
             _ => "mp4",
         }
     }
-}
-
-/// Audio codec for encoding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[non_exhaustive]
-pub enum AudioCodec {
-    /// AAC (most compatible)
-    #[default]
-    Aac,
-
-    /// Opus (high quality, low latency)
-    Opus,
-
-    /// MP3
-    Mp3,
-
-    /// FLAC (lossless)
-    Flac,
-
-    /// PCM (uncompressed)
-    Pcm,
-
-    /// Vorbis (OGG)
-    Vorbis,
 }
 
 #[cfg(test)]
@@ -100,23 +64,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_video_codec_lgpl() {
+    fn video_codec_is_lgpl_compatible_should_return_true_for_open_codecs() {
         assert!(VideoCodec::Vp9.is_lgpl_compatible());
         assert!(VideoCodec::Av1.is_lgpl_compatible());
         assert!(VideoCodec::Mpeg4.is_lgpl_compatible());
+        assert!(VideoCodec::ProRes.is_lgpl_compatible());
+        assert!(VideoCodec::DnxHd.is_lgpl_compatible());
+    }
+
+    #[test]
+    fn video_codec_is_lgpl_compatible_should_return_false_for_gpl_codecs() {
         assert!(!VideoCodec::H264.is_lgpl_compatible());
         assert!(!VideoCodec::H265.is_lgpl_compatible());
     }
 
     #[test]
-    fn test_video_codec_extension() {
+    fn video_codec_default_extension_should_return_webm_for_web_codecs() {
         assert_eq!(VideoCodec::H264.default_extension(), "mp4");
         assert_eq!(VideoCodec::Vp9.default_extension(), "webm");
         assert_eq!(VideoCodec::Av1.default_extension(), "webm");
     }
 
     #[test]
-    fn test_default_codecs() {
+    fn video_and_audio_codec_default_should_be_accessible() {
         assert_eq!(VideoCodec::default(), VideoCodec::H264);
         assert_eq!(AudioCodec::default(), AudioCodec::Aac);
     }

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -205,7 +205,7 @@ mod video;
 
 pub use audio::{AudioEncoder, AudioEncoderBuilder};
 pub use bitrate::{BitrateMode, CRF_MAX};
-pub use codec::{AudioCodec, VideoCodec};
+pub use codec::{AudioCodec, VideoCodec, VideoCodecEncodeExt};
 pub use container::Container;
 pub use error::EncodeError;
 pub use hardware::HardwareEncoder;

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -13,15 +13,18 @@ use crate::{AudioCodec, EncodeError, VideoCodec};
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
     AV_TIME_BASE, AVChannelLayout, AVChapter, AVCodecContext, AVCodecID, AVCodecID_AV_CODEC_ID_AAC,
-    AVCodecID_AV_CODEC_ID_AV1, AVCodecID_AV_CODEC_ID_DNXHD, AVCodecID_AV_CODEC_ID_FLAC,
-    AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC, AVCodecID_AV_CODEC_ID_MP3,
-    AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
-    AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP9,
-    AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext, SwsContext, av_frame_alloc, av_frame_free,
-    av_interleaved_write_frame, av_mallocz, av_packet_alloc, av_packet_free, av_packet_unref,
-    av_write_trailer, avcodec, avformat_alloc_output_context2, avformat_free_context,
-    avformat_new_stream, avformat_write_header, swresample, swscale,
+    AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_AV1,
+    AVCodecID_AV_CODEC_ID_DNXHD, AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3,
+    AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC,
+    AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
+    AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS,
+    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS,
+    AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9, AVFormatContext, AVFrame,
+    AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext,
+    SwsContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_mallocz,
+    av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer, avcodec,
+    avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat_write_header, swresample, swscale,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -552,6 +555,10 @@ impl VideoEncoderInner {
             VideoCodec::ProRes => vec!["prores_ks", "prores"],
             VideoCodec::DnxHd => vec!["dnxhd"],
             VideoCodec::Mpeg4 => vec!["mpeg4"],
+            VideoCodec::Vp8 => vec!["libvpx"],
+            VideoCodec::Mpeg2 => vec!["mpeg2video"],
+            VideoCodec::Mjpeg => vec!["mjpeg"],
+            _ => vec![],
         };
 
         // Try each candidate
@@ -733,6 +740,11 @@ impl VideoEncoderInner {
                 AudioCodec::Flac => 0, // Lossless
                 AudioCodec::Pcm => 0,  // Uncompressed
                 AudioCodec::Vorbis => 192_000,
+                AudioCodec::Ac3 => 192_000,
+                AudioCodec::Eac3 => 192_000,
+                AudioCodec::Dts => 0,  // Lossless/variable
+                AudioCodec::Alac => 0, // Lossless
+                _ => 192_000,
             };
         }
 
@@ -782,6 +794,11 @@ impl VideoEncoderInner {
             AudioCodec::Flac => vec!["flac"],
             AudioCodec::Pcm => vec!["pcm_s16le"],
             AudioCodec::Vorbis => vec!["libvorbis", "vorbis"],
+            AudioCodec::Ac3 => vec!["ac3"],
+            AudioCodec::Eac3 => vec!["eac3"],
+            AudioCodec::Dts => vec![],
+            AudioCodec::Alac => vec!["alac"],
+            _ => vec![],
         };
 
         // Try each candidate
@@ -2152,6 +2169,10 @@ fn codec_to_id(codec: VideoCodec) -> AVCodecID {
         VideoCodec::ProRes => AVCodecID_AV_CODEC_ID_PRORES,
         VideoCodec::DnxHd => AVCodecID_AV_CODEC_ID_DNXHD,
         VideoCodec::Mpeg4 => AVCodecID_AV_CODEC_ID_MPEG4,
+        VideoCodec::Vp8 => AVCodecID_AV_CODEC_ID_VP8,
+        VideoCodec::Mpeg2 => AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
+        VideoCodec::Mjpeg => AVCodecID_AV_CODEC_ID_MJPEG,
+        _ => AVCodecID_AV_CODEC_ID_NONE,
     }
 }
 
@@ -2177,6 +2198,11 @@ fn audio_codec_to_id(codec: AudioCodec) -> AVCodecID {
         AudioCodec::Flac => AVCodecID_AV_CODEC_ID_FLAC,
         AudioCodec::Pcm => AVCodecID_AV_CODEC_ID_PCM_S16LE,
         AudioCodec::Vorbis => AVCodecID_AV_CODEC_ID_VORBIS,
+        AudioCodec::Ac3 => AVCodecID_AV_CODEC_ID_AC3,
+        AudioCodec::Eac3 => AVCodecID_AV_CODEC_ID_EAC3,
+        AudioCodec::Dts => AVCodecID_AV_CODEC_ID_DTS,
+        AudioCodec::Alac => AVCodecID_AV_CODEC_ID_ALAC,
+        _ => AVCodecID_AV_CODEC_ID_NONE,
     }
 }
 


### PR DESCRIPTION
## Summary

`ff-encode` previously defined its own `VideoCodec` and `AudioCodec` enums independently of `ff-format`, causing type mismatches when callers tried to pass `ff-format` codec values into encoder APIs. This PR removes the duplicate definitions and re-exports the canonical types from `ff-format`, making `ff_encode::VideoCodec` and `ff_encode::AudioCodec` identical to their `ff-format` counterparts.

## Changes

- **`codec.rs`**: Replaced `VideoCodec` and `AudioCodec` enum definitions with `pub use ff_format::{AudioCodec, VideoCodec}`. Encode-specific methods (`is_lgpl_compatible`, `default_extension`) moved to the new `VideoCodecEncodeExt` extension trait, implemented for `ff_format::VideoCodec` from within `ff-encode`.
- **`lib.rs`**: Added `VideoCodecEncodeExt` to public re-exports so existing callers can access the methods by importing the trait.
- **`video/encoder_inner.rs`** and **`audio/encoder_inner.rs`**: Added `_` wildcard arms and explicit arms for `ff-format` variants not previously in `ff-encode` (`Vp8`, `Mpeg2`, `Mjpeg`, `Ac3`, `Eac3`, `Dts`, `Alac`, `Unknown`) — including correct FFmpeg `AVCodecID` mappings and encoder candidate lists for the new audio codecs.

## Related Issues

Resolves #498

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes