### PR TITLE
feat(ff-encode): extend H265Options with preset and x265_params passthrough

### DIFF
--- a/crates/ff-encode/src/video/codec_options.rs
+++ b/crates/ff-encode/src/video/codec_options.rs
@@ -200,6 +200,19 @@ pub struct H265Options {
     ///
     /// `None` leaves the encoder default.
     pub level: Option<u32>,
+    /// libx265 encoding speed/quality preset (e.g. `"ultrafast"`, `"medium"`, `"slow"`).
+    ///
+    /// `None` leaves the encoder default. Invalid or unsupported values are logged as a
+    /// warning and skipped — `build()` never fails due to an unsupported preset.
+    /// Hardware HEVC encoders (hevc_nvenc, etc.) ignore this option.
+    pub preset: Option<String>,
+    /// Raw x265-params string passed verbatim to libx265 (e.g. `"ctu=32:ref=4"`).
+    ///
+    /// **Note**: H.265 encoding requires an FFmpeg build with `--enable-libx265`.
+    ///
+    /// An invalid parameter string is logged as a warning and skipped. It never causes
+    /// `build()` to return an error.
+    pub x265_params: Option<String>,
 }
 
 impl Default for H265Options {
@@ -208,6 +221,8 @@ impl Default for H265Options {
             profile: H265Profile::Main,
             tier: H265Tier::Main,
             level: None,
+            preset: None,
+            x265_params: None,
         }
     }
 }
@@ -388,6 +403,20 @@ mod tests {
         assert_eq!(opts.profile, H265Profile::Main);
         assert_eq!(opts.tier, H265Tier::Main);
         assert_eq!(opts.level, None);
+        assert!(opts.preset.is_none());
+        assert!(opts.x265_params.is_none());
+    }
+
+    #[test]
+    fn h265_preset_should_be_none_by_default() {
+        let opts = H265Options::default();
+        assert!(opts.preset.is_none());
+    }
+
+    #[test]
+    fn h265_x265_params_should_be_none_by_default() {
+        let opts = H265Options::default();
+        assert!(opts.x265_params.is_none());
     }
 
     #[test]

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -428,6 +428,45 @@ impl VideoEncoderInner {
                         }
                     }
                 }
+                // preset (libx265-specific; hardware HEVC encoders return a negative value
+                // which we log and skip — never returned as an error)
+                if let Some(ref preset) = h265.preset
+                    && let Ok(s) = CString::new(preset.as_str())
+                {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name
+                    // and value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"preset\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=preset value={preset} \
+                             encoder={encoder_name}"
+                        );
+                    }
+                }
+                // x265-params raw passthrough (libx265 only)
+                if let Some(ref params) = h265.x265_params
+                    && let Ok(s) = CString::new(params.as_str())
+                {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name
+                    // and value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"x265-params\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=x265-params value={params} \
+                             encoder={encoder_name}"
+                        );
+                    }
+                }
             }
             VideoCodecOptions::Av1(av1) => {
                 // cpu-used

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -374,6 +374,7 @@ fn h265_main_profile_should_produce_valid_output() {
             profile: H265Profile::Main,
             tier: H265Tier::Main,
             level: None,
+            ..H265Options::default()
         }))
         .build();
 
@@ -413,6 +414,7 @@ fn h265_main10_profile_should_produce_valid_output() {
             profile: H265Profile::Main10,
             tier: H265Tier::Main,
             level: None,
+            ..H265Options::default()
         }))
         .build();
 
@@ -452,6 +454,7 @@ fn h265_high_tier_should_produce_valid_output() {
             profile: H265Profile::Main,
             tier: H265Tier::High,
             level: None,
+            ..H265Options::default()
         }))
         .build();
 
@@ -491,6 +494,7 @@ fn h265_level51_should_produce_valid_output() {
             profile: H265Profile::Main,
             tier: H265Tier::Main,
             level: Some(51),
+            ..H265Options::default()
         }))
         .build();
 
@@ -514,6 +518,82 @@ fn h265_level51_should_produce_valid_output() {
     encoder.finish().expect("Failed to finish encoding");
     assert_valid_output_file(&output_path);
     println!("h265_level51: codec={codec_name}");
+}
+
+#[test]
+fn h265_preset_ultrafast_should_produce_valid_output() {
+    let output_path = test_output_path("h265_preset_ultrafast.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H265)
+        .bitrate_mode(BitrateMode::Crf(28))
+        .preset(Preset::Ultrafast)
+        .codec_options(VideoCodecOptions::H265(H265Options {
+            preset: Some("ultrafast".to_string()),
+            ..H265Options::default()
+        }))
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping h265_preset_ultrafast test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let codec_name = encoder.actual_video_codec().to_string();
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("h265_preset_ultrafast: codec={codec_name}");
+}
+
+#[test]
+fn h265_x265_params_log_level_none_should_not_crash() {
+    let output_path = test_output_path("h265_x265_params.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H265)
+        .bitrate_mode(BitrateMode::Crf(28))
+        .preset(Preset::Ultrafast)
+        .codec_options(VideoCodecOptions::H265(H265Options {
+            x265_params: Some("log-level=none".to_string()),
+            ..H265Options::default()
+        }))
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping h265_x265_params test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let codec_name = encoder.actual_video_codec().to_string();
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("h265_x265_params: codec={codec_name}");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Extends `H265Options` with two new optional fields — `preset: Option<String>` for the libx265 speed/quality preset and `x265_params: Option<String>` for raw passthrough of any libx265 parameter string. Both are applied via `av_opt_set` before `avcodec_open2`, following the same warn-and-skip pattern established for `H264Options::preset` and `H264Options::tune`. An unsupported or invalid value is logged as a warning and never causes `build()` to fail.

## Changes

- **`src/video/codec_options.rs`**: Added `preset` and `x265_params` fields to `H265Options` with doc-comments; updated `Default` impl; added two unit tests (`h265_preset_should_be_none_by_default`, `h265_x265_params_should_be_none_by_default`); updated existing `h265_options_default_should_have_main_profile` assertion to cover new fields.
- **`src/video/encoder_inner.rs`**: Extended H265 arm of `apply_codec_options` with `preset` and `x265-params` av_opt_set blocks, each with `// SAFETY:` comment and warn-on-negative-return behavior.
- **`tests/video_encoder_tests.rs`**: Added `h265_preset_ultrafast_should_produce_valid_output` and `h265_x265_params_log_level_none_should_not_crash`; updated four existing H265 tests to use `..H265Options::default()` spread syntax for forward compatibility.

## Related Issues

Closes #194

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes