### PR TITLE
refactor(ff-pipeline): update EncoderConfig to use ff-format codec types

### DIFF
--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -9,9 +9,9 @@
 use std::time::Instant;
 
 use ff_decode::{AudioDecoder, VideoDecoder};
-use ff_encode::{AudioCodec, BitrateMode, HardwareEncoder, VideoCodec, VideoEncoder};
+use ff_encode::{BitrateMode, HardwareEncoder, VideoEncoder};
 use ff_filter::{FilterGraph, HwAccel};
-use ff_format::Timestamp;
+use ff_format::{AudioCodec, Timestamp, VideoCodec};
 
 use crate::error::PipelineError;
 use crate::progress::{Progress, ProgressCallback};
@@ -63,7 +63,8 @@ impl Pipeline {
     ///
     /// ```ignore
     /// use ff_pipeline::{Pipeline, EncoderConfig};
-    /// use ff_encode::{VideoCodec, AudioCodec, BitrateMode};
+    /// use ff_format::{VideoCodec, AudioCodec};
+    /// use ff_encode::BitrateMode;
     ///
     /// let pipeline = Pipeline::builder()
     ///     .input("input.mp4")
@@ -371,7 +372,8 @@ impl Default for PipelineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
+    use ff_encode::BitrateMode;
+    use ff_format::{AudioCodec, VideoCodec};
 
     fn dummy_config() -> EncoderConfig {
         EncoderConfig {


### PR DESCRIPTION
## Summary

`EncoderConfig.video_codec` and `.audio_codec` previously held `ff_encode::VideoCodec` / `ff_encode::AudioCodec`, which are now re-exported aliases of the canonical `ff_format` types. This PR updates `pipeline.rs` to import `VideoCodec` and `AudioCodec` directly from `ff_format`, making the field types unambiguous and matching what the `avio` facade exposes to users.

## Changes

- Updated the production `use` statement in `pipeline.rs`: removed `AudioCodec` and `VideoCodec` from the `ff_encode` import; added them to the `ff_format` import alongside `Timestamp`.
- Updated the doc-comment `ignore` example to reflect the new import path.
- Updated the test-module `use` block to import `AudioCodec` and `VideoCodec` from `ff_format`.

## Related Issues

Resolves #499

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes