### PR TITLE
docs(ff-format/ff-decode): add u32 rationale and rodio/cpal cast note to channels()

### DIFF
--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -352,6 +352,11 @@ impl AudioDecoder {
     }
 
     /// Returns the number of audio channels.
+    ///
+    /// The type is `u32` to match `FFmpeg` and professional audio APIs. When
+    /// integrating with `rodio` or `cpal` (which require `u16`), cast with
+    /// `decoder.channels() as u16` — channel counts never exceed `u16::MAX`
+    /// in practice.
     #[must_use]
     pub fn channels(&self) -> u32 {
         self.stream_info.channels()

--- a/crates/ff-format/src/frame/audio.rs
+++ b/crates/ff-format/src/frame/audio.rs
@@ -237,6 +237,15 @@ impl AudioFrame {
 
     /// Returns the number of audio channels.
     ///
+    /// The return type is `u32` to match `FFmpeg`'s `AVFrame::ch_layout.nb_channels`
+    /// and professional audio APIs (Core Audio, WASAPI, JACK, Dolby Atmos).
+    ///
+    /// # Integration
+    ///
+    /// Playback libraries such as `rodio` and `cpal` accept channel counts as
+    /// `u16`. Cast with `frame.channels() as u16`; the truncation is always safe
+    /// because no real-world format exceeds `u16::MAX` (65 535) channels.
+    ///
     /// # Examples
     ///
     /// ```

--- a/crates/ff-format/src/media.rs
+++ b/crates/ff-format/src/media.rs
@@ -349,6 +349,10 @@ impl MediaInfo {
     /// Returns the channel count of the primary audio stream.
     ///
     /// Returns `None` if there are no audio streams.
+    ///
+    /// The type is `u32` to match `FFmpeg` and professional audio APIs. For `rodio`
+    /// or `cpal` (which require `u16`), cast with `.map(|c| c as u16)` — channel
+    /// counts never exceed `u16::MAX` in practice.
     #[must_use]
     #[inline]
     pub fn channels(&self) -> Option<u32> {

--- a/crates/ff-format/src/stream.rs
+++ b/crates/ff-format/src/stream.rs
@@ -551,6 +551,11 @@ impl AudioStreamInfo {
     }
 
     /// Returns the number of audio channels.
+    ///
+    /// The type is `u32` to match `FFmpeg`'s `AVCodecParameters::ch_layout.nb_channels`
+    /// and professional audio APIs. When passing to `rodio` or `cpal` (which require
+    /// `u16`), cast with `info.channels() as u16` — channel counts never exceed
+    /// `u16::MAX` in practice.
     #[must_use]
     #[inline]
     pub const fn channels(&self) -> u32 {


### PR DESCRIPTION
## Summary

\`channels()\` returns \`u32\` across the workspace, but the doc comments gave no explanation for that choice. Developers integrating with \`rodio\` or \`cpal\` (which require \`u16\`) were left without guidance on when and whether the cast is safe.

## Changes

- \`AudioFrame::channels()\` — new \`# Integration\` section explaining the \`u32\` type choice and the \`channels() as u16\` cast pattern for \`rodio\`/\`cpal\`
- \`AudioStreamInfo::channels()\` — appended one sentence with type rationale and cast note
- \`MediaInfo::channels()\` — appended one sentence with type rationale and \`.map(|c| c as u16)\` pattern
- \`AudioDecoder::channels()\` — appended one sentence with type rationale and cast note

## Related Issues

Closes #613

## Test Plan

- [x] \`cargo test --all --all-features\` passes
- [x] \`cargo clippy --all --all-features -- -D warnings\` passes
- [x] \`cargo fmt --all -- --check\` passes
- [x] \`cargo doc --all-features --no-deps\` passes