### PR TITLE
feat(ff-encode): VideoCodecOptions enum + codec_options() setter

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -230,9 +230,10 @@ pub use ff_decode::{
 // default_extension) on the shared VideoCodec type; import it to call them.
 #[cfg(feature = "encode")]
 pub use ff_encode::{
-    AudioEncoder, BitrateMode, CRF_MAX, Container, EncodeError, EncodeProgress,
-    EncodeProgressCallback, HardwareEncoder, ImageEncoder, Preset, VideoCodecEncodeExt,
-    VideoEncoder,
+    AudioEncoder, Av1Options, Av1Usage, BitrateMode, CRF_MAX, Container, DnxhdOptions, EncodeError,
+    EncodeProgress, EncodeProgressCallback, H264Options, H264Profile, H265Options, H265Profile,
+    H265Tier, HardwareEncoder, ImageEncoder, Preset, ProResOptions, VideoCodecEncodeExt,
+    VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -212,7 +212,10 @@ pub use hardware::HardwareEncoder;
 pub use image::{ImageEncoder, ImageEncoderBuilder};
 pub use preset::Preset;
 pub use progress::{EncodeProgress, EncodeProgressCallback};
-pub use video::{VideoEncoder, VideoEncoderBuilder};
+pub use video::{
+    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Profile, H265Options, H265Profile,
+    H265Tier, ProResOptions, VideoCodecOptions, VideoEncoder, VideoEncoderBuilder, Vp9Options,
+};
 
 #[cfg(feature = "tokio")]
 pub use audio::AsyncAudioEncoder;

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 
 use ff_format::{AudioFrame, VideoFrame};
 
+use super::codec_options::VideoCodecOptions;
 use super::encoder_inner::{VideoEncoderConfig, VideoEncoderInner, preset_to_string};
 use crate::{
     AudioCodec, Container, EncodeError, EncodeProgressCallback, HardwareEncoder, Preset, VideoCodec,
@@ -48,6 +49,7 @@ pub struct VideoEncoderBuilder {
     pub(crate) metadata: Vec<(String, String)>,
     pub(crate) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(crate) subtitle_passthrough: Option<(String, usize)>,
+    pub(crate) codec_options: Option<VideoCodecOptions>,
 }
 
 impl std::fmt::Debug for VideoEncoderBuilder {
@@ -74,6 +76,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             .field("metadata", &self.metadata)
             .field("chapters", &self.chapters)
             .field("subtitle_passthrough", &self.subtitle_passthrough)
+            .field("codec_options", &self.codec_options)
             .finish()
     }
 }
@@ -99,6 +102,7 @@ impl VideoEncoderBuilder {
             metadata: Vec::new(),
             chapters: Vec::new(),
             subtitle_passthrough: None,
+            codec_options: None,
         }
     }
 
@@ -246,6 +250,23 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn subtitle_passthrough(mut self, source_path: &str, stream_index: usize) -> Self {
         self.subtitle_passthrough = Some((source_path.to_string(), stream_index));
+        self
+    }
+
+    // === Per-codec options ===
+
+    /// Set per-codec encoding options.
+    ///
+    /// Applied via `av_opt_set` before `avcodec_open2` during [`build()`](Self::build).
+    /// This is additive — omitting it leaves codec defaults unchanged.
+    /// Any option that the chosen encoder does not support is logged as a
+    /// warning and skipped; it never causes `build()` to return an error.
+    ///
+    /// The [`VideoCodecOptions`] variant should match the codec selected via
+    /// [`video_codec()`](Self::video_codec).  A mismatch is silently ignored.
+    #[must_use]
+    pub fn codec_options(mut self, opts: VideoCodecOptions) -> Self {
+        self.codec_options = Some(opts);
         self
     }
 
@@ -400,6 +421,7 @@ impl VideoEncoder {
             metadata: builder.metadata,
             chapters: builder.chapters,
             subtitle_passthrough: builder.subtitle_passthrough,
+            codec_options: builder.codec_options,
         };
 
         let inner = if config.video_width.is_some() {
@@ -642,6 +664,7 @@ mod tests {
                 metadata: Vec::new(),
                 chapters: Vec::new(),
                 subtitle_passthrough: None,
+                codec_options: None,
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,

--- a/crates/ff-encode/src/video/codec_options.rs
+++ b/crates/ff-encode/src/video/codec_options.rs
@@ -1,0 +1,283 @@
+//! Per-codec encoding options for [`VideoEncoderBuilder`](super::builder::VideoEncoderBuilder).
+//!
+//! Pass a [`VideoCodecOptions`] value to
+//! `VideoEncoderBuilder::codec_options()` to control codec-specific behaviour.
+//! Options are applied via `av_opt_set` / direct field assignment **before**
+//! `avcodec_open2`.  Any option that the chosen encoder does not support is
+//! logged as a warning and skipped — it never causes `build()` to return an
+//! error.
+
+/// Per-codec encoding options.
+///
+/// The variant must match the codec passed to
+/// `VideoEncoderBuilder::video_codec()`.  A mismatch is silently ignored
+/// (the options are not applied).
+///
+/// Variants without struct fields (`Vp9`, `ProRes`, `Dnxhd`) are reserved
+/// for future issues and currently have no effect.
+#[derive(Debug, Clone)]
+pub enum VideoCodecOptions {
+    /// H.264 (AVC) encoding options.
+    H264(H264Options),
+    /// H.265 (HEVC) encoding options.
+    H265(H265Options),
+    /// AV1 encoding options.
+    Av1(Av1Options),
+    /// VP9 encoding options (reserved for a future issue).
+    Vp9(Vp9Options),
+    /// Apple ProRes encoding options (reserved for a future issue).
+    ProRes(ProResOptions),
+    /// Avid DNxHD / DNxHR encoding options (reserved for a future issue).
+    Dnxhd(DnxhdOptions),
+}
+
+// ── H.264 ────────────────────────────────────────────────────────────────────
+
+/// H.264 (AVC) per-codec options.
+#[derive(Debug, Clone)]
+pub struct H264Options {
+    /// Encoding profile.
+    pub profile: H264Profile,
+    /// Encoding level as an integer (e.g. `31` = 3.1, `40` = 4.0, `51` = 5.1).
+    ///
+    /// `None` leaves the encoder default.
+    pub level: Option<u32>,
+    /// Maximum consecutive B-frames (0–16).
+    pub bframes: u32,
+    /// GOP size: number of frames between keyframes.
+    pub gop_size: u32,
+    /// Number of reference frames.
+    pub refs: u32,
+}
+
+impl Default for H264Options {
+    fn default() -> Self {
+        Self {
+            profile: H264Profile::High,
+            level: None,
+            bframes: 3,
+            gop_size: 250,
+            refs: 3,
+        }
+    }
+}
+
+/// H.264 encoding profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum H264Profile {
+    /// Baseline profile — no B-frames, no CABAC (low latency / mobile).
+    Baseline,
+    /// Main profile.
+    Main,
+    /// High profile (recommended for most uses).
+    #[default]
+    High,
+    /// High 10-bit profile.
+    High10,
+}
+
+impl H264Profile {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+            Self::Main => "main",
+            Self::High => "high",
+            Self::High10 => "high10",
+        }
+    }
+}
+
+// ── H.265 ────────────────────────────────────────────────────────────────────
+
+/// H.265 (HEVC) per-codec options.
+#[derive(Debug, Clone)]
+pub struct H265Options {
+    /// Encoding profile.
+    pub profile: H265Profile,
+    /// Encoding tier.
+    pub tier: H265Tier,
+    /// Encoding level as an integer (e.g. `31` = 3.1, `51` = 5.1).
+    ///
+    /// `None` leaves the encoder default.
+    pub level: Option<u32>,
+}
+
+impl Default for H265Options {
+    fn default() -> Self {
+        Self {
+            profile: H265Profile::Main,
+            tier: H265Tier::Main,
+            level: None,
+        }
+    }
+}
+
+/// H.265 encoding profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum H265Profile {
+    /// Main profile (8-bit, 4:2:0).
+    #[default]
+    Main,
+    /// Main 10-bit profile (HDR-capable).
+    Main10,
+}
+
+impl H265Profile {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Main => "main",
+            Self::Main10 => "main10",
+        }
+    }
+}
+
+/// H.265 encoding tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum H265Tier {
+    /// Main tier — lower bitrate ceiling (consumer content).
+    #[default]
+    Main,
+    /// High tier — higher bitrate ceiling (broadcast / professional).
+    High,
+}
+
+impl H265Tier {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Main => "main",
+            Self::High => "high",
+        }
+    }
+}
+
+// ── AV1 ──────────────────────────────────────────────────────────────────────
+
+/// AV1 per-codec options (libaom-av1).
+#[derive(Debug, Clone)]
+pub struct Av1Options {
+    /// CPU effort level: `0` = slowest / best quality, `8` = fastest / lowest quality.
+    pub cpu_used: u8,
+    /// Log2 of the number of tile rows (0–6).
+    pub tile_rows: u8,
+    /// Log2 of the number of tile columns (0–6).
+    pub tile_cols: u8,
+    /// Encoding usage mode.
+    pub usage: Av1Usage,
+}
+
+impl Default for Av1Options {
+    fn default() -> Self {
+        Self {
+            cpu_used: 4,
+            tile_rows: 0,
+            tile_cols: 0,
+            usage: Av1Usage::VoD,
+        }
+    }
+}
+
+/// AV1 encoding usage mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Av1Usage {
+    /// Video-on-demand: maximise quality at the cost of speed.
+    #[default]
+    VoD,
+    /// Real-time: minimise encoding latency.
+    RealTime,
+}
+
+impl Av1Usage {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::VoD => "vod",
+            Self::RealTime => "realtime",
+        }
+    }
+}
+
+// ── Placeholder variants ──────────────────────────────────────────────────────
+
+/// VP9 per-codec options (reserved for a future issue).
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct Vp9Options {}
+
+/// Apple ProRes per-codec options (reserved for a future issue).
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ProResOptions {}
+
+/// Avid DNxHD / DNxHR per-codec options (reserved for a future issue).
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct DnxhdOptions {}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn h264_profile_should_return_correct_str() {
+        assert_eq!(H264Profile::Baseline.as_str(), "baseline");
+        assert_eq!(H264Profile::Main.as_str(), "main");
+        assert_eq!(H264Profile::High.as_str(), "high");
+        assert_eq!(H264Profile::High10.as_str(), "high10");
+    }
+
+    #[test]
+    fn h265_profile_should_return_correct_str() {
+        assert_eq!(H265Profile::Main.as_str(), "main");
+        assert_eq!(H265Profile::Main10.as_str(), "main10");
+    }
+
+    #[test]
+    fn h265_tier_should_return_correct_str() {
+        assert_eq!(H265Tier::Main.as_str(), "main");
+        assert_eq!(H265Tier::High.as_str(), "high");
+    }
+
+    #[test]
+    fn av1_usage_should_return_correct_str() {
+        assert_eq!(Av1Usage::VoD.as_str(), "vod");
+        assert_eq!(Av1Usage::RealTime.as_str(), "realtime");
+    }
+
+    #[test]
+    fn h264_options_default_should_have_high_profile() {
+        let opts = H264Options::default();
+        assert_eq!(opts.profile, H264Profile::High);
+        assert_eq!(opts.level, None);
+        assert_eq!(opts.bframes, 3);
+        assert_eq!(opts.gop_size, 250);
+        assert_eq!(opts.refs, 3);
+    }
+
+    #[test]
+    fn h265_options_default_should_have_main_profile() {
+        let opts = H265Options::default();
+        assert_eq!(opts.profile, H265Profile::Main);
+        assert_eq!(opts.tier, H265Tier::Main);
+        assert_eq!(opts.level, None);
+    }
+
+    #[test]
+    fn av1_options_default_should_have_vod_usage() {
+        let opts = Av1Options::default();
+        assert_eq!(opts.cpu_used, 4);
+        assert_eq!(opts.tile_rows, 0);
+        assert_eq!(opts.tile_cols, 0);
+        assert_eq!(opts.usage, Av1Usage::VoD);
+    }
+
+    #[test]
+    fn video_codec_options_enum_variants_are_accessible() {
+        let _h264 = VideoCodecOptions::H264(H264Options::default());
+        let _h265 = VideoCodecOptions::H265(H265Options::default());
+        let _av1 = VideoCodecOptions::Av1(Av1Options::default());
+        let _vp9 = VideoCodecOptions::Vp9(Vp9Options::default());
+        let _prores = VideoCodecOptions::ProRes(ProResOptions::default());
+        let _dnxhd = VideoCodecOptions::Dnxhd(DnxhdOptions::default());
+    }
+}

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -153,6 +153,7 @@ pub(super) struct VideoEncoderConfig {
     pub(super) metadata: Vec<(String, String)>,
     pub(super) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(super) subtitle_passthrough: Option<(String, usize)>,
+    pub(super) codec_options: Option<crate::video::codec_options::VideoCodecOptions>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -267,6 +268,187 @@ impl VideoEncoderInner {
         }
     }
 
+    /// Apply per-codec options to an allocated (not yet opened) codec context.
+    ///
+    /// All `av_opt_set` return values are checked; a negative value is logged
+    /// as a warning and skipped — it never propagates as an error.
+    ///
+    /// # Safety
+    ///
+    /// `codec_ctx` must be a valid non-null pointer to an allocated
+    /// `AVCodecContext` whose `priv_data` has been set by
+    /// `avcodec_alloc_context3`. Must be called **before** `avcodec_open2`.
+    unsafe fn apply_codec_options(
+        codec_ctx: *mut AVCodecContext,
+        opts: &crate::video::codec_options::VideoCodecOptions,
+        encoder_name: &str,
+    ) {
+        use crate::video::codec_options::VideoCodecOptions;
+        use std::ffi::CString;
+
+        match opts {
+            VideoCodecOptions::H264(h264) => {
+                // profile
+                if let Ok(s) = CString::new(h264.profile.as_str()) {
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"profile\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=profile value={} encoder={encoder_name}",
+                            h264.profile.as_str()
+                        );
+                    }
+                }
+                // level (only when explicitly set)
+                if let Some(level) = h264.level {
+                    let level_str = level.to_string();
+                    if let Ok(s) = CString::new(level_str.as_str()) {
+                        let ret = ff_sys::av_opt_set(
+                            (*codec_ctx).priv_data,
+                            b"level\0".as_ptr() as *const i8,
+                            s.as_ptr(),
+                            0,
+                        );
+                        if ret < 0 {
+                            log::warn!(
+                                "av_opt_set failed option=level value={level} \
+                                 encoder={encoder_name}"
+                            );
+                        }
+                    }
+                }
+                // Direct codec context fields
+                (*codec_ctx).max_b_frames = h264.bframes as i32;
+                (*codec_ctx).gop_size = h264.gop_size as i32;
+                (*codec_ctx).refs = h264.refs as i32;
+            }
+            VideoCodecOptions::H265(h265) => {
+                // profile
+                if let Ok(s) = CString::new(h265.profile.as_str()) {
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"profile\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=profile value={} encoder={encoder_name}",
+                            h265.profile.as_str()
+                        );
+                    }
+                }
+                // tier
+                if let Ok(s) = CString::new(h265.tier.as_str()) {
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tier\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tier value={} encoder={encoder_name}",
+                            h265.tier.as_str()
+                        );
+                    }
+                }
+                // level (only when explicitly set)
+                if let Some(level) = h265.level {
+                    let level_str = level.to_string();
+                    if let Ok(s) = CString::new(level_str.as_str()) {
+                        let ret = ff_sys::av_opt_set(
+                            (*codec_ctx).priv_data,
+                            b"level\0".as_ptr() as *const i8,
+                            s.as_ptr(),
+                            0,
+                        );
+                        if ret < 0 {
+                            log::warn!(
+                                "av_opt_set failed option=level value={level} \
+                                 encoder={encoder_name}"
+                            );
+                        }
+                    }
+                }
+            }
+            VideoCodecOptions::Av1(av1) => {
+                // cpu-used
+                let cpu_used_str = av1.cpu_used.to_string();
+                if let Ok(s) = CString::new(cpu_used_str.as_str()) {
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"cpu-used\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=cpu-used value={} encoder={encoder_name}",
+                            av1.cpu_used
+                        );
+                    }
+                }
+                // tile-rows
+                let tile_rows_str = av1.tile_rows.to_string();
+                if let Ok(s) = CString::new(tile_rows_str.as_str()) {
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tile-rows\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tile-rows value={} encoder={encoder_name}",
+                            av1.tile_rows
+                        );
+                    }
+                }
+                // tile-columns
+                let tile_cols_str = av1.tile_cols.to_string();
+                if let Ok(s) = CString::new(tile_cols_str.as_str()) {
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tile-columns\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tile-columns value={} \
+                             encoder={encoder_name}",
+                            av1.tile_cols
+                        );
+                    }
+                }
+                // usage
+                if let Ok(s) = CString::new(av1.usage.as_str()) {
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"usage\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=usage value={} encoder={encoder_name}",
+                            av1.usage.as_str()
+                        );
+                    }
+                }
+            }
+            // Vp9, ProRes, Dnxhd: options reserved for future issues
+            VideoCodecOptions::Vp9(_)
+            | VideoCodecOptions::ProRes(_)
+            | VideoCodecOptions::Dnxhd(_) => {}
+        }
+    }
+
     /// Create a new encoder with the given configuration.
     pub(super) fn new(config: &VideoEncoderConfig) -> Result<Self, EncodeError> {
         unsafe {
@@ -337,6 +519,7 @@ impl VideoEncoderInner {
                     &config.preset,
                     config.hardware_encoder,
                     config.two_pass,
+                    config.codec_options.as_ref(),
                 )?;
             }
 
@@ -409,6 +592,7 @@ impl VideoEncoderInner {
         preset: &str,
         hardware_encoder: crate::HardwareEncoder,
         two_pass: bool,
+        codec_options: Option<&crate::video::codec_options::VideoCodecOptions>,
     ) -> Result<(), EncodeError> {
         use crate::BitrateMode;
         // Select encoder based on codec and availability
@@ -498,6 +682,14 @@ impl VideoEncoderInner {
                      encoder={encoder_name} preset={preset}"
                 );
             }
+        }
+
+        // Apply per-codec options before opening the codec context.
+        if let Some(opts) = codec_options {
+            // SAFETY: codec_ctx is valid and allocated; priv_data is set by
+            // avcodec_alloc_context3. Options are applied before avcodec_open2
+            // so they take effect during codec initialisation.
+            Self::apply_codec_options(codec_ctx, opts, &encoder_name);
         }
 
         // For two-pass, set the pass-1 flag before opening the codec.
@@ -1841,6 +2033,14 @@ impl VideoEncoderInner {
                     config.preset
                 );
             }
+        }
+
+        // Apply per-codec options before opening the pass-2 codec context.
+        if let Some(opts) = config.codec_options.as_ref() {
+            // SAFETY: codec_ctx is valid and allocated; priv_data is set by
+            // avcodec_alloc_context3. Options are applied before avcodec_open2
+            // so they take effect during codec initialisation.
+            Self::apply_codec_options(codec_ctx, opts, &encoder_name);
         }
 
         // Set the pass-2 flag and provide stats_in.

--- a/crates/ff-encode/src/video/mod.rs
+++ b/crates/ff-encode/src/video/mod.rs
@@ -7,8 +7,13 @@
 #[cfg(feature = "tokio")]
 pub mod async_encoder;
 pub mod builder;
+pub mod codec_options;
 mod encoder_inner;
 
 #[cfg(feature = "tokio")]
 pub use async_encoder::AsyncVideoEncoder;
 pub use builder::{VideoEncoder, VideoEncoderBuilder};
+pub use codec_options::{
+    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Profile, H265Options, H265Profile,
+    H265Tier, ProResOptions, VideoCodecOptions, Vp9Options,
+};


### PR DESCRIPTION
## Summary

Adds `VideoCodecOptions` enum and `VideoEncoderBuilder::codec_options()` to `ff-encode`, exposing per-codec encoding parameters (H.264 profile/level/B-frames, H.265 profile/tier/level, AV1 cpu-used/tiles/usage) via `av_opt_set` applied before `avcodec_open2`. The setter is purely additive — existing builders without `codec_options()` are unaffected.

## Changes

- New `crates/ff-encode/src/video/codec_options.rs` with `VideoCodecOptions` enum (H264, H265, Av1, Vp9, ProRes, Dnxhd variants), per-codec options structs (`H264Options`, `H265Options`, `Av1Options`) with their supporting enums, and `#[non_exhaustive]` placeholder structs for Vp9/ProRes/Dnxhd
- `VideoEncoderBuilder::codec_options(opts: VideoCodecOptions)` consuming setter stored as `Option<VideoCodecOptions>`
- `VideoEncoderInner::apply_codec_options()` unsafe fn applies options via `av_opt_set` + direct field assignment before `avcodec_open2`; called in both single-pass and two-pass (`init_pass2_codec_ctx`) paths; all `av_opt_set` failures are logged as `warn!` and skipped, never returned as errors
- Re-exported all new public types from `ff-encode` and `avio`
- 9 unit tests covering profile/tier/usage `as_str()` values and `Default` implementations

## Related Issues

Closes #190

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes