### PR TITLE
feat(ff-encode): implement Vp9Options with CQ mode and tile configuration

### DIFF
--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -368,6 +368,23 @@ impl VideoEncoderBuilder {
             });
         }
 
+        if let Some(VideoCodecOptions::Vp9(ref opts)) = self.codec_options {
+            if opts.cpu_used < -8 || opts.cpu_used > 8 {
+                return Err(EncodeError::InvalidOption {
+                    name: "cpu_used".to_string(),
+                    reason: "must be -8–8".to_string(),
+                });
+            }
+            if let Some(cq) = opts.cq_level
+                && cq > 63
+            {
+                return Err(EncodeError::InvalidOption {
+                    name: "cq_level".to_string(),
+                    reason: "must be 0–63".to_string(),
+                });
+            }
+        }
+
         if has_audio {
             if let Some(rate) = self.audio_sample_rate
                 && rate == 0

--- a/crates/ff-encode/src/video/codec_options.rs
+++ b/crates/ff-encode/src/video/codec_options.rs
@@ -345,12 +345,28 @@ impl Default for SvtAv1Options {
     }
 }
 
-// ── Placeholder variants ──────────────────────────────────────────────────────
+// ── VP9 ───────────────────────────────────────────────────────────────────────
 
-/// VP9 per-codec options (reserved for a future issue).
+/// VP9 (libvpx-vp9) per-codec options.
 #[derive(Debug, Clone, Default)]
-#[non_exhaustive]
-pub struct Vp9Options {}
+pub struct Vp9Options {
+    /// Encoder speed/quality trade-off: -8 = best quality / slowest, 8 = fastest.
+    pub cpu_used: i8,
+    /// Constrained Quality level (0–63).
+    ///
+    /// `Some(q)` enables CQ mode: sets `bit_rate = 0` and applies `q` as the `crf`
+    /// option, producing variable-bitrate output governed by perceptual quality.
+    /// `None` uses the bitrate mode configured on the builder.
+    pub cq_level: Option<u8>,
+    /// Log2 number of tile columns (0–6).
+    pub tile_columns: u8,
+    /// Log2 number of tile rows (0–6).
+    pub tile_rows: u8,
+    /// Enable row-based multithreading for better CPU utilisation.
+    pub row_mt: bool,
+}
+
+// ── Placeholder variants ──────────────────────────────────────────────────────
 
 /// Apple ProRes per-codec options (reserved for a future issue).
 #[derive(Debug, Clone, Default)]
@@ -472,6 +488,21 @@ mod tests {
         let _vp9 = VideoCodecOptions::Vp9(Vp9Options::default());
         let _prores = VideoCodecOptions::ProRes(ProResOptions::default());
         let _dnxhd = VideoCodecOptions::Dnxhd(DnxhdOptions::default());
+    }
+
+    #[test]
+    fn vp9_options_default_should_have_cpu_used_0() {
+        let opts = Vp9Options::default();
+        assert_eq!(opts.cpu_used, 0);
+        assert_eq!(opts.tile_columns, 0);
+        assert_eq!(opts.tile_rows, 0);
+        assert!(!opts.row_mt);
+    }
+
+    #[test]
+    fn vp9_options_default_should_have_no_cq_level() {
+        let opts = Vp9Options::default();
+        assert!(opts.cq_level.is_none());
     }
 
     #[test]

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -620,10 +620,107 @@ impl VideoEncoderInner {
                     }
                 }
             }
-            // Vp9, ProRes, Dnxhd: options reserved for future issues
-            VideoCodecOptions::Vp9(_)
-            | VideoCodecOptions::ProRes(_)
-            | VideoCodecOptions::Dnxhd(_) => {}
+            VideoCodecOptions::Vp9(vp9) => {
+                // CQ mode: override bitrate to 0 and set crf
+                if let Some(cq) = vp9.cq_level {
+                    // SAFETY: codec_ctx is non-null; direct field write is safe.
+                    (*codec_ctx).bit_rate = 0;
+                    let cq_str = cq.to_string();
+                    if let Ok(s) = CString::new(cq_str.as_str()) {
+                        // SAFETY: codec_ctx and priv_data are non-null; strings are
+                        // NUL-terminated.
+                        let ret = ff_sys::av_opt_set(
+                            (*codec_ctx).priv_data,
+                            b"crf\0".as_ptr() as *const i8,
+                            s.as_ptr(),
+                            0,
+                        );
+                        if ret < 0 {
+                            log::warn!(
+                                "av_opt_set failed option=crf value={cq} \
+                                 encoder={encoder_name}"
+                            );
+                        }
+                    }
+                }
+                // cpu-used
+                let cpu_used_str = vp9.cpu_used.to_string();
+                if let Ok(s) = CString::new(cpu_used_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; strings are
+                    // NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"cpu-used\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=cpu-used value={} \
+                             encoder={encoder_name}",
+                            vp9.cpu_used
+                        );
+                    }
+                }
+                // tile-columns
+                let tile_cols_str = vp9.tile_columns.to_string();
+                if let Ok(s) = CString::new(tile_cols_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; strings are
+                    // NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tile-columns\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tile-columns value={} \
+                             encoder={encoder_name}",
+                            vp9.tile_columns
+                        );
+                    }
+                }
+                // tile-rows
+                let tile_rows_str = vp9.tile_rows.to_string();
+                if let Ok(s) = CString::new(tile_rows_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; strings are
+                    // NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"tile-rows\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=tile-rows value={} \
+                             encoder={encoder_name}",
+                            vp9.tile_rows
+                        );
+                    }
+                }
+                // row-mt
+                let row_mt_str = if vp9.row_mt { "1" } else { "0" };
+                if let Ok(s) = CString::new(row_mt_str) {
+                    // SAFETY: codec_ctx and priv_data are non-null; strings are
+                    // NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"row-mt\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=row-mt value={row_mt_str} \
+                             encoder={encoder_name}"
+                        );
+                    }
+                }
+            }
+            // ProRes, Dnxhd: options reserved for future issues
+            VideoCodecOptions::ProRes(_) | VideoCodecOptions::Dnxhd(_) => {}
         }
     }
 

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -15,7 +15,7 @@ mod fixtures;
 use ff_encode::{
     Av1Options, Av1Usage, BitrateMode, EncodeError, H264Options, H264Preset, H264Profile, H264Tune,
     H265Options, H265Profile, H265Tier, Preset, SvtAv1Options, VideoCodec, VideoCodecOptions,
-    VideoEncoder,
+    VideoEncoder, Vp9Options,
 };
 use fixtures::{
     FileGuard, assert_valid_output_file, create_black_frame, get_file_size, test_output_path,
@@ -777,6 +777,101 @@ fn svtav1_preset_14_should_return_invalid_option_error() {
         .codec_options(VideoCodecOptions::Av1Svt(SvtAv1Options {
             preset: 14,
             ..SvtAv1Options::default()
+        }))
+        .build();
+
+    assert!(
+        matches!(result, Err(EncodeError::InvalidOption { .. })),
+        "Expected InvalidOption error"
+    );
+}
+
+// ============================================================================
+// VP9 codec_options Tests
+// ============================================================================
+
+#[test]
+fn vp9_cpu_used_4_should_produce_valid_output() {
+    let output_path = test_output_path("vp9_cpu_used_4.webm");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let mut encoder = match VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Vp9)
+        .codec_options(VideoCodecOptions::Vp9(Vp9Options {
+            cpu_used: 4,
+            ..Vp9Options::default()
+        }))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping vp9_cpu_used_4 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let codec_name = encoder.actual_video_codec().to_string();
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("vp9_cpu_used_4: codec={codec_name}");
+}
+
+#[test]
+fn vp9_cq_mode_should_produce_valid_output() {
+    let output_path = test_output_path("vp9_cq_mode.webm");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let mut encoder = match VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Vp9)
+        .codec_options(VideoCodecOptions::Vp9(Vp9Options {
+            cpu_used: 4,
+            cq_level: Some(33),
+            ..Vp9Options::default()
+        }))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping vp9_cq_mode test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let codec_name = encoder.actual_video_codec().to_string();
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("vp9_cq_mode: codec={codec_name}");
+}
+
+#[test]
+fn vp9_cpu_used_out_of_range_should_return_invalid_option_error() {
+    let output_path = test_output_path("vp9_cpu_used_oob.webm");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Vp9)
+        .codec_options(VideoCodecOptions::Vp9(Vp9Options {
+            cpu_used: 9,
+            ..Vp9Options::default()
         }))
         .build();
 


### PR DESCRIPTION
## Summary

Replaces the placeholder `Vp9Options {}` with a fully functional implementation for VP9 encoding. The main addition is CQ (Constrained Quality) mode, which overrides `bit_rate = 0` and sets a `crf` value via `av_opt_set`, producing variable-bitrate output controlled by perceptual quality. Tile configuration and row-based multithreading are also supported.

## Changes

- `codec_options.rs`: replace `#[non_exhaustive] struct Vp9Options {}` with `Vp9Options { cpu_used: i8, cq_level: Option<u8>, tile_columns: u8, tile_rows: u8, row_mt: bool }` (derives `Default`); 2 unit tests
- `encoder_inner.rs`: implement `Vp9` arm in `apply_codec_options` — CQ mode sets `bit_rate = 0` + `av_opt_set("crf", …)`; applies `cpu-used`, `tile-columns`, `tile-rows`, `row-mt` via `av_opt_set` on `priv_data`
- `builder.rs`: validate `cpu_used ∈ [-8, 8]` and `cq_level ≤ 63`, returning `EncodeError::InvalidOption` on violation
- Integration tests: `vp9_cpu_used_4_should_produce_valid_output`, `vp9_cq_mode_should_produce_valid_output`, `vp9_cpu_used_out_of_range_should_return_invalid_option_error`

## Related Issues

Closes #197

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes