### PR TITLE
refactor(error): unify Ffmpeg error variant to { code, message } across all crates

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -49,11 +49,9 @@ impl AvFormatContextGuard {
     unsafe fn new(path: &Path) -> Result<Self, DecodeError> {
         // SAFETY: Caller ensures FFmpeg is initialized and path is valid
         let format_ctx = unsafe {
-            ff_sys::avformat::open_input(path).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to open file: {}",
-                    ff_sys::av_error_string(e)
-                ))
+            ff_sys::avformat::open_input(path).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to open file: {}", ff_sys::av_error_string(e)),
             })?
         };
         Ok(Self(format_ctx))
@@ -95,8 +93,9 @@ impl AvCodecContextGuard {
     unsafe fn new(codec: *const ff_sys::AVCodec) -> Result<Self, DecodeError> {
         // SAFETY: Caller ensures codec pointer is valid
         let codec_ctx = unsafe {
-            ff_sys::avcodec::alloc_context3(codec).map_err(|e| {
-                DecodeError::Ffmpeg(format!("Failed to allocate codec context: {e}"))
+            ff_sys::avcodec::alloc_context3(codec).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to allocate codec context: {e}"),
             })?
         };
         Ok(Self(codec_ctx))
@@ -139,7 +138,10 @@ impl AvPacketGuard {
         // SAFETY: Caller ensures FFmpeg is initialized
         let packet = unsafe { ff_sys::av_packet_alloc() };
         if packet.is_null() {
-            return Err(DecodeError::Ffmpeg("Failed to allocate packet".to_string()));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to allocate packet".to_string(),
+            });
         }
         Ok(Self(packet))
     }
@@ -176,7 +178,10 @@ impl AvFrameGuard {
         // SAFETY: Caller ensures FFmpeg is initialized
         let frame = unsafe { ff_sys::av_frame_alloc() };
         if frame.is_null() {
-            return Err(DecodeError::Ffmpeg("Failed to allocate frame".to_string()));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to allocate frame".to_string(),
+            });
         }
         Ok(Self(frame))
     }
@@ -287,11 +292,9 @@ impl AudioDecoderInner {
         // Read stream information
         // SAFETY: format_ctx is valid and owned by guard
         unsafe {
-            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to find stream info: {}",
-                    ff_sys::av_error_string(e)
-                ))
+            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to find stream info: {}", ff_sys::av_error_string(e)),
             })?;
         }
 
@@ -325,10 +328,13 @@ impl AudioDecoderInner {
             let stream = (*format_ctx).streams.add(stream_index as usize);
             let codecpar = (*(*stream)).codecpar;
             ff_sys::avcodec::parameters_to_context(codec_ctx, codecpar).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to copy codec parameters: {}",
-                    ff_sys::av_error_string(e)
-                ))
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "Failed to copy codec parameters: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                }
             })?;
         }
 
@@ -336,10 +342,10 @@ impl AudioDecoderInner {
         // SAFETY: codec_ctx and codec are valid
         unsafe {
             ff_sys::avcodec::open2(codec_ctx, codec, ptr::null_mut()).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to open codec: {}",
-                    ff_sys::av_error_string(e)
-                ))
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!("Failed to open codec: {}", ff_sys::av_error_string(e)),
+                }
             })?;
         }
 
@@ -596,10 +602,13 @@ impl AudioDecoderInner {
                         self.eof = true;
                         continue;
                     } else if read_ret < 0 {
-                        return Err(DecodeError::Ffmpeg(format!(
-                            "Failed to read frame: {}",
-                            ff_sys::av_error_string(read_ret)
-                        )));
+                        return Err(DecodeError::Ffmpeg {
+                            code: read_ret,
+                            message: format!(
+                                "Failed to read frame: {}",
+                                ff_sys::av_error_string(read_ret)
+                            ),
+                        });
                     }
 
                     // Check if this packet belongs to the audio stream
@@ -609,10 +618,13 @@ impl AudioDecoderInner {
                         ff_sys::av_packet_unref(self.packet);
 
                         if send_ret < 0 && send_ret != ff_sys::error_codes::EAGAIN {
-                            return Err(DecodeError::Ffmpeg(format!(
-                                "Failed to send packet: {}",
-                                ff_sys::av_error_string(send_ret)
-                            )));
+                            return Err(DecodeError::Ffmpeg {
+                                code: send_ret,
+                                message: format!(
+                                    "Failed to send packet: {}",
+                                    ff_sys::av_error_string(send_ret)
+                                ),
+                            });
                         }
                     } else {
                         // Not our stream, unref and continue
@@ -706,10 +718,13 @@ impl AudioDecoderInner {
                 ff_sys::av_channel_layout_uninit(&raw mut src_ch_layout);
                 ff_sys::av_channel_layout_uninit(&raw mut dst_ch_layout);
             }
-            return Err(DecodeError::Ffmpeg(format!(
-                "Failed to allocate SwrContext: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(DecodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Failed to allocate SwrContext: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // Wrap in RAII guard for automatic cleanup
@@ -724,10 +739,13 @@ impl AudioDecoderInner {
                 ff_sys::av_channel_layout_uninit(&raw mut src_ch_layout);
                 ff_sys::av_channel_layout_uninit(&raw mut dst_ch_layout);
             }
-            return Err(DecodeError::Ffmpeg(format!(
-                "Failed to initialize SwrContext: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(DecodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Failed to initialize SwrContext: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // Calculate output sample count
@@ -740,9 +758,10 @@ impl AudioDecoderInner {
                 ff_sys::av_channel_layout_uninit(&raw mut src_ch_layout);
                 ff_sys::av_channel_layout_uninit(&raw mut dst_ch_layout);
             }
-            return Err(DecodeError::Ffmpeg(
-                "Failed to calculate output sample count".to_string(),
-            ));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to calculate output sample count".to_string(),
+            });
         }
 
         let out_samples = out_samples as usize;
@@ -801,10 +820,13 @@ impl AudioDecoderInner {
         }
 
         if converted_samples < 0 {
-            return Err(DecodeError::Ffmpeg(format!(
-                "Failed to convert samples: {}",
-                ff_sys::av_error_string(converted_samples)
-            )));
+            return Err(DecodeError::Ffmpeg {
+                code: converted_samples,
+                message: format!(
+                    "Failed to convert samples: {}",
+                    ff_sys::av_error_string(converted_samples)
+                ),
+            });
         }
 
         // Extract timestamp from original frame
@@ -847,7 +869,10 @@ impl AudioDecoderInner {
             dst_sample_fmt,
             timestamp,
         )
-        .map_err(|e| DecodeError::Ffmpeg(format!("Failed to create AudioFrame: {e}")))
+        .map_err(|e| DecodeError::Ffmpeg {
+            code: 0,
+            message: format!("Failed to create AudioFrame: {e}"),
+        })
     }
 
     /// Converts an AVFrame to an AudioFrame.
@@ -878,8 +903,12 @@ impl AudioDecoderInner {
             // Convert frame to planes
             let planes = Self::extract_planes(frame, nb_samples, channels, format)?;
 
-            AudioFrame::new(planes, nb_samples, channels, sample_rate, format, timestamp)
-                .map_err(|e| DecodeError::Ffmpeg(format!("Failed to create AudioFrame: {e}")))
+            AudioFrame::new(planes, nb_samples, channels, sample_rate, format, timestamp).map_err(
+                |e| DecodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Failed to create AudioFrame: {e}"),
+                },
+            )
         }
     }
 

--- a/crates/ff-decode/src/error.rs
+++ b/crates/ff-decode/src/error.rs
@@ -111,8 +111,13 @@ pub enum DecodeError {
     ///
     /// This wraps errors from the underlying `FFmpeg` library that don't
     /// fit into other categories.
-    #[error("FFmpeg error: {0}")]
-    Ffmpeg(String),
+    #[error("ffmpeg error: {message} (code={code})")]
+    Ffmpeg {
+        /// Raw `FFmpeg` error code (negative integer). `0` when no numeric code is available.
+        code: i32,
+        /// Human-readable error message from `av_strerror` or an internal description.
+        message: String,
+    },
 
     /// I/O error during file operations.
     ///
@@ -206,19 +211,25 @@ impl DecodeError {
     ///
     /// # Arguments
     ///
-    /// * `message` - The `FFmpeg` error message.
+    /// * `code` - The raw `FFmpeg` error code (negative integer). Pass `0` when no
+    ///   numeric code is available.
+    /// * `message` - Human-readable description of the error.
     ///
     /// # Examples
     ///
     /// ```
     /// use ff_decode::DecodeError;
     ///
-    /// let error = DecodeError::ffmpeg("AVERROR_INVALIDDATA");
-    /// assert!(error.to_string().contains("AVERROR_INVALIDDATA"));
+    /// let error = DecodeError::ffmpeg(-22, "Invalid data found when processing input");
+    /// assert!(error.to_string().contains("Invalid data"));
+    /// assert!(error.to_string().contains("code=-22"));
     /// ```
     #[must_use]
-    pub fn ffmpeg(message: impl Into<String>) -> Self {
-        Self::Ffmpeg(message.into())
+    pub fn ffmpeg(code: i32, message: impl Into<String>) -> Self {
+        Self::Ffmpeg {
+            code,
+            message: message.into(),
+        }
     }
 
     /// Returns `true` if this error indicates end of stream.
@@ -360,13 +371,27 @@ mod tests {
 
     #[test]
     fn test_ffmpeg_constructor() {
-        let error = DecodeError::ffmpeg("AVERROR_INVALIDDATA");
+        let error = DecodeError::ffmpeg(-22, "AVERROR_INVALIDDATA");
         match error {
-            DecodeError::Ffmpeg(msg) => {
-                assert_eq!(msg, "AVERROR_INVALIDDATA");
+            DecodeError::Ffmpeg { code, message } => {
+                assert_eq!(code, -22);
+                assert_eq!(message, "AVERROR_INVALIDDATA");
             }
             _ => panic!("Wrong error type"),
         }
+    }
+
+    #[test]
+    fn ffmpeg_should_format_with_code_and_message() {
+        let error = DecodeError::ffmpeg(-22, "Invalid data");
+        assert!(error.to_string().contains("code=-22"));
+        assert!(error.to_string().contains("Invalid data"));
+    }
+
+    #[test]
+    fn ffmpeg_with_zero_code_should_be_constructible() {
+        let error = DecodeError::ffmpeg(0, "allocation failed");
+        assert!(matches!(error, DecodeError::Ffmpeg { code: 0, .. }));
     }
 
     #[test]

--- a/crates/ff-decode/src/image/builder.rs
+++ b/crates/ff-decode/src/image/builder.rs
@@ -154,8 +154,10 @@ impl ImageDecoder {
     /// Returns [`DecodeError`] if the image cannot be decoded or was already
     /// decoded.
     pub fn decode(mut self) -> Result<VideoFrame, DecodeError> {
-        self.decode_one()?
-            .ok_or_else(|| DecodeError::Ffmpeg("Image already decoded".to_string()))
+        self.decode_one()?.ok_or_else(|| DecodeError::Ffmpeg {
+            code: 0,
+            message: "Image already decoded".to_string(),
+        })
     }
 }
 

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -39,11 +39,9 @@ impl AvFormatContextGuard {
     unsafe fn new(path: &Path) -> Result<Self, DecodeError> {
         // SAFETY: Caller ensures FFmpeg is initialized and path is valid
         let format_ctx = unsafe {
-            ff_sys::avformat::open_input(path).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to open file: {}",
-                    ff_sys::av_error_string(e)
-                ))
+            ff_sys::avformat::open_input(path).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to open file: {}", ff_sys::av_error_string(e)),
             })?
         };
         Ok(Self(format_ctx))
@@ -78,8 +76,9 @@ impl AvCodecContextGuard {
     unsafe fn new(codec: *const ff_sys::AVCodec) -> Result<Self, DecodeError> {
         // SAFETY: Caller ensures codec pointer is valid
         let codec_ctx = unsafe {
-            ff_sys::avcodec::alloc_context3(codec).map_err(|e| {
-                DecodeError::Ffmpeg(format!("Failed to allocate codec context: {e}"))
+            ff_sys::avcodec::alloc_context3(codec).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to allocate codec context: {e}"),
             })?
         };
         Ok(Self(codec_ctx))
@@ -152,11 +151,9 @@ impl ImageDecoderInner {
         // 2. avformat_find_stream_info
         // SAFETY: format_ctx is valid and owned by the guard.
         unsafe {
-            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to find stream info: {}",
-                    ff_sys::av_error_string(e)
-                ))
+            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to find stream info: {}", ff_sys::av_error_string(e)),
             })?;
         }
 
@@ -190,10 +187,13 @@ impl ImageDecoderInner {
             let stream = (*format_ctx).streams.add(stream_index);
             let codecpar = (*(*stream)).codecpar;
             ff_sys::avcodec::parameters_to_context(codec_ctx, codecpar).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to copy codec parameters: {}",
-                    ff_sys::av_error_string(e)
-                ))
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "Failed to copy codec parameters: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                }
             })?;
         }
 
@@ -201,10 +201,10 @@ impl ImageDecoderInner {
         // SAFETY: codec_ctx and codec are valid; no hardware acceleration for images.
         unsafe {
             ff_sys::avcodec::open2(codec_ctx, codec, ptr::null_mut()).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to open codec: {}",
-                    ff_sys::av_error_string(e)
-                ))
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!("Failed to open codec: {}", ff_sys::av_error_string(e)),
+                }
             })?;
         }
 
@@ -212,12 +212,18 @@ impl ImageDecoderInner {
         // SAFETY: FFmpeg is initialized.
         let packet = unsafe { ff_sys::av_packet_alloc() };
         if packet.is_null() {
-            return Err(DecodeError::Ffmpeg("Failed to allocate packet".to_string()));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to allocate packet".to_string(),
+            });
         }
         let frame = unsafe { ff_sys::av_frame_alloc() };
         if frame.is_null() {
             unsafe { ff_sys::av_packet_free(&mut (packet as *mut _)) };
-            return Err(DecodeError::Ffmpeg("Failed to allocate frame".to_string()));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to allocate frame".to_string(),
+            });
         }
 
         Ok(Self {
@@ -253,10 +259,10 @@ impl ImageDecoderInner {
         // SAFETY: format_ctx and packet are valid.
         let ret = unsafe { ff_sys::av_read_frame(self.format_ctx, self.packet) };
         if ret < 0 {
-            return Err(DecodeError::Ffmpeg(format!(
-                "Failed to read frame: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(DecodeError::Ffmpeg {
+                code: ret,
+                message: format!("Failed to read frame: {}", ff_sys::av_error_string(ret)),
+            });
         }
 
         // 2. avcodec_send_packet
@@ -264,20 +270,26 @@ impl ImageDecoderInner {
         let ret = unsafe { ff_sys::avcodec_send_packet(self.codec_ctx, self.packet) };
         unsafe { ff_sys::av_packet_unref(self.packet) };
         if ret < 0 {
-            return Err(DecodeError::Ffmpeg(format!(
-                "Failed to send packet to decoder: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(DecodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Failed to send packet to decoder: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // 3. avcodec_receive_frame
         // SAFETY: codec_ctx and frame are valid.
         let ret = unsafe { ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame) };
         if ret < 0 {
-            return Err(DecodeError::Ffmpeg(format!(
-                "Failed to receive decoded frame: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(DecodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Failed to receive decoded frame: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // 4. Convert to VideoFrame.
@@ -374,8 +386,12 @@ impl ImageDecoderInner {
             let (planes, strides) = Self::extract_planes_and_strides(frame, width, height, format)?;
 
             // Images are always key frames.
-            VideoFrame::new(planes, strides, width, height, format, timestamp, true)
-                .map_err(|e| DecodeError::Ffmpeg(format!("Failed to create VideoFrame: {e}")))
+            VideoFrame::new(planes, strides, width, height, format, timestamp, true).map_err(|e| {
+                DecodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Failed to create VideoFrame: {e}"),
+                }
+            })
         }
     }
 
@@ -408,9 +424,10 @@ impl ImageDecoderInner {
                     let mut buf = vec![0u8; row_w * h];
                     let src = (*frame).data[0];
                     if src.is_null() {
-                        return Err(DecodeError::Ffmpeg(
-                            "Null plane data for packed format".to_string(),
-                        ));
+                        return Err(DecodeError::Ffmpeg {
+                            code: 0,
+                            message: "Null plane data for packed format".to_string(),
+                        });
                     }
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
@@ -429,9 +446,10 @@ impl ImageDecoderInner {
                     let mut buf = vec![0u8; row_w * h];
                     let src = (*frame).data[0];
                     if src.is_null() {
-                        return Err(DecodeError::Ffmpeg(
-                            "Null plane data for packed format".to_string(),
-                        ));
+                        return Err(DecodeError::Ffmpeg {
+                            code: 0,
+                            message: "Null plane data for packed format".to_string(),
+                        });
                     }
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
@@ -448,7 +466,10 @@ impl ImageDecoderInner {
                     let mut buf = vec![0u8; w * h];
                     let src = (*frame).data[0];
                     if src.is_null() {
-                        return Err(DecodeError::Ffmpeg("Null plane data for Gray8".to_string()));
+                        return Err(DecodeError::Ffmpeg {
+                            code: 0,
+                            message: "Null plane data for Gray8".to_string(),
+                        });
                     }
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
@@ -466,7 +487,10 @@ impl ImageDecoderInner {
                     let mut y_buf = vec![0u8; w * h];
                     let y_src = (*frame).data[0];
                     if y_src.is_null() {
-                        return Err(DecodeError::Ffmpeg("Null Y plane".to_string()));
+                        return Err(DecodeError::Ffmpeg {
+                            code: 0,
+                            message: "Null Y plane".to_string(),
+                        });
                     }
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
@@ -558,9 +582,10 @@ impl ImageDecoderInner {
                     }
                 }
                 _ => {
-                    return Err(DecodeError::Ffmpeg(format!(
-                        "Unsupported pixel format for image decoding: {format:?}"
-                    )));
+                    return Err(DecodeError::Ffmpeg {
+                        code: 0,
+                        message: format!("Unsupported pixel format for image decoding: {format:?}"),
+                    });
                 }
             }
 

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -1153,7 +1153,7 @@ mod tests {
             // Should get either NoVideoStream or Ffmpeg error
             assert!(
                 matches!(e, DecodeError::NoVideoStream { .. })
-                    || matches!(e, DecodeError::Ffmpeg(_))
+                    || matches!(e, DecodeError::Ffmpeg { .. })
             );
         }
     }

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -61,11 +61,9 @@ impl AvFormatContextGuard {
     unsafe fn new(path: &Path) -> Result<Self, DecodeError> {
         // SAFETY: Caller ensures FFmpeg is initialized and path is valid
         let format_ctx = unsafe {
-            ff_sys::avformat::open_input(path).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to open file: {}",
-                    ff_sys::av_error_string(e)
-                ))
+            ff_sys::avformat::open_input(path).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to open file: {}", ff_sys::av_error_string(e)),
             })?
         };
         Ok(Self(format_ctx))
@@ -107,8 +105,9 @@ impl AvCodecContextGuard {
     unsafe fn new(codec: *const ff_sys::AVCodec) -> Result<Self, DecodeError> {
         // SAFETY: Caller ensures codec pointer is valid
         let codec_ctx = unsafe {
-            ff_sys::avcodec::alloc_context3(codec).map_err(|e| {
-                DecodeError::Ffmpeg(format!("Failed to allocate codec context: {e}"))
+            ff_sys::avcodec::alloc_context3(codec).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to allocate codec context: {e}"),
             })?
         };
         Ok(Self(codec_ctx))
@@ -151,7 +150,10 @@ impl AvPacketGuard {
         // SAFETY: Caller ensures FFmpeg is initialized
         let packet = unsafe { ff_sys::av_packet_alloc() };
         if packet.is_null() {
-            return Err(DecodeError::Ffmpeg("Failed to allocate packet".to_string()));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to allocate packet".to_string(),
+            });
         }
         Ok(Self(packet))
     }
@@ -194,7 +196,10 @@ impl AvFrameGuard {
         // SAFETY: Caller ensures FFmpeg is initialized
         let frame = unsafe { ff_sys::av_frame_alloc() };
         if frame.is_null() {
-            return Err(DecodeError::Ffmpeg("Failed to allocate frame".to_string()));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to allocate frame".to_string(),
+            });
         }
         Ok(Self(frame))
     }
@@ -430,9 +435,10 @@ impl VideoDecoderInner {
         // SAFETY: FFmpeg is initialized
         let sw_frame = unsafe { ff_sys::av_frame_alloc() };
         if sw_frame.is_null() {
-            return Err(DecodeError::Ffmpeg(
-                "Failed to allocate software frame for hardware transfer".to_string(),
-            ));
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "Failed to allocate software frame for hardware transfer".to_string(),
+            });
         }
 
         // Transfer data from hardware frame to software frame
@@ -448,10 +454,13 @@ impl VideoDecoderInner {
             unsafe {
                 ff_sys::av_frame_free(&mut (sw_frame as *mut _));
             }
-            return Err(DecodeError::Ffmpeg(format!(
-                "Failed to transfer hardware frame to CPU memory: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(DecodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Failed to transfer hardware frame to CPU memory: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // Copy metadata (pts, duration, etc.) from hardware frame to software frame
@@ -508,11 +517,9 @@ impl VideoDecoderInner {
         // Read stream information
         // SAFETY: format_ctx is valid and owned by guard
         unsafe {
-            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to find stream info: {}",
-                    ff_sys::av_error_string(e)
-                ))
+            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| DecodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to find stream info: {}", ff_sys::av_error_string(e)),
             })?;
         }
 
@@ -546,10 +553,13 @@ impl VideoDecoderInner {
             let stream = (*format_ctx).streams.add(stream_index as usize);
             let codecpar = (*(*stream)).codecpar;
             ff_sys::avcodec::parameters_to_context(codec_ctx, codecpar).map_err(|e| {
-                DecodeError::Ffmpeg(format!(
-                    "Failed to copy codec parameters: {}",
-                    ff_sys::av_error_string(e)
-                ))
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "Failed to copy codec parameters: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                }
             })?;
 
             // Set thread count
@@ -574,10 +584,10 @@ impl VideoDecoderInner {
                 if let Some(hw_ctx) = hw_device_ctx {
                     ff_sys::av_buffer_unref(&mut (hw_ctx as *mut _));
                 }
-                DecodeError::Ffmpeg(format!(
-                    "Failed to open codec: {}",
-                    ff_sys::av_error_string(e)
-                ))
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!("Failed to open codec: {}", ff_sys::av_error_string(e)),
+                }
             })?;
         }
 
@@ -873,10 +883,13 @@ impl VideoDecoderInner {
                         self.eof = true;
                         continue;
                     } else if read_ret < 0 {
-                        return Err(DecodeError::Ffmpeg(format!(
-                            "Failed to read frame: {}",
-                            ff_sys::av_error_string(read_ret)
-                        )));
+                        return Err(DecodeError::Ffmpeg {
+                            code: read_ret,
+                            message: format!(
+                                "Failed to read frame: {}",
+                                ff_sys::av_error_string(read_ret)
+                            ),
+                        });
                     }
 
                     // Check if this packet belongs to the video stream
@@ -886,10 +899,13 @@ impl VideoDecoderInner {
                         ff_sys::av_packet_unref(self.packet);
 
                         if send_ret < 0 && send_ret != ff_sys::error_codes::EAGAIN {
-                            return Err(DecodeError::Ffmpeg(format!(
-                                "Failed to send packet: {}",
-                                ff_sys::av_error_string(send_ret)
-                            )));
+                            return Err(DecodeError::Ffmpeg {
+                                code: send_ret,
+                                message: format!(
+                                    "Failed to send packet: {}",
+                                    ff_sys::av_error_string(send_ret)
+                                ),
+                            });
                         }
                     } else {
                         // Not our stream, unref and continue
@@ -956,15 +972,19 @@ impl VideoDecoderInner {
                     dst_format,
                     ff_sys::swscale::scale_flags::BILINEAR,
                 )
-                .map_err(|e| DecodeError::Ffmpeg(format!("Failed to create sws context: {e}")))?;
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Failed to create sws context: {e}"),
+                })?;
 
                 self.sws_ctx = Some(ctx);
             }
 
             let Some(sws_ctx) = self.sws_ctx else {
-                return Err(DecodeError::Ffmpeg(
-                    "SwsContext not initialized".to_string(),
-                ));
+                return Err(DecodeError::Ffmpeg {
+                    code: 0,
+                    message: "SwsContext not initialized".to_string(),
+                });
             };
 
             // Allocate destination frame (with RAII guard)
@@ -978,10 +998,13 @@ impl VideoDecoderInner {
             // Allocate buffer for destination frame
             let buffer_ret = ff_sys::av_frame_get_buffer(dst_frame, 0);
             if buffer_ret < 0 {
-                return Err(DecodeError::Ffmpeg(format!(
-                    "Failed to allocate frame buffer: {}",
-                    ff_sys::av_error_string(buffer_ret)
-                )));
+                return Err(DecodeError::Ffmpeg {
+                    code: buffer_ret,
+                    message: format!(
+                        "Failed to allocate frame buffer: {}",
+                        ff_sys::av_error_string(buffer_ret)
+                    ),
+                });
             }
 
             // Perform conversion
@@ -994,7 +1017,10 @@ impl VideoDecoderInner {
                 (*dst_frame).data.as_ptr() as *const *mut u8,
                 (*dst_frame).linesize.as_ptr(),
             )
-            .map_err(|e| DecodeError::Ffmpeg(format!("Failed to scale frame: {e}")))?;
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("Failed to scale frame: {e}"),
+            })?;
 
             // Copy timestamp
             (*dst_frame).pts = (*self.frame).pts;
@@ -1036,8 +1062,12 @@ impl VideoDecoderInner {
             let (planes, strides) =
                 self.extract_planes_and_strides(frame, width, height, format)?;
 
-            VideoFrame::new(planes, strides, width, height, format, timestamp, false)
-                .map_err(|e| DecodeError::Ffmpeg(format!("Failed to create VideoFrame: {e}")))
+            VideoFrame::new(planes, strides, width, height, format, timestamp, false).map_err(|e| {
+                DecodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Failed to create VideoFrame: {e}"),
+                }
+            })
         }
     }
 
@@ -1247,9 +1277,10 @@ impl VideoDecoderInner {
                     strides.push(uv_stride);
                 }
                 _ => {
-                    return Err(DecodeError::Ffmpeg(format!(
-                        "Unsupported pixel format: {format:?}"
-                    )));
+                    return Err(DecodeError::Ffmpeg {
+                        code: 0,
+                        message: format!("Unsupported pixel format: {format:?}"),
+                    });
                 }
             }
 
@@ -1635,8 +1666,9 @@ impl VideoDecoderInner {
                         av_format,
                         ff_sys::swscale::scale_flags::BILINEAR,
                     )
-                    .map_err(|e| {
-                        DecodeError::Ffmpeg(format!("Failed to create scaling context: {e}"))
+                    .map_err(|e| DecodeError::Ffmpeg {
+                        code: 0,
+                        message: format!("Failed to create scaling context: {e}"),
                     })?;
 
                     // Don't cache yet - will cache after successful scaling
@@ -1653,8 +1685,9 @@ impl VideoDecoderInner {
                     av_format,
                     ff_sys::swscale::scale_flags::BILINEAR,
                 )
-                .map_err(|e| {
-                    DecodeError::Ffmpeg(format!("Failed to create scaling context: {e}"))
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Failed to create scaling context: {e}"),
                 })?;
 
                 // Don't cache yet - will cache after successful scaling
@@ -1696,10 +1729,13 @@ impl VideoDecoderInner {
                 if !is_cached {
                     ff_sys::swscale::free_context(sws_ctx);
                 }
-                return Err(DecodeError::Ffmpeg(format!(
-                    "Failed to allocate destination frame buffer: {}",
-                    ff_sys::av_error_string(buffer_ret)
-                )));
+                return Err(DecodeError::Ffmpeg {
+                    code: buffer_ret,
+                    message: format!(
+                        "Failed to allocate destination frame buffer: {}",
+                        ff_sys::av_error_string(buffer_ret)
+                    ),
+                });
             }
 
             // Perform scaling
@@ -1718,7 +1754,10 @@ impl VideoDecoderInner {
                 if !is_cached {
                     ff_sys::swscale::free_context(sws_ctx);
                 }
-                return Err(DecodeError::Ffmpeg(format!("Failed to scale frame: {e}")));
+                return Err(DecodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Failed to scale frame: {e}"),
+                });
             }
 
             // Scaling successful - cache the context if it's new

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -84,10 +84,13 @@ impl AudioEncoderInner {
             );
 
             if ret < 0 || format_ctx.is_null() {
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Cannot create output context: {}",
-                    ff_sys::av_error_string(ret)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!(
+                        "Cannot create output context: {}",
+                        ff_sys::av_error_string(ret)
+                    ),
+                });
             }
 
             let mut encoder = Self {
@@ -118,10 +121,10 @@ impl AudioEncoderInner {
             let ret = avformat_write_header(format_ctx, ptr::null_mut());
             if ret < 0 {
                 encoder.cleanup();
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Cannot write header: {}",
-                    ff_sys::av_error_string(ret)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!("Cannot write header: {}", ff_sys::av_error_string(ret)),
+                });
             }
 
             Ok(encoder)
@@ -137,8 +140,11 @@ impl AudioEncoderInner {
         let encoder_name = self.select_audio_encoder(config.codec)?;
         self.actual_codec = encoder_name.clone();
 
-        let c_encoder_name = CString::new(encoder_name.as_str())
-            .map_err(|_| EncodeError::Ffmpeg("Invalid encoder name".to_string()))?;
+        let c_encoder_name =
+            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Invalid encoder name".to_string(),
+            })?;
 
         let codec_ptr =
             avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
@@ -198,7 +204,10 @@ impl AudioEncoderInner {
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
             avcodec::free_context(&mut codec_ctx as *mut *mut _);
-            return Err(EncodeError::Ffmpeg("Cannot create stream".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot create stream".to_string(),
+            });
         }
 
         (*stream).time_base = (*codec_ctx).time_base;
@@ -242,8 +251,10 @@ impl AudioEncoderInner {
         // Try each candidate
         for &name in &candidates {
             unsafe {
-                let c_name = CString::new(name)
-                    .map_err(|_| EncodeError::Ffmpeg("Invalid encoder name".to_string()))?;
+                let c_name = CString::new(name).map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Invalid encoder name".to_string(),
+                })?;
                 if avcodec::find_encoder_by_name(c_name.as_ptr()).is_some() {
                     return Ok(name.to_string());
                 }
@@ -265,7 +276,10 @@ impl AudioEncoderInner {
         // Allocate AVFrame
         let mut av_frame = av_frame_alloc();
         if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate frame".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate frame".to_string(),
+            });
         }
 
         // Convert AudioFrame to AVFrame
@@ -282,10 +296,10 @@ impl AudioEncoderInner {
         let send_result = avcodec::send_frame(codec_ctx, av_frame);
         if let Err(e) = send_result {
             av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(EncodeError::Ffmpeg(format!(
-                "Failed to send audio frame: {}",
-                ff_sys::av_error_string(e)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to send audio frame: {}", ff_sys::av_error_string(e)),
+            });
         }
 
         // Receive packets
@@ -346,8 +360,9 @@ impl AudioEncoderInner {
                 self.swr_ctx = Some(swr_ctx);
             }
 
-            let swr_ctx = self.swr_ctx.ok_or_else(|| {
-                EncodeError::Ffmpeg("Resampling context not initialized".to_string())
+            let swr_ctx = self.swr_ctx.ok_or_else(|| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Resampling context not initialized".to_string(),
             })?;
 
             // Estimate output sample count
@@ -369,10 +384,13 @@ impl AudioEncoderInner {
             // Allocate frame buffer
             let ret = ff_sys::av_frame_get_buffer(dst, 0);
             if ret < 0 {
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Cannot allocate audio frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!(
+                        "Cannot allocate audio frame buffer: {}",
+                        ff_sys::av_error_string(ret)
+                    ),
+                });
             }
 
             // Prepare input pointers
@@ -408,10 +426,13 @@ impl AudioEncoderInner {
             // Allocate frame buffer
             let ret = ff_sys::av_frame_get_buffer(dst, 0);
             if ret < 0 {
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Cannot allocate audio frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!(
+                        "Cannot allocate audio frame buffer: {}",
+                        ff_sys::av_error_string(ret)
+                    ),
+                });
             }
 
             // Copy audio data
@@ -443,7 +464,10 @@ impl AudioEncoderInner {
 
         let mut packet = av_packet_alloc();
         if packet.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate packet".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate packet".to_string(),
+            });
         }
 
         loop {
@@ -457,10 +481,13 @@ impl AudioEncoderInner {
                 }
                 Err(e) => {
                     av_packet_free(&mut packet as *mut *mut _);
-                    return Err(EncodeError::Ffmpeg(format!(
-                        "Error receiving audio packet: {}",
-                        ff_sys::av_error_string(e)
-                    )));
+                    return Err(EncodeError::Ffmpeg {
+                        code: e,
+                        message: format!(
+                            "Error receiving audio packet: {}",
+                            ff_sys::av_error_string(e)
+                        ),
+                    });
                 }
             }
 
@@ -498,10 +525,10 @@ impl AudioEncoderInner {
         // Write trailer
         let ret = av_write_trailer(self.format_ctx);
         if ret < 0 {
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot write trailer: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
+            });
         }
 
         Ok(())

--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -60,8 +60,13 @@ pub enum EncodeError {
     },
 
     /// `FFmpeg` error
-    #[error("FFmpeg error: {0}")]
-    Ffmpeg(String),
+    #[error("ffmpeg error: {message} (code={code})")]
+    Ffmpeg {
+        /// Raw `FFmpeg` error code (negative integer). `0` when no numeric code is available.
+        code: i32,
+        /// Human-readable error message from `av_strerror` or an internal description.
+        message: String,
+    },
 
     /// IO error
     #[error("IO error: {0}")]
@@ -79,8 +84,10 @@ impl EncodeError {
     /// as it makes the conversion explicit and prevents accidental
     /// conversion of arbitrary i32 values.
     pub(crate) fn from_ffmpeg_error(errnum: i32) -> Self {
-        let error_msg = ff_sys::av_error_string(errnum);
-        EncodeError::Ffmpeg(format!("{} (code: {})", error_msg, errnum))
+        EncodeError::Ffmpeg {
+            code: errnum,
+            message: ff_sys::av_error_string(errnum),
+        }
     }
 }
 
@@ -89,29 +96,37 @@ mod tests {
     use super::EncodeError;
 
     #[test]
-    fn from_ffmpeg_error_returns_ffmpeg_variant() {
+    fn from_ffmpeg_error_should_return_ffmpeg_variant() {
         let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::EINVAL);
-        assert!(matches!(err, EncodeError::Ffmpeg(_)));
+        assert!(matches!(err, EncodeError::Ffmpeg { .. }));
     }
 
     #[test]
-    fn from_ffmpeg_error_message_contains_code() {
+    fn from_ffmpeg_error_should_carry_numeric_code() {
+        let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::EINVAL);
+        match err {
+            EncodeError::Ffmpeg { code, .. } => assert_eq!(code, ff_sys::error_codes::EINVAL),
+            _ => panic!("expected Ffmpeg variant"),
+        }
+    }
+
+    #[test]
+    fn from_ffmpeg_error_should_format_with_code_in_display() {
         let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::EINVAL);
         let msg = err.to_string();
-        assert!(msg.contains("code: -22"), "expected 'code: -22' in '{msg}'");
+        assert!(msg.contains("code=-22"), "expected 'code=-22' in '{msg}'");
     }
 
     #[test]
-    fn from_ffmpeg_error_message_nonempty() {
+    fn from_ffmpeg_error_message_should_be_nonempty() {
         let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::ENOMEM);
-        let msg = err.to_string();
-        assert!(!msg.is_empty());
+        assert!(!err.to_string().is_empty());
     }
 
     #[test]
-    fn from_ffmpeg_error_eof() {
+    fn from_ffmpeg_error_eof_should_be_constructible() {
         let err = EncodeError::from_ffmpeg_error(ff_sys::error_codes::EOF);
-        assert!(matches!(err, EncodeError::Ffmpeg(_)));
+        assert!(matches!(err, EncodeError::Ffmpeg { .. }));
         assert!(!err.to_string().is_empty());
     }
 }

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -127,18 +127,22 @@ impl ImageEncoderInner {
             c_path.as_ptr(),
         );
         if ret < 0 || inner.format_ctx.is_null() {
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot create output context: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Cannot create output context: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // ── Step 2: Video stream ──────────────────────────────────────────────
         let stream = avformat_new_stream(inner.format_ctx, ptr::null());
         if stream.is_null() {
-            return Err(EncodeError::Ffmpeg(
-                "Cannot create output stream".to_string(),
-            ));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot create output stream".to_string(),
+            });
         }
 
         // ── Step 3: Find encoder ──────────────────────────────────────────────
@@ -187,9 +191,10 @@ impl ImageEncoderInner {
         // ── Step 10: Allocate destination frame ───────────────────────────────
         inner.dst_frame = av_frame_alloc();
         if inner.dst_frame.is_null() {
-            return Err(EncodeError::Ffmpeg(
-                "Cannot allocate destination frame".to_string(),
-            ));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate destination frame".to_string(),
+            });
         }
         (*inner.dst_frame).format = pix_fmt;
         (*inner.dst_frame).width = dst_width as i32;
@@ -203,7 +208,10 @@ impl ImageEncoderInner {
         // ── Step 11: Allocate packet ──────────────────────────────────────────
         inner.packet = av_packet_alloc();
         if inner.packet.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate packet".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate packet".to_string(),
+            });
         }
 
         Ok(inner)

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -291,10 +291,13 @@ impl VideoEncoderInner {
             );
 
             if ret < 0 || format_ctx.is_null() {
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Cannot create output context: {}",
-                    ff_sys::av_error_string(ret)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!(
+                        "Cannot create output context: {}",
+                        ff_sys::av_error_string(ret)
+                    ),
+                });
             }
 
             let mut encoder = Self {
@@ -380,10 +383,10 @@ impl VideoEncoderInner {
                 let ret = avformat_write_header(format_ctx, ptr::null_mut());
                 if ret < 0 {
                     encoder.cleanup();
-                    return Err(EncodeError::Ffmpeg(format!(
-                        "Cannot write header: {}",
-                        ff_sys::av_error_string(ret)
-                    )));
+                    return Err(EncodeError::Ffmpeg {
+                        code: ret,
+                        message: format!("Cannot write header: {}", ff_sys::av_error_string(ret)),
+                    });
                 }
             }
 
@@ -412,8 +415,11 @@ impl VideoEncoderInner {
         let encoder_name = self.select_video_encoder(codec, hardware_encoder)?;
         self.actual_video_codec = encoder_name.clone();
 
-        let c_encoder_name = CString::new(encoder_name.as_str())
-            .map_err(|_| EncodeError::Ffmpeg("Invalid encoder name".to_string()))?;
+        let c_encoder_name =
+            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Invalid encoder name".to_string(),
+            })?;
 
         let codec_ptr =
             avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
@@ -448,8 +454,10 @@ impl VideoEncoderInner {
                 (*codec_ctx).rc_buffer_size = (*max * 2) as i32;
             }
             Some(BitrateMode::Crf(q)) => {
-                let crf_str = CString::new(q.to_string())
-                    .map_err(|_| EncodeError::Ffmpeg("Invalid CRF value".to_string()))?;
+                let crf_str = CString::new(q.to_string()).map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Invalid CRF value".to_string(),
+                })?;
                 // SAFETY: priv_data, option name, and value are all valid pointers
                 let ret = ff_sys::av_opt_set(
                     (*codec_ctx).priv_data,
@@ -473,8 +481,10 @@ impl VideoEncoderInner {
 
         // Set preset for x264/x265
         if encoder_name.contains("264") || encoder_name.contains("265") {
-            let preset_cstr = CString::new(preset)
-                .map_err(|_| EncodeError::Ffmpeg("Invalid preset value".to_string()))?;
+            let preset_cstr = CString::new(preset).map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Invalid preset value".to_string(),
+            })?;
             // SAFETY: priv_data, option name, and value are all valid pointers
             let ret = ff_sys::av_opt_set(
                 (*codec_ctx).priv_data,
@@ -505,7 +515,10 @@ impl VideoEncoderInner {
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
             avcodec::free_context(&mut codec_ctx as *mut *mut _);
-            return Err(EncodeError::Ffmpeg("Cannot create stream".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot create stream".to_string(),
+            });
         }
 
         (*stream).time_base = (*codec_ctx).time_base;
@@ -564,8 +577,10 @@ impl VideoEncoderInner {
         // Try each candidate
         for &name in &candidates {
             unsafe {
-                let c_name = CString::new(name)
-                    .map_err(|_| EncodeError::Ffmpeg("Invalid encoder name".to_string()))?;
+                let c_name = CString::new(name).map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Invalid encoder name".to_string(),
+                })?;
                 if avcodec::find_encoder_by_name(c_name.as_ptr()).is_some() {
                     return Ok(name.to_string());
                 }
@@ -702,8 +717,11 @@ impl VideoEncoderInner {
         let encoder_name = self.select_audio_encoder(codec)?;
         self.actual_audio_codec = encoder_name.clone();
 
-        let c_encoder_name = CString::new(encoder_name.as_str())
-            .map_err(|_| EncodeError::Ffmpeg("Invalid encoder name".to_string()))?;
+        let c_encoder_name =
+            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Invalid encoder name".to_string(),
+            })?;
 
         let codec_ptr =
             avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
@@ -760,7 +778,10 @@ impl VideoEncoderInner {
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
             avcodec::free_context(&mut codec_ctx as *mut *mut _);
-            return Err(EncodeError::Ffmpeg("Cannot create stream".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot create stream".to_string(),
+            });
         }
 
         (*stream).time_base = (*codec_ctx).time_base;
@@ -804,8 +825,10 @@ impl VideoEncoderInner {
         // Try each candidate
         for &name in &candidates {
             unsafe {
-                let c_name = CString::new(name)
-                    .map_err(|_| EncodeError::Ffmpeg("Invalid encoder name".to_string()))?;
+                let c_name = CString::new(name).map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Invalid encoder name".to_string(),
+                })?;
                 if avcodec::find_encoder_by_name(c_name.as_ptr()).is_some() {
                     return Ok(name.to_string());
                 }
@@ -838,7 +861,10 @@ impl VideoEncoderInner {
             // Convert the incoming frame to YUV420P (the pass-1 codec's format).
             let mut av_frame = av_frame_alloc();
             if av_frame.is_null() {
-                return Err(EncodeError::Ffmpeg("Cannot allocate frame".to_string()));
+                return Err(EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Cannot allocate frame".to_string(),
+                });
             }
 
             let convert_result = self.convert_video_frame(frame, av_frame, pass1_ctx);
@@ -880,10 +906,13 @@ impl VideoEncoderInner {
             let send_result = avcodec::send_frame(pass1_ctx, av_frame);
             if let Err(e) = send_result {
                 av_frame_free(&mut av_frame as *mut *mut _);
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Failed to send frame to pass-1 encoder: {}",
-                    ff_sys::av_error_string(e)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "Failed to send frame to pass-1 encoder: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                });
             }
 
             let drain_result = self.drain_pass1_packets(pass1_ctx);
@@ -904,7 +933,10 @@ impl VideoEncoderInner {
         // Allocate AVFrame
         let mut av_frame = av_frame_alloc();
         if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate frame".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate frame".to_string(),
+            });
         }
 
         // Convert VideoFrame to AVFrame
@@ -921,10 +953,10 @@ impl VideoEncoderInner {
         let send_result = avcodec::send_frame(codec_ctx, av_frame);
         if let Err(e) = send_result {
             av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(EncodeError::Ffmpeg(format!(
-                "Failed to send frame: {}",
-                ff_sys::av_error_string(e)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to send frame: {}", ff_sys::av_error_string(e)),
+            });
         }
 
         // Receive packets
@@ -955,7 +987,10 @@ impl VideoEncoderInner {
     ) -> Result<(), EncodeError> {
         let mut packet = av_packet_alloc();
         if packet.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate packet".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate packet".to_string(),
+            });
         }
 
         loop {
@@ -969,10 +1004,13 @@ impl VideoEncoderInner {
                 }
                 Err(e) => {
                     av_packet_free(&mut packet as *mut *mut _);
-                    return Err(EncodeError::Ffmpeg(format!(
-                        "Error receiving packet from pass-1 encoder: {}",
-                        ff_sys::av_error_string(e)
-                    )));
+                    return Err(EncodeError::Ffmpeg {
+                        code: e,
+                        message: format!(
+                            "Error receiving packet from pass-1 encoder: {}",
+                            ff_sys::av_error_string(e)
+                        ),
+                    });
                 }
             }
         }
@@ -1070,10 +1108,13 @@ impl VideoEncoderInner {
         // Allocate frame buffer
         let ret = ff_sys::av_frame_get_buffer(dst, 0);
         if ret < 0 {
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot allocate frame buffer: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Cannot allocate frame buffer: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // Copy each plane directly
@@ -1083,9 +1124,13 @@ impl VideoEncoderInner {
             }
 
             // Bounds check for strides array
-            let src_stride =
-                src.strides().get(i).copied().ok_or_else(|| {
-                    EncodeError::Ffmpeg(format!("Missing stride for plane {}", i))
+            let src_stride = src
+                .strides()
+                .get(i)
+                .copied()
+                .ok_or_else(|| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Missing stride for plane {}", i),
                 })?;
 
             let dst_stride = (*dst).linesize[i] as usize;
@@ -1137,10 +1182,13 @@ impl VideoEncoderInner {
         // Allocate frame buffer
         let ret = ff_sys::av_frame_get_buffer(dst, 0);
         if ret < 0 {
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot allocate frame buffer: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Cannot allocate frame buffer: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // Prepare source data pointers and strides
@@ -1155,9 +1203,10 @@ impl VideoEncoderInner {
         }
 
         // Perform scaling/conversion
-        let sws_ctx = self
-            .sws_ctx
-            .ok_or_else(|| EncodeError::Ffmpeg("Scaling context not initialized".to_string()))?;
+        let sws_ctx = self.sws_ctx.ok_or_else(|| EncodeError::Ffmpeg {
+            code: 0,
+            message: "Scaling context not initialized".to_string(),
+        })?;
 
         swscale::scale(
             sws_ctx,
@@ -1232,7 +1281,10 @@ impl VideoEncoderInner {
 
         let mut packet = av_packet_alloc();
         if packet.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate packet".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate packet".to_string(),
+            });
         }
 
         loop {
@@ -1246,10 +1298,10 @@ impl VideoEncoderInner {
                 }
                 Err(e) => {
                     av_packet_free(&mut packet as *mut *mut _);
-                    return Err(EncodeError::Ffmpeg(format!(
-                        "Error receiving packet: {}",
-                        ff_sys::av_error_string(e)
-                    )));
+                    return Err(EncodeError::Ffmpeg {
+                        code: e,
+                        message: format!("Error receiving packet: {}", ff_sys::av_error_string(e)),
+                    });
                 }
             }
 
@@ -1289,7 +1341,10 @@ impl VideoEncoderInner {
         // Allocate AVFrame
         let mut av_frame = av_frame_alloc();
         if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate frame".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate frame".to_string(),
+            });
         }
 
         // Convert AudioFrame to AVFrame
@@ -1306,10 +1361,10 @@ impl VideoEncoderInner {
         let send_result = avcodec::send_frame(codec_ctx, av_frame);
         if let Err(e) = send_result {
             av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(EncodeError::Ffmpeg(format!(
-                "Failed to send audio frame: {}",
-                ff_sys::av_error_string(e)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: e,
+                message: format!("Failed to send audio frame: {}", ff_sys::av_error_string(e)),
+            });
         }
 
         // Receive packets
@@ -1372,8 +1427,9 @@ impl VideoEncoderInner {
                 self.swr_ctx = Some(swr_ctx);
             }
 
-            let swr_ctx = self.swr_ctx.ok_or_else(|| {
-                EncodeError::Ffmpeg("Resampling context not initialized".to_string())
+            let swr_ctx = self.swr_ctx.ok_or_else(|| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Resampling context not initialized".to_string(),
             })?;
 
             // Estimate output sample count
@@ -1395,10 +1451,13 @@ impl VideoEncoderInner {
             // Allocate frame buffer
             let ret = ff_sys::av_frame_get_buffer(dst, 0);
             if ret < 0 {
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Cannot allocate audio frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!(
+                        "Cannot allocate audio frame buffer: {}",
+                        ff_sys::av_error_string(ret)
+                    ),
+                });
             }
 
             // Prepare input pointers
@@ -1434,10 +1493,13 @@ impl VideoEncoderInner {
             // Allocate frame buffer
             let ret = ff_sys::av_frame_get_buffer(dst, 0);
             if ret < 0 {
-                return Err(EncodeError::Ffmpeg(format!(
-                    "Cannot allocate audio frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!(
+                        "Cannot allocate audio frame buffer: {}",
+                        ff_sys::av_error_string(ret)
+                    ),
+                });
             }
 
             // Copy audio data
@@ -1471,7 +1533,10 @@ impl VideoEncoderInner {
 
         let mut packet = av_packet_alloc();
         if packet.is_null() {
-            return Err(EncodeError::Ffmpeg("Cannot allocate packet".to_string()));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate packet".to_string(),
+            });
         }
 
         loop {
@@ -1485,10 +1550,13 @@ impl VideoEncoderInner {
                 }
                 Err(e) => {
                     av_packet_free(&mut packet as *mut *mut _);
-                    return Err(EncodeError::Ffmpeg(format!(
-                        "Error receiving audio packet: {}",
-                        ff_sys::av_error_string(e)
-                    )));
+                    return Err(EncodeError::Ffmpeg {
+                        code: e,
+                        message: format!(
+                            "Error receiving audio packet: {}",
+                            ff_sys::av_error_string(e)
+                        ),
+                    });
                 }
             }
 
@@ -1541,10 +1609,10 @@ impl VideoEncoderInner {
         // Write trailer
         let ret = av_write_trailer(self.format_ctx);
         if ret < 0 {
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot write trailer: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
+            });
         }
 
         Ok(())
@@ -1575,10 +1643,10 @@ impl VideoEncoderInner {
         if let Err(e) = avcodec::send_frame(pass1_ctx, ptr::null())
             && e != ff_sys::error_codes::EOF
         {
-            return Err(EncodeError::Ffmpeg(format!(
-                "pass1 flush send_frame: {}",
-                ff_sys::av_error_string(e)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: e,
+                message: format!("pass1 flush send_frame: {}", ff_sys::av_error_string(e)),
+            });
         }
         self.drain_pass1_packets(pass1_ctx)?;
 
@@ -1627,10 +1695,13 @@ impl VideoEncoderInner {
         Self::apply_chapters(self.format_ctx, &config.chapters);
         let ret = avformat_write_header(self.format_ctx, ptr::null_mut());
         if ret < 0 {
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot write header in pass 2: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Cannot write header in pass 2: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // ── Step 6: Re-encode all buffered frames ────────────────────────────
@@ -1646,10 +1717,10 @@ impl VideoEncoderInner {
             if let Err(e) = avcodec::send_frame(codec_ctx, ptr::null())
                 && e != ff_sys::error_codes::EOF
             {
-                return Err(EncodeError::Ffmpeg(format!(
-                    "pass2 flush send_frame: {}",
-                    ff_sys::av_error_string(e)
-                )));
+                return Err(EncodeError::Ffmpeg {
+                    code: e,
+                    message: format!("pass2 flush send_frame: {}", ff_sys::av_error_string(e)),
+                });
             }
             self.receive_packets()?;
         }
@@ -1659,10 +1730,10 @@ impl VideoEncoderInner {
 
         let ret = av_write_trailer(self.format_ctx);
         if ret < 0 {
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot write trailer: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
+            });
         }
 
         Ok(())
@@ -1689,8 +1760,11 @@ impl VideoEncoderInner {
         let fps = config.video_fps.unwrap_or(30.0);
         let encoder_name = self.actual_video_codec.clone();
 
-        let c_encoder_name = CString::new(encoder_name.as_str())
-            .map_err(|_| EncodeError::Ffmpeg("Invalid encoder name for pass 2".to_string()))?;
+        let c_encoder_name =
+            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Invalid encoder name for pass 2".to_string(),
+            })?;
 
         let codec_ptr =
             avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
@@ -1723,8 +1797,10 @@ impl VideoEncoderInner {
                 (*codec_ctx).rc_buffer_size = (*max * 2) as i32;
             }
             Some(BitrateMode::Crf(q)) => {
-                let crf_str = CString::new(q.to_string())
-                    .map_err(|_| EncodeError::Ffmpeg("Invalid CRF value".to_string()))?;
+                let crf_str = CString::new(q.to_string()).map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Invalid CRF value".to_string(),
+                })?;
                 // SAFETY: priv_data, option name, and value are all valid pointers.
                 let ret = ff_sys::av_opt_set(
                     (*codec_ctx).priv_data,
@@ -1746,8 +1822,11 @@ impl VideoEncoderInner {
         }
 
         if encoder_name.contains("264") || encoder_name.contains("265") {
-            let preset_cstr = CString::new(config.preset.as_str())
-                .map_err(|_| EncodeError::Ffmpeg("Invalid preset value".to_string()))?;
+            let preset_cstr =
+                CString::new(config.preset.as_str()).map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Invalid preset value".to_string(),
+                })?;
             // SAFETY: priv_data, option name, and value are all valid pointers.
             let ret = ff_sys::av_opt_set(
                 (*codec_ctx).priv_data,
@@ -1771,8 +1850,10 @@ impl VideoEncoderInner {
         // Point stats_in to our owned CString (kept alive in self.stats_in_cstr
         // until cleanup() nulls the pointer and drops it).
         if !stats.is_empty() {
-            let stats_cstr = CString::new(stats)
-                .map_err(|_| EncodeError::Ffmpeg("Invalid stats string from pass 1".to_string()))?;
+            let stats_cstr = CString::new(stats).map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Invalid stats string from pass 1".to_string(),
+            })?;
             // SAFETY: stats_cstr.as_ptr() is valid for the lifetime of stats_cstr,
             // which is stored in self.stats_in_cstr and dropped only after the codec
             // context is freed in cleanup().
@@ -1793,10 +1874,13 @@ impl VideoEncoderInner {
             (*codec_ctx).stats_in = ptr::null_mut();
             self.stats_in_cstr = None;
             avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut()).map_err(|e| {
-                EncodeError::Ffmpeg(format!(
-                    "pass2 avcodec_open2 fallback: {}",
-                    ff_sys::av_error_string(e)
-                ))
+                EncodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "pass2 avcodec_open2 fallback: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                }
             })?;
         }
         log::info!(
@@ -1825,9 +1909,10 @@ impl VideoEncoderInner {
 
         let mut av_frame = av_frame_alloc();
         if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg(
-                "Cannot allocate frame for pass 2".to_string(),
-            ));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate frame for pass 2".to_string(),
+            });
         }
 
         // Set frame format — always YUV420P (converted during pass 1).
@@ -1839,10 +1924,13 @@ impl VideoEncoderInner {
         let ret = ff_sys::av_frame_get_buffer(av_frame, 0);
         if ret < 0 {
             av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(EncodeError::Ffmpeg(format!(
-                "Cannot allocate pass-2 frame buffer: {}",
-                ff_sys::av_error_string(ret)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: ret,
+                message: format!(
+                    "Cannot allocate pass-2 frame buffer: {}",
+                    ff_sys::av_error_string(ret)
+                ),
+            });
         }
 
         // Copy the buffered YUV420P data into the AVFrame.
@@ -1883,10 +1971,13 @@ impl VideoEncoderInner {
         let send_result = avcodec::send_frame(codec_ctx, av_frame);
         if let Err(e) = send_result {
             av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(EncodeError::Ffmpeg(format!(
-                "Failed to send frame to pass-2 encoder: {}",
-                ff_sys::av_error_string(e)
-            )));
+            return Err(EncodeError::Ffmpeg {
+                code: e,
+                message: format!(
+                    "Failed to send frame to pass-2 encoder: {}",
+                    ff_sys::av_error_string(e)
+                ),
+            });
         }
 
         let receive_result = self.receive_packets();
@@ -2051,9 +2142,10 @@ impl VideoEncoderInner {
         if pkt.is_null() {
             let mut src_ctx_ptr = src_ctx;
             ff_sys::avformat::close_input(&mut src_ctx_ptr);
-            return Err(EncodeError::Ffmpeg(
-                "subtitle_passthrough: av_packet_alloc failed".to_string(),
-            ));
+            return Err(EncodeError::Ffmpeg {
+                code: 0,
+                message: "subtitle_passthrough: av_packet_alloc failed".to_string(),
+            });
         }
 
         loop {

--- a/crates/ff-probe/src/error.rs
+++ b/crates/ff-probe/src/error.rs
@@ -43,8 +43,13 @@ pub enum ProbeError {
     Io(#[from] std::io::Error),
 
     /// An `FFmpeg` error occurred.
-    #[error("FFmpeg error: {0}")]
-    Ffmpeg(String),
+    #[error("ffmpeg error: {message} (code={code})")]
+    Ffmpeg {
+        /// Raw `FFmpeg` error code (negative integer). `0` when no numeric code is available.
+        code: i32,
+        /// Human-readable error message from `av_strerror` or an internal description.
+        message: String,
+    },
 }
 
 #[cfg(test)]
@@ -93,11 +98,15 @@ mod tests {
     }
 
     #[test]
-    fn test_ffmpeg_error() {
-        let err = ProbeError::Ffmpeg("codec not found".to_string());
+    fn ffmpeg_should_display_code_and_message() {
+        let err = ProbeError::Ffmpeg {
+            code: -2,
+            message: "codec not found".to_string(),
+        };
         let msg = err.to_string();
-        assert!(msg.contains("FFmpeg error"));
+        assert!(msg.contains("ffmpeg error"));
         assert!(msg.contains("codec not found"));
+        assert!(msg.contains("code=-2"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ff-filter` and `ff-stream` already represented FFmpeg errors as `Ffmpeg { code: i32, message: String }`, but `ff-decode`, `ff-encode`, and `ff-probe` still used a tuple variant `Ffmpeg(String)` that discarded the numeric error code. This PR unifies all three to the same struct shape, making the raw FFmpeg error code machine-readable for root-cause analysis, and standardises the display format to lowercase `"ffmpeg error: {message} (code={code})"`.

## Changes

- **`ff-decode/src/error.rs`**: `Ffmpeg(String)` → `Ffmpeg { code: i32, message: String }`; `ffmpeg(message)` constructor updated to `ffmpeg(code, message)`; display format lowercased; tests updated and extended
- **`ff-encode/src/error.rs`**: same variant change; `from_ffmpeg_error(errnum)` now sets `code: errnum` and `message: av_error_string(errnum)` separately instead of embedding the code in the message string; tests renamed to `feature_should_expected_result` convention
- **`ff-probe/src/error.rs`**: same variant change; test updated
- **`ff-decode` inner files** (`video/decoder_inner.rs`, `audio/decoder_inner.rs`, `image/decoder_inner.rs`, `image/builder.rs`, `video/builder.rs`): ~44 call sites migrated — sites with an FFmpeg return code use it as `code`; sites with only a message string use `code: 0`; pattern match `Ffmpeg(_)` updated to `Ffmpeg { .. }`
- **`ff-encode` inner files** (`video/encoder_inner.rs`, `audio/encoder_inner.rs`, `image/encoder_inner.rs`): ~53 call sites migrated with the same rules

## Related Issues

Closes #486

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes