### PR TITLE
fix(ux): address API usability issues found during example audit

### DIFF
--- a/crates/avio/examples/audio_filters.rs
+++ b/crates/avio/examples/audio_filters.rs
@@ -169,8 +169,15 @@ fn main() {
     println!();
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/audio_transcode.rs
+++ b/crates/avio/examples/audio_transcode.rs
@@ -106,8 +106,13 @@ fn main() {
         .and_then(|n| n.to_str())
         .unwrap_or(&output);
 
+    let in_codec_display = if in_codec.is_empty() {
+        String::new()
+    } else {
+        format!("  {in_codec}")
+    };
     println!(
-        "Input:   {in_name}  {channels}ch  {sample_rate} Hz  {in_codec}  {}",
+        "Input:   {in_name}  {channels}ch  {sample_rate} Hz{in_codec_display}  {}",
         format_duration(duration)
     );
     println!(
@@ -131,8 +136,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/concat_clips.rs
+++ b/crates/avio/examples/concat_clips.rs
@@ -158,8 +158,15 @@ fn main() {
     println!();
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/container_format.rs
+++ b/crates/avio/examples/container_format.rs
@@ -167,8 +167,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/encode_audio_direct.rs
+++ b/crates/avio/examples/encode_audio_direct.rs
@@ -159,8 +159,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/encode_video_direct.rs
+++ b/crates/avio/examples/encode_video_direct.rs
@@ -229,8 +229,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/encode_with_progress.rs
+++ b/crates/avio/examples/encode_with_progress.rs
@@ -251,8 +251,15 @@ fn main() {
         println!("Encoding cancelled after {final_frames} frames.");
     } else {
         let size_str = match std::fs::metadata(&output) {
-            #[allow(clippy::cast_precision_loss)]
-            Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+            Ok(m) => {
+                #[allow(clippy::cast_precision_loss)]
+                let kb = m.len() as f64 / 1024.0;
+                if kb < 1024.0 {
+                    format!("{kb:.0} KB")
+                } else {
+                    format!("{:.1} MB", kb / 1024.0)
+                }
+            }
             Err(_) => "(unknown size)".to_string(),
         };
         println!("Done. {out_name}  {size_str}  {final_frames} frames");

--- a/crates/avio/examples/filter_direct.rs
+++ b/crates/avio/examples/filter_direct.rs
@@ -224,8 +224,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/hw_transcode.rs
+++ b/crates/avio/examples/hw_transcode.rs
@@ -214,8 +214,15 @@ fn main() {
     let frames = *last_frames.lock().unwrap_or_else(|e| e.into_inner());
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/tone_map_hdr.rs
+++ b/crates/avio/examples/tone_map_hdr.rs
@@ -179,8 +179,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/transcode.rs
+++ b/crates/avio/examples/transcode.rs
@@ -297,8 +297,12 @@ fn main() {
     let size_str = match std::fs::metadata(&args.output) {
         Ok(m) => {
             #[allow(clippy::cast_precision_loss)]
-            let mb = m.len() as f64 / 1_048_576.0;
-            format!("{mb:.1} MB")
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
         }
         Err(_) => "(unknown size)".to_string(),
     };

--- a/crates/avio/examples/trim_and_scale.rs
+++ b/crates/avio/examples/trim_and_scale.rs
@@ -211,8 +211,15 @@ fn main() {
     println!();
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/two_pass_encode.rs
+++ b/crates/avio/examples/two_pass_encode.rs
@@ -132,8 +132,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/video_effects.rs
+++ b/crates/avio/examples/video_effects.rs
@@ -210,8 +210,15 @@ fn main() {
     println!();
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/video_transcode.rs
+++ b/crates/avio/examples/video_transcode.rs
@@ -92,9 +92,9 @@ fn main() {
         BitrateMode::Vbr { .. } => "custom".to_string(),
     };
 
-    println!("Input:   {in_name}  {width}x{height}  {fps:.2} fps  {in_codec}");
+    println!("Input:   {in_name}  {width}×{height}  {fps:.2} fps  {in_codec}");
     println!(
-        "Output:  {out_name}  {width}x{height}  {fps:.2} fps  {}  {quality_str}",
+        "Output:  {out_name}  {width}×{height}  {fps:.2} fps  {}  {quality_str}",
         out_codec.default_extension()
     );
     println!();
@@ -115,8 +115,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/avio/examples/write_metadata.rs
+++ b/crates/avio/examples/write_metadata.rs
@@ -242,8 +242,15 @@ fn main() {
     }
 
     let size_str = match std::fs::metadata(&output) {
-        #[allow(clippy::cast_precision_loss)]
-        Ok(m) => format!("{:.1} MB", m.len() as f64 / 1_048_576.0),
+        Ok(m) => {
+            #[allow(clippy::cast_precision_loss)]
+            let kb = m.len() as f64 / 1024.0;
+            if kb < 1024.0 {
+                format!("{kb:.0} KB")
+            } else {
+                format!("{:.1} MB", kb / 1024.0)
+            }
+        }
         Err(_) => "(unknown size)".to_string(),
     };
 

--- a/crates/ff-encode/src/hardware.rs
+++ b/crates/ff-encode/src/hardware.rs
@@ -35,11 +35,12 @@ pub enum HardwareEncoder {
 }
 
 impl HardwareEncoder {
-    /// Get the list of available hardware encoders.
+    /// Get the list of concrete hardware encoder backends available on this system.
     ///
-    /// Queries FFmpeg for available hardware encoders on the system.
-    /// This is useful for UI to show which hardware acceleration options
-    /// the user can select.
+    /// Returns only actual hardware backends (NVENC, QSV, AMF, VideoToolbox,
+    /// VA-API). The control variants [`Auto`](Self::Auto) and [`None`](Self::None)
+    /// are intentionally excluded — they are configuration options, not hardware
+    /// backends.
     ///
     /// The result is cached on first call for performance.
     ///
@@ -48,9 +49,13 @@ impl HardwareEncoder {
     /// ```no_run
     /// use ff_encode::HardwareEncoder;
     ///
-    /// let available = HardwareEncoder::available();
-    /// for hw in available {
-    ///     println!("Available: {:?}", hw);
+    /// let backends = HardwareEncoder::available();
+    /// if backends.is_empty() {
+    ///     println!("No hardware encoders detected");
+    /// } else {
+    ///     for hw in backends {
+    ///         println!("Available: {:?}", hw);
+    ///     }
     /// }
     /// ```
     #[must_use]
@@ -60,11 +65,8 @@ impl HardwareEncoder {
         AVAILABLE.get_or_init(|| {
             let mut result = Vec::new();
 
-            // Auto and None are always available
-            result.push(Self::Auto);
-            result.push(Self::None);
-
-            // Check each hardware encoder type
+            // Check each concrete hardware encoder type.
+            // Auto and None are control variants, not hardware backends — excluded.
             if Self::Nvenc.is_available() {
                 result.push(Self::Nvenc);
             }
@@ -156,11 +158,17 @@ mod tests {
     }
 
     #[test]
-    fn test_available_returns_at_least_auto_and_none() {
+    fn available_should_contain_only_hardware_backends() {
         let available = HardwareEncoder::available();
-        assert!(available.contains(&HardwareEncoder::Auto));
-        assert!(available.contains(&HardwareEncoder::None));
-        assert!(available.len() >= 2);
+        assert!(
+            !available.contains(&HardwareEncoder::Auto),
+            "Auto is a control variant, not a hardware backend"
+        );
+        assert!(
+            !available.contains(&HardwareEncoder::None),
+            "None is a control variant, not a hardware backend"
+        );
+        // May be empty on systems with no hardware encoders — that is correct.
     }
 
     #[test]

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -23,12 +23,12 @@ use std::ptr;
 use ff_format::{PixelFormat, VideoFrame};
 use ff_sys::{
     AVCodecID, AVCodecID_AV_CODEC_ID_BMP, AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_PNG,
-    AVCodecID_AV_CODEC_ID_TIFF, AVCodecID_AV_CODEC_ID_WEBP, AVFormatContext, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_BGR24, AVPixelFormat_AV_PIX_FMT_RGB24,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVPixelFormat_AV_PIX_FMT_YUVJ420P, AVRational,
-    av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
-    av_packet_unref, av_write_trailer, avcodec, avformat, avformat_alloc_output_context2,
-    avformat_free_context, avformat_new_stream, avformat_write_header, swscale,
+    AVCodecID_AV_CODEC_ID_TIFF, AVCodecID_AV_CODEC_ID_WEBP, AVColorRange_AVCOL_RANGE_JPEG,
+    AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_BGR24, AVPixelFormat_AV_PIX_FMT_RGB24,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, av_frame_alloc, av_frame_free,
+    av_interleaved_write_frame, av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer,
+    avcodec, avformat, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat_write_header, swscale,
 };
 
 use crate::EncodeError;
@@ -120,28 +120,43 @@ impl ImageEncoderInner {
             path: path.to_path_buf(),
         })?;
 
-        // Primary attempt: let FFmpeg infer the muxer from the file extension.
-        // This works on all platforms for ordinary filenames.
-        let mut ret = avformat_alloc_output_context2(
-            &mut inner.format_ctx,
-            ptr::null_mut(),
-            ptr::null(),
-            c_path.as_ptr(),
-        );
+        // Prefer an explicit muxer name when one is available.
+        //
+        // The auto-detection path (NULL format name) resolves to the `image2`
+        // muxer for most still-image formats.  `image2` expects filenames that
+        // contain a `%d` sequence-number pattern and emits a cosmetic warning:
+        //   "[image2 @ …] The specified filename '…' does not contain an image
+        //    sequence pattern"
+        // for any ordinary name like "frame.jpg".  Using a dedicated single-image
+        // muxer ("mjpeg", "apng", …) avoids that warning entirely.
+        //
+        // If no explicit muxer is known (e.g. BMP), or if the explicit muxer
+        // fails for any reason, we fall back to auto-detection.
+        let explicit_fmt = codec_fallback_format(codec_id);
 
-        // Fallback: on some Linux FFmpeg builds, av_guess_format() returns NULL
-        // for filenames whose basename contains a run of digits before the
-        // extension (e.g. "thumb_0000.jpg"), causing EINVAL above.  Retry with
-        // an explicit muxer name derived from the codec.  These names ("mjpeg",
-        // "apng", …) do not perform sequence-pattern validation and are present
-        // in all standard FFmpeg builds.
-        if (ret < 0 || inner.format_ctx.is_null())
-            && let Some(fmt) = codec_fallback_format(codec_id)
-        {
-            ret = avformat_alloc_output_context2(
+        let mut ret = if let Some(fmt) = explicit_fmt {
+            avformat_alloc_output_context2(
                 &mut inner.format_ctx,
                 ptr::null_mut(),
                 fmt,
+                c_path.as_ptr(),
+            )
+        } else {
+            avformat_alloc_output_context2(
+                &mut inner.format_ctx,
+                ptr::null_mut(),
+                ptr::null(),
+                c_path.as_ptr(),
+            )
+        };
+
+        // Fallback to auto-detection if the explicit muxer was unavailable or
+        // failed (e.g. on a minimal FFmpeg build that omits the dedicated muxer).
+        if ret < 0 || inner.format_ctx.is_null() {
+            ret = avformat_alloc_output_context2(
+                &mut inner.format_ctx,
+                ptr::null_mut(),
+                ptr::null(),
                 c_path.as_ptr(),
             );
         }
@@ -178,6 +193,15 @@ impl ImageEncoderInner {
         (*inner.codec_ctx).height = dst_height as i32;
         (*inner.codec_ctx).time_base = AVRational { num: 1, den: 1 };
         (*inner.codec_ctx).pix_fmt = pix_fmt;
+
+        // For MJPEG, declare full-range (JPEG) color so FFmpeg does not emit
+        // "deprecated pixel format used" warnings that appear when using the
+        // deprecated YUVJ420P format. Using YUV420P + AVCOL_RANGE_JPEG is the
+        // recommended replacement since FFmpeg 5.x.
+        if codec_id == AVCodecID_AV_CODEC_ID_MJPEG {
+            // SAFETY: codec_ctx is non-null; color_range is a plain integer field.
+            (*inner.codec_ctx).color_range = AVColorRange_AVCOL_RANGE_JPEG;
+        }
 
         if let Some(q) = opts.quality {
             // SAFETY: codec_ctx is non-null and freshly allocated.
@@ -471,7 +495,9 @@ fn codec_fallback_format(codec_id: AVCodecID) -> Option<*const std::os::raw::c_c
 /// Return the preferred `AVPixelFormat` for the given codec.
 fn preferred_pix_fmt(codec_id: AVCodecID) -> AVPixelFormat {
     match codec_id {
-        x if x == AVCodecID_AV_CODEC_ID_MJPEG => AVPixelFormat_AV_PIX_FMT_YUVJ420P,
+        // Use YUV420P + AVCOL_RANGE_JPEG (set in open()) instead of the
+        // deprecated YUVJ420P alias to avoid "deprecated pixel format" warnings.
+        x if x == AVCodecID_AV_CODEC_ID_MJPEG => AVPixelFormat_AV_PIX_FMT_YUV420P,
         x if x == AVCodecID_AV_CODEC_ID_PNG => AVPixelFormat_AV_PIX_FMT_RGB24,
         x if x == AVCodecID_AV_CODEC_ID_BMP => AVPixelFormat_AV_PIX_FMT_BGR24,
         x if x == AVCodecID_AV_CODEC_ID_TIFF => AVPixelFormat_AV_PIX_FMT_RGB24,
@@ -568,10 +594,15 @@ unsafe fn apply_quality(codec_ctx: *mut ff_sys::AVCodecContext, codec_id: AVCode
             log::info!("WebP quality applied quality={q}");
         }
     } else {
-        log::warn!(
-            "quality option has no effect for this codec \
-             codec_id={codec_id} quality={q}"
-        );
+        // BMP and TIFF have no quality concept; any other codec is unrecognised.
+        let fmt_name = if codec_id == AVCodecID_AV_CODEC_ID_BMP {
+            "bmp"
+        } else if codec_id == AVCodecID_AV_CODEC_ID_TIFF {
+            "tiff"
+        } else {
+            "this format"
+        };
+        log::warn!("quality option has no effect for {fmt_name} images, ignoring quality={q}");
     }
 }
 
@@ -676,10 +707,12 @@ mod tests {
     }
 
     #[test]
-    fn preferred_pix_fmt_mjpeg_should_return_yuvj420p() {
+    fn preferred_pix_fmt_mjpeg_should_return_yuv420p() {
+        // Uses YUV420P (not the deprecated YUVJ420P); color range is set
+        // separately via color_range = AVCOL_RANGE_JPEG in open().
         assert_eq!(
             preferred_pix_fmt(AVCodecID_AV_CODEC_ID_MJPEG),
-            AVPixelFormat_AV_PIX_FMT_YUVJ420P
+            AVPixelFormat_AV_PIX_FMT_YUV420P
         );
     }
 

--- a/crates/ff-filter/src/error.rs
+++ b/crates/ff-filter/src/error.rs
@@ -14,6 +14,13 @@ pub enum FilterError {
     #[error("failed to process frame")]
     ProcessFailed,
 
+    /// An invalid configuration was detected during graph construction.
+    #[error("invalid filter configuration: {reason}")]
+    InvalidConfig {
+        /// Human-readable reason for the failure.
+        reason: String,
+    },
+
     /// A frame was pushed to an invalid input slot.
     #[error("invalid input: slot={slot} reason={reason}")]
     InvalidInput {

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -291,6 +291,24 @@ impl FilterGraphBuilder {
         if self.steps.is_empty() {
             return Err(FilterError::BuildFailed);
         }
+
+        // Validate overlay coordinates: negative x or y places the overlay
+        // entirely off-screen, which is almost always a misconfiguration
+        // (e.g. a watermark larger than the video). Catch it early with a
+        // descriptive error rather than silently producing invisible output.
+        for step in &self.steps {
+            if let FilterStep::Overlay { x, y } = step
+                && (*x < 0 || *y < 0)
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: format!(
+                        "overlay position ({x}, {y}) is off-screen; \
+                         ensure the watermark fits within the video dimensions"
+                    ),
+                });
+            }
+        }
+
         crate::filter_inner::validate_filter_steps(&self.steps)?;
         let output_resolution = self.steps.iter().rev().find_map(|s| {
             if let FilterStep::Scale { width, height } = s {


### PR DESCRIPTION
## Summary

Resolves 8 usability issues discovered while running all `crates/avio/examples/` against real media files. None were functional bugs, but each created friction or incorrect output for users learning the API.

## Changes

- **`HardwareEncoder::available()`** — excludes `Auto` and `None` control variants; now returns only concrete hardware backends (empty slice when no HW is present). Updated test reflects new contract.
- **File size display** — 16 examples previously showed `0.0 MB` for small outputs (e.g. 14 KB AAC files). All now fall back to KB display for files smaller than 1 MB.
- **JPEG encoder warnings** — two FFmpeg warnings eliminated:
  - `[swscaler] deprecated pixel format` — fixed by replacing `YUVJ420P` with `YUV420P` + `color_range = AVCOL_RANGE_JPEG` on the codec context.
  - `[image2] does not contain an image sequence pattern` — fixed by preferring explicit single-image muxers (`mjpeg`, `apng`, `tiff`, `webp`) over the `image2` muxer in `ImageEncoderInner::open()`.
- **`FilterGraphBuilder::overlay()` validation** — `build()` now returns `FilterError::InvalidConfig` when overlay coordinates are negative (off-screen). Added `InvalidConfig { reason }` variant to `FilterError`.
- **BMP quality warning** — `apply_quality()` now logs `"quality option has no effect for bmp images"` instead of a raw `codec_id` integer.
- **`video_transcode`** — resolution strings use Unicode `×` instead of ASCII `x`, consistent with all other examples.
- **`audio_transcode`** — format string guards against empty codec name to avoid doubled whitespace.

## Related Issues

Closes #576

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes