### PR TITLE
feat(ff-encode): add WorkerMsg::Finish sentinel and async encoder tests

### DIFF
--- a/crates/ff-encode/Cargo.toml
+++ b/crates/ff-encode/Cargo.toml
@@ -41,6 +41,7 @@ tokio = ["dep:tokio"]
 criterion = { workspace = true }
 ff-decode = { workspace = true }
 ff-probe  = { workspace = true }
+tokio = { version = "1.50.0", features = ["macros", "rt", "rt-multi-thread"] }
 
 # Benchmark configuration
 [[bench]]

--- a/crates/ff-encode/src/audio/async_encoder.rs
+++ b/crates/ff-encode/src/audio/async_encoder.rs
@@ -9,6 +9,7 @@ use crate::EncodeError;
 /// Messages sent from the async front-end to the worker thread.
 enum WorkerMsg {
     Frame(AudioFrame),
+    Finish,
 }
 
 /// Async wrapper around [`AudioEncoder`].
@@ -71,10 +72,14 @@ impl AsyncAudioEncoder {
         let handle = std::thread::spawn(move || -> Result<(), EncodeError> {
             let mut encoder: AudioEncoder = encoder;
             let mut rx = rx;
-            while let Some(WorkerMsg::Frame(frame)) = rx.blocking_recv() {
-                encoder.push(&frame)?;
+            #[allow(clippy::while_let_loop)]
+            loop {
+                match rx.blocking_recv() {
+                    Some(WorkerMsg::Frame(frame)) => encoder.push(&frame)?,
+                    Some(WorkerMsg::Finish) | None => break,
+                }
             }
-            // Channel closed (sender dropped) → flush remaining frames and write trailer.
+            // Flush remaining frames and write the container trailer.
             encoder.finish()
         });
 
@@ -115,8 +120,12 @@ impl AsyncAudioEncoder {
             sender,
             join_handle,
         } = self;
-        // Dropping the sender closes the channel; the worker's blocking_recv()
-        // returns None, breaks out of the loop, and calls encoder.finish().
+        // Send the Finish sentinel so the worker exits its loop cleanly, then
+        // drop the sender to close the channel.
+        sender
+            .send(WorkerMsg::Finish)
+            .await
+            .map_err(|_| EncodeError::WorkerPanicked)?;
         drop(sender);
         if let Some(handle) = join_handle {
             // Join on a spawn_blocking thread so the async executor is not blocked.

--- a/crates/ff-encode/src/video/async_encoder.rs
+++ b/crates/ff-encode/src/video/async_encoder.rs
@@ -9,6 +9,7 @@ use crate::EncodeError;
 /// Messages sent from the async front-end to the worker thread.
 enum WorkerMsg {
     Frame(VideoFrame),
+    Finish,
 }
 
 /// Async wrapper around [`VideoEncoder`].
@@ -71,10 +72,14 @@ impl AsyncVideoEncoder {
         let handle = std::thread::spawn(move || -> Result<(), EncodeError> {
             let mut encoder: VideoEncoder = encoder;
             let mut rx = rx;
-            while let Some(WorkerMsg::Frame(frame)) = rx.blocking_recv() {
-                encoder.push_video(&frame)?;
+            #[allow(clippy::while_let_loop)]
+            loop {
+                match rx.blocking_recv() {
+                    Some(WorkerMsg::Frame(frame)) => encoder.push_video(&frame)?,
+                    Some(WorkerMsg::Finish) | None => break,
+                }
             }
-            // Channel closed (sender dropped) → flush remaining frames and write trailer.
+            // Flush remaining frames and write the container trailer.
             encoder.finish()
         });
 
@@ -115,8 +120,12 @@ impl AsyncVideoEncoder {
             sender,
             join_handle,
         } = self;
-        // Dropping the sender closes the channel; the worker's blocking_recv()
-        // returns None, breaks out of the loop, and calls encoder.finish().
+        // Send the Finish sentinel so the worker exits its loop cleanly, then
+        // drop the sender to close the channel.
+        sender
+            .send(WorkerMsg::Finish)
+            .await
+            .map_err(|_| EncodeError::WorkerPanicked)?;
         drop(sender);
         if let Some(handle) = join_handle {
             // Join on a spawn_blocking thread so the async executor is not blocked.

--- a/crates/ff-encode/tests/async_encoder_tests.rs
+++ b/crates/ff-encode/tests/async_encoder_tests.rs
@@ -1,0 +1,133 @@
+//! Integration tests for async encoder `finish()`.
+//!
+//! These tests verify that `finish()` drains all queued frames, flushes the
+//! codec, writes the container trailer, and produces a valid output file.
+
+#![cfg(feature = "tokio")]
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+use fixtures::{FileGuard, assert_valid_output_file, create_black_frame, test_output_path};
+
+use ff_encode::{
+    AsyncAudioEncoder, AsyncVideoEncoder, AudioCodec, AudioEncoder, VideoCodec, VideoEncoder,
+};
+use ff_format::{AudioFrame, SampleFormat};
+
+// ============================================================================
+// AsyncVideoEncoder
+// ============================================================================
+
+#[tokio::test]
+async fn async_video_encoder_finish_should_produce_valid_output() {
+    let output = test_output_path("async_video_finish.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let mut encoder = match AsyncVideoEncoder::from_builder(
+        VideoEncoder::create(&output)
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Mpeg4),
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder.push(frame).await.expect("push failed");
+    }
+
+    encoder.finish().await.expect("finish failed");
+
+    assert_valid_output_file(&output);
+    ff_probe::open(&output).expect("output not parseable by ff_probe");
+}
+
+#[tokio::test]
+async fn async_video_encoder_finish_with_many_frames_should_apply_backpressure() {
+    // Push more frames than the channel capacity (8) to exercise back-pressure.
+    let output = test_output_path("async_video_backpressure.mp4");
+    let _guard = FileGuard::new(output.clone());
+
+    let mut encoder = match AsyncVideoEncoder::from_builder(
+        VideoEncoder::create(&output)
+            .video(320, 240, 30.0)
+            .video_codec(VideoCodec::Mpeg4),
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..30 {
+        let frame = create_black_frame(320, 240);
+        encoder.push(frame).await.expect("push failed");
+    }
+
+    encoder.finish().await.expect("finish failed");
+    assert_valid_output_file(&output);
+}
+
+// ============================================================================
+// AsyncAudioEncoder
+// ============================================================================
+
+#[tokio::test]
+async fn async_audio_encoder_finish_should_produce_valid_output() {
+    let output = test_output_path("async_audio_finish.m4a");
+    let _guard = FileGuard::new(output.clone());
+
+    let mut encoder = match AsyncAudioEncoder::from_builder(
+        AudioEncoder::create(&output)
+            .audio(48000, 2)
+            .audio_codec(AudioCodec::Aac),
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..20 {
+        let frame = AudioFrame::empty(1024, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(frame).await.expect("push failed");
+    }
+
+    encoder.finish().await.expect("finish failed");
+
+    assert_valid_output_file(&output);
+    ff_probe::open(&output).expect("output not parseable by ff_probe");
+}
+
+#[tokio::test]
+async fn async_audio_encoder_finish_with_many_frames_should_apply_backpressure() {
+    // Push more frames than the channel capacity (8) to exercise back-pressure.
+    let output = test_output_path("async_audio_backpressure.m4a");
+    let _guard = FileGuard::new(output.clone());
+
+    let mut encoder = match AsyncAudioEncoder::from_builder(
+        AudioEncoder::create(&output)
+            .audio(48000, 2)
+            .audio_codec(AudioCodec::Aac),
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..30 {
+        let frame = AudioFrame::empty(1024, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(frame).await.expect("push failed");
+    }
+
+    encoder.finish().await.expect("finish failed");
+    assert_valid_output_file(&output);
+}


### PR DESCRIPTION
## Summary

Upgrades the `finish()` shutdown contract in `AsyncVideoEncoder` and `AsyncAudioEncoder` from an implicit channel-drop signal to an explicit `WorkerMsg::Finish` sentinel. The worker loop now exhaustively matches all message variants, making the end-of-stream handshake unambiguous. Integration tests verify that `finish()` produces a valid, probe-parseable output file and that back-pressure works when frame bursts exceed channel capacity.

## Changes

- `src/video/async_encoder.rs` — added `WorkerMsg::Finish` variant; replaced `while let` with an explicit `loop { match ... }` (guarded with `#[allow(clippy::while_let_loop)]` to preserve exhaustive matching); `finish()` now sends `Finish` before dropping the sender
- `src/audio/async_encoder.rs` — same changes mirrored for the audio encoder
- `Cargo.toml` — added `tokio` to `[dev-dependencies]` with `macros`, `rt`, `rt-multi-thread` features for `#[tokio::test]`
- `tests/async_encoder_tests.rs` — new integration test file (4 tests): `async_video_encoder_finish_should_produce_valid_output`, `async_audio_encoder_finish_should_produce_valid_output`, and two back-pressure tests; output validity verified with `ff_probe::open`

## Related Issues

Closes #184

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes