### PR TITLE
fix(ff-decode): return frame buffers to pool on drop

### DIFF
--- a/crates/ff-common/src/pool.rs
+++ b/crates/ff-common/src/pool.rs
@@ -565,4 +565,41 @@ mod tests {
         assert_eq!(pool.capacity(), 4);
         assert_eq!(pool.available(), 0);
     }
+
+    #[test]
+    fn vec_pool_acquired_buffer_should_return_on_drop_when_pool_was_empty() {
+        let pool = VecPool::new(4);
+        assert_eq!(pool.available(), 0);
+        assert!(pool.acquire(1024).is_none());
+
+        // Simulate what allocate_buffer does: attach fresh memory to the pool.
+        let pool_dyn: Arc<dyn FramePool> = Arc::clone(&pool) as Arc<dyn FramePool>;
+        let buf = PooledBuffer::new(vec![0u8; 1024], Arc::downgrade(&pool_dyn));
+        drop(buf);
+
+        assert_eq!(pool.available(), 1);
+    }
+
+    #[test]
+    fn vec_pool_should_grow_from_zero_via_connected_alloc() {
+        let pool = VecPool::new(8);
+        let pool_dyn: Arc<dyn FramePool> = Arc::clone(&pool) as Arc<dyn FramePool>;
+
+        // Allocate three buffers with pool reference (pool empty on each call).
+        let b1 = PooledBuffer::new(vec![0u8; 1024], Arc::downgrade(&pool_dyn));
+        let b2 = PooledBuffer::new(vec![0u8; 1024], Arc::downgrade(&pool_dyn));
+        let b3 = PooledBuffer::new(vec![0u8; 1024], Arc::downgrade(&pool_dyn));
+        assert_eq!(pool.available(), 0);
+
+        drop(b1);
+        drop(b2);
+        drop(b3);
+
+        assert_eq!(pool.available(), 3);
+
+        // Next acquire should succeed.
+        let buf = pool.acquire(512);
+        assert!(buf.is_some());
+        assert_eq!(pool.available(), 2);
+    }
 }

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -1095,15 +1095,16 @@ impl VideoDecoderInner {
     /// If a frame pool is configured, attempts to acquire a buffer from the pool.
     /// The returned PooledBuffer will automatically be returned to the pool when dropped.
     fn allocate_buffer(&self, size: usize) -> PooledBuffer {
-        if let Some(ref pool) = self.frame_pool
-            && let Some(pooled_buffer) = pool.acquire(size)
-        {
-            // Return the pooled buffer directly - it will be automatically
-            // returned to the pool when the VideoFrame is dropped
-            return pooled_buffer;
+        if let Some(ref pool) = self.frame_pool {
+            if let Some(pooled_buffer) = pool.acquire(size) {
+                return pooled_buffer;
+            }
+            // Pool is configured but currently empty (or has no buffer large
+            // enough). Allocate fresh memory and attach it to the pool so
+            // that when the VideoFrame is dropped the buffer is returned via
+            // pool.release() and becomes available for the next frame.
+            return PooledBuffer::new(vec![0u8; size], Arc::downgrade(pool));
         }
-
-        // Pool not available or exhausted - allocate a standalone buffer
         PooledBuffer::standalone(vec![0u8; size])
     }
 

--- a/crates/ff-decode/tests/memory_usage_tests.rs
+++ b/crates/ff-decode/tests/memory_usage_tests.rs
@@ -13,7 +13,9 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use ff_decode::{HardwareAccel, SeekMode, VideoDecoder};
+use std::sync::Arc;
+
+use ff_decode::{FramePool, HardwareAccel, SeekMode, SimpleFramePool, VideoDecoder};
 
 // ============================================================================
 // Test Helpers
@@ -409,4 +411,79 @@ fn test_decoder_memory_overhead() {
     }
 
     drop(decoder);
+}
+
+// ============================================================================
+// Frame Pool Tests
+// ============================================================================
+
+#[test]
+fn frame_pool_should_accumulate_buffers_after_decode() {
+    let pool = SimpleFramePool::new(8);
+    let pool_dyn: Arc<dyn FramePool> = Arc::clone(&pool) as Arc<dyn FramePool>;
+
+    let mut decoder = VideoDecoder::open(&test_video_path())
+        .hardware_accel(HardwareAccel::None)
+        .frame_pool(pool_dyn)
+        .build()
+        .expect("Failed to create decoder");
+
+    // Decode and immediately drop 5 frames. Each drop should return the
+    // buffer to the pool, growing pool.available().
+    for _ in 0..5 {
+        match decoder.decode_one() {
+            Ok(Some(frame)) => drop(frame),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+
+    assert!(
+        pool.available() > 0,
+        "pool.available() should be > 0 after dropping decoded frames, got {}",
+        pool.available()
+    );
+}
+
+#[test]
+fn frame_pool_available_should_be_zero_while_frames_are_held() {
+    // Case C: decode multiple frames simultaneously, verify pool is empty
+    // while they're held, then verify it fills after they're dropped.
+    let pool = SimpleFramePool::new(8);
+    let pool_dyn: Arc<dyn FramePool> = Arc::clone(&pool) as Arc<dyn FramePool>;
+
+    let mut decoder = VideoDecoder::open(&test_video_path())
+        .hardware_accel(HardwareAccel::None)
+        .frame_pool(pool_dyn)
+        .build()
+        .expect("Failed to create decoder");
+
+    // Decode 4 frames and hold them all.
+    let mut held_frames = Vec::new();
+    for _ in 0..4 {
+        match decoder.decode_one() {
+            Ok(Some(frame)) => held_frames.push(frame),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+
+    assert_eq!(held_frames.len(), 4, "Should have decoded 4 frames");
+
+    // All buffers are in use — pool must be empty.
+    assert_eq!(
+        pool.available(),
+        0,
+        "pool.available() should be 0 while frames are held, got {}",
+        pool.available()
+    );
+
+    // Drop all frames — buffers should return to the pool.
+    drop(held_frames);
+
+    assert!(
+        pool.available() > 0,
+        "pool.available() should be > 0 after dropping all held frames, got {}",
+        pool.available()
+    );
 }


### PR DESCRIPTION
## Summary

`VecPool::available()` always returned 0 because `allocate_buffer` fell back to `PooledBuffer::standalone` whenever the pool was empty (the initial state). Standalone buffers carry no pool reference, so their `Drop` impl frees memory directly instead of calling `pool.release()`. The pool never accumulated buffers, making `VideoDecoderBuilder::frame_pool()` a no-op.

The fix attaches freshly allocated memory to the pool when `acquire` returns `None`, so buffers are returned on frame drop and become available for reuse on the next decode call.

## Changes

- **`crates/ff-decode/src/video/decoder_inner.rs`** — `allocate_buffer`: when a pool is configured but `acquire` returns `None`, create `PooledBuffer::new(data, Arc::downgrade(pool))` instead of `PooledBuffer::standalone`. Buffers now call `pool.release()` on drop regardless of whether they were acquired from the pool or freshly allocated.
- **`crates/ff-common/src/pool.rs`** — add two unit tests:
  - `vec_pool_acquired_buffer_should_return_on_drop_when_pool_was_empty`: cold-allocation path returns buffer to pool
  - `vec_pool_should_grow_from_zero_via_connected_alloc`: pool grows from 0 to N after N connected buffers are dropped
- **`crates/ff-decode/tests/memory_usage_tests.rs`** — add two integration tests:
  - `frame_pool_should_accumulate_buffers_after_decode`: sequential decode-drop loop, assert `available() > 0` after 5 frames
  - `frame_pool_available_should_be_zero_while_frames_are_held`: hold 4 frames simultaneously, assert `available() == 0` while held and `> 0` after drop

## Related Issues

Fixes #571

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes