### PR TITLE
feat(ff-decode): upgrade AsyncVideoDecoder::decode_frame to spawn_blocking

### DIFF
--- a/crates/ff-decode/src/video/async_decoder.rs
+++ b/crates/ff-decode/src/video/async_decoder.rs
@@ -1,6 +1,7 @@
 //! Async video decoder backed by `tokio::task::spawn_blocking`.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use ff_format::VideoFrame;
 use futures::stream::{self, Stream};
@@ -10,9 +11,9 @@ use crate::video::builder::VideoDecoder;
 
 /// Async wrapper around [`VideoDecoder`].
 ///
-/// All blocking `FFmpeg` calls are offloaded to a `spawn_blocking` thread during
-/// `open`. Frame decoding calls `decode_one` directly on the async thread —
-/// each call takes microseconds, so the brief blocking is acceptable.
+/// `open` and `decode_frame` both execute on a `spawn_blocking` thread so the
+/// Tokio executor is never blocked by `FFmpeg` I/O or decoding work.
+/// Multiple concurrent callers share the inner decoder through `Arc<Mutex<...>>`.
 ///
 /// # Examples
 ///
@@ -26,7 +27,7 @@ use crate::video::builder::VideoDecoder;
 /// }
 /// ```
 pub struct AsyncVideoDecoder {
-    inner: VideoDecoder,
+    inner: Arc<Mutex<VideoDecoder>>,
 }
 
 impl AsyncVideoDecoder {
@@ -47,21 +48,37 @@ impl AsyncVideoDecoder {
                 code: 0,
                 message: format!("spawn_blocking panicked: {e}"),
             })??;
-        Ok(Self { inner: decoder })
+        Ok(Self {
+            inner: Arc::new(Mutex::new(decoder)),
+        })
     }
 
     /// Decodes the next video frame.
+    ///
+    /// The blocking `FFmpeg` call is offloaded to a `spawn_blocking` thread so
+    /// the Tokio executor is never blocked.
     ///
     /// Returns `Ok(None)` at end of stream.
     ///
     /// # Errors
     ///
     /// Returns [`DecodeError`] on codec or I/O errors.
-    // decode_one() is synchronous but the method is intentionally `async` so
-    // callers can uniformly `.await` it alongside other async operations.
-    #[allow(clippy::unused_async)]
     pub async fn decode_frame(&mut self) -> Result<Option<VideoFrame>, DecodeError> {
-        self.inner.decode_one()
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            inner
+                .lock()
+                .map_err(|_| DecodeError::Ffmpeg {
+                    code: 0,
+                    message: "mutex poisoned".to_string(),
+                })?
+                .decode_one()
+        })
+        .await
+        .map_err(|e| DecodeError::Ffmpeg {
+            code: 0,
+            message: format!("spawn_blocking panicked: {e}"),
+        })?
     }
 
     /// Converts this decoder into a [`Stream`] of video frames.

--- a/crates/ff-decode/tests/async_video_decoder_tests.rs
+++ b/crates/ff-decode/tests/async_video_decoder_tests.rs
@@ -1,0 +1,37 @@
+#![cfg(feature = "tokio")]
+
+mod fixtures;
+use fixtures::test_video_path;
+
+use ff_decode::AsyncVideoDecoder;
+
+#[tokio::test]
+async fn async_video_decoder_open_should_succeed_on_valid_file() {
+    let result = AsyncVideoDecoder::open(test_video_path()).await;
+    assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+}
+
+#[tokio::test]
+async fn async_video_decoder_decode_frame_should_return_first_frame() {
+    let mut decoder = match AsyncVideoDecoder::open(test_video_path()).await {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = decoder.decode_frame().await;
+    assert!(
+        matches!(frame, Ok(Some(_))),
+        "expected first frame, got {frame:?}"
+    );
+}
+
+#[tokio::test]
+async fn async_video_decoder_should_fail_on_missing_file() {
+    let result = AsyncVideoDecoder::open("/nonexistent/video.mp4").await;
+    assert!(matches!(
+        result,
+        Err(ff_decode::DecodeError::FileNotFound { .. })
+    ));
+}


### PR DESCRIPTION
## Summary

Upgrades `AsyncVideoDecoder` to fully offload FFmpeg work off the Tokio executor. The #176 scaffold called `decode_one()` synchronously inside an `async fn` — acceptable as a placeholder but incorrect for a true async API. This PR moves both `open` and `decode_frame` onto `tokio::task::spawn_blocking` threads and restructures the inner state as `Arc<Mutex<VideoDecoder>>` to satisfy the `'static + Send` closure requirement.

## Changes

- `inner: VideoDecoder` → `inner: Arc<Mutex<VideoDecoder>>` in `AsyncVideoDecoder`
- `decode_frame` now clones the `Arc`, moves it into `spawn_blocking`, acquires the `Mutex`, and calls `decode_one()` — the executor thread is never blocked
- `Mutex::lock()` errors are mapped to `DecodeError::Ffmpeg` (no `unwrap()`)
- Removed `#[allow(clippy::unused_async)]` since `decode_frame` is now genuinely async
- Added `crates/ff-decode/tests/async_video_decoder_tests.rs` with three integration tests guarded by `#![cfg(feature = "tokio")]`: successful open, first-frame decode, and missing-file error path

## Related Issues

Closes #177

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes