### PR TITLE
feat(ff-encode): implement DNxHD/DNxHR encode support

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -231,11 +231,11 @@ pub use ff_decode::{
 #[cfg(feature = "encode")]
 pub use ff_encode::{
     AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode,
-    CRF_MAX, Container, DnxhdOptions, EncodeError, EncodeProgress, EncodeProgressCallback,
-    FlacOptions, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
-    H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
-    Preset, ProResOptions, ProResProfile, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions,
-    VideoEncoder, Vp9Options,
+    CRF_MAX, Container, DnxhdOptions, DnxhdVariant, EncodeError, EncodeProgress,
+    EncodeProgressCallback, FlacOptions, H264Options, H264Preset, H264Profile, H264Tune,
+    H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality,
+    OpusApplication, OpusOptions, Preset, ProResOptions, ProResProfile, SvtAv1Options,
+    VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -216,8 +216,8 @@ pub use image::{ImageEncoder, ImageEncoderBuilder};
 pub use preset::Preset;
 pub use progress::{EncodeProgress, EncodeProgressCallback};
 pub use video::{
-    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, ProResOptions, ProResProfile, SvtAv1Options,
+    Av1Options, Av1Usage, DnxhdOptions, DnxhdVariant, H264Options, H264Preset, H264Profile,
+    H264Tune, H265Options, H265Profile, H265Tier, ProResOptions, ProResProfile, SvtAv1Options,
     VideoCodecOptions, VideoEncoder, VideoEncoderBuilder, Vp9Options,
 };
 

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -385,6 +385,21 @@ impl VideoEncoderBuilder {
             }
         }
 
+        if let Some(VideoCodecOptions::Dnxhd(ref opts)) = self.codec_options
+            && opts.variant.is_dnxhd()
+        {
+            let valid = matches!(
+                (self.video_width, self.video_height),
+                (Some(1920), Some(1080)) | (Some(1280), Some(720))
+            );
+            if !valid {
+                return Err(EncodeError::InvalidOption {
+                    name: "variant".to_string(),
+                    reason: "DNxHD variants require 1920×1080 or 1280×720 resolution".to_string(),
+                });
+            }
+        }
+
         if has_audio {
             if let Some(rate) = self.audio_sample_rate
                 && rate == 0

--- a/crates/ff-encode/src/video/codec_options.rs
+++ b/crates/ff-encode/src/video/codec_options.rs
@@ -13,8 +13,7 @@
 /// `VideoEncoderBuilder::video_codec()`.  A mismatch is silently ignored
 /// (the options are not applied).
 ///
-/// Variants without struct fields (`Vp9`, `ProRes`, `Dnxhd`) are reserved
-/// for future issues and currently have no effect.
+/// All variants are fully implemented.
 #[derive(Debug, Clone)]
 pub enum VideoCodecOptions {
     /// H.264 (AVC) encoding options.
@@ -432,12 +431,95 @@ impl Default for ProResOptions {
     }
 }
 
-// ── Placeholder variants ──────────────────────────────────────────────────────
+// ── Avid DNxHD / DNxHR ───────────────────────────────────────────────────────
 
-/// Avid DNxHD / DNxHR per-codec options (reserved for a future issue).
+/// DNxHD / DNxHR encoding variant.
+///
+/// Legacy DNxHD variants (`Dnxhd*`) are constrained to 1920×1080 or 1280×720
+/// and require a fixed bitrate. DNxHR variants (`Dnxhr*`) work at any resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DnxhdVariant {
+    // ── DNxHD (legacy fixed-bitrate, 1920×1080 or 1280×720 only) ─────────────
+    /// 1080i/p 115 Mbps, 8-bit yuv422p.
+    Dnxhd115,
+    /// 1080i/p 145 Mbps, 8-bit yuv422p.
+    Dnxhd145,
+    /// 1080p 220 Mbps, 8-bit yuv422p.
+    Dnxhd220,
+    /// 1080p 220 Mbps, 10-bit yuv422p10le.
+    Dnxhd220x,
+    // ── DNxHR (resolution-agnostic) ───────────────────────────────────────────
+    /// Low Bandwidth, 8-bit yuv422p.
+    DnxhrLb,
+    /// Standard Quality, 8-bit yuv422p (default).
+    #[default]
+    DnxhrSq,
+    /// High Quality, 8-bit yuv422p.
+    DnxhrHq,
+    /// High Quality 10-bit, yuv422p10le.
+    DnxhrHqx,
+    /// 4:4:4 12-bit, yuv444p10le.
+    DnxhrR444,
+}
+
+impl DnxhdVariant {
+    /// Returns the `vprofile` string passed to the `dnxhd` encoder.
+    pub(super) fn vprofile_str(self) -> &'static str {
+        match self {
+            Self::Dnxhd115 | Self::Dnxhd145 | Self::Dnxhd220 | Self::Dnxhd220x => "dnxhd",
+            Self::DnxhrLb => "dnxhr_lb",
+            Self::DnxhrSq => "dnxhr_sq",
+            Self::DnxhrHq => "dnxhr_hq",
+            Self::DnxhrHqx => "dnxhr_hqx",
+            Self::DnxhrR444 => "dnxhr_444",
+        }
+    }
+
+    /// Returns the required pixel format for this variant.
+    pub(super) fn pixel_format(self) -> ff_format::PixelFormat {
+        use ff_format::PixelFormat;
+        match self {
+            Self::Dnxhd115
+            | Self::Dnxhd145
+            | Self::Dnxhd220
+            | Self::DnxhrLb
+            | Self::DnxhrSq
+            | Self::DnxhrHq => PixelFormat::Yuv422p,
+            Self::Dnxhd220x | Self::DnxhrHqx => PixelFormat::Yuv422p10le,
+            Self::DnxhrR444 => PixelFormat::Yuv444p10le,
+        }
+    }
+
+    /// For legacy DNxHD variants, returns the required fixed bitrate in bps.
+    ///
+    /// DNxHR variants return `None` — the encoder selects the bitrate automatically.
+    pub(super) fn fixed_bitrate_bps(self) -> Option<i64> {
+        match self {
+            Self::Dnxhd115 => Some(115_000_000),
+            Self::Dnxhd145 => Some(145_000_000),
+            Self::Dnxhd220 | Self::Dnxhd220x => Some(220_000_000),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` for legacy DNxHD variants that require 1920×1080 or 1280×720.
+    pub(super) fn is_dnxhd(self) -> bool {
+        matches!(
+            self,
+            Self::Dnxhd115 | Self::Dnxhd145 | Self::Dnxhd220 | Self::Dnxhd220x
+        )
+    }
+}
+
+/// Avid DNxHD / DNxHR per-codec options.
+///
+/// Output should use a `.mxf` or `.mov` container. Legacy DNxHD variants
+/// (`Dnxhd*`) are validated in `build()` to require 1920×1080 or 1280×720.
 #[derive(Debug, Clone, Default)]
-#[non_exhaustive]
-pub struct DnxhdOptions {}
+pub struct DnxhdOptions {
+    /// DNxHD/DNxHR encoding variant.
+    pub variant: DnxhdVariant,
+}
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -600,5 +682,85 @@ mod tests {
         assert!(!ProResProfile::Hq.is_4444());
         assert!(ProResProfile::P4444.is_4444());
         assert!(ProResProfile::P4444Xq.is_4444());
+    }
+
+    #[test]
+    fn dnxhd_options_default_should_have_dnxhr_sq_variant() {
+        let opts = DnxhdOptions::default();
+        assert_eq!(opts.variant, DnxhdVariant::DnxhrSq);
+    }
+
+    #[test]
+    fn dnxhd_variant_vprofile_str_should_match_spec() {
+        assert_eq!(DnxhdVariant::Dnxhd115.vprofile_str(), "dnxhd");
+        assert_eq!(DnxhdVariant::Dnxhd145.vprofile_str(), "dnxhd");
+        assert_eq!(DnxhdVariant::Dnxhd220.vprofile_str(), "dnxhd");
+        assert_eq!(DnxhdVariant::Dnxhd220x.vprofile_str(), "dnxhd");
+        assert_eq!(DnxhdVariant::DnxhrLb.vprofile_str(), "dnxhr_lb");
+        assert_eq!(DnxhdVariant::DnxhrSq.vprofile_str(), "dnxhr_sq");
+        assert_eq!(DnxhdVariant::DnxhrHq.vprofile_str(), "dnxhr_hq");
+        assert_eq!(DnxhdVariant::DnxhrHqx.vprofile_str(), "dnxhr_hqx");
+        assert_eq!(DnxhdVariant::DnxhrR444.vprofile_str(), "dnxhr_444");
+    }
+
+    #[test]
+    fn dnxhd_variant_pixel_format_should_match_spec() {
+        use ff_format::PixelFormat;
+        assert_eq!(DnxhdVariant::Dnxhd115.pixel_format(), PixelFormat::Yuv422p);
+        assert_eq!(DnxhdVariant::Dnxhd145.pixel_format(), PixelFormat::Yuv422p);
+        assert_eq!(DnxhdVariant::Dnxhd220.pixel_format(), PixelFormat::Yuv422p);
+        assert_eq!(
+            DnxhdVariant::Dnxhd220x.pixel_format(),
+            PixelFormat::Yuv422p10le
+        );
+        assert_eq!(DnxhdVariant::DnxhrLb.pixel_format(), PixelFormat::Yuv422p);
+        assert_eq!(DnxhdVariant::DnxhrSq.pixel_format(), PixelFormat::Yuv422p);
+        assert_eq!(DnxhdVariant::DnxhrHq.pixel_format(), PixelFormat::Yuv422p);
+        assert_eq!(
+            DnxhdVariant::DnxhrHqx.pixel_format(),
+            PixelFormat::Yuv422p10le
+        );
+        assert_eq!(
+            DnxhdVariant::DnxhrR444.pixel_format(),
+            PixelFormat::Yuv444p10le
+        );
+    }
+
+    #[test]
+    fn dnxhd_variant_fixed_bitrate_should_return_none_for_dnxhr() {
+        assert_eq!(
+            DnxhdVariant::Dnxhd115.fixed_bitrate_bps(),
+            Some(115_000_000)
+        );
+        assert_eq!(
+            DnxhdVariant::Dnxhd145.fixed_bitrate_bps(),
+            Some(145_000_000)
+        );
+        assert_eq!(
+            DnxhdVariant::Dnxhd220.fixed_bitrate_bps(),
+            Some(220_000_000)
+        );
+        assert_eq!(
+            DnxhdVariant::Dnxhd220x.fixed_bitrate_bps(),
+            Some(220_000_000)
+        );
+        assert!(DnxhdVariant::DnxhrLb.fixed_bitrate_bps().is_none());
+        assert!(DnxhdVariant::DnxhrSq.fixed_bitrate_bps().is_none());
+        assert!(DnxhdVariant::DnxhrHq.fixed_bitrate_bps().is_none());
+        assert!(DnxhdVariant::DnxhrHqx.fixed_bitrate_bps().is_none());
+        assert!(DnxhdVariant::DnxhrR444.fixed_bitrate_bps().is_none());
+    }
+
+    #[test]
+    fn dnxhd_variant_is_dnxhd_should_return_true_only_for_legacy_variants() {
+        assert!(DnxhdVariant::Dnxhd115.is_dnxhd());
+        assert!(DnxhdVariant::Dnxhd145.is_dnxhd());
+        assert!(DnxhdVariant::Dnxhd220.is_dnxhd());
+        assert!(DnxhdVariant::Dnxhd220x.is_dnxhd());
+        assert!(!DnxhdVariant::DnxhrLb.is_dnxhd());
+        assert!(!DnxhdVariant::DnxhrSq.is_dnxhd());
+        assert!(!DnxhdVariant::DnxhrHq.is_dnxhd());
+        assert!(!DnxhdVariant::DnxhrHqx.is_dnxhd());
+        assert!(!DnxhdVariant::DnxhrR444.is_dnxhd());
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -769,8 +769,46 @@ impl VideoEncoderInner {
                     }
                 }
             }
-            // Dnxhd: options reserved for a future issue
-            VideoCodecOptions::Dnxhd(_) => {}
+            VideoCodecOptions::Dnxhd(dnxhd) => {
+                use ff_format::PixelFormat;
+
+                // Set pixel format based on variant before avcodec_open2.
+                // SAFETY: codec_ctx is non-null; direct field write is safe.
+                (*codec_ctx).pix_fmt = match dnxhd.variant.pixel_format() {
+                    PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
+                    PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
+                    PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
+                    _ => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
+                };
+
+                // For DNxHD variants, override bit_rate with the required fixed rate.
+                if let Some(bps) = dnxhd.variant.fixed_bitrate_bps() {
+                    // SAFETY: codec_ctx is non-null; direct field write is safe.
+                    (*codec_ctx).bit_rate = bps;
+                }
+
+                // Apply vprofile via av_opt_set on codec_ctx with AV_OPT_SEARCH_CHILDREN.
+                // Using the codec context (not priv_data) with SEARCH_CHILDREN allows the
+                // option to be found in child objects including priv_data.
+                if let Ok(s) = CString::new(dnxhd.variant.vprofile_str()) {
+                    // SAFETY: codec_ctx is non-null and cast to *mut c_void as required
+                    // by av_opt_set. AV_OPT_SEARCH_CHILDREN (1) searches child objects.
+                    // Strings are valid NUL-terminated C strings.
+                    let ret = ff_sys::av_opt_set(
+                        codec_ctx as *mut std::ffi::c_void,
+                        b"vprofile\0".as_ptr() as *const i8,
+                        s.as_ptr(),
+                        ff_sys::AV_OPT_SEARCH_CHILDREN as i32,
+                    );
+                    if ret < 0 {
+                        log::warn!(
+                            "av_opt_set failed option=vprofile value={} \
+                             encoder={encoder_name}",
+                            dnxhd.variant.vprofile_str()
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/crates/ff-encode/src/video/mod.rs
+++ b/crates/ff-encode/src/video/mod.rs
@@ -14,7 +14,7 @@ mod encoder_inner;
 pub use async_encoder::AsyncVideoEncoder;
 pub use builder::{VideoEncoder, VideoEncoderBuilder};
 pub use codec_options::{
-    Av1Options, Av1Usage, DnxhdOptions, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, ProResOptions, ProResProfile, SvtAv1Options,
+    Av1Options, Av1Usage, DnxhdOptions, DnxhdVariant, H264Options, H264Preset, H264Profile,
+    H264Tune, H265Options, H265Profile, H265Tier, ProResOptions, ProResProfile, SvtAv1Options,
     VideoCodecOptions, Vp9Options,
 };

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -13,9 +13,9 @@
 mod fixtures;
 
 use ff_encode::{
-    Av1Options, Av1Usage, BitrateMode, EncodeError, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, Preset, ProResOptions, ProResProfile, SvtAv1Options,
-    VideoCodec, VideoCodecOptions, VideoEncoder, Vp9Options,
+    Av1Options, Av1Usage, BitrateMode, DnxhdOptions, DnxhdVariant, EncodeError, H264Options,
+    H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier, Preset, ProResOptions,
+    ProResProfile, SvtAv1Options, VideoCodec, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 use fixtures::{
     FileGuard, assert_valid_output_file, create_black_frame, get_file_size, test_output_path,
@@ -990,6 +990,99 @@ fn prores_vendor_tag_should_not_crash() {
     println!(
         "ProRes vendor tag: codec={codec_name} size={} bytes",
         get_file_size(&output_path)
+    );
+}
+
+// ============================================================================
+// DNxHD / DNxHR Tests
+// ============================================================================
+
+#[test]
+fn dnxhd_145_1080p_should_produce_valid_output() {
+    let output_path = test_output_path("dnxhd_145.mov");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(1920, 1080, 30.0)
+        .video_codec(VideoCodec::DnxHd)
+        .codec_options(VideoCodecOptions::Dnxhd(DnxhdOptions {
+            variant: DnxhdVariant::Dnxhd145,
+        }))
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping dnxhd_145 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(1920, 1080);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!(
+        "DNxHD 145: codec={codec_name} size={} bytes",
+        get_file_size(&output_path)
+    );
+}
+
+#[test]
+fn dnxhr_sq_should_produce_valid_output() {
+    let output_path = test_output_path("dnxhr_sq.mov");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::DnxHd)
+        .codec_options(VideoCodecOptions::Dnxhd(DnxhdOptions {
+            variant: DnxhdVariant::DnxhrSq,
+        }))
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping dnxhr_sq test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!(
+        "DNxHR SQ: codec={codec_name} size={} bytes",
+        get_file_size(&output_path)
+    );
+}
+
+#[test]
+fn dnxhd_invalid_resolution_should_return_error() {
+    let output_path = test_output_path("dnxhd_invalid_res.mov");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::DnxHd)
+        .codec_options(VideoCodecOptions::Dnxhd(DnxhdOptions {
+            variant: DnxhdVariant::Dnxhd145,
+        }))
+        .build();
+
+    assert!(
+        matches!(result, Err(EncodeError::InvalidOption { .. })),
+        "Expected InvalidOption error for DNxHD with non-standard resolution"
     );
 }
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -263,6 +263,7 @@ pub const AVPixelFormat_AV_PIX_FMT_BGRA: AVPixelFormat = 28;
 pub const AVPixelFormat_AV_PIX_FMT_YUVJ420P: AVPixelFormat = 12;
 pub const AVPixelFormat_AV_PIX_FMT_VAAPI: AVPixelFormat = 51;
 pub const AVPixelFormat_AV_PIX_FMT_DXVA2_VLD: AVPixelFormat = 53;
+pub const AV_OPT_SEARCH_CHILDREN: u32 = 1;
 pub const AVPixelFormat_AV_PIX_FMT_YUV420P10LE: AVPixelFormat = 66;
 pub const AVPixelFormat_AV_PIX_FMT_YUV422P10LE: AVPixelFormat = 64;
 pub const AVPixelFormat_AV_PIX_FMT_YUV444P10LE: AVPixelFormat = 68;


### PR DESCRIPTION
## Summary

Replaces the placeholder `DnxhdOptions {}` with a complete implementation for DNxHD and DNxHR encoding via FFmpeg's `dnxhd` encoder. Nine variants are supported across two families: legacy fixed-bitrate DNxHD (1080/720 only) and resolution-agnostic DNxHR. The variant drives pixel format selection, bitrate override for DNxHD, and `vprofile` applied via `av_opt_set` with `AV_OPT_SEARCH_CHILDREN`.

## Changes

- `codec_options.rs`: Add `DnxhdVariant` enum (9 variants) with `vprofile_str()`, `pixel_format()`, `fixed_bitrate_bps()`, and `is_dnxhd()` helpers; replace `DnxhdOptions {}` with `DnxhdOptions { variant: DnxhdVariant }`
- `encoder_inner.rs`: Implement `VideoCodecOptions::Dnxhd` arm — sets `pix_fmt`, overrides `bit_rate` for DNxHD variants, and applies `vprofile` via `av_opt_set(codec_ctx, ..., AV_OPT_SEARCH_CHILDREN)`
- `builder.rs`: Validate that DNxHD (fixed-bitrate) variants require 1920×1080 or 1280×720 resolution
- `docsrs_stubs.rs`: Add `AV_OPT_SEARCH_CHILDREN = 1` constant for docs.rs builds
- Re-export `DnxhdVariant` from `video/mod.rs`, `ff-encode/src/lib.rs`, and `avio/src/lib.rs`
- Integration tests: `dnxhd_145_1080p_should_produce_valid_output`, `dnxhr_sq_should_produce_valid_output`, `dnxhd_invalid_resolution_should_return_error`

## Related Issues

Closes #204

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes