### PR TITLE
feat(ff-pipeline): add two-pass encoding support to PipelineBuilder

### DIFF
--- a/crates/avio/examples/two_pass_encode.rs
+++ b/crates/avio/examples/two_pass_encode.rs
@@ -19,14 +19,9 @@
 //!   --bitrate 4000000     # target bitrate in bps (required)
 //! ```
 
-use std::{
-    io::{self, Write as _},
-    path::Path,
-    process,
-    time::Instant,
-};
+use std::{path::Path, process};
 
-use avio::{BitrateMode, VideoCodec, VideoDecoder, VideoEncoder};
+use avio::{BitrateMode, EncoderConfig, Pipeline, VideoCodec, VideoDecoder};
 
 fn format_bitrate(bps: u64) -> String {
     // Insert non-breaking spaces every 3 digits for readability.
@@ -38,12 +33,6 @@ fn format_bitrate(bps: u64) -> String {
         i = i.saturating_sub(3);
     }
     chars.into_iter().collect::<String>() + " kbps"
-}
-
-fn format_elapsed(d: std::time::Duration) -> String {
-    let s = d.as_secs();
-    let m = s / 60;
-    format!("{:02}:{:02}", m, s % 60)
 }
 
 fn main() {
@@ -92,7 +81,6 @@ fn main() {
 
     let src_w = probe.width();
     let src_h = probe.height();
-    let fps = probe.frame_rate();
     let in_codec = probe.stream_info().codec_name().to_string();
     let dur = probe.duration();
     drop(probe); // release file handle before encoding
@@ -121,68 +109,27 @@ fn main() {
     println!();
     println!("Encoding (both passes handled internally)...");
 
-    // ── Build encoder (two-pass, video-only) ─────────────────────────────────
-    //
-    // `.two_pass()` is incompatible with audio streams — the encoder buffers
-    // all video frames on the first internal pass (analysis), then re-encodes
-    // them with the accumulated statistics on the second pass when `finish()`
-    // is called.
+    // ── Run pipeline ──────────────────────────────────────────────────────────
 
-    let mut enc = match VideoEncoder::create(&output)
-        .video(src_w, src_h, fps)
+    let config = EncoderConfig::builder()
         .video_codec(VideoCodec::H264)
         .bitrate_mode(BitrateMode::Cbr(bitrate))
+        .build();
+
+    if let Err(e) = Pipeline::builder()
+        .input(&input)
+        .output(&output, config)
         .two_pass()
         .build()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        })
+        .run()
     {
-        Ok(e) => e,
-        Err(e) => {
-            eprintln!("Error: {e}");
-            process::exit(1);
-        }
-    };
-
-    // ── Decode → encode loop ──────────────────────────────────────────────────
-
-    let mut dec = match VideoDecoder::open(&input).build() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("Error: {e}");
-            process::exit(1);
-        }
-    };
-
-    let start = Instant::now();
-    let mut frames: u64 = 0;
-
-    loop {
-        let frame = match dec.decode_one() {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                eprintln!("Error decoding: {e}");
-                process::exit(1);
-            }
-        };
-        if let Err(e) = enc.push_video(&frame) {
-            eprintln!("Error encoding: {e}");
-            process::exit(1);
-        }
-        frames += 1;
-        if frames.is_multiple_of(100) {
-            print!("\r{frames} frames    ");
-            let _ = io::stdout().flush();
-        }
-    }
-
-    // `finish()` triggers the second pass internally when `two_pass` is set.
-    if let Err(e) = enc.finish() {
-        println!();
-        eprintln!("Error finishing: {e}");
+        eprintln!("Error: {e}");
         process::exit(1);
     }
-
-    println!();
 
     let size_str = match std::fs::metadata(&output) {
         #[allow(clippy::cast_precision_loss)]
@@ -190,8 +137,5 @@ fn main() {
         Err(_) => "(unknown size)".to_string(),
     };
 
-    println!(
-        "Done. {out_name}  {size_str}  {frames} frames  {}",
-        format_elapsed(start.elapsed())
-    );
+    println!("Done. {out_name}  {size_str}");
 }

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -164,6 +164,7 @@ pub struct Pipeline {
     callback: Option<ProgressCallback>,
     metadata: Vec<(String, String)>,
     chapters: Vec<ChapterInfo>,
+    two_pass: bool,
 }
 
 impl Pipeline {
@@ -242,6 +243,15 @@ impl Pipeline {
             }
         };
 
+        // Two-pass encoding is video-only; suppress audio when the flag is set.
+        let run_audio = !self.two_pass;
+        if self.two_pass && audio_config.is_some() {
+            log::warn!(
+                "two-pass encoding is video-only; audio stream will be skipped \
+                 path={first_input}"
+            );
+        }
+
         // Build encoder, adding audio track only when the first input has audio.
         let hw = hwaccel_to_hardware_encoder(enc_config.hardware);
         let mut enc_builder = VideoEncoder::create(&out_path)
@@ -250,10 +260,14 @@ impl Pipeline {
             .bitrate_mode(enc_config.bitrate_mode)
             .hardware_encoder(hw);
 
-        if let Some((sample_rate, channels)) = audio_config {
+        if run_audio && let Some((sample_rate, channels)) = audio_config {
             enc_builder = enc_builder
                 .audio(sample_rate, channels)
                 .audio_codec(enc_config.audio_codec);
+        }
+
+        if self.two_pass {
+            enc_builder = enc_builder.two_pass();
         }
 
         for (key, value) in self.metadata {
@@ -366,7 +380,7 @@ impl Pipeline {
         }
 
         // Audio pass: process each input sequentially, rebasing timestamps.
-        if !cancelled && audio_config.is_some() {
+        if !cancelled && run_audio && audio_config.is_some() {
             let mut audio_offset_secs: f64 = 0.0;
             for input in &self.inputs {
                 match AudioDecoder::open(input).build() {
@@ -445,6 +459,7 @@ pub struct PipelineBuilder {
     callback: Option<ProgressCallback>,
     metadata: Vec<(String, String)>,
     chapters: Vec<ChapterInfo>,
+    two_pass: bool,
 }
 
 impl PipelineBuilder {
@@ -459,6 +474,7 @@ impl PipelineBuilder {
             callback: None,
             metadata: Vec::new(),
             chapters: Vec::new(),
+            two_pass: false,
         }
     }
 
@@ -543,6 +559,17 @@ impl PipelineBuilder {
         self
     }
 
+    /// Enable two-pass encoding for more accurate bitrate control at a given file size.
+    ///
+    /// Two-pass encoding is video-only; any audio stream present in the input is
+    /// silently skipped when this flag is set.  Requires [`BitrateMode::Cbr`] or
+    /// [`BitrateMode::Vbr`] on the [`EncoderConfig`].
+    #[must_use]
+    pub fn two_pass(mut self) -> Self {
+        self.two_pass = true;
+        self
+    }
+
     /// Sets the output file path and encoder configuration.
     #[must_use]
     pub fn output(mut self, path: &str, config: EncoderConfig) -> Self {
@@ -587,6 +614,7 @@ impl PipelineBuilder {
             callback: self.callback,
             metadata: self.metadata,
             chapters: self.chapters,
+            two_pass: self.two_pass,
         })
     }
 }
@@ -742,6 +770,31 @@ mod tests {
         let builder = Pipeline::builder();
         assert!(builder.metadata.is_empty());
         assert!(builder.chapters.is_empty());
+    }
+
+    #[test]
+    fn two_pass_flag_should_default_to_false() {
+        let builder = Pipeline::builder();
+        assert!(!builder.two_pass);
+    }
+
+    #[test]
+    fn two_pass_should_set_flag() {
+        let builder = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .output("/tmp/out.mp4", dummy_config())
+            .two_pass();
+        assert!(builder.two_pass);
+    }
+
+    #[test]
+    fn two_pass_should_not_prevent_successful_build() {
+        let result = Pipeline::builder()
+            .input("/tmp/in.mp4")
+            .output("/tmp/out.mp4", dummy_config())
+            .two_pass()
+            .build();
+        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `.two_pass()` to `PipelineBuilder`, allowing users to enable two-pass CBR/VBR encoding without writing a manual decode loop. The flag is forwarded through `Pipeline::run()` to `VideoEncoderBuilder::two_pass()`. Because two-pass is video-only, audio is suppressed when the flag is set (with a `warn`-level log when audio was present). The `two_pass_encode` example is simplified from ~50 lines of manual decode loop to a single `Pipeline` builder chain.

## Changes

- `Pipeline` and `PipelineBuilder`: add `two_pass: bool` field (defaults to `false`)
- `PipelineBuilder::two_pass()`: consuming setter, documented with bitrate-mode requirement
- `Pipeline::run()`: compute `run_audio = !self.two_pass`; warn and skip audio config when two-pass is active; call `enc_builder.two_pass()` when set; guard the audio decode pass behind `run_audio`
- Three new unit tests: `two_pass_flag_should_default_to_false`, `two_pass_should_set_flag`, `two_pass_should_not_prevent_successful_build`
- `crates/avio/examples/two_pass_encode.rs`: replace manual `VideoEncoder` + decode loop with `Pipeline`

## Related Issues

Closes #543

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes