### PR TITLE
feat(ff-encode): H264Preset + H264Tune for H264Options

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -231,9 +231,9 @@ pub use ff_decode::{
 #[cfg(feature = "encode")]
 pub use ff_encode::{
     AudioEncoder, Av1Options, Av1Usage, BitrateMode, CRF_MAX, Container, DnxhdOptions, EncodeError,
-    EncodeProgress, EncodeProgressCallback, H264Options, H264Profile, H265Options, H265Profile,
-    H265Tier, HardwareEncoder, ImageEncoder, Preset, ProResOptions, VideoCodecEncodeExt,
-    VideoCodecOptions, VideoEncoder, Vp9Options,
+    EncodeProgress, EncodeProgressCallback, H264Options, H264Preset, H264Profile, H264Tune,
+    H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Preset, ProResOptions,
+    VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -213,8 +213,9 @@ pub use image::{ImageEncoder, ImageEncoderBuilder};
 pub use preset::Preset;
 pub use progress::{EncodeProgress, EncodeProgressCallback};
 pub use video::{
-    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Profile, H265Options, H265Profile,
-    H265Tier, ProResOptions, VideoCodecOptions, VideoEncoder, VideoEncoderBuilder, Vp9Options,
+    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Preset, H264Profile, H264Tune,
+    H265Options, H265Profile, H265Tier, ProResOptions, VideoCodecOptions, VideoEncoder,
+    VideoEncoderBuilder, Vp9Options,
 };
 
 #[cfg(feature = "tokio")]

--- a/crates/ff-encode/src/video/codec_options.rs
+++ b/crates/ff-encode/src/video/codec_options.rs
@@ -48,6 +48,18 @@ pub struct H264Options {
     pub gop_size: u32,
     /// Number of reference frames.
     pub refs: u32,
+    /// libx264 encoding speed/quality preset.
+    ///
+    /// Overrides the global [`Preset`](crate::Preset) when set. `None` falls
+    /// back to whatever the builder's `.preset()` selector chose.
+    /// Hardware encoders do not support libx264 presets — the option is
+    /// silently skipped with a `warn!` log when unsupported.
+    pub preset: Option<H264Preset>,
+    /// libx264 perceptual tuning parameter.
+    ///
+    /// `None` leaves the encoder default. Hardware encoders ignore this
+    /// option (logged as a warning and skipped).
+    pub tune: Option<H264Tune>,
 }
 
 impl Default for H264Options {
@@ -58,6 +70,8 @@ impl Default for H264Options {
             bframes: 2,
             gop_size: 250,
             refs: 3,
+            preset: None,
+            tune: None,
         }
     }
 }
@@ -83,6 +97,92 @@ impl H264Profile {
             Self::Main => "main",
             Self::High => "high",
             Self::High10 => "high10",
+        }
+    }
+}
+
+/// libx264 encoding speed/quality preset.
+///
+/// Slower presets produce higher quality at the same bitrate but take longer
+/// to encode. Not supported by hardware encoders (NVENC, QSV, etc.) — the
+/// option is skipped with a warning when the encoder does not recognise it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum H264Preset {
+    /// Fastest encoding, lowest quality.
+    Ultrafast,
+    /// Very fast encoding.
+    Superfast,
+    /// Fast encoding.
+    Veryfast,
+    /// Faster than default.
+    Faster,
+    /// Slightly faster than default.
+    Fast,
+    /// Default preset — balanced speed and quality.
+    Medium,
+    /// Slower encoding, better quality.
+    Slow,
+    /// Noticeably slower, noticeably better quality.
+    Slower,
+    /// Very slow, near-optimal quality.
+    Veryslow,
+    /// Slowest, maximum compression (not recommended for production).
+    Placebo,
+}
+
+impl H264Preset {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ultrafast => "ultrafast",
+            Self::Superfast => "superfast",
+            Self::Veryfast => "veryfast",
+            Self::Faster => "faster",
+            Self::Fast => "fast",
+            Self::Medium => "medium",
+            Self::Slow => "slow",
+            Self::Slower => "slower",
+            Self::Veryslow => "veryslow",
+            Self::Placebo => "placebo",
+        }
+    }
+}
+
+/// libx264 perceptual tuning parameter.
+///
+/// Adjusts encoder settings for a specific type of source content or
+/// quality metric. Not supported by hardware encoders — skipped with a
+/// warning when the encoder does not recognise the option.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum H264Tune {
+    /// Optimised for live-action film content.
+    Film,
+    /// Optimised for animation.
+    Animation,
+    /// Optimised for grainy content.
+    Grain,
+    /// Optimised for still images (single-frame encoding).
+    Stillimage,
+    /// Optimise for PSNR quality metric.
+    Psnr,
+    /// Optimise for SSIM quality metric.
+    Ssim,
+    /// Reduce decoding complexity (disables certain features).
+    Fastdecode,
+    /// Minimise encoding latency (no B-frames, no lookahead).
+    Zerolatency,
+}
+
+impl H264Tune {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Film => "film",
+            Self::Animation => "animation",
+            Self::Grain => "grain",
+            Self::Stillimage => "stillimage",
+            Self::Psnr => "psnr",
+            Self::Ssim => "ssim",
+            Self::Fastdecode => "fastdecode",
+            Self::Zerolatency => "zerolatency",
         }
     }
 }
@@ -252,6 +352,34 @@ mod tests {
         assert_eq!(opts.bframes, 2);
         assert_eq!(opts.gop_size, 250);
         assert_eq!(opts.refs, 3);
+        assert!(opts.preset.is_none());
+        assert!(opts.tune.is_none());
+    }
+
+    #[test]
+    fn h264_preset_should_return_correct_str() {
+        assert_eq!(H264Preset::Ultrafast.as_str(), "ultrafast");
+        assert_eq!(H264Preset::Superfast.as_str(), "superfast");
+        assert_eq!(H264Preset::Veryfast.as_str(), "veryfast");
+        assert_eq!(H264Preset::Faster.as_str(), "faster");
+        assert_eq!(H264Preset::Fast.as_str(), "fast");
+        assert_eq!(H264Preset::Medium.as_str(), "medium");
+        assert_eq!(H264Preset::Slow.as_str(), "slow");
+        assert_eq!(H264Preset::Slower.as_str(), "slower");
+        assert_eq!(H264Preset::Veryslow.as_str(), "veryslow");
+        assert_eq!(H264Preset::Placebo.as_str(), "placebo");
+    }
+
+    #[test]
+    fn h264_tune_should_return_correct_str() {
+        assert_eq!(H264Tune::Film.as_str(), "film");
+        assert_eq!(H264Tune::Animation.as_str(), "animation");
+        assert_eq!(H264Tune::Grain.as_str(), "grain");
+        assert_eq!(H264Tune::Stillimage.as_str(), "stillimage");
+        assert_eq!(H264Tune::Psnr.as_str(), "psnr");
+        assert_eq!(H264Tune::Ssim.as_str(), "ssim");
+        assert_eq!(H264Tune::Fastdecode.as_str(), "fastdecode");
+        assert_eq!(H264Tune::Zerolatency.as_str(), "zerolatency");
     }
 
     #[test]

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -325,11 +325,53 @@ impl VideoEncoderInner {
                         }
                     }
                 }
-                // Direct codec context fields (safe: codec_ctx is valid and non-null).
+                // Direct codec context fields.
                 // SAFETY: codec_ctx is a valid allocated AVCodecContext.
                 (*codec_ctx).max_b_frames = h264.bframes as i32;
                 (*codec_ctx).gop_size = h264.gop_size as i32;
                 (*codec_ctx).refs = h264.refs as i32;
+                // preset (libx264-specific; hardware encoders return a negative value
+                // which we log and skip — never returned as an error)
+                if let Some(preset) = h264.preset
+                    && let Ok(s) = CString::new(preset.as_str())
+                {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name
+                    // and value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"preset\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=preset value={} \
+                             encoder={encoder_name}",
+                            preset.as_str()
+                        );
+                    }
+                }
+                // tune (libx264-specific; hardware encoders return a negative value
+                // which we log and skip — never returned as an error)
+                if let Some(tune) = h264.tune
+                    && let Ok(s) = CString::new(tune.as_str())
+                {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name
+                    // and value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tune\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tune value={} \
+                             encoder={encoder_name}",
+                            tune.as_str()
+                        );
+                    }
+                }
             }
             VideoCodecOptions::H265(h265) => {
                 // profile

--- a/crates/ff-encode/src/video/mod.rs
+++ b/crates/ff-encode/src/video/mod.rs
@@ -14,6 +14,6 @@ mod encoder_inner;
 pub use async_encoder::AsyncVideoEncoder;
 pub use builder::{VideoEncoder, VideoEncoderBuilder};
 pub use codec_options::{
-    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Profile, H265Options, H265Profile,
-    H265Tier, ProResOptions, VideoCodecOptions, Vp9Options,
+    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Preset, H264Profile, H264Tune,
+    H265Options, H265Profile, H265Tier, ProResOptions, VideoCodecOptions, Vp9Options,
 };

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -13,7 +13,8 @@
 mod fixtures;
 
 use ff_encode::{
-    BitrateMode, H264Options, H264Profile, Preset, VideoCodec, VideoCodecOptions, VideoEncoder,
+    BitrateMode, H264Options, H264Preset, H264Profile, H264Tune, Preset, VideoCodec,
+    VideoCodecOptions, VideoEncoder,
 };
 use fixtures::{
     FileGuard, assert_valid_output_file, create_black_frame, get_file_size, test_output_path,
@@ -867,6 +868,87 @@ fn h264_baseline_profile_should_produce_valid_output() {
     assert_valid_output_file(&output_path);
     println!(
         "H264 Baseline: codec={codec_name} size={} bytes",
+        get_file_size(&output_path)
+    );
+}
+
+#[test]
+fn h264_veryslow_preset_should_produce_valid_output() {
+    let output_path = test_output_path("h264_veryslow_preset.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let opts = VideoCodecOptions::H264(H264Options {
+        preset: Some(H264Preset::Veryslow),
+        ..H264Options::default()
+    });
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::H264)
+        .codec_options(opts)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: no H.264 encoder available: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!(
+        "H264 veryslow preset: codec={codec_name} size={} bytes",
+        get_file_size(&output_path)
+    );
+}
+
+#[test]
+fn h264_zerolatency_tune_should_produce_valid_output() {
+    let output_path = test_output_path("h264_zerolatency_tune.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let opts = VideoCodecOptions::H264(H264Options {
+        preset: Some(H264Preset::Ultrafast),
+        tune: Some(H264Tune::Zerolatency),
+        ..H264Options::default()
+    });
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::H264)
+        .codec_options(opts)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: no H.264 encoder available: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!(
+        "H264 zerolatency tune: codec={codec_name} size={} bytes",
         get_file_size(&output_path)
     );
 }


### PR DESCRIPTION
## Summary

Extends `H264Options` with `preset: Option<H264Preset>` and `tune: Option<H264Tune>` for libx264-specific quality/speed control. Both options are applied via `av_opt_set` on `priv_data` before `avcodec_open2`. When the encoder does not support the option (e.g. hardware encoders), `av_opt_set` returns a negative value, a `warn!` is logged, and encoding continues without error.

## Changes

- `codec_options.rs`: add `H264Preset` enum (Ultrafast–Placebo, 10 variants) with `as_str()`; add `H264Tune` enum (Film, Animation, Grain, Stillimage, Psnr, Ssim, Fastdecode, Zerolatency) with `as_str()`; add `preset: Option<H264Preset>` and `tune: Option<H264Tune>` fields to `H264Options` (both default to `None`); unit tests for all `as_str()` values and updated `default` test
- `encoder_inner.rs`: apply `preset` and `tune` via `av_opt_set` in `apply_codec_options()` with `// SAFETY:` comments; negative return logs a warning and continues
- `mod.rs`, `lib.rs`, `avio/src/lib.rs`: re-export `H264Preset` and `H264Tune`
- `video_encoder_tests.rs`: add `h264_veryslow_preset_should_produce_valid_output` and `h264_zerolatency_tune_should_produce_valid_output` integration tests

## Related Issues

Closes #192

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes