### PR TITLE
feat(ff-decode): add tokio feature flag with async decoder wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ bindgen = "0.72.1"
 pkg-config = "0.3.32"
 vcpkg = "0.2.15"
 
+# Async runtime
+tokio   = { version = "1.50.0", features = ["rt"] }
+futures = { version = "0.3.32" }
+
 # Testing
 criterion = "0.8.1"
 

--- a/crates/ff-decode/Cargo.toml
+++ b/crates/ff-decode/Cargo.toml
@@ -19,9 +19,12 @@ ff-format = { workspace = true }
 ff-sys = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
+tokio   = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+tokio = { version = "1.50.0", features = ["macros", "rt", "rt-multi-thread"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { workspace = true, features = ["processthreadsapi", "psapi"] }
@@ -29,6 +32,7 @@ winapi = { workspace = true, features = ["processthreadsapi", "psapi"] }
 [features]
 default = ["hwaccel"]
 hwaccel = []  # Hardware acceleration
+tokio = ["dep:tokio", "dep:futures"]
 
 [[bench]]
 name = "decode_bench"

--- a/crates/ff-decode/src/audio/async_decoder.rs
+++ b/crates/ff-decode/src/audio/async_decoder.rs
@@ -1,0 +1,95 @@
+//! Async audio decoder backed by `tokio::task::spawn_blocking`.
+
+use std::path::{Path, PathBuf};
+
+use ff_format::AudioFrame;
+use futures::stream::{self, Stream};
+
+use crate::audio::builder::AudioDecoder;
+use crate::error::DecodeError;
+
+/// Async wrapper around [`AudioDecoder`].
+///
+/// All blocking `FFmpeg` calls are offloaded to a `spawn_blocking` thread during
+/// `open`. Frame decoding calls `decode_one` directly on the async thread —
+/// each call takes microseconds, so the brief blocking is acceptable.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::AsyncAudioDecoder;
+/// use futures::StreamExt;
+///
+/// let mut decoder = AsyncAudioDecoder::open("audio.mp3").await?;
+/// while let Some(frame) = decoder.decode_frame().await? {
+///     println!("audio frame with {} samples", frame.samples());
+/// }
+/// ```
+pub struct AsyncAudioDecoder {
+    inner: AudioDecoder,
+}
+
+impl AsyncAudioDecoder {
+    /// Opens the audio file asynchronously.
+    ///
+    /// File I/O and codec initialisation are performed on a `spawn_blocking`
+    /// thread so the async executor is not blocked.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if the file is missing, contains no audio
+    /// stream, or uses an unsupported codec.
+    pub async fn open(path: impl AsRef<Path> + Send + 'static) -> Result<Self, DecodeError> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        let decoder = tokio::task::spawn_blocking(move || AudioDecoder::open(&path).build())
+            .await
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("spawn_blocking panicked: {e}"),
+            })??;
+        Ok(Self { inner: decoder })
+    }
+
+    /// Decodes the next audio frame.
+    ///
+    /// Returns `Ok(None)` at end of stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] on codec or I/O errors.
+    // decode_one() is synchronous but the method is intentionally `async` so
+    // callers can uniformly `.await` it alongside other async operations.
+    #[allow(clippy::unused_async)]
+    pub async fn decode_frame(&mut self) -> Result<Option<AudioFrame>, DecodeError> {
+        self.inner.decode_one()
+    }
+
+    /// Converts this decoder into a [`Stream`] of audio frames.
+    ///
+    /// The stream ends when the decoder reaches end-of-file or encounters an
+    /// error.
+    pub fn into_stream(self) -> impl Stream<Item = Result<AudioFrame, DecodeError>> {
+        stream::unfold(Some(self), |state| async move {
+            let mut decoder = state?;
+            match decoder.decode_frame().await {
+                Ok(Some(frame)) => Some((Ok(frame), Some(decoder))),
+                Ok(None) => None,
+                Err(e) => Some((Err(e), None)),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn async_audio_decoder_should_fail_on_missing_file() {
+        let result = AsyncAudioDecoder::open("/nonexistent/path/audio.mp3").await;
+        assert!(
+            matches!(result, Err(DecodeError::FileNotFound { .. })),
+            "expected FileNotFound"
+        );
+    }
+}

--- a/crates/ff-decode/src/audio/mod.rs
+++ b/crates/ff-decode/src/audio/mod.rs
@@ -3,7 +3,11 @@
 //! This module provides the audio decoder implementation for extracting audio
 //! frames from media files.
 
+#[cfg(feature = "tokio")]
+pub mod async_decoder;
 pub mod builder;
 pub mod decoder_inner;
 
+#[cfg(feature = "tokio")]
+pub use async_decoder::AsyncAudioDecoder;
 pub use builder::{AudioDecoder, AudioDecoderBuilder};

--- a/crates/ff-decode/src/image/async_decoder.rs
+++ b/crates/ff-decode/src/image/async_decoder.rs
@@ -1,0 +1,80 @@
+//! Async image decoder backed by `tokio::task::spawn_blocking`.
+
+use std::path::{Path, PathBuf};
+
+use ff_format::VideoFrame;
+
+use crate::error::DecodeError;
+use crate::image::builder::ImageDecoder;
+
+/// Async wrapper around [`ImageDecoder`].
+///
+/// Both `open` (file I/O + codec init) and `decode` (pixel conversion) are
+/// performed on `spawn_blocking` threads so the async executor is not blocked.
+///
+/// There is no `into_stream` method because an image is a single frame, not a
+/// sequence.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::AsyncImageDecoder;
+///
+/// let frame = AsyncImageDecoder::open("photo.png").await?.decode().await?;
+/// println!("{}x{}", frame.width(), frame.height());
+/// ```
+pub struct AsyncImageDecoder {
+    inner: ImageDecoder,
+}
+
+impl AsyncImageDecoder {
+    /// Opens the image file asynchronously.
+    ///
+    /// File I/O and codec initialisation are performed on a `spawn_blocking`
+    /// thread so the async executor is not blocked.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if the file is missing, contains no video
+    /// stream, or uses an unsupported codec.
+    pub async fn open(path: impl AsRef<Path> + Send + 'static) -> Result<Self, DecodeError> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        let decoder = tokio::task::spawn_blocking(move || ImageDecoder::open(&path).build())
+            .await
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("spawn_blocking panicked: {e}"),
+            })??;
+        Ok(Self { inner: decoder })
+    }
+
+    /// Decodes the image into a [`VideoFrame`].
+    ///
+    /// This consuming method runs on a `spawn_blocking` thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] on codec or I/O errors.
+    pub async fn decode(self) -> Result<VideoFrame, DecodeError> {
+        tokio::task::spawn_blocking(move || self.inner.decode())
+            .await
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("spawn_blocking panicked: {e}"),
+            })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn async_image_decoder_should_fail_on_missing_file() {
+        let result = AsyncImageDecoder::open("/nonexistent/path/photo.png").await;
+        assert!(
+            matches!(result, Err(DecodeError::FileNotFound { .. })),
+            "expected FileNotFound"
+        );
+    }
+}

--- a/crates/ff-decode/src/image/mod.rs
+++ b/crates/ff-decode/src/image/mod.rs
@@ -3,7 +3,11 @@
 //! This module provides the image decoder implementation for decoding still
 //! images (JPEG, PNG, BMP, TIFF, WebP) into [`VideoFrame`](ff_format::VideoFrame)s.
 
+#[cfg(feature = "tokio")]
+pub mod async_decoder;
 pub mod builder;
 pub mod decoder_inner;
 
+#[cfg(feature = "tokio")]
+pub use async_decoder::AsyncImageDecoder;
 pub use builder::{ImageDecoder, ImageDecoderBuilder};

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -112,6 +112,13 @@ pub use ff_common::{FramePool, PooledBuffer};
 pub use image::{ImageDecoder, ImageDecoderBuilder};
 pub use video::{VideoDecoder, VideoDecoderBuilder};
 
+#[cfg(feature = "tokio")]
+pub use audio::AsyncAudioDecoder;
+#[cfg(feature = "tokio")]
+pub use image::AsyncImageDecoder;
+#[cfg(feature = "tokio")]
+pub use video::AsyncVideoDecoder;
+
 /// Seek mode for positioning the decoder.
 ///
 /// This enum determines how seeking is performed when navigating
@@ -286,6 +293,8 @@ impl HardwareAccel {
 /// use ff_decode::prelude::*;
 /// ```
 pub mod prelude {
+    #[cfg(feature = "tokio")]
+    pub use crate::{AsyncAudioDecoder, AsyncImageDecoder, AsyncVideoDecoder};
     pub use crate::{
         AudioDecoder, AudioDecoderBuilder, DecodeError, FramePool, HardwareAccel, ImageDecoder,
         ImageDecoderBuilder, PooledBuffer, SeekMode, VideoDecoder, VideoDecoderBuilder,

--- a/crates/ff-decode/src/video/async_decoder.rs
+++ b/crates/ff-decode/src/video/async_decoder.rs
@@ -1,0 +1,95 @@
+//! Async video decoder backed by `tokio::task::spawn_blocking`.
+
+use std::path::{Path, PathBuf};
+
+use ff_format::VideoFrame;
+use futures::stream::{self, Stream};
+
+use crate::error::DecodeError;
+use crate::video::builder::VideoDecoder;
+
+/// Async wrapper around [`VideoDecoder`].
+///
+/// All blocking `FFmpeg` calls are offloaded to a `spawn_blocking` thread during
+/// `open`. Frame decoding calls `decode_one` directly on the async thread —
+/// each call takes microseconds, so the brief blocking is acceptable.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::AsyncVideoDecoder;
+/// use futures::StreamExt;
+///
+/// let mut decoder = AsyncVideoDecoder::open("video.mp4").await?;
+/// while let Some(frame) = decoder.decode_frame().await? {
+///     println!("frame at {:?}", frame.timestamp().as_duration());
+/// }
+/// ```
+pub struct AsyncVideoDecoder {
+    inner: VideoDecoder,
+}
+
+impl AsyncVideoDecoder {
+    /// Opens the video file asynchronously.
+    ///
+    /// File I/O and codec initialisation are performed on a `spawn_blocking`
+    /// thread so the async executor is not blocked.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if the file is missing, contains no video
+    /// stream, or uses an unsupported codec.
+    pub async fn open(path: impl AsRef<Path> + Send + 'static) -> Result<Self, DecodeError> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        let decoder = tokio::task::spawn_blocking(move || VideoDecoder::open(&path).build())
+            .await
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("spawn_blocking panicked: {e}"),
+            })??;
+        Ok(Self { inner: decoder })
+    }
+
+    /// Decodes the next video frame.
+    ///
+    /// Returns `Ok(None)` at end of stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] on codec or I/O errors.
+    // decode_one() is synchronous but the method is intentionally `async` so
+    // callers can uniformly `.await` it alongside other async operations.
+    #[allow(clippy::unused_async)]
+    pub async fn decode_frame(&mut self) -> Result<Option<VideoFrame>, DecodeError> {
+        self.inner.decode_one()
+    }
+
+    /// Converts this decoder into a [`Stream`] of video frames.
+    ///
+    /// The stream ends when the decoder reaches end-of-file or encounters an
+    /// error.
+    pub fn into_stream(self) -> impl Stream<Item = Result<VideoFrame, DecodeError>> {
+        stream::unfold(Some(self), |state| async move {
+            let mut decoder = state?;
+            match decoder.decode_frame().await {
+                Ok(Some(frame)) => Some((Ok(frame), Some(decoder))),
+                Ok(None) => None,
+                Err(e) => Some((Err(e), None)),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn async_video_decoder_should_fail_on_missing_file() {
+        let result = AsyncVideoDecoder::open("/nonexistent/path/video.mp4").await;
+        assert!(
+            matches!(result, Err(DecodeError::FileNotFound { .. })),
+            "expected FileNotFound"
+        );
+    }
+}

--- a/crates/ff-decode/src/video/mod.rs
+++ b/crates/ff-decode/src/video/mod.rs
@@ -3,7 +3,11 @@
 //! This module provides the video decoder implementation for extracting video
 //! frames from media files with hardware acceleration support.
 
+#[cfg(feature = "tokio")]
+pub mod async_decoder;
 pub mod builder;
 pub mod decoder_inner;
 
+#[cfg(feature = "tokio")]
+pub use async_decoder::AsyncVideoDecoder;
 pub use builder::{VideoDecoder, VideoDecoderBuilder};


### PR DESCRIPTION
## Summary

Adds an optional `tokio` feature to `ff-decode` that exposes three async decoder structs: `AsyncVideoDecoder`, `AsyncAudioDecoder`, and `AsyncImageDecoder`. Each wraps its synchronous counterpart; `open()` offloads blocking FFmpeg initialisation to `tokio::task::spawn_blocking`, and `into_stream()` (video/audio) drives frame-by-frame decoding via `futures::stream::unfold`. `AsyncImageDecoder` provides a consuming `decode()` instead of a stream, since a still image produces one frame.

## Changes

- `Cargo.toml` (workspace): add `tokio = "1.50.0"` and `futures = "0.3.32"` to `[workspace.dependencies]`
- `crates/ff-decode/Cargo.toml`: add `tokio` feature that activates both optional deps; add `tokio` (with `macros`/`rt-multi-thread`) to dev-dependencies for `#[tokio::test]`
- `src/video/async_decoder.rs` (new): `AsyncVideoDecoder` with `open`, `decode_frame`, `into_stream`
- `src/audio/async_decoder.rs` (new): `AsyncAudioDecoder` with `open`, `decode_frame`, `into_stream`
- `src/image/async_decoder.rs` (new): `AsyncImageDecoder` with `open` and consuming `decode`
- `src/video/mod.rs`, `src/audio/mod.rs`, `src/image/mod.rs`: `#[cfg(feature = "tokio")]` module declarations and re-exports
- `src/lib.rs`: top-level `#[cfg(feature = "tokio")]` re-exports and prelude entries

## Related Issues

Closes #176

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes