### PR TITLE
feat(ff-filter): auto-infer encoder resolution from scale filter

### DIFF
--- a/crates/avio/examples/transcode.rs
+++ b/crates/avio/examples/transcode.rs
@@ -243,19 +243,11 @@ fn main() {
 
     // ── Build encoder config ─────────────────────────────────────────────────
 
-    let resolution = match (args.width, args.height) {
-        (Some(w), Some(h)) => Some((w, h)),
-        _ => None,
-    };
-
-    let mut b = EncoderConfig::builder()
+    let config = EncoderConfig::builder()
         .video_codec(args.codec)
         .audio_codec(args.audio_codec)
-        .crf(args.crf);
-    if let Some((w, h)) = resolution {
-        b = b.resolution(w, h);
-    }
-    let config = b.build();
+        .crf(args.crf)
+        .build();
 
     // ── Assemble pipeline ─────────────────────────────────────────────────────
 

--- a/crates/avio/examples/trim_and_scale.rs
+++ b/crates/avio/examples/trim_and_scale.rs
@@ -179,19 +179,11 @@ fn main() {
         }
     };
 
-    let resolution = match (width, height) {
-        (Some(w), Some(h)) => Some((w, h)),
-        _ => None,
-    };
-
-    let mut b = EncoderConfig::builder()
+    let config = EncoderConfig::builder()
         .video_codec(VideoCodec::H264)
         .audio_codec(AudioCodec::Aac)
-        .crf(23);
-    if let Some((w, h)) = resolution {
-        b = b.resolution(w, h);
-    }
-    let config = b.build();
+        .crf(23)
+        .build();
 
     let pipeline = match Pipeline::builder()
         .input(&input)

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -275,8 +275,16 @@ impl FilterGraphBuilder {
             return Err(FilterError::BuildFailed);
         }
         crate::filter_inner::validate_filter_steps(&self.steps)?;
+        let output_resolution = self.steps.iter().rev().find_map(|s| {
+            if let FilterStep::Scale { width, height } = s {
+                Some((*width, *height))
+            } else {
+                None
+            }
+        });
         Ok(FilterGraph {
             inner: FilterGraphInner::new(self.steps, self.hw),
+            output_resolution,
         })
     }
 }
@@ -308,6 +316,7 @@ impl FilterGraphBuilder {
 /// ```
 pub struct FilterGraph {
     inner: FilterGraphInner,
+    output_resolution: Option<(u32, u32)>,
 }
 
 impl std::fmt::Debug for FilterGraph {
@@ -321,6 +330,16 @@ impl FilterGraph {
     #[must_use]
     pub fn builder() -> FilterGraphBuilder {
         FilterGraphBuilder::new()
+    }
+
+    /// Returns the output resolution produced by this graph's `scale` filter step,
+    /// if one was configured.
+    ///
+    /// When multiple `scale` steps are chained, the **last** one's dimensions are
+    /// returned. Returns `None` when no `scale` step was added.
+    #[must_use]
+    pub fn output_resolution(&self) -> Option<(u32, u32)> {
+        self.output_resolution
     }
 
     /// Push a video frame into input slot `slot`.
@@ -509,5 +528,27 @@ mod tests {
             result.is_ok(),
             "builder with a known filter step must succeed, got {result:?}"
         );
+    }
+
+    #[test]
+    fn output_resolution_should_return_scale_dimensions() {
+        let fg = FilterGraph::builder().scale(1280, 720).build().unwrap();
+        assert_eq!(fg.output_resolution(), Some((1280, 720)));
+    }
+
+    #[test]
+    fn output_resolution_should_return_last_scale_when_chained() {
+        let fg = FilterGraph::builder()
+            .scale(1920, 1080)
+            .scale(1280, 720)
+            .build()
+            .unwrap();
+        assert_eq!(fg.output_resolution(), Some((1280, 720)));
+    }
+
+    #[test]
+    fn output_resolution_should_return_none_when_no_scale() {
+        let fg = FilterGraph::builder().trim(0.0, 5.0).build().unwrap();
+        assert_eq!(fg.output_resolution(), None);
     }
 }

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -34,7 +34,15 @@ pub struct EncoderConfig {
 
     /// Output resolution as `(width, height)` in pixels.
     ///
-    /// `None` preserves the source resolution.
+    /// Resolution precedence in [`Pipeline::run`]:
+    /// 1. This field when `Some` — explicit value always wins.
+    /// 2. The output dimensions of a `scale` filter, inferred automatically.
+    /// 3. The source video's native resolution.
+    ///
+    /// When a `scale` filter is used via [`PipelineBuilder::filter`] you
+    /// typically do **not** need to set this field; the pipeline infers the
+    /// encoder dimensions from the filter. Set it explicitly only to override
+    /// the filter's output size or to resize without a filter.
     pub resolution: Option<(u32, u32)>,
 
     /// Output frame rate in frames per second.
@@ -194,9 +202,12 @@ impl Pipeline {
 
         // Open the first input to determine output dimensions.
         let first_vdec = VideoDecoder::open(first_input).build()?;
-        let (out_width, out_height) = enc_config
-            .resolution
-            .unwrap_or_else(|| (first_vdec.width(), first_vdec.height()));
+        let (out_width, out_height) = enc_config.resolution.unwrap_or_else(|| {
+            filter
+                .as_ref()
+                .and_then(|fg| fg.output_resolution())
+                .unwrap_or_else(|| (first_vdec.width(), first_vdec.height()))
+        });
         let fps = enc_config
             .framerate
             .unwrap_or_else(|| first_vdec.frame_rate());


### PR DESCRIPTION
## Summary

When a `scale` filter is present in the pipeline but `EncoderConfig::resolution` is not set, the encoder was previously configured with the source dimensions while the filter output scaled frames — a silent dimension mismatch. The workaround was to set the same `(w, h)` in both the scale filter and `EncoderConfig::resolution`, which was redundant and confusing.

This PR implements Option B from issue #537: add `FilterGraph::output_resolution()` and use it as an automatic fallback in `Pipeline::run()`, so users no longer need to duplicate the resolution.

## Changes

- `ff-filter/src/graph.rs`: added `output_resolution` field to `FilterGraph`, populated in `build()` by scanning for the last `Scale` step; exposed via `output_resolution()` getter
- `ff-pipeline/src/pipeline.rs`: changed the resolution fallback in `run()` to a three-level precedence — explicit `EncoderConfig::resolution` → filter's scale dims → source dims; updated `resolution` field doc comment to document the precedence
- `crates/avio/examples/transcode.rs`: removed redundant `resolution` variable and conditional `.resolution(w, h)` call
- `crates/avio/examples/trim_and_scale.rs`: same redundancy removal

## Related Issues

Closes #537

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes