### PR TITLE
feat(avio): add 10 runnable examples covering the full public API

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -32,5 +32,45 @@ ff-filter   = { workspace = true, optional = true }
 ff-pipeline = { workspace = true, optional = true }
 ff-stream   = { workspace = true, optional = true }
 
+[[example]]
+name = "probe_info"
+required-features = ["probe"]
+
+[[example]]
+name = "transcode"
+required-features = ["pipeline"]
+
+[[example]]
+name = "extract_thumbnails"
+required-features = ["pipeline", "encode"]
+
+[[example]]
+name = "trim_and_scale"
+required-features = ["pipeline"]
+
+[[example]]
+name = "concat_clips"
+required-features = ["pipeline", "probe"]
+
+[[example]]
+name = "add_watermark"
+required-features = ["pipeline", "decode", "encode"]
+
+[[example]]
+name = "decode_image"
+required-features = ["decode"]
+
+[[example]]
+name = "encode_image"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "hls_output"
+required-features = ["stream"]
+
+[[example]]
+name = "abr_ladder"
+required-features = ["stream", "probe"]
+
 [lints]
 workspace = true

--- a/crates/avio/examples/abr_ladder.rs
+++ b/crates/avio/examples/abr_ladder.rs
@@ -1,0 +1,246 @@
+//! Generate an adaptive bitrate HLS or DASH stream using `AbrLadder`.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example abr_ladder --features stream -- \
+//!   --input   input.mp4 \
+//!   --output  ./abr/    \
+//!   [--format hls]      \
+//!   [--ladder 1080,6000000:720,3000000:480,1500000]
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{AbrLadder, Rendition, StreamError, open};
+
+// Default rendition ladder (height_px, bitrate_bps)
+const DEFAULT_LADDER: &[(u32, u64)] = &[(1080, 6_000_000), (720, 3_000_000), (480, 1_500_000)];
+
+fn parse_ladder(s: &str) -> Result<Vec<(u32, u64)>, String> {
+    s.split(':')
+        .map(|pair| {
+            let mut parts = pair.splitn(2, ',');
+            let height: u32 = parts
+                .next()
+                .ok_or_else(|| format!("missing height in '{pair}'"))?
+                .parse()
+                .map_err(|_| format!("invalid height in '{pair}'"))?;
+            let bitrate: u64 = parts
+                .next()
+                .ok_or_else(|| format!("missing bitrate in '{pair}'"))?
+                .parse()
+                .map_err(|_| format!("invalid bitrate in '{pair}'"))?;
+            Ok((height, bitrate))
+        })
+        .collect()
+}
+
+fn warn_if_not_descending(ladder: &[(u32, u64)]) {
+    for i in 1..ladder.len() {
+        if ladder[i].1 > ladder[i - 1].1 {
+            println!(
+                "  Warning: rendition #{i} bitrate {} > rendition #{} bitrate {} — expected descending order",
+                ladder[i].1,
+                i - 1,
+                ladder[i - 1].1
+            );
+        }
+    }
+}
+
+fn dir_summary(output: &str) -> (Vec<(String, u64)>, u64) {
+    let Ok(entries) = std::fs::read_dir(output) else {
+        return (Vec::new(), 0);
+    };
+    let mut files: Vec<(String, u64)> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let size = e.metadata().ok()?.len();
+            Some((name, size))
+        })
+        .collect();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let total: u64 = files.iter().map(|(_, s)| s).sum();
+    (files, total)
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut format = "hls".to_string();
+    let mut ladder_str = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--format" | "-f" => format = args.next().unwrap_or_else(|| "hls".to_string()),
+            "--ladder" => ladder_str = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: abr_ladder --input <file> --output <dir> [--format hls|dash] [--ladder H,BPS:H,BPS]");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    let format_lower = format.to_lowercase();
+    if format_lower != "hls" && format_lower != "dash" {
+        eprintln!("Error: --format must be 'hls' or 'dash'");
+        process::exit(1);
+    }
+
+    // Parse ladder
+    let ladder_pairs = match ladder_str {
+        Some(ref s) => parse_ladder(s).unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }),
+        None => DEFAULT_LADDER.to_vec(),
+    };
+
+    // Probe source to get aspect ratio for width computation
+    let src_info = match open(&input) {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let (src_w, src_h) = src_info
+        .video_streams()
+        .first()
+        .map_or((1920, 1080), |v| (v.width(), v.height()));
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let dur = src_info.duration();
+    let dur_secs = dur.as_secs();
+    let dur_str = format!(
+        "{:02}:{:02}:{:02}",
+        dur_secs / 3600,
+        (dur_secs % 3600) / 60,
+        dur_secs % 60
+    );
+
+    println!("Input:   {in_name}  ({src_w}×{src_h}  {dur_str})");
+    println!("Format:  {}", format_lower.to_uppercase());
+    println!("Output:  {output}");
+    println!();
+
+    // Build renditions, computing width from aspect ratio
+    let aspect = if src_h > 0 {
+        f64::from(src_w) / f64::from(src_h)
+    } else {
+        16.0 / 9.0
+    };
+
+    println!("Renditions:");
+    warn_if_not_descending(&ladder_pairs);
+    let mut abr = AbrLadder::new(&input);
+    for (i, &(height, bitrate)) in ladder_pairs.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let width = ((f64::from(height) * aspect).round() as u32 / 2) * 2; // ensure even
+        println!("  #{i}  {width}×{height}  {bitrate} bps");
+        abr = abr.add_rendition(Rendition {
+            width,
+            height,
+            bitrate,
+        });
+    }
+    println!();
+
+    // Create output directory
+    if let Err(e) = std::fs::create_dir_all(&output) {
+        eprintln!("Error: cannot create output directory: {e}");
+        process::exit(1);
+    }
+
+    print!("Encoding...");
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
+    let result = if format_lower == "hls" {
+        abr.hls(&output)
+    } else {
+        abr.dash(&output)
+    };
+
+    match result {
+        Ok(()) => println!(" done."),
+        Err(StreamError::Ffmpeg { code, message }) => {
+            println!();
+            eprintln!("Error: FFmpeg failed: {message} (code={code})");
+            process::exit(1);
+        }
+        Err(e) => {
+            println!();
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    }
+
+    println!();
+    println!("Output structure:");
+
+    if format_lower == "hls" {
+        // master.m3u8 + subdirs
+        let (top_files, _) = dir_summary(&output);
+        for (name, size) in &top_files {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = *size as f64 / 1024.0;
+            if std::path::Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("m3u8"))
+            {
+                println!("  {name}  ({kb:.1} KB)");
+            }
+        }
+        for i in 0..ladder_pairs.len() {
+            let subdir = Path::new(&output).join(i.to_string());
+            let subdir_str = subdir.to_string_lossy();
+            let (sub_files, sub_total) = dir_summary(&subdir_str);
+            let seg_count = sub_files
+                .iter()
+                .filter(|(n, _)| {
+                    std::path::Path::new(n)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("ts"))
+                })
+                .count();
+            #[allow(clippy::cast_precision_loss)]
+            let sub_mb = sub_total as f64 / 1_048_576.0;
+            println!("  {i}/  playlist.m3u8 + {seg_count} segments  ({sub_mb:.1} MB)");
+        }
+    } else {
+        // Single manifest.mpd
+        let manifest = Path::new(&output).join("manifest.mpd");
+        if manifest.exists() {
+            let size = manifest.metadata().map_or(0, |m| m.len());
+            #[allow(clippy::cast_precision_loss)]
+            let kb = size as f64 / 1024.0;
+            println!("  manifest.mpd  ({kb:.1} KB)");
+        }
+        println!("  (segment files alongside manifest.mpd)");
+    }
+
+    println!();
+    if format_lower == "hls" {
+        println!("Serve with: npx serve {output}  (open http://localhost:3000/master.m3u8)");
+    } else {
+        println!("Serve with: npx serve {output}  (open http://localhost:3000/manifest.mpd)");
+    }
+}

--- a/crates/avio/examples/add_watermark.rs
+++ b/crates/avio/examples/add_watermark.rs
@@ -1,0 +1,241 @@
+//! Overlay a PNG watermark onto a video using the `overlay` filter.
+//!
+//! The `overlay` filter requires **two** video input streams:
+//! - slot 0: the main video frames (pushed per decoded frame)
+//! - slot 1: the watermark frame (pushed per decoded frame; same image repeated)
+//!
+//! Because `Pipeline` only drives slot 0, this example uses the lower-level
+//! `VideoDecoder` → `FilterGraph` → `VideoEncoder` path directly.
+//!
+//! Note: audio is not copied to the output in this example.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example add_watermark --features pipeline -- \
+//!   --input     input.mp4   \
+//!   --watermark logo.png    \
+//!   --output    branded.mp4 \
+//!   [--position bottom-right]  \
+//!   [--margin   20]
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{BitrateMode, FilterGraphBuilder, ImageDecoder, VideoDecoder, VideoEncoder};
+
+// ── Position helpers ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy)]
+enum Position {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+    Center,
+}
+
+impl Position {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "top-left" => Some(Self::TopLeft),
+            "top-right" => Some(Self::TopRight),
+            "bottom-left" => Some(Self::BottomLeft),
+            "bottom-right" => Some(Self::BottomRight),
+            "center" => Some(Self::Center),
+            _ => None,
+        }
+    }
+
+    fn compute(self, vid_w: u32, vid_h: u32, wm_w: u32, wm_h: u32, margin: u32) -> (i32, i32) {
+        let m = margin.cast_signed();
+        let x = match self {
+            Self::TopLeft | Self::BottomLeft => m,
+            Self::TopRight | Self::BottomRight => vid_w.cast_signed() - wm_w.cast_signed() - m,
+            Self::Center => (vid_w.cast_signed() - wm_w.cast_signed()) / 2,
+        };
+        let y = match self {
+            Self::TopLeft | Self::TopRight => m,
+            Self::BottomLeft | Self::BottomRight => vid_h.cast_signed() - wm_h.cast_signed() - m,
+            Self::Center => (vid_h.cast_signed() - wm_h.cast_signed()) / 2,
+        };
+        (x, y)
+    }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut watermark = None::<String>;
+    let mut output = None::<String>;
+    let mut position = Position::BottomRight;
+    let mut margin: u32 = 20;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--watermark" | "-w" => watermark = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--position" => {
+                let s = args.next().unwrap_or_default();
+                position = Position::from_str(&s).unwrap_or_else(|| {
+                    eprintln!("Unknown position '{s}' (try top-left, top-right, bottom-left, bottom-right, center)");
+                    process::exit(1);
+                });
+            }
+            "--margin" => {
+                let v = args.next().unwrap_or_default();
+                margin = v.parse().unwrap_or(20);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: add_watermark --input <video> --watermark <logo.png> --output <branded.mp4> [--position top-left|top-right|bottom-left|bottom-right|center] [--margin N]");
+        process::exit(1);
+    });
+    let watermark = watermark.unwrap_or_else(|| {
+        eprintln!("--watermark is required");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Decode watermark image ────────────────────────────────────────────────
+
+    let wm_dec = match ImageDecoder::open(&watermark).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening watermark: {e}");
+            process::exit(1);
+        }
+    };
+    let wm_frame = match wm_dec.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error decoding watermark: {e}");
+            process::exit(1);
+        }
+    };
+    let wm_w = wm_frame.width();
+    let wm_h = wm_frame.height();
+
+    // ── Open video decoder ────────────────────────────────────────────────────
+
+    let mut vid_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening video: {e}");
+            process::exit(1);
+        }
+    };
+    let vid_w = vid_dec.width();
+    let vid_h = vid_dec.height();
+    let fps = vid_dec.frame_rate();
+
+    // ── Compute overlay position ──────────────────────────────────────────────
+
+    let (x, y) = position.compute(vid_w, vid_h, wm_w, wm_h, margin);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let wm_name = Path::new(&watermark)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&watermark);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:      {in_name}  {vid_w}×{vid_h}");
+    println!("Watermark:  {wm_name}  {wm_w}×{wm_h}");
+    println!("Position:   {position:?}  (x={x}, y={y})");
+    println!("Output:     {out_name}");
+    println!();
+
+    // ── Build overlay filter graph ────────────────────────────────────────────
+    //
+    // The overlay filter expects two buffersrc inputs:
+    //   slot 0 → main video frame  (pushed for every decoded frame)
+    //   slot 1 → watermark frame   (same image pushed again each iteration)
+
+    let mut filter = match FilterGraphBuilder::new().overlay(x, y).build() {
+        Ok(fg) => fg,
+        Err(e) => {
+            eprintln!("Error building filter graph: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Build video encoder ───────────────────────────────────────────────────
+
+    // Audio is not handled in this example; output is video-only.
+    let mut enc = match VideoEncoder::create(&output)
+        .video(vid_w, vid_h, fps)
+        .video_codec(avio::VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error creating encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Decode → filter → encode loop ────────────────────────────────────────
+
+    let mut frames_out = 0u64;
+    loop {
+        let frame = match vid_dec.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error decoding: {e}");
+                process::exit(1);
+            }
+        };
+
+        // Push main video frame to slot 0.
+        if let Err(e) = filter.push_video(0, &frame) {
+            eprintln!("Error pushing to filter slot 0: {e}");
+            process::exit(1);
+        }
+
+        // Push watermark to slot 1 (repeat each frame so the buffersrc stays fed).
+        if let Err(e) = filter.push_video(1, &wm_frame) {
+            eprintln!("Error pushing watermark to filter slot 1: {e}");
+            process::exit(1);
+        }
+
+        while let Ok(Some(filtered)) = filter.pull_video() {
+            if let Err(e) = enc.push_video(&filtered) {
+                eprintln!("Error encoding: {e}");
+                process::exit(1);
+            }
+            frames_out += 1;
+            if frames_out.is_multiple_of(100) {
+                print!("\r{frames_out} frames encoded    ");
+                let _ = std::io::Write::flush(&mut std::io::stdout());
+            }
+        }
+    }
+
+    if let Err(e) = enc.finish() {
+        eprintln!("\nError finishing encode: {e}");
+        process::exit(1);
+    }
+
+    println!("\rDone. {out_name}  {frames_out} frames");
+}

--- a/crates/avio/examples/concat_clips.rs
+++ b/crates/avio/examples/concat_clips.rs
@@ -1,0 +1,170 @@
+//! Concatenate multiple video files end-to-end using `Pipeline`'s multi-input mode.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example concat_clips --features pipeline -- \
+//!   --output joined.mp4 \
+//!   clip1.mp4 clip2.mp4 clip3.mp4
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+    time::Duration,
+};
+
+use avio::{AudioCodec, BitrateMode, EncoderConfig, Pipeline, Progress, VideoCodec, open};
+
+fn format_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+fn format_elapsed(d: Duration) -> String {
+    let s = d.as_secs();
+    let m = s / 60;
+    format!("{:02}:{:02}", m, s % 60)
+}
+
+fn render_progress(p: &Progress) {
+    match p.percent() {
+        Some(pct) => {
+            let bar_width = 20usize;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+            let filled = filled.min(bar_width);
+            let bar = "=".repeat(filled) + &" ".repeat(bar_width - filled);
+            print!("\r{pct:5.1}%  [{bar}]  {}    ", format_elapsed(p.elapsed));
+        }
+        None => {
+            print!(
+                "\r{} frames  {}    ",
+                p.frames_processed,
+                format_elapsed(p.elapsed)
+            );
+        }
+    }
+    let _ = io::stdout().flush();
+}
+
+fn main() {
+    let mut args_iter = std::env::args().skip(1);
+    let mut output = None::<String>;
+    let mut inputs: Vec<String> = Vec::new();
+
+    while let Some(arg) = args_iter.next() {
+        match arg.as_str() {
+            "--output" | "-o" => output = Some(args_iter.next().unwrap_or_default()),
+            other if other.starts_with('-') => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+            _ => inputs.push(arg),
+        }
+    }
+
+    let output = output.unwrap_or_else(|| {
+        eprintln!("Usage: concat_clips --output <file> clip1.mp4 clip2.mp4 ...");
+        process::exit(1);
+    });
+
+    if inputs.len() < 2 {
+        eprintln!("Error: at least two input clips are required");
+        process::exit(1);
+    }
+
+    // Probe each input
+    let mut total_duration = Duration::ZERO;
+    let mut first_width = 0u32;
+    let mut first_height = 0u32;
+
+    println!("Inputs ({}):", inputs.len());
+    for (i, path) in inputs.iter().enumerate() {
+        let name = Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(path);
+        match open(path) {
+            Ok(info) => {
+                let dur = info.duration();
+                let w = info.video_streams().first().map_or(0, |v| v.width());
+                let h = info.video_streams().first().map_or(0, |v| v.height());
+                if i == 0 {
+                    first_width = w;
+                    first_height = h;
+                } else if w != first_width || h != first_height {
+                    println!(
+                        "  Warning: #{i} resolution {w}×{h} differs from #0 {first_width}×{first_height}; will use source dimensions"
+                    );
+                }
+                total_duration += dur;
+                println!("  #{i}  {name}  {w}×{h}  {}", format_duration(dur));
+            }
+            Err(e) => {
+                eprintln!("  Error probing {name}: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    println!("Expected total: {}", format_duration(total_duration));
+    println!();
+
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    let config = EncoderConfig {
+        video_codec: VideoCodec::H264,
+        audio_codec: AudioCodec::Aac,
+        bitrate_mode: BitrateMode::Crf(23),
+        resolution: None,
+        framerate: None,
+        hardware: None,
+    };
+
+    let mut builder = Pipeline::builder();
+    for input in &inputs {
+        builder = builder.input(input);
+    }
+    let pipeline = match builder
+        .output(&output, config)
+        .on_progress(|p: &Progress| {
+            render_progress(p);
+            true
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = pipeline.run() {
+        println!();
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    println!();
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}");
+}

--- a/crates/avio/examples/decode_image.rs
+++ b/crates/avio/examples/decode_image.rs
@@ -1,0 +1,122 @@
+//! Decode a still image and inspect its properties.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example decode_image -- \
+//!   --input photo.jpg \
+//!   [--dump raw.yuv]
+//! ```
+
+use std::{io::Write as _, path::Path, process};
+
+use avio::ImageDecoder;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut dump = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--dump" => dump = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: decode_image --input <file> [--dump <raw.yuv>]");
+        process::exit(1);
+    });
+
+    // Check supported extension
+    let ext = Path::new(&input)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_lowercase)
+        .unwrap_or_default();
+    match ext.as_str() {
+        "jpg" | "jpeg" | "png" | "bmp" | "webp" | "tiff" | "tif" => {}
+        other => {
+            eprintln!("Error: unsupported image format '.{other}' (try jpg, png, bmp, webp, tiff)");
+            process::exit(1);
+        }
+    }
+
+    let format_name = match ext.as_str() {
+        "jpg" | "jpeg" => "JPEG",
+        "png" => "PNG",
+        "bmp" => "BMP",
+        "webp" => "WebP",
+        "tiff" | "tif" => "TIFF",
+        _ => "Unknown",
+    };
+
+    let file_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    let dec = match ImageDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let frame = match dec.decode() {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let w = frame.width();
+    let h = frame.height();
+    let pix_fmt = frame.format();
+    let num_planes = frame.num_planes();
+    let total_size = frame.total_size();
+
+    println!("File:         {file_name}");
+    println!("Format:       {format_name}");
+    println!("Dimensions:   {w}×{h}");
+    println!("Pixel format: {pix_fmt:?}");
+    println!("Planes:       {num_planes}");
+
+    for i in 0..num_planes {
+        let stride = frame.stride(i).unwrap_or(0);
+        let plane_len = frame.plane(i).map_or(0, |p| p.len());
+        let label = match i {
+            0 => " (Y)",
+            1 => " (U)",
+            2 => " (V)",
+            _ => "",
+        };
+        println!("  plane {i}{label}  stride={stride}  size={plane_len} bytes");
+    }
+
+    println!("Total size:   {total_size} bytes");
+
+    if let Some(dump_path) = dump {
+        let data = frame.data();
+        match std::fs::File::create(&dump_path) {
+            Ok(mut f) => {
+                if let Err(e) = f.write_all(&data) {
+                    eprintln!("Error writing dump: {e}");
+                    process::exit(1);
+                }
+                println!("\nRaw pixels written to: {dump_path}");
+            }
+            Err(e) => {
+                eprintln!("Error creating dump file: {e}");
+                process::exit(1);
+            }
+        }
+    }
+}

--- a/crates/avio/examples/encode_image.rs
+++ b/crates/avio/examples/encode_image.rs
@@ -1,0 +1,212 @@
+//! Read one frame from a video at a given timestamp and save it as a still image.
+//!
+//! Demonstrates all three `SeekMode` variants:
+//! - `keyframe` (default) — seeks to the nearest keyframe before the target (fast)
+//! - `exact`              — decodes from the previous keyframe to hit the exact PTS (slow)
+//! - `backward`           — seeks backward to the nearest keyframe
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example encode_image -- \
+//!   --input     video.mp4   \
+//!   --output    frame.jpg   \
+//!   [--time     00:01:23]   \
+//!   [--quality  85]         \
+//!   [--seek-mode keyframe|exact|backward]
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{ImageEncoder, SeekMode, VideoDecoder};
+
+fn parse_time(s: &str) -> Result<f64, String> {
+    if s.contains(':') {
+        let parts: Vec<&str> = s.splitn(3, ':').collect();
+        if parts.len() == 3 {
+            let h: f64 = parts[0]
+                .parse()
+                .map_err(|_| format!("invalid hours in '{s}'"))?;
+            let m: f64 = parts[1]
+                .parse()
+                .map_err(|_| format!("invalid minutes in '{s}'"))?;
+            let sec: f64 = parts[2]
+                .parse()
+                .map_err(|_| format!("invalid seconds in '{s}'"))?;
+            Ok(h * 3600.0 + m * 60.0 + sec)
+        } else {
+            Err(format!("invalid time '{s}'"))
+        }
+    } else {
+        s.parse::<f64>().map_err(|_| format!("invalid time '{s}'"))
+    }
+}
+
+fn format_time(secs: f64) -> String {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let total = secs as u64;
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut time_str = None::<String>;
+    let mut quality: u32 = 85;
+    let mut seek_mode = SeekMode::Keyframe;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--time" | "-t" => time_str = Some(args.next().unwrap_or_default()),
+            "--quality" => {
+                let v = args.next().unwrap_or_default();
+                quality = v.parse().unwrap_or(85);
+            }
+            "--seek-mode" => {
+                let v = args.next().unwrap_or_default();
+                seek_mode = match v.as_str() {
+                    "keyframe" => SeekMode::Keyframe,
+                    "exact" => SeekMode::Exact,
+                    "backward" => SeekMode::Backward,
+                    other => {
+                        eprintln!("Unknown seek mode '{other}' (try keyframe, exact, backward)");
+                        process::exit(1);
+                    }
+                };
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: encode_image --input <video> --output <frame.jpg> \
+             [--time HH:MM:SS] [--quality N] [--seek-mode keyframe|exact|backward]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // Determine output format from extension
+    let ext = Path::new(&output)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_lowercase)
+        .unwrap_or_default();
+    let fmt_label = match ext.as_str() {
+        "jpg" | "jpeg" => "JPEG",
+        "png" => "PNG",
+        "bmp" => "BMP",
+        _ => {
+            eprintln!("Error: unsupported output format '.{ext}' (try .jpg, .png, .bmp)");
+            process::exit(1);
+        }
+    };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    // Open decoder
+    let mut dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let src_w = dec.width();
+    let src_h = dec.height();
+    println!("Input:   {in_name}  ({src_w}×{src_h})");
+
+    // Seek if a timestamp was requested
+    if let Some(ref ts) = time_str {
+        let secs = parse_time(ts).unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+        let mode_label = match seek_mode {
+            SeekMode::Keyframe => "keyframe",
+            SeekMode::Exact => "exact",
+            SeekMode::Backward => "backward",
+        };
+        println!("Seeking: {}  (mode={})", format_time(secs), mode_label);
+        if let Err(e) = dec.seek(Duration::from_secs_f64(secs), seek_mode) {
+            eprintln!("Error seeking: {e}");
+            process::exit(1);
+        }
+    }
+
+    // Decode one frame
+    let frame = match dec.decode_one() {
+        Ok(Some(f)) => f,
+        Ok(None) => {
+            eprintln!("Error: no frame decoded (end of stream or empty file)");
+            process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let pts_secs = frame.timestamp().as_secs_f64();
+    let w = frame.width();
+    let h = frame.height();
+    let fmt = frame.format();
+    println!("Frame:   pts={pts_secs:.3}s  {w}×{h}  {fmt:?}");
+    println!("Output:  {out_name}  ({fmt_label}  quality={quality})");
+    println!();
+
+    // Encode to image
+    let enc = match ImageEncoder::create(&output)
+        .width(w)
+        .height(h)
+        .quality(quality)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = enc.encode(&frame) {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}");
+}

--- a/crates/avio/examples/extract_thumbnails.rs
+++ b/crates/avio/examples/extract_thumbnails.rs
@@ -1,0 +1,181 @@
+//! Extract JPEG thumbnails at given timestamps using `ThumbnailPipeline`.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example extract_thumbnails --features pipeline -- \
+//!   --input  video.mp4 \
+//!   --output thumbs/   \
+//!   --times  0,30,60,90 \
+//!   [--width 320]
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{ImageEncoder, ThumbnailPipeline, VideoDecoder};
+
+fn parse_time(s: &str) -> Result<f64, String> {
+    // Accept plain seconds "30" or HH:MM:SS "00:01:30"
+    if s.contains(':') {
+        let parts: Vec<&str> = s.splitn(3, ':').collect();
+        if parts.len() == 3 {
+            let h: f64 = parts[0]
+                .parse()
+                .map_err(|_| format!("invalid hours in '{s}'"))?;
+            let m: f64 = parts[1]
+                .parse()
+                .map_err(|_| format!("invalid minutes in '{s}'"))?;
+            let sec: f64 = parts[2]
+                .parse()
+                .map_err(|_| format!("invalid seconds in '{s}'"))?;
+            Ok(h * 3600.0 + m * 60.0 + sec)
+        } else {
+            Err(format!(
+                "invalid time format '{s}' (use HH:MM:SS or plain seconds)"
+            ))
+        }
+    } else {
+        s.parse::<f64>().map_err(|_| format!("invalid time '{s}'"))
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut times_str = None::<String>;
+    let mut width: u32 = 320;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--times" | "-t" => times_str = Some(args.next().unwrap_or_default()),
+            "--width" => {
+                let v = args.next().unwrap_or_default();
+                width = v.parse().unwrap_or(320);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: extract_thumbnails --input <file> --output <dir> --times 0,30,60");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+    let times_str = times_str.unwrap_or_else(|| {
+        eprintln!("--times is required (e.g. 0,30,60)");
+        process::exit(1);
+    });
+
+    // Parse timestamps
+    let timestamps: Vec<f64> = times_str
+        .split(',')
+        .map(|s| {
+            parse_time(s.trim()).unwrap_or_else(|e| {
+                eprintln!("Error parsing time: {e}");
+                process::exit(1);
+            })
+        })
+        .collect();
+
+    // Probe source duration so out-of-range timestamps can be skipped gracefully.
+    let src_duration = match VideoDecoder::open(&input).build() {
+        Ok(dec) => dec.duration(),
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+
+    // Filter timestamps that are within the file duration
+    let valid_timestamps: Vec<f64> = timestamps
+        .iter()
+        .copied()
+        .filter(|&t| Duration::from_secs_f64(t) <= src_duration)
+        .collect();
+    let skipped = timestamps.len() - valid_timestamps.len();
+
+    // Create output directory
+    if let Err(e) = std::fs::create_dir_all(&output) {
+        eprintln!("Error: cannot create output directory: {e}");
+        process::exit(1);
+    }
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!(
+        "Extracting {} thumbnails from {in_name}...",
+        valid_timestamps.len()
+    );
+    if skipped > 0 {
+        println!("  (skipping {skipped} timestamps beyond file duration)");
+    }
+
+    // Run ThumbnailPipeline
+    let frames = match ThumbnailPipeline::new(&input)
+        .timestamps(valid_timestamps.clone())
+        .run()
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // Encode each frame as JPEG
+    for (frame, &timestamp) in frames.iter().zip(valid_timestamps.iter()) {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let secs = timestamp as u64;
+        let out_name = format!("thumb_{secs:03}.jpg");
+        let out_path = Path::new(&output).join(&out_name);
+
+        let w = frame.width();
+        let h = frame.height();
+
+        // Scale width if needed (keep aspect ratio)
+        let (enc_w, enc_h) = if w > width {
+            let scale = f64::from(width) / f64::from(w);
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let enc_h = (f64::from(h) * scale).round() as u32;
+            (width, enc_h)
+        } else {
+            (w, h)
+        };
+
+        match ImageEncoder::create(&out_path)
+            .width(enc_w)
+            .height(enc_h)
+            .build()
+        {
+            Ok(enc) => {
+                if let Err(e) = enc.encode(frame) {
+                    eprintln!("  Warning: failed to encode {out_name}: {e}");
+                    continue;
+                }
+            }
+            Err(e) => {
+                eprintln!("  Warning: failed to create encoder for {out_name}: {e}");
+                continue;
+            }
+        }
+
+        let hh = secs / 3600;
+        let mm = (secs % 3600) / 60;
+        let ss = secs % 60;
+        println!("  {hh:02}:{mm:02}:{ss:02}  →  {out_name}  ({enc_w}×{enc_h})");
+    }
+
+    println!("Done.");
+}

--- a/crates/avio/examples/hls_output.rs
+++ b/crates/avio/examples/hls_output.rs
@@ -1,0 +1,142 @@
+//! Package a video as an HLS stream using `HlsOutput`.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example hls_output --features stream -- \
+//!   --input    input.mp4  \
+//!   --output   ./hls/     \
+//!   [--segment 6]         \
+//!   [--bitrate 2000000]
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::HlsOutput;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut segment_secs: u64 = 6;
+    let mut bitrate = None::<u64>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--segment" | "-s" => {
+                let v = args.next().unwrap_or_default();
+                segment_secs = v.parse().unwrap_or(6);
+            }
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().ok();
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: hls_output --input <file> --output <dir> [--segment N] [--bitrate N]");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // Create output directory
+    if let Err(e) = std::fs::create_dir_all(&output) {
+        eprintln!("Error: cannot create output directory: {e}");
+        process::exit(1);
+    }
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    // Print header
+    println!("Input:    {in_name}");
+    println!("Output:   {output}");
+    println!("Segment:  {segment_secs} s");
+    if let Some(br) = bitrate {
+        println!("Bitrate:  {br} bps");
+    }
+    println!();
+    println!("Writing HLS segments...");
+
+    // Build and write
+    let mut builder = HlsOutput::new(&output)
+        .input(&input)
+        .segment_duration(Duration::from_secs(segment_secs));
+
+    if let Some(br) = bitrate {
+        builder = builder.bitrate(br);
+    }
+
+    let hls = match builder.build() {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = hls.write() {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    println!("Done.");
+    println!();
+
+    // List output directory
+    let entries = match std::fs::read_dir(&output) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Warning: cannot list output: {e}");
+            return;
+        }
+    };
+
+    let mut files: Vec<(String, u64)> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let size = e.metadata().ok()?.len();
+            Some((name, size))
+        })
+        .collect();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let segment_count = files
+        .iter()
+        .filter(|(n, _)| {
+            std::path::Path::new(n)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("ts"))
+        })
+        .count();
+    let total_bytes: u64 = files.iter().map(|(_, s)| s).sum();
+
+    println!("Output directory:");
+    for (name, size) in &files {
+        #[allow(clippy::cast_precision_loss)]
+        let kb = *size as f64 / 1024.0;
+        if kb < 1024.0 {
+            println!("  {name:<30}  ({kb:.1} KB)");
+        } else {
+            println!("  {name:<30}  ({:.1} MB)", kb / 1024.0);
+        }
+    }
+    println!();
+    #[allow(clippy::cast_precision_loss)]
+    let total_mb = total_bytes as f64 / 1_048_576.0;
+    println!("Total: {segment_count} segments  {total_mb:.1} MB");
+    println!("Serve with: npx serve {output}  (open http://localhost:3000/playlist.m3u8)");
+}

--- a/crates/avio/examples/probe_info.rs
+++ b/crates/avio/examples/probe_info.rs
@@ -1,0 +1,192 @@
+//! Display media file metadata.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example probe_info -- <input_file>
+//! ```
+//!
+//! # Example output
+//!
+//! ```text
+//! File:     video.mp4
+//! Duration: 00:02:34.560
+//! Bitrate:  3 842 kbps
+//! Chapters: 3
+//!
+//! Video streams (1):
+//!   #0  H.264  1920×1080  29.97 fps  yuv420p
+//!
+//! Audio streams (2):
+//!   #0  AAC  stereo  48000 Hz  192 kbps
+//!   #1  AAC  stereo  48000 Hz  128 kbps  [jpn]
+//!
+//! Subtitle streams (1):
+//!   #0  ASS  [eng]
+//! ```
+
+use std::{fmt::Write as _, process, time::Duration};
+
+fn format_duration(d: Duration) -> String {
+    let total_ms = d.as_millis();
+    let ms = total_ms % 1000;
+    let total_s = total_ms / 1000;
+    let s = total_s % 60;
+    let total_m = total_s / 60;
+    let m = total_m % 60;
+    let h = total_m / 60;
+    format!("{h:02}:{m:02}:{s:02}.{ms:03}")
+}
+
+fn format_bitrate(bps: u64) -> String {
+    let kbps = bps / 1000;
+    // Format with spaces as thousands separator (e.g. "3 842")
+    let s = kbps.to_string();
+    let mut chars: Vec<char> = s.chars().collect();
+    let mut i = chars.len().saturating_sub(3);
+    while i > 0 {
+        chars.insert(i, '\u{a0}'); // narrow no-break space → readable space
+        i = i.saturating_sub(3);
+    }
+    chars.into_iter().collect::<String>() + " kbps"
+}
+
+fn main() {
+    let mut args = std::env::args();
+    let _program = args.next();
+
+    let Some(input_path) = args.next() else {
+        eprintln!("Usage: probe_info <input_file>");
+        process::exit(1);
+    };
+
+    let info = match avio::open(&input_path) {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── File header ──────────────────────────────────────────────────────────
+
+    let filename = std::path::Path::new(&input_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input_path);
+
+    println!("File:     {filename}");
+    println!("Duration: {}", format_duration(info.duration()));
+    if let Some(br) = info.bitrate() {
+        println!("Bitrate:  {}", format_bitrate(br));
+    }
+    let chapter_count = info.chapter_count();
+    if chapter_count > 0 {
+        println!("Chapters: {chapter_count}");
+    }
+    if let Some(title) = info.title() {
+        println!("Title:    {title}");
+    }
+
+    // ── Video streams ────────────────────────────────────────────────────────
+
+    let video_streams = info.video_streams();
+    println!("\nVideo streams ({}):", video_streams.len());
+    if video_streams.is_empty() {
+        println!("  (none)");
+    } else {
+        for v in video_streams {
+            let idx = v.index();
+            let codec = v.codec_name();
+            let w = v.width();
+            let h = v.height();
+            let fps = v.fps();
+            let pix_fmt = v.pixel_format();
+
+            let mut line = format!("  #{idx}  {codec}  {w}\u{d7}{h}  {fps:.2} fps  {pix_fmt:?}");
+
+            if let Some(br) = v.bitrate() {
+                let _ = write!(line, "  {}", format_bitrate(br));
+            }
+            if v.is_hdr() {
+                line.push_str("  [HDR]");
+            }
+            if v.is_4k() {
+                line.push_str("  [4K]");
+            } else if v.is_full_hd() {
+                line.push_str("  [FHD]");
+            } else if v.is_hd() {
+                line.push_str("  [HD]");
+            }
+
+            println!("{line}");
+        }
+    }
+
+    // ── Audio streams ────────────────────────────────────────────────────────
+
+    let audio_streams = info.audio_streams();
+    println!("\nAudio streams ({}):", audio_streams.len());
+    if audio_streams.is_empty() {
+        println!("  (none)");
+    } else {
+        for a in audio_streams {
+            let idx = a.index();
+            let codec = a.codec_name();
+            let layout = a.channel_layout();
+            let rate = a.sample_rate();
+
+            let mut line = format!("  #{idx}  {codec}  {layout:?}  {rate} Hz");
+
+            if let Some(br) = a.bitrate() {
+                let _ = write!(line, "  {}", format_bitrate(br));
+            }
+            if let Some(lang) = a.language() {
+                let _ = write!(line, "  [{lang}]");
+            }
+
+            println!("{line}");
+        }
+    }
+
+    // ── Subtitle streams ─────────────────────────────────────────────────────
+
+    let subtitle_streams = info.subtitle_streams();
+    println!("\nSubtitle streams ({}):", subtitle_streams.len());
+    if subtitle_streams.is_empty() {
+        println!("  (none)");
+    } else {
+        for s in subtitle_streams {
+            let idx = s.index();
+            let codec = s.codec_name();
+
+            let mut line = format!("  #{idx}  {codec}");
+
+            if let Some(lang) = s.language() {
+                let _ = write!(line, "  [{lang}]");
+            }
+            if let Some(title) = s.title()
+                && !title.is_empty()
+            {
+                let _ = write!(line, "  \"{title}\"");
+            }
+            if s.is_forced() {
+                line.push_str("  [forced]");
+            }
+
+            println!("{line}");
+        }
+    }
+
+    // ── Chapters ─────────────────────────────────────────────────────────────
+
+    if info.has_chapters() {
+        println!("\nChapters:");
+        for chapter in info.chapters() {
+            let start = format_duration(chapter.start());
+            let end = format_duration(chapter.end());
+            let title = chapter.title().unwrap_or("(untitled)");
+            println!("  {start}\u{2013}{end}  {title}");
+        }
+    }
+}

--- a/crates/avio/examples/transcode.rs
+++ b/crates/avio/examples/transcode.rs
@@ -1,0 +1,319 @@
+//! Re-encode a video file using the high-level `Pipeline` API.
+//!
+//! Demonstrates pairing `VideoCodec` and `AudioCodec` together — both are
+//! required to produce a valid audio+video output file.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example transcode --features pipeline -- \
+//!   --input        input.mp4 \
+//!   --output       output.mp4 \
+//!   [--codec       h265]        # video codec: h264 | h265 | vp9 | av1 (default: h264)
+//!   [--audio-codec opus]        # audio codec: aac | mp3 | opus | flac (default: aac)
+//!   [--crf         28]          # default: 23
+//!   [--width       1280]        # default: keep source
+//!   [--height      720]         # default: keep source
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use avio::{
+    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, PipelineError, Progress,
+    VideoCodec,
+};
+
+// ── Argument parsing ─────────────────────────────────────────────────────────
+
+struct Args {
+    input: String,
+    output: String,
+    codec: VideoCodec,
+    audio_codec: AudioCodec,
+    crf: u32,
+    width: Option<u32>,
+    height: Option<u32>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut codec_str = "h264".to_string();
+    let mut audio_codec_str = "aac".to_string();
+    let mut crf: u32 = 23;
+    let mut width = None::<u32>;
+    let mut height = None::<u32>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => {
+                input = Some(args.next().ok_or("--input requires a value")?);
+            }
+            "--output" | "-o" => {
+                output = Some(args.next().ok_or("--output requires a value")?);
+            }
+            "--codec" | "-c" => {
+                codec_str = args.next().ok_or("--codec requires a value")?;
+            }
+            "--audio-codec" => {
+                audio_codec_str = args.next().ok_or("--audio-codec requires a value")?;
+            }
+            "--crf" => {
+                let v = args.next().ok_or("--crf requires a value")?;
+                crf = v
+                    .parse()
+                    .map_err(|_| format!("--crf: invalid number '{v}'"))?;
+            }
+            "--width" => {
+                let v = args.next().ok_or("--width requires a value")?;
+                width = Some(
+                    v.parse()
+                        .map_err(|_| format!("--width: invalid number '{v}'"))?,
+                );
+            }
+            "--height" => {
+                let v = args.next().ok_or("--height requires a value")?;
+                height = Some(
+                    v.parse()
+                        .map_err(|_| format!("--height: invalid number '{v}'"))?,
+                );
+            }
+            other => return Err(format!("Unknown flag: {other}")),
+        }
+    }
+
+    let codec = match codec_str.to_lowercase().as_str() {
+        "h264" | "avc" => VideoCodec::H264,
+        "h265" | "hevc" => VideoCodec::H265,
+        "vp9" => VideoCodec::Vp9,
+        "av1" => VideoCodec::Av1,
+        other => {
+            return Err(format!(
+                "Unknown codec: '{other}' (try h264, h265, vp9, av1)"
+            ));
+        }
+    };
+
+    let audio_codec = match audio_codec_str.to_lowercase().as_str() {
+        "aac" => AudioCodec::Aac,
+        "mp3" => AudioCodec::Mp3,
+        "opus" => AudioCodec::Opus,
+        "flac" => AudioCodec::Flac,
+        other => {
+            return Err(format!(
+                "Unknown audio codec: '{other}' (try aac, mp3, opus, flac)"
+            ));
+        }
+    };
+
+    Ok(Args {
+        input: input.ok_or("--input is required")?,
+        output: output.ok_or("--output is required")?,
+        codec,
+        audio_codec,
+        crf,
+        width,
+        height,
+    })
+}
+
+// ── Progress rendering ────────────────────────────────────────────────────────
+
+fn format_elapsed(elapsed: std::time::Duration) -> String {
+    let s = elapsed.as_secs();
+    let m = s / 60;
+    let h = m / 60;
+    if h > 0 {
+        format!("{h:02}:{:02}:{:02}", m % 60, s % 60)
+    } else {
+        format!("{:02}:{:02}", m, s % 60)
+    }
+}
+
+fn render_progress(p: &Progress) {
+    let elapsed = format_elapsed(p.elapsed);
+
+    match p.percent() {
+        Some(pct) => {
+            let bar_width = 20usize;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+            let filled = filled.min(bar_width);
+            let bar: String = "=".repeat(filled) + &" ".repeat(bar_width - filled);
+
+            let remaining = if pct > 0.0 {
+                let total_secs = p.elapsed.as_secs_f64() / (pct / 100.0);
+                let rem_secs = (total_secs - p.elapsed.as_secs_f64()).max(0.0);
+                let rem = std::time::Duration::from_secs_f64(rem_secs);
+                format!("  ~{} remaining", format_elapsed(rem))
+            } else {
+                String::new()
+            };
+
+            print!("\r{pct:5.1}%  [{bar}]  {elapsed} elapsed{remaining}    ");
+        }
+        None => {
+            print!("\r{} frames  {elapsed} elapsed    ", p.frames_processed);
+        }
+    }
+
+    // Flush stdout so the line appears immediately (no newline → stays in place)
+    let _ = io::stdout().flush();
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            eprintln!(
+                "Usage: transcode --input <file> --output <file> \
+                 [--codec h264|h265|vp9|av1] [--audio-codec aac|mp3|opus|flac] \
+                 [--crf N] [--width W] [--height H]"
+            );
+            process::exit(1);
+        }
+    };
+
+    // ── Print header ─────────────────────────────────────────────────────────
+
+    let in_name = Path::new(&args.input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&args.input);
+    let out_name = Path::new(&args.output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&args.output);
+
+    let codec_name = match args.codec {
+        VideoCodec::H264 => "H.264",
+        VideoCodec::H265 => "H.265",
+        VideoCodec::Vp9 => "VP9",
+        VideoCodec::Av1 => "AV1",
+        _ => "unknown",
+    };
+
+    let audio_codec_name = match args.audio_codec {
+        AudioCodec::Aac => "AAC",
+        AudioCodec::Mp3 => "MP3",
+        AudioCodec::Opus => "Opus",
+        AudioCodec::Flac => "FLAC",
+        _ => "unknown",
+    };
+
+    let res_str = match (args.width, args.height) {
+        (Some(w), Some(h)) => format!("{w}×{h}"),
+        (Some(w), None) => format!("{w}×(auto)"),
+        (None, Some(h)) => format!("(auto)×{h}"),
+        (None, None) => "(source)".to_string(),
+    };
+
+    println!("Input:  {in_name}");
+    println!(
+        "Output: {out_name}  video={codec_name}  audio={audio_codec_name}  crf={}  resolution={res_str}",
+        args.crf
+    );
+    println!();
+
+    // ── Build optional scale filter ───────────────────────────────────────────
+
+    let filter = match (args.width, args.height) {
+        (Some(w), Some(h)) => match FilterGraphBuilder::new().scale(w, h).build() {
+            Ok(fg) => Some(fg),
+            Err(e) => {
+                eprintln!("Error: failed to build filter graph: {e}");
+                process::exit(1);
+            }
+        },
+        _ => None,
+    };
+
+    // ── Build encoder config ─────────────────────────────────────────────────
+
+    let resolution = match (args.width, args.height) {
+        (Some(w), Some(h)) => Some((w, h)),
+        _ => None,
+    };
+
+    let config = EncoderConfig {
+        video_codec: args.codec,
+        audio_codec: args.audio_codec,
+        bitrate_mode: BitrateMode::Crf(args.crf),
+        resolution,
+        framerate: None,
+        hardware: None,
+    };
+
+    // ── Assemble pipeline ─────────────────────────────────────────────────────
+
+    let start = Instant::now();
+    // Store last_frames inside an Arc<Mutex> so we can print final count after run().
+    let last_frames: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
+    let last_frames_cb = Arc::clone(&last_frames);
+
+    let mut builder = Pipeline::builder()
+        .input(&args.input)
+        .output(&args.output, config)
+        .on_progress(move |p: &Progress| {
+            render_progress(p);
+            if let Ok(mut f) = last_frames_cb.lock() {
+                *f = p.frames_processed;
+            }
+            true // always continue
+        });
+
+    if let Some(fg) = filter {
+        builder = builder.filter(fg);
+    }
+
+    let pipeline = match builder.build() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Run ───────────────────────────────────────────────────────────────────
+
+    match pipeline.run() {
+        Ok(()) | Err(PipelineError::Cancelled) => {}
+        Err(e) => {
+            println!(); // end progress line
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    }
+
+    println!(); // end progress line
+
+    // ── Final summary ─────────────────────────────────────────────────────────
+
+    let elapsed = format_elapsed(start.elapsed());
+    let frames = *last_frames.lock().unwrap_or_else(|e| e.into_inner());
+
+    let size_str = match std::fs::metadata(&args.output) {
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let mb = m.len() as f64 / 1_048_576.0;
+            format!("{mb:.1} MB")
+        }
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done.  {out_name}  {size_str}  {frames} frames  {elapsed}");
+}

--- a/crates/avio/examples/trim_and_scale.rs
+++ b/crates/avio/examples/trim_and_scale.rs
@@ -1,0 +1,230 @@
+//! Trim a segment from a video and scale it using `FilterGraph` + `Pipeline`.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example trim_and_scale --features pipeline -- \
+//!   --input   input.mp4 \
+//!   --output  clip.mp4  \
+//!   --start   00:00:10  \
+//!   --end     00:00:40  \
+//!   --width   1280      \
+//!   --height  720
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+    time::Duration,
+};
+
+use avio::{
+    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec,
+};
+
+fn parse_time(s: &str) -> Result<f64, String> {
+    if s.contains(':') {
+        let parts: Vec<&str> = s.splitn(3, ':').collect();
+        if parts.len() == 3 {
+            let h: f64 = parts[0]
+                .parse()
+                .map_err(|_| format!("invalid hours in '{s}'"))?;
+            let m: f64 = parts[1]
+                .parse()
+                .map_err(|_| format!("invalid minutes in '{s}'"))?;
+            let sec: f64 = parts[2]
+                .parse()
+                .map_err(|_| format!("invalid seconds in '{s}'"))?;
+            Ok(h * 3600.0 + m * 60.0 + sec)
+        } else {
+            Err(format!("invalid time '{s}'"))
+        }
+    } else {
+        s.parse::<f64>().map_err(|_| format!("invalid time '{s}'"))
+    }
+}
+
+fn format_duration(secs: f64) -> String {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let total = secs as u64;
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+fn format_elapsed(d: Duration) -> String {
+    let s = d.as_secs();
+    let m = s / 60;
+    format!("{:02}:{:02}", m, s % 60)
+}
+
+fn render_progress(p: &Progress) {
+    match p.percent() {
+        Some(pct) => {
+            let bar_width = 20usize;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+            let filled = filled.min(bar_width);
+            let bar = "=".repeat(filled) + &" ".repeat(bar_width - filled);
+            print!("\r{pct:5.1}%  [{bar}]  {}    ", format_elapsed(p.elapsed));
+        }
+        None => {
+            print!(
+                "\r{} frames  {}    ",
+                p.frames_processed,
+                format_elapsed(p.elapsed)
+            );
+        }
+    }
+    let _ = io::stdout().flush();
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut start_str = None::<String>;
+    let mut end_str = None::<String>;
+    let mut width = None::<u32>;
+    let mut height = None::<u32>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--start" => start_str = Some(args.next().unwrap_or_default()),
+            "--end" => end_str = Some(args.next().unwrap_or_default()),
+            "--width" => {
+                let v = args.next().unwrap_or_default();
+                width = v.parse().ok();
+            }
+            "--height" => {
+                let v = args.next().unwrap_or_default();
+                height = v.parse().ok();
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: trim_and_scale --input <file> --output <file> --start <time> --end <time> [--width W] [--height H]");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+    let start_str = start_str.unwrap_or_else(|| {
+        eprintln!("--start is required");
+        process::exit(1);
+    });
+    let end_str = end_str.unwrap_or_else(|| {
+        eprintln!("--end is required");
+        process::exit(1);
+    });
+
+    let start = parse_time(&start_str).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
+    let end = parse_time(&end_str).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
+
+    if end <= start {
+        eprintln!("Error: --end ({end_str}) must be greater than --start ({start_str})");
+        process::exit(1);
+    }
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}");
+    println!(
+        "Trim:   {} → {}  ({:.1} s)",
+        format_duration(start),
+        format_duration(end),
+        end - start
+    );
+    if let (Some(w), Some(h)) = (width, height) {
+        println!("Scale:  → {w}×{h}");
+    }
+    println!("Output: {out_name}");
+    println!();
+
+    // Build filter graph: trim → scale (if requested)
+    let mut builder = FilterGraphBuilder::new().trim(start, end);
+    if let (Some(w), Some(h)) = (width, height) {
+        builder = builder.scale(w, h);
+    }
+    let filter = match builder.build() {
+        Ok(fg) => fg,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let resolution = match (width, height) {
+        (Some(w), Some(h)) => Some((w, h)),
+        _ => None,
+    };
+
+    let config = EncoderConfig {
+        video_codec: VideoCodec::H264,
+        audio_codec: AudioCodec::Aac,
+        bitrate_mode: BitrateMode::Crf(23),
+        resolution,
+        framerate: None,
+        hardware: None,
+    };
+
+    let pipeline = match Pipeline::builder()
+        .input(&input)
+        .filter(filter)
+        .output(&output, config)
+        .on_progress(|p: &Progress| {
+            render_progress(p);
+            true
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = pipeline.run() {
+        println!();
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    println!();
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}  ({:.1} s)", end - start);
+}


### PR DESCRIPTION
## Summary

Adds 10 runnable example programs to the `avio` facade crate, covering every major feature exposed under its feature flags. Each example is a self-contained CLI program with argument parsing, progress output, and clear inline comments explaining the API being demonstrated.

## Changes

- `Cargo.toml` — 10 `[[example]]` entries with `required-features` guards
- `probe_info.rs` — `avio::open()`, `MediaInfo`, `VideoStreamInfo`, `AudioStreamInfo`, `SubtitleStreamInfo`, `ChapterInfo`
- `transcode.rs` — `Pipeline` with `EncoderConfig`; demonstrates `VideoCodec` + `AudioCodec` pairing, optional scale filter, progress callback
- `extract_thumbnails.rs` — `ThumbnailPipeline` + `ImageEncoder`; skips out-of-range timestamps using `VideoDecoder::duration()`
- `trim_and_scale.rs` — `FilterGraphBuilder::trim().scale()` + `Pipeline`
- `concat_clips.rs` — multi-input `Pipeline`; probes each input with `open()` for resolution mismatch warnings
- `add_watermark.rs` — `VideoDecoder` → `FilterGraph` (overlay, two-slot) → `VideoEncoder`; explains why `Pipeline` is bypassed
- `decode_image.rs` — `ImageDecoder`, plane/stride inspection, optional raw YUV dump
- `encode_image.rs` — `VideoDecoder` + all three `SeekMode` variants (`Keyframe`, `Exact`, `Backward`) + `ImageEncoder`
- `hls_output.rs` — `HlsOutput` builder; lists output segments with sizes
- `abr_ladder.rs` — `AbrLadder` with custom rendition ladder; aspect-ratio-aware width computation; HLS and DASH output

## Related Issues

Closes #517
Closes #518
Closes #519
Closes #520
Closes #521
Closes #522
Closes #523
Closes #524
Closes #525
Closes #526

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes