### PR TITLE
feat(ff-decode): impl Iterator + FusedIterator for VideoDecoder and AudioDecoder

### DIFF
--- a/crates/avio/examples/decode_iterator.rs
+++ b/crates/avio/examples/decode_iterator.rs
@@ -1,14 +1,14 @@
 //! Decode video, audio, and images using the iterator API.
 //!
 //! Demonstrates:
-//! - `VideoDecoder::frames()` — `for frame in vdec.frames()`
-//! - `AudioDecoder::frames()` — `for frame in adec.frames()`
-//! - `ImageDecoder::frames()` — `for frame in idec.frames()`
+//! - `VideoDecoder` — `for result in &mut vdec`
+//! - `AudioDecoder` — `for result in &mut adec`
+//! - `ImageDecoder::frames()` — `for result in idec.frames()`
 //!
-//! Each decoder exposes `.frames()` which returns an iterator with
-//! `Item = Result<Frame, DecodeError>`. This is an alternative to the manual
-//! `loop { decode_one() }` pattern — it integrates naturally with iterator
-//! adaptors (`take`, `filter_map`, `enumerate`, etc.).
+//! `VideoDecoder` and `AudioDecoder` implement `Iterator` directly, so they
+//! integrate naturally with iterator adaptors (`take`, `filter_map`, `enumerate`,
+//! etc.) and also implement `FusedIterator` (no further items after an error).
+//! `ImageDecoder` still uses the `.frames()` method.
 //!
 //! # Usage
 //!
@@ -51,12 +51,13 @@ fn main() {
     println!("Input: {in_name}");
     println!();
 
-    // ── VideoDecoder::frames() ────────────────────────────────────────────────
+    // ── VideoDecoder ──────────────────────────────────────────────────────────
     //
-    // frames() returns an iterator whose Item is Result<VideoFrame, DecodeError>.
+    // VideoDecoder implements Iterator directly. Item = Result<VideoFrame, DecodeError>.
     //
     // The `for` loop terminates when the iterator returns None (EOF).
     // Errors are surfaced as Err variants inside the loop body.
+    // FusedIterator guarantees None after the first error.
 
     println!("=== Video frames ===");
 
@@ -72,8 +73,8 @@ fn main() {
 
             let mut video_frames: u64 = 0;
 
-            // Iterator form: no manual `loop { decode_one() }` needed.
-            for result in vdec.frames() {
+            // Iterator form: VideoDecoder implements Iterator directly.
+            for result in &mut vdec {
                 match result {
                     Ok(_frame) => video_frames += 1,
                     Err(e) => {
@@ -90,9 +91,9 @@ fn main() {
 
     println!();
 
-    // ── AudioDecoder::frames() ────────────────────────────────────────────────
+    // ── AudioDecoder ──────────────────────────────────────────────────────────
     //
-    // frames() returns an iterator with Item = Result<AudioFrame, DecodeError>.
+    // AudioDecoder implements Iterator directly. Item = Result<AudioFrame, DecodeError>.
 
     println!("=== Audio frames ===");
 
@@ -108,7 +109,7 @@ fn main() {
             let mut audio_frames: u64 = 0;
             let mut total_samples: u64 = 0;
 
-            for result in adec.frames() {
+            for result in &mut adec {
                 match result {
                     Ok(frame) => {
                         audio_frames += 1;

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -58,7 +58,7 @@
 //! let mut vdec = VideoDecoder::open("video.mp4")
 //!     .output_format(PixelFormat::Rgb24)
 //!     .build()?;
-//! for frame in vdec.frames() { /* ... */ }
+//! for result in &mut vdec { /* ... */ }
 //!
 //! // Audio — resample to 16-bit 44.1 kHz
 //! let mut adec = AudioDecoder::open("video.mp4")

--- a/crates/ff-decode/benches/decode_bench.rs
+++ b/crates/ff-decode/benches/decode_bench.rs
@@ -90,7 +90,7 @@ fn bench_frame_iterator(c: &mut Criterion) {
         b.iter_batched(
             || create_decoder(),
             |mut decoder| {
-                let frames: Vec<_> = decoder.frames().take(10).filter_map(|r| r.ok()).collect();
+                let frames: Vec<_> = decoder.by_ref().take(10).filter_map(|r| r.ok()).collect();
                 black_box(frames)
             },
             criterion::BatchSize::LargeInput,

--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -203,8 +203,8 @@ impl AudioDecoderBuilder {
     ///     .build()?;
     ///
     /// // Start decoding
-    /// for frame in decoder.frames().take(100) {
-    ///     let frame = frame?;
+    /// for result in &mut decoder {
+    ///     let frame = result?;
     ///     // Process frame...
     /// }
     /// ```
@@ -236,6 +236,7 @@ impl AudioDecoderBuilder {
             config,
             inner,
             stream_info,
+            fused: false,
         })
     }
 }
@@ -269,9 +270,9 @@ impl AudioDecoderBuilder {
 ///     println!("Frame with {} samples", frame.samples());
 /// }
 ///
-/// // Use iterator
-/// for frame in decoder.frames().take(100) {
-///     let frame = frame?;
+/// // Iterator form — AudioDecoder implements Iterator directly
+/// for result in &mut decoder {
+///     let frame = result?;
 ///     // Process frame...
 /// }
 /// ```
@@ -296,6 +297,8 @@ pub struct AudioDecoder {
     inner: AudioDecoderInner,
     /// Audio stream information
     stream_info: AudioStreamInfo,
+    /// Set to `true` after a decoding error; causes [`Iterator::next`] to return `None`.
+    fused: bool,
 }
 
 impl AudioDecoder {
@@ -425,28 +428,6 @@ impl AudioDecoder {
         self.inner.decode_one()
     }
 
-    /// Returns an iterator over decoded frames.
-    ///
-    /// This provides a convenient way to iterate over all frames in the audio.
-    /// The iterator will continue until end of stream or an error occurs.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use ff_decode::AudioDecoder;
-    ///
-    /// let mut decoder = AudioDecoder::open("audio.mp3")?.build()?;
-    ///
-    /// // Process first 100 frames
-    /// for frame in decoder.frames().take(100) {
-    ///     let frame = frame?;
-    ///     // Process frame...
-    /// }
-    /// ```
-    pub fn frames(&mut self) -> impl Iterator<Item = Result<AudioFrame, DecodeError>> + '_ {
-        AudioFrameIterator { decoder: self }
-    }
-
     /// Decodes all frames and returns their raw PCM data.
     ///
     /// This method decodes the entire audio file and returns all samples
@@ -490,9 +471,7 @@ impl AudioDecoder {
     pub fn decode_all(&mut self) -> Result<Vec<u8>, DecodeError> {
         let mut buffer = Vec::new();
 
-        for frame_result in self.frames() {
-            let frame = frame_result?;
-
+        while let Some(frame) = self.decode_one()? {
             // Collect samples from all planes
             for plane in frame.planes() {
                 buffer.extend_from_slice(plane);
@@ -556,8 +535,7 @@ impl AudioDecoder {
         // Collect frames in the range
         let mut buffer = Vec::new();
 
-        for frame_result in self.frames() {
-            let frame = frame_result?;
+        while let Some(frame) = self.decode_one()? {
             let frame_time = frame.timestamp().as_duration();
 
             // Stop if we've passed the end of the range
@@ -628,25 +606,25 @@ impl AudioDecoder {
     }
 }
 
-/// Iterator over decoded audio frames.
-///
-/// Created by calling [`AudioDecoder::frames()`]. Yields frames until the end
-/// of the stream is reached or an error occurs.
-pub(crate) struct AudioFrameIterator<'a> {
-    decoder: &'a mut AudioDecoder,
-}
-
-impl Iterator for AudioFrameIterator<'_> {
+impl Iterator for AudioDecoder {
     type Item = Result<AudioFrame, DecodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.decoder.decode_one() {
+        if self.fused {
+            return None;
+        }
+        match self.decode_one() {
             Ok(Some(frame)) => Some(Ok(frame)),
-            Ok(None) => None, // EOF
-            Err(e) => Some(Err(e)),
+            Ok(None) => None,
+            Err(e) => {
+                self.fused = true;
+                Some(Err(e))
+            }
         }
     }
 }
+
+impl std::iter::FusedIterator for AudioDecoder {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -34,8 +34,8 @@
 //! println!("Resolution: {}x{}", decoder.width(), decoder.height());
 //!
 //! // Decode frames sequentially
-//! for frame in decoder.frames().take(100) {
-//!     let frame = frame?;
+//! for result in &mut decoder {
+//!     let frame = result?;
 //!     println!("Frame at {:?}", frame.timestamp().as_duration());
 //! }
 //!
@@ -55,8 +55,8 @@
 //!     .build()?;
 //!
 //! // Decode all audio samples
-//! for frame in decoder.frames().take(100) {
-//!     let frame = frame?;
+//! for result in &mut decoder {
+//!     let frame = result?;
 //!     println!("Audio frame with {} samples", frame.samples());
 //! }
 //! ```

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -445,8 +445,8 @@ impl VideoDecoderBuilder {
     ///     .build()?;
     ///
     /// // Start decoding
-    /// for frame in decoder.frames().take(100) {
-    ///     let frame = frame?;
+    /// for result in &mut decoder {
+    ///     let frame = result?;
     ///     // Process frame...
     /// }
     /// ```
@@ -499,6 +499,7 @@ impl VideoDecoderBuilder {
             frame_pool: self.frame_pool,
             inner,
             stream_info,
+            fused: false,
         })
     }
 }
@@ -523,7 +524,7 @@ impl VideoDecoderBuilder {
 ///
 /// # Frame Decoding
 ///
-/// Frames can be decoded one at a time or using an iterator:
+/// Frames can be decoded one at a time or using the built-in iterator:
 ///
 /// ```ignore
 /// // Decode one frame
@@ -531,9 +532,9 @@ impl VideoDecoderBuilder {
 ///     println!("Frame at {:?}", frame.timestamp().as_duration());
 /// }
 ///
-/// // Use iterator
-/// for frame in decoder.frames().take(100) {
-///     let frame = frame?;
+/// // Iterator form — VideoDecoder implements Iterator directly
+/// for result in &mut decoder {
+///     let frame = result?;
 ///     // Process frame...
 /// }
 /// ```
@@ -567,6 +568,8 @@ pub struct VideoDecoder {
     inner: VideoDecoderInner,
     /// Video stream information
     stream_info: VideoStreamInfo,
+    /// Set to `true` after a decoding error; causes [`Iterator::next`] to return `None`.
+    fused: bool,
 }
 
 impl VideoDecoder {
@@ -742,28 +745,6 @@ impl VideoDecoder {
         self.inner.decode_one()
     }
 
-    /// Returns an iterator over decoded frames.
-    ///
-    /// This provides a convenient way to iterate over all frames in the video.
-    /// The iterator will continue until end of stream or an error occurs.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use ff_decode::VideoDecoder;
-    ///
-    /// let mut decoder = VideoDecoder::open("video.mp4")?.build()?;
-    ///
-    /// // Process first 100 frames
-    /// for frame in decoder.frames().take(100) {
-    ///     let frame = frame?;
-    ///     // Process frame...
-    /// }
-    /// ```
-    pub fn frames(&mut self) -> impl Iterator<Item = Result<VideoFrame, DecodeError>> + '_ {
-        VideoFrameIterator { decoder: self }
-    }
-
     /// Decodes all frames within a specified time range.
     ///
     /// This method seeks to the start position and decodes all frames until
@@ -777,7 +758,7 @@ impl VideoDecoder {
     /// - The decoder position after this call will be at or past `end`
     ///
     /// For large time ranges or high frame rates, this may allocate significant
-    /// memory. Consider using [`frames()`](Self::frames) with manual filtering
+    /// memory. Consider iterating manually with [`decode_one()`](Self::decode_one)
     /// for very large ranges.
     ///
     /// # Arguments
@@ -845,8 +826,7 @@ impl VideoDecoder {
         // Collect frames in the range
         let mut frames = Vec::new();
 
-        for frame_result in self.frames() {
-            let frame = frame_result?;
+        while let Some(frame) = self.decode_one()? {
             let frame_time = frame.timestamp().as_duration();
 
             // Stop if we've passed the end of the range
@@ -1170,25 +1150,25 @@ impl VideoDecoder {
     }
 }
 
-/// Iterator over decoded video frames.
-///
-/// Created by calling [`VideoDecoder::frames()`]. Yields frames until the end
-/// of the stream is reached or an error occurs.
-pub(crate) struct VideoFrameIterator<'a> {
-    decoder: &'a mut VideoDecoder,
-}
-
-impl Iterator for VideoFrameIterator<'_> {
+impl Iterator for VideoDecoder {
     type Item = Result<VideoFrame, DecodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.decoder.decode_one() {
+        if self.fused {
+            return None;
+        }
+        match self.decode_one() {
             Ok(Some(frame)) => Some(Ok(frame)),
-            Ok(None) => None, // EOF
-            Err(e) => Some(Err(e)),
+            Ok(None) => None,
+            Err(e) => {
+                self.fused = true;
+                Some(Err(e))
+            }
         }
     }
 }
+
+impl std::iter::FusedIterator for VideoDecoder {}
 
 #[cfg(test)]
 #[allow(clippy::panic, clippy::expect_used, clippy::float_cmp)]
@@ -1326,14 +1306,6 @@ mod tests {
 
         let default_mode = SeekMode::default();
         assert_eq!(default_mode, SeekMode::Keyframe);
-    }
-
-    #[test]
-    fn test_frame_iterator_structure() {
-        // Test that VideoFrameIterator can be created (compile-time check)
-        // The actual iteration test is in integration tests with real video files
-        let builder = VideoDecoderBuilder::new(PathBuf::from("test.mp4"));
-        let _ = builder; // Ensure it compiles
     }
 
     #[test]

--- a/crates/ff-decode/tests/audio_decoder_tests.rs
+++ b/crates/ff-decode/tests/audio_decoder_tests.rs
@@ -759,7 +759,7 @@ fn test_audio_frame_iterator_basic() {
     let mut decoder = create_audio_decoder().expect("Failed to create audio decoder");
 
     // Use iterator to decode first 10 frames
-    let frames: Vec<_> = decoder.frames().take(10).collect();
+    let frames: Vec<_> = decoder.by_ref().take(10).collect();
 
     assert_eq!(frames.len(), 10, "Should collect 10 audio frames");
 
@@ -781,7 +781,7 @@ fn test_audio_frame_iterator_timestamps_increase() {
     let mut last_pts = None;
 
     // Iterate over first 20 frames
-    for (i, frame_result) in decoder.frames().take(20).enumerate() {
+    for (i, frame_result) in decoder.by_ref().take(20).enumerate() {
         let frame =
             frame_result.unwrap_or_else(|e| panic!("Failed to decode audio frame {}: {:?}", i, e));
 
@@ -813,7 +813,7 @@ fn test_audio_frame_iterator_with_filter() {
         .expect("Seek to 2s should succeed");
 
     // Collect 5 frames from the seeked position
-    let frames: Vec<_> = decoder.frames().take(5).collect();
+    let frames: Vec<_> = decoder.by_ref().take(5).collect();
 
     assert_eq!(frames.len(), 5, "Should collect 5 audio frames after 2s");
 
@@ -832,7 +832,7 @@ fn test_audio_frame_iterator_early_break() {
 
     // Break early in iteration
     let mut count = 0;
-    for frame_result in decoder.frames() {
+    for frame_result in &mut decoder {
         let _ = frame_result.expect("Audio frame should decode successfully");
         count += 1;
         if count >= 3 {
@@ -859,7 +859,7 @@ fn test_audio_frame_iterator_multiple_iterations() {
     let mut decoder = create_audio_decoder().expect("Failed to create audio decoder");
 
     // First iteration
-    let first_batch: Vec<_> = decoder.frames().take(5).collect();
+    let first_batch: Vec<_> = decoder.by_ref().take(5).collect();
     assert_eq!(
         first_batch.len(),
         5,
@@ -872,7 +872,7 @@ fn test_audio_frame_iterator_multiple_iterations() {
         .expect("Seek should succeed");
 
     // Second iteration
-    let second_batch: Vec<_> = decoder.frames().take(5).collect();
+    let second_batch: Vec<_> = decoder.by_ref().take(5).collect();
     assert_eq!(
         second_batch.len(),
         5,

--- a/crates/ff-decode/tests/iterator_tests.rs
+++ b/crates/ff-decode/tests/iterator_tests.rs
@@ -1,0 +1,152 @@
+//! Integration tests for `Iterator` and `FusedIterator` on `VideoDecoder` and
+//! `AudioDecoder`.
+
+mod fixtures;
+use fixtures::*;
+
+// ============================================================================
+// Compile-time trait-bound checks
+// ============================================================================
+
+fn _assert_video_fused(_: impl std::iter::FusedIterator) {}
+fn _assert_audio_fused(_: impl std::iter::FusedIterator) {}
+
+// ============================================================================
+// VideoDecoder Iterator tests
+// ============================================================================
+
+#[test]
+fn video_iterator_should_yield_frames_until_eof() {
+    let mut decoder = match create_decoder() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let mut count = 0u64;
+    for result in &mut decoder {
+        match result {
+            Ok(_) => count += 1,
+            Err(e) => panic!("Unexpected decode error: {e}"),
+        }
+    }
+
+    assert!(count > 0, "Expected at least one video frame");
+}
+
+#[test]
+fn video_iterator_should_support_take_adapter() {
+    let mut decoder = match create_decoder() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frames: Vec<_> = decoder
+        .by_ref()
+        .take(5)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("Failed to decode frames");
+
+    assert_eq!(frames.len(), 5, "take(5) should yield exactly 5 frames");
+}
+
+#[test]
+fn video_iterator_should_return_none_after_eof() {
+    let mut decoder = match create_decoder() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    // Drain all frames
+    for result in &mut decoder {
+        result.expect("Unexpected decode error while draining");
+    }
+
+    assert!(decoder.is_eof(), "Decoder should report EOF");
+
+    // FusedIterator: subsequent next() calls must return None
+    assert!(
+        decoder.next().is_none(),
+        "next() after EOF should return None (first call)"
+    );
+    assert!(
+        decoder.next().is_none(),
+        "next() after EOF should return None (second call)"
+    );
+}
+
+// ============================================================================
+// AudioDecoder Iterator tests
+// ============================================================================
+
+#[test]
+fn audio_iterator_should_yield_frames_until_eof() {
+    let mut decoder = match create_audio_decoder() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let mut count = 0u64;
+    for result in &mut decoder {
+        match result {
+            Ok(_) => count += 1,
+            Err(e) => panic!("Unexpected decode error: {e}"),
+        }
+    }
+
+    assert!(count > 0, "Expected at least one audio frame");
+}
+
+#[test]
+fn audio_iterator_should_support_take_adapter() {
+    let mut decoder = match create_audio_decoder() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frames: Vec<_> = decoder
+        .by_ref()
+        .take(10)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("Failed to decode audio frames");
+
+    assert_eq!(frames.len(), 10, "take(10) should yield exactly 10 frames");
+}
+
+#[test]
+fn audio_iterator_collect_should_return_all_frames() {
+    let mut decoder = match create_audio_decoder() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frames: Vec<_> = decoder
+        .by_ref()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("Failed to collect audio frames");
+
+    assert!(!frames.is_empty(), "Expected at least one audio frame");
+
+    // FusedIterator: next() after collection must return None
+    assert!(
+        decoder.next().is_none(),
+        "next() after collect should return None"
+    );
+}

--- a/crates/ff-decode/tests/thumbnail_tests.rs
+++ b/crates/ff-decode/tests/thumbnail_tests.rs
@@ -416,7 +416,7 @@ fn test_thumbnails_after_decode() {
     let mut decoder = create_decoder().expect("Failed to create decoder");
 
     // Decode some frames first
-    let _frames: Vec<_> = decoder.frames().take(10).collect();
+    let _frames: Vec<_> = decoder.by_ref().take(10).collect();
 
     // Then generate thumbnails
     let thumbnails = decoder

--- a/crates/ff-decode/tests/video_seeking_tests.rs
+++ b/crates/ff-decode/tests/video_seeking_tests.rs
@@ -300,7 +300,7 @@ fn test_frame_iterator_basic() {
     let mut decoder = create_decoder().expect("Failed to create decoder");
 
     // Use iterator to decode first 10 frames
-    let frames: Vec<_> = decoder.frames().take(10).collect();
+    let frames: Vec<_> = decoder.by_ref().take(10).collect();
 
     assert_eq!(frames.len(), 10, "Should collect 10 frames");
 
@@ -322,7 +322,7 @@ fn test_frame_iterator_timestamps_increase() {
     let mut last_pts = None;
 
     // Iterate over first 20 frames
-    for (i, frame_result) in decoder.frames().take(20).enumerate() {
+    for (i, frame_result) in decoder.by_ref().take(20).enumerate() {
         let frame =
             frame_result.unwrap_or_else(|e| panic!("Failed to decode frame {}: {:?}", i, e));
 
@@ -350,8 +350,8 @@ fn test_frame_iterator_with_filter() {
     let target = Duration::from_secs(2);
 
     let late_frames: Vec<_> = decoder
-        .frames()
-        .filter_map(|r| r.ok())
+        .by_ref()
+        .filter_map(|r: Result<_, _>| r.ok())
         .filter(|f| f.timestamp().as_duration() >= target)
         .take(5)
         .collect();
@@ -373,7 +373,7 @@ fn test_frame_iterator_early_break() {
 
     // Break early in iteration
     let mut count = 0;
-    for frame_result in decoder.frames() {
+    for frame_result in &mut decoder {
         let _ = frame_result.expect("Frame should decode successfully");
         count += 1;
         if count >= 3 {
@@ -397,7 +397,7 @@ fn test_frame_iterator_multiple_iterations() {
     let mut decoder = create_decoder().expect("Failed to create decoder");
 
     // First iteration
-    let first_batch: Vec<_> = decoder.frames().take(5).collect();
+    let first_batch: Vec<_> = decoder.by_ref().take(5).collect();
     assert_eq!(first_batch.len(), 5, "First batch should have 5 frames");
 
     // Seek back to beginning
@@ -406,6 +406,6 @@ fn test_frame_iterator_multiple_iterations() {
         .expect("Seek should succeed");
 
     // Second iteration
-    let second_batch: Vec<_> = decoder.frames().take(5).collect();
+    let second_batch: Vec<_> = decoder.by_ref().take(5).collect();
     assert_eq!(second_batch.len(), 5, "Second batch should have 5 frames");
 }


### PR DESCRIPTION
## Summary

Implements `Iterator` and `FusedIterator` directly on `VideoDecoder` and `AudioDecoder`, removing the intermediate `VideoFrameIterator` / `AudioFrameIterator` wrapper types and the `frames()` method. After a decoding error the `fused` flag is set so that subsequent `next()` calls return `None`, giving callers a safe, predictable iterator contract. Internal helpers (`decode_range`, `decode_all`) are rewritten to use `decode_one()` directly so they do not set the `fused` flag as a side effect.

## Changes

- Add `fused: bool` field to `VideoDecoder` and `AudioDecoder`; initialized to `false` in `build()`
- Remove `VideoFrameIterator`, `AudioFrameIterator` structs and `frames()` methods
- Add `impl Iterator` and `impl FusedIterator` for both decoder types
- Rewrite `decode_range` (video & audio) and `decode_all` (audio) to use `decode_one()` in a `while let` loop
- Add `crates/ff-decode/tests/iterator_tests.rs` with 6 integration tests covering frame iteration, `take` adapter, EOF fusing, and `collect`; includes compile-time `FusedIterator` bound checks
- Update all call sites in examples, benches, integration tests, and doc comments to use `for r in &mut decoder` / `decoder.by_ref().take(n)`

## Related Issues

Closes #616

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes