### PR TITLE
refactor(ff-encode): rename Progress/ProgressCallback to EncodeProgress/EncodeProgressCallback

### DIFF
--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -103,8 +103,8 @@
 //!     cancelled: Arc<AtomicBool>,
 //! }
 //!
-//! impl ProgressCallback for CancellableProgress {
-//!     fn on_progress(&mut self, progress: &Progress) {
+//! impl EncodeProgressCallback for CancellableProgress {
+//!     fn on_progress(&mut self, progress: &EncodeProgress) {
 //!         println!("Progress: {:.1}%", progress.percent());
 //!     }
 //!
@@ -211,5 +211,5 @@ pub use error::EncodeError;
 pub use hardware::HardwareEncoder;
 pub use image::{ImageEncoder, ImageEncoderBuilder};
 pub use preset::Preset;
-pub use progress::{Progress, ProgressCallback};
+pub use progress::{EncodeProgress, EncodeProgressCallback};
 pub use video::{VideoEncoder, VideoEncoderBuilder};

--- a/crates/ff-encode/src/progress.rs
+++ b/crates/ff-encode/src/progress.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 /// Provides real-time information about the encoding process,
 /// including frames encoded, bytes written, and time estimates.
 #[derive(Debug, Clone)]
-pub struct Progress {
+pub struct EncodeProgress {
     /// Number of frames encoded so far
     pub frames_encoded: u64,
 
@@ -35,7 +35,7 @@ pub struct Progress {
     pub current_fps: f64,
 }
 
-impl Progress {
+impl EncodeProgress {
     /// Calculate progress percentage (0.0 - 100.0).
     ///
     /// Returns 0.0 if total frames is unknown.
@@ -52,7 +52,7 @@ impl Progress {
     }
 }
 
-/// Progress callback trait for monitoring encoding progress.
+/// EncodeProgress callback trait for monitoring encoding progress.
 ///
 /// Implement this trait to receive real-time encoding progress updates
 /// and optionally support encoding cancellation.
@@ -60,16 +60,16 @@ impl Progress {
 /// # Examples
 ///
 /// ```ignore
-/// use ff_encode::{Progress, ProgressCallback};
+/// use ff_encode::{EncodeProgress, EncodeProgressCallback};
 /// use std::sync::Arc;
 /// use std::sync::atomic::{AtomicBool, Ordering};
 ///
-/// struct MyProgressHandler {
+/// struct MyEncodeProgressHandler {
 ///     cancelled: Arc<AtomicBool>,
 /// }
 ///
-/// impl ProgressCallback for MyProgressHandler {
-///     fn on_progress(&mut self, progress: &Progress) {
+/// impl EncodeProgressCallback for MyEncodeProgressHandler {
+///     fn on_progress(&mut self, progress: &EncodeProgress) {
 ///         println!("Encoded {} frames at {:.1} fps",
 ///             progress.frames_encoded,
 ///             progress.current_fps
@@ -81,7 +81,7 @@ impl Progress {
 ///     }
 /// }
 /// ```
-pub trait ProgressCallback: Send {
+pub trait EncodeProgressCallback: Send {
     /// Called when encoding progress is updated.
     ///
     /// This method is called periodically during encoding to report progress.
@@ -90,7 +90,7 @@ pub trait ProgressCallback: Send {
     /// # Arguments
     ///
     /// * `progress` - Current encoding progress information
-    fn on_progress(&mut self, progress: &Progress);
+    fn on_progress(&mut self, progress: &EncodeProgress);
 
     /// Check if encoding should be cancelled.
     ///
@@ -109,15 +109,15 @@ pub trait ProgressCallback: Send {
     }
 }
 
-/// Implement ProgressCallback for closures.
+/// Implement EncodeProgressCallback for closures.
 ///
 /// This allows using simple closures as progress callbacks without
 /// needing to define a custom struct implementing the trait.
-impl<F> ProgressCallback for F
+impl<F> EncodeProgressCallback for F
 where
-    F: FnMut(&Progress) + Send,
+    F: FnMut(&EncodeProgress) + Send,
 {
-    fn on_progress(&mut self, progress: &Progress) {
+    fn on_progress(&mut self, progress: &EncodeProgress) {
         self(progress);
     }
 }
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn test_progress_percent() {
-        let progress = Progress {
+        let progress = EncodeProgress {
             frames_encoded: 50,
             total_frames: Some(100),
             bytes_written: 1_000_000,
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_progress_percent_unknown_total() {
-        let progress = Progress {
+        let progress = EncodeProgress {
             frames_encoded: 50,
             total_frames: None,
             bytes_written: 1_000_000,
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_progress_percent_zero_total() {
-        let progress = Progress {
+        let progress = EncodeProgress {
             frames_encoded: 0,
             total_frames: Some(0),
             bytes_written: 0,
@@ -174,12 +174,12 @@ mod tests {
     #[test]
     fn test_progress_callback_closure() {
         let mut called = false;
-        let mut callback = |progress: &Progress| {
+        let mut callback = |progress: &EncodeProgress| {
             called = true;
             assert_eq!(progress.frames_encoded, 42);
         };
 
-        let progress = Progress {
+        let progress = EncodeProgress {
             frames_encoded: 42,
             total_frames: Some(100),
             bytes_written: 500_000,
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_progress_callback_should_cancel_default() {
-        let callback = |_progress: &Progress| {};
+        let callback = |_progress: &EncodeProgress| {};
         assert!(!callback.should_cancel());
     }
 
@@ -209,8 +209,8 @@ mod tests {
             cancelled: Arc<AtomicBool>,
         }
 
-        impl ProgressCallback for TestCallback {
-            fn on_progress(&mut self, progress: &Progress) {
+        impl EncodeProgressCallback for TestCallback {
+            fn on_progress(&mut self, progress: &EncodeProgress) {
                 self.counter
                     .store(progress.frames_encoded, Ordering::Relaxed);
             }
@@ -228,7 +228,7 @@ mod tests {
             cancelled: cancelled.clone(),
         };
 
-        let progress = Progress {
+        let progress = EncodeProgress {
             frames_encoded: 100,
             total_frames: Some(200),
             bytes_written: 1_000_000,

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -10,7 +10,7 @@ use ff_format::{AudioFrame, VideoFrame};
 
 use super::encoder_inner::{VideoEncoderConfig, VideoEncoderInner, preset_to_string};
 use crate::{
-    AudioCodec, Container, EncodeError, HardwareEncoder, Preset, ProgressCallback, VideoCodec,
+    AudioCodec, Container, EncodeError, EncodeProgressCallback, HardwareEncoder, Preset, VideoCodec,
 };
 
 /// Builder for constructing a [`VideoEncoder`].
@@ -43,7 +43,7 @@ pub struct VideoEncoderBuilder {
     pub(crate) audio_channels: Option<u32>,
     pub(crate) audio_codec: AudioCodec,
     pub(crate) audio_bitrate: Option<u64>,
-    pub(crate) progress_callback: Option<Box<dyn ProgressCallback>>,
+    pub(crate) progress_callback: Option<Box<dyn EncodeProgressCallback>>,
     pub(crate) two_pass: bool,
     pub(crate) metadata: Vec<(String, String)>,
     pub(crate) chapters: Vec<ff_format::chapter::ChapterInfo>,
@@ -180,15 +180,15 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn on_progress<F>(mut self, callback: F) -> Self
     where
-        F: FnMut(&crate::Progress) + Send + 'static,
+        F: FnMut(&crate::EncodeProgress) + Send + 'static,
     {
         self.progress_callback = Some(Box::new(callback));
         self
     }
 
-    /// Set a [`ProgressCallback`] trait object (supports cancellation).
+    /// Set a [`EncodeProgressCallback`] trait object (supports cancellation).
     #[must_use]
-    pub fn progress_callback<C: ProgressCallback + 'static>(mut self, callback: C) -> Self {
+    pub fn progress_callback<C: EncodeProgressCallback + 'static>(mut self, callback: C) -> Self {
         self.progress_callback = Some(Box::new(callback));
         self
     }
@@ -369,7 +369,7 @@ pub struct VideoEncoder {
     inner: Option<VideoEncoderInner>,
     _config: VideoEncoderConfig,
     start_time: Instant,
-    progress_callback: Option<Box<dyn crate::ProgressCallback>>,
+    progress_callback: Option<Box<dyn crate::EncodeProgressCallback>>,
 }
 
 impl VideoEncoder {
@@ -551,7 +551,7 @@ impl VideoEncoder {
         Ok(())
     }
 
-    fn create_progress_info(&self) -> crate::Progress {
+    fn create_progress_info(&self) -> crate::EncodeProgress {
         let elapsed = self.start_time.elapsed();
         let (frames_encoded, bytes_written) = self
             .inner
@@ -574,7 +574,7 @@ impl VideoEncoder {
         } else {
             0
         };
-        crate::Progress {
+        crate::EncodeProgress {
             frames_encoded,
             total_frames: None,
             bytes_written,

--- a/crates/ff-encode/tests/progress_callback_tests.rs
+++ b/crates/ff-encode/tests/progress_callback_tests.rs
@@ -9,7 +9,7 @@
 
 mod fixtures;
 
-use ff_encode::{Progress, ProgressCallback, VideoCodec, VideoEncoder};
+use ff_encode::{EncodeProgress, EncodeProgressCallback, VideoCodec, VideoEncoder};
 use fixtures::{FileGuard, assert_valid_output_file, create_black_frame, test_output_path};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -29,7 +29,7 @@ fn test_progress_callback_closure() {
     let result = VideoEncoder::create(&output_path)
         .video(640, 480, 30.0)
         .video_codec(VideoCodec::Mpeg4)
-        .on_progress(move |progress: &Progress| {
+        .on_progress(move |progress: &EncodeProgress| {
             progress_count_clone.fetch_add(1, Ordering::Relaxed);
             println!(
                 "Progress: {} frames encoded at {:.1} fps",
@@ -71,8 +71,8 @@ struct TestProgressCallback {
     max_frames: u64,
 }
 
-impl ProgressCallback for TestProgressCallback {
-    fn on_progress(&mut self, progress: &Progress) {
+impl EncodeProgressCallback for TestProgressCallback {
+    fn on_progress(&mut self, progress: &EncodeProgress) {
         self.frames_seen
             .store(progress.frames_encoded, Ordering::Relaxed);
         println!(
@@ -136,8 +136,8 @@ struct CancellableCallback {
     cancelled: Arc<AtomicBool>,
 }
 
-impl ProgressCallback for CancellableCallback {
-    fn on_progress(&mut self, progress: &Progress) {
+impl EncodeProgressCallback for CancellableCallback {
+    fn on_progress(&mut self, progress: &EncodeProgress) {
         println!("Progress: {} frames", progress.frames_encoded);
     }
 
@@ -205,7 +205,7 @@ fn test_progress_information_accuracy() {
     let result = VideoEncoder::create(&output_path)
         .video(640, 480, 30.0)
         .video_codec(VideoCodec::Mpeg4)
-        .on_progress(move |progress: &Progress| {
+        .on_progress(move |progress: &EncodeProgress| {
             let mut last = last_progress_clone.lock().unwrap();
             *last = Some(progress.clone());
         })


### PR DESCRIPTION
## Summary

`ff-encode` and `ff-pipeline` each defined `Progress` and `ProgressCallback` with incompatible semantics, making it impossible for the `avio` facade to re-export all four types without a naming collision. This PR renames the encode-specific types to `EncodeProgress` and `EncodeProgressCallback`, scoping them clearly to encoding and freeing the plain names for `ff-pipeline`.

## Changes

- **`progress.rs`**: Renamed `Progress` → `EncodeProgress` and `ProgressCallback` (trait) → `EncodeProgressCallback` throughout struct definition, trait definition, blanket impl, and all unit tests.
- **`video/builder.rs`**: Updated all references to `EncodeProgressCallback` and `EncodeProgress`.
- **`lib.rs`**: Updated `pub use` re-export and doc-comment example to use the new names.
- **`tests/progress_callback_tests.rs`**: Updated all import and usage sites in the integration test.

## Related Issues

Resolves #500

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes