### PR TITLE
feat(ff-pipeline): add secondary_input() for multi-slot filter support

### DIFF
--- a/crates/avio/examples/add_watermark.rs
+++ b/crates/avio/examples/add_watermark.rs
@@ -1,13 +1,8 @@
 //! Overlay a PNG watermark onto a video using the `overlay` filter.
 //!
 //! The `overlay` filter requires **two** video input streams:
-//! - slot 0: the main video frames (pushed per decoded frame)
-//! - slot 1: the watermark frame (pushed per decoded frame; same image repeated)
-//!
-//! Because `Pipeline` only drives slot 0, this example uses the lower-level
-//! `VideoDecoder` → `FilterGraph` → `VideoEncoder` path directly.
-//!
-//! Note: audio is not copied to the output in this example.
+//! - slot 0: the main video frames (driven by `Pipeline` internally)
+//! - slot 1: the watermark frame (fed via `secondary_input`)
 //!
 //! # Usage
 //!
@@ -22,7 +17,7 @@
 
 use std::{path::Path, process};
 
-use avio::{BitrateMode, FilterGraphBuilder, ImageDecoder, VideoDecoder, VideoEncoder};
+use avio::{EncoderConfig, FilterGraphBuilder, ImageDecoder, Pipeline, VideoCodec, VideoDecoder};
 
 // ── Position helpers ──────────────────────────────────────────────────────────
 
@@ -109,7 +104,7 @@ fn main() {
         process::exit(1);
     });
 
-    // ── Decode watermark image ────────────────────────────────────────────────
+    // ── Probe watermark dimensions ────────────────────────────────────────────
 
     let wm_dec = match ImageDecoder::open(&watermark).build() {
         Ok(d) => d,
@@ -128,9 +123,9 @@ fn main() {
     let wm_w = wm_frame.width();
     let wm_h = wm_frame.height();
 
-    // ── Open video decoder ────────────────────────────────────────────────────
+    // ── Probe video dimensions ────────────────────────────────────────────────
 
-    let mut vid_dec = match VideoDecoder::open(&input).build() {
+    let vid_dec = match VideoDecoder::open(&input).build() {
         Ok(d) => d,
         Err(e) => {
             eprintln!("Error opening video: {e}");
@@ -139,7 +134,6 @@ fn main() {
     };
     let vid_w = vid_dec.width();
     let vid_h = vid_dec.height();
-    let fps = vid_dec.frame_rate();
 
     // ── Compute overlay position ──────────────────────────────────────────────
 
@@ -165,12 +159,8 @@ fn main() {
     println!();
 
     // ── Build overlay filter graph ────────────────────────────────────────────
-    //
-    // The overlay filter expects two buffersrc inputs:
-    //   slot 0 → main video frame  (pushed for every decoded frame)
-    //   slot 1 → watermark frame   (same image pushed again each iteration)
 
-    let mut filter = match FilterGraphBuilder::new().overlay(x, y).build() {
+    let filter = match FilterGraphBuilder::new().overlay(x, y).build() {
         Ok(fg) => fg,
         Err(e) => {
             eprintln!("Error building filter graph: {e}");
@@ -178,64 +168,31 @@ fn main() {
         }
     };
 
-    // ── Build video encoder ───────────────────────────────────────────────────
+    // ── Build and run pipeline ────────────────────────────────────────────────
 
-    // Audio is not handled in this example; output is video-only.
-    let mut enc = match VideoEncoder::create(&output)
-        .video(vid_w, vid_h, fps)
-        .video_codec(avio::VideoCodec::H264)
-        .bitrate_mode(BitrateMode::Crf(23))
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .crf(23)
+        .build();
+
+    let pipeline = match Pipeline::builder()
+        .input(&input)
+        .secondary_input(&watermark)
+        .filter(filter)
+        .output(&output, config)
         .build()
     {
-        Ok(e) => e,
+        Ok(p) => p,
         Err(e) => {
-            eprintln!("Error creating encoder: {e}");
+            eprintln!("Error: {e}");
             process::exit(1);
         }
     };
 
-    // ── Decode → filter → encode loop ────────────────────────────────────────
-
-    let mut frames_out = 0u64;
-    loop {
-        let frame = match vid_dec.decode_one() {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                eprintln!("Error decoding: {e}");
-                process::exit(1);
-            }
-        };
-
-        // Push main video frame to slot 0.
-        if let Err(e) = filter.push_video(0, &frame) {
-            eprintln!("Error pushing to filter slot 0: {e}");
-            process::exit(1);
-        }
-
-        // Push watermark to slot 1 (repeat each frame so the buffersrc stays fed).
-        if let Err(e) = filter.push_video(1, &wm_frame) {
-            eprintln!("Error pushing watermark to filter slot 1: {e}");
-            process::exit(1);
-        }
-
-        while let Ok(Some(filtered)) = filter.pull_video() {
-            if let Err(e) = enc.push_video(&filtered) {
-                eprintln!("Error encoding: {e}");
-                process::exit(1);
-            }
-            frames_out += 1;
-            if frames_out.is_multiple_of(100) {
-                print!("\r{frames_out} frames encoded    ");
-                let _ = std::io::Write::flush(&mut std::io::stdout());
-            }
-        }
-    }
-
-    if let Err(e) = enc.finish() {
-        eprintln!("\nError finishing encode: {e}");
+    if let Err(e) = pipeline.run() {
+        eprintln!("Error: {e}");
         process::exit(1);
     }
 
-    println!("\rDone. {out_name}  {frames_out} frames");
+    println!("Done. {out_name}");
 }

--- a/crates/ff-pipeline/src/error.rs
+++ b/crates/ff-pipeline/src/error.rs
@@ -9,7 +9,8 @@
 ///
 /// - **Downstream errors**: [`Decode`](Self::Decode), [`Filter`](Self::Filter),
 ///   [`Encode`](Self::Encode) — propagated from the underlying crates via `#[from]`
-/// - **Configuration errors**: [`NoInput`](Self::NoInput), [`NoOutput`](Self::NoOutput)
+/// - **Configuration errors**: [`NoInput`](Self::NoInput), [`NoOutput`](Self::NoOutput),
+///   [`SecondaryInputWithoutFilter`](Self::SecondaryInputWithoutFilter)
 ///   — returned by [`PipelineBuilder::build`](crate::PipelineBuilder::build)
 /// - **Runtime control**: [`Cancelled`](Self::Cancelled) — returned by
 ///   [`Pipeline::run`](crate::Pipeline::run) when the progress callback returns `false`
@@ -49,6 +50,13 @@ pub enum PipelineError {
     /// required before [`PipelineBuilder::build`](crate::PipelineBuilder::build).
     #[error("no output specified")]
     NoOutput,
+
+    /// `secondary_input()` was called but no filter graph was provided.
+    ///
+    /// A secondary input only makes sense when a multi-slot filter is set via
+    /// [`PipelineBuilder::filter`](crate::PipelineBuilder::filter).
+    #[error("secondary input provided without a filter graph")]
+    SecondaryInputWithoutFilter,
 
     /// The pipeline was cancelled by the progress callback.
     ///

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -8,7 +8,7 @@
 
 use std::time::Instant;
 
-use ff_decode::{AudioDecoder, VideoDecoder};
+use ff_decode::{AudioDecoder, ImageDecoder, VideoDecoder};
 use ff_encode::{BitrateMode, HardwareEncoder, VideoEncoder};
 use ff_filter::{FilterGraph, HwAccel};
 use ff_format::{AudioCodec, Timestamp, VideoCodec};
@@ -150,6 +150,7 @@ impl EncoderConfigBuilder {
 /// Execute by calling [`run`](Self::run).
 pub struct Pipeline {
     inputs: Vec<String>,
+    secondary_inputs: Vec<String>,
     filter: Option<FilterGraph>,
     output: Option<(String, EncoderConfig)>,
     callback: Option<ProgressCallback>,
@@ -208,8 +209,9 @@ impl Pipeline {
         };
 
         log::info!(
-            "pipeline starting inputs={num_inputs} output={out_path} \
-             width={out_width} height={out_height} fps={fps} total_frames={total_frames:?}"
+            "pipeline starting inputs={num_inputs} secondary_inputs={} output={out_path} \
+             width={out_width} height={out_height} fps={fps} total_frames={total_frames:?}",
+            self.secondary_inputs.len()
         );
 
         // Probe audio from the first input to configure the encoder audio track.
@@ -255,6 +257,32 @@ impl Pipeline {
         // PTS offset in seconds: accumulates the duration of all processed inputs.
         let mut pts_offset_secs: f64 = 0.0;
 
+        // Decode one frame from each secondary input before the main loop.
+        // secondary_frames[i] feeds filter slot (i + 1).
+        let secondary_frames: Vec<_> = {
+            let mut frames = Vec::with_capacity(self.secondary_inputs.len());
+            for path in &self.secondary_inputs {
+                let ext = std::path::Path::new(path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(str::to_lowercase)
+                    .unwrap_or_default();
+                let frame = if matches!(
+                    ext.as_str(),
+                    "jpg" | "jpeg" | "png" | "bmp" | "webp" | "tiff" | "tif"
+                ) {
+                    let dec = ImageDecoder::open(path).build()?;
+                    dec.decode()?
+                } else {
+                    let mut dec = VideoDecoder::open(path).build()?;
+                    dec.decode_one()?
+                        .ok_or(ff_decode::DecodeError::EndOfStream)?
+                };
+                frames.push(frame);
+            }
+            frames
+        };
+
         // Reuse the already-opened first decoder; open fresh decoders for subsequent inputs.
         let mut maybe_first_vdec = Some(first_vdec);
 
@@ -280,6 +308,10 @@ impl Pipeline {
 
                 let frame = if let Some(ref mut fg) = filter {
                     fg.push_video(0, &raw_frame)?;
+                    // Feed secondary inputs to slots 1..N.
+                    for (slot_idx, sec_frame) in secondary_frames.iter().enumerate() {
+                        fg.push_video(slot_idx + 1, sec_frame)?;
+                    }
                     match fg.pull_video()? {
                         Some(f) => f,
                         None => continue, // filter is buffering; feed more input
@@ -387,6 +419,7 @@ fn hwaccel_to_hardware_encoder(hw: Option<HwAccel>) -> HardwareEncoder {
 /// All setter methods take `self` by value and return `Self` for chaining.
 pub struct PipelineBuilder {
     inputs: Vec<String>,
+    secondary_inputs: Vec<String>,
     filter: Option<FilterGraph>,
     output: Option<(String, EncoderConfig)>,
     callback: Option<ProgressCallback>,
@@ -398,6 +431,7 @@ impl PipelineBuilder {
     pub fn new() -> Self {
         Self {
             inputs: Vec::new(),
+            secondary_inputs: Vec::new(),
             filter: None,
             output: None,
             callback: None,
@@ -410,6 +444,29 @@ impl PipelineBuilder {
     #[must_use]
     pub fn input(mut self, path: &str) -> Self {
         self.inputs.push(path.to_owned());
+        self
+    }
+
+    /// Adds a secondary input path that will be fed to filter slot 1, 2, … in order.
+    ///
+    /// The first call maps to slot 1, the second to slot 2, and so on.
+    /// A filter graph **must** also be set via [`filter`](Self::filter); calling this
+    /// without a filter causes [`build`](Self::build) to return
+    /// [`PipelineError::SecondaryInputWithoutFilter`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// Pipeline::builder()
+    ///     .input("video.mp4")
+    ///     .secondary_input("logo.png")   // → slot 1
+    ///     .filter(fg)
+    ///     .output("out.mp4", config)
+    ///     .build()?
+    /// ```
+    #[must_use]
+    pub fn secondary_input(mut self, path: &str) -> Self {
+        self.secondary_inputs.push(path.to_owned());
         self
     }
 
@@ -446,6 +503,8 @@ impl PipelineBuilder {
     ///
     /// - [`PipelineError::NoInput`] — no input was added via [`input`](Self::input)
     /// - [`PipelineError::NoOutput`] — [`output`](Self::output) was not called
+    /// - [`PipelineError::SecondaryInputWithoutFilter`] — [`secondary_input`](Self::secondary_input)
+    ///   was called but no filter was set via [`filter`](Self::filter)
     pub fn build(self) -> Result<Pipeline, PipelineError> {
         if self.inputs.is_empty() {
             return Err(PipelineError::NoInput);
@@ -453,8 +512,12 @@ impl PipelineBuilder {
         if self.output.is_none() {
             return Err(PipelineError::NoOutput);
         }
+        if !self.secondary_inputs.is_empty() && self.filter.is_none() {
+            return Err(PipelineError::SecondaryInputWithoutFilter);
+        }
         Ok(Pipeline {
             inputs: self.inputs,
+            secondary_inputs: self.secondary_inputs,
             filter: self.filter,
             output: self.output,
             callback: self.callback,
@@ -548,6 +611,19 @@ mod tests {
         assert!(matches!(
             Pipeline::builder().input("/tmp/in.mp4").build(),
             Err(PipelineError::NoOutput)
+        ));
+    }
+
+    #[test]
+    fn secondary_input_without_filter_should_return_error() {
+        let result = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .secondary_input("/tmp/logo.png")
+            .output("/tmp/out.mp4", dummy_config())
+            .build();
+        assert!(matches!(
+            result,
+            Err(PipelineError::SecondaryInputWithoutFilter)
         ));
     }
 }

--- a/crates/ff-pipeline/tests/pipeline_run_tests.rs
+++ b/crates/ff-pipeline/tests/pipeline_run_tests.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
 use ff_filter::FilterGraph;
 use ff_pipeline::{EncoderConfig, Pipeline, PipelineError};
-use fixtures::{FileGuard, test_output_path, test_video_path};
+use fixtures::{FileGuard, assets_dir, test_output_path, test_video_path};
 
 fn basic_config() -> EncoderConfig {
     EncoderConfig::builder()
@@ -519,6 +519,66 @@ fn concat_two_inputs_should_produce_output_with_approx_sum_duration() {
         }
         Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
         Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn pipeline_with_secondary_input_should_produce_valid_output() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+    let watermark = assets_dir().join("img/hello-triangle.png");
+    if !watermark.exists() {
+        println!("Skipping: watermark asset not found at {watermark:?}");
+        return;
+    }
+    let output = test_output_path("pipeline_secondary_input.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let filter = match FilterGraph::builder().overlay(0, 0).build() {
+        Ok(f) => f,
+        Err(e) => {
+            println!("Skipping: filter build failed: {e}");
+            return;
+        }
+    };
+
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::Mpeg4)
+        .audio_codec(AudioCodec::Aac)
+        .bitrate_mode(BitrateMode::Cbr(1_000_000))
+        .resolution(320, 240)
+        .framerate(24.0)
+        .build();
+
+    let pipeline = match Pipeline::builder()
+        .input(input.to_str().unwrap())
+        .secondary_input(watermark.to_str().unwrap())
+        .filter(filter)
+        .output(output.to_str().unwrap(), config)
+        .build()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Skipping: build failed: {e}");
+            return;
+        }
+    };
+
+    match pipeline.run() {
+        Ok(()) => {
+            assert!(output.exists(), "output file must exist after run");
+            assert!(
+                std::fs::metadata(&output).unwrap().len() > 0,
+                "output file must be non-empty"
+            );
+        }
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(PipelineError::Filter(e)) => println!("Skipping: filter unavailable: {e}"),
         Err(e) => panic!("unexpected error: {e}"),
     }
 }


### PR DESCRIPTION
## Summary

Adds `PipelineBuilder::secondary_input(path)` so multi-slot filters such as `overlay` can be used via the high-level `Pipeline` API. Previously, applying a watermark required dropping down to the manual `VideoDecoder → FilterGraph → VideoEncoder` loop; now it can be expressed in a single builder chain.

## Changes

- **`ff-pipeline/src/error.rs`**: add `SecondaryInputWithoutFilter` variant to `PipelineError`, returned when `secondary_input()` is called without a filter graph
- **`ff-pipeline/src/pipeline.rs`**:
  - Add `secondary_inputs: Vec<String>` field to `Pipeline` and `PipelineBuilder`
  - Add `secondary_input()` builder method — first call feeds filter slot 1, second feeds slot 2, etc.
  - Decode secondary frames once before the main loop (uses `ImageDecoder` for still-image extensions, `VideoDecoder` otherwise); re-feeds each frame on every main-loop tick
  - Validate in `build()` that `secondary_input()` requires a filter
  - Add unit test `secondary_input_without_filter_should_return_error`
- **`crates/avio/examples/add_watermark.rs`**: rewrite to use `Pipeline::builder().secondary_input()` instead of the manual loop
- **`ff-pipeline/tests/pipeline_run_tests.rs`**: add integration test `pipeline_with_secondary_input_should_produce_valid_output`

## Related Issues

Closes #536

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes