### PR TITLE
fix(ff-encode,avio): correct stale doc imports and re-export VecPool

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -52,6 +52,10 @@ pub use ff_probe::{ProbeError, open};
 //
 // PooledBuffer and the frame/codec types are already re-exported from ff-format
 // above, so we omit them here to keep a single canonical source.
+// FramePool, SimpleFramePool, and VecPool come from ff-common (re-exported via
+// ff-decode). VecPool is the canonical concrete pool; SimpleFramePool is its alias.
+#[cfg(feature = "decode")]
+pub use ff_common::VecPool;
 #[cfg(feature = "decode")]
 pub use ff_decode::{
     AudioDecoder, AudioDecoderBuilder, AudioFrameIterator, DecodeError, FramePool, HardwareAccel,
@@ -165,6 +169,14 @@ mod tests {
     fn decode_hardware_accel_should_be_accessible() {
         let _: HardwareAccel = HardwareAccel::Auto;
         let _: HardwareAccel = HardwareAccel::None;
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn decode_vec_pool_should_be_accessible() {
+        let pool: std::sync::Arc<VecPool> = VecPool::new(8);
+        assert_eq!(pool.capacity(), 8);
+        assert_eq!(pool.available(), 0);
     }
 
     // ── encode feature ────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -77,7 +77,7 @@
 //! ### Progress Callbacks
 //!
 //! ```ignore
-//! use ff_encode::{VideoEncoder, Progress};
+//! use ff_encode::{VideoEncoder, EncodeProgress};
 //!
 //! // Simple closure-based callback
 //! let mut encoder = VideoEncoder::create("output.mp4")?
@@ -95,7 +95,7 @@
 //! ### Progress Callbacks with Cancellation
 //!
 //! ```ignore
-//! use ff_encode::{VideoEncoder, ProgressCallback, Progress};
+//! use ff_encode::{VideoEncoder, EncodeProgressCallback, EncodeProgress};
 //! use std::sync::Arc;
 //! use std::sync::atomic::{AtomicBool, Ordering};
 //!


### PR DESCRIPTION
## Summary

Two follow-up fixes surfaced during a post-#508 codebase review.

1. `ff-encode/src/lib.rs` still had doc examples importing `Progress` and `ProgressCallback` — the names before the #500 rename. These are dead imports that would fail for any user copying from the rendered docs.
2. `avio` re-exported `SimpleFramePool` (the backwards-compat alias for `VecPool`) but not `VecPool` itself, forcing users to depend directly on `ff-common` to use the canonical type name.

## Changes

- `crates/ff-encode/src/lib.rs`: update two `use` lines in `ignore` doc examples: `Progress` → `EncodeProgress`, `ProgressCallback` → `EncodeProgressCallback`
- `crates/avio/src/lib.rs`: add `pub use ff_common::VecPool` under `#[cfg(feature = "decode")]`; update comment; add `decode_vec_pool_should_be_accessible` test

## Related Issues

Closes #509
Closes #510

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes