### PR TITLE
feat(avio): add 7 examples for audio, DASH, effects, two-pass, metadata, HW transcode

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -72,5 +72,33 @@ required-features = ["stream"]
 name = "abr_ladder"
 required-features = ["stream", "probe"]
 
+[[example]]
+name = "audio_transcode"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "dash_output"
+required-features = ["stream"]
+
+[[example]]
+name = "video_effects"
+required-features = ["pipeline"]
+
+[[example]]
+name = "audio_filters"
+required-features = ["pipeline"]
+
+[[example]]
+name = "two_pass_encode"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "write_metadata"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "hw_transcode"
+required-features = ["pipeline"]
+
 [lints]
 workspace = true

--- a/crates/avio/examples/audio_filters.rs
+++ b/crates/avio/examples/audio_filters.rs
@@ -1,0 +1,183 @@
+//! Adjust audio volume or apply an equalizer using `FilterGraphBuilder` + `Pipeline`.
+//!
+//! Available effects:
+//!   `volume`    — adjust loudness by a gain in dB (`+` = louder, `-` = quieter)
+//!   `equalizer` — boost or cut a specific frequency band
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example audio_filters --features pipeline -- \
+//!   --input   input.mp4     \
+//!   --output  filtered.mp4  \
+//!   --effect  volume        \
+//!   [--db    6.0]            # gain in dB for volume (default: 6.0)
+//!   [--freq  1000.0]         # center frequency in Hz for equalizer (default: 1000.0)
+//!   [--gain  3.0]            # gain in dB for equalizer (default: 3.0)
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+};
+
+use avio::{
+    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec,
+};
+
+fn render_progress(p: &Progress) {
+    match p.percent() {
+        Some(pct) => {
+            let bar_width = 20usize;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+            let filled = filled.min(bar_width);
+            let bar = "=".repeat(filled) + &" ".repeat(bar_width - filled);
+            print!("\r{pct:5.1}%  [{bar}]    ");
+        }
+        None => {
+            print!("\r{} frames    ", p.frames_processed);
+        }
+    }
+    let _ = io::stdout().flush();
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut effect = None::<String>;
+    let mut db: f64 = 6.0;
+    let mut freq: f64 = 1000.0;
+    let mut gain: f64 = 3.0;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--effect" | "-e" => effect = Some(args.next().unwrap_or_default()),
+            "--db" => {
+                let v = args.next().unwrap_or_default();
+                db = v.parse().unwrap_or(6.0);
+            }
+            "--freq" => {
+                let v = args.next().unwrap_or_default();
+                freq = v.parse().unwrap_or(1000.0);
+            }
+            "--gain" => {
+                let v = args.next().unwrap_or_default();
+                gain = v.parse().unwrap_or(3.0);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: audio_filters --input <file> --output <file> \
+             --effect volume|equalizer [options]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+    let effect = effect.unwrap_or_else(|| {
+        eprintln!("--effect is required (volume|equalizer)");
+        process::exit(1);
+    });
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    // ── Build filter graph ────────────────────────────────────────────────────
+
+    let filter_result = match effect.as_str() {
+        "volume" => {
+            let sign = if db >= 0.0 { "+" } else { "" };
+            println!("Input:   {in_name}");
+            println!("Effect:  volume  ({sign}{db} dB)");
+            println!("Output:  {out_name}");
+            FilterGraphBuilder::new().volume(db).build()
+        }
+        "equalizer" => {
+            println!("Input:   {in_name}");
+            println!("Effect:  equalizer  (freq={freq} Hz  gain={gain:+.1} dB)");
+            println!("Output:  {out_name}");
+            FilterGraphBuilder::new().equalizer(freq, gain).build()
+        }
+        other => {
+            eprintln!("Unknown effect '{other}' (try volume, equalizer)");
+            process::exit(1);
+        }
+    };
+
+    let filter = match filter_result {
+        Ok(fg) => fg,
+        Err(e) => {
+            eprintln!("Error building filter graph: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!();
+
+    // ── Assemble pipeline ─────────────────────────────────────────────────────
+
+    let config = EncoderConfig {
+        video_codec: VideoCodec::H264,
+        audio_codec: AudioCodec::Aac,
+        bitrate_mode: BitrateMode::Crf(23),
+        resolution: None,
+        framerate: None,
+        hardware: None,
+    };
+
+    let pipeline = match Pipeline::builder()
+        .input(&input)
+        .filter(filter)
+        .output(&output, config)
+        .on_progress(|p: &Progress| {
+            render_progress(p);
+            true
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = pipeline.run() {
+        println!();
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    println!();
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}");
+}

--- a/crates/avio/examples/audio_transcode.rs
+++ b/crates/avio/examples/audio_transcode.rs
@@ -1,0 +1,166 @@
+//! Decode an audio file and re-encode it to a different codec or bitrate.
+//!
+//! Demonstrates the audio-only decode → encode pipeline using `AudioDecoder`
+//! and `AudioEncoder` — the building blocks for podcast processing, audio
+//! format conversion, and soundtrack extraction.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example audio_transcode -- \
+//!   --input   input.mp3  \
+//!   --output  output.aac \
+//!   [--codec  aac]        # aac | mp3 | opus | flac (default: aac)
+//!   [--bitrate 128000]    # target bitrate in bps (default: 128000)
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{AudioCodec, AudioDecoder, AudioEncoder};
+
+fn format_duration(d: Duration) -> String {
+    let s = d.as_secs();
+    let h = s / 3600;
+    let m = (s % 3600) / 60;
+    let sec = s % 60;
+    format!("{h:02}:{m:02}:{sec:02}")
+}
+
+fn codec_label(c: AudioCodec) -> &'static str {
+    match c {
+        AudioCodec::Aac => "AAC",
+        AudioCodec::Mp3 => "MP3",
+        AudioCodec::Opus => "Opus",
+        AudioCodec::Flac => "FLAC",
+        _ => "unknown",
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut codec_str = "aac".to_string();
+    let mut bitrate: u64 = 128_000;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--codec" | "-c" => codec_str = args.next().unwrap_or_else(|| "aac".to_string()),
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().unwrap_or(128_000);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: audio_transcode --input <file> --output <file> \
+             [--codec aac|mp3|opus|flac] [--bitrate N]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    let codec = match codec_str.to_lowercase().as_str() {
+        "aac" => AudioCodec::Aac,
+        "mp3" => AudioCodec::Mp3,
+        "opus" => AudioCodec::Opus,
+        "flac" => AudioCodec::Flac,
+        other => {
+            eprintln!("Unknown codec '{other}' (try aac, mp3, opus, flac)");
+            process::exit(1);
+        }
+    };
+
+    // ── Open decoder ──────────────────────────────────────────────────────────
+
+    let mut dec = match AudioDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let sample_rate = dec.sample_rate();
+    let channels = dec.channels();
+    let duration = dec.duration();
+    let in_codec = dec.stream_info().codec_name().to_string();
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!(
+        "Input:   {in_name}  {channels}ch  {sample_rate} Hz  {in_codec}  {}",
+        format_duration(duration)
+    );
+    println!(
+        "Output:  {out_name}  {channels}ch  {sample_rate} Hz  {}  bitrate={bitrate}",
+        codec_label(codec)
+    );
+    println!();
+    println!("Encoding...");
+
+    // ── Open encoder ──────────────────────────────────────────────────────────
+
+    let mut enc = match AudioEncoder::create(&output)
+        .audio(sample_rate, channels)
+        .audio_codec(codec)
+        .audio_bitrate(bitrate)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error creating encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Decode → encode loop ──────────────────────────────────────────────────
+
+    let mut frames: u64 = 0;
+    loop {
+        let frame = match dec.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error decoding: {e}");
+                process::exit(1);
+            }
+        };
+        if let Err(e) = enc.push(&frame) {
+            eprintln!("Error encoding: {e}");
+            process::exit(1);
+        }
+        frames += 1;
+    }
+
+    if let Err(e) = enc.finish() {
+        eprintln!("Error finishing: {e}");
+        process::exit(1);
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+}

--- a/crates/avio/examples/dash_output.rs
+++ b/crates/avio/examples/dash_output.rs
@@ -1,0 +1,130 @@
+//! Package a video as a single-rendition DASH stream using `DashOutput`.
+//!
+//! Pairs with `hls_output.rs` to show both adaptive streaming formats
+//! side-by-side, helping you choose between HLS and DASH for your deployment.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example dash_output --features stream -- \
+//!   --input    input.mp4  \
+//!   --output   ./dash/    \
+//!   [--segment 4]          # segment duration in seconds (default: 4)
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::DashOutput;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut segment_secs: u64 = 4;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--segment" | "-s" => {
+                let v = args.next().unwrap_or_default();
+                segment_secs = v.parse().unwrap_or(4);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: dash_output --input <file> --output <dir> [--segment N]");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    if let Err(e) = std::fs::create_dir_all(&output) {
+        eprintln!("Error: cannot create output directory: {e}");
+        process::exit(1);
+    }
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:    {in_name}");
+    println!("Output:   {output}");
+    println!("Segment:  {segment_secs} s");
+    println!();
+    println!("Writing DASH segments...");
+
+    let dash = match DashOutput::new(&output)
+        .input(&input)
+        .segment_duration(Duration::from_secs(segment_secs))
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = dash.write() {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    println!("Done.");
+    println!();
+
+    // ── List output directory ─────────────────────────────────────────────────
+
+    let entries = match std::fs::read_dir(&output) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Warning: cannot list output: {e}");
+            return;
+        }
+    };
+
+    let mut files: Vec<(String, u64)> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let size = e.metadata().ok()?.len();
+            Some((name, size))
+        })
+        .collect();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let segment_count = files
+        .iter()
+        .filter(|(n, _)| {
+            std::path::Path::new(n)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("m4s"))
+        })
+        .count();
+    let total_bytes: u64 = files.iter().map(|(_, s)| s).sum();
+
+    println!("Output directory:");
+    for (name, size) in &files {
+        #[allow(clippy::cast_precision_loss)]
+        let kb = *size as f64 / 1024.0;
+        if kb < 1024.0 {
+            println!("  {name:<40}  ({kb:.1} KB)");
+        } else {
+            println!("  {name:<40}  ({:.1} MB)", kb / 1024.0);
+        }
+    }
+    println!();
+    #[allow(clippy::cast_precision_loss)]
+    let total_mb = total_bytes as f64 / 1_048_576.0;
+    println!("Total: {segment_count} segments  {total_mb:.1} MB");
+    println!("Serve with: npx serve {output}  (open http://localhost:3000/manifest.mpd)");
+}

--- a/crates/avio/examples/hw_transcode.rs
+++ b/crates/avio/examples/hw_transcode.rs
@@ -1,0 +1,225 @@
+//! Transcode a video using hardware-accelerated encoding via `Pipeline`.
+//!
+//! Hardware encoding is orders of magnitude faster than software encoding on
+//! supported hardware, making it the recommended path for production workloads.
+//!
+//! Available backends (via `--hw`):
+//!   `cuda`         — NVIDIA CUDA / NVENC
+//!   `videotoolbox` — Apple `VideoToolbox` (macOS)
+//!   `vaapi`        — VA-API (Linux)
+//!   `none`         — software encoding only (useful for comparison)
+//!
+//! The pipeline falls back to software encoding if the requested hardware
+//! backend is unavailable on the current system.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example hw_transcode --features pipeline -- \
+//!   --input   input.mp4   \
+//!   --output  output.mp4  \
+//!   --hw      cuda         \  # cuda | videotoolbox | vaapi | none
+//!   [--codec  h264]           # h264 | h265 (default: h264)
+//!   [--crf    23]             # quality (default: 23)
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use avio::{
+    AudioCodec, BitrateMode, EncoderConfig, HwAccel, Pipeline, PipelineError, Progress, VideoCodec,
+};
+
+fn format_elapsed(d: std::time::Duration) -> String {
+    let s = d.as_secs();
+    let m = s / 60;
+    let h = m / 60;
+    if h > 0 {
+        format!("{h:02}:{:02}:{:02}", m % 60, s % 60)
+    } else {
+        format!("{:02}:{:02}", m, s % 60)
+    }
+}
+
+fn render_progress(p: &Progress) {
+    match p.percent() {
+        Some(pct) => {
+            let bar_width = 20usize;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+            let filled = filled.min(bar_width);
+            let bar = "=".repeat(filled) + &" ".repeat(bar_width - filled);
+            let elapsed = format_elapsed(p.elapsed);
+            print!("\r{pct:5.1}%  [{bar}]  {elapsed}    ");
+        }
+        None => {
+            print!(
+                "\r{} frames  {}    ",
+                p.frames_processed,
+                format_elapsed(p.elapsed)
+            );
+        }
+    }
+    let _ = io::stdout().flush();
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut hw_str = None::<String>;
+    let mut codec_str = "h264".to_string();
+    let mut crf: u32 = 23;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--hw" => hw_str = Some(args.next().unwrap_or_default()),
+            "--codec" | "-c" => codec_str = args.next().unwrap_or_else(|| "h264".to_string()),
+            "--crf" => {
+                let v = args.next().unwrap_or_default();
+                crf = v.parse().unwrap_or(23);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: hw_transcode --input <file> --output <file> \
+             --hw cuda|videotoolbox|vaapi|none [--codec h264|h265] [--crf N]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+    let hw_str = hw_str.unwrap_or_else(|| {
+        eprintln!("--hw is required (cuda|videotoolbox|vaapi|none)");
+        process::exit(1);
+    });
+
+    // Map --hw to HwAccel. `cuda` covers NVIDIA NVENC hardware via the CUDA
+    // device context; `none` disables hardware acceleration entirely.
+    let hw_accel: Option<HwAccel> = match hw_str.to_lowercase().as_str() {
+        "cuda" | "nvenc" => Some(HwAccel::Cuda),
+        "videotoolbox" => Some(HwAccel::VideoToolbox),
+        "vaapi" => Some(HwAccel::Vaapi),
+        "none" | "software" => None,
+        other => {
+            eprintln!("Unknown hw backend '{other}' (try cuda, videotoolbox, vaapi, none)");
+            process::exit(1);
+        }
+    };
+
+    let video_codec = match codec_str.to_lowercase().as_str() {
+        "h264" | "avc" => VideoCodec::H264,
+        "h265" | "hevc" => VideoCodec::H265,
+        other => {
+            eprintln!("Unknown codec '{other}' (try h264, h265)");
+            process::exit(1);
+        }
+    };
+
+    let hw_label = hw_accel.map_or("software", |hw| match hw {
+        HwAccel::Cuda => "CUDA (NVENC)",
+        HwAccel::VideoToolbox => "VideoToolbox",
+        HwAccel::Vaapi => "VA-API",
+    });
+
+    let codec_label = match video_codec {
+        VideoCodec::H264 => "H.264",
+        VideoCodec::H265 => "H.265",
+        _ => "unknown",
+    };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:   {in_name}");
+    println!("Output:  {out_name}  {codec_label}  {hw_label}  crf={crf}");
+    println!();
+
+    // ── Build pipeline with hardware backend ──────────────────────────────────
+
+    let config = EncoderConfig {
+        video_codec,
+        audio_codec: AudioCodec::Aac,
+        bitrate_mode: BitrateMode::Crf(crf),
+        resolution: None,
+        framerate: None,
+        hardware: hw_accel,
+    };
+
+    let start = Instant::now();
+    let last_frames: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
+    let last_frames_cb = Arc::clone(&last_frames);
+
+    let pipeline = match Pipeline::builder()
+        .input(&input)
+        .output(&output, config)
+        .on_progress(move |p: &Progress| {
+            render_progress(p);
+            if let Ok(mut f) = last_frames_cb.lock() {
+                *f = p.frames_processed;
+            }
+            true
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    match pipeline.run() {
+        Ok(()) | Err(PipelineError::Cancelled) => {}
+        Err(e) => {
+            println!();
+            eprintln!("Error: {e}");
+            // Hardware encoder unavailable — suggest fallback.
+            if hw_accel.is_some() {
+                eprintln!(
+                    "Hint: hardware backend may be unavailable on this system. \
+                     Try --hw none to use software encoding."
+                );
+            }
+            process::exit(1);
+        }
+    }
+
+    println!();
+
+    let elapsed = format_elapsed(start.elapsed());
+    let frames = *last_frames.lock().unwrap_or_else(|e| e.into_inner());
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames  {elapsed}");
+}

--- a/crates/avio/examples/two_pass_encode.rs
+++ b/crates/avio/examples/two_pass_encode.rs
@@ -1,0 +1,197 @@
+//! Encode a video at a precise target bitrate using two-pass encoding.
+//!
+//! Two-pass encoding produces better quality at a given file size than
+//! single-pass CBR, making it the standard approach for distribution targets
+//! such as streaming platform upload limits or archival at exact target sizes.
+//!
+//! Both passes are handled internally by `VideoEncoder` when `.two_pass()` is
+//! set — the encoder buffers frames during the analysis pass then re-encodes
+//! them in the output pass automatically when `finish()` is called.
+//!
+//! Note: two-pass encoding is video-only; audio cannot be included.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example two_pass_encode -- \
+//!   --input   input.mp4  \
+//!   --output  output.mp4 \
+//!   --bitrate 4000000     # target bitrate in bps (required)
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+    time::Instant,
+};
+
+use avio::{BitrateMode, VideoCodec, VideoDecoder, VideoEncoder};
+
+fn format_bitrate(bps: u64) -> String {
+    // Insert non-breaking spaces every 3 digits for readability.
+    let s = (bps / 1000).to_string();
+    let mut chars: Vec<char> = s.chars().collect();
+    let mut i = chars.len().saturating_sub(3);
+    while i > 0 {
+        chars.insert(i, '\u{a0}');
+        i = i.saturating_sub(3);
+    }
+    chars.into_iter().collect::<String>() + " kbps"
+}
+
+fn format_elapsed(d: std::time::Duration) -> String {
+    let s = d.as_secs();
+    let m = s / 60;
+    format!("{:02}:{:02}", m, s % 60)
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut bitrate = None::<u64>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().ok();
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: two_pass_encode --input <file> --output <file> --bitrate <bps>");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+    let bitrate = bitrate.unwrap_or_else(|| {
+        eprintln!("--bitrate is required (e.g. --bitrate 4000000)");
+        process::exit(1);
+    });
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let src_w = probe.width();
+    let src_h = probe.height();
+    let fps = probe.frame_rate();
+    let in_codec = probe.stream_info().codec_name().to_string();
+    let dur = probe.duration();
+    drop(probe); // release file handle before encoding
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+    let dur_secs = dur.as_secs();
+    let dur_str = format!(
+        "{:02}:{:02}:{:02}",
+        dur_secs / 3600,
+        (dur_secs % 3600) / 60,
+        dur_secs % 60
+    );
+
+    println!("Input:   {in_name}  {src_w}×{src_h}  {in_codec}  {dur_str}");
+    println!(
+        "Output:  {out_name}  H.264  CBR  {}  (two-pass, video-only)",
+        format_bitrate(bitrate)
+    );
+    println!();
+    println!("Encoding (both passes handled internally)...");
+
+    // ── Build encoder (two-pass, video-only) ─────────────────────────────────
+    //
+    // `.two_pass()` is incompatible with audio streams — the encoder buffers
+    // all video frames on the first internal pass (analysis), then re-encodes
+    // them with the accumulated statistics on the second pass when `finish()`
+    // is called.
+
+    let mut enc = match VideoEncoder::create(&output)
+        .video(src_w, src_h, fps)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Cbr(bitrate))
+        .two_pass()
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Decode → encode loop ──────────────────────────────────────────────────
+
+    let mut dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let start = Instant::now();
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match dec.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error decoding: {e}");
+                process::exit(1);
+            }
+        };
+        if let Err(e) = enc.push_video(&frame) {
+            eprintln!("Error encoding: {e}");
+            process::exit(1);
+        }
+        frames += 1;
+        if frames.is_multiple_of(100) {
+            print!("\r{frames} frames    ");
+            let _ = io::stdout().flush();
+        }
+    }
+
+    // `finish()` triggers the second pass internally when `two_pass` is set.
+    if let Err(e) = enc.finish() {
+        println!();
+        eprintln!("Error finishing: {e}");
+        process::exit(1);
+    }
+
+    println!();
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!(
+        "Done. {out_name}  {size_str}  {frames} frames  {}",
+        format_elapsed(start.elapsed())
+    );
+}

--- a/crates/avio/examples/video_effects.rs
+++ b/crates/avio/examples/video_effects.rs
@@ -1,0 +1,224 @@
+//! Apply visual effects to a video using `FilterGraphBuilder` + `Pipeline`.
+//!
+//! Available effects:
+//!   `fade-in`  — fade from black at the start of the video
+//!   `fade-out` — fade to black at the end of the video
+//!   `rotate`   — rotate by a fixed angle (degrees, clockwise)
+//!   `crop`     — crop to a sub-region
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example video_effects --features pipeline -- \
+//!   --input   input.mp4  \
+//!   --output  effect.mp4 \
+//!   --effect  fade-in    \
+//!   [--duration 2.0]      # fade duration in seconds (default: 2.0)
+//!   [--angle   90.0]      # rotation angle in degrees (default: 90.0)
+//!   [--x 0 --y 0 --width 1280 --height 720]  # crop region
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+    time::Duration,
+};
+
+use avio::{
+    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec,
+};
+
+fn render_progress(p: &Progress) {
+    match p.percent() {
+        Some(pct) => {
+            let bar_width = 20usize;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+            let filled = filled.min(bar_width);
+            let bar = "=".repeat(filled) + &" ".repeat(bar_width - filled);
+            print!("\r{pct:5.1}%  [{bar}]    ");
+        }
+        None => {
+            print!("\r{} frames    ", p.frames_processed);
+        }
+    }
+    let _ = io::stdout().flush();
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut effect = None::<String>;
+    let mut duration_secs: f64 = 2.0;
+    let mut angle: f64 = 90.0;
+    let mut crop_x: u32 = 0;
+    let mut crop_y: u32 = 0;
+    let mut crop_w = None::<u32>;
+    let mut crop_h = None::<u32>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--effect" | "-e" => effect = Some(args.next().unwrap_or_default()),
+            "--duration" => {
+                let v = args.next().unwrap_or_default();
+                duration_secs = v.parse().unwrap_or(2.0);
+            }
+            "--angle" => {
+                let v = args.next().unwrap_or_default();
+                angle = v.parse().unwrap_or(90.0);
+            }
+            "--x" => {
+                let v = args.next().unwrap_or_default();
+                crop_x = v.parse().unwrap_or(0);
+            }
+            "--y" => {
+                let v = args.next().unwrap_or_default();
+                crop_y = v.parse().unwrap_or(0);
+            }
+            "--width" => {
+                let v = args.next().unwrap_or_default();
+                crop_w = v.parse().ok();
+            }
+            "--height" => {
+                let v = args.next().unwrap_or_default();
+                crop_h = v.parse().ok();
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: video_effects --input <file> --output <file> \
+             --effect fade-in|fade-out|rotate|crop [options]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+    let effect = effect.unwrap_or_else(|| {
+        eprintln!("--effect is required (fade-in|fade-out|rotate|crop)");
+        process::exit(1);
+    });
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    // ── Build filter graph ────────────────────────────────────────────────────
+
+    let filter_result = match effect.as_str() {
+        "fade-in" => {
+            println!("Input:   {in_name}");
+            println!("Effect:  fade-in  (duration={duration_secs} s)");
+            println!("Output:  {out_name}");
+            FilterGraphBuilder::new()
+                .fade_in(Duration::from_secs_f64(duration_secs))
+                .build()
+        }
+        "fade-out" => {
+            println!("Input:   {in_name}");
+            println!("Effect:  fade-out  (duration={duration_secs} s)");
+            println!("Output:  {out_name}");
+            FilterGraphBuilder::new()
+                .fade_out(Duration::from_secs_f64(duration_secs))
+                .build()
+        }
+        "rotate" => {
+            println!("Input:   {in_name}");
+            println!("Effect:  rotate  (angle={angle}°)");
+            println!("Output:  {out_name}");
+            FilterGraphBuilder::new().rotate(angle).build()
+        }
+        "crop" => {
+            let w = crop_w.unwrap_or_else(|| {
+                eprintln!("--width is required for crop");
+                process::exit(1);
+            });
+            let h = crop_h.unwrap_or_else(|| {
+                eprintln!("--height is required for crop");
+                process::exit(1);
+            });
+            println!("Input:   {in_name}");
+            println!("Effect:  crop  (x={crop_x}, y={crop_y}, {w}×{h})");
+            println!("Output:  {out_name}");
+            FilterGraphBuilder::new().crop(crop_x, crop_y, w, h).build()
+        }
+        other => {
+            eprintln!("Unknown effect '{other}' (try fade-in, fade-out, rotate, crop)");
+            process::exit(1);
+        }
+    };
+
+    let filter = match filter_result {
+        Ok(fg) => fg,
+        Err(e) => {
+            eprintln!("Error building filter graph: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!();
+
+    // ── Assemble pipeline ─────────────────────────────────────────────────────
+
+    let config = EncoderConfig {
+        video_codec: VideoCodec::H264,
+        audio_codec: AudioCodec::Aac,
+        bitrate_mode: BitrateMode::Crf(23),
+        resolution: None,
+        framerate: None,
+        hardware: None,
+    };
+
+    let pipeline = match Pipeline::builder()
+        .input(&input)
+        .filter(filter)
+        .output(&output, config)
+        .on_progress(|p: &Progress| {
+            render_progress(p);
+            true
+        })
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = pipeline.run() {
+        println!();
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    println!();
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}");
+}

--- a/crates/avio/examples/write_metadata.rs
+++ b/crates/avio/examples/write_metadata.rs
@@ -1,0 +1,279 @@
+//! Transcode a video while embedding metadata tags and chapter markers.
+//!
+//! Demonstrates `VideoEncoderBuilder::metadata()` and `.chapter()` — essential
+//! for podcast distribution (ID3-style tags), video platform uploads, and
+//! structured long-form content (documentaries, lectures, audiobooks).
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example write_metadata -- \
+//!   --input    input.mp4            \
+//!   --output   tagged.mp4           \
+//!   [--title   "My Video"]          \
+//!   [--artist  "Author Name"]       \
+//!   [--year    2026]                \
+//!   [--chapters "00:00:00=Intro,00:01:30=Main,00:05:00=Credits"]
+//! ```
+//!
+//! Verify the output with:
+//! ```bash
+//! cargo run --example probe_info -- tagged.mp4
+//! ```
+
+use std::{
+    io::{self, Write as _},
+    path::Path,
+    process,
+    time::Duration,
+};
+
+use avio::{AudioCodec, BitrateMode, ChapterInfo, VideoCodec, VideoDecoder, VideoEncoder};
+
+fn parse_time(s: &str) -> Result<Duration, String> {
+    if s.contains(':') {
+        let parts: Vec<&str> = s.splitn(3, ':').collect();
+        if parts.len() == 3 {
+            let h: u64 = parts[0]
+                .parse()
+                .map_err(|_| format!("invalid hours in '{s}'"))?;
+            let m: u64 = parts[1]
+                .parse()
+                .map_err(|_| format!("invalid minutes in '{s}'"))?;
+            let sec: f64 = parts[2]
+                .parse()
+                .map_err(|_| format!("invalid seconds in '{s}'"))?;
+            let total = Duration::from_secs(h * 3600 + m * 60) + Duration::from_secs_f64(sec);
+            Ok(total)
+        } else {
+            Err(format!("invalid time '{s}' (use HH:MM:SS)"))
+        }
+    } else {
+        let secs: f64 = s.parse().map_err(|_| format!("invalid time '{s}'"))?;
+        Ok(Duration::from_secs_f64(secs))
+    }
+}
+
+fn format_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut title = None::<String>;
+    let mut artist = None::<String>;
+    let mut year = None::<String>;
+    let mut chapters_str = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--title" => title = Some(args.next().unwrap_or_default()),
+            "--artist" => artist = Some(args.next().unwrap_or_default()),
+            "--year" => year = Some(args.next().unwrap_or_default()),
+            "--chapters" => chapters_str = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: write_metadata --input <file> --output <file> \
+             [--title T] [--artist A] [--year Y] \
+             [--chapters \"HH:MM:SS=Title,...\"]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Parse chapter markers ─────────────────────────────────────────────────
+    //
+    // Format: "HH:MM:SS=Title,HH:MM:SS=Title,..."
+    // Each chapter's end time is the next chapter's start (last chapter ends at
+    // the file's total duration, probed below).
+
+    let raw_chapters: Vec<(Duration, String)> = if let Some(ref s) = chapters_str {
+        s.split(',')
+            .filter(|p| !p.is_empty())
+            .map(|pair| {
+                let mut parts = pair.splitn(2, '=');
+                let time_str = parts.next().unwrap_or("").trim();
+                let title_str = parts.next().unwrap_or("(untitled)").trim().to_string();
+                let t = parse_time(time_str).unwrap_or_else(|e| {
+                    eprintln!("Error parsing chapter time: {e}");
+                    process::exit(1);
+                });
+                (t, title_str)
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // ── Open decoder — probe source dimensions and duration ───────────────────
+
+    let mut vid_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let src_w = vid_dec.width();
+    let src_h = vid_dec.height();
+    let fps = vid_dec.frame_rate();
+    let in_codec = vid_dec.stream_info().codec_name().to_string();
+    let total_duration = vid_dec.duration();
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!(
+        "Input:   {in_name}  {src_w}×{src_h}  {in_codec}  {}",
+        format_duration(total_duration)
+    );
+    println!("Output:  {out_name}");
+    println!();
+
+    // ── Print metadata that will be written ───────────────────────────────────
+
+    let has_meta = title.is_some() || artist.is_some() || year.is_some();
+    if has_meta {
+        println!("Metadata:");
+        if let Some(ref t) = title {
+            println!("  title  = {t}");
+        }
+        if let Some(ref a) = artist {
+            println!("  artist = {a}");
+        }
+        if let Some(ref y) = year {
+            println!("  year   = {y}");
+        }
+        println!();
+    }
+
+    // ── Build ChapterInfo list ────────────────────────────────────────────────
+    //
+    // Chapter end = next chapter's start; last chapter ends at total_duration.
+
+    let chapters: Vec<ChapterInfo> = raw_chapters
+        .iter()
+        .enumerate()
+        .map(|(i, (start, ch_title))| {
+            let end = raw_chapters
+                .get(i + 1)
+                .map_or(total_duration, |(next_start, _)| *next_start);
+            #[allow(clippy::cast_possible_wrap)]
+            let id = i as i64;
+            ChapterInfo::builder()
+                .id(id)
+                .title(ch_title.clone())
+                .start(*start)
+                .end(end)
+                .build()
+        })
+        .collect();
+
+    if !chapters.is_empty() {
+        println!("Chapters ({}):", chapters.len());
+        for ch in &chapters {
+            let t = ch.title().unwrap_or("(untitled)");
+            println!(
+                "  {}–{}  {t}",
+                format_duration(ch.start()),
+                format_duration(ch.end())
+            );
+        }
+        println!();
+    }
+
+    // ── Build encoder with metadata and chapters ──────────────────────────────
+
+    let mut enc_builder = VideoEncoder::create(&output)
+        .video(src_w, src_h, fps)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Aac);
+
+    if let Some(ref t) = title {
+        enc_builder = enc_builder.metadata("title", t);
+    }
+    if let Some(ref a) = artist {
+        enc_builder = enc_builder.metadata("artist", a);
+    }
+    if let Some(ref y) = year {
+        enc_builder = enc_builder.metadata("date", y);
+    }
+    for ch in chapters {
+        enc_builder = enc_builder.chapter(ch);
+    }
+
+    let mut enc = match enc_builder.build() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Decode → encode loop ──────────────────────────────────────────────────
+
+    let mut frames: u64 = 0;
+    loop {
+        let frame = match vid_dec.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error decoding: {e}");
+                process::exit(1);
+            }
+        };
+        if let Err(e) = enc.push_video(&frame) {
+            eprintln!("Error encoding: {e}");
+            process::exit(1);
+        }
+        frames += 1;
+        if frames.is_multiple_of(100) {
+            print!("\r{frames} frames    ");
+            let _ = io::stdout().flush();
+        }
+    }
+
+    if let Err(e) = enc.finish() {
+        println!();
+        eprintln!("Error finishing: {e}");
+        process::exit(1);
+    }
+
+    println!();
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+    println!("Verify with: cargo run --example probe_info -- {out_name}");
+}


### PR DESCRIPTION
## Summary

Adds seven new runnable examples to the `avio` crate, covering the API surface described in issues #527–#533. Each example is self-contained with its own argument parser and usage doc-comment, and demonstrates a distinct feature area not covered by the earlier example set.

## Changes

- `audio_transcode.rs` — audio-only decode → re-encode using `AudioDecoder` + `AudioEncoder` (#527)
- `dash_output.rs` — single-rendition DASH packaging using `DashOutput` (#528)
- `video_effects.rs` — visual effects (fade-in/out, rotate, crop) via `FilterGraphBuilder` + `Pipeline` (#529)
- `audio_filters.rs` — audio effects (volume, equalizer) via `FilterGraphBuilder` + `Pipeline` (#530)
- `two_pass_encode.rs` — precise CBR encoding using `VideoEncoder::two_pass()` (#531)
- `write_metadata.rs` — ID3-style tags and chapter markers via `VideoEncoderBuilder::metadata()` / `.chapter()` (#532)
- `hw_transcode.rs` — hardware-accelerated encoding via `Pipeline` + `EncoderConfig::hardware` (#533)
- `Cargo.toml` — added `[[example]]` entries with correct `required-features` for all seven

**Note:** `audio_transcode`, `two_pass_encode`, and `write_metadata` currently use the low-level decoder/encoder API directly because `Pipeline` does not yet expose audio-only (#541), two-pass (#543), or metadata injection (#542) paths. These examples will be updated when those issues are resolved.

## Related Issues

Closes #527
Closes #528
Closes #529
Closes #530
Closes #531
Closes #532
Closes #533

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes