### PR TITLE
feat(ff-decode): add compile-time Send assertions for async decoders

### DIFF
--- a/crates/ff-decode/src/audio/async_decoder.rs
+++ b/crates/ff-decode/src/audio/async_decoder.rs
@@ -105,6 +105,13 @@ impl AsyncAudioDecoder {
 mod tests {
     use super::*;
 
+    // Compile-time proof that AsyncAudioDecoder satisfies the Send bound
+    // required by tokio::spawn and other Send-requiring contexts.
+    fn _assert_send() {
+        fn is_send<T: Send>() {}
+        is_send::<AsyncAudioDecoder>();
+    }
+
     #[tokio::test]
     async fn async_audio_decoder_should_fail_on_missing_file() {
         let result = AsyncAudioDecoder::open("/nonexistent/path/audio.mp3").await;

--- a/crates/ff-decode/src/video/async_decoder.rs
+++ b/crates/ff-decode/src/video/async_decoder.rs
@@ -105,6 +105,13 @@ impl AsyncVideoDecoder {
 mod tests {
     use super::*;
 
+    // Compile-time proof that AsyncVideoDecoder satisfies the Send bound
+    // required by tokio::spawn and other Send-requiring contexts.
+    fn _assert_send() {
+        fn is_send<T: Send>() {}
+        is_send::<AsyncVideoDecoder>();
+    }
+
     #[tokio::test]
     async fn async_video_decoder_should_fail_on_missing_file() {
         let result = AsyncVideoDecoder::open("/nonexistent/path/video.mp4").await;


### PR DESCRIPTION
## Summary

The `Arc<Mutex<T>>` wrapping and `unsafe impl Send` for `VideoDecoderInner` / `AudioDecoderInner` were established in earlier issues (#177–#179). This PR completes issue #180 by adding the specified compile-time `_assert_send()` proofs to the test modules of both async decoder files, making the `Send` guarantees explicit and regression-proof.

## Changes

- Add `fn _assert_send()` to `video/async_decoder.rs` test module — verifies `AsyncVideoDecoder: Send` at compile time
- Add `fn _assert_send()` to `audio/async_decoder.rs` test module — verifies `AsyncAudioDecoder: Send` at compile time
- Both functions use a local `fn is_send<T: Send>() {}` helper; they have zero runtime cost and produce a build error the moment a non-`Send` field is introduced

## Related Issues

Closes #180

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes