### PR TITLE
feat(ff-pipeline): add VideoPipeline for video-only transcoding

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -100,5 +100,9 @@ required-features = ["decode", "encode"]
 name = "hw_transcode"
 required-features = ["pipeline"]
 
+[[example]]
+name = "video_transcode"
+required-features = ["pipeline", "encode"]
+
 [lints]
 workspace = true

--- a/crates/avio/examples/video_transcode.rs
+++ b/crates/avio/examples/video_transcode.rs
@@ -1,0 +1,124 @@
+//! Decode a video file and re-encode it (video only) to a different codec or quality.
+//!
+//! Demonstrates the video-only decode → encode pipeline using `VideoPipeline`
+//! — a high-level builder that wraps the manual decode/encode loop.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example video_transcode -- \
+//!   --input   input.mp4   \
+//!   --output  output.mp4  \
+//!   [--crf    23]          # CRF quality value (default: 23)
+//!   [--bitrate 4000000]    # target CBR bitrate in bps (overrides --crf)
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{BitrateMode, VideoCodecEncodeExt};
+use avio::{VideoCodec, VideoDecoder, VideoPipeline};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut crf: u32 = 23;
+    let mut bitrate: Option<u64> = None;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--crf" => {
+                let v = args.next().unwrap_or_default();
+                crf = v.parse().unwrap_or(23);
+            }
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().ok();
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: video_transcode --input <file> --output <file> \
+             [--crf N] [--bitrate N]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Probe input for display info ──────────────────────────────────────────
+
+    let dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    let width = dec.width();
+    let height = dec.height();
+    let fps = dec.frame_rate();
+    let in_codec = dec.stream_info().codec_name().to_string();
+    drop(dec);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    let out_codec = VideoCodec::H264;
+    let bmode = match bitrate {
+        Some(bps) => BitrateMode::Cbr(bps),
+        None => BitrateMode::Crf(crf),
+    };
+    let quality_str = match &bmode {
+        BitrateMode::Cbr(bps) => format!("bitrate={bps}"),
+        BitrateMode::Crf(q) => format!("crf={q}"),
+        BitrateMode::Vbr { .. } => "custom".to_string(),
+    };
+
+    println!("Input:   {in_name}  {width}x{height}  {fps:.2} fps  {in_codec}");
+    println!(
+        "Output:  {out_name}  {width}x{height}  {fps:.2} fps  {}  {quality_str}",
+        out_codec.default_extension()
+    );
+    println!();
+    println!("Encoding (video only)...");
+
+    // ── Run pipeline ──────────────────────────────────────────────────────────
+
+    if let Err(e) = VideoPipeline::new()
+        .input(&input)
+        .output(&output)
+        .video_codec(out_codec)
+        .bitrate_mode(bmode)
+        .mute()
+        .run()
+    {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}");
+}

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -88,7 +88,7 @@ pub use ff_filter::{FilterError, FilterGraph, FilterGraphBuilder, HwAccel, ToneM
 #[cfg(feature = "pipeline")]
 pub use ff_pipeline::{
     AudioPipeline, EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder, PipelineError,
-    Progress, ProgressCallback, ThumbnailPipeline,
+    Progress, ProgressCallback, ThumbnailPipeline, VideoPipeline,
 };
 
 // ── stream feature ────────────────────────────────────────────────────────────

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -46,6 +46,7 @@
 //! - [`pipeline`] — [`Pipeline`], [`PipelineBuilder`], [`EncoderConfig`]
 //! - [`progress`] — [`Progress`], [`ProgressCallback`]
 //! - [`thumbnail`] — [`ThumbnailPipeline`]
+//! - [`video_pipeline`] — [`VideoPipeline`]
 
 #![warn(missing_docs)]
 
@@ -54,9 +55,11 @@ pub mod error;
 pub mod pipeline;
 pub mod progress;
 pub mod thumbnail;
+pub mod video_pipeline;
 
 pub use audio_pipeline::AudioPipeline;
 pub use error::PipelineError;
 pub use pipeline::{EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder};
 pub use progress::{Progress, ProgressCallback};
 pub use thumbnail::ThumbnailPipeline;
+pub use video_pipeline::VideoPipeline;

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -438,7 +438,7 @@ impl Pipeline {
 ///
 /// `HwAccel` (ff-filter) and `HardwareEncoder` (ff-encode) are separate types
 /// to avoid a cross-crate dependency.  This function maps between them.
-fn hwaccel_to_hardware_encoder(hw: Option<HwAccel>) -> HardwareEncoder {
+pub(crate) fn hwaccel_to_hardware_encoder(hw: Option<HwAccel>) -> HardwareEncoder {
     match hw {
         None => HardwareEncoder::None,
         Some(HwAccel::Cuda) => HardwareEncoder::Nvenc,

--- a/crates/ff-pipeline/src/video_pipeline.rs
+++ b/crates/ff-pipeline/src/video_pipeline.rs
@@ -1,0 +1,339 @@
+//! Video-only transcoding pipeline.
+//!
+//! This module provides [`VideoPipeline`], which wraps the
+//! `VideoDecoder` → `VideoEncoder` decode/encode loop behind a
+//! single high-level builder API.  It mirrors the design of
+//! [`AudioPipeline`](crate::AudioPipeline) but targets video-only
+//! output and supports multi-input concatenation.
+
+use std::time::Instant;
+
+use ff_decode::VideoDecoder;
+use ff_encode::{BitrateMode, VideoEncoder};
+use ff_filter::HwAccel;
+use ff_format::{Timestamp, VideoCodec};
+
+use crate::error::PipelineError;
+use crate::pipeline::hwaccel_to_hardware_encoder;
+use crate::progress::{Progress, ProgressCallback};
+
+/// High-level video-only transcode pipeline.
+///
+/// Audio is never encoded; this pipeline always produces video-only output.
+/// Calling [`.mute()`](Self::mute) makes that intent explicit in code, but
+/// is otherwise a no-op.
+///
+/// # Construction
+///
+/// Use the consuming builder pattern:
+///
+/// ```ignore
+/// use ff_pipeline::VideoPipeline;
+/// use ff_format::VideoCodec;
+/// use ff_encode::BitrateMode;
+///
+/// VideoPipeline::new()
+///     .input("input.mp4")
+///     .output("output.mp4")
+///     .video_codec(VideoCodec::H265)
+///     .bitrate_mode(BitrateMode::Crf(28))
+///     .mute()
+///     .run()?;
+/// ```
+pub struct VideoPipeline {
+    inputs: Vec<String>,
+    output: Option<String>,
+    video_codec: VideoCodec,
+    resolution: Option<(u32, u32)>,
+    framerate: Option<f64>,
+    bitrate_mode: BitrateMode,
+    /// Declarative marker — this pipeline always produces video-only output;
+    /// calling `.mute()` makes the intent explicit in code.
+    mute: bool,
+    hardware: Option<HwAccel>,
+    callback: Option<ProgressCallback>,
+}
+
+impl Default for VideoPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VideoPipeline {
+    /// Creates a new pipeline with default settings (H.264 codec, CRF 23, software encoding).
+    pub fn new() -> Self {
+        Self {
+            inputs: Vec::new(),
+            output: None,
+            video_codec: VideoCodec::H264,
+            resolution: None,
+            framerate: None,
+            bitrate_mode: BitrateMode::Crf(23),
+            mute: false,
+            hardware: None,
+            callback: None,
+        }
+    }
+
+    /// Appends an input file path.
+    ///
+    /// Multiple inputs are concatenated in order.
+    #[must_use]
+    pub fn input(mut self, path: &str) -> Self {
+        self.inputs.push(path.to_owned());
+        self
+    }
+
+    /// Sets the output file path.
+    #[must_use]
+    pub fn output(mut self, path: &str) -> Self {
+        self.output = Some(path.to_owned());
+        self
+    }
+
+    /// Sets the video codec for the output.
+    #[must_use]
+    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
+        self.video_codec = codec;
+        self
+    }
+
+    /// Sets the output resolution in pixels.
+    ///
+    /// Defaults to the source resolution when not set.
+    #[must_use]
+    pub fn resolution(mut self, width: u32, height: u32) -> Self {
+        self.resolution = Some((width, height));
+        self
+    }
+
+    /// Sets the output frame rate in frames per second.
+    ///
+    /// Defaults to the source frame rate when not set.
+    #[must_use]
+    pub fn framerate(mut self, fps: f64) -> Self {
+        self.framerate = Some(fps);
+        self
+    }
+
+    /// Sets the bitrate control mode (CBR, VBR, or CRF).
+    #[must_use]
+    pub fn bitrate_mode(mut self, mode: BitrateMode) -> Self {
+        self.bitrate_mode = mode;
+        self
+    }
+
+    /// Declarative marker — this pipeline always produces video-only output;
+    /// calling `.mute()` makes the intent explicit in code.
+    #[must_use]
+    pub fn mute(mut self) -> Self {
+        self.mute = true;
+        self
+    }
+
+    /// Sets the hardware acceleration backend.
+    #[must_use]
+    pub fn hardware(mut self, hw: HwAccel) -> Self {
+        self.hardware = Some(hw);
+        self
+    }
+
+    /// Registers a progress callback.
+    ///
+    /// The closure receives a [`Progress`] reference on each encoded frame
+    /// and must return `true` to continue or `false` to cancel the pipeline.
+    #[must_use]
+    pub fn on_progress(mut self, cb: impl Fn(&Progress) -> bool + Send + 'static) -> Self {
+        self.callback = Some(Box::new(cb));
+        self
+    }
+
+    /// Runs the pipeline: decodes all inputs in sequence and encodes to output (video only).
+    ///
+    /// # Errors
+    ///
+    /// - [`PipelineError::NoOutput`]  — no output path was set
+    /// - [`PipelineError::NoInput`]   — no input paths were provided
+    /// - [`PipelineError::Decode`]    — a decoding error occurred
+    /// - [`PipelineError::Encode`]    — an encoding error occurred
+    /// - [`PipelineError::Cancelled`] — the progress callback returned `false`
+    pub fn run(mut self) -> Result<(), PipelineError> {
+        let out_path = self.output.take().ok_or(PipelineError::NoOutput)?;
+
+        if self.inputs.is_empty() {
+            return Err(PipelineError::NoInput);
+        }
+
+        let num_inputs = self.inputs.len();
+
+        // Open the first input to determine output dimensions and frame rate.
+        let first_vdec = VideoDecoder::open(&self.inputs[0]).build()?;
+        let (out_w, out_h) = self
+            .resolution
+            .unwrap_or_else(|| (first_vdec.width(), first_vdec.height()));
+        let fps = self.framerate.unwrap_or_else(|| first_vdec.frame_rate());
+
+        // total_frames is only meaningful for single-input pipelines.
+        let total_frames = if num_inputs == 1 {
+            first_vdec.stream_info().frame_count()
+        } else {
+            None
+        };
+
+        log::info!(
+            "video pipeline starting inputs={num_inputs} output={out_path} \
+             width={out_w} height={out_h} fps={fps} total_frames={total_frames:?}"
+        );
+
+        let hw = hwaccel_to_hardware_encoder(self.hardware);
+        let mut encoder = VideoEncoder::create(&out_path)
+            .video(out_w, out_h, fps)
+            .video_codec(self.video_codec)
+            .bitrate_mode(self.bitrate_mode)
+            .hardware_encoder(hw)
+            .build()?;
+
+        let start = Instant::now();
+        let mut frames_processed: u64 = 0;
+        let mut cancelled = false;
+        let frame_period_secs = if fps > 0.0 { 1.0 / fps } else { 0.0 };
+
+        // PTS offset in seconds: accumulates the duration of all processed inputs.
+        let mut pts_offset_secs: f64 = 0.0;
+
+        // Reuse the already-opened first decoder; open fresh decoders for subsequent inputs.
+        let mut maybe_first_vdec = Some(first_vdec);
+
+        'inputs: for input in &self.inputs {
+            let mut vdec = if let Some(vd) = maybe_first_vdec.take() {
+                vd
+            } else {
+                VideoDecoder::open(input).build()?
+            };
+
+            let mut last_frame_end_secs: f64 = pts_offset_secs;
+
+            loop {
+                let Some(mut raw_frame) = vdec.decode_one()? else {
+                    break;
+                };
+
+                // Rebase timestamp so this clip follows the previous one.
+                let ts = raw_frame.timestamp();
+                let new_pts_secs = pts_offset_secs + ts.as_secs_f64();
+                last_frame_end_secs = new_pts_secs + frame_period_secs;
+                raw_frame.set_timestamp(Timestamp::from_secs_f64(new_pts_secs, ts.time_base()));
+
+                encoder.push_video(&raw_frame)?;
+                frames_processed += 1;
+
+                if let Some(ref cb) = self.callback {
+                    let progress = Progress {
+                        frames_processed,
+                        total_frames,
+                        elapsed: start.elapsed(),
+                    };
+                    if !cb(&progress) {
+                        log::info!(
+                            "video pipeline cancelled by callback \
+                             frames_processed={frames_processed}"
+                        );
+                        cancelled = true;
+                        break 'inputs;
+                    }
+                }
+            }
+
+            // Advance PTS offset to the end of the last frame of this input.
+            pts_offset_secs = last_frame_end_secs;
+            log::debug!("input complete path={input} pts_offset_secs={pts_offset_secs:.3}");
+        }
+
+        encoder.finish()?;
+
+        let elapsed = start.elapsed();
+        log::info!(
+            "video pipeline finished frames_processed={frames_processed} elapsed={elapsed:?}"
+        );
+
+        if cancelled {
+            return Err(PipelineError::Cancelled);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_encode::BitrateMode;
+    use ff_format::VideoCodec;
+
+    #[test]
+    fn new_should_have_default_h264_codec() {
+        let p = VideoPipeline::new();
+        assert_eq!(p.video_codec, VideoCodec::H264);
+    }
+
+    #[test]
+    fn new_should_have_default_crf_23_bitrate_mode() {
+        let p = VideoPipeline::new();
+        assert!(matches!(p.bitrate_mode, BitrateMode::Crf(23)));
+    }
+
+    #[test]
+    fn input_should_append_to_inputs() {
+        let p = VideoPipeline::new().input("a.mp4").input("b.mp4");
+        assert_eq!(p.inputs, vec!["a.mp4", "b.mp4"]);
+    }
+
+    #[test]
+    fn output_should_store_path() {
+        let p = VideoPipeline::new().output("out.mp4");
+        assert_eq!(p.output.as_deref(), Some("out.mp4"));
+    }
+
+    #[test]
+    fn video_codec_should_store_value() {
+        let p = VideoPipeline::new().video_codec(VideoCodec::H265);
+        assert_eq!(p.video_codec, VideoCodec::H265);
+    }
+
+    #[test]
+    fn resolution_should_store_value() {
+        let p = VideoPipeline::new().resolution(1920, 1080);
+        assert_eq!(p.resolution, Some((1920, 1080)));
+    }
+
+    #[test]
+    fn framerate_should_store_value() {
+        let p = VideoPipeline::new().framerate(60.0);
+        assert_eq!(p.framerate, Some(60.0));
+    }
+
+    #[test]
+    fn mute_should_set_flag() {
+        let p = VideoPipeline::new().mute();
+        assert!(p.mute);
+    }
+
+    #[test]
+    fn hardware_should_store_value() {
+        let p = VideoPipeline::new().hardware(HwAccel::Cuda);
+        assert_eq!(p.hardware, Some(HwAccel::Cuda));
+    }
+
+    #[test]
+    fn run_with_no_output_should_return_no_output_error() {
+        let result = VideoPipeline::new().input("x.mp4").run();
+        assert!(matches!(result, Err(PipelineError::NoOutput)));
+    }
+
+    #[test]
+    fn run_with_no_inputs_should_return_no_input_error() {
+        let result = VideoPipeline::new().output("out.mp4").run();
+        assert!(matches!(result, Err(PipelineError::NoInput)));
+    }
+}

--- a/crates/ff-pipeline/tests/video_pipeline_tests.rs
+++ b/crates/ff-pipeline/tests/video_pipeline_tests.rs
@@ -1,0 +1,54 @@
+//! Integration tests for `VideoPipeline`.
+//!
+//! These tests call the real FFmpeg API and are skipped gracefully when the
+//! required codecs are unavailable or the test asset is missing.
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use ff_pipeline::{PipelineError, VideoPipeline};
+use fixtures::{FileGuard, test_output_path, test_video_path};
+
+#[test]
+fn video_pipeline_should_produce_valid_output_file() {
+    let input = test_video_path();
+    if !input.exists() {
+        println!("Skipping: test asset not found at {input:?}");
+        return;
+    }
+
+    let out_path = test_output_path("video_pipeline_out.mp4");
+    let _guard = FileGuard::new(out_path.clone());
+
+    let result = VideoPipeline::new()
+        .input(input.to_str().unwrap())
+        .output(out_path.to_str().unwrap())
+        .mute()
+        .run();
+
+    match result {
+        Ok(()) => {
+            assert!(out_path.exists(), "output file should exist");
+            assert!(
+                out_path.metadata().unwrap().len() > 0,
+                "output file should be non-empty"
+            );
+        }
+        Err(PipelineError::Decode(e)) => println!("Skipping: decoder unavailable: {e}"),
+        Err(PipelineError::Encode(e)) => println!("Skipping: encoder unavailable: {e}"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn video_pipeline_with_no_output_should_return_no_output_error() {
+    let result = VideoPipeline::new().input("in.mp4").run();
+    assert!(matches!(result, Err(PipelineError::NoOutput)));
+}
+
+#[test]
+fn video_pipeline_with_no_inputs_should_return_no_input_error() {
+    let result = VideoPipeline::new().output("out.mp4").run();
+    assert!(matches!(result, Err(PipelineError::NoInput)));
+}


### PR DESCRIPTION
## Summary

Adds `VideoPipeline`, a high-level builder that wraps the VideoDecoder → VideoEncoder loop for video-only output — the symmetric counterpart to `AudioPipeline`. Audio is always skipped; `.mute()` is a declarative no-op that makes intent explicit in calling code. Supports multi-input concatenation, hardware acceleration, CRF/CBR/VBR bitrate modes, resolution and framerate overrides, and progress callbacks with cancellation.

## Changes

- **`crates/ff-pipeline/src/video_pipeline.rs`** (new): `VideoPipeline` struct with consuming builder setters (`input`, `output`, `video_codec`, `resolution`, `framerate`, `bitrate_mode`, `mute`, `hardware`, `on_progress`), `run()` with PTS-rebasing multi-input loop, and 11 unit tests
- **`crates/ff-pipeline/src/pipeline.rs`**: expose `hwaccel_to_hardware_encoder` as `pub(crate)` so `VideoPipeline` can reuse it
- **`crates/ff-pipeline/src/lib.rs`**: add `pub mod video_pipeline` and re-export `VideoPipeline`
- **`crates/avio/src/lib.rs`**: re-export `VideoPipeline` under the `pipeline` feature
- **`crates/avio/Cargo.toml`**: add `[[example]]` entry for `video_transcode` with `required-features = ["pipeline", "encode"]`
- **`crates/avio/examples/video_transcode.rs`** (new): CLI example with `--input`, `--output`, `--crf`, `--bitrate` flags
- **`crates/ff-pipeline/tests/video_pipeline_tests.rs`** (new): 3 integration tests mirroring `audio_pipeline_tests.rs`

## Related Issues

Closes #551

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes