### PR TITLE
feat(ff-decode): remove DecodeError::EndOfStream and unify EOF to Ok(None)

### DIFF
--- a/crates/avio/examples/async_decode_audio.rs
+++ b/crates/avio/examples/async_decode_audio.rs
@@ -22,7 +22,7 @@
 
 use std::{path::Path, process};
 
-use avio::{AsyncAudioDecoder, DecodeError};
+use avio::AsyncAudioDecoder;
 use futures::StreamExt;
 
 #[tokio::main]
@@ -90,7 +90,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 frame_count += 1;
             }
             Ok(None) => break,
-            Err(DecodeError::EndOfStream) => break,
             Err(e) => {
                 eprintln!("Decode error: {e}");
                 break;
@@ -157,7 +156,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         while let Some(result) = stream.next().await {
             match result {
                 Ok(frame) => total += frame.samples() as u64,
-                Err(DecodeError::EndOfStream) => break,
                 Err(e) => {
                     eprintln!("Background decode error: {e}");
                     break;

--- a/crates/avio/examples/async_decode_video.rs
+++ b/crates/avio/examples/async_decode_video.rs
@@ -23,7 +23,7 @@
 
 use std::{path::Path, process};
 
-use avio::{AsyncVideoDecoder, DecodeError};
+use avio::AsyncVideoDecoder;
 use futures::StreamExt;
 
 #[tokio::main]
@@ -87,7 +87,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 frame_count += 1;
             }
             Ok(None) => break,
-            Err(DecodeError::EndOfStream) => break,
             Err(e) => {
                 eprintln!("Decode error: {e}");
                 break;
@@ -152,7 +151,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         while let Some(result) = stream.next().await {
             match result {
                 Ok(_frame) => count += 1,
-                Err(DecodeError::EndOfStream) => break,
                 Err(e) => {
                     eprintln!("Background decode error: {e}");
                     break;

--- a/crates/avio/examples/async_encode_audio.rs
+++ b/crates/avio/examples/async_encode_audio.rs
@@ -31,9 +31,7 @@
 
 use std::{path::Path, process};
 
-use avio::{
-    AsyncAudioDecoder, AsyncAudioEncoder, AudioCodec, AudioDecoder, AudioEncoder, DecodeError,
-};
+use avio::{AsyncAudioDecoder, AsyncAudioEncoder, AudioCodec, AudioDecoder, AudioEncoder};
 use futures::StreamExt;
 
 #[tokio::main]
@@ -159,7 +157,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 encoder.push(frame).await?;
                 frames += 1;
             }
-            Err(DecodeError::EndOfStream) => break,
             Err(e) => {
                 eprintln!("Decode error: {e}");
                 break;
@@ -204,7 +201,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 break; // Consumer dropped; stop producing.
                             }
                         }
-                        Err(DecodeError::EndOfStream) => break,
                         Err(e) => {
                             eprintln!("Producer decode error: {e}");
                             break;

--- a/crates/avio/examples/async_encode_video.rs
+++ b/crates/avio/examples/async_encode_video.rs
@@ -24,9 +24,7 @@
 
 use std::{path::Path, process};
 
-use avio::{
-    AsyncVideoDecoder, AsyncVideoEncoder, DecodeError, VideoCodec, VideoDecoder, VideoEncoder,
-};
+use avio::{AsyncVideoDecoder, AsyncVideoEncoder, VideoCodec, VideoDecoder, VideoEncoder};
 use futures::StreamExt;
 
 #[tokio::main]
@@ -134,7 +132,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 encoder.push(frame).await?;
                 frames += 1;
             }
-            Err(DecodeError::EndOfStream) => break,
             Err(e) => {
                 eprintln!("Decode error: {e}");
                 break;
@@ -183,7 +180,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 break;
                             }
                         }
-                        Err(DecodeError::EndOfStream) => break,
                         Err(e) => {
                             eprintln!("Producer decode error: {e}");
                             break;

--- a/crates/avio/examples/async_transcode.rs
+++ b/crates/avio/examples/async_transcode.rs
@@ -28,9 +28,7 @@
 
 use std::{path::Path, process};
 
-use avio::{
-    AsyncVideoDecoder, AsyncVideoEncoder, DecodeError, VideoCodec, VideoDecoder, VideoEncoder,
-};
+use avio::{AsyncVideoDecoder, AsyncVideoEncoder, VideoCodec, VideoDecoder, VideoEncoder};
 use futures::StreamExt;
 
 #[tokio::main]
@@ -155,7 +153,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 frames += 1;
             }
-            Err(DecodeError::EndOfStream) => break,
             Err(e) => {
                 eprintln!("Decode error: {e}");
                 break;

--- a/crates/avio/examples/decode_iterator.rs
+++ b/crates/avio/examples/decode_iterator.rs
@@ -20,7 +20,7 @@
 
 use std::{path::Path, process};
 
-use avio::{AudioDecoder, DecodeError, ImageDecoder, VideoDecoder};
+use avio::{AudioDecoder, ImageDecoder, VideoDecoder};
 
 fn main() {
     let mut args = std::env::args().skip(1);
@@ -76,7 +76,6 @@ fn main() {
             for result in vdec.frames() {
                 match result {
                     Ok(_frame) => video_frames += 1,
-                    Err(DecodeError::EndOfStream) => break,
                     Err(e) => {
                         eprintln!("Video decode error: {e}");
                         break;
@@ -115,7 +114,6 @@ fn main() {
                         audio_frames += 1;
                         total_samples += frame.samples() as u64;
                     }
-                    Err(DecodeError::EndOfStream) => break,
                     Err(e) => {
                         eprintln!("Audio decode error: {e}");
                         break;
@@ -155,7 +153,6 @@ fn main() {
                                 frame.format(),
                             );
                         }
-                        Err(DecodeError::EndOfStream) => break,
                         Err(e) => {
                             eprintln!("Image decode error: {e}");
                             break;

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -322,7 +322,7 @@ mod tests {
     #[cfg(feature = "decode")]
     #[test]
     fn decode_error_should_be_accessible() {
-        let _: DecodeError = DecodeError::EndOfStream;
+        let _: DecodeError = DecodeError::decoding_failed("test");
     }
 
     #[cfg(feature = "decode")]

--- a/crates/avio/tests/feature_combinations_test.rs
+++ b/crates/avio/tests/feature_combinations_test.rs
@@ -42,7 +42,7 @@ fn probe_feature_should_expose_probe_error_and_open() {
 #[cfg(feature = "decode")]
 #[test]
 fn decode_feature_should_expose_decode_error_and_decoders() {
-    let _: avio::DecodeError = avio::DecodeError::EndOfStream;
+    let _: avio::DecodeError = avio::DecodeError::decoding_failed("test");
     let _: avio::SeekMode = avio::SeekMode::Keyframe;
     let _: avio::HardwareAccel = avio::HardwareAccel::None;
     // VecPool::new() returns Arc<VecPool>

--- a/crates/ff-decode/src/error.rs
+++ b/crates/ff-decode/src/error.rs
@@ -22,7 +22,6 @@ use crate::HardwareAccel;
 /// - **Codec errors**: [`UnsupportedCodec`](Self::UnsupportedCodec)
 /// - **Runtime errors**: [`DecodingFailed`](Self::DecodingFailed), [`SeekFailed`](Self::SeekFailed)
 /// - **Hardware errors**: [`HwAccelUnavailable`](Self::HwAccelUnavailable)
-/// - **Stream state**: [`EndOfStream`](Self::EndOfStream)
 /// - **Internal errors**: [`Ffmpeg`](Self::Ffmpeg), [`Io`](Self::Io)
 #[derive(Error, Debug)]
 pub enum DecodeError {
@@ -99,13 +98,6 @@ pub enum DecodeError {
         /// The unavailable hardware acceleration type.
         accel: HardwareAccel,
     },
-
-    /// End of stream has been reached.
-    ///
-    /// This is returned when attempting to decode past the end of the file.
-    /// It's a normal condition that indicates all frames have been decoded.
-    #[error("End of stream")]
-    EndOfStream,
 
     /// `FFmpeg` internal error.
     ///
@@ -232,21 +224,6 @@ impl DecodeError {
         }
     }
 
-    /// Returns `true` if this error indicates end of stream.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ff_decode::DecodeError;
-    ///
-    /// assert!(DecodeError::EndOfStream.is_eof());
-    /// assert!(!DecodeError::decoding_failed("test").is_eof());
-    /// ```
-    #[must_use]
-    pub fn is_eof(&self) -> bool {
-        matches!(self, Self::EndOfStream)
-    }
-
     /// Returns `true` if this error is recoverable.
     ///
     /// Recoverable errors are those where the decoder can continue
@@ -265,8 +242,6 @@ impl DecodeError {
     /// // Seek failures are recoverable
     /// assert!(DecodeError::seek_failed(Duration::from_secs(1), "test").is_recoverable());
     ///
-    /// // End of stream is not recoverable
-    /// assert!(!DecodeError::EndOfStream.is_recoverable());
     /// ```
     #[must_use]
     pub fn is_recoverable(&self) -> bool {
@@ -290,8 +265,6 @@ impl DecodeError {
     /// // Unsupported codec is fatal
     /// assert!(DecodeError::UnsupportedCodec { codec: "test".to_string() }.is_fatal());
     ///
-    /// // End of stream is not fatal
-    /// assert!(!DecodeError::EndOfStream.is_fatal());
     /// ```
     #[must_use]
     pub fn is_fatal(&self) -> bool {
@@ -328,9 +301,6 @@ mod tests {
         };
         assert!(error.to_string().contains("Codec not supported"));
         assert!(error.to_string().contains("unknown_codec"));
-
-        let error = DecodeError::EndOfStream;
-        assert_eq!(error.to_string(), "End of stream");
     }
 
     #[test]
@@ -395,22 +365,9 @@ mod tests {
     }
 
     #[test]
-    fn test_is_eof() {
-        assert!(DecodeError::EndOfStream.is_eof());
-        assert!(!DecodeError::decoding_failed("test").is_eof());
-        assert!(
-            !DecodeError::FileNotFound {
-                path: PathBuf::new()
-            }
-            .is_eof()
-        );
-    }
-
-    #[test]
     fn test_is_recoverable() {
         assert!(DecodeError::decoding_failed("test").is_recoverable());
         assert!(DecodeError::seek_failed(Duration::from_secs(1), "test").is_recoverable());
-        assert!(!DecodeError::EndOfStream.is_recoverable());
         assert!(
             !DecodeError::FileNotFound {
                 path: PathBuf::new()
@@ -445,7 +402,6 @@ mod tests {
             }
             .is_fatal()
         );
-        assert!(!DecodeError::EndOfStream.is_fatal());
         assert!(!DecodeError::decoding_failed("test").is_fatal());
     }
 

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -383,9 +383,6 @@ mod tests {
             codec: "unknown_codec".to_string(),
         };
         assert!(error.to_string().contains("Codec not supported"));
-
-        let error = DecodeError::EndOfStream;
-        assert_eq!(error.to_string(), "End of stream");
     }
 
     #[test]

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -872,7 +872,7 @@ impl VideoDecoder {
     ///
     /// Returns [`DecodeError`] if:
     /// - Seeking to the position fails
-    /// - No frame can be decoded at that position ([`DecodeError::EndOfStream`])
+    /// - No frame can be decoded at that position (returns `Ok(None)`)
     /// - Scaling fails
     ///
     /// # Examples
@@ -905,15 +905,15 @@ impl VideoDecoder {
         position: Duration,
         width: u32,
         height: u32,
-    ) -> Result<VideoFrame, DecodeError> {
+    ) -> Result<Option<VideoFrame>, DecodeError> {
         // 1. Seek to the specified position (keyframe mode for speed)
         self.seek(position, crate::SeekMode::Keyframe)?;
 
-        // 2. Decode one frame
-        let frame = self.decode_one()?.ok_or(DecodeError::EndOfStream)?;
-
-        // 3. Scale the frame to target dimensions
-        self.inner.scale_frame(&frame, width, height)
+        // 2. Decode one frame — Ok(None) means no frame at this position
+        match self.decode_one()? {
+            Some(frame) => self.inner.scale_frame(&frame, width, height).map(Some),
+            None => Ok(None),
+        }
     }
 
     /// Generates multiple thumbnails evenly distributed across the video.
@@ -1026,8 +1026,9 @@ impl VideoDecoder {
             let position_nanos_u64 = position_nanos.min(u128::from(u64::MAX)) as u64;
             let position = Duration::from_nanos(position_nanos_u64);
 
-            let thumbnail = self.thumbnail_at(position, width, height)?;
-            thumbnails.push(thumbnail);
+            if let Some(thumbnail) = self.thumbnail_at(position, width, height)? {
+                thumbnails.push(thumbnail);
+            }
         }
 
         Ok(thumbnails)

--- a/crates/ff-decode/tests/performance_validation_tests.rs
+++ b/crates/ff-decode/tests/performance_validation_tests.rs
@@ -251,6 +251,7 @@ fn test_thumbnail_generation_performance() {
         decoder
             .thumbnail_at(Duration::from_secs(2), 320, 180)
             .expect("Thumbnail generation failed")
+            .expect("frame should be available")
     });
 
     assert!(!result.planes().is_empty(), "Should generate thumbnail");

--- a/crates/ff-decode/tests/thumbnail_tests.rs
+++ b/crates/ff-decode/tests/thumbnail_tests.rs
@@ -25,7 +25,8 @@ fn test_thumbnail_at_basic() {
 
     let thumbnail = decoder
         .thumbnail_at(position, width, height)
-        .expect("thumbnail_at should succeed");
+        .expect("thumbnail_at should succeed")
+        .expect("frame should be available");
 
     // Verify dimensions
     assert_eq!(
@@ -50,7 +51,8 @@ fn test_thumbnail_at_timestamp() {
     let position = Duration::from_secs(3);
     let thumbnail = decoder
         .thumbnail_at(position, 320, 180)
-        .expect("thumbnail_at should succeed");
+        .expect("thumbnail_at should succeed")
+        .expect("frame should be available");
 
     // Timestamp should be close to requested position
     // (may not be exact due to keyframe seeking)
@@ -71,7 +73,8 @@ fn test_thumbnail_at_beginning() {
 
     let thumbnail = decoder
         .thumbnail_at(Duration::ZERO, 160, 90)
-        .expect("thumbnail_at at beginning should succeed");
+        .expect("thumbnail_at at beginning should succeed")
+        .expect("frame should be available");
 
     assert_eq!(thumbnail.width(), 160, "Width should be 160");
     assert_eq!(thumbnail.height(), 90, "Height should be 90");
@@ -101,7 +104,8 @@ fn test_thumbnail_at_different_sizes() {
             .thumbnail_at(Duration::from_secs(1), width, height)
             .unwrap_or_else(|e| {
                 panic!("thumbnail_at({}x{}) should succeed: {:?}", width, height, e)
-            });
+            })
+            .expect("frame should be available");
 
         assert_eq!(
             thumbnail.width(),
@@ -129,7 +133,8 @@ fn test_thumbnail_at_with_rgba_output() {
 
     let thumbnail = decoder
         .thumbnail_at(Duration::from_secs(1), 320, 180)
-        .expect("thumbnail_at should succeed");
+        .expect("thumbnail_at should succeed")
+        .expect("frame should be available");
 
     // Should be RGBA format
     assert_eq!(
@@ -342,7 +347,8 @@ fn test_thumbnail_aspect_ratio_preservation() {
 
     let thumbnail = decoder
         .thumbnail_at(Duration::from_secs(1), target_width, target_height)
-        .expect("thumbnail_at should succeed");
+        .expect("thumbnail_at should succeed")
+        .expect("frame should be available");
 
     // Thumbnail should preserve aspect ratio by fitting within target dimensions
     // The thumbnail will not be exactly 320x320 but will fit within it
@@ -384,7 +390,8 @@ fn test_thumbnail_small_dimensions() {
     // Very small thumbnail
     let thumbnail = decoder
         .thumbnail_at(Duration::from_secs(1), 64, 36)
-        .expect("Small thumbnail should succeed");
+        .expect("Small thumbnail should succeed")
+        .expect("frame should be available");
 
     assert_eq!(thumbnail.width(), 64, "Width should be 64");
     assert_eq!(thumbnail.height(), 36, "Height should be 36");
@@ -397,7 +404,8 @@ fn test_thumbnail_large_dimensions() {
     // Large thumbnail (upscaling)
     let thumbnail = decoder
         .thumbnail_at(Duration::from_secs(1), 1920, 1080)
-        .expect("Large thumbnail should succeed");
+        .expect("Large thumbnail should succeed")
+        .expect("frame should be available");
 
     assert_eq!(thumbnail.width(), 1920, "Width should be 1920");
     assert_eq!(thumbnail.height(), 1080, "Height should be 1080");
@@ -430,7 +438,8 @@ fn test_thumbnail_at_after_seek() {
     // Generate thumbnail at a different position
     let thumbnail = decoder
         .thumbnail_at(Duration::from_secs(2), 320, 180)
-        .expect("thumbnail_at after seek should succeed");
+        .expect("thumbnail_at after seek should succeed")
+        .expect("frame should be available");
 
     assert_eq!(thumbnail.width(), 320, "Width should be 320");
     assert_eq!(thumbnail.height(), 180, "Height should be 180");
@@ -450,7 +459,8 @@ fn test_multiple_thumbnail_calls() {
     for (i, position) in positions.iter().enumerate() {
         let thumbnail = decoder
             .thumbnail_at(*position, 160, 90)
-            .unwrap_or_else(|e| panic!("Thumbnail {} should succeed: {:?}", i, e));
+            .unwrap_or_else(|e| panic!("Thumbnail {} should succeed: {:?}", i, e))
+            .expect("frame should be available");
 
         assert_eq!(thumbnail.width(), 160, "Thumbnail {} width", i);
         assert_eq!(thumbnail.height(), 90, "Thumbnail {} height", i);

--- a/crates/ff-pipeline/src/error.rs
+++ b/crates/ff-pipeline/src/error.rs
@@ -14,6 +14,7 @@
 ///   — returned by [`PipelineBuilder::build`](crate::PipelineBuilder::build)
 /// - **Runtime control**: [`Cancelled`](Self::Cancelled) — returned by
 ///   [`Pipeline::run`](crate::Pipeline::run) when the progress callback returns `false`
+/// - **Availability**: [`FrameNotAvailable`](Self::FrameNotAvailable) — no frame at position
 #[derive(Debug, thiserror::Error)]
 pub enum PipelineError {
     /// A decoding step failed.
@@ -68,6 +69,14 @@ pub enum PipelineError {
     /// An I/O error (e.g. creating the output directory for thumbnails).
     #[error("i/o error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// No frame was available at the requested position.
+    ///
+    /// Returned by thumbnail and seek-and-decode operations when the decoder
+    /// reports `Ok(None)` — the position is past the end of the stream or no
+    /// decodable frame exists at that point.
+    #[error("no frame available at the requested position")]
+    FrameNotAvailable,
 }
 
 #[cfg(test)]
@@ -100,8 +109,8 @@ mod tests {
 
     #[test]
     fn decode_should_prefix_inner_message() {
-        let err = PipelineError::Decode(ff_decode::DecodeError::EndOfStream);
-        assert_eq!(err.to_string(), "decode failed: End of stream");
+        let err = PipelineError::Decode(ff_decode::DecodeError::decoding_failed("test error"));
+        assert!(err.to_string().starts_with("decode failed:"));
     }
 
     #[test]
@@ -123,7 +132,7 @@ mod tests {
 
     #[test]
     fn decode_error_should_convert_into_pipeline_error() {
-        let inner = ff_decode::DecodeError::EndOfStream;
+        let inner = ff_decode::DecodeError::decoding_failed("test error");
         let err: PipelineError = inner.into();
         assert!(matches!(err, PipelineError::Decode(_)));
     }
@@ -146,7 +155,7 @@ mod tests {
 
     #[test]
     fn decode_should_expose_source() {
-        let err = PipelineError::Decode(ff_decode::DecodeError::EndOfStream);
+        let err = PipelineError::Decode(ff_decode::DecodeError::decoding_failed("test error"));
         assert!(err.source().is_some());
     }
 

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -309,8 +309,7 @@ impl Pipeline {
                     dec.decode()?
                 } else {
                     let mut dec = VideoDecoder::open(path).build()?;
-                    dec.decode_one()?
-                        .ok_or(ff_decode::DecodeError::EndOfStream)?
+                    dec.decode_one()?.ok_or(PipelineError::FrameNotAvailable)?
                 };
                 frames.push(frame);
             }

--- a/crates/ff-pipeline/src/thumbnail.rs
+++ b/crates/ff-pipeline/src/thumbnail.rs
@@ -7,7 +7,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use ff_decode::{DecodeError, SeekMode, VideoDecoder};
+use ff_decode::{SeekMode, VideoDecoder};
 use ff_format::VideoFrame;
 
 use crate::PipelineError;
@@ -176,7 +176,9 @@ fn decode_frames(path: &str, timestamps: &mut [f64]) -> Result<Vec<VideoFrame>, 
             .map(|ts| {
                 let mut decoder = VideoDecoder::open(path).build()?;
                 decoder.seek(Duration::from_secs_f64(*ts), SeekMode::Keyframe)?;
-                let frame = decoder.decode_one()?.ok_or(DecodeError::EndOfStream)?;
+                let frame = decoder
+                    .decode_one()?
+                    .ok_or(PipelineError::FrameNotAvailable)?;
                 Ok(frame)
             })
             .collect()
@@ -190,7 +192,9 @@ fn decode_frames(path: &str, timestamps: &mut [f64]) -> Result<Vec<VideoFrame>, 
         let mut frames = Vec::with_capacity(timestamps.len());
         for ts in timestamps.iter() {
             decoder.seek(Duration::from_secs_f64(*ts), SeekMode::Keyframe)?;
-            let frame = decoder.decode_one()?.ok_or(DecodeError::EndOfStream)?;
+            let frame = decoder
+                .decode_one()?
+                .ok_or(PipelineError::FrameNotAvailable)?;
             frames.push(frame);
         }
 


### PR DESCRIPTION
## Summary

Removes the `DecodeError::EndOfStream` variant and its associated `is_eof()` method from the public API. This variant was never emitted by any decoder — all decoders already signal EOF via `Ok(None)` — making it a dead, misleading public surface. This PR unifies EOF handling to `Ok(None)` across the workspace and introduces `PipelineError::FrameNotAvailable` for cases where a frame is expected but not present.

## Changes

- **`ff-decode`**: Remove `DecodeError::EndOfStream` variant and `is_eof()` method; update doc comments and tests
- **`ff-decode`**: Change `thumbnail_at()` return type from `Result<VideoFrame>` to `Result<Option<VideoFrame>>`; returns `Ok(None)` when no frame is available at the requested position
- **`ff-pipeline`**: Add `PipelineError::FrameNotAvailable` variant for seek-and-decode paths that expect a frame
- **`ff-pipeline`**: Replace `.ok_or(DecodeError::EndOfStream)?` with `.ok_or(PipelineError::FrameNotAvailable)?` in `pipeline.rs` and `thumbnail.rs`; remove unused `DecodeError` import
- **`avio`**: Remove dead `EndOfStream` references from unit tests, integration tests, and all async/iterator examples; remove unused `DecodeError` imports where applicable
- **`ff-decode` tests**: Update `thumbnail_tests.rs` and `performance_validation_tests.rs` call sites to unwrap `Option` from the new `thumbnail_at()` return type

## Related Issues

Closes #624

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes