### PR TITLE
test(avio): add accessibility tests for stream feature re-exports

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -306,4 +306,45 @@ mod tests {
             hardware: None,
         };
     }
+
+    // ── stream feature ────────────────────────────────────────────────────────
+
+    #[cfg(feature = "stream")]
+    #[test]
+    fn stream_hls_output_should_be_accessible() {
+        // HlsOutput::new() is the public entry point; verify name resolution.
+        let _hls: HlsOutput = HlsOutput::new("/tmp/hls");
+    }
+
+    #[cfg(feature = "stream")]
+    #[test]
+    fn stream_dash_output_should_be_accessible() {
+        // DashOutput::new() is the public entry point; verify name resolution.
+        let _dash: DashOutput = DashOutput::new("/tmp/dash");
+    }
+
+    #[cfg(feature = "stream")]
+    #[test]
+    fn stream_abr_ladder_should_be_accessible() {
+        // AbrLadder::new() is the public entry point; verify name resolution.
+        let _ladder: AbrLadder = AbrLadder::new("/no/such/file.mp4");
+    }
+
+    #[cfg(feature = "stream")]
+    #[test]
+    fn stream_rendition_should_be_accessible() {
+        let _r: Rendition = Rendition {
+            width: 1280,
+            height: 720,
+            bitrate: 3_000_000,
+        };
+    }
+
+    #[cfg(feature = "stream")]
+    #[test]
+    fn stream_error_should_be_accessible() {
+        let _err: StreamError = StreamError::InvalidConfig {
+            reason: "test".into(),
+        };
+    }
 }


### PR DESCRIPTION
## Summary

The `stream` feature re-exports (`HlsOutput`, `DashOutput`, `AbrLadder`, `Rendition`, `StreamError`) were already present in `avio/src/lib.rs`, but there were no tests verifying that the re-exported symbols were correctly accessible from the facade crate. This PR adds those tests.

## Changes

- Added 5 `#[cfg(feature = "stream")]` unit tests to `crates/avio/src/lib.rs`:
  - `stream_hls_output_should_be_accessible` — verifies `HlsOutput::new()` resolves
  - `stream_dash_output_should_be_accessible` — verifies `DashOutput::new()` resolves
  - `stream_abr_ladder_should_be_accessible` — verifies `AbrLadder::new()` resolves
  - `stream_rendition_should_be_accessible` — verifies `Rendition` struct literal construction
  - `stream_error_should_be_accessible` — verifies `StreamError::InvalidConfig` variant is in scope

## Related Issues

Closes #82

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes