### PR TITLE
feat(ff-encode): implement AacOptions with profile and VBR quality mode

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -230,11 +230,11 @@ pub use ff_decode::{
 // default_extension) on the shared VideoCodec type; import it to call them.
 #[cfg(feature = "encode")]
 pub use ff_encode::{
-    AacOptions, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode, CRF_MAX,
-    Container, DnxhdOptions, EncodeError, EncodeProgress, EncodeProgressCallback, FlacOptions,
-    H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier,
-    HardwareEncoder, ImageEncoder, Mp3Options, OpusApplication, OpusOptions, Preset, ProResOptions,
-    SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode,
+    CRF_MAX, Container, DnxhdOptions, EncodeError, EncodeProgress, EncodeProgressCallback,
+    FlacOptions, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
+    H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, OpusApplication, OpusOptions, Preset,
+    ProResOptions, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -141,6 +141,15 @@ impl AudioEncoder {
                 reason: "must be one of: 2, 5, 10, 20, 40, 60".to_string(),
             });
         }
+        if let Some(AudioCodecOptions::Aac(ref opts)) = builder.codec_options
+            && let Some(q) = opts.vbr_quality
+            && !(1..=5).contains(&q)
+        {
+            return Err(EncodeError::InvalidOption {
+                name: "vbr_quality".to_string(),
+                reason: "must be 1–5".to_string(),
+            });
+        }
 
         let config = AudioEncoderConfig {
             path: builder.path.clone(),

--- a/crates/ff-encode/src/audio/codec_options.rs
+++ b/crates/ff-encode/src/audio/codec_options.rs
@@ -76,16 +76,49 @@ impl OpusApplication {
 /// AAC per-codec options.
 #[derive(Debug, Clone)]
 pub struct AacOptions {
-    /// Enable the afterburner quality enhancement pass (libfdk_aac only).
+    /// AAC encoding profile.
     ///
-    /// Increases quality at the cost of slightly higher CPU usage. Silently
-    /// ignored when using the native `aac` encoder (logged as a warning).
-    pub afterburner: bool,
+    /// `He` and `Hev2` typically require `libfdk_aac` (non-free). The built-in
+    /// FFmpeg `aac` encoder may not support them — the failure is logged as a
+    /// warning and encoding continues with the encoder's default profile.
+    pub profile: AacProfile,
+    /// VBR quality mode (1–5). `Some(q)` enables VBR; `None` uses CBR.
+    ///
+    /// Only supported by `libfdk_aac`. The built-in `aac` encoder ignores this
+    /// option (logged as a warning). `build()` returns
+    /// [`EncodeError::InvalidOption`](crate::EncodeError::InvalidOption) if the
+    /// value is outside 1–5.
+    pub vbr_quality: Option<u8>,
 }
 
 impl Default for AacOptions {
     fn default() -> Self {
-        Self { afterburner: true }
+        Self {
+            profile: AacProfile::Lc,
+            vbr_quality: None,
+        }
+    }
+}
+
+/// AAC encoding profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AacProfile {
+    /// AAC-LC (Low Complexity) — widest compatibility. Default.
+    #[default]
+    Lc,
+    /// HE-AAC v1 — with Spectral Band Replication (SBR). Typically requires `libfdk_aac`.
+    He,
+    /// HE-AAC v2 — with SBR + Parametric Stereo (PS). Typically requires `libfdk_aac`.
+    Hev2,
+}
+
+impl AacProfile {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Lc => "aac_low",
+            Self::He => "aac_he",
+            Self::Hev2 => "aac_he_v2",
+        }
     }
 }
 
@@ -145,9 +178,17 @@ mod tests {
     }
 
     #[test]
-    fn aac_options_default_should_have_afterburner_enabled() {
+    fn aac_profile_should_return_correct_str() {
+        assert_eq!(AacProfile::Lc.as_str(), "aac_low");
+        assert_eq!(AacProfile::He.as_str(), "aac_he");
+        assert_eq!(AacProfile::Hev2.as_str(), "aac_he_v2");
+    }
+
+    #[test]
+    fn aac_options_default_should_have_lc_profile_and_no_vbr() {
         let opts = AacOptions::default();
-        assert!(opts.afterburner);
+        assert_eq!(opts.profile, AacProfile::Lc);
+        assert!(opts.vbr_quality.is_none());
     }
 
     #[test]

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -322,21 +322,40 @@ impl AudioEncoderInner {
                 }
             }
             AudioCodecOptions::Aac(aac) => {
-                // afterburner (libfdk_aac specific)
-                let val = if aac.afterburner { "1" } else { "0" };
-                if let Ok(s) = CString::new(val) {
+                // profile (aac_low / aac_he / aac_he_v2)
+                let profile_str = aac.profile.as_str();
+                if let Ok(s) = CString::new(profile_str) {
                     // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
                     let ret = ff_sys::av_opt_set(
                         (*codec_ctx).priv_data,
-                        b"afterburner\0".as_ptr() as *const i8,
+                        b"profile\0".as_ptr() as *const i8,
                         s.as_ptr(),
                         0,
                     );
                     if ret < 0 {
                         log::warn!(
-                            "av_opt_set failed option=afterburner value={val} \
-                             encoder={encoder_name}"
+                            "AAC profile={profile_str} not supported by encoder \
+                             ret={ret} encoder={encoder_name}"
                         );
+                    }
+                }
+                // vbr (libfdk_aac VBR quality 1–5)
+                if let Some(q) = aac.vbr_quality {
+                    let q_str = q.to_string();
+                    if let Ok(s) = CString::new(q_str.as_str()) {
+                        // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                        let ret = ff_sys::av_opt_set(
+                            (*codec_ctx).priv_data,
+                            b"vbr\0".as_ptr() as *const i8,
+                            s.as_ptr(),
+                            0,
+                        );
+                        if ret < 0 {
+                            log::warn!(
+                                "av_opt_set failed option=vbr value={q} \
+                                 encoder={encoder_name}"
+                            );
+                        }
                     }
                 }
             }

--- a/crates/ff-encode/src/audio/mod.rs
+++ b/crates/ff-encode/src/audio/mod.rs
@@ -14,5 +14,6 @@ mod encoder_inner;
 pub use async_encoder::AsyncAudioEncoder;
 pub use builder::{AudioEncoder, AudioEncoderBuilder};
 pub use codec_options::{
-    AacOptions, AudioCodecOptions, FlacOptions, Mp3Options, OpusApplication, OpusOptions,
+    AacOptions, AacProfile, AudioCodecOptions, FlacOptions, Mp3Options, OpusApplication,
+    OpusOptions,
 };

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -204,8 +204,8 @@ mod progress;
 mod video;
 
 pub use audio::{
-    AacOptions, AudioCodecOptions, AudioEncoder, AudioEncoderBuilder, FlacOptions, Mp3Options,
-    OpusApplication, OpusOptions,
+    AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, AudioEncoderBuilder, FlacOptions,
+    Mp3Options, OpusApplication, OpusOptions,
 };
 pub use bitrate::{BitrateMode, CRF_MAX};
 pub use codec::{AudioCodec, VideoCodec, VideoCodecEncodeExt};

--- a/crates/ff-encode/tests/audio_encoder_tests.rs
+++ b/crates/ff-encode/tests/audio_encoder_tests.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use ff_decode::AudioDecoder;
 use ff_encode::{
-    AacOptions, AudioCodec, AudioCodecOptions, AudioEncoder, EncodeError, FlacOptions, Mp3Options,
-    OpusApplication, OpusOptions,
+    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioEncoder, EncodeError, FlacOptions,
+    Mp3Options, OpusApplication, OpusOptions,
 };
 use ff_format::{AudioFrame, SampleFormat};
 
@@ -277,10 +277,13 @@ fn opus_audio_options_should_produce_valid_output() {
 }
 
 #[test]
-fn aac_afterburner_options_should_produce_valid_output() {
+fn aac_lc_profile_should_produce_valid_output() {
     let output = FileGuard::new(test_output_path("aac_codec_opts.m4a"));
 
-    let opts = AacOptions { afterburner: true };
+    let opts = AacOptions {
+        profile: AacProfile::Lc,
+        vbr_quality: None,
+    };
     let mut encoder = match AudioEncoder::create(output.path())
         .audio(48000, 2)
         .audio_codec(AudioCodec::Aac)
@@ -437,5 +440,55 @@ fn opus_invalid_frame_duration_should_return_invalid_option_error() {
     assert!(
         matches!(result, Err(EncodeError::InvalidOption { ref name, .. }) if name == "frame_duration_ms"),
         "expected InvalidOption for frame_duration_ms"
+    );
+}
+
+#[test]
+fn aac_vbr_quality_3_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("aac_vbr_quality.m4a"));
+
+    let opts = AacOptions {
+        profile: AacProfile::Lc,
+        vbr_quality: Some(3),
+    };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .codec_options(AudioCodecOptions::Aac(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(1024, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn aac_vbr_quality_out_of_range_should_return_invalid_option_error() {
+    let output = test_output_path("aac_vbr_invalid.m4a");
+
+    let opts = AacOptions {
+        profile: AacProfile::Lc,
+        vbr_quality: Some(6),
+    };
+    let result = AudioEncoder::create(&output)
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .codec_options(AudioCodecOptions::Aac(opts))
+        .build();
+
+    assert!(
+        matches!(result, Err(EncodeError::InvalidOption { ref name, .. }) if name == "vbr_quality"),
+        "expected InvalidOption for vbr_quality"
     );
 }


### PR DESCRIPTION
## Summary

Implements `AacOptions` with `AacProfile` (LC, HE, HEv2) and `vbr_quality` (1–5) for the AAC audio encoder. Profile is applied via `av_opt_set("profile", ...)` and VBR quality via `av_opt_set("vbr", ...)` before `avcodec_open2`. Out-of-range `vbr_quality` values are rejected at `build()` time with `EncodeError::InvalidOption`.

## Changes

- `codec_options.rs`: replace stub `AacOptions { afterburner }` with `AacOptions { profile: AacProfile, vbr_quality: Option<u8> }` and `AacProfile` enum (Lc/He/Hev2)
- `encoder_inner.rs`: implement AAC arm in `apply_codec_options` — set `profile` and `vbr` options
- `builder.rs`: validate `vbr_quality` range (1–5) in `from_builder`
- `mod.rs` / `lib.rs` / `avio/src/lib.rs`: re-export `AacProfile`
- `audio_encoder_tests.rs`: add `aac_lc_profile_should_produce_valid_output`, `aac_vbr_quality_3_should_produce_valid_output`, `aac_vbr_quality_out_of_range_should_return_invalid_option_error`

## Related Issues

Closes #200

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes