### PR TITLE
feat(ff-pipeline): add metadata and chapter injection to PipelineBuilder

### DIFF
--- a/crates/avio/examples/write_metadata.rs
+++ b/crates/avio/examples/write_metadata.rs
@@ -1,6 +1,6 @@
 //! Transcode a video while embedding metadata tags and chapter markers.
 //!
-//! Demonstrates `VideoEncoderBuilder::metadata()` and `.chapter()` — essential
+//! Demonstrates `PipelineBuilder::metadata()` and `.chapter()` — essential
 //! for podcast distribution (ID3-style tags), video platform uploads, and
 //! structured long-form content (documentaries, lectures, audiobooks).
 //!
@@ -21,14 +21,11 @@
 //! cargo run --example probe_info -- tagged.mp4
 //! ```
 
-use std::{
-    io::{self, Write as _},
-    path::Path,
-    process,
-    time::Duration,
-};
+use std::{path::Path, process, time::Duration};
 
-use avio::{AudioCodec, BitrateMode, ChapterInfo, VideoCodec, VideoDecoder, VideoEncoder};
+use avio::{
+    AudioCodec, BitrateMode, ChapterInfo, EncoderConfig, Pipeline, VideoCodec, VideoDecoder,
+};
 
 fn parse_time(s: &str) -> Result<Duration, String> {
     if s.contains(':') {
@@ -125,7 +122,7 @@ fn main() {
 
     // ── Open decoder — probe source dimensions and duration ───────────────────
 
-    let mut vid_dec = match VideoDecoder::open(&input).build() {
+    let vid_dec = match VideoDecoder::open(&input).build() {
         Ok(d) => d,
         Err(e) => {
             eprintln!("Error: {e}");
@@ -135,7 +132,6 @@ fn main() {
 
     let src_w = vid_dec.width();
     let src_h = vid_dec.height();
-    let fps = vid_dec.frame_rate();
     let in_codec = vid_dec.stream_info().codec_name().to_string();
     let total_duration = vid_dec.duration();
 
@@ -207,66 +203,40 @@ fn main() {
         println!();
     }
 
-    // ── Build encoder with metadata and chapters ──────────────────────────────
+    // ── Build pipeline with metadata and chapters ─────────────────────────────
 
-    let mut enc_builder = VideoEncoder::create(&output)
-        .video(src_w, src_h, fps)
+    let config = EncoderConfig::builder()
         .video_codec(VideoCodec::H264)
+        .audio_codec(AudioCodec::Aac)
         .bitrate_mode(BitrateMode::Crf(23))
-        .audio(48000, 2)
-        .audio_codec(AudioCodec::Aac);
+        .build();
+
+    let mut builder = Pipeline::builder().input(&input).output(&output, config);
 
     if let Some(ref t) = title {
-        enc_builder = enc_builder.metadata("title", t);
+        builder = builder.metadata("title", t);
     }
     if let Some(ref a) = artist {
-        enc_builder = enc_builder.metadata("artist", a);
+        builder = builder.metadata("artist", a);
     }
     if let Some(ref y) = year {
-        enc_builder = enc_builder.metadata("date", y);
+        builder = builder.metadata("date", y);
     }
     for ch in chapters {
-        enc_builder = enc_builder.chapter(ch);
+        builder = builder.chapter(ch);
     }
 
-    let mut enc = match enc_builder.build() {
-        Ok(e) => e,
-        Err(e) => {
+    if let Err(e) = builder
+        .build()
+        .unwrap_or_else(|e| {
             eprintln!("Error: {e}");
             process::exit(1);
-        }
-    };
-
-    // ── Decode → encode loop ──────────────────────────────────────────────────
-
-    let mut frames: u64 = 0;
-    loop {
-        let frame = match vid_dec.decode_one() {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                eprintln!("Error decoding: {e}");
-                process::exit(1);
-            }
-        };
-        if let Err(e) = enc.push_video(&frame) {
-            eprintln!("Error encoding: {e}");
-            process::exit(1);
-        }
-        frames += 1;
-        if frames.is_multiple_of(100) {
-            print!("\r{frames} frames    ");
-            let _ = io::stdout().flush();
-        }
-    }
-
-    if let Err(e) = enc.finish() {
-        println!();
-        eprintln!("Error finishing: {e}");
+        })
+        .run()
+    {
+        eprintln!("Error: {e}");
         process::exit(1);
     }
-
-    println!();
 
     let size_str = match std::fs::metadata(&output) {
         #[allow(clippy::cast_precision_loss)]
@@ -274,6 +244,6 @@ fn main() {
         Err(_) => "(unknown size)".to_string(),
     };
 
-    println!("Done. {out_name}  {size_str}  {frames} frames");
+    println!("Done. {out_name}  {size_str}");
     println!("Verify with: cargo run --example probe_info -- {out_name}");
 }

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use ff_decode::{AudioDecoder, ImageDecoder, VideoDecoder};
 use ff_encode::{BitrateMode, HardwareEncoder, VideoEncoder};
 use ff_filter::{FilterGraph, HwAccel};
-use ff_format::{AudioCodec, Timestamp, VideoCodec};
+use ff_format::{AudioCodec, ChapterInfo, Timestamp, VideoCodec};
 
 use crate::error::PipelineError;
 use crate::progress::{Progress, ProgressCallback};
@@ -162,6 +162,8 @@ pub struct Pipeline {
     filter: Option<FilterGraph>,
     output: Option<(String, EncoderConfig)>,
     callback: Option<ProgressCallback>,
+    metadata: Vec<(String, String)>,
+    chapters: Vec<ChapterInfo>,
 }
 
 impl Pipeline {
@@ -252,6 +254,13 @@ impl Pipeline {
             enc_builder = enc_builder
                 .audio(sample_rate, channels)
                 .audio_codec(enc_config.audio_codec);
+        }
+
+        for (key, value) in self.metadata {
+            enc_builder = enc_builder.metadata(&key, &value);
+        }
+        for chapter in self.chapters {
+            enc_builder = enc_builder.chapter(chapter);
         }
 
         let mut encoder = enc_builder.build()?;
@@ -434,6 +443,8 @@ pub struct PipelineBuilder {
     filter: Option<FilterGraph>,
     output: Option<(String, EncoderConfig)>,
     callback: Option<ProgressCallback>,
+    metadata: Vec<(String, String)>,
+    chapters: Vec<ChapterInfo>,
 }
 
 impl PipelineBuilder {
@@ -446,6 +457,8 @@ impl PipelineBuilder {
             filter: None,
             output: None,
             callback: None,
+            metadata: Vec::new(),
+            chapters: Vec::new(),
         }
     }
 
@@ -510,6 +523,26 @@ impl PipelineBuilder {
         }
     }
 
+    /// Embed a metadata tag in the output container.
+    ///
+    /// Calls `av_dict_set` on `AVFormatContext->metadata` before the header
+    /// is written. Multiple calls accumulate entries; duplicate keys use the
+    /// last value.
+    #[must_use]
+    pub fn metadata(mut self, key: &str, value: &str) -> Self {
+        self.metadata.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// Add a chapter marker to the output container.
+    ///
+    /// Multiple calls accumulate chapters in the order added.
+    #[must_use]
+    pub fn chapter(mut self, chapter: ChapterInfo) -> Self {
+        self.chapters.push(chapter);
+        self
+    }
+
     /// Sets the output file path and encoder configuration.
     #[must_use]
     pub fn output(mut self, path: &str, config: EncoderConfig) -> Self {
@@ -552,6 +585,8 @@ impl PipelineBuilder {
             filter: self.filter,
             output: self.output,
             callback: self.callback,
+            metadata: self.metadata,
+            chapters: self.chapters,
         })
     }
 }
@@ -666,6 +701,47 @@ mod tests {
             .filter_opt(None)
             .build();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn metadata_should_accumulate_key_value_pairs() {
+        let builder = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .output("/tmp/out.mp4", dummy_config())
+            .metadata("title", "My Video")
+            .metadata("artist", "Author");
+        assert_eq!(builder.metadata.len(), 2);
+        assert_eq!(
+            builder.metadata[0],
+            ("title".to_string(), "My Video".to_string())
+        );
+        assert_eq!(
+            builder.metadata[1],
+            ("artist".to_string(), "Author".to_string())
+        );
+    }
+
+    #[test]
+    fn chapter_should_append_chapter_info() {
+        use std::time::Duration;
+        let ch = ChapterInfo::builder()
+            .id(0)
+            .title("Intro")
+            .start(Duration::ZERO)
+            .end(Duration::from_secs(10))
+            .build();
+        let builder = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .output("/tmp/out.mp4", dummy_config())
+            .chapter(ch);
+        assert_eq!(builder.chapters.len(), 1);
+    }
+
+    #[test]
+    fn metadata_and_chapters_should_be_empty_by_default() {
+        let builder = Pipeline::builder();
+        assert!(builder.metadata.is_empty());
+        assert!(builder.chapters.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `.metadata(key, value)` and `.chapter(ChapterInfo)` setters to `PipelineBuilder`, closing the gap that forced users to abandon `Pipeline` and write a manual decode→encode loop just to embed container metadata or chapter markers. Both setters accumulate entries that are forwarded to `VideoEncoderBuilder` before the encoder is built in `Pipeline::run()`.

## Changes

- `crates/ff-pipeline/src/pipeline.rs`
  - Import `ChapterInfo` from `ff_format`
  - Add `metadata: Vec<(String, String)>` and `chapters: Vec<ChapterInfo>` fields to `Pipeline` and `PipelineBuilder`
  - Add `.metadata(key, value)` and `.chapter(chapter)` consuming setters on `PipelineBuilder` (placed after `filter_opt`, before `output`)
  - Forward both fields through `build()` into `Pipeline`
  - In `run()`, loop over `self.metadata` and `self.chapters` to forward them to `enc_builder` before `.build()`
  - Add three unit tests: `metadata_should_accumulate_key_value_pairs`, `chapter_should_append_chapter_info`, `metadata_and_chapters_should_be_empty_by_default`
- `crates/avio/examples/write_metadata.rs`
  - Replace `VideoEncoder` + manual decode→encode loop (~50 lines) with a `Pipeline::builder()` chain
  - Update imports accordingly; simplify done message to file size only

## Related Issues

Closes #542

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes