### PR TITLE
refactor(avio): hide internal types from public API surface

### DIFF
--- a/crates/avio/examples/container_format.rs
+++ b/crates/avio/examples/container_format.rs
@@ -4,7 +4,7 @@
 //! - `Container` enum — `Mp4`, `Mkv`, `WebM`, `Avi`, `Mov`
 //! - `Container::as_str()` — `FFmpeg` format name
 //! - `Container::default_extension()` — canonical file extension
-//! - `VideoEncoderBuilder::container()` — override the container inferred
+//! - `VideoEncoder::create().container()` — override the container inferred
 //!   from the output file extension
 //!
 //! By default the container is auto-detected from the output extension.

--- a/crates/avio/examples/decode_iterator.rs
+++ b/crates/avio/examples/decode_iterator.rs
@@ -1,9 +1,9 @@
 //! Decode video, audio, and images using the iterator API.
 //!
 //! Demonstrates:
-//! - `VideoDecoder::frames()` → `VideoFrameIterator` — `for frame in vdec.frames()`
-//! - `AudioDecoder::frames()` → `AudioFrameIterator` — `for frame in adec.frames()`
-//! - `ImageDecoder::frames()` → `ImageFrameIterator` — `for frame in idec.frames()`
+//! - `VideoDecoder::frames()` — `for frame in vdec.frames()`
+//! - `AudioDecoder::frames()` — `for frame in adec.frames()`
+//! - `ImageDecoder::frames()` — `for frame in idec.frames()`
 //!
 //! Each decoder exposes `.frames()` which returns an iterator with
 //! `Item = Result<Frame, DecodeError>`. This is an alternative to the manual
@@ -51,15 +51,14 @@ fn main() {
     println!("Input: {in_name}");
     println!();
 
-    // ── VideoFrameIterator ────────────────────────────────────────────────────
+    // ── VideoDecoder::frames() ────────────────────────────────────────────────
     //
-    // VideoDecoder::frames() returns a VideoFrameIterator whose Item is
-    // Result<VideoFrame, DecodeError>.
+    // frames() returns an iterator whose Item is Result<VideoFrame, DecodeError>.
     //
     // The `for` loop terminates when the iterator returns None (EOF).
     // Errors are surfaced as Err variants inside the loop body.
 
-    println!("=== VideoFrameIterator ===");
+    println!("=== Video frames ===");
 
     match VideoDecoder::open(&input).build() {
         Ok(mut vdec) => {
@@ -92,12 +91,11 @@ fn main() {
 
     println!();
 
-    // ── AudioFrameIterator ────────────────────────────────────────────────────
+    // ── AudioDecoder::frames() ────────────────────────────────────────────────
     //
-    // AudioDecoder::frames() returns an AudioFrameIterator with
-    // Item = Result<AudioFrame, DecodeError>.
+    // frames() returns an iterator with Item = Result<AudioFrame, DecodeError>.
 
-    println!("=== AudioFrameIterator ===");
+    println!("=== Audio frames ===");
 
     match AudioDecoder::open(&input).build() {
         Ok(mut adec) => {
@@ -132,9 +130,8 @@ fn main() {
 
     // ── ImageFrameIterator ────────────────────────────────────────────────────
     //
-    // ImageDecoder::frames() returns an ImageFrameIterator with
+    // ImageDecoder::frames() returns an iterator with
     // Item = Result<VideoFrame, DecodeError>.
-    //
     // For a still image exactly one frame is expected.
 
     if let Some(ref img_path) = image {
@@ -144,7 +141,7 @@ fn main() {
             .and_then(|n| n.to_str())
             .unwrap_or(img_path.as_str());
 
-        println!("=== ImageFrameIterator ({img_name}) ===");
+        println!("=== Image frame ({img_name}) ===");
 
         match ImageDecoder::open(img_path).build() {
             Ok(mut idec) => {

--- a/crates/avio/examples/encode_with_progress.rs
+++ b/crates/avio/examples/encode_with_progress.rs
@@ -5,7 +5,7 @@
 //! - `EncodeProgressCallback::should_cancel()` — signal cancellation from within
 //!   the callback (no external flag needed)
 //! - `EncodeProgress::frames_encoded` / `current_fps` / `elapsed` — progress fields
-//! - `VideoEncoderBuilder::progress_callback()` — attach a trait object to the encoder
+//! - `VideoEncoder::create().progress_callback()` — attach a trait object to the encoder
 //!
 //! The simpler closure form (`on_progress(|p| …)`) is shown in `transcode.rs`.
 //! This example shows the trait-based form which supports state and cancellation.

--- a/crates/avio/examples/frame_pool_usage.rs
+++ b/crates/avio/examples/frame_pool_usage.rs
@@ -4,7 +4,6 @@
 //! - `VecPool::new(capacity)` — create a pool that retains up to N buffers
 //! - `VecPool::capacity()` — the configured pool size
 //! - `VecPool::available()` — buffers currently held in the pool
-//! - `SimpleFramePool` — type alias for `VecPool`
 //! - `FramePool` — the shared trait implemented by all pool types
 //! - `VideoDecoderBuilder::frame_pool()` — attach the pool to the decoder
 //!
@@ -22,7 +21,7 @@
 
 use std::{path::Path, process, sync::Arc};
 
-use avio::{FramePool, SimpleFramePool, VecPool, VideoDecoder};
+use avio::{FramePool, VecPool, VideoDecoder};
 
 fn main() {
     let mut args = std::env::args().skip(1);
@@ -65,14 +64,6 @@ fn main() {
         pool.capacity(),
         pool.available()
     );
-
-    // ── SimpleFramePool ───────────────────────────────────────────────────────
-    //
-    // SimpleFramePool is a type alias for VecPool.
-    // Both names refer to exactly the same type.
-
-    let _simple: Arc<SimpleFramePool> = SimpleFramePool::new(pool_size);
-    println!("SimpleFramePool::new() — same type as VecPool");
 
     // ── FramePool (trait) ─────────────────────────────────────────────────────
     //

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -29,6 +29,84 @@
 //! # Full stack (implies filter + pipeline)
 //! avio = { version = "0.5", features = ["stream"] }
 //! ```
+//!
+//! # Quick Start
+//!
+//! ## Probe
+//!
+//! [`open`] is a free function (not a method) that reads metadata without
+//! decoding:
+//!
+//! ```ignore
+//! use avio::open;
+//!
+//! let info = open("video.mp4")?;
+//! println!("duration: {:?}", info.duration());
+//! ```
+//!
+//! ## Decode
+//!
+//! All decoders follow the same builder pattern. Use
+//! `.output_format()` / `.output_sample_rate()` to request automatic
+//! format conversion inside the decoder:
+//!
+//! ```ignore
+//! use avio::{VideoDecoder, AudioDecoder, PixelFormat, SampleFormat};
+//!
+//! // Video — request RGB24 output (FFmpeg converts internally)
+//! let mut vdec = VideoDecoder::open("video.mp4")
+//!     .output_format(PixelFormat::Rgb24)
+//!     .build()?;
+//! for frame in vdec.frames() { /* ... */ }
+//!
+//! // Audio — resample to 16-bit 44.1 kHz
+//! let mut adec = AudioDecoder::open("video.mp4")
+//!     .output_format(SampleFormat::I16)
+//!     .output_sample_rate(44_100)
+//!     .build()?;
+//! ```
+//!
+//! ## Encode
+//!
+//! For simple single-file encoding use `VideoEncoder` / `AudioEncoder`
+//! directly. For transcoding with optional filtering prefer `Pipeline`.
+//!
+//! ```ignore
+//! use avio::{VideoEncoder, VideoCodec, BitrateMode};
+//!
+//! VideoEncoder::create("out.mp4")
+//!     .video_codec(VideoCodec::H264)
+//!     .bitrate_mode(BitrateMode::Crf(23))
+//!     .build()?
+//!     .encode_file("input.mp4")?;
+//! ```
+//!
+//! ### Extension trait
+//!
+//! `VideoCodecEncodeExt` adds encode-specific helpers (`.default_extension()`,
+//! `.is_lgpl_compatible()`) to `VideoCodec`. Import the trait to call them:
+//!
+//! ```ignore
+//! use avio::{VideoCodec, VideoCodecEncodeExt};
+//!
+//! let ext = VideoCodec::H264.default_extension(); // "mp4"
+//! ```
+//!
+//! ## Pipeline (high-level transcode)
+//!
+//! ```ignore
+//! use avio::{Pipeline, EncoderConfig, VideoCodec, AudioCodec, BitrateMode};
+//!
+//! Pipeline::builder()
+//!     .input("input.mp4")
+//!     .output("output.mp4", EncoderConfig::builder()
+//!         .video_codec(VideoCodec::H264)
+//!         .audio_codec(AudioCodec::Aac)
+//!         .bitrate_mode(BitrateMode::Crf(23))
+//!         .build())
+//!     .build()?
+//!     .run()?;
+//! ```
 
 // ── Always-available types from ff-format ────────────────────────────────────
 //
@@ -39,9 +117,9 @@
 // in from ff-format anyway).
 pub use ff_format::{
     AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder,
-    ColorPrimaries, ColorRange, ColorSpace, FormatError, FrameError, MediaInfo, MediaInfoBuilder,
-    PixelFormat, PooledBuffer, Rational, SampleFormat, SubtitleCodec, SubtitleStreamInfo,
-    SubtitleStreamInfoBuilder, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
+    ColorPrimaries, ColorRange, ColorSpace, MediaInfo, MediaInfoBuilder, PixelFormat, Rational,
+    SampleFormat, SubtitleCodec, SubtitleStreamInfo, Timestamp, VideoCodec, VideoFrame,
+    VideoStreamInfo,
 };
 
 // ── probe feature ─────────────────────────────────────────────────────────────
@@ -50,17 +128,16 @@ pub use ff_probe::{ProbeError, open};
 
 // ── decode feature ────────────────────────────────────────────────────────────
 //
-// PooledBuffer and the frame/codec types are already re-exported from ff-format
-// above, so we omit them here to keep a single canonical source.
-// FramePool, SimpleFramePool, and VecPool come from ff-common (re-exported via
-// ff-decode). VecPool is the canonical concrete pool; SimpleFramePool is its alias.
+// Frame/codec types are already re-exported from ff-format above, so we omit
+// them here to keep a single canonical source.
+// Memory pooling: VecPool is the concrete pool implementation; FramePool is the
+// trait for accepting custom pool implementations. Use VecPool directly, or
+// Arc<dyn FramePool> when you need to pass a pool through an abstraction boundary.
 #[cfg(feature = "decode")]
 pub use ff_common::VecPool;
 #[cfg(feature = "decode")]
 pub use ff_decode::{
-    AudioDecoder, AudioDecoderBuilder, AudioFrameIterator, DecodeError, FramePool, HardwareAccel,
-    ImageDecoder, ImageDecoderBuilder, ImageFrameIterator, SeekMode, SimpleFramePool, VideoDecoder,
-    VideoDecoderBuilder, VideoFrameIterator,
+    AudioDecoder, DecodeError, FramePool, HardwareAccel, ImageDecoder, SeekMode, VideoDecoder,
 };
 
 // ── encode feature ────────────────────────────────────────────────────────────
@@ -72,9 +149,9 @@ pub use ff_decode::{
 // default_extension) on the shared VideoCodec type; import it to call them.
 #[cfg(feature = "encode")]
 pub use ff_encode::{
-    AudioEncoder, AudioEncoderBuilder, BitrateMode, CRF_MAX, Container, EncodeError,
-    EncodeProgress, EncodeProgressCallback, HardwareEncoder, ImageEncoder, ImageEncoderBuilder,
-    Preset, VideoCodecEncodeExt, VideoEncoder, VideoEncoderBuilder,
+    AudioEncoder, BitrateMode, CRF_MAX, Container, EncodeError, EncodeProgress,
+    EncodeProgressCallback, HardwareEncoder, ImageEncoder, Preset, VideoCodecEncodeExt,
+    VideoEncoder,
 };
 
 // ── filter feature ────────────────────────────────────────────────────────────
@@ -145,9 +222,9 @@ mod tests {
         // Builder entry points are static methods on the decoder types.
         // Calling them with a dummy path exercises name resolution without
         // touching FFmpeg.
-        let _builder: VideoDecoderBuilder = VideoDecoder::open("/no/such/file.mp4");
-        let _builder: AudioDecoderBuilder = AudioDecoder::open("/no/such/file.mp4");
-        let _builder: ImageDecoderBuilder = ImageDecoder::open("/no/such/file.mp4");
+        let _ = VideoDecoder::open("/no/such/file.mp4");
+        let _ = AudioDecoder::open("/no/such/file.mp4");
+        let _ = ImageDecoder::open("/no/such/file.mp4");
     }
 
     #[cfg(feature = "decode")]
@@ -186,8 +263,8 @@ mod tests {
     fn encode_builder_types_should_be_accessible() {
         // VideoEncoder::create / AudioEncoder::create are the public entry
         // points that return their respective builder types.
-        let _builder: VideoEncoderBuilder = VideoEncoder::create("/tmp/out.mp4");
-        let _builder: AudioEncoderBuilder = AudioEncoder::create("/tmp/out.mp3");
+        let _ = VideoEncoder::create("/tmp/out.mp4");
+        let _ = AudioEncoder::create("/tmp/out.mp3");
     }
 
     #[cfg(feature = "encode")]

--- a/crates/ff-common/src/lib.rs
+++ b/crates/ff-common/src/lib.rs
@@ -7,4 +7,4 @@
 
 mod pool;
 
-pub use pool::{FramePool, PooledBuffer, SimpleFramePool, VecPool};
+pub use pool::{FramePool, PooledBuffer, VecPool};

--- a/crates/ff-common/src/pool.rs
+++ b/crates/ff-common/src/pool.rs
@@ -302,11 +302,6 @@ impl FramePool for VecPool {
     }
 }
 
-/// Alias for [`VecPool`] kept for backwards compatibility with `ff-decode`.
-///
-/// Prefer [`VecPool`] for new code.
-pub type SimpleFramePool = VecPool;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -557,13 +552,6 @@ mod tests {
         assert!(pool.acquire(1024).is_none());
         // Original buffer must still be in the pool
         assert_eq!(pool.available(), 1);
-    }
-
-    #[test]
-    fn simple_frame_pool_alias_should_behave_identically_to_vec_pool() {
-        let pool = SimpleFramePool::new(4);
-        assert_eq!(pool.capacity(), 4);
-        assert_eq!(pool.available(), 0);
     }
 
     #[test]

--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -438,7 +438,7 @@ impl AudioDecoder {
     ///     // Process frame...
     /// }
     /// ```
-    pub fn frames(&mut self) -> AudioFrameIterator<'_> {
+    pub fn frames(&mut self) -> impl Iterator<Item = Result<AudioFrame, DecodeError>> + '_ {
         AudioFrameIterator { decoder: self }
     }
 
@@ -627,7 +627,7 @@ impl AudioDecoder {
 ///
 /// Created by calling [`AudioDecoder::frames()`]. Yields frames until the end
 /// of the stream is reached or an error occurs.
-pub struct AudioFrameIterator<'a> {
+pub(crate) struct AudioFrameIterator<'a> {
     decoder: &'a mut AudioDecoder,
 }
 

--- a/crates/ff-decode/src/audio/mod.rs
+++ b/crates/ff-decode/src/audio/mod.rs
@@ -6,4 +6,4 @@
 pub mod builder;
 pub mod decoder_inner;
 
-pub use builder::{AudioDecoder, AudioDecoderBuilder, AudioFrameIterator};
+pub use builder::{AudioDecoder, AudioDecoderBuilder};

--- a/crates/ff-decode/src/image/builder.rs
+++ b/crates/ff-decode/src/image/builder.rs
@@ -140,7 +140,7 @@ impl ImageDecoder {
     ///
     /// [`VideoDecoder`]: crate::VideoDecoder
     /// [`AudioDecoder`]: crate::AudioDecoder
-    pub fn frames(&mut self) -> ImageFrameIterator<'_> {
+    pub fn frames(&mut self) -> impl Iterator<Item = Result<VideoFrame, DecodeError>> + '_ {
         ImageFrameIterator { decoder: self }
     }
 
@@ -166,12 +166,9 @@ impl ImageDecoder {
 /// Created by calling [`ImageDecoder::frames()`]. Yields exactly one item —
 /// the decoded [`VideoFrame`] — then returns `None`.
 ///
-/// This type exists for API consistency with [`VideoFrameIterator`] and
-/// [`AudioFrameIterator`].
-///
-/// [`VideoFrameIterator`]: crate::VideoFrameIterator
-/// [`AudioFrameIterator`]: crate::AudioFrameIterator
-pub struct ImageFrameIterator<'a> {
+/// This type exists for API consistency with `VideoDecoder::frames()` and
+/// `AudioDecoder::frames()`.
+pub(crate) struct ImageFrameIterator<'a> {
     decoder: &'a mut ImageDecoder,
 }
 

--- a/crates/ff-decode/src/image/mod.rs
+++ b/crates/ff-decode/src/image/mod.rs
@@ -6,4 +6,4 @@
 pub mod builder;
 pub mod decoder_inner;
 
-pub use builder::{ImageDecoder, ImageDecoderBuilder, ImageFrameIterator};
+pub use builder::{ImageDecoder, ImageDecoderBuilder};

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -89,7 +89,7 @@
 //! - [`audio`] - Audio decoder for extracting audio frames
 //! - [`video`] - Video decoder for extracting video frames
 //! - [`error`] - Error types for decoding operations
-//! - Frame pool types (`FramePool`, `PooledBuffer`, `SimpleFramePool`) are provided by `ff-common`
+//! - Frame pool types (`FramePool`, `PooledBuffer`, `VecPool`) are provided by `ff-common`
 //!
 //! ## Re-exports
 //!
@@ -106,11 +106,11 @@ pub mod image;
 pub mod video;
 
 // Re-exports for convenience
-pub use audio::{AudioDecoder, AudioDecoderBuilder, AudioFrameIterator};
+pub use audio::{AudioDecoder, AudioDecoderBuilder};
 pub use error::DecodeError;
-pub use ff_common::{FramePool, PooledBuffer, SimpleFramePool};
-pub use image::{ImageDecoder, ImageDecoderBuilder, ImageFrameIterator};
-pub use video::{VideoDecoder, VideoDecoderBuilder, VideoFrameIterator};
+pub use ff_common::{FramePool, PooledBuffer};
+pub use image::{ImageDecoder, ImageDecoderBuilder};
+pub use video::{VideoDecoder, VideoDecoderBuilder};
 
 /// Seek mode for positioning the decoder.
 ///
@@ -287,9 +287,8 @@ impl HardwareAccel {
 /// ```
 pub mod prelude {
     pub use crate::{
-        AudioDecoder, AudioDecoderBuilder, AudioFrameIterator, DecodeError, FramePool,
-        HardwareAccel, ImageDecoder, ImageDecoderBuilder, ImageFrameIterator, PooledBuffer,
-        SeekMode, SimpleFramePool, VideoDecoder, VideoDecoderBuilder, VideoFrameIterator,
+        AudioDecoder, AudioDecoderBuilder, DecodeError, FramePool, HardwareAccel, ImageDecoder,
+        ImageDecoderBuilder, PooledBuffer, SeekMode, VideoDecoder, VideoDecoderBuilder,
     };
 }
 

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -625,7 +625,7 @@ impl VideoDecoder {
     ///     // Process frame...
     /// }
     /// ```
-    pub fn frames(&mut self) -> VideoFrameIterator<'_> {
+    pub fn frames(&mut self) -> impl Iterator<Item = Result<VideoFrame, DecodeError>> + '_ {
         VideoFrameIterator { decoder: self }
     }
 
@@ -1038,7 +1038,7 @@ impl VideoDecoder {
 ///
 /// Created by calling [`VideoDecoder::frames()`]. Yields frames until the end
 /// of the stream is reached or an error occurs.
-pub struct VideoFrameIterator<'a> {
+pub(crate) struct VideoFrameIterator<'a> {
     decoder: &'a mut VideoDecoder,
 }
 

--- a/crates/ff-decode/src/video/mod.rs
+++ b/crates/ff-decode/src/video/mod.rs
@@ -6,4 +6,4 @@
 pub mod builder;
 pub mod decoder_inner;
 
-pub use builder::{VideoDecoder, VideoDecoderBuilder, VideoFrameIterator};
+pub use builder::{VideoDecoder, VideoDecoderBuilder};

--- a/crates/ff-decode/tests/image_decoder_tests.rs
+++ b/crates/ff-decode/tests/image_decoder_tests.rs
@@ -1,5 +1,4 @@
-//! Integration tests for [`ImageDecoder`], [`ImageDecoderBuilder`], and
-//! [`ImageFrameIterator`].
+//! Integration tests for [`ImageDecoder`] and [`ImageDecoderBuilder`].
 //!
 //! The real assets `assets/img/hello-triangle.png` and
 //! `assets/img/hello-triangle.jpg` are used for happy-path tests.
@@ -12,7 +11,7 @@ mod fixtures;
 
 use std::path::PathBuf;
 
-use ff_decode::{ImageDecoder, ImageDecoderBuilder, ImageFrameIterator};
+use ff_decode::{ImageDecoder, ImageDecoderBuilder};
 
 fn png_path() -> PathBuf {
     fixtures::assets_dir().join("img/hello-triangle.png")
@@ -24,13 +23,12 @@ fn jpeg_path() -> PathBuf {
 
 // ── crate-root exports ────────────────────────────────────────────────────────
 
-/// `ImageDecoder`, `ImageDecoderBuilder`, and `ImageFrameIterator` must all be
-/// importable from the crate root without any extra path segments.
+/// `ImageDecoder` and `ImageDecoderBuilder` must be importable from the crate
+/// root without any extra path segments.
 #[test]
 fn crate_root_should_export_image_decoder_types() {
     // If these types are not re-exported the test won't compile.
     let _: fn(&str) -> ImageDecoderBuilder = |p| ImageDecoder::open(p);
-    let _: std::marker::PhantomData<ImageFrameIterator> = std::marker::PhantomData;
 }
 
 // ── open() / build() — error cases ───────────────────────────────────────────

--- a/crates/ff-decode/tests/memory_usage_tests.rs
+++ b/crates/ff-decode/tests/memory_usage_tests.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 
 use std::sync::Arc;
 
-use ff_decode::{FramePool, HardwareAccel, SeekMode, SimpleFramePool, VideoDecoder};
+use ff_common::VecPool;
+use ff_decode::{FramePool, HardwareAccel, SeekMode, VideoDecoder};
 
 // ============================================================================
 // Test Helpers
@@ -419,7 +420,7 @@ fn test_decoder_memory_overhead() {
 
 #[test]
 fn frame_pool_should_accumulate_buffers_after_decode() {
-    let pool = SimpleFramePool::new(8);
+    let pool = VecPool::new(8);
     let pool_dyn: Arc<dyn FramePool> = Arc::clone(&pool) as Arc<dyn FramePool>;
 
     let mut decoder = VideoDecoder::open(&test_video_path())
@@ -449,7 +450,7 @@ fn frame_pool_should_accumulate_buffers_after_decode() {
 fn frame_pool_available_should_be_zero_while_frames_are_held() {
     // Case C: decode multiple frames simultaneously, verify pool is empty
     // while they're held, then verify it fills after they're dropped.
-    let pool = SimpleFramePool::new(8);
+    let pool = VecPool::new(8);
     let pool_dyn: Arc<dyn FramePool> = Arc::clone(&pool) as Arc<dyn FramePool>;
 
     let mut decoder = VideoDecoder::open(&test_video_path())

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -12,13 +12,30 @@ use crate::filter_inner::FilterGraphInner;
 /// Tone-mapping algorithm for HDR-to-SDR conversion.
 ///
 /// Used with [`FilterGraphBuilder::tone_map`].
+///
+/// # Choosing an algorithm
+///
+/// | Variant | Characteristic | When to use |
+/// |---------|---------------|-------------|
+/// | [`Hable`](Self::Hable) | Filmic, rich contrast | Film / cinematic content |
+/// | [`Reinhard`](Self::Reinhard) | Simple, fast, neutral | Fast previews, general video |
+/// | [`Mobius`](Self::Mobius) | Smooth highlights | Bright outdoor or HDR10 content |
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToneMap {
     /// Hable (Uncharted 2) filmic tone mapping.
+    ///
+    /// Produces a warm, cinematic look with compressed shadows and highlights.
+    /// The most commonly used algorithm for film and narrative video content.
     Hable,
     /// Reinhard tone mapping.
+    ///
+    /// A simple, globally uniform operator. Fast and neutral; a safe default
+    /// when color-accurate reproduction matters more than filmic aesthetics.
     Reinhard,
     /// Mobius tone mapping.
+    ///
+    /// A smooth, shoulder-based curve that preserves mid-tones while gently
+    /// rolling off bright highlights. Well suited for outdoor and HDR10 content.
     Mobius,
 }
 

--- a/crates/ff-stream/src/abr.rs
+++ b/crates/ff-stream/src/abr.rs
@@ -20,8 +20,9 @@ use crate::error::StreamError;
 /// ```
 /// use ff_stream::Rendition;
 ///
-/// let r = Rendition { width: 1280, height: 720, bitrate: 3_000_000 };
+/// let r = Rendition::new(1280, 720, 3_000_000);
 /// assert_eq!(r.width, 1280);
+/// assert_eq!(r.bitrate, 3_000_000);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rendition {
@@ -31,6 +32,27 @@ pub struct Rendition {
     pub height: u32,
     /// Target bitrate in bits per second.
     pub bitrate: u64,
+}
+
+impl Rendition {
+    /// Create a rendition with the given width, height, and bitrate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_stream::Rendition;
+    ///
+    /// let hd = Rendition::new(1280, 720, 3_000_000);
+    /// let fhd = Rendition::new(1920, 1080, 6_000_000);
+    /// ```
+    #[must_use]
+    pub const fn new(width: u32, height: u32, bitrate: u64) -> Self {
+        Self {
+            width,
+            height,
+            bitrate,
+        }
+    }
 }
 
 /// Produces multi-rendition HLS or DASH output from a single input.

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -63,10 +63,9 @@
 //!
 //! ## Status
 //!
-//! The public API is stable. The `write()` / `hls()` / `dash()` methods that
-//! perform actual `FFmpeg` muxing are stubs and will return
-//! [`StreamError::InvalidConfig`] with `"not yet implemented"` until the
-//! `FFmpeg` HLS/DASH integration is complete.
+//! The public API is stable. HLS and DASH muxing are fully implemented via the
+//! `FFmpeg` HLS/DASH muxers. `write()` / `hls()` / `dash()` perform real
+//! encode-and-mux operations against the filesystem.
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
## Summary

Removes implementation-detail types that users of `cargo add avio` should never need to name directly, and applies a number of related API consistency improvements. The public behaviour of all APIs is unchanged — only what names are visible at the `avio` facade level is affected.

## Changes

**Iterator types made `pub(crate)` in `ff-decode`**
- `VideoFrameIterator`, `AudioFrameIterator`, `ImageFrameIterator` → `pub(crate)`
- `.frames()` return type changed to `impl Iterator<Item = Result<…>>` so callers are unaffected

**Builder types removed from `avio` facade**
- Decoder builders (`VideoDecoderBuilder`, `AudioDecoderBuilder`, `ImageDecoderBuilder`) no longer re-exported — type inference covers all real usage
- Encoder builders (`VideoEncoderBuilder`, `AudioEncoderBuilder`, `ImageEncoderBuilder`) removed for consistency with the decoder decision
- `FormatError`, `FrameError`, `SubtitleStreamInfoBuilder`, `PooledBuffer` removed from `avio` re-exports (still `pub` in their owning crates)

**`SimpleFramePool` removed entirely**
- The `SimpleFramePool = VecPool` alias added no value and created confusion (three names for two things)
- Deleted from `ff-common`, `ff-decode`, and all usage sites; replaced with `VecPool` directly

**Other improvements**
- `Rendition::new(width, height, bitrate)` constructor added to `ff-stream`
- `ToneMap` variants gain doc comments explaining when to use each algorithm (Hable / Reinhard / Mobius)
- `ff-stream` crate-level status note corrected: HLS/DASH muxing is fully implemented, not a stub
- `avio` crate-level doc gains a **Quick Start** section covering `open()`, decoder `.output_format()`, encoder API levels, and the `VideoCodecEncodeExt` extension-trait import

## Related Issues

Closes #575

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes