### PR TITLE
feat(ff-pipeline): add PipelineBuilder::filter_opt(Option<FilterGraph>)

### DIFF
--- a/crates/avio/examples/transcode.rs
+++ b/crates/avio/examples/transcode.rs
@@ -256,22 +256,19 @@ fn main() {
     let last_frames: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
     let last_frames_cb = Arc::clone(&last_frames);
 
-    let mut builder = Pipeline::builder()
+    let pipeline = match Pipeline::builder()
         .input(&args.input)
         .output(&args.output, config)
+        .filter_opt(filter)
         .on_progress(move |p: &Progress| {
             render_progress(p);
             if let Ok(mut f) = last_frames_cb.lock() {
                 *f = p.frames_processed;
             }
             true // always continue
-        });
-
-    if let Some(fg) = filter {
-        builder = builder.filter(fg);
-    }
-
-    let pipeline = match builder.build() {
+        })
+        .build()
+    {
         Ok(p) => p,
         Err(e) => {
             eprintln!("Error: {e}");

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -490,6 +490,26 @@ impl PipelineBuilder {
         self
     }
 
+    /// Sets the filter graph when `graph` is `Some`; no-op when `None`.
+    ///
+    /// This is a convenience wrapper over [`filter`](Self::filter) for
+    /// use when the filter is conditionally constructed:
+    ///
+    /// ```ignore
+    /// let pipeline = Pipeline::builder()
+    ///     .input(&args.input)
+    ///     .output(&args.output, config)
+    ///     .filter_opt(maybe_filter)   // Option<FilterGraph> — no rebind needed
+    ///     .build()?;
+    /// ```
+    #[must_use]
+    pub fn filter_opt(self, graph: Option<FilterGraph>) -> Self {
+        match graph {
+            Some(g) => self.filter(g),
+            None => self,
+        }
+    }
+
     /// Sets the output file path and encoder configuration.
     #[must_use]
     pub fn output(mut self, path: &str, config: EncoderConfig) -> Self {
@@ -631,6 +651,32 @@ mod tests {
             .input("/tmp/in.mp4")
             .secondary_input("/tmp/logo.png")
             .output("/tmp/out.mp4", dummy_config())
+            .build();
+        assert!(matches!(
+            result,
+            Err(PipelineError::SecondaryInputWithoutFilter)
+        ));
+    }
+
+    #[test]
+    fn filter_opt_with_none_should_not_prevent_successful_build() {
+        let result = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .output("/tmp/out.mp4", dummy_config())
+            .filter_opt(None)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn filter_opt_with_none_should_behave_like_no_filter_call() {
+        // secondary_input without a filter must still be rejected even when
+        // filter_opt(None) is called — None is a strict no-op.
+        let result = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .secondary_input("/tmp/logo.png")
+            .output("/tmp/out.mp4", dummy_config())
+            .filter_opt(None)
             .build();
         assert!(matches!(
             result,


### PR DESCRIPTION
## Summary

Adds `PipelineBuilder::filter_opt(graph: Option<FilterGraph>) -> Self` as a convenience wrapper over `.filter()`. When the filter is conditionally constructed, the consuming builder pattern required an awkward `let mut` rebind; `filter_opt` accepts `Option<FilterGraph>` and is a no-op when `None`, enabling a clean single-expression chain.

## Changes

- `crates/ff-pipeline/src/pipeline.rs`: Added `PipelineBuilder::filter_opt` method after `filter`; added two unit tests (`filter_opt_with_none_should_not_prevent_successful_build`, `filter_opt_with_none_should_behave_like_no_filter_call`)
- `crates/avio/examples/transcode.rs`: Replaced `let mut builder` + conditional rebind with `.filter_opt(filter)` in a single chain

## Related Issues

Closes #539

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes