### PR TITLE
test(ff-stream,avio): add integration tests for HLS, ABR ladder, and avio feature flags

### DIFF
--- a/crates/avio/tests/feature_combinations_test.rs
+++ b/crates/avio/tests/feature_combinations_test.rs
@@ -1,0 +1,124 @@
+//! Compile-time integration test: verifies the avio facade compiles correctly
+//! with each feature combination.
+//!
+//! Each `#[test]` function contains only name-resolution and construction
+//! expressions; they always pass when they compile.  Running with specific
+//! feature sets (or `--all-features`) activates the corresponding sections:
+//!
+//! ```text
+//! cargo test -p avio                        # default: probe + decode + encode
+//! cargo test -p avio --features filter      # adds filter
+//! cargo test -p avio --features pipeline    # adds pipeline (implies filter)
+//! cargo test -p avio --features stream      # adds stream  (implies pipeline)
+//! cargo test -p avio --all-features         # all combinations at once
+//! ```
+
+// ── Always-on types (ff-format, no feature gate) ─────────────────────────────
+
+#[test]
+fn format_types_should_be_accessible_without_any_feature() {
+    let _: avio::VideoCodec = avio::VideoCodec::default();
+    let _: avio::AudioCodec = avio::AudioCodec::default();
+    let _: avio::PixelFormat = avio::PixelFormat::default();
+    let _: avio::SampleFormat = avio::SampleFormat::default();
+    let _: avio::ChannelLayout = avio::ChannelLayout::default();
+    let _: avio::Rational = avio::Rational::default();
+    let _: avio::Timestamp = avio::Timestamp::default();
+    let _: avio::MediaInfo = avio::MediaInfo::default();
+}
+
+// ── probe feature ─────────────────────────────────────────────────────────────
+
+#[cfg(feature = "probe")]
+#[test]
+fn probe_feature_should_expose_probe_error_and_open() {
+    // open() is a function — a missing file returns ProbeError
+    let result = avio::open("/no/such/file.mp4");
+    assert!(matches!(result, Err(avio::ProbeError::FileNotFound { .. })));
+}
+
+// ── decode feature ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "decode")]
+#[test]
+fn decode_feature_should_expose_decode_error_and_decoders() {
+    let _: avio::DecodeError = avio::DecodeError::EndOfStream;
+    let _: avio::SeekMode = avio::SeekMode::Keyframe;
+    let _: avio::HardwareAccel = avio::HardwareAccel::None;
+    // VecPool::new() returns Arc<VecPool>
+    let pool = avio::VecPool::new(4);
+    assert_eq!(pool.capacity(), 4);
+}
+
+// ── encode feature ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "encode")]
+#[test]
+fn encode_feature_should_expose_encode_error_and_bitrate_mode() {
+    let _: avio::EncodeError = avio::EncodeError::Cancelled;
+    let _: avio::BitrateMode = avio::BitrateMode::Cbr(2_000_000);
+    let _: avio::BitrateMode = avio::BitrateMode::Crf(28);
+}
+
+// ── filter feature ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "filter")]
+#[test]
+fn filter_feature_should_expose_filter_error_and_graph_builder() {
+    let _: avio::FilterError = avio::FilterError::BuildFailed;
+    let _builder: avio::FilterGraphBuilder = avio::FilterGraphBuilder::new();
+    let _: avio::ToneMap = avio::ToneMap::Hable;
+    let _: avio::HwAccel = avio::HwAccel::Cuda;
+}
+
+// ── pipeline feature ──────────────────────────────────────────────────────────
+
+#[cfg(feature = "pipeline")]
+#[test]
+fn pipeline_feature_should_expose_pipeline_error_and_builder() {
+    let _: avio::PipelineError = avio::PipelineError::NoInput;
+    let _builder: avio::PipelineBuilder = avio::Pipeline::builder();
+    let _t: avio::ThumbnailPipeline = avio::ThumbnailPipeline::new("/no/such/file.mp4");
+    let _cb: avio::ProgressCallback = Box::new(|_: &avio::Progress| true);
+}
+
+// ── stream feature ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "stream")]
+#[test]
+fn stream_feature_should_expose_stream_error_and_output_builders() {
+    let _: avio::StreamError = avio::StreamError::InvalidConfig {
+        reason: "test".into(),
+    };
+    let _hls: avio::HlsOutput = avio::HlsOutput::new("/tmp/hls");
+    let _dash: avio::DashOutput = avio::DashOutput::new("/tmp/dash");
+    let _ladder: avio::AbrLadder = avio::AbrLadder::new("/no/such/file.mp4");
+    let _r: avio::Rendition = avio::Rendition {
+        width: 1280,
+        height: 720,
+        bitrate: 3_000_000,
+    };
+}
+
+// ── all-features combination ──────────────────────────────────────────────────
+
+#[cfg(all(feature = "filter", feature = "pipeline", feature = "stream"))]
+#[test]
+fn all_features_should_expose_symbols_without_conflicts() {
+    // EncodeProgress (from encode) and Progress (from pipeline) are distinct
+    // types that coexist without collision.
+    assert!(std::mem::size_of::<avio::EncodeProgress>() > 0);
+    let p = avio::Progress {
+        frames_processed: 5,
+        total_frames: Some(10),
+        elapsed: std::time::Duration::from_secs(1),
+    };
+    assert_eq!(p.percent(), Some(50.0));
+
+    // All error types are accessible simultaneously.
+    let _: avio::FilterError = avio::FilterError::BuildFailed;
+    let _: avio::PipelineError = avio::PipelineError::Cancelled;
+    let _: avio::StreamError = avio::StreamError::InvalidConfig {
+        reason: "all-features test".into(),
+    };
+}

--- a/crates/ff-stream/tests/abr_ladder_tests.rs
+++ b/crates/ff-stream/tests/abr_ladder_tests.rs
@@ -163,3 +163,23 @@ fn dash_manifest_should_contain_representation_elements() {
         "manifest.mpd should contain Representation elements"
     );
 }
+
+#[test]
+fn each_variant_subdirectory_should_contain_ts_segments() {
+    let Some((out_dir, _guard)) = run_abr_hls("abr_hls_segments_test") else {
+        return;
+    };
+
+    for i in 0..2 {
+        let subdir = out_dir.join(i.to_string());
+        let segments: Vec<_> = std::fs::read_dir(&subdir)
+            .unwrap_or_else(|e| panic!("cannot read subdir {i}: {e}"))
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".ts"))
+            .collect();
+        assert!(
+            !segments.is_empty(),
+            "rendition subdir {i}/ should contain at least one .ts segment"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the missing integration test coverage for HLS/ABR output and the avio facade's feature-flag combinations. Issue #84 (HLS output integration test) was already fully covered by `hls_output_tests.rs`; this PR closes it and addresses the remaining gaps in #85 and #86.

## Changes

- **`crates/ff-stream/tests/abr_ladder_tests.rs`** (#85): Add `each_variant_subdirectory_should_contain_ts_segments` — asserts that each rendition subdirectory (`0/`, `1/`) produced by `AbrLadder::hls()` contains at least one `.ts` segment file. The existing test already checked for per-rendition `.m3u8` playlists; this completes the requirement.

- **`crates/avio/tests/feature_combinations_test.rs`** (new, #86): Compile-time integration test for the avio facade with 8 test functions:
  - `format_types_should_be_accessible_without_any_feature` — always-on ff-format types
  - `probe_feature_should_expose_probe_error_and_open`
  - `decode_feature_should_expose_decode_error_and_decoders`
  - `encode_feature_should_expose_encode_error_and_bitrate_mode`
  - `filter_feature_should_expose_filter_error_and_graph_builder`
  - `pipeline_feature_should_expose_pipeline_error_and_builder`
  - `stream_feature_should_expose_stream_error_and_output_builders`
  - `all_features_should_expose_symbols_without_conflicts`

  With default features: 4 tests activate. With `--all-features`: all 8 activate. Each test verifies name resolution and basic construction; they pass whenever they compile.

## Related Issues

Closes #84
Closes #85
Closes #86

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes