### PR TITLE
feat(avio/examples): add comprehensive public API coverage examples

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -74,7 +74,7 @@ required-features = ["stream", "probe"]
 
 [[example]]
 name = "audio_transcode"
-required-features = ["decode", "encode"]
+required-features = ["pipeline", "decode", "encode"]
 
 [[example]]
 name = "dash_output"
@@ -90,11 +90,11 @@ required-features = ["pipeline"]
 
 [[example]]
 name = "two_pass_encode"
-required-features = ["decode", "encode"]
+required-features = ["pipeline", "decode", "encode"]
 
 [[example]]
 name = "write_metadata"
-required-features = ["decode", "encode"]
+required-features = ["pipeline", "decode", "encode"]
 
 [[example]]
 name = "hw_transcode"
@@ -103,6 +103,46 @@ required-features = ["pipeline"]
 [[example]]
 name = "video_transcode"
 required-features = ["pipeline", "encode"]
+
+[[example]]
+name = "encode_audio_direct"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "encode_video_direct"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "decode_format_convert"
+required-features = ["decode"]
+
+[[example]]
+name = "filter_direct"
+required-features = ["decode", "encode", "filter"]
+
+[[example]]
+name = "encode_with_progress"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "hardware_decode"
+required-features = ["decode"]
+
+[[example]]
+name = "frame_pool_usage"
+required-features = ["decode"]
+
+[[example]]
+name = "container_format"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "tone_map_hdr"
+required-features = ["pipeline", "probe"]
+
+[[example]]
+name = "decode_iterator"
+required-features = ["decode"]
 
 [lints]
 workspace = true

--- a/crates/avio/examples/container_format.rs
+++ b/crates/avio/examples/container_format.rs
@@ -1,0 +1,176 @@
+//! Encode video with an explicitly selected output container format.
+//!
+//! Demonstrates:
+//! - `Container` enum — `Mp4`, `Mkv`, `WebM`, `Avi`, `Mov`
+//! - `Container::as_str()` — `FFmpeg` format name
+//! - `Container::default_extension()` — canonical file extension
+//! - `VideoEncoderBuilder::container()` — override the container inferred
+//!   from the output file extension
+//!
+//! By default the container is auto-detected from the output extension.
+//! Use `container()` when the extension does not match the desired format
+//! or when you need to guarantee a specific muxer regardless of the path.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example container_format --features "decode encode" -- \
+//!   --input     input.mp4    \
+//!   --output    output.mkv   \
+//!   [--container mp4|mkv|webm|avi|mov]  # default: infer from extension
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{Container, VideoCodec, VideoDecoder, VideoEncoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut container_str: Option<String> = None;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--container" | "-f" => container_str = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: container_format --input <file> --output <file> \
+             [--container mp4|mkv|webm|avi|mov]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Parse Container variant ───────────────────────────────────────────────
+
+    let container = container_str
+        .as_deref()
+        .map(|s| match s.to_lowercase().as_str() {
+            "mp4" => Container::Mp4,
+            "mkv" | "matroska" => Container::Mkv,
+            "webm" => Container::WebM,
+            "avi" => Container::Avi,
+            "mov" => Container::Mov,
+            other => {
+                eprintln!("Unknown container '{other}' (try mp4, mkv, webm, avi, mov)");
+                process::exit(1);
+            }
+        });
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+    let width = probe.width();
+    let height = probe.height();
+    let fps = probe.frame_rate();
+    let in_codec = probe.stream_info().codec_name().to_string();
+    drop(probe);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}  {width}×{height}  {fps:.2} fps  codec={in_codec}");
+
+    match container {
+        Some(c) => println!(
+            "Container: {c:?} (format='{}')  default_ext='{}'",
+            c.as_str(),
+            c.default_extension()
+        ),
+        None => println!("Container: (inferred from output extension)"),
+    }
+
+    println!("Output: {out_name}");
+    println!();
+
+    // ── Build encoder with explicit container ─────────────────────────────────
+    //
+    // .container() overrides the muxer selection.
+    // When omitted, FFmpeg infers the container from the output path extension.
+
+    let mut enc_builder = VideoEncoder::create(&output)
+        .video(width, height, fps)
+        .video_codec(VideoCodec::H264);
+
+    if let Some(c) = container {
+        enc_builder = enc_builder.container(c);
+    }
+
+    let mut encoder = match enc_builder.build() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!("Encoding...");
+
+    // ── Decode + encode loop ──────────────────────────────────────────────────
+
+    let mut decoder = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push_video(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+}

--- a/crates/avio/examples/decode_format_convert.rs
+++ b/crates/avio/examples/decode_format_convert.rs
@@ -1,0 +1,158 @@
+//! Decode video and audio with explicit output format conversion.
+//!
+//! Demonstrates:
+//! - `VideoDecoderBuilder::output_format()` — request a specific pixel format
+//!   (e.g. `PixelFormat::Rgb24` for image-processing pipelines)
+//! - `AudioDecoderBuilder::output_format()` — request a specific sample format
+//!   (e.g. `SampleFormat::I16` for audio mixing / playback)
+//! - `AudioDecoderBuilder::output_sample_rate()` — resample to a target rate
+//!
+//! `FFmpeg` performs the conversion automatically inside the decoder; the caller
+//! simply requests the desired format and receives already-converted frames.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example decode_format_convert --features decode -- \
+//!   --input input.mp4
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{AudioDecoder, PixelFormat, SampleFormat, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: decode_format_convert --input <file>");
+        process::exit(1);
+    });
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input: {in_name}");
+    println!();
+
+    // ── Video: decode to RGB24 ────────────────────────────────────────────────
+    //
+    // output_format() instructs FFmpeg to convert the decoded frame to the
+    // requested pixel format before returning it. This avoids a separate
+    // swscale call in user code.
+    //
+    // Common targets:
+    //   PixelFormat::Rgb24   — packed RGB for image processing / display
+    //   PixelFormat::Rgba    — packed RGBA for compositing
+    //   PixelFormat::Yuv420p — planar YUV for software encoders
+
+    println!("=== Video: output_format(PixelFormat::Rgb24) ===");
+
+    let mut vdec = match VideoDecoder::open(&input)
+        .output_format(PixelFormat::Rgb24)
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Skipping video: {e}");
+            return;
+        }
+    };
+
+    let src_w = vdec.width();
+    let src_h = vdec.height();
+    println!(
+        "Source:   {src_w}×{src_h}  codec={}",
+        vdec.stream_info().codec_name()
+    );
+
+    match vdec.decode_one() {
+        Ok(Some(frame)) => {
+            println!(
+                "Frame:    {}×{}  format={}  planes={}  total_bytes={}",
+                frame.width(),
+                frame.height(),
+                frame.format(),
+                frame.num_planes(),
+                frame.total_size(),
+            );
+            // With Rgb24, all pixel data is in a single packed plane.
+            let plane = frame.plane(0);
+            println!(
+                "Plane[0]: stride={}  data_len={}",
+                frame.stride(0).unwrap_or(0),
+                plane.map_or(0, |p| p.len()),
+            );
+        }
+        Ok(None) => println!("No frames in file"),
+        Err(e) => println!("Decode error: {e}"),
+    }
+    println!();
+
+    // ── Audio: decode to I16 at 44 100 Hz ────────────────────────────────────
+    //
+    // output_format(SampleFormat::I16) converts the decoded samples to
+    // signed 16-bit interleaved PCM — the standard format for CD audio,
+    // WAV files, and most playback APIs.
+    //
+    // output_sample_rate() adds a resampler so frames arrive at exactly
+    // the requested rate, regardless of the source file's native rate.
+    //
+    // Common targets:
+    //   SampleFormat::I16  — 16-bit signed PCM (compact, wide support)
+    //   SampleFormat::F32  — 32-bit float (lossless mixing, audio editing)
+    //   SampleFormat::F32p — 32-bit float planar (common FFmpeg decoder output)
+
+    println!("=== Audio: output_format(SampleFormat::I16) + output_sample_rate(44100) ===");
+
+    let mut adec = match AudioDecoder::open(&input)
+        .output_format(SampleFormat::I16)
+        .output_sample_rate(44_100)
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Skipping audio: {e}");
+            return;
+        }
+    };
+
+    println!(
+        "Source:   sample_rate={}  channels={}  codec={}",
+        adec.sample_rate(),
+        adec.channels(),
+        adec.stream_info().codec_name()
+    );
+
+    match adec.decode_one() {
+        Ok(Some(frame)) => {
+            println!(
+                "Frame:    samples={}  channels={}  sample_rate={}  format={}",
+                frame.samples(),
+                frame.channels(),
+                frame.sample_rate(),
+                frame.format(),
+            );
+            let plane = frame.data();
+            println!(
+                "Plane[0]: data_len={}  bytes_per_sample=2",
+                plane.map_or(0, |p| p.len())
+            );
+        }
+        Ok(None) => println!("No audio frames in file"),
+        Err(e) => println!("Decode error: {e}"),
+    }
+}

--- a/crates/avio/examples/decode_iterator.rs
+++ b/crates/avio/examples/decode_iterator.rs
@@ -1,0 +1,172 @@
+//! Decode video, audio, and images using the iterator API.
+//!
+//! Demonstrates:
+//! - `VideoDecoder::frames()` → `VideoFrameIterator` — `for frame in vdec.frames()`
+//! - `AudioDecoder::frames()` → `AudioFrameIterator` — `for frame in adec.frames()`
+//! - `ImageDecoder::frames()` → `ImageFrameIterator` — `for frame in idec.frames()`
+//!
+//! Each decoder exposes `.frames()` which returns an iterator with
+//! `Item = Result<Frame, DecodeError>`. This is an alternative to the manual
+//! `loop { decode_one() }` pattern — it integrates naturally with iterator
+//! adaptors (`take`, `filter_map`, `enumerate`, etc.).
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example decode_iterator --features decode -- \
+//!   --input input.mp4   \
+//!   [--image photo.png]  # optional: also decode a still image
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{AudioDecoder, DecodeError, ImageDecoder, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut image = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--image" => image = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: decode_iterator --input <file> [--image <file>]");
+        process::exit(1);
+    });
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input: {in_name}");
+    println!();
+
+    // ── VideoFrameIterator ────────────────────────────────────────────────────
+    //
+    // VideoDecoder::frames() returns a VideoFrameIterator whose Item is
+    // Result<VideoFrame, DecodeError>.
+    //
+    // The `for` loop terminates when the iterator returns None (EOF).
+    // Errors are surfaced as Err variants inside the loop body.
+
+    println!("=== VideoFrameIterator ===");
+
+    match VideoDecoder::open(&input).build() {
+        Ok(mut vdec) => {
+            println!(
+                "Source: {}×{}  {:.2} fps  codec={}",
+                vdec.width(),
+                vdec.height(),
+                vdec.frame_rate(),
+                vdec.stream_info().codec_name(),
+            );
+
+            let mut video_frames: u64 = 0;
+
+            // Iterator form: no manual `loop { decode_one() }` needed.
+            for result in vdec.frames() {
+                match result {
+                    Ok(_frame) => video_frames += 1,
+                    Err(DecodeError::EndOfStream) => break,
+                    Err(e) => {
+                        eprintln!("Video decode error: {e}");
+                        break;
+                    }
+                }
+            }
+
+            println!("Decoded {video_frames} video frames");
+        }
+        Err(e) => println!("Skipping video: {e}"),
+    }
+
+    println!();
+
+    // ── AudioFrameIterator ────────────────────────────────────────────────────
+    //
+    // AudioDecoder::frames() returns an AudioFrameIterator with
+    // Item = Result<AudioFrame, DecodeError>.
+
+    println!("=== AudioFrameIterator ===");
+
+    match AudioDecoder::open(&input).build() {
+        Ok(mut adec) => {
+            println!(
+                "Source: {} Hz  channels={}  codec={}",
+                adec.sample_rate(),
+                adec.channels(),
+                adec.stream_info().codec_name(),
+            );
+
+            let mut audio_frames: u64 = 0;
+            let mut total_samples: u64 = 0;
+
+            for result in adec.frames() {
+                match result {
+                    Ok(frame) => {
+                        audio_frames += 1;
+                        total_samples += frame.samples() as u64;
+                    }
+                    Err(DecodeError::EndOfStream) => break,
+                    Err(e) => {
+                        eprintln!("Audio decode error: {e}");
+                        break;
+                    }
+                }
+            }
+
+            println!("Decoded {audio_frames} audio frames  ({total_samples} samples)");
+        }
+        Err(e) => println!("Skipping audio (no audio stream): {e}"),
+    }
+
+    // ── ImageFrameIterator ────────────────────────────────────────────────────
+    //
+    // ImageDecoder::frames() returns an ImageFrameIterator with
+    // Item = Result<VideoFrame, DecodeError>.
+    //
+    // For a still image exactly one frame is expected.
+
+    if let Some(ref img_path) = image {
+        println!();
+        let img_name = Path::new(img_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(img_path.as_str());
+
+        println!("=== ImageFrameIterator ({img_name}) ===");
+
+        match ImageDecoder::open(img_path).build() {
+            Ok(mut idec) => {
+                for result in idec.frames() {
+                    match result {
+                        Ok(frame) => {
+                            println!(
+                                "Frame: {}×{}  format={}",
+                                frame.width(),
+                                frame.height(),
+                                frame.format(),
+                            );
+                        }
+                        Err(DecodeError::EndOfStream) => break,
+                        Err(e) => {
+                            eprintln!("Image decode error: {e}");
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(e) => println!("Skipping image: {e}"),
+        }
+    }
+}

--- a/crates/avio/examples/encode_audio_direct.rs
+++ b/crates/avio/examples/encode_audio_direct.rs
@@ -1,0 +1,168 @@
+//! Encode audio directly using `AudioEncoder` without the pipeline abstraction.
+//!
+//! Demonstrates the low-level encode loop:
+//! `AudioDecoder` → `AudioEncoder::create()` → `push()` → `finish()`.
+//! This gives full frame-level control over the encode process.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example encode_audio_direct --features "decode encode" -- \
+//!   --input   input.mp3   \
+//!   --output  output.aac  \
+//!   [--codec  aac]        # aac | mp3 | opus | flac (default: aac)
+//!   [--bitrate 192000]    # target bitrate in bps (default: 192000)
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{AudioCodec, AudioDecoder, AudioEncoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut codec_str = "aac".to_string();
+    let mut bitrate: u64 = 192_000;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--codec" | "-c" => codec_str = args.next().unwrap_or_else(|| "aac".to_string()),
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().unwrap_or(192_000);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: encode_audio_direct --input <file> --output <file> \
+             [--codec aac|mp3|opus|flac] [--bitrate N]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    let codec = match codec_str.to_lowercase().as_str() {
+        "aac" => AudioCodec::Aac,
+        "mp3" => AudioCodec::Mp3,
+        "opus" => AudioCodec::Opus,
+        "flac" => AudioCodec::Flac,
+        other => {
+            eprintln!("Unknown codec '{other}' (try aac, mp3, opus, flac)");
+            process::exit(1);
+        }
+    };
+
+    // ── Probe source parameters ───────────────────────────────────────────────
+
+    let probe_dec = match AudioDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+
+    let sample_rate = probe_dec.sample_rate();
+    let channels = probe_dec.channels();
+    let in_codec = probe_dec.stream_info().codec_name().to_string();
+    drop(probe_dec);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!(
+        "Input:    {in_name}  codec={in_codec}  sample_rate={sample_rate}  channels={channels}"
+    );
+    println!("Output:   {out_name}  codec={codec_str}  bitrate={bitrate}");
+    println!();
+
+    // ── Build encoder directly ────────────────────────────────────────────────
+    //
+    // AudioEncoder::create() is the low-level entry point.
+    // .audio() sets the output sample rate and channel count.
+    // .audio_codec() chooses the codec.
+    // .audio_bitrate() sets the target bitrate in bits per second.
+
+    let mut encoder = match AudioEncoder::create(&output)
+        .audio(sample_rate, channels)
+        .audio_codec(codec)
+        .audio_bitrate(bitrate)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!("Encoding...");
+
+    // ── Manual decode → encode loop ───────────────────────────────────────────
+    //
+    // Open a second decoder for the actual decode loop (the first was probe-only).
+    // push() feeds one decoded frame into the encoder.
+
+    let mut decoder = match AudioDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break, // end of stream
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    // ── Flush and finalise ────────────────────────────────────────────────────
+    //
+    // finish() flushes buffered frames and writes the container trailer.
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+}

--- a/crates/avio/examples/encode_video_direct.rs
+++ b/crates/avio/examples/encode_video_direct.rs
@@ -1,0 +1,238 @@
+//! Encode video directly using `VideoEncoder` without the pipeline abstraction.
+//!
+//! Demonstrates the low-level encode loop:
+//! `VideoDecoder` → `VideoEncoder::create()` → `push_video()` → `finish()`.
+//!
+//! Also covers:
+//! - `Preset` — speed/quality tradeoff (ultrafast → veryslow)
+//! - `BitrateMode::Vbr` — variable bitrate with target and ceiling
+//! - `CRF_MAX` — the upper-bound constant for `BitrateMode::Crf` (value: 51)
+//! - `HardwareEncoder::available()` — runtime hardware encoder detection
+//! - `VideoCodecEncodeExt::is_lgpl_compatible()` — codec license check
+//! - `VideoEncoder::actual_video_codec()` — actual codec used after open
+//! - `VideoEncoder::is_hardware_encoding()` — whether HW path is active
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example encode_video_direct --features "decode encode" -- \
+//!   --input   input.mp4   \
+//!   --output  output.mp4  \
+//!   [--preset medium]     # ultrafast | faster | fast | medium | slow | slower | veryslow
+//!   [--crf    23]         # CRF quality value (default: 23)
+//!   [--vbr    4000000]    # VBR target bps — overrides --crf
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{
+    BitrateMode, CRF_MAX, HardwareEncoder, Preset, VideoCodec, VideoCodecEncodeExt, VideoDecoder,
+    VideoEncoder,
+};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut preset_str = "medium".to_string();
+    let mut crf: u32 = 23;
+    let mut vbr: Option<u64> = None;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--preset" => preset_str = args.next().unwrap_or_else(|| "medium".to_string()),
+            "--crf" => {
+                let v = args.next().unwrap_or_default();
+                crf = v.parse().unwrap_or(23);
+            }
+            "--vbr" => {
+                let v = args.next().unwrap_or_default();
+                vbr = v.parse().ok();
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: encode_video_direct --input <file> --output <file> \
+             [--preset ultrafast|faster|fast|medium|slow|slower|veryslow] \
+             [--crf N] [--vbr N]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    let preset = match preset_str.to_lowercase().as_str() {
+        "ultrafast" => Preset::Ultrafast,
+        "faster" => Preset::Faster,
+        "fast" => Preset::Fast,
+        "medium" => Preset::Medium,
+        "slow" => Preset::Slow,
+        "slower" => Preset::Slower,
+        "veryslow" => Preset::Veryslow,
+        other => {
+            eprintln!(
+                "Unknown preset '{other}' \
+                 (try ultrafast, faster, fast, medium, slow, slower, veryslow)"
+            );
+            process::exit(1);
+        }
+    };
+
+    // CRF_MAX (= 51) is the upper bound for BitrateMode::Crf.
+    // Values above it are rejected by the encoder; lower = better quality.
+    let crf = crf.min(CRF_MAX);
+
+    // BitrateMode::Vbr requires both a target and a hard ceiling.
+    // When --vbr is given, set the ceiling to 2× the target as a
+    // reasonable starting point.
+    let bmode = match vbr {
+        Some(target) => BitrateMode::Vbr {
+            target,
+            max: target * 2,
+        },
+        None => BitrateMode::Crf(crf),
+    };
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+
+    let width = probe.width();
+    let height = probe.height();
+    let fps = probe.frame_rate();
+    let in_codec = probe.stream_info().codec_name().to_string();
+    drop(probe);
+
+    let out_codec = VideoCodec::H264;
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}  {width}×{height}  {fps:.2} fps  codec={in_codec}");
+
+    // ── VideoCodecEncodeExt — codec licence check ─────────────────────────────
+    //
+    // is_lgpl_compatible() returns true for open codecs (VP9, AV1, MPEG-4, …)
+    // and false for codecs with licensing obligations (H.264, H.265).
+
+    println!(
+        "Codec:  {}  lgpl_compatible={}",
+        out_codec.default_extension(),
+        out_codec.is_lgpl_compatible()
+    );
+
+    // ── HardwareEncoder::available() — runtime HW detection ──────────────────
+
+    let hw_list: Vec<String> = HardwareEncoder::available()
+        .iter()
+        .map(|hw| format!("{hw:?}"))
+        .collect();
+    println!("HW encoders available: {}", hw_list.join(", "));
+
+    let quality_str = match &bmode {
+        BitrateMode::Cbr(bps) => format!("cbr={bps}"),
+        BitrateMode::Crf(q) => format!("crf={q}"),
+        BitrateMode::Vbr { target, max } => format!("vbr target={target} max={max}"),
+    };
+    println!("Output: {out_name}  {width}×{height}  preset={preset_str}  {quality_str}");
+    println!();
+
+    // ── Build encoder directly ────────────────────────────────────────────────
+    //
+    // VideoEncoder::create() is the low-level entry point.
+    // .video()          — set output resolution and frame rate.
+    // .video_codec()    — choose the codec.
+    // .preset()         — speed/quality tradeoff.
+    // .bitrate_mode()   — CRF, CBR, or VBR rate control.
+
+    let mut encoder = match VideoEncoder::create(&output)
+        .video(width, height, fps)
+        .video_codec(out_codec)
+        .preset(preset)
+        .bitrate_mode(bmode)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    // actual_video_codec() reflects the codec FFmpeg actually opened,
+    // which may differ from the requested one on some platforms.
+    // is_hardware_encoding() confirms whether a hardware path is active.
+    println!(
+        "Encoder opened: actual_codec={}  hardware={}",
+        encoder.actual_video_codec(),
+        encoder.is_hardware_encoding()
+    );
+    println!("Encoding...");
+
+    // ── Manual decode → encode loop ───────────────────────────────────────────
+
+    let mut decoder = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push_video(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    // ── Flush and finalise ────────────────────────────────────────────────────
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+}

--- a/crates/avio/examples/encode_with_progress.rs
+++ b/crates/avio/examples/encode_with_progress.rs
@@ -1,0 +1,260 @@
+//! Encode video with a structured progress callback and frame-limit cancellation.
+//!
+//! Demonstrates:
+//! - `EncodeProgressCallback` trait — implement `on_progress()` on a custom struct
+//! - `EncodeProgressCallback::should_cancel()` — signal cancellation from within
+//!   the callback (no external flag needed)
+//! - `EncodeProgress::frames_encoded` / `current_fps` / `elapsed` — progress fields
+//! - `VideoEncoderBuilder::progress_callback()` — attach a trait object to the encoder
+//!
+//! The simpler closure form (`on_progress(|p| …)`) is shown in `transcode.rs`.
+//! This example shows the trait-based form which supports state and cancellation.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example encode_with_progress --features "decode encode" -- \
+//!   --input       input.mp4   \
+//!   --output      output.mp4  \
+//!   [--max-frames 100]        # stop after N frames (default: encode all)
+//! ```
+
+use std::{
+    io::Write as _,
+    path::Path,
+    process,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+};
+
+use avio::{
+    EncodeError, EncodeProgress, EncodeProgressCallback, VideoCodec, VideoDecoder, VideoEncoder,
+};
+
+// ── Custom progress handler ───────────────────────────────────────────────────
+//
+// Implement EncodeProgressCallback on a concrete struct so that state
+// (the frame counter, the optional limit) travels with the callback.
+//
+// FrameLimitProgress shows the simplest form: print progress, no cancellation.
+
+#[allow(dead_code)]
+struct FrameLimitProgress {
+    /// Maximum number of frames to encode, or None for no limit.
+    max_frames: Option<u64>,
+}
+
+impl EncodeProgressCallback for FrameLimitProgress {
+    /// Called by the encoder after each encoded frame.
+    ///
+    /// Prints the live progress line with frame count, encoding speed (fps),
+    /// and wall-clock elapsed time.
+    fn on_progress(&mut self, progress: &EncodeProgress) {
+        print!(
+            "\rframes={:>6}  fps={:>6.1}  elapsed={:.1}s",
+            progress.frames_encoded,
+            progress.current_fps,
+            progress.elapsed.as_secs_f64(),
+        );
+        // Flush the line so the counter updates in-place.
+        let _ = std::io::stdout().flush();
+    }
+
+    /// Return `true` to cancel encoding at the next frame boundary.
+    ///
+    /// The encoder calls this after every `on_progress` invocation.
+    /// When `true` is returned the encoder stops and `push_video` / `finish`
+    /// return `EncodeError::Cancelled`.
+    fn should_cancel(&self) -> bool {
+        // We use frames_encoded from the last on_progress call — but since
+        // should_cancel() doesn't receive progress, we track it ourselves.
+        // For this example we re-implement the counter inside should_cancel
+        // using a shared atomic, which is the idiomatic pattern.
+        false // cancellation is via the atomic counter below
+    }
+}
+
+// A second callback that actually cancels via an atomic frame counter.
+// This shows the common production pattern: hold a cancel flag in the struct.
+
+struct CancellableProgress {
+    max_frames: Option<u64>,
+    frames_seen: Arc<AtomicU64>,
+    cancel_flag: Arc<AtomicBool>,
+}
+
+impl EncodeProgressCallback for CancellableProgress {
+    fn on_progress(&mut self, progress: &EncodeProgress) {
+        self.frames_seen
+            .store(progress.frames_encoded, Ordering::Relaxed);
+
+        print!(
+            "\rframes={:>6}  fps={:>6.1}  elapsed={:.1}s",
+            progress.frames_encoded,
+            progress.current_fps,
+            progress.elapsed.as_secs_f64(),
+        );
+        let _ = std::io::stdout().flush();
+
+        if let Some(max) = self.max_frames
+            && progress.frames_encoded >= max
+        {
+            self.cancel_flag.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn should_cancel(&self) -> bool {
+        self.cancel_flag.load(Ordering::Relaxed)
+    }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut max_frames: Option<u64> = None;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--max-frames" => {
+                let v = args.next().unwrap_or_default();
+                max_frames = v.parse().ok();
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: encode_with_progress --input <file> --output <file> [--max-frames N]");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+    let width = probe.width();
+    let height = probe.height();
+    let fps = probe.frame_rate();
+    drop(probe);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}  {width}×{height}  {fps:.2} fps");
+    match max_frames {
+        Some(n) => println!("Output: {out_name}  limit={n} frames"),
+        None => println!("Output: {out_name}  (all frames)"),
+    }
+    println!();
+
+    // ── Shared state for cancellation ─────────────────────────────────────────
+
+    let frames_seen = Arc::new(AtomicU64::new(0));
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+
+    let callback = CancellableProgress {
+        max_frames,
+        frames_seen: Arc::clone(&frames_seen),
+        cancel_flag: Arc::clone(&cancel_flag),
+    };
+
+    // ── Build encoder with trait-based progress callback ──────────────────────
+    //
+    // progress_callback() accepts any type implementing EncodeProgressCallback.
+    // Use on_progress() (the simpler form) when you only need a closure.
+
+    let mut encoder = match VideoEncoder::create(&output)
+        .video(width, height, fps)
+        .video_codec(VideoCodec::H264)
+        .progress_callback(callback)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Decode loop ───────────────────────────────────────────────────────────
+
+    let mut decoder = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("\nDecode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        match encoder.push_video(&frame) {
+            Ok(()) => {}
+            // EncodeError::Cancelled is returned when should_cancel() fired.
+            Err(EncodeError::Cancelled) => break,
+            Err(e) => {
+                eprintln!("\nEncode error: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    // ── Finalise ──────────────────────────────────────────────────────────────
+
+    let cancelled = match encoder.finish() {
+        Ok(()) => false,
+        Err(EncodeError::Cancelled) => true,
+        Err(e) => {
+            eprintln!("\nError finalising: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!(); // end the progress line
+
+    let final_frames = frames_seen.load(Ordering::Relaxed);
+
+    if cancelled {
+        println!("Encoding cancelled after {final_frames} frames.");
+    } else {
+        let size_str = match std::fs::metadata(&output) {
+            #[allow(clippy::cast_precision_loss)]
+            Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+            Err(_) => "(unknown size)".to_string(),
+        };
+        println!("Done. {out_name}  {size_str}  {final_frames} frames");
+    }
+}

--- a/crates/avio/examples/filter_direct.rs
+++ b/crates/avio/examples/filter_direct.rs
@@ -1,0 +1,235 @@
+//! Apply a filter graph directly, managing the push/pull loop without Pipeline.
+//!
+//! Demonstrates the low-level filter graph API:
+//! - `FilterGraph::push_video()` / `pull_video()` — feed and drain video frames
+//! - `FilterGraph::push_audio()` / `pull_audio()` — feed and drain audio frames
+//!
+//! The `Pipeline` type manages these calls internally; this example shows the
+//! underlying loop for callers who need frame-level control (e.g. custom
+//! schedulers, real-time processing, or mixing multiple sources manually).
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example filter_direct --features "decode encode filter" -- \
+//!   --input  input.mp4  \
+//!   --output output.mp4
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{AudioCodec, AudioDecoder, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: filter_direct --input <file> --output <file>");
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening video: {e}");
+            process::exit(1);
+        }
+    };
+    let src_w = probe.width();
+    let src_h = probe.height();
+    let fps = probe.frame_rate();
+    drop(probe);
+
+    let audio_probe = AudioDecoder::open(&input).build().ok();
+    let (sample_rate, channels) = audio_probe
+        .as_ref()
+        .map_or((48_000, 2), |d| (d.sample_rate(), d.channels()));
+    drop(audio_probe);
+
+    // Scale to 1280×720 (or source size if smaller)
+    let out_w = src_w.min(1280);
+    let out_h = src_h.min(720);
+
+    println!("Input:   {in_name}  {src_w}×{src_h}  {fps:.2} fps");
+    println!("Output:  {out_name}  {out_w}×{out_h}  scale + volume(0.8)");
+    println!();
+
+    // ── Build filter graph ────────────────────────────────────────────────────
+    //
+    // FilterGraphBuilder chains filter operations. The resulting FilterGraph
+    // exposes push_video/pull_video for the video path and push_audio/pull_audio
+    // for the audio path on the same graph object.
+
+    let mut filter = match FilterGraphBuilder::new()
+        .scale(out_w, out_h)
+        .volume(0.8)
+        .build()
+    {
+        Ok(fg) => fg,
+        Err(e) => {
+            eprintln!("Error building filter graph: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Build encoder ─────────────────────────────────────────────────────────
+
+    let mut enc_builder = VideoEncoder::create(&output)
+        .video(out_w, out_h, fps)
+        .video_codec(VideoCodec::H264);
+
+    if sample_rate > 0 {
+        enc_builder = enc_builder
+            .audio(sample_rate, channels)
+            .audio_codec(AudioCodec::Aac);
+    }
+
+    let mut encoder = match enc_builder.build() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!("Encoding...");
+
+    // ── Video loop: decode → push_video → pull_video → encode ─────────────────
+    //
+    // push_video(slot, frame) feeds a raw frame into filter slot 0.
+    // pull_video() drains one filtered frame; returns None when the filter
+    // is buffering (e.g. between inputs) — keep feeding until Some is returned.
+
+    let mut vdec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening video decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut video_frames: u64 = 0;
+
+    loop {
+        let raw = match vdec.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Video decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = filter.push_video(0, &raw) {
+            eprintln!("Filter push_video error: {e}");
+            process::exit(1);
+        }
+
+        // pull_video may return None if the filter needs more input before
+        // producing output — loop until drained.
+        loop {
+            match filter.pull_video() {
+                Ok(Some(filtered)) => {
+                    if let Err(e) = encoder.push_video(&filtered) {
+                        eprintln!("Encode push_video error: {e}");
+                        process::exit(1);
+                    }
+                    video_frames += 1;
+                }
+                Ok(None) => break, // filter needs more input
+                Err(e) => {
+                    eprintln!("Filter pull_video error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    // ── Audio loop: decode → push_audio → pull_audio → encode ─────────────────
+    //
+    // push_audio(slot, frame) feeds a raw audio frame into the filter graph.
+    // pull_audio() drains one filtered audio frame.
+    // The same filter graph object handles both video and audio paths.
+
+    let mut audio_frames: u64 = 0;
+
+    if let Ok(mut adec) = AudioDecoder::open(&input).build() {
+        loop {
+            let raw = match adec.decode_one() {
+                Ok(Some(f)) => f,
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Audio decode error: {e}");
+                    break;
+                }
+            };
+
+            if let Err(e) = filter.push_audio(0, &raw) {
+                eprintln!("Filter push_audio error: {e}");
+                break;
+            }
+
+            loop {
+                match filter.pull_audio() {
+                    Ok(Some(filtered)) => {
+                        if let Err(e) = encoder.push_audio(&filtered) {
+                            eprintln!("Encode push_audio error: {e}");
+                            break;
+                        }
+                        audio_frames += 1;
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        eprintln!("Filter pull_audio error: {e}");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Finalise ──────────────────────────────────────────────────────────────
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!(
+        "Done. {out_name}  {size_str}  video_frames={video_frames}  audio_frames={audio_frames}"
+    );
+}

--- a/crates/avio/examples/frame_pool_usage.rs
+++ b/crates/avio/examples/frame_pool_usage.rs
@@ -1,0 +1,139 @@
+//! Decode video with an explicit frame pool to bound memory allocation.
+//!
+//! Demonstrates:
+//! - `VecPool::new(capacity)` — create a pool that retains up to N buffers
+//! - `VecPool::capacity()` — the configured pool size
+//! - `VecPool::available()` — buffers currently held in the pool
+//! - `SimpleFramePool` — type alias for `VecPool`
+//! - `FramePool` — the shared trait implemented by all pool types
+//! - `VideoDecoderBuilder::frame_pool()` — attach the pool to the decoder
+//!
+//! Without a pool, each decoded frame allocates fresh memory.
+//! With a pool, the decoder reuses buffers that have been dropped by the caller,
+//! capping peak heap usage to roughly `capacity × frame_size`.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example frame_pool_usage --features decode -- \
+//!   --input      input.mp4  \
+//!   [--pool-size 8]         # number of frame buffers to retain (default: 8)
+//! ```
+
+use std::{path::Path, process, sync::Arc};
+
+use avio::{FramePool, SimpleFramePool, VecPool, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut pool_size: usize = 8;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--pool-size" => {
+                let v = args.next().unwrap_or_default();
+                pool_size = v.parse().unwrap_or(8);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: frame_pool_usage --input <file> [--pool-size N]");
+        process::exit(1);
+    });
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    // ── VecPool ───────────────────────────────────────────────────────────────
+    //
+    // VecPool::new() returns Arc<VecPool>.
+    // capacity() is the maximum number of buffers retained between frames.
+    // available() counts buffers currently sitting in the pool ready for reuse.
+
+    let pool: Arc<VecPool> = VecPool::new(pool_size);
+    println!(
+        "Pool created: capacity={}  available={}",
+        pool.capacity(),
+        pool.available()
+    );
+
+    // ── SimpleFramePool ───────────────────────────────────────────────────────
+    //
+    // SimpleFramePool is a type alias for VecPool.
+    // Both names refer to exactly the same type.
+
+    let _simple: Arc<SimpleFramePool> = SimpleFramePool::new(pool_size);
+    println!("SimpleFramePool::new() — same type as VecPool");
+
+    // ── FramePool (trait) ─────────────────────────────────────────────────────
+    //
+    // FramePool is the trait that abstracts over pool implementations.
+    // The decoder accepts Arc<dyn FramePool>.
+
+    let pool_as_trait: Arc<dyn FramePool> = pool.clone();
+
+    // ── Attach pool to decoder ────────────────────────────────────────────────
+    //
+    // frame_pool() passes the pool to the decoder. On each decoded frame, the
+    // decoder attempts to claim a buffer from the pool instead of allocating.
+    // When the frame is dropped, the buffer returns to the pool automatically.
+
+    let mut decoder = match VideoDecoder::open(&input).frame_pool(pool_as_trait).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!(
+        "Input:   {in_name}  {}×{}  codec={}",
+        decoder.width(),
+        decoder.height(),
+        decoder.stream_info().codec_name()
+    );
+    println!("Decoding (pool-size={pool_size})...");
+    println!();
+
+    let mut count: u64 = 0;
+    let report_interval = 30;
+
+    loop {
+        match decoder.decode_one() {
+            Ok(Some(frame)) => {
+                count += 1;
+
+                // Periodically print pool stats to show buffer reuse.
+                if count.is_multiple_of(report_interval) {
+                    println!("  frame={count:>5}  pool.available()={}", pool.available());
+                }
+
+                // Dropping `frame` here returns its buffer to the pool.
+                // With pool_size=8, at most 8 buffers are retained;
+                // older ones are freed if the pool is full.
+                drop(frame);
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "Done. {count} frames decoded.  pool.capacity()={}  pool.available()={}",
+        pool.capacity(),
+        pool.available()
+    );
+}

--- a/crates/avio/examples/hardware_decode.rs
+++ b/crates/avio/examples/hardware_decode.rs
@@ -1,0 +1,170 @@
+//! Decode video using hardware acceleration.
+//!
+//! Demonstrates:
+//! - `VideoDecoderBuilder::hardware_accel()` — request a hardware decode backend
+//! - `HardwareAccel` variants: `Auto`, `None`, `Nvdec`, `Qsv`, `Amf`,
+//!   `VideoToolbox`, `Vaapi`
+//! - `HardwareAccel::name()` — canonical name string
+//! - `HardwareAccel::is_specific()` — whether a concrete backend was requested
+//! - `SeekMode::Backward` — backward seek to the nearest keyframe
+//!
+//! Gracefully skips if the requested hardware backend is unavailable.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example hardware_decode --features decode -- \
+//!   --input  input.mp4                                     \
+//!   [--accel nvdec|qsv|amf|videotoolbox|vaapi|auto|none]
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{HardwareAccel, SeekMode, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut accel_str = "auto".to_string();
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--accel" => accel_str = args.next().unwrap_or_else(|| "auto".to_string()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: hardware_decode --input <file> \
+             [--accel nvdec|qsv|amf|videotoolbox|vaapi|auto|none]"
+        );
+        process::exit(1);
+    });
+
+    // ── Parse HardwareAccel variant ───────────────────────────────────────────
+    //
+    // Each variant maps to a specific FFmpeg hardware decoder:
+    //   Auto         — probe and use the best available backend
+    //   None         — software decoding only
+    //   Nvdec        — NVIDIA CUVID/NVDEC (CUDA)
+    //   Qsv          — Intel Quick Sync Video
+    //   Amf          — AMD Advanced Media Framework
+    //   VideoToolbox — Apple VideoToolbox (macOS/iOS)
+    //   Vaapi        — VA-API (Linux, Intel/AMD/Nouveau)
+
+    let accel = match accel_str.to_lowercase().as_str() {
+        "auto" => HardwareAccel::Auto,
+        "none" => HardwareAccel::None,
+        "nvdec" => HardwareAccel::Nvdec,
+        "qsv" => HardwareAccel::Qsv,
+        "amf" => HardwareAccel::Amf,
+        "videotoolbox" => HardwareAccel::VideoToolbox,
+        "vaapi" => HardwareAccel::Vaapi,
+        other => {
+            eprintln!(
+                "Unknown accel '{other}' \
+                 (try auto, none, nvdec, qsv, amf, videotoolbox, vaapi)"
+            );
+            process::exit(1);
+        }
+    };
+
+    // name() returns the canonical lowercase string ("nvdec", "auto", …).
+    // is_specific() is false for Auto and None, true for all hardware backends.
+    println!(
+        "Requested accel: {}  (is_specific={})",
+        accel.name(),
+        accel.is_specific()
+    );
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    // ── Open decoder with hardware acceleration ───────────────────────────────
+    //
+    // hardware_accel() configures the decode backend. If the requested backend
+    // is unavailable, build() returns a DecodeError — skip gracefully.
+
+    let mut decoder = match VideoDecoder::open(&input).hardware_accel(accel).build() {
+        Ok(d) => d,
+        Err(e) => {
+            println!(
+                "Skipping: hardware backend '{}' unavailable — {e}",
+                accel.name()
+            );
+            return;
+        }
+    };
+
+    println!(
+        "Input:   {in_name}  {}×{}  {:.2} fps  codec={}",
+        decoder.width(),
+        decoder.height(),
+        decoder.frame_rate(),
+        decoder.stream_info().codec_name(),
+    );
+
+    // ── SeekMode::Backward ────────────────────────────────────────────────────
+    //
+    // Backward seek moves to the nearest keyframe at or before the target.
+    // It is the mirror of Keyframe (which seeks forward to the next keyframe)
+    // and is useful when you want to ensure you don't overshoot a target time.
+
+    let seek_to = Duration::from_secs(1);
+    println!(
+        "Seeking to {:.1}s with SeekMode::Backward ...",
+        seek_to.as_secs_f64()
+    );
+
+    if let Err(e) = decoder.seek(seek_to, SeekMode::Backward) {
+        println!("Seek not supported or failed: {e}");
+        // Non-fatal — continue from start
+        if let Err(e2) = VideoDecoder::open(&input)
+            .hardware_accel(accel)
+            .build()
+            .map(|_| ())
+        {
+            eprintln!("Could not re-open: {e2}");
+            process::exit(1);
+        }
+    }
+
+    // ── Decode a few frames ───────────────────────────────────────────────────
+
+    let mut count = 0u32;
+    let limit = 30;
+
+    loop {
+        match decoder.decode_one() {
+            Ok(Some(frame)) => {
+                if count == 0 {
+                    println!(
+                        "First frame: {}×{}  format={}  pts={:.3}s",
+                        frame.width(),
+                        frame.height(),
+                        frame.format(),
+                        frame.timestamp().as_secs_f64(),
+                    );
+                }
+                count += 1;
+                if count >= limit {
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    println!("Decoded {count} frames using accel='{}'", accel.name());
+}

--- a/crates/avio/examples/hls_output.rs
+++ b/crates/avio/examples/hls_output.rs
@@ -1,13 +1,26 @@
 //! Package a video as an HLS stream using `HlsOutput`.
 //!
+//! Demonstrates:
+//! - `HlsOutput::new()` — create an HLS output builder
+//! - `HlsOutput::input()` — set the source file
+//! - `HlsOutput::segment_duration()` — target segment length
+//! - `HlsOutput::keyframe_interval()` — force an IDR every N frames
+//! - `HlsOutput::bitrate()` — target video bitrate
+//! - `HlsOutput::build()` / `write()` — finalise and write all segments
+//!
+//! `keyframe_interval(N)` inserts a forced keyframe every N frames so that
+//! HLS segment boundaries fall exactly on IDR frames. The default is 48.
+//! Set it to `fps * segment_duration` for clean segment alignment.
+//!
 //! # Usage
 //!
 //! ```bash
 //! cargo run --example hls_output --features stream -- \
-//!   --input    input.mp4  \
-//!   --output   ./hls/     \
-//!   [--segment 6]         \
-//!   [--bitrate 2000000]
+//!   --input              input.mp4  \
+//!   --output             ./hls/     \
+//!   [--segment           6]         \
+//!   [--keyframe-interval 48]        \
+//!   [--bitrate           2000000]
 //! ```
 
 use std::{path::Path, process, time::Duration};
@@ -20,6 +33,7 @@ fn main() {
     let mut output = None::<String>;
     let mut segment_secs: u64 = 6;
     let mut bitrate = None::<u64>;
+    let mut keyframe_interval = None::<u32>;
 
     while let Some(flag) = args.next() {
         match flag.as_str() {
@@ -28,6 +42,10 @@ fn main() {
             "--segment" | "-s" => {
                 let v = args.next().unwrap_or_default();
                 segment_secs = v.parse().unwrap_or(6);
+            }
+            "--keyframe-interval" | "-k" => {
+                let v = args.next().unwrap_or_default();
+                keyframe_interval = v.parse().ok();
             }
             "--bitrate" => {
                 let v = args.next().unwrap_or_default();
@@ -41,7 +59,10 @@ fn main() {
     }
 
     let input = input.unwrap_or_else(|| {
-        eprintln!("Usage: hls_output --input <file> --output <dir> [--segment N] [--bitrate N]");
+        eprintln!(
+            "Usage: hls_output --input <file> --output <dir> \
+             [--segment N] [--keyframe-interval N] [--bitrate N]"
+        );
         process::exit(1);
     });
     let output = output.unwrap_or_else(|| {
@@ -64,16 +85,27 @@ fn main() {
     println!("Input:    {in_name}");
     println!("Output:   {output}");
     println!("Segment:  {segment_secs} s");
+    if let Some(kfi) = keyframe_interval {
+        println!("Keyframe: every {kfi} frames");
+    }
     if let Some(br) = bitrate {
         println!("Bitrate:  {br} bps");
     }
     println!();
     println!("Writing HLS segments...");
 
-    // Build and write
+    // ── Build HLS output ──────────────────────────────────────────────────────
+    //
+    // keyframe_interval(N) forces an IDR frame every N frames.
+    // The default is 48; for clean segment alignment use fps × segment_duration.
+
     let mut builder = HlsOutput::new(&output)
         .input(&input)
         .segment_duration(Duration::from_secs(segment_secs));
+
+    if let Some(kfi) = keyframe_interval {
+        builder = builder.keyframe_interval(kfi);
+    }
 
     if let Some(br) = bitrate {
         builder = builder.bitrate(br);

--- a/crates/avio/examples/probe_info.rs
+++ b/crates/avio/examples/probe_info.rs
@@ -27,6 +27,8 @@
 
 use std::{fmt::Write as _, process, time::Duration};
 
+use avio::{ColorRange, Rational};
+
 fn format_duration(d: Duration) -> String {
     let total_ms = d.as_millis();
     let ms = total_ms % 1000;
@@ -103,7 +105,21 @@ fn main() {
             let fps = v.fps();
             let pix_fmt = v.pixel_format();
 
+            // frame_rate() returns Rational (numerator/denominator fraction).
+            // This is more precise than fps() for rates like 30000/1001 (≈29.97).
+            let frame_rate: Rational = v.frame_rate();
+
+            // color_range() reports whether the signal is Full, Limited, or Unknown.
+            let color_range: ColorRange = v.color_range();
+
             let mut line = format!("  #{idx}  {codec}  {w}\u{d7}{h}  {fps:.2} fps  {pix_fmt}");
+            let _ = write!(
+                line,
+                "  fps={}/{} color_range={}",
+                frame_rate.num(),
+                frame_rate.den(),
+                color_range.name(),
+            );
 
             if let Some(br) = v.bitrate() {
                 let _ = write!(line, "  {}", format_bitrate(br));

--- a/crates/avio/examples/tone_map_hdr.rs
+++ b/crates/avio/examples/tone_map_hdr.rs
@@ -1,0 +1,188 @@
+//! Convert an HDR video to SDR using tone mapping.
+//!
+//! Demonstrates:
+//! - `FilterGraphBuilder::tone_map()` — add an HDR-to-SDR tone mapping filter
+//! - `ToneMap::Hable` / `ToneMap::Reinhard` / `ToneMap::Mobius` — algorithm choice
+//! - `VideoStreamInfo::is_hdr()` — detect HDR content before processing
+//! - `VideoStreamInfo::color_space()` / `color_primaries()` — HDR metadata
+//!
+//! The three algorithms produce different results:
+//!   Hable    — filmic, preserves highlights (default)
+//!   Reinhard — simple, photographic tone mapping
+//!   Mobius   — smooth roll-off, good for animation
+//!
+//! The example skips gracefully if the input is not flagged as HDR.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example tone_map_hdr --features "pipeline probe" -- \
+//!   --input   input_hdr.mp4   \
+//!   --output  output_sdr.mp4  \
+//!   [--method hable|reinhard|mobius]
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{
+    BitrateMode, EncoderConfig, FilterGraphBuilder, Pipeline, PipelineError, ToneMap, VideoCodec,
+    open,
+};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut method_str = "hable".to_string();
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--method" => method_str = args.next().unwrap_or_else(|| "hable".to_string()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: tone_map_hdr --input <hdr_file> --output <sdr_file> \
+             [--method hable|reinhard|mobius]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Parse ToneMap variant ─────────────────────────────────────────────────
+
+    let tone_map = match method_str.to_lowercase().as_str() {
+        "hable" => ToneMap::Hable,
+        "reinhard" => ToneMap::Reinhard,
+        "mobius" => ToneMap::Mobius,
+        other => {
+            eprintln!("Unknown method '{other}' (try hable, reinhard, mobius)");
+            process::exit(1);
+        }
+    };
+
+    // ── Probe: detect HDR and print colour metadata ───────────────────────────
+
+    let info = match open(&input) {
+        Ok(i) => i,
+        Err(e) => {
+            eprintln!("Error probing input: {e}");
+            process::exit(1);
+        }
+    };
+
+    let Some(video) = info.primary_video() else {
+        eprintln!("Error: no video stream found in '{input}'");
+        process::exit(1);
+    };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!(
+        "Input:    {in_name}  {}×{}  {:.2} fps  codec={}",
+        video.width(),
+        video.height(),
+        video.fps(),
+        video.codec_name()
+    );
+    println!(
+        "HDR info: is_hdr={}  color_space={}  color_primaries={}",
+        video.is_hdr(),
+        video.color_space(),
+        video.color_primaries()
+    );
+
+    // ── Skip if not HDR ───────────────────────────────────────────────────────
+
+    if !video.is_hdr() {
+        println!(
+            "Skipping: '{in_name}' is not flagged as HDR \
+             (color_space={}, color_primaries={}).",
+            video.color_space(),
+            video.color_primaries()
+        );
+        println!(
+            "Tip: supply an HDR source with BT.2020 primaries and \
+             PQ or HLG transfer characteristics."
+        );
+        return;
+    }
+
+    println!("Output:   {out_name}  tone_map={method_str}");
+    println!();
+
+    // ── Build tone-mapping filter ─────────────────────────────────────────────
+    //
+    // tone_map() inserts libavfilter's `tonemap` filter into the graph.
+    // The three ToneMap variants select the tone-mapping algorithm:
+    //   Hable    → "hable"
+    //   Reinhard → "reinhard"
+    //   Mobius   → "mobius"
+
+    let filter = match FilterGraphBuilder::new().tone_map(tone_map).build() {
+        Ok(fg) => fg,
+        Err(e) => {
+            eprintln!("Error building filter graph: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Run pipeline ──────────────────────────────────────────────────────────
+
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .build();
+
+    match Pipeline::builder()
+        .input(&input)
+        .filter(filter)
+        .output(&output, config)
+        .build()
+    {
+        Ok(p) => match p.run() {
+            Ok(()) => {}
+            Err(PipelineError::Decode(e)) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+            Err(PipelineError::Encode(e)) => {
+                eprintln!("Encode error: {e}");
+                process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("Pipeline error: {e}");
+                process::exit(1);
+            }
+        },
+        Err(e) => {
+            eprintln!("Error building pipeline: {e}");
+            process::exit(1);
+        }
+    }
+
+    let size_str = match std::fs::metadata(&output) {
+        #[allow(clippy::cast_precision_loss)]
+        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Err(_) => "(unknown size)".to_string(),
+    };
+
+    println!("Done. {out_name}  {size_str}");
+}

--- a/crates/avio/examples/write_metadata.rs
+++ b/crates/avio/examples/write_metadata.rs
@@ -24,7 +24,8 @@
 use std::{path::Path, process, time::Duration};
 
 use avio::{
-    AudioCodec, BitrateMode, ChapterInfo, EncoderConfig, Pipeline, VideoCodec, VideoDecoder,
+    AudioCodec, BitrateMode, ChapterInfo, ChapterInfoBuilder, EncoderConfig, Pipeline, VideoCodec,
+    VideoDecoder,
 };
 
 fn parse_time(s: &str) -> Result<Duration, String> {
@@ -181,12 +182,14 @@ fn main() {
                 .map_or(total_duration, |(next_start, _)| *next_start);
             #[allow(clippy::cast_possible_wrap)]
             let id = i as i64;
-            ChapterInfo::builder()
+            // ChapterInfo::builder() returns ChapterInfoBuilder — name it
+            // explicitly so the type is visible to readers of this example.
+            let builder: ChapterInfoBuilder = ChapterInfo::builder()
                 .id(id)
                 .title(ch_title.clone())
                 .start(*start)
-                .end(end)
-                .build()
+                .end(end);
+            builder.build()
         })
         .collect();
 


### PR DESCRIPTION
## Summary

Adds 10 new example files and updates 4 existing ones in `crates/avio/examples/` so that every public type and function exported from the `avio` facade crate is demonstrated by at least one runnable example. Also fixes pre-existing wrong `required-features` in `Cargo.toml` for three examples that referenced `pipeline` types without declaring the feature.

## Changes

**New examples (10 files):**
- `encode_audio_direct.rs` — `AudioEncoder::create` / `push` / `finish` (#556)
- `encode_video_direct.rs` — `VideoEncoder`, `Preset`, `BitrateMode::Vbr`, `CRF_MAX`, `HardwareEncoder::available`, `VideoCodecEncodeExt` (#557, #568)
- `decode_format_convert.rs` — `output_format(PixelFormat/SampleFormat)`, `output_sample_rate` (#558)
- `filter_direct.rs` — `FilterGraph::push_video` / `pull_video` / `push_audio` / `pull_audio` without `Pipeline` (#559)
- `encode_with_progress.rs` — `EncodeProgressCallback` trait, `should_cancel`, `Arc<AtomicBool>` cancel flag (#560)
- `hardware_decode.rs` — all `HardwareAccel` variants, `SeekMode::Backward` (#561)
- `frame_pool_usage.rs` — `VecPool`, `SimpleFramePool`, `FramePool` trait, `frame_pool()` (#562)
- `container_format.rs` — `Container` enum, `as_str`, `default_extension` (#563)
- `tone_map_hdr.rs` — `ToneMap::Hable/Reinhard/Mobius`, `VideoStreamInfo::is_hdr`, `color_space`, `color_primaries` (#564)
- `decode_iterator.rs` — `VideoFrameIterator`, `AudioFrameIterator`, `ImageFrameIterator` via `.frames()` (#566)

**Updated examples (4 files):**
- `hls_output.rs` — add `--keyframe-interval` / `keyframe_interval()` (#565)
- `probe_info.rs` — add `ColorRange` and `Rational` via `color_range()` and `frame_rate()` (#567)
- `write_metadata.rs` — explicit `ChapterInfoBuilder` type annotation in import and usage (#568)
- `encode_video_direct.rs` — add `CRF_MAX` import and clamp usage (#568)

**`Cargo.toml` fixes:**
- Add `[[example]]` entries for all 11 new and supplement examples
- Fix pre-existing missing `"pipeline"` feature in `required-features` for `audio_transcode`, `two_pass_encode`, and `write_metadata`

## Related Issues

Closes #556
Closes #557 
Closes #558 
Closes #559 
Closes #560 
Closes #561 
Closes #562 
Closes #563 
Closes #564 
Closes #565 
Closes #566 
Closes #567 
Closes #568

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes