### PR TITLE
feat(ff-pipeline): add AudioPipeline for audio-only transcoding

### DIFF
--- a/crates/avio/examples/audio_transcode.rs
+++ b/crates/avio/examples/audio_transcode.rs
@@ -1,8 +1,7 @@
 //! Decode an audio file and re-encode it to a different codec or bitrate.
 //!
-//! Demonstrates the audio-only decode → encode pipeline using `AudioDecoder`
-//! and `AudioEncoder` — the building blocks for podcast processing, audio
-//! format conversion, and soundtrack extraction.
+//! Demonstrates the audio-only decode → encode pipeline using `AudioPipeline`
+//! — a high-level builder that wraps the manual decode/encode loop.
 //!
 //! # Usage
 //!
@@ -16,7 +15,7 @@
 
 use std::{path::Path, process, time::Duration};
 
-use avio::{AudioCodec, AudioDecoder, AudioEncoder};
+use avio::{AudioCodec, AudioDecoder, AudioPipeline};
 
 fn format_duration(d: Duration) -> String {
     let s = d.as_secs();
@@ -82,9 +81,9 @@ fn main() {
         }
     };
 
-    // ── Open decoder ──────────────────────────────────────────────────────────
+    // ── Probe input for display info ──────────────────────────────────────────
 
-    let mut dec = match AudioDecoder::open(&input).build() {
+    let dec = match AudioDecoder::open(&input).build() {
         Ok(d) => d,
         Err(e) => {
             eprintln!("Error: {e}");
@@ -96,6 +95,7 @@ fn main() {
     let channels = dec.channels();
     let duration = dec.duration();
     let in_codec = dec.stream_info().codec_name().to_string();
+    drop(dec);
 
     let in_name = Path::new(&input)
         .file_name()
@@ -117,42 +117,16 @@ fn main() {
     println!();
     println!("Encoding...");
 
-    // ── Open encoder ──────────────────────────────────────────────────────────
+    // ── Run pipeline ──────────────────────────────────────────────────────────
 
-    let mut enc = match AudioEncoder::create(&output)
-        .audio(sample_rate, channels)
+    if let Err(e) = AudioPipeline::new()
+        .input(&input)
+        .output(&output)
         .audio_codec(codec)
-        .audio_bitrate(bitrate)
-        .build()
+        .bitrate(bitrate)
+        .run()
     {
-        Ok(e) => e,
-        Err(e) => {
-            eprintln!("Error creating encoder: {e}");
-            process::exit(1);
-        }
-    };
-
-    // ── Decode → encode loop ──────────────────────────────────────────────────
-
-    let mut frames: u64 = 0;
-    loop {
-        let frame = match dec.decode_one() {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                eprintln!("Error decoding: {e}");
-                process::exit(1);
-            }
-        };
-        if let Err(e) = enc.push(&frame) {
-            eprintln!("Error encoding: {e}");
-            process::exit(1);
-        }
-        frames += 1;
-    }
-
-    if let Err(e) = enc.finish() {
-        eprintln!("Error finishing: {e}");
+        eprintln!("Error: {e}");
         process::exit(1);
     }
 
@@ -162,5 +136,5 @@ fn main() {
         Err(_) => "(unknown size)".to_string(),
     };
 
-    println!("Done. {out_name}  {size_str}  {frames} frames");
+    println!("Done. {out_name}  {size_str}");
 }

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -87,8 +87,8 @@ pub use ff_filter::{FilterError, FilterGraph, FilterGraphBuilder, HwAccel, ToneM
 // Progress / ProgressCallback are re-exported here as the canonical source.
 #[cfg(feature = "pipeline")]
 pub use ff_pipeline::{
-    EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder, PipelineError, Progress,
-    ProgressCallback, ThumbnailPipeline,
+    AudioPipeline, EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder, PipelineError,
+    Progress, ProgressCallback, ThumbnailPipeline,
 };
 
 // ── stream feature ────────────────────────────────────────────────────────────
@@ -292,6 +292,12 @@ mod tests {
     fn pipeline_thumbnail_pipeline_should_be_accessible() {
         // ThumbnailPipeline::new constructs without opening a file.
         let _t: ThumbnailPipeline = ThumbnailPipeline::new("/no/such/file.mp4");
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn pipeline_audio_pipeline_should_be_accessible() {
+        let _: AudioPipeline = AudioPipeline::new();
     }
 
     #[cfg(all(feature = "pipeline", feature = "encode"))]

--- a/crates/ff-pipeline/src/audio_pipeline.rs
+++ b/crates/ff-pipeline/src/audio_pipeline.rs
@@ -1,0 +1,251 @@
+//! Audio-only transcoding pipeline.
+//!
+//! This module provides [`AudioPipeline`], which wraps the
+//! `AudioDecoder` → `AudioEncoder` decode/encode loop behind a
+//! single high-level builder API.  It mirrors the design of
+//! [`ThumbnailPipeline`](crate::ThumbnailPipeline) but targets
+//! audio-only files and supports multi-input concatenation.
+
+use std::time::Instant;
+
+use ff_decode::AudioDecoder;
+use ff_encode::AudioEncoder;
+use ff_format::{AudioCodec, Timestamp};
+
+use crate::error::PipelineError;
+use crate::progress::{Progress, ProgressCallback};
+
+/// High-level audio-only transcode pipeline.
+///
+/// # Construction
+///
+/// Use the consuming builder pattern:
+///
+/// ```ignore
+/// use ff_pipeline::AudioPipeline;
+/// use ff_format::AudioCodec;
+///
+/// AudioPipeline::new()
+///     .input("input.mp3")
+///     .output("output.aac")
+///     .audio_codec(AudioCodec::Aac)
+///     .bitrate(128_000)
+///     .run()?;
+/// ```
+pub struct AudioPipeline {
+    inputs: Vec<String>,
+    output: Option<String>,
+    audio_codec: AudioCodec,
+    bitrate: Option<u64>,
+    callback: Option<ProgressCallback>,
+}
+
+impl Default for AudioPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioPipeline {
+    /// Creates a new pipeline with default settings (AAC codec, no bitrate override).
+    pub fn new() -> Self {
+        Self {
+            inputs: Vec::new(),
+            output: None,
+            audio_codec: AudioCodec::default(),
+            bitrate: None,
+            callback: None,
+        }
+    }
+
+    /// Appends an input file path.
+    ///
+    /// Multiple inputs are concatenated in order.
+    #[must_use]
+    pub fn input(mut self, path: &str) -> Self {
+        self.inputs.push(path.to_owned());
+        self
+    }
+
+    /// Sets the output file path.
+    #[must_use]
+    pub fn output(mut self, path: &str) -> Self {
+        self.output = Some(path.to_owned());
+        self
+    }
+
+    /// Sets the audio codec for the output.
+    #[must_use]
+    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
+        self.audio_codec = codec;
+        self
+    }
+
+    /// Sets the target bitrate in bits per second.
+    #[must_use]
+    pub fn bitrate(mut self, bps: u64) -> Self {
+        self.bitrate = Some(bps);
+        self
+    }
+
+    /// Registers a progress callback.
+    ///
+    /// The closure receives a [`Progress`] reference on each decoded frame
+    /// and must return `true` to continue or `false` to cancel the pipeline.
+    #[must_use]
+    pub fn on_progress(mut self, cb: impl Fn(&Progress) -> bool + Send + 'static) -> Self {
+        self.callback = Some(Box::new(cb));
+        self
+    }
+
+    /// Runs the pipeline: decodes all inputs in sequence and encodes to output.
+    ///
+    /// # Errors
+    ///
+    /// - [`PipelineError::NoOutput`]  — no output path was set
+    /// - [`PipelineError::NoInput`]   — no input paths were provided
+    /// - [`PipelineError::Decode`]    — a decoding error occurred
+    /// - [`PipelineError::Encode`]    — an encoding error occurred
+    /// - [`PipelineError::Cancelled`] — the progress callback returned `false`
+    pub fn run(mut self) -> Result<(), PipelineError> {
+        let out_path = self.output.take().ok_or(PipelineError::NoOutput)?;
+
+        if self.inputs.is_empty() {
+            return Err(PipelineError::NoInput);
+        }
+
+        // Probe the first input for sample rate and channel count.
+        let first_dec = AudioDecoder::open(&self.inputs[0]).build()?;
+        let sample_rate = first_dec.sample_rate();
+        let channels = first_dec.channels();
+        drop(first_dec);
+
+        // Build the encoder.
+        let mut enc_builder = AudioEncoder::create(&out_path)
+            .audio(sample_rate, channels)
+            .audio_codec(self.audio_codec);
+        if let Some(bps) = self.bitrate {
+            enc_builder = enc_builder.audio_bitrate(bps);
+        }
+        let mut encoder = enc_builder.build()?;
+
+        log::info!(
+            "audio pipeline starting inputs={} output={out_path} \
+             sample_rate={sample_rate} channels={channels}",
+            self.inputs.len()
+        );
+
+        let start = Instant::now();
+        let mut frames_processed: u64 = 0;
+        let mut cancelled = false;
+        let mut pts_offset_secs: f64 = 0.0;
+
+        'inputs: for input in &self.inputs {
+            let mut adec = AudioDecoder::open(input).build()?;
+            let mut last_end_secs = pts_offset_secs;
+
+            loop {
+                let Some(mut aframe) = adec.decode_one()? else {
+                    break;
+                };
+
+                let ts = aframe.timestamp();
+                let new_pts = pts_offset_secs + ts.as_secs_f64();
+                let frame_dur = frame_duration_secs(aframe.samples(), sample_rate);
+                last_end_secs = new_pts + frame_dur;
+
+                aframe.set_timestamp(Timestamp::from_secs_f64(new_pts, ts.time_base()));
+                encoder.push(&aframe)?;
+
+                frames_processed += 1;
+
+                if let Some(ref cb) = self.callback {
+                    let progress = Progress {
+                        frames_processed,
+                        total_frames: None,
+                        elapsed: start.elapsed(),
+                    };
+                    if !cb(&progress) {
+                        cancelled = true;
+                        break 'inputs;
+                    }
+                }
+            }
+
+            pts_offset_secs = last_end_secs;
+            log::debug!(
+                "audio input complete path={input} pts_offset_secs={:.3}",
+                pts_offset_secs
+            );
+        }
+
+        encoder.finish()?;
+
+        log::info!(
+            "audio pipeline finished frames_processed={frames_processed} elapsed={:?}",
+            start.elapsed()
+        );
+
+        if cancelled {
+            return Err(PipelineError::Cancelled);
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn frame_duration_secs(samples: usize, sample_rate: u32) -> f64 {
+    if sample_rate > 0 {
+        samples as f64 / f64::from(sample_rate)
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_should_have_default_aac_codec() {
+        let p = AudioPipeline::new();
+        assert_eq!(p.audio_codec, AudioCodec::Aac);
+    }
+
+    #[test]
+    fn input_should_append_to_inputs() {
+        let p = AudioPipeline::new().input("a.mp3").input("b.mp3");
+        assert_eq!(p.inputs, vec!["a.mp3", "b.mp3"]);
+    }
+
+    #[test]
+    fn output_should_store_path() {
+        let p = AudioPipeline::new().output("out.aac");
+        assert_eq!(p.output.as_deref(), Some("out.aac"));
+    }
+
+    #[test]
+    fn audio_codec_should_store_value() {
+        let p = AudioPipeline::new().audio_codec(AudioCodec::Mp3);
+        assert_eq!(p.audio_codec, AudioCodec::Mp3);
+    }
+
+    #[test]
+    fn bitrate_should_store_value() {
+        let p = AudioPipeline::new().bitrate(192_000);
+        assert_eq!(p.bitrate, Some(192_000));
+    }
+
+    #[test]
+    fn run_with_no_output_should_return_no_output_error() {
+        let result = AudioPipeline::new().input("x.mp3").run();
+        assert!(matches!(result, Err(PipelineError::NoOutput)));
+    }
+
+    #[test]
+    fn run_with_no_inputs_should_return_no_input_error() {
+        let result = AudioPipeline::new().output("out.aac").run();
+        assert!(matches!(result, Err(PipelineError::NoInput)));
+    }
+}

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -41,6 +41,7 @@
 //!
 //! ## Module Structure
 //!
+//! - [`audio_pipeline`] — [`AudioPipeline`]
 //! - [`error`] — [`PipelineError`]
 //! - [`pipeline`] — [`Pipeline`], [`PipelineBuilder`], [`EncoderConfig`]
 //! - [`progress`] — [`Progress`], [`ProgressCallback`]
@@ -48,11 +49,13 @@
 
 #![warn(missing_docs)]
 
+pub mod audio_pipeline;
 pub mod error;
 pub mod pipeline;
 pub mod progress;
 pub mod thumbnail;
 
+pub use audio_pipeline::AudioPipeline;
 pub use error::PipelineError;
 pub use pipeline::{EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder};
 pub use progress::{Progress, ProgressCallback};

--- a/crates/ff-pipeline/tests/audio_pipeline_tests.rs
+++ b/crates/ff-pipeline/tests/audio_pipeline_tests.rs
@@ -1,0 +1,53 @@
+//! Integration tests for `AudioPipeline`.
+//!
+//! These tests call the real FFmpeg API and are skipped gracefully when the
+//! required codecs are unavailable or the test asset is missing.
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use ff_pipeline::{AudioPipeline, PipelineError};
+use fixtures::{FileGuard, test_audio_path, test_output_path};
+
+#[test]
+fn audio_pipeline_should_produce_valid_output_file() {
+    let input = test_audio_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+
+    let out_path = test_output_path("audio_pipeline_out.aac");
+    let _guard = FileGuard::new(out_path.clone());
+
+    let result = AudioPipeline::new()
+        .input(input.to_str().unwrap())
+        .output(out_path.to_str().unwrap())
+        .run();
+
+    match result {
+        Ok(()) => {
+            assert!(out_path.exists(), "output file should exist");
+            assert!(
+                out_path.metadata().unwrap().len() > 0,
+                "output file should be non-empty"
+            );
+        }
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn audio_pipeline_with_no_output_should_return_no_output_error() {
+    let result = AudioPipeline::new().input("in.mp3").run();
+    assert!(matches!(result, Err(PipelineError::NoOutput)));
+}
+
+#[test]
+fn audio_pipeline_with_no_inputs_should_return_no_input_error() {
+    let result = AudioPipeline::new().output("out.mp3").run();
+    assert!(matches!(result, Err(PipelineError::NoInput)));
+}

--- a/crates/ff-pipeline/tests/fixtures/mod.rs
+++ b/crates/ff-pipeline/tests/fixtures/mod.rs
@@ -15,6 +15,11 @@ pub fn test_video_path() -> PathBuf {
     assets_dir().join("video/gameplay.mp4")
 }
 
+/// Returns the path to the test audio file.
+pub fn test_audio_path() -> PathBuf {
+    assets_dir().join("audio/konekonoosanpo.mp3")
+}
+
 /// Returns the directory used for test output files.
 pub fn test_output_dir() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");


### PR DESCRIPTION
## Summary

Adds `AudioPipeline`, a high-level consuming builder that wraps the
`AudioDecoder` → `AudioEncoder` decode/encode loop behind a single `run()` call.
It mirrors the design of `ThumbnailPipeline` and provides a clean, purpose-named
counterpart to the existing `Pipeline` (which targets A/V transcoding).

## Changes

- **`crates/ff-pipeline/src/audio_pipeline.rs`** — new `AudioPipeline` struct with
  consuming builder setters (`input`, `output`, `audio_codec`, `bitrate`,
  `on_progress`), multi-input concatenation with PTS offset, progress callback
  with cancellation, and unit tests
- **`crates/ff-pipeline/src/lib.rs`** — export `AudioPipeline`; add module to doc list
- **`crates/ff-pipeline/tests/audio_pipeline_tests.rs`** — integration tests
  (valid output, `NoOutput` error, `NoInput` error)
- **`crates/ff-pipeline/tests/fixtures/mod.rs`** — add `test_audio_path()` helper
- **`crates/avio/src/lib.rs`** — re-export `AudioPipeline` under `pipeline` feature;
  add accessibility test
- **`crates/avio/examples/audio_transcode.rs`** — replace manual decode/encode loop
  with `AudioPipeline`

## Related Issues

Closes #541

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes