### PR TITLE
feat(ff-pipeline): add EncoderConfigBuilder, mark EncoderConfig #[non_exhaustive]

### DIFF
--- a/crates/avio/examples/audio_filters.rs
+++ b/crates/avio/examples/audio_filters.rs
@@ -22,9 +22,7 @@ use std::{
     process,
 };
 
-use avio::{
-    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec,
-};
+use avio::{AudioCodec, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec};
 
 fn render_progress(p: &Progress) {
     match p.percent() {
@@ -139,14 +137,11 @@ fn main() {
 
     // ── Assemble pipeline ─────────────────────────────────────────────────────
 
-    let config = EncoderConfig {
-        video_codec: VideoCodec::H264,
-        audio_codec: AudioCodec::Aac,
-        bitrate_mode: BitrateMode::Crf(23),
-        resolution: None,
-        framerate: None,
-        hardware: None,
-    };
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .audio_codec(AudioCodec::Aac)
+        .crf(23)
+        .build();
 
     let pipeline = match Pipeline::builder()
         .input(&input)

--- a/crates/avio/examples/concat_clips.rs
+++ b/crates/avio/examples/concat_clips.rs
@@ -15,7 +15,7 @@ use std::{
     time::Duration,
 };
 
-use avio::{AudioCodec, BitrateMode, EncoderConfig, Pipeline, Progress, VideoCodec, open};
+use avio::{AudioCodec, EncoderConfig, Pipeline, Progress, VideoCodec, open};
 
 fn format_duration(d: Duration) -> String {
     let total = d.as_secs();
@@ -124,14 +124,11 @@ fn main() {
         .and_then(|n| n.to_str())
         .unwrap_or(&output);
 
-    let config = EncoderConfig {
-        video_codec: VideoCodec::H264,
-        audio_codec: AudioCodec::Aac,
-        bitrate_mode: BitrateMode::Crf(23),
-        resolution: None,
-        framerate: None,
-        hardware: None,
-    };
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .audio_codec(AudioCodec::Aac)
+        .crf(23)
+        .build();
 
     let mut builder = Pipeline::builder();
     for input in &inputs {

--- a/crates/avio/examples/hw_transcode.rs
+++ b/crates/avio/examples/hw_transcode.rs
@@ -31,9 +31,7 @@ use std::{
     time::Instant,
 };
 
-use avio::{
-    AudioCodec, BitrateMode, EncoderConfig, HwAccel, Pipeline, PipelineError, Progress, VideoCodec,
-};
+use avio::{AudioCodec, EncoderConfig, HwAccel, Pipeline, PipelineError, Progress, VideoCodec};
 
 fn format_elapsed(d: std::time::Duration) -> String {
     let s = d.as_secs();
@@ -162,14 +160,14 @@ fn main() {
 
     // ── Build pipeline with hardware backend ──────────────────────────────────
 
-    let config = EncoderConfig {
-        video_codec,
-        audio_codec: AudioCodec::Aac,
-        bitrate_mode: BitrateMode::Crf(crf),
-        resolution: None,
-        framerate: None,
-        hardware: hw_accel,
-    };
+    let mut b = EncoderConfig::builder()
+        .video_codec(video_codec)
+        .audio_codec(AudioCodec::Aac)
+        .crf(crf);
+    if let Some(hw) = hw_accel {
+        b = b.hardware(hw);
+    }
+    let config = b.build();
 
     let start = Instant::now();
     let last_frames: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));

--- a/crates/avio/examples/transcode.rs
+++ b/crates/avio/examples/transcode.rs
@@ -25,8 +25,7 @@ use std::{
 };
 
 use avio::{
-    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, PipelineError, Progress,
-    VideoCodec,
+    AudioCodec, EncoderConfig, FilterGraphBuilder, Pipeline, PipelineError, Progress, VideoCodec,
 };
 
 // ── Argument parsing ─────────────────────────────────────────────────────────
@@ -249,14 +248,14 @@ fn main() {
         _ => None,
     };
 
-    let config = EncoderConfig {
-        video_codec: args.codec,
-        audio_codec: args.audio_codec,
-        bitrate_mode: BitrateMode::Crf(args.crf),
-        resolution,
-        framerate: None,
-        hardware: None,
-    };
+    let mut b = EncoderConfig::builder()
+        .video_codec(args.codec)
+        .audio_codec(args.audio_codec)
+        .crf(args.crf);
+    if let Some((w, h)) = resolution {
+        b = b.resolution(w, h);
+    }
+    let config = b.build();
 
     // ── Assemble pipeline ─────────────────────────────────────────────────────
 

--- a/crates/avio/examples/trim_and_scale.rs
+++ b/crates/avio/examples/trim_and_scale.rs
@@ -19,9 +19,7 @@ use std::{
     time::Duration,
 };
 
-use avio::{
-    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec,
-};
+use avio::{AudioCodec, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec};
 
 fn parse_time(s: &str) -> Result<f64, String> {
     if s.contains(':') {
@@ -186,14 +184,14 @@ fn main() {
         _ => None,
     };
 
-    let config = EncoderConfig {
-        video_codec: VideoCodec::H264,
-        audio_codec: AudioCodec::Aac,
-        bitrate_mode: BitrateMode::Crf(23),
-        resolution,
-        framerate: None,
-        hardware: None,
-    };
+    let mut b = EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .audio_codec(AudioCodec::Aac)
+        .crf(23);
+    if let Some((w, h)) = resolution {
+        b = b.resolution(w, h);
+    }
+    let config = b.build();
 
     let pipeline = match Pipeline::builder()
         .input(&input)

--- a/crates/avio/examples/video_effects.rs
+++ b/crates/avio/examples/video_effects.rs
@@ -25,9 +25,7 @@ use std::{
     time::Duration,
 };
 
-use avio::{
-    AudioCodec, BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec,
-};
+use avio::{AudioCodec, EncoderConfig, FilterGraphBuilder, Pipeline, Progress, VideoCodec};
 
 fn render_progress(p: &Progress) {
     match p.percent() {
@@ -180,14 +178,11 @@ fn main() {
 
     // ── Assemble pipeline ─────────────────────────────────────────────────────
 
-    let config = EncoderConfig {
-        video_codec: VideoCodec::H264,
-        audio_codec: AudioCodec::Aac,
-        bitrate_mode: BitrateMode::Crf(23),
-        resolution: None,
-        framerate: None,
-        hardware: None,
-    };
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .audio_codec(AudioCodec::Aac)
+        .crf(23)
+        .build();
 
     let pipeline = match Pipeline::builder()
         .input(&input)

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -87,8 +87,8 @@ pub use ff_filter::{FilterError, FilterGraph, FilterGraphBuilder, HwAccel, ToneM
 // Progress / ProgressCallback are re-exported here as the canonical source.
 #[cfg(feature = "pipeline")]
 pub use ff_pipeline::{
-    EncoderConfig, Pipeline, PipelineBuilder, PipelineError, Progress, ProgressCallback,
-    ThumbnailPipeline,
+    EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder, PipelineError, Progress,
+    ProgressCallback, ThumbnailPipeline,
 };
 
 // ── stream feature ────────────────────────────────────────────────────────────
@@ -297,14 +297,11 @@ mod tests {
     #[cfg(all(feature = "pipeline", feature = "encode"))]
     #[test]
     fn pipeline_encoder_config_should_be_accessible() {
-        let _config = EncoderConfig {
-            video_codec: VideoCodec::H264,
-            audio_codec: AudioCodec::Aac,
-            bitrate_mode: BitrateMode::Cbr(4_000_000),
-            resolution: None,
-            framerate: None,
-            hardware: None,
-        };
+        let _config = EncoderConfig::builder()
+            .video_codec(VideoCodec::H264)
+            .audio_codec(AudioCodec::Aac)
+            .bitrate_mode(BitrateMode::Cbr(4_000_000))
+            .build();
     }
 
     // ── stream feature ────────────────────────────────────────────────────────

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -13,16 +13,15 @@ ff-pipeline = "0.3"
 
 ```rust
 use ff_pipeline::{Pipeline, EncoderConfig};
-use ff_encode::{VideoCodec, AudioCodec, BitrateMode};
+use ff_format::{VideoCodec, AudioCodec};
+use ff_encode::BitrateMode;
 
-let config = EncoderConfig {
-    video_codec:  VideoCodec::H264,
-    audio_codec:  AudioCodec::Aac,
-    bitrate_mode: BitrateMode::Cbr(4_000_000),
-    resolution:   Some((1280, 720)),
-    framerate:    None,
-    hardware:     None,
-};
+let config = EncoderConfig::builder()
+    .video_codec(VideoCodec::H264)
+    .audio_codec(AudioCodec::Aac)
+    .bitrate_mode(BitrateMode::Cbr(4_000_000))
+    .resolution(1280, 720)
+    .build();
 
 let pipeline = Pipeline::builder()
     .input("input.mp4")

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -17,16 +17,16 @@
 //!
 //! ```ignore
 //! use ff_pipeline::{Pipeline, EncoderConfig};
-//! use ff_encode::{VideoCodec, AudioCodec, BitrateMode};
+//! use ff_format::{VideoCodec, AudioCodec};
+//! use ff_encode::BitrateMode;
 //!
-//! let config = EncoderConfig {
-//!     video_codec:  VideoCodec::H264,
-//!     audio_codec:  AudioCodec::Aac,
-//!     bitrate_mode: BitrateMode::Cbr(4_000_000),
-//!     resolution:   Some((1280, 720)),
-//!     framerate:    Some(30.0),
-//!     hardware:     None,
-//! };
+//! let config = EncoderConfig::builder()
+//!     .video_codec(VideoCodec::H264)
+//!     .audio_codec(AudioCodec::Aac)
+//!     .bitrate_mode(BitrateMode::Cbr(4_000_000))
+//!     .resolution(1280, 720)
+//!     .framerate(30.0)
+//!     .build();
 //!
 //! Pipeline::builder()
 //!     .input("input.mp4")
@@ -54,6 +54,6 @@ pub mod progress;
 pub mod thumbnail;
 
 pub use error::PipelineError;
-pub use pipeline::{EncoderConfig, Pipeline, PipelineBuilder};
+pub use pipeline::{EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder};
 pub use progress::{Progress, ProgressCallback};
 pub use thumbnail::ThumbnailPipeline;

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -19,6 +19,9 @@ use crate::progress::{Progress, ProgressCallback};
 /// Codec and quality configuration for the pipeline output.
 ///
 /// Passed to [`PipelineBuilder::output`] alongside the output path.
+///
+/// Construct via [`EncoderConfig::builder`].
+#[non_exhaustive]
 pub struct EncoderConfig {
     /// Video codec to use for the output stream.
     pub video_codec: VideoCodec,
@@ -43,6 +46,102 @@ pub struct EncoderConfig {
     ///
     /// `None` uses software (CPU) encoding.
     pub hardware: Option<HwAccel>,
+}
+
+impl EncoderConfig {
+    /// Returns an [`EncoderConfigBuilder`] with sensible defaults:
+    /// H.264 video, AAC audio, CRF 23, no resolution/framerate override, software encoding.
+    #[must_use]
+    pub fn builder() -> EncoderConfigBuilder {
+        EncoderConfigBuilder::new()
+    }
+}
+
+/// Consuming builder for [`EncoderConfig`].
+///
+/// Obtain via [`EncoderConfig::builder`].
+pub struct EncoderConfigBuilder {
+    video_codec: VideoCodec,
+    audio_codec: AudioCodec,
+    bitrate_mode: BitrateMode,
+    resolution: Option<(u32, u32)>,
+    framerate: Option<f64>,
+    hardware: Option<HwAccel>,
+}
+
+impl EncoderConfigBuilder {
+    fn new() -> Self {
+        Self {
+            video_codec: VideoCodec::H264,
+            audio_codec: AudioCodec::Aac,
+            bitrate_mode: BitrateMode::Crf(23),
+            resolution: None,
+            framerate: None,
+            hardware: None,
+        }
+    }
+
+    /// Sets the video codec.
+    #[must_use]
+    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
+        self.video_codec = codec;
+        self
+    }
+
+    /// Sets the audio codec.
+    #[must_use]
+    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
+        self.audio_codec = codec;
+        self
+    }
+
+    /// Sets the bitrate control mode.
+    #[must_use]
+    pub fn bitrate_mode(mut self, mode: BitrateMode) -> Self {
+        self.bitrate_mode = mode;
+        self
+    }
+
+    /// Convenience: sets `BitrateMode::Crf(crf)`.
+    #[must_use]
+    pub fn crf(mut self, crf: u32) -> Self {
+        self.bitrate_mode = BitrateMode::Crf(crf);
+        self
+    }
+
+    /// Sets the output resolution in pixels.
+    #[must_use]
+    pub fn resolution(mut self, width: u32, height: u32) -> Self {
+        self.resolution = Some((width, height));
+        self
+    }
+
+    /// Sets the output frame rate in frames per second.
+    #[must_use]
+    pub fn framerate(mut self, fps: f64) -> Self {
+        self.framerate = Some(fps);
+        self
+    }
+
+    /// Sets the hardware acceleration backend.
+    #[must_use]
+    pub fn hardware(mut self, hw: HwAccel) -> Self {
+        self.hardware = Some(hw);
+        self
+    }
+
+    /// Builds the [`EncoderConfig`]. Never fails; returns the config directly.
+    #[must_use]
+    pub fn build(self) -> EncoderConfig {
+        EncoderConfig {
+            video_codec: self.video_codec,
+            audio_codec: self.audio_codec,
+            bitrate_mode: self.bitrate_mode,
+            resolution: self.resolution,
+            framerate: self.framerate,
+            hardware: self.hardware,
+        }
+    }
 }
 
 /// A configured, ready-to-run transcode pipeline.
@@ -376,14 +475,11 @@ mod tests {
     use ff_format::{AudioCodec, VideoCodec};
 
     fn dummy_config() -> EncoderConfig {
-        EncoderConfig {
-            video_codec: VideoCodec::H264,
-            audio_codec: AudioCodec::Aac,
-            bitrate_mode: BitrateMode::Cbr(4_000_000),
-            resolution: None,
-            framerate: None,
-            hardware: None,
-        }
+        EncoderConfig::builder()
+            .video_codec(VideoCodec::H264)
+            .audio_codec(AudioCodec::Aac)
+            .bitrate_mode(BitrateMode::Cbr(4_000_000))
+            .build()
     }
 
     #[test]

--- a/crates/ff-pipeline/tests/pipeline_run_tests.rs
+++ b/crates/ff-pipeline/tests/pipeline_run_tests.rs
@@ -16,14 +16,13 @@ use ff_pipeline::{EncoderConfig, Pipeline, PipelineError};
 use fixtures::{FileGuard, test_output_path, test_video_path};
 
 fn basic_config() -> EncoderConfig {
-    EncoderConfig {
-        video_codec: VideoCodec::Mpeg4,
-        audio_codec: AudioCodec::Aac,
-        bitrate_mode: BitrateMode::Cbr(1_000_000),
-        resolution: Some((320, 240)),
-        framerate: Some(24.0),
-        hardware: None,
-    }
+    EncoderConfig::builder()
+        .video_codec(VideoCodec::Mpeg4)
+        .audio_codec(AudioCodec::Aac)
+        .bitrate_mode(BitrateMode::Cbr(1_000_000))
+        .resolution(320, 240)
+        .framerate(24.0)
+        .build()
 }
 
 #[test]
@@ -200,14 +199,13 @@ fn transcode_with_scale_filter_should_produce_valid_output() {
     };
 
     // Resolution matches filter output; no override needed.
-    let config = EncoderConfig {
-        video_codec: VideoCodec::Mpeg4,
-        audio_codec: AudioCodec::Aac,
-        bitrate_mode: BitrateMode::Cbr(500_000),
-        resolution: Some((160, 120)),
-        framerate: Some(24.0),
-        hardware: None,
-    };
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::Mpeg4)
+        .audio_codec(AudioCodec::Aac)
+        .bitrate_mode(BitrateMode::Cbr(500_000))
+        .resolution(160, 120)
+        .framerate(24.0)
+        .build();
 
     let pipeline = match Pipeline::builder()
         .input(input.to_str().unwrap())


### PR DESCRIPTION
## Summary

Adds `EncoderConfig::builder()` returning a new `EncoderConfigBuilder` type, so callers no longer need to write struct literals to configure the pipeline encoder. Marks `EncoderConfig` with `#[non_exhaustive]` so adding fields in the future is not a breaking change. All existing struct-literal construction sites are migrated to the builder.

## Changes

- `crates/ff-pipeline/src/pipeline.rs`: added `#[non_exhaustive]` to `EncoderConfig`, added `EncoderConfig::builder()` associated method, added `EncoderConfigBuilder` with setters `video_codec`, `audio_codec`, `bitrate_mode`, `crf` (convenience), `resolution`, `framerate`, `hardware`, and `build()`
- `crates/ff-pipeline/src/lib.rs`: re-exported `EncoderConfigBuilder`; updated crate-level doc example to use builder
- `crates/ff-pipeline/tests/pipeline_run_tests.rs`: migrated `basic_config()` and inline config literal to builder
- `crates/avio/src/lib.rs`: added `EncoderConfigBuilder` to pipeline re-export; migrated `pipeline_encoder_config_should_be_accessible` test
- `crates/avio/examples/transcode.rs`, `concat_clips.rs`, `trim_and_scale.rs`, `hw_transcode.rs`, `video_effects.rs`, `audio_filters.rs`: migrated all six examples; removed now-unused `BitrateMode` imports
- `crates/ff-pipeline/README.md`: updated example to builder form

## Related Issues

Closes #534

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes