### PR TITLE
feat(ff-encode): AudioCodecOptions enum + AudioEncoderBuilder::codec_options()

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -230,10 +230,11 @@ pub use ff_decode::{
 // default_extension) on the shared VideoCodec type; import it to call them.
 #[cfg(feature = "encode")]
 pub use ff_encode::{
-    AudioEncoder, Av1Options, Av1Usage, BitrateMode, CRF_MAX, Container, DnxhdOptions, EncodeError,
-    EncodeProgress, EncodeProgressCallback, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Preset, ProResOptions,
-    SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    AacOptions, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode, CRF_MAX,
+    Container, DnxhdOptions, EncodeError, EncodeProgress, EncodeProgressCallback, FlacOptions,
+    H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier,
+    HardwareEncoder, ImageEncoder, Mp3Options, OpusApplication, OpusOptions, OpusVbr, Preset,
+    ProResOptions, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 
 use ff_format::AudioFrame;
 
+use super::codec_options::AudioCodecOptions;
 use super::encoder_inner::{AudioEncoderConfig, AudioEncoderInner};
 use crate::{AudioCodec, Container, EncodeError};
 
@@ -33,6 +34,7 @@ pub struct AudioEncoderBuilder {
     pub(crate) audio_channels: Option<u32>,
     pub(crate) audio_codec: AudioCodec,
     pub(crate) audio_bitrate: Option<u64>,
+    pub(crate) codec_options: Option<AudioCodecOptions>,
 }
 
 impl AudioEncoderBuilder {
@@ -44,6 +46,7 @@ impl AudioEncoderBuilder {
             audio_channels: None,
             audio_codec: AudioCodec::default(),
             audio_bitrate: None,
+            codec_options: None,
         }
     }
 
@@ -73,6 +76,16 @@ impl AudioEncoderBuilder {
     #[must_use]
     pub fn container(mut self, container: Container) -> Self {
         self.container = Some(container);
+        self
+    }
+
+    /// Set per-codec encoding options.
+    ///
+    /// The variant must match the codec set via [`audio_codec()`](Self::audio_codec).
+    /// A mismatch is silently ignored.
+    #[must_use]
+    pub fn codec_options(mut self, opts: AudioCodecOptions) -> Self {
+        self.codec_options = Some(opts);
         self
     }
 
@@ -132,6 +145,7 @@ impl AudioEncoder {
                 })?,
             codec: builder.audio_codec,
             bitrate: builder.audio_bitrate,
+            codec_options: builder.codec_options,
             _progress_callback: false,
         };
 

--- a/crates/ff-encode/src/audio/codec_options.rs
+++ b/crates/ff-encode/src/audio/codec_options.rs
@@ -1,0 +1,196 @@
+//! Per-codec encoding options for [`AudioEncoderBuilder`](super::builder::AudioEncoderBuilder).
+//!
+//! Pass an [`AudioCodecOptions`] value to
+//! `AudioEncoderBuilder::codec_options()` to control codec-specific behaviour.
+//! Options are applied via `av_opt_set` / direct field assignment **before**
+//! `avcodec_open2`.  Any option that the chosen encoder does not support is
+//! logged as a warning and skipped — it never causes `build()` to return an
+//! error.
+
+/// Per-codec encoding options for audio.
+///
+/// The variant must match the codec passed to
+/// `AudioEncoderBuilder::audio_codec()`.  A mismatch is silently ignored
+/// (the options are not applied).
+#[derive(Debug, Clone)]
+pub enum AudioCodecOptions {
+    /// Opus (libopus) encoding options.
+    Opus(OpusOptions),
+    /// AAC encoding options.
+    Aac(AacOptions),
+    /// MP3 (libmp3lame) encoding options.
+    Mp3(Mp3Options),
+    /// FLAC encoding options.
+    Flac(FlacOptions),
+}
+
+// ── Opus ──────────────────────────────────────────────────────────────────────
+
+/// Opus (libopus) per-codec options.
+#[derive(Debug, Clone)]
+pub struct OpusOptions {
+    /// Encoder application mode, optimised for the content type.
+    pub application: OpusApplication,
+    /// Variable bit-rate mode.
+    pub vbr: OpusVbr,
+}
+
+impl Default for OpusOptions {
+    fn default() -> Self {
+        Self {
+            application: OpusApplication::Audio,
+            vbr: OpusVbr::On,
+        }
+    }
+}
+
+/// Opus encoder application mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OpusApplication {
+    /// Optimised for general audio (music, speech mix). Default.
+    #[default]
+    Audio,
+    /// Optimised for VoIP / speech clarity at low bitrates.
+    VoIP,
+    /// Minimum latency mode — disables lookahead.
+    LowDelay,
+}
+
+impl OpusApplication {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Audio => "audio",
+            Self::VoIP => "voip",
+            Self::LowDelay => "lowdelay",
+        }
+    }
+}
+
+/// Opus variable bit-rate mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OpusVbr {
+    /// Constant bit-rate.
+    Off,
+    /// Variable bit-rate (recommended). Default.
+    #[default]
+    On,
+    /// Constrained VBR — guaranteed never to exceed the target bitrate per packet.
+    Constrained,
+}
+
+impl OpusVbr {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::On => "on",
+            Self::Constrained => "constrained",
+        }
+    }
+}
+
+// ── AAC ───────────────────────────────────────────────────────────────────────
+
+/// AAC per-codec options.
+#[derive(Debug, Clone)]
+pub struct AacOptions {
+    /// Enable the afterburner quality enhancement pass (libfdk_aac only).
+    ///
+    /// Increases quality at the cost of slightly higher CPU usage. Silently
+    /// ignored when using the native `aac` encoder (logged as a warning).
+    pub afterburner: bool,
+}
+
+impl Default for AacOptions {
+    fn default() -> Self {
+        Self { afterburner: true }
+    }
+}
+
+// ── MP3 ───────────────────────────────────────────────────────────────────────
+
+/// MP3 (libmp3lame) per-codec options.
+#[derive(Debug, Clone)]
+pub struct Mp3Options {
+    /// VBR quality level (0–9). `0` = best quality, `9` = smallest file.
+    ///
+    /// Only takes effect when the builder is configured for VBR-style encoding.
+    /// Silently ignored if `av_opt_set` does not accept the value.
+    pub quality: u8,
+}
+
+impl Default for Mp3Options {
+    fn default() -> Self {
+        Self { quality: 4 }
+    }
+}
+
+// ── FLAC ──────────────────────────────────────────────────────────────────────
+
+/// FLAC per-codec options.
+#[derive(Debug, Clone)]
+pub struct FlacOptions {
+    /// Compression level (0–12). `0` = fastest / largest, `12` = slowest / smallest.
+    pub compression_level: u8,
+}
+
+impl Default for FlacOptions {
+    fn default() -> Self {
+        Self {
+            compression_level: 5,
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opus_application_should_return_correct_str() {
+        assert_eq!(OpusApplication::Audio.as_str(), "audio");
+        assert_eq!(OpusApplication::VoIP.as_str(), "voip");
+        assert_eq!(OpusApplication::LowDelay.as_str(), "lowdelay");
+    }
+
+    #[test]
+    fn opus_vbr_should_return_correct_str() {
+        assert_eq!(OpusVbr::Off.as_str(), "off");
+        assert_eq!(OpusVbr::On.as_str(), "on");
+        assert_eq!(OpusVbr::Constrained.as_str(), "constrained");
+    }
+
+    #[test]
+    fn opus_options_default_should_have_audio_application() {
+        let opts = OpusOptions::default();
+        assert_eq!(opts.application, OpusApplication::Audio);
+        assert_eq!(opts.vbr, OpusVbr::On);
+    }
+
+    #[test]
+    fn aac_options_default_should_have_afterburner_enabled() {
+        let opts = AacOptions::default();
+        assert!(opts.afterburner);
+    }
+
+    #[test]
+    fn mp3_options_default_should_have_quality_4() {
+        let opts = Mp3Options::default();
+        assert_eq!(opts.quality, 4);
+    }
+
+    #[test]
+    fn flac_options_default_should_have_compression_level_5() {
+        let opts = FlacOptions::default();
+        assert_eq!(opts.compression_level, 5);
+    }
+
+    #[test]
+    fn audio_codec_options_enum_variants_are_accessible() {
+        let _opus = AudioCodecOptions::Opus(OpusOptions::default());
+        let _aac = AudioCodecOptions::Aac(AacOptions::default());
+        let _mp3 = AudioCodecOptions::Mp3(Mp3Options::default());
+        let _flac = AudioCodecOptions::Flac(FlacOptions::default());
+    }
+}

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
 
+use crate::audio::codec_options::AudioCodecOptions;
 use crate::{AudioCodec, EncodeError};
 use ff_format::AudioFrame;
 use ff_sys::{
@@ -63,6 +64,7 @@ pub(super) struct AudioEncoderConfig {
     pub(super) channels: u32,
     pub(super) codec: AudioCodec,
     pub(super) bitrate: Option<u64>,
+    pub(super) codec_options: Option<AudioCodecOptions>,
     pub(super) _progress_callback: bool,
 }
 
@@ -215,6 +217,14 @@ impl AudioEncoderInner {
         (*codec_ctx).time_base.num = 1;
         (*codec_ctx).time_base.den = config.sample_rate as i32;
 
+        // Apply per-codec options before opening the codec context.
+        if let Some(opts) = &config.codec_options {
+            // SAFETY: codec_ctx is valid and allocated; priv_data is set by
+            // avcodec_alloc_context3. Options are applied before avcodec_open2
+            // so they take effect during codec initialisation.
+            Self::apply_codec_options(codec_ctx, opts, &encoder_name);
+        }
+
         // Open codec
         avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut())
             .map_err(EncodeError::from_ffmpeg_error)?;
@@ -262,6 +272,111 @@ impl AudioEncoderInner {
         self.codec_ctx = Some(codec_ctx);
 
         Ok(())
+    }
+
+    /// Apply per-codec options via `av_opt_set` before `avcodec_open2`.
+    ///
+    /// All `av_opt_set` return values are checked; a negative value is logged
+    /// as a warning and the option is skipped (never returns an error).
+    unsafe fn apply_codec_options(
+        codec_ctx: *mut AVCodecContext,
+        opts: &AudioCodecOptions,
+        encoder_name: &str,
+    ) {
+        match opts {
+            AudioCodecOptions::Opus(opus) => {
+                // application
+                if let Ok(s) = CString::new(opus.application.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"application\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=application value={} encoder={encoder_name}",
+                            opus.application.as_str()
+                        );
+                    }
+                }
+                // vbr
+                if let Ok(s) = CString::new(opus.vbr.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"vbr\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=vbr value={} encoder={encoder_name}",
+                            opus.vbr.as_str()
+                        );
+                    }
+                }
+            }
+            AudioCodecOptions::Aac(aac) => {
+                // afterburner (libfdk_aac specific)
+                let val = if aac.afterburner { "1" } else { "0" };
+                if let Ok(s) = CString::new(val) {
+                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"afterburner\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=afterburner value={val} \
+                             encoder={encoder_name}"
+                        );
+                    }
+                }
+            }
+            AudioCodecOptions::Mp3(mp3) => {
+                // q (VBR quality, 0-9)
+                let q_str = mp3.quality.to_string();
+                if let Ok(s) = CString::new(q_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"q\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=q value={} encoder={encoder_name}",
+                            mp3.quality
+                        );
+                    }
+                }
+            }
+            AudioCodecOptions::Flac(flac) => {
+                // compression_level
+                let level_str = flac.compression_level.to_string();
+                if let Ok(s) = CString::new(level_str.as_str()) {
+                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                    let ret = ff_sys::av_opt_set(
+                        (*codec_ctx).priv_data,
+                        b"compression_level\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        0,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=compression_level value={} \
+                             encoder={encoder_name}",
+                            flac.compression_level
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// Select best available audio encoder for the given codec.

--- a/crates/ff-encode/src/audio/mod.rs
+++ b/crates/ff-encode/src/audio/mod.rs
@@ -7,8 +7,12 @@
 #[cfg(feature = "tokio")]
 pub mod async_encoder;
 pub mod builder;
+pub mod codec_options;
 mod encoder_inner;
 
 #[cfg(feature = "tokio")]
 pub use async_encoder::AsyncAudioEncoder;
 pub use builder::{AudioEncoder, AudioEncoderBuilder};
+pub use codec_options::{
+    AacOptions, AudioCodecOptions, FlacOptions, Mp3Options, OpusApplication, OpusOptions, OpusVbr,
+};

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -203,7 +203,10 @@ mod preset;
 mod progress;
 mod video;
 
-pub use audio::{AudioEncoder, AudioEncoderBuilder};
+pub use audio::{
+    AacOptions, AudioCodecOptions, AudioEncoder, AudioEncoderBuilder, FlacOptions, Mp3Options,
+    OpusApplication, OpusOptions, OpusVbr,
+};
 pub use bitrate::{BitrateMode, CRF_MAX};
 pub use codec::{AudioCodec, VideoCodec, VideoCodecEncodeExt};
 pub use container::Container;

--- a/crates/ff-encode/tests/audio_encoder_tests.rs
+++ b/crates/ff-encode/tests/audio_encoder_tests.rs
@@ -3,7 +3,10 @@
 use std::path::PathBuf;
 
 use ff_decode::AudioDecoder;
-use ff_encode::{AudioCodec, AudioEncoder};
+use ff_encode::{
+    AacOptions, AudioCodec, AudioCodecOptions, AudioEncoder, FlacOptions, Mp3Options,
+    OpusApplication, OpusOptions, OpusVbr,
+};
 use ff_format::{AudioFrame, SampleFormat};
 
 mod fixtures;
@@ -239,4 +242,119 @@ fn aac_encoder_with_non_multiple_frame_count_should_succeed() {
 
     encoder.finish().expect("Failed to finish encoding");
     assert_valid_output_file(&output);
+}
+
+// ── AudioCodecOptions integration tests ──────────────────────────────────────
+
+#[test]
+fn opus_audio_options_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("opus_codec_opts.opus"));
+
+    let opts = OpusOptions {
+        application: OpusApplication::Audio,
+        vbr: OpusVbr::On,
+    };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Opus)
+        .codec_options(AudioCodecOptions::Opus(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(960, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn aac_afterburner_options_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("aac_codec_opts.m4a"));
+
+    let opts = AacOptions { afterburner: true };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .codec_options(AudioCodecOptions::Aac(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(1024, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn flac_compression_level_options_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("flac_codec_opts.flac"));
+
+    let opts = FlacOptions {
+        compression_level: 5,
+    };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Flac)
+        .codec_options(AudioCodecOptions::Flac(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(4096, 2, 44100, SampleFormat::F32p).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn mp3_quality_options_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("mp3_codec_opts.mp3"));
+
+    let opts = Mp3Options { quality: 2 };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Mp3)
+        .codec_options(AudioCodecOptions::Mp3(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(1152, 2, 44100, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
 }


### PR DESCRIPTION
## Summary

Implements `AudioCodecOptions` enum and `AudioEncoderBuilder::codec_options()` following the same additive pattern as `VideoCodecOptions`. Options are applied via `av_opt_set` before `avcodec_open2`; any unsupported option is logged as a warning and skipped — `build()` never fails due to a codec option.

## Changes

- Add `crates/ff-encode/src/audio/codec_options.rs` with `AudioCodecOptions` enum and four option structs:
  - `OpusOptions`: `application` (Audio/VoIP/LowDelay), `vbr` (Off/On/Constrained)
  - `AacOptions`: `afterburner` (libfdk_aac quality pass; skipped on native aac)
  - `Mp3Options`: `quality` (0–9 VBR quality for libmp3lame)
  - `FlacOptions`: `compression_level` (0–12)
- Add `AudioEncoderBuilder::codec_options()` setter and wire through `AudioEncoderConfig`
- Add `AudioEncoderInner::apply_codec_options()` unsafe fn called before `avcodec_open2`
- Re-export all new types from `ff-encode` and `avio`
- Add 4 integration tests: `opus_audio_options_should_produce_valid_output`, `aac_afterburner_options_should_produce_valid_output`, `flac_compression_level_options_should_produce_valid_output`, `mp3_quality_options_should_produce_valid_output`

## Related Issues

Closes #198

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes