### PR TITLE
feat(ff-encode): H264Options SAFETY comments, bframes default fix, integration tests

### DIFF
--- a/crates/ff-encode/src/video/codec_options.rs
+++ b/crates/ff-encode/src/video/codec_options.rs
@@ -55,7 +55,7 @@ impl Default for H264Options {
         Self {
             profile: H264Profile::High,
             level: None,
-            bframes: 3,
+            bframes: 2,
             gop_size: 250,
             refs: 3,
         }
@@ -249,7 +249,7 @@ mod tests {
         let opts = H264Options::default();
         assert_eq!(opts.profile, H264Profile::High);
         assert_eq!(opts.level, None);
-        assert_eq!(opts.bframes, 3);
+        assert_eq!(opts.bframes, 2);
         assert_eq!(opts.gop_size, 250);
         assert_eq!(opts.refs, 3);
     }

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -290,6 +290,8 @@ impl VideoEncoderInner {
             VideoCodecOptions::H264(h264) => {
                 // profile
                 if let Ok(s) = CString::new(h264.profile.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null (set by avcodec_alloc_context3);
+                    // option name and value are valid NUL-terminated C strings.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
                         b"profile\0".as_ptr() as *const i8,
@@ -307,6 +309,8 @@ impl VideoEncoderInner {
                 if let Some(level) = h264.level {
                     let level_str = level.to_string();
                     if let Ok(s) = CString::new(level_str.as_str()) {
+                        // SAFETY: codec_ctx and priv_data are non-null; option name and
+                        // value are valid NUL-terminated C strings.
                         let ret = ff_sys::av_opt_set(
                             (*codec_ctx).priv_data,
                             b"level\0".as_ptr() as *const i8,
@@ -321,7 +325,8 @@ impl VideoEncoderInner {
                         }
                     }
                 }
-                // Direct codec context fields
+                // Direct codec context fields (safe: codec_ctx is valid and non-null).
+                // SAFETY: codec_ctx is a valid allocated AVCodecContext.
                 (*codec_ctx).max_b_frames = h264.bframes as i32;
                 (*codec_ctx).gop_size = h264.gop_size as i32;
                 (*codec_ctx).refs = h264.refs as i32;
@@ -329,6 +334,8 @@ impl VideoEncoderInner {
             VideoCodecOptions::H265(h265) => {
                 // profile
                 if let Ok(s) = CString::new(h265.profile.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
                         b"profile\0".as_ptr() as *const i8,
@@ -344,6 +351,8 @@ impl VideoEncoderInner {
                 }
                 // tier
                 if let Ok(s) = CString::new(h265.tier.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
                         b"tier\0".as_ptr() as *const i8,
@@ -361,6 +370,8 @@ impl VideoEncoderInner {
                 if let Some(level) = h265.level {
                     let level_str = level.to_string();
                     if let Ok(s) = CString::new(level_str.as_str()) {
+                        // SAFETY: codec_ctx and priv_data are non-null; option name and
+                        // value are valid NUL-terminated C strings.
                         let ret = ff_sys::av_opt_set(
                             (*codec_ctx).priv_data,
                             b"level\0".as_ptr() as *const i8,
@@ -380,6 +391,8 @@ impl VideoEncoderInner {
                 // cpu-used
                 let cpu_used_str = av1.cpu_used.to_string();
                 if let Ok(s) = CString::new(cpu_used_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
                         b"cpu-used\0".as_ptr() as *const i8,
@@ -396,6 +409,8 @@ impl VideoEncoderInner {
                 // tile-rows
                 let tile_rows_str = av1.tile_rows.to_string();
                 if let Ok(s) = CString::new(tile_rows_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
                         b"tile-rows\0".as_ptr() as *const i8,
@@ -412,6 +427,8 @@ impl VideoEncoderInner {
                 // tile-columns
                 let tile_cols_str = av1.tile_cols.to_string();
                 if let Ok(s) = CString::new(tile_cols_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
                         b"tile-columns\0".as_ptr() as *const i8,
@@ -428,6 +445,8 @@ impl VideoEncoderInner {
                 }
                 // usage
                 if let Ok(s) = CString::new(av1.usage.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
                         b"usage\0".as_ptr() as *const i8,

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -12,7 +12,9 @@
 
 mod fixtures;
 
-use ff_encode::{BitrateMode, Preset, VideoCodec, VideoEncoder};
+use ff_encode::{
+    BitrateMode, H264Options, H264Profile, Preset, VideoCodec, VideoCodecOptions, VideoEncoder,
+};
 use fixtures::{
     FileGuard, assert_valid_output_file, create_black_frame, get_file_size, test_output_path,
 };
@@ -778,4 +780,93 @@ fn chapter_round_trip_should_preserve_count_titles_and_timestamps() {
             actual.end()
         );
     }
+}
+
+// ============================================================================
+// Codec Options Tests
+// ============================================================================
+
+#[test]
+fn h264_high_profile_level41_should_produce_valid_output() {
+    let output_path = test_output_path("h264_high_profile_level41.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let opts = VideoCodecOptions::H264(H264Options {
+        profile: H264Profile::High,
+        level: Some(41),
+        ..H264Options::default()
+    });
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .preset(Preset::Ultrafast)
+        .codec_options(opts)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: no H.264 encoder available: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..30 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+
+    let file_size = get_file_size(&output_path);
+    assert!(file_size > 1000, "Output too small, likely corrupted");
+    println!("H264 High@4.1: codec={codec_name} size={file_size} bytes");
+}
+
+#[test]
+fn h264_baseline_profile_should_produce_valid_output() {
+    let output_path = test_output_path("h264_baseline_profile.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let opts = VideoCodecOptions::H264(H264Options {
+        profile: H264Profile::Baseline,
+        level: None,
+        bframes: 0, // Baseline does not support B-frames
+        ..H264Options::default()
+    });
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .preset(Preset::Ultrafast)
+        .codec_options(opts)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: no H.264 encoder available: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..30 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!(
+        "H264 Baseline: codec={codec_name} size={} bytes",
+        get_file_size(&output_path)
+    );
 }


### PR DESCRIPTION
## Summary

Completes `H264Options` implementation by fixing the `bframes` default value, adding required `// SAFETY:` comments on every `av_opt_set` call in `apply_codec_options()`, and adding integration tests that verify H.264 High@4.1 and Baseline profiles encode to valid output.

## Changes

- `codec_options.rs`: fix `H264Options` default `bframes` from `3` to `2` (spec says default 2); update corresponding unit test
- `encoder_inner.rs`: add `// SAFETY:` comments to every `av_opt_set` call and `(*codec_ctx)` field write inside `apply_codec_options()` — satisfies the acceptance criteria and aligns with the project unsafe coding conventions
- `video_encoder_tests.rs`: add two integration tests:
  - `h264_high_profile_level41_should_produce_valid_output` — encodes 30 frames with `H264Profile::High` + `level: Some(41)`, asserts valid non-empty output (acceptance criteria)
  - `h264_baseline_profile_should_produce_valid_output` — encodes with `H264Profile::Baseline` + `bframes: 0`, verifies Baseline profile produces valid output

## Related Issues

Closes #191

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes