### PR TITLE
test(avio): add accessibility tests for pipeline feature re-exports

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -251,4 +251,59 @@ mod tests {
         let _: FilterError = FilterError::BuildFailed;
         let _: FilterError = FilterError::ProcessFailed;
     }
+
+    // ── pipeline feature ──────────────────────────────────────────────────────
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn pipeline_builder_should_be_accessible() {
+        // Pipeline::builder() is the public entry point; verify name resolution.
+        let _builder: PipelineBuilder = Pipeline::builder();
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn pipeline_error_should_be_accessible() {
+        let _: PipelineError = PipelineError::NoInput;
+        let _: PipelineError = PipelineError::NoOutput;
+        let _: PipelineError = PipelineError::Cancelled;
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn pipeline_progress_should_be_accessible() {
+        let p = Progress {
+            frames_processed: 10,
+            total_frames: Some(100),
+            elapsed: std::time::Duration::from_secs(1),
+        };
+        assert_eq!(p.percent(), Some(10.0));
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn pipeline_progress_callback_should_be_accessible() {
+        // ProgressCallback is Box<dyn Fn(&Progress) -> bool + Send>.
+        let _cb: ProgressCallback = Box::new(|_: &Progress| true);
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn pipeline_thumbnail_pipeline_should_be_accessible() {
+        // ThumbnailPipeline::new constructs without opening a file.
+        let _t: ThumbnailPipeline = ThumbnailPipeline::new("/no/such/file.mp4");
+    }
+
+    #[cfg(all(feature = "pipeline", feature = "encode"))]
+    #[test]
+    fn pipeline_encoder_config_should_be_accessible() {
+        let _config = EncoderConfig {
+            video_codec: VideoCodec::H264,
+            audio_codec: AudioCodec::Aac,
+            bitrate_mode: BitrateMode::Cbr(4_000_000),
+            resolution: None,
+            framerate: None,
+            hardware: None,
+        };
+    }
 }


### PR DESCRIPTION
## Summary

The `pipeline` feature re-exports (`Pipeline`, `PipelineBuilder`, `PipelineError`, `Progress`, `ProgressCallback`, `ThumbnailPipeline`, `EncoderConfig`) were already present in `avio/src/lib.rs`, but there were no tests verifying that the re-exported symbols were correctly accessible from the facade crate. This PR adds those tests.

## Changes

- Added 6 `#[cfg(feature = "pipeline")]` unit tests to `crates/avio/src/lib.rs`:
  - `pipeline_builder_should_be_accessible` — verifies `Pipeline::builder()` returns `PipelineBuilder`
  - `pipeline_error_should_be_accessible` — verifies `PipelineError` variants are in scope
  - `pipeline_progress_should_be_accessible` — verifies `Progress` fields and `percent()` method
  - `pipeline_progress_callback_should_be_accessible` — verifies `ProgressCallback` type alias resolves
  - `pipeline_thumbnail_pipeline_should_be_accessible` — verifies `ThumbnailPipeline::new()` resolves
  - `pipeline_encoder_config_should_be_accessible` (gated on `pipeline + encode`) — verifies `EncoderConfig` struct literal construction

## Related Issues

Closes #81

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes