### PR TITLE
fix(ff-decode): include codec name in UnsupportedCodec error message

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -310,10 +310,11 @@ impl AudioDecoderInner {
 
         // Find the decoder for this codec
         // SAFETY: codec_id is valid from FFmpeg
+        let codec_name = unsafe { Self::extract_codec_name(codec_id) };
         let codec = unsafe {
             ff_sys::avcodec::find_decoder(codec_id).ok_or_else(|| {
                 DecodeError::UnsupportedCodec {
-                    codec: format!("codec_id={codec_id:?}"),
+                    codec: format!("{codec_name} (codec_id={codec_id:?})"),
                 }
             })?
         };
@@ -1300,5 +1301,20 @@ mod tests {
         let name =
             unsafe { AudioDecoderInner::extract_codec_name(ff_sys::AVCodecID_AV_CODEC_ID_NONE) };
         assert_eq!(name, "none");
+    }
+
+    #[test]
+    fn unsupported_codec_error_should_include_codec_name() {
+        let codec_id = ff_sys::AVCodecID_AV_CODEC_ID_MP3;
+        let codec_name = unsafe { AudioDecoderInner::extract_codec_name(codec_id) };
+        let error = crate::error::DecodeError::UnsupportedCodec {
+            codec: format!("{codec_name} (codec_id={codec_id:?})"),
+        };
+        let msg = error.to_string();
+        assert!(msg.contains("mp3"), "expected codec name in error: {msg}");
+        assert!(
+            msg.contains("codec_id="),
+            "expected codec_id in error: {msg}"
+        );
     }
 }

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -18,6 +18,7 @@
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_lossless)]
 
+use std::ffi::CStr;
 use std::path::Path;
 use std::ptr;
 
@@ -168,10 +169,19 @@ impl ImageDecoderInner {
 
         // 4. avcodec_find_decoder
         // SAFETY: codec_id comes from FFmpeg.
+        // SAFETY: avcodec_get_name is safe for any codec ID value and returns a static C string.
+        let codec_name = unsafe {
+            let name_ptr = ff_sys::avcodec_get_name(codec_id);
+            if name_ptr.is_null() {
+                String::from("unknown")
+            } else {
+                CStr::from_ptr(name_ptr).to_string_lossy().into_owned()
+            }
+        };
         let codec = unsafe {
             ff_sys::avcodec::find_decoder(codec_id).ok_or_else(|| {
                 DecodeError::UnsupportedCodec {
-                    codec: format!("codec_id={codec_id:?}"),
+                    codec: format!("{codec_name} (codec_id={codec_id:?})"),
                 }
             })?
         };
@@ -656,6 +666,31 @@ mod tests {
         assert_eq!(
             ImageDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8),
             PixelFormat::Gray8
+        );
+    }
+
+    #[test]
+    fn unsupported_codec_error_should_include_codec_name() {
+        let codec_id = ff_sys::AVCodecID_AV_CODEC_ID_PNG;
+        // SAFETY: avcodec_get_name is safe for any codec ID value and returns a static C string.
+        let codec_name = unsafe {
+            let name_ptr = ff_sys::avcodec_get_name(codec_id);
+            if name_ptr.is_null() {
+                String::from("unknown")
+            } else {
+                std::ffi::CStr::from_ptr(name_ptr)
+                    .to_string_lossy()
+                    .into_owned()
+            }
+        };
+        let error = crate::error::DecodeError::UnsupportedCodec {
+            codec: format!("{codec_name} (codec_id={codec_id:?})"),
+        };
+        let msg = error.to_string();
+        assert!(msg.contains("png"), "expected codec name in error: {msg}");
+        assert!(
+            msg.contains("codec_id="),
+            "expected codec_id in error: {msg}"
         );
     }
 }

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -535,10 +535,11 @@ impl VideoDecoderInner {
 
         // Find the decoder for this codec
         // SAFETY: codec_id is valid from FFmpeg
+        let codec_name = unsafe { Self::extract_codec_name(codec_id) };
         let codec = unsafe {
             ff_sys::avcodec::find_decoder(codec_id).ok_or_else(|| {
                 DecodeError::UnsupportedCodec {
-                    codec: format!("codec_id={codec_id:?}"),
+                    codec: format!("{codec_name} (codec_id={codec_id:?})"),
                 }
             })?
         };
@@ -2324,5 +2325,20 @@ mod tests {
         let name =
             unsafe { VideoDecoderInner::extract_codec_name(ff_sys::AVCodecID_AV_CODEC_ID_NONE) };
         assert_eq!(name, "none");
+    }
+
+    #[test]
+    fn unsupported_codec_error_should_include_codec_name() {
+        let codec_id = ff_sys::AVCodecID_AV_CODEC_ID_H264;
+        let codec_name = unsafe { VideoDecoderInner::extract_codec_name(codec_id) };
+        let error = crate::error::DecodeError::UnsupportedCodec {
+            codec: format!("{codec_name} (codec_id={codec_id:?})"),
+        };
+        let msg = error.to_string();
+        assert!(msg.contains("h264"), "expected codec name in error: {msg}");
+        assert!(
+            msg.contains("codec_id="),
+            "expected codec_id in error: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

When `avcodec_find_decoder` returns null for an unsupported codec, the error message only contained the raw numeric codec ID (e.g. `codec_id=61`), giving no human-readable context. This PR calls `avcodec_get_name` at each error site to include the codec name in the message (e.g. `png (codec_id=61)`).

## Changes

- **Root cause**: `UnsupportedCodec` error construction in all three decoder inner modules used `format!("codec_id={codec_id:?}")`, omitting the codec name.
- **Fix — `video/decoder_inner.rs`**: Call the existing `extract_codec_name` helper before `find_decoder` and embed the name in the error: `"h264 (codec_id=27)"`.
- **Fix — `audio/decoder_inner.rs`**: Same pattern using the existing `extract_codec_name` helper.
- **Fix — `image/decoder_inner.rs`**: No existing helper; added `use std::ffi::CStr` and inlined `avcodec_get_name` lookup before `find_decoder`.
- **Tests**: Added `unsupported_codec_error_should_include_codec_name` unit test in each of the three `decoder_inner` modules to assert the error string contains both the codec name and `codec_id=`.

## Related Issues

Fixes #573

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes