### PR TITLE
feat(ff-encode): implement AsyncAudioEncoder with bounded mpsc channel

### DIFF
--- a/crates/ff-encode/src/audio/async_encoder.rs
+++ b/crates/ff-encode/src/audio/async_encoder.rs
@@ -1,0 +1,158 @@
+//! Async audio encoder backed by a bounded `tokio::sync::mpsc` channel.
+
+use ff_format::AudioFrame;
+use tokio::sync::mpsc;
+
+use super::builder::{AudioEncoder, AudioEncoderBuilder};
+use crate::EncodeError;
+
+/// Messages sent from the async front-end to the worker thread.
+enum WorkerMsg {
+    Frame(AudioFrame),
+}
+
+/// Async wrapper around [`AudioEncoder`].
+///
+/// Frames are queued into a bounded channel (capacity 8) and encoded by a
+/// dedicated worker thread. When the channel is full, [`push`] suspends the
+/// caller, providing natural back-pressure.
+///
+/// # Construction
+///
+/// Use [`AudioEncoder::create`] to configure the encoder, then call
+/// [`AsyncAudioEncoder::from_builder`]:
+///
+/// ```ignore
+/// use ff_encode::{AsyncAudioEncoder, AudioEncoder, AudioCodec};
+///
+/// let mut encoder = AsyncAudioEncoder::from_builder(
+///     AudioEncoder::create("output.m4a")
+///         .audio(48000, 2)
+///         .audio_codec(AudioCodec::Aac),
+/// )?;
+///
+/// encoder.push(frame).await?;
+/// encoder.finish().await?;
+/// ```
+///
+/// # Back-pressure
+///
+/// The internal channel holds at most 8 frames. Once that buffer is full,
+/// [`push`] yields until the worker drains a slot. This prevents unbounded
+/// memory growth when the encoder cannot keep up with the incoming frame rate.
+///
+/// [`push`]: AsyncAudioEncoder::push
+pub struct AsyncAudioEncoder {
+    sender: mpsc::Sender<WorkerMsg>,
+    join_handle: Option<std::thread::JoinHandle<Result<(), EncodeError>>>,
+}
+
+impl std::fmt::Debug for AsyncAudioEncoder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsyncAudioEncoder").finish_non_exhaustive()
+    }
+}
+
+impl AsyncAudioEncoder {
+    /// Builds an async encoder from a configured builder.
+    ///
+    /// Consumes the builder, validates the configuration, opens the output
+    /// file, and starts the worker thread. The worker runs the synchronous
+    /// FFmpeg encode loop in the background.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError`] if the builder configuration is invalid or
+    /// the output file cannot be created.
+    pub fn from_builder(builder: AudioEncoderBuilder) -> Result<Self, EncodeError> {
+        let encoder = builder.build()?;
+        let (tx, rx) = mpsc::channel::<WorkerMsg>(8);
+
+        let handle = std::thread::spawn(move || -> Result<(), EncodeError> {
+            let mut encoder: AudioEncoder = encoder;
+            let mut rx = rx;
+            while let Some(WorkerMsg::Frame(frame)) = rx.blocking_recv() {
+                encoder.push(&frame)?;
+            }
+            // Channel closed (sender dropped) → flush remaining frames and write trailer.
+            encoder.finish()
+        });
+
+        Ok(Self {
+            sender: tx,
+            join_handle: Some(handle),
+        })
+    }
+
+    /// Queues an audio frame for encoding.
+    ///
+    /// If the internal channel (capacity 8) is full, this method suspends
+    /// the caller until the worker drains a slot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError::WorkerPanicked`] if the worker thread has
+    /// exited unexpectedly.
+    pub async fn push(&mut self, frame: AudioFrame) -> Result<(), EncodeError> {
+        self.sender
+            .send(WorkerMsg::Frame(frame))
+            .await
+            .map_err(|_| EncodeError::WorkerPanicked)
+    }
+
+    /// Signals end-of-stream, flushes remaining frames, and writes the file trailer.
+    ///
+    /// Drops the channel sender (signalling EOF to the worker), then waits
+    /// for the worker thread to finish without blocking the async executor.
+    /// Any error from the worker is propagated back to the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError`] if encoding fails during flush or if the
+    /// worker thread panicked.
+    pub async fn finish(self) -> Result<(), EncodeError> {
+        let Self {
+            sender,
+            join_handle,
+        } = self;
+        // Dropping the sender closes the channel; the worker's blocking_recv()
+        // returns None, breaks out of the loop, and calls encoder.finish().
+        drop(sender);
+        if let Some(handle) = join_handle {
+            // Join on a spawn_blocking thread so the async executor is not blocked.
+            tokio::task::spawn_blocking(move || {
+                handle.join().map_err(|_| EncodeError::WorkerPanicked)?
+            })
+            .await
+            .map_err(|_| EncodeError::WorkerPanicked)?
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time proof that AsyncAudioEncoder satisfies Send.
+    fn _assert_send() {
+        fn is_send<T: Send>() {}
+        is_send::<AsyncAudioEncoder>();
+    }
+
+    #[test]
+    fn from_builder_should_fail_on_invalid_config() {
+        // A builder with no streams configured is rejected at build time,
+        // not in the worker thread — the error surfaces from from_builder.
+        let result = AsyncAudioEncoder::from_builder(AudioEncoder::create("out.m4a"));
+        assert!(
+            result.is_err(),
+            "expected error for unconfigured builder, got Ok"
+        );
+        assert!(
+            matches!(result.unwrap_err(), EncodeError::InvalidConfig { .. }),
+            "expected InvalidConfig"
+        );
+    }
+}

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -786,6 +786,13 @@ fn sample_format_to_av(format: ff_format::SampleFormat) -> ff_sys::AVSampleForma
     }
 }
 
+// SAFETY: AudioEncoderInner owns all FFmpeg contexts exclusively.
+//         These contexts are not accessed from multiple threads simultaneously;
+//         all access is serialized by whichever thread holds the AudioEncoder.
+//         Ownership transfer between threads is safe because FFmpeg contexts
+//         are created and destroyed on the same thread (via std::thread::spawn).
+unsafe impl Send for AudioEncoderInner {}
+
 #[cfg(test)]
 mod tests {
     use ff_format::SampleFormat;

--- a/crates/ff-encode/src/audio/mod.rs
+++ b/crates/ff-encode/src/audio/mod.rs
@@ -4,7 +4,11 @@
 //! The implementation is split into public API ([`builder`]) and internal
 //! implementation details ([`encoder_inner`]).
 
+#[cfg(feature = "tokio")]
+pub mod async_encoder;
 pub mod builder;
 mod encoder_inner;
 
+#[cfg(feature = "tokio")]
+pub use async_encoder::AsyncAudioEncoder;
 pub use builder::{AudioEncoder, AudioEncoderBuilder};

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -215,4 +215,6 @@ pub use progress::{EncodeProgress, EncodeProgressCallback};
 pub use video::{VideoEncoder, VideoEncoderBuilder};
 
 #[cfg(feature = "tokio")]
+pub use audio::AsyncAudioEncoder;
+#[cfg(feature = "tokio")]
 pub use video::AsyncVideoEncoder;


### PR DESCRIPTION
## Summary

Implements `AsyncAudioEncoder` for the `ff-encode` crate under the `tokio` feature flag. The encoder wraps the synchronous `AudioEncoder` in a `std::thread` worker and communicates via a bounded `tokio::sync::mpsc` channel (capacity 8), providing natural back-pressure when the worker cannot keep up. This mirrors the `AsyncVideoEncoder` added in #182.

## Changes

- `src/audio/async_encoder.rs` — new `AsyncAudioEncoder` with `from_builder`, `push`, and `finish` methods; compile-time `_assert_send` proof; unit test for invalid-config rejection
- `src/audio/encoder_inner.rs` — added `unsafe impl Send for AudioEncoderInner` so the encoder can be moved into `std::thread::spawn`
- `src/audio/mod.rs` — registered `async_encoder` module and re-exported `AsyncAudioEncoder` under `#[cfg(feature = "tokio")]`
- `src/lib.rs` — added `pub use audio::AsyncAudioEncoder` under `#[cfg(feature = "tokio")]`

## Related Issues

Closes #183

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes