### PR TITLE
feat(ff-encode,ff-format): add SVT-AV1 encoder support (VideoCodec::Av1Svt)

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -233,7 +233,7 @@ pub use ff_encode::{
     AudioEncoder, Av1Options, Av1Usage, BitrateMode, CRF_MAX, Container, DnxhdOptions, EncodeError,
     EncodeProgress, EncodeProgressCallback, H264Options, H264Preset, H264Profile, H264Tune,
     H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Preset, ProResOptions,
-    VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -214,8 +214,8 @@ pub use preset::Preset;
 pub use progress::{EncodeProgress, EncodeProgressCallback};
 pub use video::{
     Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, ProResOptions, VideoCodecOptions, VideoEncoder,
-    VideoEncoderBuilder, Vp9Options,
+    H265Options, H265Profile, H265Tier, ProResOptions, SvtAv1Options, VideoCodecOptions,
+    VideoEncoder, VideoEncoderBuilder, Vp9Options,
 };
 
 #[cfg(feature = "tokio")]

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -359,6 +359,15 @@ impl VideoEncoderBuilder {
             });
         }
 
+        if let Some(VideoCodecOptions::Av1Svt(ref opts)) = self.codec_options
+            && opts.preset > 13
+        {
+            return Err(EncodeError::InvalidOption {
+                name: "preset".to_string(),
+                reason: "must be 0–13".to_string(),
+            });
+        }
+
         if has_audio {
             if let Some(rate) = self.audio_sample_rate
                 && rate == 0

--- a/crates/ff-encode/src/video/codec_options.rs
+++ b/crates/ff-encode/src/video/codec_options.rs
@@ -21,8 +21,10 @@ pub enum VideoCodecOptions {
     H264(H264Options),
     /// H.265 (HEVC) encoding options.
     H265(H265Options),
-    /// AV1 encoding options.
+    /// AV1 (libaom-av1) encoding options.
     Av1(Av1Options),
+    /// AV1 (SVT-AV1 / libsvtav1) encoding options.
+    Av1Svt(SvtAv1Options),
     /// VP9 encoding options (reserved for a future issue).
     Vp9(Vp9Options),
     /// Apple ProRes encoding options (reserved for a future issue).
@@ -310,6 +312,39 @@ impl Av1Usage {
     }
 }
 
+// ── SVT-AV1 ──────────────────────────────────────────────────────────────────
+
+/// SVT-AV1 (libsvtav1) per-codec options.
+///
+/// **Note**: Requires an FFmpeg build with `--enable-libsvtav1` (LGPL).
+/// `build()` returns [`EncodeError::EncoderUnavailable`](crate::EncodeError::EncoderUnavailable)
+/// when libsvtav1 is absent from the FFmpeg build.
+#[derive(Debug, Clone)]
+pub struct SvtAv1Options {
+    /// Encoder preset: 0 = best quality / slowest, 13 = fastest / lowest quality.
+    pub preset: u8,
+    /// Log2 number of tile rows (0–6).
+    pub tile_rows: u8,
+    /// Log2 number of tile columns (0–6).
+    pub tile_cols: u8,
+    /// Raw SVT-AV1 params string passed verbatim (e.g. `"fast-decode=1:hdr=0"`).
+    ///
+    /// `None` leaves the encoder default. Invalid values are logged as a warning
+    /// and skipped — `build()` never fails due to an unsupported parameter.
+    pub svtav1_params: Option<String>,
+}
+
+impl Default for SvtAv1Options {
+    fn default() -> Self {
+        Self {
+            preset: 8,
+            tile_rows: 0,
+            tile_cols: 0,
+            svtav1_params: None,
+        }
+    }
+}
+
 // ── Placeholder variants ──────────────────────────────────────────────────────
 
 /// VP9 per-codec options (reserved for a future issue).
@@ -433,8 +468,18 @@ mod tests {
         let _h264 = VideoCodecOptions::H264(H264Options::default());
         let _h265 = VideoCodecOptions::H265(H265Options::default());
         let _av1 = VideoCodecOptions::Av1(Av1Options::default());
+        let _av1svt = VideoCodecOptions::Av1Svt(SvtAv1Options::default());
         let _vp9 = VideoCodecOptions::Vp9(Vp9Options::default());
         let _prores = VideoCodecOptions::ProRes(ProResOptions::default());
         let _dnxhd = VideoCodecOptions::Dnxhd(DnxhdOptions::default());
+    }
+
+    #[test]
+    fn svtav1_options_default_should_have_preset_8() {
+        let opts = SvtAv1Options::default();
+        assert_eq!(opts.preset, 8);
+        assert_eq!(opts.tile_rows, 0);
+        assert_eq!(opts.tile_cols, 0);
+        assert!(opts.svtav1_params.is_none());
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -542,6 +542,84 @@ impl VideoEncoderInner {
                     }
                 }
             }
+            VideoCodecOptions::Av1Svt(svt) => {
+                // preset (0–13)
+                let preset_str = svt.preset.to_string();
+                if let Ok(s) = CString::new(preset_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"preset\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=preset value={} \
+                             encoder={encoder_name}",
+                            svt.preset
+                        );
+                    }
+                }
+                // tile-rows
+                let tile_rows_str = svt.tile_rows.to_string();
+                if let Ok(s) = CString::new(tile_rows_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tile_rows\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tile_rows value={} \
+                             encoder={encoder_name}",
+                            svt.tile_rows
+                        );
+                    }
+                }
+                // tile-columns
+                let tile_cols_str = svt.tile_cols.to_string();
+                if let Ok(s) = CString::new(tile_cols_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tile_columns\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tile_columns value={} \
+                             encoder={encoder_name}",
+                            svt.tile_cols
+                        );
+                    }
+                }
+                // svtav1-params raw passthrough
+                if let Some(ref params) = svt.svtav1_params
+                    && let Ok(s) = CString::new(params.as_str())
+                {
+                    // SAFETY: codec_ctx and priv_data are non-null; option name and
+                    // value are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"svtav1-params\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=svtav1-params value={params} \
+                             encoder={encoder_name}"
+                        );
+                    }
+                }
+            }
             // Vp9, ProRes, Dnxhd: options reserved for future issues
             VideoCodecOptions::Vp9(_)
             | VideoCodecOptions::ProRes(_)
@@ -852,6 +930,21 @@ impl VideoEncoderInner {
         codec: VideoCodec,
         hardware_encoder: crate::HardwareEncoder,
     ) -> Result<String, EncodeError> {
+        // Early check: when Av1Svt is requested, verify that libsvtav1 is registered.
+        if codec == VideoCodec::Av1Svt {
+            // SAFETY: find_encoder_by_name is always safe to call with a valid NUL-terminated
+            // C string literal; the returned pointer is owned by FFmpeg and must not be freed.
+            let has_svt = unsafe {
+                avcodec::find_encoder_by_name(b"libsvtav1\0".as_ptr() as *const i8).is_some()
+            };
+            if !has_svt {
+                return Err(EncodeError::EncoderUnavailable {
+                    codec: "av1/svt".to_string(),
+                    hint: "Requires an FFmpeg build with --enable-libsvtav1 (LGPL)".to_string(),
+                });
+            }
+        }
+
         // Early check: when H265 is requested, verify that at least one HEVC encoder
         // is registered in this FFmpeg build before attempting candidate selection.
         if codec == VideoCodec::H265 {
@@ -874,6 +967,7 @@ impl VideoEncoderInner {
             VideoCodec::H265 => self.select_h265_encoder_candidates(hardware_encoder),
             VideoCodec::Vp9 => vec!["libvpx-vp9"],
             VideoCodec::Av1 => vec!["libaom-av1", "libsvtav1", "av1"],
+            VideoCodec::Av1Svt => vec!["libsvtav1"],
             VideoCodec::ProRes => vec!["prores_ks", "prores"],
             VideoCodec::DnxHd => vec!["dnxhd"],
             VideoCodec::Mpeg4 => vec!["mpeg4"],
@@ -2575,6 +2669,7 @@ fn codec_to_id(codec: VideoCodec) -> AVCodecID {
         VideoCodec::H265 => AVCodecID_AV_CODEC_ID_HEVC,
         VideoCodec::Vp9 => AVCodecID_AV_CODEC_ID_VP9,
         VideoCodec::Av1 => AVCodecID_AV_CODEC_ID_AV1,
+        VideoCodec::Av1Svt => AVCodecID_AV_CODEC_ID_AV1,
         VideoCodec::ProRes => AVCodecID_AV_CODEC_ID_PRORES,
         VideoCodec::DnxHd => AVCodecID_AV_CODEC_ID_DNXHD,
         VideoCodec::Mpeg4 => AVCodecID_AV_CODEC_ID_MPEG4,

--- a/crates/ff-encode/src/video/mod.rs
+++ b/crates/ff-encode/src/video/mod.rs
@@ -15,5 +15,6 @@ pub use async_encoder::AsyncVideoEncoder;
 pub use builder::{VideoEncoder, VideoEncoderBuilder};
 pub use codec_options::{
     Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, ProResOptions, VideoCodecOptions, Vp9Options,
+    H265Options, H265Profile, H265Tier, ProResOptions, SvtAv1Options, VideoCodecOptions,
+    Vp9Options,
 };

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -14,7 +14,8 @@ mod fixtures;
 
 use ff_encode::{
     Av1Options, Av1Usage, BitrateMode, EncodeError, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, Preset, VideoCodec, VideoCodecOptions, VideoEncoder,
+    H265Options, H265Profile, H265Tier, Preset, SvtAv1Options, VideoCodec, VideoCodecOptions,
+    VideoEncoder,
 };
 use fixtures::{
     FileGuard, assert_valid_output_file, create_black_frame, get_file_size, test_output_path,
@@ -682,6 +683,100 @@ fn av1_cpu_used_9_should_return_invalid_option_error() {
         .codec_options(VideoCodecOptions::Av1(Av1Options {
             cpu_used: 9,
             ..Av1Options::default()
+        }))
+        .build();
+
+    assert!(
+        matches!(result, Err(EncodeError::InvalidOption { .. })),
+        "Expected InvalidOption error"
+    );
+}
+
+// ============================================================================
+// SVT-AV1 codec_options Tests
+// ============================================================================
+
+#[test]
+fn svtav1_preset_8_should_produce_valid_output() {
+    let output_path = test_output_path("svtav1_preset_8.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let mut encoder = match VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Av1Svt)
+        .codec_options(VideoCodecOptions::Av1Svt(SvtAv1Options {
+            preset: 8,
+            ..SvtAv1Options::default()
+        }))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping svtav1_preset_8 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let codec_name = encoder.actual_video_codec().to_string();
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("svtav1_preset_8: codec={codec_name}");
+}
+
+#[test]
+fn svtav1_params_passthrough_should_not_crash() {
+    let output_path = test_output_path("svtav1_params.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let mut encoder = match VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Av1Svt)
+        .codec_options(VideoCodecOptions::Av1Svt(SvtAv1Options {
+            svtav1_params: Some("fast-decode=1".to_string()),
+            ..SvtAv1Options::default()
+        }))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping svtav1_params test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let codec_name = encoder.actual_video_codec().to_string();
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("svtav1_params: codec={codec_name}");
+}
+
+#[test]
+fn svtav1_preset_14_should_return_invalid_option_error() {
+    let output_path = test_output_path("svtav1_preset_14.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Av1Svt)
+        .codec_options(VideoCodecOptions::Av1Svt(SvtAv1Options {
+            preset: 14,
+            ..SvtAv1Options::default()
         }))
         .build();
 

--- a/crates/ff-format/src/codec.rs
+++ b/crates/ff-format/src/codec.rs
@@ -45,6 +45,10 @@ pub enum VideoCodec {
     Vp9,
     /// AV1 - Alliance for Open Media codec, next-gen compression
     Av1,
+    /// AV1 encoded via SVT-AV1 (libsvtav1) — LGPL-licensed, often faster than libaom-av1.
+    ///
+    /// Requires an `FFmpeg` build with `--enable-libsvtav1`.
+    Av1Svt,
     /// Apple's professional editing codec
     ProRes,
     /// Avid DNxHD/DNxHR — professional editing codec for post-production
@@ -77,7 +81,7 @@ impl VideoCodec {
             Self::H265 => "hevc",
             Self::Vp8 => "vp8",
             Self::Vp9 => "vp9",
-            Self::Av1 => "av1",
+            Self::Av1 | Self::Av1Svt => "av1",
             Self::ProRes => "prores",
             Self::DnxHd => "dnxhd",
             Self::Mpeg4 => "mpeg4",
@@ -105,6 +109,7 @@ impl VideoCodec {
             Self::Vp8 => "VP8",
             Self::Vp9 => "VP9",
             Self::Av1 => "AV1",
+            Self::Av1Svt => "AV1 (SVT)",
             Self::ProRes => "Apple ProRes",
             Self::DnxHd => "Avid DNxHD/DNxHR",
             Self::Mpeg4 => "MPEG-4 Part 2",
@@ -568,6 +573,16 @@ mod tests {
             assert!(VideoCodec::DnxHd.is_professional());
             assert!(!VideoCodec::H264.is_professional());
             assert!(!VideoCodec::Unknown.is_professional());
+        }
+
+        #[test]
+        fn av1svt_name_should_return_av1() {
+            assert_eq!(VideoCodec::Av1Svt.name(), "av1");
+        }
+
+        #[test]
+        fn av1svt_display_name_should_return_av1_svt() {
+            assert_eq!(VideoCodec::Av1Svt.display_name(), "AV1 (SVT)");
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Adds SVT-AV1 (`libsvtav1`) encoding as a first-class codec via `VideoCodec::Av1Svt` and `SvtAv1Options`. Returns `EncodeError::EncoderUnavailable` when `libsvtav1` is absent from the FFmpeg build. SVT-AV1 is LGPL-licensed and requires no GPL flags.

## Changes

- `ff-format`: add `VideoCodec::Av1Svt` variant (`name()="av1"`, `display_name()="AV1 (SVT)"`)
- `ff-encode`: add `SvtAv1Options { preset, tile_rows, tile_cols, svtav1_params }` (default preset=8) and `VideoCodecOptions::Av1Svt`
- `encoder_inner`: early `EncoderUnavailable` check via `find_encoder_by_name("libsvtav1")`; `Av1Svt` candidates/codec_to_id arms; `apply_codec_options` arm for preset, tile_rows, tile_columns, svtav1-params
- `builder`: validate `preset > 13` → `EncodeError::InvalidOption`
- Re-export `SvtAv1Options` from `ff-encode` and `avio`
- Integration tests: `svtav1_preset_8_should_produce_valid_output`, `svtav1_params_passthrough_should_not_crash`, `svtav1_preset_14_should_return_invalid_option_error`

## Related Issues

Closes #196

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes