### PR TITLE
refactor(avio): re-export EncodeProgress/EncodeProgressCallback after ff-encode rename

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -61,13 +61,16 @@ pub use ff_decode::{
 
 // ── encode feature ────────────────────────────────────────────────────────────
 //
-// Progress / ProgressCallback are intentionally omitted here: they are also
-// exported by ff-pipeline, and exposing them from two paths under the same name
-// would be ambiguous when the `pipeline` feature is also enabled.
+// EncodeProgress / EncodeProgressCallback carry encode-specific metrics and are
+// distinct from ff-pipeline's Progress / ProgressCallback, so both sets can be
+// re-exported from avio without ambiguity.
+// VideoCodecEncodeExt provides encode-specific helpers (is_lgpl_compatible,
+// default_extension) on the shared VideoCodec type; import it to call them.
 #[cfg(feature = "encode")]
 pub use ff_encode::{
     AudioEncoder, AudioEncoderBuilder, BitrateMode, CRF_MAX, Container, EncodeError,
-    HardwareEncoder, ImageEncoder, ImageEncoderBuilder, Preset, VideoEncoder, VideoEncoderBuilder,
+    EncodeProgress, EncodeProgressCallback, HardwareEncoder, ImageEncoder, ImageEncoderBuilder,
+    Preset, VideoCodecEncodeExt, VideoEncoder, VideoEncoderBuilder,
 };
 
 // ── filter feature ────────────────────────────────────────────────────────────
@@ -186,6 +189,24 @@ mod tests {
     #[test]
     fn encode_error_should_be_accessible() {
         let _: EncodeError = EncodeError::Cancelled;
+    }
+
+    #[cfg(feature = "encode")]
+    #[test]
+    fn encode_progress_should_be_accessible() {
+        assert!(std::mem::size_of::<EncodeProgress>() > 0);
+    }
+
+    #[cfg(feature = "encode")]
+    #[test]
+    fn encode_progress_callback_should_be_accessible() {
+        // EncodeProgressCallback is a trait — verify it is in scope by creating
+        // a minimal no-op implementation.
+        struct NoOp;
+        impl EncodeProgressCallback for NoOp {
+            fn on_progress(&mut self, _: &EncodeProgress) {}
+        }
+        let _ = NoOp;
     }
 
     // ── filter feature ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

After `ff-encode` renamed `Progress`/`ProgressCallback` to `EncodeProgress`/`EncodeProgressCallback`, the naming collision with `ff-pipeline`'s `Progress`/`ProgressCallback` is resolved. This PR lifts the restriction that previously prevented the encode-side progress types from being re-exported from `avio`, and also adds `VideoCodecEncodeExt` so encode-specific codec helpers are accessible from the facade.

## Changes

- Updated the `encode` feature section in `lib.rs`:
  - Replaced the "intentionally omitted" comment with an accurate explanation of the now-separate names
  - Added `EncodeProgress`, `EncodeProgressCallback`, and `VideoCodecEncodeExt` to the `pub use ff_encode` block
- Added two unit tests under `#[cfg(feature = "encode")]`:
  - `encode_progress_should_be_accessible` — verifies `EncodeProgress` is in scope
  - `encode_progress_callback_should_be_accessible` — verifies `EncodeProgressCallback` trait is in scope via a minimal no-op impl

## Related Issues

Resolves #501

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes