### PR TITLE
fix(ff-sys): add missing docsrs_stubs symbols to fix docs.rs build failures

### DIFF
--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -730,6 +730,21 @@ pub mod avcodec {
     }
 
     pub unsafe fn flush_buffers(_ctx: *mut AVCodecContext) {}
+
+    pub unsafe fn parameters_from_context(
+        _par: *mut AVCodecParameters,
+        _ctx: *const AVCodecContext,
+    ) -> Result<(), c_int> {
+        Err(-1)
+    }
+
+    pub mod codec_caps {
+        pub const EXPERIMENTAL: u32 = 1 << 9;
+        pub const HARDWARE: u32 = 1 << 10;
+        pub const HYBRID: u32 = 1 << 11;
+        pub const VARIABLE_FRAME_SIZE: u32 = 1 << 16;
+        pub const AVOID_PROBING: u32 = 1 << 17;
+    }
 }
 
 /// Stub `swresample` wrapper module.


### PR DESCRIPTION
## Summary

Four crates (`ff-encode`, `ff-pipeline`, `ff-stream`, `avio`) were failing on
docs.rs because `docsrs_stubs.rs` was missing symbols that those crates
reference from `ff-sys`. On docs.rs the real bindgen-generated bindings are
replaced by these hand-written stubs (`DOCS_RS=1` path in `ff-sys/build.rs`),
so any missing symbol causes a compile error in dependent crates.

## Changes

- `avcodec::parameters_from_context` — used by `ff-pipeline` and `ff-stream`
  to copy codec parameters from a codec context to stream parameters during
  output container setup
- `avcodec::codec_caps` submodule with `EXPERIMENTAL`, `HARDWARE`, `HYBRID`,
  `VARIABLE_FRAME_SIZE`, `AVOID_PROBING` — used by `ff-encode` audio encoder
  to detect whether a codec requires a fixed frame size

## Related Issues

N/A — docs.rs infrastructure fix

## Test Plan

- [x] `cargo clippy -p ff-sys -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc -p ff-sys --no-deps` passes