### PR TITLE
feat(ff-encode): OpusOptions with application mode and frame duration

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -233,8 +233,8 @@ pub use ff_encode::{
     AacOptions, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode, CRF_MAX,
     Container, DnxhdOptions, EncodeError, EncodeProgress, EncodeProgressCallback, FlacOptions,
     H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier,
-    HardwareEncoder, ImageEncoder, Mp3Options, OpusApplication, OpusOptions, OpusVbr, Preset,
-    ProResOptions, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    HardwareEncoder, ImageEncoder, Mp3Options, OpusApplication, OpusOptions, Preset, ProResOptions,
+    SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -131,6 +131,17 @@ impl AudioEncoder {
     }
 
     pub(crate) fn from_builder(builder: AudioEncoderBuilder) -> Result<Self, EncodeError> {
+        // Validate per-codec options before constructing the inner encoder.
+        if let Some(AudioCodecOptions::Opus(ref opts)) = builder.codec_options
+            && let Some(dur) = opts.frame_duration_ms
+            && ![2u32, 5, 10, 20, 40, 60].contains(&dur)
+        {
+            return Err(EncodeError::InvalidOption {
+                name: "frame_duration_ms".to_string(),
+                reason: "must be one of: 2, 5, 10, 20, 40, 60".to_string(),
+            });
+        }
+
         let config = AudioEncoderConfig {
             path: builder.path.clone(),
             sample_rate: builder

--- a/crates/ff-encode/src/audio/codec_options.rs
+++ b/crates/ff-encode/src/audio/codec_options.rs
@@ -31,15 +31,20 @@ pub enum AudioCodecOptions {
 pub struct OpusOptions {
     /// Encoder application mode, optimised for the content type.
     pub application: OpusApplication,
-    /// Variable bit-rate mode.
-    pub vbr: OpusVbr,
+    /// Frame duration in milliseconds.
+    ///
+    /// Must be one of `2`, `5`, `10`, `20`, `40`, or `60`.
+    /// `None` uses the libopus default (20 ms).
+    /// `build()` returns [`EncodeError::InvalidOption`](crate::EncodeError::InvalidOption)
+    /// if the value is not in the allowed set.
+    pub frame_duration_ms: Option<u32>,
 }
 
 impl Default for OpusOptions {
     fn default() -> Self {
         Self {
             application: OpusApplication::Audio,
-            vbr: OpusVbr::On,
+            frame_duration_ms: None,
         }
     }
 }
@@ -51,7 +56,7 @@ pub enum OpusApplication {
     #[default]
     Audio,
     /// Optimised for VoIP / speech clarity at low bitrates.
-    VoIP,
+    Voip,
     /// Minimum latency mode — disables lookahead.
     LowDelay,
 }
@@ -60,30 +65,8 @@ impl OpusApplication {
     pub(super) fn as_str(self) -> &'static str {
         match self {
             Self::Audio => "audio",
-            Self::VoIP => "voip",
+            Self::Voip => "voip",
             Self::LowDelay => "lowdelay",
-        }
-    }
-}
-
-/// Opus variable bit-rate mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum OpusVbr {
-    /// Constant bit-rate.
-    Off,
-    /// Variable bit-rate (recommended). Default.
-    #[default]
-    On,
-    /// Constrained VBR — guaranteed never to exceed the target bitrate per packet.
-    Constrained,
-}
-
-impl OpusVbr {
-    pub(super) fn as_str(self) -> &'static str {
-        match self {
-            Self::Off => "off",
-            Self::On => "on",
-            Self::Constrained => "constrained",
         }
     }
 }
@@ -150,22 +133,15 @@ mod tests {
     #[test]
     fn opus_application_should_return_correct_str() {
         assert_eq!(OpusApplication::Audio.as_str(), "audio");
-        assert_eq!(OpusApplication::VoIP.as_str(), "voip");
+        assert_eq!(OpusApplication::Voip.as_str(), "voip");
         assert_eq!(OpusApplication::LowDelay.as_str(), "lowdelay");
     }
 
     #[test]
-    fn opus_vbr_should_return_correct_str() {
-        assert_eq!(OpusVbr::Off.as_str(), "off");
-        assert_eq!(OpusVbr::On.as_str(), "on");
-        assert_eq!(OpusVbr::Constrained.as_str(), "constrained");
-    }
-
-    #[test]
-    fn opus_options_default_should_have_audio_application() {
+    fn opus_options_default_should_have_audio_application_and_no_frame_duration() {
         let opts = OpusOptions::default();
         assert_eq!(opts.application, OpusApplication::Audio);
-        assert_eq!(opts.vbr, OpusVbr::On);
+        assert!(opts.frame_duration_ms.is_none());
     }
 
     #[test]

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -301,20 +301,23 @@ impl AudioEncoderInner {
                         );
                     }
                 }
-                // vbr
-                if let Ok(s) = CString::new(opus.vbr.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"vbr\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
-                    );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=vbr value={} encoder={encoder_name}",
-                            opus.vbr.as_str()
+                // frame_duration (libopus expects microseconds)
+                if let Some(dur_ms) = opus.frame_duration_ms {
+                    let dur_us_str = (i64::from(dur_ms) * 1000).to_string();
+                    if let Ok(s) = CString::new(dur_us_str.as_str()) {
+                        // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                        let ret = ff_sys::av_opt_set(
+                            (*codec_ctx).priv_data,
+                            b"frame_duration\0".as_ptr() as *const i8,
+                            s.as_ptr(),
+                            0,
                         );
+                        if ret < 0 {
+                            log::warn!(
+                                "av_opt_set failed option=frame_duration value={dur_us_str} \
+                                 encoder={encoder_name}"
+                            );
+                        }
                     }
                 }
             }

--- a/crates/ff-encode/src/audio/mod.rs
+++ b/crates/ff-encode/src/audio/mod.rs
@@ -14,5 +14,5 @@ mod encoder_inner;
 pub use async_encoder::AsyncAudioEncoder;
 pub use builder::{AudioEncoder, AudioEncoderBuilder};
 pub use codec_options::{
-    AacOptions, AudioCodecOptions, FlacOptions, Mp3Options, OpusApplication, OpusOptions, OpusVbr,
+    AacOptions, AudioCodecOptions, FlacOptions, Mp3Options, OpusApplication, OpusOptions,
 };

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -205,7 +205,7 @@ mod video;
 
 pub use audio::{
     AacOptions, AudioCodecOptions, AudioEncoder, AudioEncoderBuilder, FlacOptions, Mp3Options,
-    OpusApplication, OpusOptions, OpusVbr,
+    OpusApplication, OpusOptions,
 };
 pub use bitrate::{BitrateMode, CRF_MAX};
 pub use codec::{AudioCodec, VideoCodec, VideoCodecEncodeExt};

--- a/crates/ff-encode/tests/audio_encoder_tests.rs
+++ b/crates/ff-encode/tests/audio_encoder_tests.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use ff_decode::AudioDecoder;
 use ff_encode::{
-    AacOptions, AudioCodec, AudioCodecOptions, AudioEncoder, FlacOptions, Mp3Options,
-    OpusApplication, OpusOptions, OpusVbr,
+    AacOptions, AudioCodec, AudioCodecOptions, AudioEncoder, EncodeError, FlacOptions, Mp3Options,
+    OpusApplication, OpusOptions,
 };
 use ff_format::{AudioFrame, SampleFormat};
 
@@ -252,7 +252,7 @@ fn opus_audio_options_should_produce_valid_output() {
 
     let opts = OpusOptions {
         application: OpusApplication::Audio,
-        vbr: OpusVbr::On,
+        frame_duration_ms: None,
     };
     let mut encoder = match AudioEncoder::create(output.path())
         .audio(48000, 2)
@@ -357,4 +357,85 @@ fn mp3_quality_options_should_produce_valid_output() {
 
     encoder.finish().expect("Failed to finish encoding");
     assert_valid_output_file(output.path());
+}
+
+#[test]
+fn opus_low_delay_application_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("opus_low_delay.opus"));
+
+    let opts = OpusOptions {
+        application: OpusApplication::LowDelay,
+        frame_duration_ms: None,
+    };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Opus)
+        .codec_options(AudioCodecOptions::Opus(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(960, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn opus_frame_duration_20ms_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("opus_frame_duration_20ms.opus"));
+
+    let opts = OpusOptions {
+        application: OpusApplication::Audio,
+        frame_duration_ms: Some(20),
+    };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Opus)
+        .codec_options(AudioCodecOptions::Opus(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    // 20 ms at 48000 Hz = 960 samples per frame
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(960, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn opus_invalid_frame_duration_should_return_invalid_option_error() {
+    let output = test_output_path("opus_invalid_frame_duration.opus");
+
+    let opts = OpusOptions {
+        application: OpusApplication::Audio,
+        frame_duration_ms: Some(15),
+    };
+    let result = AudioEncoder::create(&output)
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Opus)
+        .codec_options(AudioCodecOptions::Opus(opts))
+        .build();
+
+    assert!(
+        matches!(result, Err(EncodeError::InvalidOption { ref name, .. }) if name == "frame_duration_ms"),
+        "expected InvalidOption for frame_duration_ms"
+    );
 }


### PR DESCRIPTION
## Summary

Refines `OpusOptions` introduced in #642 to match the issue #199 specification. Replaces the unspecified `vbr: OpusVbr` field with `frame_duration_ms: Option<u32>`, renames `OpusApplication::VoIP` to `Voip`, and adds validation that rejects frame durations outside the allowed set `{2, 5, 10, 20, 40, 60}` ms.

## Changes

- `OpusOptions`: replace `vbr: OpusVbr` with `frame_duration_ms: Option<u32>`; `None` uses the libopus default (20 ms)
- `OpusApplication::VoIP` renamed to `Voip` for consistent casing
- `OpusVbr` enum removed (libopus defaults to VBR; explicit control deferred to a future issue)
- `build()` returns `EncodeError::InvalidOption` when `frame_duration_ms` is not one of 2, 5, 10, 20, 40, or 60
- `apply_codec_options`: sets `frame_duration` via `av_opt_set` using microseconds (`ms * 1000`) before `avcodec_open2`
- Re-exports updated across `ff-encode` and `avio` (remove `OpusVbr`)
- Integration tests: `opus_low_delay_application_should_produce_valid_output`, `opus_frame_duration_20ms_should_produce_valid_output`, `opus_invalid_frame_duration_should_return_invalid_option_error`

## Related Issues

Closes #199

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes