### PR TITLE
feat(ff-encode): implement Mp3Quality with VBR and CBR modes

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -233,8 +233,9 @@ pub use ff_encode::{
     AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode,
     CRF_MAX, Container, DnxhdOptions, EncodeError, EncodeProgress, EncodeProgressCallback,
     FlacOptions, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
-    H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, OpusApplication, OpusOptions, Preset,
-    ProResOptions, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
+    Preset, ProResOptions, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder,
+    Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 use ff_format::AudioFrame;
 
-use super::codec_options::AudioCodecOptions;
+use super::codec_options::{AudioCodecOptions, Mp3Quality};
 use super::encoder_inner::{AudioEncoderConfig, AudioEncoderInner};
 use crate::{AudioCodec, Container, EncodeError};
 
@@ -148,6 +148,15 @@ impl AudioEncoder {
             return Err(EncodeError::InvalidOption {
                 name: "vbr_quality".to_string(),
                 reason: "must be 1–5".to_string(),
+            });
+        }
+        if let Some(AudioCodecOptions::Mp3(ref opts)) = builder.codec_options
+            && let Mp3Quality::Vbr(q) = opts.quality
+            && q > 9
+        {
+            return Err(EncodeError::InvalidOption {
+                name: "vbr_quality".to_string(),
+                reason: "must be 0–9 (0=best)".to_string(),
             });
         }
 

--- a/crates/ff-encode/src/audio/codec_options.rs
+++ b/crates/ff-encode/src/audio/codec_options.rs
@@ -124,19 +124,30 @@ impl AacProfile {
 
 // ── MP3 ───────────────────────────────────────────────────────────────────────
 
+/// MP3 quality mode: VBR quality scale or CBR fixed bitrate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mp3Quality {
+    /// Variable bitrate — libmp3lame `q` scale (0 = best / V0, 9 = worst / V9).
+    ///
+    /// `build()` returns [`EncodeError::InvalidOption`](crate::EncodeError::InvalidOption)
+    /// if the value exceeds 9.
+    Vbr(u8),
+    /// Constant bitrate in bits/sec (e.g. `128_000` for 128 kbps).
+    Cbr(u32),
+}
+
 /// MP3 (libmp3lame) per-codec options.
 #[derive(Debug, Clone)]
 pub struct Mp3Options {
-    /// VBR quality level (0–9). `0` = best quality, `9` = smallest file.
-    ///
-    /// Only takes effect when the builder is configured for VBR-style encoding.
-    /// Silently ignored if `av_opt_set` does not accept the value.
-    pub quality: u8,
+    /// VBR quality or CBR bitrate selection.
+    pub quality: Mp3Quality,
 }
 
 impl Default for Mp3Options {
     fn default() -> Self {
-        Self { quality: 4 }
+        Self {
+            quality: Mp3Quality::Vbr(4),
+        }
     }
 }
 
@@ -192,9 +203,15 @@ mod tests {
     }
 
     #[test]
-    fn mp3_options_default_should_have_quality_4() {
+    fn mp3_options_default_should_have_vbr_quality_4() {
         let opts = Mp3Options::default();
-        assert_eq!(opts.quality, 4);
+        assert_eq!(opts.quality, Mp3Quality::Vbr(4));
+    }
+
+    #[test]
+    fn mp3_quality_enum_variants_are_accessible() {
+        let _vbr = Mp3Quality::Vbr(0);
+        let _cbr = Mp3Quality::Cbr(192_000);
     }
 
     #[test]

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
 
-use crate::audio::codec_options::AudioCodecOptions;
+use crate::audio::codec_options::{AudioCodecOptions, Mp3Quality};
 use crate::{AudioCodec, EncodeError};
 use ff_format::AudioFrame;
 use ff_sys::{
@@ -360,21 +360,32 @@ impl AudioEncoderInner {
                 }
             }
             AudioCodecOptions::Mp3(mp3) => {
-                // q (VBR quality, 0-9)
-                let q_str = mp3.quality.to_string();
-                if let Ok(s) = CString::new(q_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"q\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
-                    );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=q value={} encoder={encoder_name}",
-                            mp3.quality
-                        );
+                match mp3.quality {
+                    Mp3Quality::Vbr(q) => {
+                        // VBR mode: override bitrate to 0 and set the libmp3lame q scale.
+                        // SAFETY: codec_ctx is non-null; direct field write is safe.
+                        (*codec_ctx).bit_rate = 0;
+                        let q_str = q.to_string();
+                        if let Ok(s) = CString::new(q_str.as_str()) {
+                            // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
+                            let ret = ff_sys::av_opt_set(
+                                (*codec_ctx).priv_data,
+                                b"q\0".as_ptr() as *const i8,
+                                s.as_ptr(),
+                                0,
+                            );
+                            if ret < 0 {
+                                log::warn!(
+                                    "av_opt_set failed option=q value={q} \
+                                     encoder={encoder_name}"
+                                );
+                            }
+                        }
+                    }
+                    Mp3Quality::Cbr(bitrate) => {
+                        // CBR mode: set the fixed bitrate directly on the codec context.
+                        // SAFETY: codec_ctx is non-null; direct field write is safe.
+                        (*codec_ctx).bit_rate = i64::from(bitrate);
                     }
                 }
             }

--- a/crates/ff-encode/src/audio/mod.rs
+++ b/crates/ff-encode/src/audio/mod.rs
@@ -14,6 +14,6 @@ mod encoder_inner;
 pub use async_encoder::AsyncAudioEncoder;
 pub use builder::{AudioEncoder, AudioEncoderBuilder};
 pub use codec_options::{
-    AacOptions, AacProfile, AudioCodecOptions, FlacOptions, Mp3Options, OpusApplication,
-    OpusOptions,
+    AacOptions, AacProfile, AudioCodecOptions, FlacOptions, Mp3Options, Mp3Quality,
+    OpusApplication, OpusOptions,
 };

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -205,7 +205,7 @@ mod video;
 
 pub use audio::{
     AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, AudioEncoderBuilder, FlacOptions,
-    Mp3Options, OpusApplication, OpusOptions,
+    Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
 };
 pub use bitrate::{BitrateMode, CRF_MAX};
 pub use codec::{AudioCodec, VideoCodec, VideoCodecEncodeExt};

--- a/crates/ff-encode/tests/audio_encoder_tests.rs
+++ b/crates/ff-encode/tests/audio_encoder_tests.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use ff_decode::AudioDecoder;
 use ff_encode::{
     AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioEncoder, EncodeError, FlacOptions,
-    Mp3Options, OpusApplication, OpusOptions,
+    Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
 };
 use ff_format::{AudioFrame, SampleFormat};
 
@@ -339,7 +339,9 @@ fn flac_compression_level_options_should_produce_valid_output() {
 fn mp3_quality_options_should_produce_valid_output() {
     let output = FileGuard::new(test_output_path("mp3_codec_opts.mp3"));
 
-    let opts = Mp3Options { quality: 2 };
+    let opts = Mp3Options {
+        quality: Mp3Quality::Vbr(2),
+    };
     let mut encoder = match AudioEncoder::create(output.path())
         .audio(44100, 2)
         .audio_codec(AudioCodec::Mp3)
@@ -485,6 +487,54 @@ fn aac_vbr_quality_out_of_range_should_return_invalid_option_error() {
         .audio(48000, 2)
         .audio_codec(AudioCodec::Aac)
         .codec_options(AudioCodecOptions::Aac(opts))
+        .build();
+
+    assert!(
+        matches!(result, Err(EncodeError::InvalidOption { ref name, .. }) if name == "vbr_quality"),
+        "expected InvalidOption for vbr_quality"
+    );
+}
+
+#[test]
+fn mp3_cbr_128kbps_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("mp3_cbr_128k.mp3"));
+
+    let opts = Mp3Options {
+        quality: Mp3Quality::Cbr(128_000),
+    };
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Mp3)
+        .codec_options(AudioCodecOptions::Mp3(opts))
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(1152, 2, 44100, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn mp3_vbr_quality_out_of_range_should_return_invalid_option_error() {
+    let output = test_output_path("mp3_vbr_invalid.mp3");
+
+    let opts = Mp3Options {
+        quality: Mp3Quality::Vbr(10),
+    };
+    let result = AudioEncoder::create(&output)
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Mp3)
+        .codec_options(AudioCodecOptions::Mp3(opts))
         .build();
 
     assert!(


### PR DESCRIPTION
## Summary

Replaces the single-field `Mp3Options { quality: u8 }` with a typed `Mp3Quality` enum that cleanly separates VBR and CBR encoding modes. `Mp3Quality::Vbr(u8)` applies the libmp3lame `q` scale and sets `bit_rate = 0` to let the encoder control bitrate; `Mp3Quality::Cbr(u32)` sets a fixed bitrate directly on the codec context. `build()` rejects `Vbr` values above 9 with `EncodeError::InvalidOption`.

## Changes

- `codec_options.rs`: add `Mp3Quality` enum (`Vbr(u8)` / `Cbr(u32)`), update `Mp3Options` field type and `Default` impl, update unit tests
- `encoder_inner.rs`: replace single VBR-only arm with `Vbr`/`Cbr` branch — `Vbr` sets `bit_rate=0` then `av_opt_set("q", ...)`, `Cbr` sets `bit_rate` via `i64::from`
- `builder.rs`: add `Mp3Quality::Vbr(q) > 9` validation matching existing Opus/AAC guard pattern
- `mod.rs` / `lib.rs` / `avio/src/lib.rs`: re-export `Mp3Quality`
- `audio_encoder_tests.rs`: update existing VBR test to use `Mp3Quality::Vbr(2)`, add `mp3_cbr_128kbps_should_produce_valid_output`, add `mp3_vbr_quality_out_of_range_should_return_invalid_option_error`

## Related Issues

Closes #201

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes