### PR TITLE
fix(avio): use Display instead of Debug for PixelFormat and ChannelLayout in examples

### DIFF
--- a/crates/avio/examples/decode_image.rs
+++ b/crates/avio/examples/decode_image.rs
@@ -86,7 +86,7 @@ fn main() {
     println!("File:         {file_name}");
     println!("Format:       {format_name}");
     println!("Dimensions:   {w}×{h}");
-    println!("Pixel format: {pix_fmt:?}");
+    println!("Pixel format: {pix_fmt}");
     println!("Planes:       {num_planes}");
 
     for i in 0..num_planes {

--- a/crates/avio/examples/encode_image.rs
+++ b/crates/avio/examples/encode_image.rs
@@ -172,7 +172,7 @@ fn main() {
     let w = frame.width();
     let h = frame.height();
     let fmt = frame.format();
-    println!("Frame:   pts={pts_secs:.3}s  {w}×{h}  {fmt:?}");
+    println!("Frame:   pts={pts_secs:.3}s  {w}×{h}  {fmt}");
     println!("Output:  {out_name}  ({fmt_label}  quality={quality})");
     println!();
 

--- a/crates/avio/examples/probe_info.rs
+++ b/crates/avio/examples/probe_info.rs
@@ -103,7 +103,7 @@ fn main() {
             let fps = v.fps();
             let pix_fmt = v.pixel_format();
 
-            let mut line = format!("  #{idx}  {codec}  {w}\u{d7}{h}  {fps:.2} fps  {pix_fmt:?}");
+            let mut line = format!("  #{idx}  {codec}  {w}\u{d7}{h}  {fps:.2} fps  {pix_fmt}");
 
             if let Some(br) = v.bitrate() {
                 let _ = write!(line, "  {}", format_bitrate(br));
@@ -136,7 +136,7 @@ fn main() {
             let layout = a.channel_layout();
             let rate = a.sample_rate();
 
-            let mut line = format!("  #{idx}  {codec}  {layout:?}  {rate} Hz");
+            let mut line = format!("  #{idx}  {codec}  {layout}  {rate} Hz");
 
             if let Some(br) = a.bitrate() {
                 let _ = write!(line, "  {}", format_bitrate(br));


### PR DESCRIPTION
## Summary

`PixelFormat` and `ChannelLayout` already implement `std::fmt::Display` in `ff-format`, but three example binaries were using the debug formatter `{:?}` instead of `{}`. This caused user-facing output to show Rust enum variant names (e.g. `Yuv420p`, `Surround5_1`) rather than the human-readable strings their `Display` impls produce (e.g. `yuv420p`, `5.1`).

## Changes

- `crates/avio/examples/probe_info.rs`: `{pix_fmt:?}` → `{pix_fmt}` (video stream line), `{layout:?}` → `{layout}` (audio stream line)
- `crates/avio/examples/encode_image.rs`: `{fmt:?}` → `{fmt}` (decoded frame info line)
- `crates/avio/examples/decode_image.rs`: `{pix_fmt:?}` → `{pix_fmt}` (pixel format info line)

No library code changed. `Display` implementations and their unit tests were already in place.

## Related Issues

Closes #535

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes