### PR TITLE
fix(ff-decode): populate codec_name in stream_info for VideoDecoder and AudioDecoder

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -22,6 +22,7 @@
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::cast_lossless)]
 
+use std::ffi::CStr;
 use std::path::Path;
 use std::ptr;
 use std::time::Duration;
@@ -405,6 +406,17 @@ impl AudioDecoderInner {
         }
     }
 
+    /// Returns the human-readable codec name for a given `AVCodecID`.
+    unsafe fn extract_codec_name(codec_id: ff_sys::AVCodecID) -> String {
+        // SAFETY: avcodec_get_name is safe for any codec ID value
+        let name_ptr = unsafe { ff_sys::avcodec_get_name(codec_id) };
+        if name_ptr.is_null() {
+            return String::from("unknown");
+        }
+        // SAFETY: avcodec_get_name returns a valid C string with static lifetime
+        unsafe { CStr::from_ptr(name_ptr).to_string_lossy().into_owned() }
+    }
+
     /// Extracts audio stream information from FFmpeg structures.
     unsafe fn extract_stream_info(
         format_ctx: *mut AVFormatContext,
@@ -442,11 +454,13 @@ impl AudioDecoderInner {
 
         // Extract codec
         let codec = Self::convert_codec(codec_id);
+        let codec_name = unsafe { Self::extract_codec_name(codec_id) };
 
         // Build stream info
         let mut builder = AudioStreamInfo::builder()
             .index(stream_index as u32)
             .codec(codec)
+            .codec_name(codec_name)
             .sample_rate(sample_rate)
             .channels(channels)
             .sample_format(sample_format)
@@ -1268,5 +1282,23 @@ mod tests {
             AudioDecoderInner::convert_channel_layout(&layout, 6),
             ChannelLayout::from_channels(6)
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // extract_codec_name
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn codec_name_should_return_h264_for_h264_codec_id() {
+        let name =
+            unsafe { AudioDecoderInner::extract_codec_name(ff_sys::AVCodecID_AV_CODEC_ID_H264) };
+        assert_eq!(name, "h264");
+    }
+
+    #[test]
+    fn codec_name_should_return_none_for_none_codec_id() {
+        let name =
+            unsafe { AudioDecoderInner::extract_codec_name(ff_sys::AVCodecID_AV_CODEC_ID_NONE) };
+        assert_eq!(name, "none");
     }
 }

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -22,6 +22,7 @@
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::cast_lossless)]
 
+use std::ffi::CStr;
 use std::path::Path;
 use std::ptr;
 use std::sync::Arc;
@@ -650,6 +651,17 @@ impl VideoDecoderInner {
         }
     }
 
+    /// Returns the human-readable codec name for a given `AVCodecID`.
+    unsafe fn extract_codec_name(codec_id: ff_sys::AVCodecID) -> String {
+        // SAFETY: avcodec_get_name is safe for any codec ID value
+        let name_ptr = unsafe { ff_sys::avcodec_get_name(codec_id) };
+        if name_ptr.is_null() {
+            return String::from("unknown");
+        }
+        // SAFETY: avcodec_get_name returns a valid C string with static lifetime
+        unsafe { CStr::from_ptr(name_ptr).to_string_lossy().into_owned() }
+    }
+
     /// Extracts video stream information from FFmpeg structures.
     unsafe fn extract_stream_info(
         format_ctx: *mut AVFormatContext,
@@ -713,11 +725,13 @@ impl VideoDecoderInner {
 
         // Extract codec
         let codec = Self::convert_codec(codec_id);
+        let codec_name = unsafe { Self::extract_codec_name(codec_id) };
 
         // Build stream info
         let mut builder = VideoStreamInfo::builder()
             .index(stream_index as u32)
             .codec(codec)
+            .codec_name(codec_name)
             .width(width)
             .height(height)
             .frame_rate(frame_rate)
@@ -2291,5 +2305,23 @@ mod tests {
             VideoDecoderInner::pixel_format_to_av(PixelFormat::Yuv420p10le),
             ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // extract_codec_name
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn codec_name_should_return_h264_for_h264_codec_id() {
+        let name =
+            unsafe { VideoDecoderInner::extract_codec_name(ff_sys::AVCodecID_AV_CODEC_ID_H264) };
+        assert_eq!(name, "h264");
+    }
+
+    #[test]
+    fn codec_name_should_return_none_for_none_codec_id() {
+        let name =
+            unsafe { VideoDecoderInner::extract_codec_name(ff_sys::AVCodecID_AV_CODEC_ID_NONE) };
+        assert_eq!(name, "none");
     }
 }

--- a/crates/ff-decode/tests/audio_decoder_tests.rs
+++ b/crates/ff-decode/tests/audio_decoder_tests.rs
@@ -879,3 +879,14 @@ fn test_audio_frame_iterator_multiple_iterations() {
         "Second batch should have 5 audio frames"
     );
 }
+
+#[test]
+fn audio_stream_info_codec_name_should_not_be_empty() {
+    let decoder = create_audio_decoder().expect("Failed to create audio decoder");
+    let info = decoder.stream_info();
+
+    assert!(
+        !info.codec_name().is_empty(),
+        "codec_name() should not be empty"
+    );
+}

--- a/crates/ff-decode/tests/video_decoder_tests.rs
+++ b/crates/ff-decode/tests/video_decoder_tests.rs
@@ -461,3 +461,14 @@ fn test_flush_decoder() {
 
     assert!(frame.width() > 0, "Frame should be valid after flush");
 }
+
+#[test]
+fn video_stream_info_codec_name_should_not_be_empty() {
+    let decoder = create_decoder().expect("Failed to create decoder");
+    let info = decoder.stream_info();
+
+    assert!(
+        !info.codec_name().is_empty(),
+        "codec_name() should not be empty"
+    );
+}


### PR DESCRIPTION
## Summary

`VideoDecoder::stream_info().codec_name()` and `AudioDecoder::stream_info().codec_name()` always returned an empty string. The `extract_stream_info` functions in both `video/decoder_inner.rs` and `audio/decoder_inner.rs` read `codec_id` from `AVCodecParameters` but never called `avcodec_get_name`, leaving the field at its default empty value. This PR replicates the pattern already used in `ff-probe` to resolve the issue.

## Changes

- Add `extract_codec_name` unsafe helper to `video/decoder_inner.rs` and `audio/decoder_inner.rs` — calls `avcodec_get_name(codec_id)` and decodes the result as UTF-8 (returns `"unknown"` for null, which never occurs in practice)
- Wire `.codec_name(codec_name)` into the `VideoStreamInfo` and `AudioStreamInfo` builder chains in `extract_stream_info`
- Add unit tests `codec_name_should_return_h264_for_h264_codec_id` and `codec_name_should_return_none_for_none_codec_id` in both `decoder_inner` test modules
- Add integration tests `video_stream_info_codec_name_should_not_be_empty` and `audio_stream_info_codec_name_should_not_be_empty`

## Related Issues

Fixes #570

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes