### PR TITLE
fix(ff-stream): correct HLS/DASH segment splitting and TARGETDURATION

### DIFF
--- a/crates/ff-stream/src/codec_utils.rs
+++ b/crates/ff-stream/src/codec_utils.rs
@@ -1,0 +1,104 @@
+//! Shared low-level packet-writing utilities for HLS and DASH muxers.
+//!
+//! This module provides [`drain_encoder`], which drains encoded packets from a
+//! codec context, rescales their timestamps to the output stream's time base,
+//! and writes them to the mux context via `av_interleaved_write_frame`.
+
+// This module is intentionally unsafe — it drives the FFmpeg C API directly.
+#![allow(unsafe_code)]
+// Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
+#![allow(unsafe_op_in_unsafe_fn)]
+#![allow(clippy::ptr_as_ptr)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::ref_as_ptr)]
+
+use ff_sys::{
+    AVCodecContext, AVFormatContext, AVRational, av_interleaved_write_frame, av_packet_alloc,
+    av_packet_free, av_packet_rescale_ts, av_packet_unref, av_rescale_q,
+};
+
+/// Drain all available encoded packets from `enc_ctx` into `out_ctx`.
+///
+/// For each packet received from the encoder:
+/// 1. Overrides `pkt->duration` (before rescaling) with one frame's worth of
+///    time expressed in `enc_ctx->time_base` units — computed from `frame_period`
+///    at drain time.  Some encoders (e.g. mpeg4) lazily mutate their `time_base`
+///    on the first `avcodec_send_frame` call, so `enc_ctx->time_base` must be
+///    read here, not in the calling code.  The HLS/DASH muxers accumulate
+///    `pkt->duration` to determine segment boundaries and `TARGETDURATION`; a
+///    near-zero duration produces `#EXT-X-TARGETDURATION:0`.
+/// 2. Rescales `pts`, `dts`, and `duration` from `enc_ctx->time_base` to the
+///    output stream's `time_base` using `av_packet_rescale_ts`.
+/// 3. Writes the packet with `av_interleaved_write_frame`.
+///
+/// # Parameters
+///
+/// - `frame_period`: rational duration of one encoder frame, expressed as a
+///   fraction of a second (e.g. `{1, fps}` for video, `{frame_size, sample_rate}`
+///   for audio).  Converted to `enc_ctx->time_base` units inside this function so
+///   it is immune to lazy time-base mutations.
+///
+/// # Safety
+///
+/// - `enc_ctx` must be a valid, fully-opened `AVCodecContext` with at least
+///   one call to `avcodec_send_frame` preceding this call.
+/// - `out_ctx` must be a valid `AVFormatContext` whose header has been written.
+/// - `stream_idx` must be a valid index into `out_ctx`'s stream array.
+pub(crate) unsafe fn drain_encoder(
+    enc_ctx: *mut AVCodecContext,
+    out_ctx: *mut AVFormatContext,
+    stream_idx: i32,
+    log_prefix: &str,
+    frame_period: AVRational,
+) {
+    let mut pkt = av_packet_alloc();
+    if pkt.is_null() {
+        return;
+    }
+
+    // SAFETY: out_ctx is valid and stream_idx is a valid stream index.
+    let stream_tb = (*(*(*out_ctx).streams.add(stream_idx as usize))).time_base;
+    // SAFETY: enc_ctx is a valid, open codec context.
+    // Read enc_tb HERE — some encoders (mpeg4) mutate time_base lazily on first
+    // send_frame, so the value may differ from what the caller observed earlier.
+    let enc_tb = (*enc_ctx).time_base;
+
+    // Compute the correct per-frame duration in enc_tb units using the live enc_tb.
+    // av_rescale_q converts 1 unit of `frame_period` (e.g. 1/fps second) into enc_tb ticks.
+    let frame_dur_enc_tb = av_rescale_q(1, frame_period, enc_tb);
+
+    loop {
+        match ff_sys::avcodec::receive_packet(enc_ctx, pkt) {
+            Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                break;
+            }
+            Err(_) => break,
+            Ok(()) => {}
+        }
+
+        // Always override duration with the correct per-frame value BEFORE rescaling.
+        if frame_dur_enc_tb > 0 {
+            (*pkt).duration = frame_dur_enc_tb;
+        }
+
+        // Rescale pts/dts/duration from encoder time_base to stream time_base.
+        // SAFETY: pkt is valid; enc_tb and stream_tb are valid AVRational values.
+        av_packet_rescale_ts(pkt, enc_tb, stream_tb);
+
+        (*pkt).stream_index = stream_idx;
+        let ret = av_interleaved_write_frame(out_ctx, pkt);
+        av_packet_unref(pkt);
+        if ret < 0 {
+            log::warn!(
+                "{log_prefix} av_interleaved_write_frame failed \
+                 stream_index={stream_idx} error={}",
+                ff_sys::av_error_string(ret)
+            );
+            break;
+        }
+    }
+
+    av_packet_free(&mut pkt);
+}

--- a/crates/ff-stream/src/dash_inner.rs
+++ b/crates/ff-stream/src/dash_inner.rs
@@ -29,8 +29,8 @@ use std::ptr;
 use ff_sys::{
     AVCodecContext, AVFormatContext, AVFrame, AVPictureType_AV_PICTURE_TYPE_I,
     AVPictureType_AV_PICTURE_TYPE_NONE, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P,
-    SwrContext, SwsContext, av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref,
-    av_interleaved_write_frame, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref,
+    AVRational, SwrContext, SwsContext, av_frame_alloc, av_frame_free, av_frame_get_buffer,
+    av_frame_unref, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref, av_rescale_q,
     av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
     avformat_write_header,
 };
@@ -124,14 +124,7 @@ unsafe fn write_dash_unsafe(
     let video_codecpar = (*video_stream).codecpar;
     let enc_width = (*video_codecpar).width;
     let enc_height = (*video_codecpar).height;
-    let video_fps = {
-        let r = (*video_stream).avg_frame_rate;
-        if r.den > 0 && r.num > 0 {
-            r.num as f64 / r.den as f64
-        } else {
-            30.0
-        }
-    };
+    let video_fps = detect_fps(video_stream, input_ctx);
     let fps_int = video_fps.round().max(1.0) as i32;
 
     // Compute keyframe interval from segment duration and fps
@@ -270,14 +263,15 @@ unsafe fn write_dash_unsafe(
     (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
     let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-    if !(*vid_out_stream).codecpar.is_null() {
-        (*(*vid_out_stream).codecpar).codec_id = (*vid_enc_ctx).codec_id;
-        (*(*vid_out_stream).codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-        (*(*vid_out_stream).codecpar).width = (*vid_enc_ctx).width;
-        (*(*vid_out_stream).codecpar).height = (*vid_enc_ctx).height;
-        (*(*vid_out_stream).codecpar).format = (*vid_enc_ctx).pix_fmt;
-        (*(*vid_out_stream).codecpar).bit_rate = (*vid_enc_ctx).bit_rate;
-    }
+    // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
+    ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
+        |e| {
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            cleanup_output_ctx(out_ctx);
+            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+            ffmpeg_err(e)
+        },
+    )?;
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
     let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
@@ -298,16 +292,14 @@ unsafe fn write_dash_unsafe(
                     (*aud_out_stream).time_base.den = aud_sample_rate;
                     aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-                    if !(*aud_out_stream).codecpar.is_null() {
-                        (*(*aud_out_stream).codecpar).codec_id = (*aud_enc_ctx).codec_id;
-                        (*(*aud_out_stream).codecpar).codec_type =
-                            ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO;
-                        (*(*aud_out_stream).codecpar).sample_rate = (*aud_enc_ctx).sample_rate;
-                        (*(*aud_out_stream).codecpar).format = (*aud_enc_ctx).sample_fmt;
-                        let _ = ff_sys::swresample::channel_layout::copy(
-                            &mut (*(*aud_out_stream).codecpar).ch_layout,
-                            &(*aud_enc_ctx).ch_layout,
-                        );
+                    // SAFETY: aud_out_stream and aud_enc_ctx are valid; avcodec_open2 called.
+                    if ff_sys::avcodec::parameters_from_context(
+                        (*aud_out_stream).codecpar,
+                        aud_enc_ctx,
+                    )
+                    .is_err()
+                    {
+                        log::warn!("dash audio stream codecpar copy failed");
                     }
 
                     // Set up resampler: decoded audio → FLTP at aud_sample_rate
@@ -420,6 +412,21 @@ unsafe fn write_dash_unsafe(
     let mut last_src_w: Option<i32> = None;
     let mut last_src_h: Option<i32> = None;
 
+    // Frame period rationals passed to drain_encoder (immune to lazy enc time_base mutations).
+    let vid_frame_period = AVRational {
+        num: 1,
+        den: fps_int,
+    };
+    // SAFETY: aud_enc_ctx (if non-null) is valid after avcodec_open2.
+    let aud_frame_period = if !aud_enc_ctx.is_null() {
+        AVRational {
+            num: (*aud_enc_ctx).frame_size,
+            den: (*aud_enc_ctx).sample_rate,
+        }
+    } else {
+        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is null
+    };
+
     loop {
         match ff_sys::avformat::read_frame(input_ctx, pkt) {
             Err(e) if e == ff_sys::error_codes::EOF => break,
@@ -495,7 +502,15 @@ unsafe fn write_dash_unsafe(
                 (*vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
                 (*vid_enc_frame).width = enc_width;
                 (*vid_enc_frame).height = enc_height;
-                (*vid_enc_frame).pts = video_frame_count as i64;
+                // SAFETY: av_rescale_q is safe for valid AVRational values.
+                (*vid_enc_frame).pts = av_rescale_q(
+                    video_frame_count as i64,
+                    AVRational {
+                        num: 1,
+                        den: fps_int,
+                    },
+                    (*vid_enc_ctx).time_base,
+                );
 
                 let buf_ret = av_frame_get_buffer(vid_enc_frame, 0);
                 if buf_ret < 0 {
@@ -517,7 +532,13 @@ unsafe fn write_dash_unsafe(
                 if scale_ok.is_ok()
                     && ff_sys::avcodec::send_frame(vid_enc_ctx, vid_enc_frame).is_ok()
                 {
-                    drain_encoder(vid_enc_ctx, out_ctx, vid_out_stream_idx);
+                    crate::codec_utils::drain_encoder(
+                        vid_enc_ctx,
+                        out_ctx,
+                        vid_out_stream_idx,
+                        "dash",
+                        vid_frame_period,
+                    );
                 }
 
                 av_frame_unref(vid_enc_frame);
@@ -578,7 +599,13 @@ unsafe fn write_dash_unsafe(
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
                     if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
-                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                        crate::codec_utils::drain_encoder(
+                            aud_enc_ctx,
+                            out_ctx,
+                            aud_out_stream_idx,
+                            "dash",
+                            aud_frame_period,
+                        );
                     }
                     audio_sample_count += i64::from(n);
                 }
@@ -593,7 +620,13 @@ unsafe fn write_dash_unsafe(
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
     let _ = ff_sys::avcodec::send_frame(vid_enc_ctx, ptr::null());
-    drain_encoder(vid_enc_ctx, out_ctx, vid_out_stream_idx);
+    crate::codec_utils::drain_encoder(
+        vid_enc_ctx,
+        out_ctx,
+        vid_out_stream_idx,
+        "dash",
+        vid_frame_period,
+    );
 
     if !aud_enc_ctx.is_null() {
         // Flush resampler
@@ -622,14 +655,26 @@ unsafe fn write_dash_unsafe(
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
                     if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
-                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                        crate::codec_utils::drain_encoder(
+                            aud_enc_ctx,
+                            out_ctx,
+                            aud_out_stream_idx,
+                            "dash",
+                            aud_frame_period,
+                        );
                     }
                 }
                 av_frame_unref(aud_enc_frame);
             }
         }
         let _ = ff_sys::avcodec::send_frame(aud_enc_ctx, ptr::null());
-        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+        crate::codec_utils::drain_encoder(
+            aud_enc_ctx,
+            out_ctx,
+            aud_out_stream_idx,
+            "dash",
+            aud_frame_period,
+        );
     }
 
     // ── 15. Finalize ──────────────────────────────────────────────────────────
@@ -654,45 +699,6 @@ unsafe fn write_dash_unsafe(
     );
 
     Ok(())
-}
-
-// ============================================================================
-// Helper: drain all available encoded packets into the output muxer
-// ============================================================================
-
-unsafe fn drain_encoder(
-    enc_ctx: *mut AVCodecContext,
-    out_ctx: *mut AVFormatContext,
-    stream_idx: i32,
-) {
-    let mut pkt = av_packet_alloc();
-    if pkt.is_null() {
-        return;
-    }
-
-    loop {
-        match ff_sys::avcodec::receive_packet(enc_ctx, pkt) {
-            Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
-                break;
-            }
-            Err(_) => break,
-            Ok(()) => {}
-        }
-
-        (*pkt).stream_index = stream_idx;
-        let ret = av_interleaved_write_frame(out_ctx, pkt);
-        av_packet_unref(pkt);
-        if ret < 0 {
-            log::warn!(
-                "dash av_interleaved_write_frame failed \
-                 stream_index={stream_idx} error={}",
-                ff_sys::av_error_string(ret)
-            );
-            break;
-        }
-    }
-
-    av_packet_free(&mut pkt);
 }
 
 // ============================================================================
@@ -750,6 +756,51 @@ unsafe fn open_aac_encoder(
 }
 
 // ============================================================================
+// FPS detection
+// ============================================================================
+
+#[allow(clippy::cast_precision_loss)]
+unsafe fn detect_fps(stream: *mut ff_sys::AVStream, fmt_ctx: *mut AVFormatContext) -> f64 {
+    const MIN_FPS: f64 = 1.0;
+    const MAX_FPS: f64 = 240.0;
+
+    let try_rational = |num: i32, den: i32| -> Option<f64> {
+        if den <= 0 || num <= 0 {
+            return None;
+        }
+        let fps = num as f64 / den as f64;
+        if (MIN_FPS..=MAX_FPS).contains(&fps) {
+            Some(fps)
+        } else {
+            None
+        }
+    };
+
+    // 1. avg_frame_rate — reliable for most containers
+    let avg = (*stream).avg_frame_rate;
+    if let Some(fps) = try_rational(avg.num, avg.den) {
+        return fps;
+    }
+
+    // 2. r_frame_rate — constant-framerate indicator
+    let rfr = (*stream).r_frame_rate;
+    if let Some(fps) = try_rational(rfr.num, rfr.den) {
+        return fps;
+    }
+
+    // 3. Derive from nb_frames and total duration (robust for MPEG-4 Part 2)
+    let nb = (*stream).nb_frames;
+    let dur = (*fmt_ctx).duration; // in AV_TIME_BASE (1 000 000) microseconds
+    if nb > 0 && dur > 0 {
+        let fps = nb as f64 / (dur as f64 / 1_000_000.0);
+        if (MIN_FPS..=MAX_FPS).contains(&fps) {
+            return fps;
+        }
+    }
+
+    25.0 // sane default
+}
+
 // Cleanup helpers (safe to call with null pointers)
 // ============================================================================
 
@@ -904,14 +955,7 @@ unsafe fn write_dash_abr_unsafe(
     // ── 3. Read video stream properties ──────────────────────────────────────
     let video_stream = *(*input_ctx).streams.add(video_stream_idx as usize);
     let video_codecpar = (*video_stream).codecpar;
-    let video_fps = {
-        let r = (*video_stream).avg_frame_rate;
-        if r.den > 0 && r.num > 0 {
-            r.num as f64 / r.den as f64
-        } else {
-            30.0
-        }
-    };
+    let video_fps = detect_fps(video_stream, input_ctx);
     let fps_int = video_fps.round().max(1.0) as i32;
     let keyframe_interval = (segment_duration_secs * fps_int as f64).round().max(1.0) as u32;
 
@@ -1064,13 +1108,13 @@ unsafe fn write_dash_abr_unsafe(
         (*out_stream).time_base = (*enc_ctx).time_base;
         let stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-        if !(*out_stream).codecpar.is_null() {
-            (*(*out_stream).codecpar).codec_id = (*enc_ctx).codec_id;
-            (*(*out_stream).codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-            (*(*out_stream).codecpar).width = (*enc_ctx).width;
-            (*(*out_stream).codecpar).height = (*enc_ctx).height;
-            (*(*out_stream).codecpar).format = (*enc_ctx).pix_fmt;
-            (*(*out_stream).codecpar).bit_rate = (*enc_ctx).bit_rate;
+        // SAFETY: out_stream and enc_ctx are valid; avcodec_open2 has been called.
+        if let Err(e) = ff_sys::avcodec::parameters_from_context((*out_stream).codecpar, enc_ctx) {
+            ff_sys::avcodec::free_context(&mut enc_ctx as *mut *mut _);
+            cleanup_renditions(&mut rendition_states);
+            cleanup_output_ctx(out_ctx);
+            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+            return Err(ffmpeg_err(e));
         }
 
         log::info!(
@@ -1228,6 +1272,21 @@ unsafe fn write_dash_abr_unsafe(
     let mut video_frame_count: u64 = 0;
     let mut audio_sample_count: i64 = 0;
 
+    // Frame period rationals passed to drain_encoder (immune to lazy enc time_base mutations).
+    let vid_frame_period = AVRational {
+        num: 1,
+        den: fps_int,
+    };
+    // SAFETY: aud_enc_ctx (if non-null) is valid after avcodec_open2.
+    let aud_frame_period = if !aud_enc_ctx.is_null() {
+        AVRational {
+            num: (*aud_enc_ctx).frame_size,
+            den: (*aud_enc_ctx).sample_rate,
+        }
+    } else {
+        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is null
+    };
+
     loop {
         match ff_sys::avformat::read_frame(input_ctx, pkt) {
             Err(e) if e == ff_sys::error_codes::EOF => break,
@@ -1299,7 +1358,15 @@ unsafe fn write_dash_abr_unsafe(
                     (*vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
                     (*vid_enc_frame).width = state.enc_width;
                     (*vid_enc_frame).height = state.enc_height;
-                    (*vid_enc_frame).pts = video_frame_count as i64;
+                    // SAFETY: av_rescale_q is safe for valid AVRational values.
+                    (*vid_enc_frame).pts = av_rescale_q(
+                        video_frame_count as i64,
+                        AVRational {
+                            num: 1,
+                            den: fps_int,
+                        },
+                        (*state.vid_enc_ctx).time_base,
+                    );
 
                     if av_frame_get_buffer(vid_enc_frame, 0) < 0 {
                         continue;
@@ -1318,7 +1385,13 @@ unsafe fn write_dash_abr_unsafe(
                     if scale_ok.is_ok()
                         && ff_sys::avcodec::send_frame(state.vid_enc_ctx, vid_enc_frame).is_ok()
                     {
-                        drain_encoder(state.vid_enc_ctx, out_ctx, state.vid_out_stream_idx);
+                        crate::codec_utils::drain_encoder(
+                            state.vid_enc_ctx,
+                            out_ctx,
+                            state.vid_out_stream_idx,
+                            "dash",
+                            vid_frame_period,
+                        );
                     }
 
                     av_frame_unref(vid_enc_frame);
@@ -1381,7 +1454,13 @@ unsafe fn write_dash_abr_unsafe(
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
                     if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
-                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                        crate::codec_utils::drain_encoder(
+                            aud_enc_ctx,
+                            out_ctx,
+                            aud_out_stream_idx,
+                            "dash",
+                            aud_frame_period,
+                        );
                     }
                     audio_sample_count += i64::from(n);
                 }
@@ -1397,7 +1476,13 @@ unsafe fn write_dash_abr_unsafe(
     // ── 14. Flush encoders ────────────────────────────────────────────────────
     for state in &rendition_states {
         let _ = ff_sys::avcodec::send_frame(state.vid_enc_ctx, ptr::null());
-        drain_encoder(state.vid_enc_ctx, out_ctx, state.vid_out_stream_idx);
+        crate::codec_utils::drain_encoder(
+            state.vid_enc_ctx,
+            out_ctx,
+            state.vid_out_stream_idx,
+            "dash",
+            vid_frame_period,
+        );
     }
 
     if !aud_enc_ctx.is_null() {
@@ -1426,14 +1511,26 @@ unsafe fn write_dash_abr_unsafe(
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
                     if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
-                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                        crate::codec_utils::drain_encoder(
+                            aud_enc_ctx,
+                            out_ctx,
+                            aud_out_stream_idx,
+                            "dash",
+                            aud_frame_period,
+                        );
                     }
                 }
                 av_frame_unref(aud_enc_frame);
             }
         }
         let _ = ff_sys::avcodec::send_frame(aud_enc_ctx, ptr::null());
-        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+        crate::codec_utils::drain_encoder(
+            aud_enc_ctx,
+            out_ctx,
+            aud_out_stream_idx,
+            "dash",
+            aud_frame_period,
+        );
     }
 
     // ── 15. Finalize ──────────────────────────────────────────────────────────

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -27,8 +27,8 @@ use std::ptr;
 use ff_sys::{
     AVCodecContext, AVFormatContext, AVFrame, AVPictureType_AV_PICTURE_TYPE_I,
     AVPictureType_AV_PICTURE_TYPE_NONE, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P,
-    SwrContext, SwsContext, av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref,
-    av_interleaved_write_frame, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref,
+    AVRational, SwrContext, SwsContext, av_frame_alloc, av_frame_free, av_frame_get_buffer,
+    av_frame_unref, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref, av_rescale_q,
     av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
     avformat_write_header,
 };
@@ -148,14 +148,7 @@ unsafe fn write_hls_unsafe(
     } else {
         (*video_codecpar).height
     };
-    let video_fps = {
-        let r = (*video_stream).avg_frame_rate;
-        if r.den > 0 && r.num > 0 {
-            r.num as f64 / r.den as f64
-        } else {
-            30.0
-        }
-    };
+    let video_fps = detect_fps(video_stream, input_ctx);
     let fps_int = video_fps.round().max(1.0) as i32;
 
     // ── 4. Open input video decoder ────────────────────────────────────────────
@@ -312,13 +305,15 @@ unsafe fn write_hls_unsafe(
     (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
     let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-    if !(*vid_out_stream).codecpar.is_null() {
-        (*(*vid_out_stream).codecpar).codec_id = (*vid_enc_ctx).codec_id;
-        (*(*vid_out_stream).codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-        (*(*vid_out_stream).codecpar).width = (*vid_enc_ctx).width;
-        (*(*vid_out_stream).codecpar).height = (*vid_enc_ctx).height;
-        (*(*vid_out_stream).codecpar).format = (*vid_enc_ctx).pix_fmt;
-    }
+    // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
+    ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
+        |e| {
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            cleanup_output_ctx(out_ctx);
+            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+            ffmpeg_err(e)
+        },
+    )?;
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
     let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
@@ -339,16 +334,14 @@ unsafe fn write_hls_unsafe(
                     (*aud_out_stream).time_base.den = aud_sample_rate;
                     aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-                    if !(*aud_out_stream).codecpar.is_null() {
-                        (*(*aud_out_stream).codecpar).codec_id = (*aud_enc_ctx).codec_id;
-                        (*(*aud_out_stream).codecpar).codec_type =
-                            ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO;
-                        (*(*aud_out_stream).codecpar).sample_rate = (*aud_enc_ctx).sample_rate;
-                        (*(*aud_out_stream).codecpar).format = (*aud_enc_ctx).sample_fmt;
-                        let _ = ff_sys::swresample::channel_layout::copy(
-                            &mut (*(*aud_out_stream).codecpar).ch_layout,
-                            &(*aud_enc_ctx).ch_layout,
-                        );
+                    // SAFETY: aud_out_stream and aud_enc_ctx are valid; avcodec_open2 called.
+                    if ff_sys::avcodec::parameters_from_context(
+                        (*aud_out_stream).codecpar,
+                        aud_enc_ctx,
+                    )
+                    .is_err()
+                    {
+                        log::warn!("hls audio stream codecpar copy failed");
                     }
 
                     // Set up resampler: decoded audio → FLTP at aud_sample_rate
@@ -421,7 +414,7 @@ unsafe fn write_hls_unsafe(
         "hls output context ready width={enc_width} height={enc_height} fps={video_fps:.1} \
          bit_rate={} audio={}",
         (*vid_enc_ctx).bit_rate,
-        audio_stream_idx >= 0
+        audio_stream_idx >= 0,
     );
 
     // ── 12. Allocate frame and packet buffers ──────────────────────────────────
@@ -462,6 +455,23 @@ unsafe fn write_hls_unsafe(
     let mut last_src_fmt: Option<AVPixelFormat> = None;
     let mut last_src_w: Option<i32> = None;
     let mut last_src_h: Option<i32> = None;
+
+    // Frame period rationals passed to drain_encoder so it can compute the correct
+    // per-frame duration in enc_tb units at drain time (immune to lazy time_base
+    // mutations by the encoder on first send_frame).
+    let vid_frame_period = AVRational {
+        num: 1,
+        den: fps_int,
+    };
+    // SAFETY: aud_enc_ctx (if non-null) is valid after avcodec_open2.
+    let aud_frame_period = if !aud_enc_ctx.is_null() {
+        AVRational {
+            num: (*aud_enc_ctx).frame_size,
+            den: (*aud_enc_ctx).sample_rate,
+        }
+    } else {
+        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is null
+    };
 
     loop {
         match ff_sys::avformat::read_frame(input_ctx, pkt) {
@@ -538,7 +548,15 @@ unsafe fn write_hls_unsafe(
                 (*vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
                 (*vid_enc_frame).width = enc_width;
                 (*vid_enc_frame).height = enc_height;
-                (*vid_enc_frame).pts = video_frame_count as i64;
+                // SAFETY: av_rescale_q is safe for valid AVRational values.
+                (*vid_enc_frame).pts = av_rescale_q(
+                    video_frame_count as i64,
+                    AVRational {
+                        num: 1,
+                        den: fps_int,
+                    },
+                    (*vid_enc_ctx).time_base,
+                );
 
                 let buf_ret = av_frame_get_buffer(vid_enc_frame, 0);
                 if buf_ret < 0 {
@@ -560,7 +578,13 @@ unsafe fn write_hls_unsafe(
                 if scale_ok.is_ok()
                     && ff_sys::avcodec::send_frame(vid_enc_ctx, vid_enc_frame).is_ok()
                 {
-                    drain_encoder(vid_enc_ctx, out_ctx, vid_out_stream_idx);
+                    crate::codec_utils::drain_encoder(
+                        vid_enc_ctx,
+                        out_ctx,
+                        vid_out_stream_idx,
+                        "hls",
+                        vid_frame_period,
+                    );
                 }
 
                 av_frame_unref(vid_enc_frame);
@@ -621,7 +645,13 @@ unsafe fn write_hls_unsafe(
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
                     if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
-                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                        crate::codec_utils::drain_encoder(
+                            aud_enc_ctx,
+                            out_ctx,
+                            aud_out_stream_idx,
+                            "hls",
+                            aud_frame_period,
+                        );
                     }
                     audio_sample_count += i64::from(n);
                 }
@@ -636,7 +666,13 @@ unsafe fn write_hls_unsafe(
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
     let _ = ff_sys::avcodec::send_frame(vid_enc_ctx, ptr::null());
-    drain_encoder(vid_enc_ctx, out_ctx, vid_out_stream_idx);
+    crate::codec_utils::drain_encoder(
+        vid_enc_ctx,
+        out_ctx,
+        vid_out_stream_idx,
+        "hls",
+        vid_frame_period,
+    );
 
     if !aud_enc_ctx.is_null() {
         // Flush resampler
@@ -665,14 +701,26 @@ unsafe fn write_hls_unsafe(
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
                     if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
-                        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+                        crate::codec_utils::drain_encoder(
+                            aud_enc_ctx,
+                            out_ctx,
+                            aud_out_stream_idx,
+                            "hls",
+                            aud_frame_period,
+                        );
                     }
                 }
                 av_frame_unref(aud_enc_frame);
             }
         }
         let _ = ff_sys::avcodec::send_frame(aud_enc_ctx, ptr::null());
-        drain_encoder(aud_enc_ctx, out_ctx, aud_out_stream_idx);
+        crate::codec_utils::drain_encoder(
+            aud_enc_ctx,
+            out_ctx,
+            aud_out_stream_idx,
+            "hls",
+            aud_frame_period,
+        );
     }
 
     // ── 15. Finalize ──────────────────────────────────────────────────────────
@@ -700,42 +748,56 @@ unsafe fn write_hls_unsafe(
 }
 
 // ============================================================================
-// Helper: drain all available encoded packets into the output muxer
+// Helper: detect video frame rate
 // ============================================================================
 
-unsafe fn drain_encoder(
-    enc_ctx: *mut AVCodecContext,
-    out_ctx: *mut AVFormatContext,
-    stream_idx: i32,
-) {
-    let mut pkt = av_packet_alloc();
-    if pkt.is_null() {
-        return;
+/// Return the best estimate of the video frame rate for `stream`.
+///
+/// Some containers (notably MPEG-4 Part 2) store pathological values in
+/// `avg_frame_rate` (e.g. 1250000/49 ≈ 25510 fps) or `r_frame_rate`
+/// (e.g. `time_increment_resolution/1` = 25000 fps).  Tries each candidate
+/// in order and rejects values outside the sane range [1, 240] fps.
+/// Falls back to `nb_frames/duration` and finally to 25 fps.
+#[allow(clippy::cast_precision_loss)]
+unsafe fn detect_fps(stream: *mut ff_sys::AVStream, fmt_ctx: *mut AVFormatContext) -> f64 {
+    const MIN_FPS: f64 = 1.0;
+    const MAX_FPS: f64 = 240.0;
+
+    let try_rational = |num: i32, den: i32| -> Option<f64> {
+        if den <= 0 || num <= 0 {
+            return None;
+        }
+        let fps = num as f64 / den as f64;
+        if (MIN_FPS..=MAX_FPS).contains(&fps) {
+            Some(fps)
+        } else {
+            None
+        }
+    };
+
+    // 1. avg_frame_rate — reliable for most containers
+    let avg = (*stream).avg_frame_rate;
+    if let Some(fps) = try_rational(avg.num, avg.den) {
+        return fps;
     }
 
-    loop {
-        match ff_sys::avcodec::receive_packet(enc_ctx, pkt) {
-            Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
-                break;
-            }
-            Err(_) => break,
-            Ok(()) => {}
-        }
+    // 2. r_frame_rate — constant-framerate indicator
+    let rfr = (*stream).r_frame_rate;
+    if let Some(fps) = try_rational(rfr.num, rfr.den) {
+        return fps;
+    }
 
-        (*pkt).stream_index = stream_idx;
-        let ret = av_interleaved_write_frame(out_ctx, pkt);
-        av_packet_unref(pkt);
-        if ret < 0 {
-            log::warn!(
-                "hls av_interleaved_write_frame failed \
-                 stream_index={stream_idx} error={}",
-                ff_sys::av_error_string(ret)
-            );
-            break;
+    // 3. Derive from nb_frames and total duration (robust for MPEG-4 Part 2)
+    let nb = (*stream).nb_frames;
+    let dur = (*fmt_ctx).duration; // in AV_TIME_BASE (1 000 000) microseconds
+    if nb > 0 && dur > 0 {
+        let fps = nb as f64 / (dur as f64 / 1_000_000.0);
+        if (MIN_FPS..=MAX_FPS).contains(&fps) {
+            return fps;
         }
     }
 
-    av_packet_free(&mut pkt);
+    25.0 // sane default
 }
 
 // ============================================================================

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -71,6 +71,7 @@
 #![warn(missing_docs)]
 
 pub mod abr;
+pub(crate) mod codec_utils;
 pub mod dash;
 pub(crate) mod dash_inner;
 /// Unified error type for the `ff-stream` crate.

--- a/crates/ff-stream/tests/hls_output_tests.rs
+++ b/crates/ff-stream/tests/hls_output_tests.rs
@@ -153,3 +153,23 @@ fn segment_duration_should_be_respected_in_playlist() {
         "#EXT-X-TARGETDURATION={target_dur} expected ≤2 for 1s configured segment duration"
     );
 }
+
+#[test]
+fn hls_target_duration_should_not_be_zero() {
+    let Some((out_dir, _guard)) = run_hls_write("hls_nonzero_duration_test", 1, 25) else {
+        return;
+    };
+
+    let content = std::fs::read_to_string(out_dir.join("playlist.m3u8")).unwrap();
+    let target_dur: u32 = content
+        .lines()
+        .find(|l| l.starts_with("#EXT-X-TARGETDURATION:"))
+        .and_then(|l| l.trim_start_matches("#EXT-X-TARGETDURATION:").parse().ok())
+        .expect("#EXT-X-TARGETDURATION not found or not an integer");
+
+    assert!(
+        target_dur > 0,
+        "#EXT-X-TARGETDURATION must be non-zero; got {target_dur} \
+         (zero means the HLS muxer received no packet durations)"
+    );
+}


### PR DESCRIPTION
## Summary

HLS and DASH output was producing a single oversized segment with `#EXT-X-TARGETDURATION:0` instead of correctly split segments at the configured boundary. Three interacting bugs in `hls_inner.rs`, `dash_inner.rs`, and the shared `drain_encoder` utility were responsible.

## Changes

- **New `crates/ff-stream/src/codec_utils.rs`**: `drain_encoder` now accepts a `frame_period: AVRational` instead of a pre-computed duration. The per-frame duration in encoder time-base units is computed *inside* the function using the live `enc_ctx->time_base` read *after* `avcodec_send_frame` may have mutated it (mpeg4 lazy mutation). Duration is overridden *before* `av_packet_rescale_ts` so the full frame period survives rescaling to the stream time base.
- **`hls_inner.rs` / `dash_inner.rs`**: Added `detect_fps()` helper that tries `avg_frame_rate`, then `r_frame_rate`, then derives fps from `nb_frames / (duration / AV_TIME_BASE)`, rejecting values outside [1, 240] fps and defaulting to 25. This fixes MPEG-4 Part 2 containers that store pathological values (e.g. 25510 fps) in `avg_frame_rate`. Updated all `drain_encoder` call sites to pass `vid_frame_period = {1, fps_int}` and `aud_frame_period = {frame_size, sample_rate}`. Applied to both the single-output path and the ABR ladder path in `dash_inner.rs`.
- **`tests/hls_output_tests.rs`**: Added `hls_target_duration_should_not_be_zero` regression test that asserts `#EXT-X-TARGETDURATION` is greater than zero.

**Root cause chain:**
1. `avg_frame_rate` from mpeg4 container → 25510 fps → `fps_int = 25510`
2. `frame_period = {1, 25510}` → `av_rescale_q(1, {1,25510}, {1,25510}) = 1` tick (identity)
3. 1 tick after `av_packet_rescale_ts` to `{1,90000}` ≈ 4 ticks = 0.044 ms per frame
4. 50 frames × 4 ticks = 200 ticks → TARGETDURATION rounds to 0

**Fix:**
1. `detect_fps()` → 25 fps via `nb_frames / duration`
2. `frame_period = {1, 25}` → inside `drain_encoder`: `av_rescale_q(1, {1,25}, {1,25510}) = 1020` enc_tb ticks
3. After rescaling to `{1,90000}`: 1020 × 90000/25510 ≈ 3600 ticks = 1/25 s ✓
4. 25 frames × 3600 = 90000 ticks = 1 s → HLS cuts segment correctly

## Related Issues

Fixes #574

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes