### PR TITLE
feat(ff-encode,ff-decode): add 10-bit pixel format support

### DIFF
--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -820,6 +820,14 @@ impl VideoDecoderInner {
             PixelFormat::Nv12
         } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_NV21 {
             PixelFormat::Nv21
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE {
+            PixelFormat::Yuv420p10le
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE {
+            PixelFormat::Yuv422p10le
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE {
+            PixelFormat::Yuv444p10le
+        } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE {
+            PixelFormat::P010le
         } else {
             log::warn!(
                 "pixel_format unsupported, falling back to Yuv420p requested={fmt} fallback=Yuv420p"
@@ -1416,6 +1424,11 @@ impl VideoDecoderInner {
             PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
             PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
             PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
+            PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
+            PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
+            PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
+            PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
+            PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
             _ => {
                 log::warn!(
                     "pixel_format has no AV mapping, falling back to Yuv420p format={format:?} fallback=AV_PIX_FMT_YUV420P"
@@ -2050,6 +2063,38 @@ mod tests {
     }
 
     #[test]
+    fn pixel_format_yuv420p10le_should_return_yuv420p10le() {
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE),
+            PixelFormat::Yuv420p10le
+        );
+    }
+
+    #[test]
+    fn pixel_format_yuv422p10le_should_return_yuv422p10le() {
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE),
+            PixelFormat::Yuv422p10le
+        );
+    }
+
+    #[test]
+    fn pixel_format_yuv444p10le_should_return_yuv444p10le() {
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE),
+            PixelFormat::Yuv444p10le
+        );
+    }
+
+    #[test]
+    fn pixel_format_p010le_should_return_p010le() {
+        assert_eq!(
+            VideoDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE),
+            PixelFormat::P010le
+        );
+    }
+
+    #[test]
     fn pixel_format_unknown_falls_back_to_yuv420p() {
         assert_eq!(
             VideoDecoderInner::convert_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_NONE),
@@ -2401,9 +2446,9 @@ mod tests {
 
     #[test]
     fn pixel_format_to_av_unknown_falls_back_to_yuv420p_av() {
-        // Yuv420p10le has no explicit mapping in pixel_format_to_av, so it hits the _ arm
+        // Other(999) has no explicit mapping and hits the _ fallback arm.
         assert_eq!(
-            VideoDecoderInner::pixel_format_to_av(PixelFormat::Yuv420p10le),
+            VideoDecoderInner::pixel_format_to_av(PixelFormat::Other(999)),
             ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P
         );
     }

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -50,6 +50,7 @@ pub struct VideoEncoderBuilder {
     pub(crate) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(crate) subtitle_passthrough: Option<(String, usize)>,
     pub(crate) codec_options: Option<VideoCodecOptions>,
+    pub(crate) pixel_format: Option<ff_format::PixelFormat>,
 }
 
 impl std::fmt::Debug for VideoEncoderBuilder {
@@ -77,6 +78,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             .field("chapters", &self.chapters)
             .field("subtitle_passthrough", &self.subtitle_passthrough)
             .field("codec_options", &self.codec_options)
+            .field("pixel_format", &self.pixel_format)
             .finish()
     }
 }
@@ -103,6 +105,7 @@ impl VideoEncoderBuilder {
             chapters: Vec::new(),
             subtitle_passthrough: None,
             codec_options: None,
+            pixel_format: None,
         }
     }
 
@@ -267,6 +270,18 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn codec_options(mut self, opts: VideoCodecOptions) -> Self {
         self.codec_options = Some(opts);
+        self
+    }
+
+    // === Pixel format ===
+
+    /// Override the pixel format for video encoding.
+    ///
+    /// When omitted the encoder uses `yuv420p` by default, except that
+    /// H.265 `Main10` automatically selects `yuv420p10le`.
+    #[must_use]
+    pub fn pixel_format(mut self, fmt: ff_format::PixelFormat) -> Self {
+        self.pixel_format = Some(fmt);
         self
     }
 
@@ -472,6 +487,7 @@ impl VideoEncoder {
             chapters: builder.chapters,
             subtitle_passthrough: builder.subtitle_passthrough,
             codec_options: builder.codec_options,
+            pixel_format: builder.pixel_format,
         };
 
         let inner = if config.video_width.is_some() {
@@ -715,6 +731,7 @@ mod tests {
                 chapters: Vec::new(),
                 subtitle_passthrough: None,
                 codec_options: None,
+                pixel_format: None,
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -154,6 +154,7 @@ pub(super) struct VideoEncoderConfig {
     pub(super) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(super) subtitle_passthrough: Option<(String, usize)>,
     pub(super) codec_options: Option<crate::video::codec_options::VideoCodecOptions>,
+    pub(super) pixel_format: Option<ff_format::PixelFormat>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -390,6 +391,12 @@ impl VideoEncoderInner {
                             h265.profile.as_str()
                         );
                     }
+                }
+                // Auto-select yuv420p10le for Main10 (may be overridden by an explicit
+                // pixel_format() call applied after apply_codec_options returns).
+                if h265.profile == crate::video::codec_options::H265Profile::Main10 {
+                    // SAFETY: codec_ctx is valid; direct field write is safe.
+                    (*codec_ctx).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE;
                 }
                 // tier
                 if let Ok(s) = CString::new(h265.tier.as_str()) {
@@ -883,6 +890,7 @@ impl VideoEncoderInner {
                     config.hardware_encoder,
                     config.two_pass,
                     config.codec_options.as_ref(),
+                    config.pixel_format.as_ref(),
                 )?;
             }
 
@@ -956,6 +964,7 @@ impl VideoEncoderInner {
         hardware_encoder: crate::HardwareEncoder,
         two_pass: bool,
         codec_options: Option<&crate::video::codec_options::VideoCodecOptions>,
+        pixel_format: Option<&ff_format::PixelFormat>,
     ) -> Result<(), EncodeError> {
         use crate::BitrateMode;
         // Select encoder based on codec and availability
@@ -1055,6 +1064,12 @@ impl VideoEncoderInner {
             Self::apply_codec_options(codec_ctx, opts, &encoder_name);
         }
 
+        // Apply explicit pixel format override (takes priority over codec-option auto-select).
+        if let Some(fmt) = pixel_format {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).pix_fmt = pixel_format_to_av(*fmt);
+        }
+
         // For two-pass, set the pass-1 flag before opening the codec.
         if two_pass {
             // SAFETY: codec_ctx is a valid allocated (but not yet opened) context.
@@ -1064,7 +1079,11 @@ impl VideoEncoderInner {
         // Open codec
         avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut())
             .map_err(EncodeError::from_ffmpeg_error)?;
-        log::info!("codec opened codec={encoder_name} width={width} height={height} fps={fps}");
+        let actual_pix_fmt = from_av_pixel_format((*codec_ctx).pix_fmt);
+        log::info!(
+            "codec opened codec={encoder_name} width={width} height={height} fps={fps} \
+             pix_fmt={actual_pix_fmt}"
+        );
 
         // Create stream
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
@@ -2439,6 +2458,12 @@ impl VideoEncoderInner {
             Self::apply_codec_options(codec_ctx, opts, &encoder_name);
         }
 
+        // Apply explicit pixel format override for pass 2 (mirrors pass 1).
+        if let Some(fmt) = config.pixel_format.as_ref() {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).pix_fmt = pixel_format_to_av(*fmt);
+        }
+
         // Set the pass-2 flag and provide stats_in.
         // SAFETY: codec_ctx is a valid allocated (but not yet opened) context.
         (*codec_ctx).flags |= AV_CODEC_FLAG_PASS2;
@@ -2951,6 +2976,47 @@ fn pixel_format_to_av(format: ff_format::PixelFormat) -> AVPixelFormat {
     }
 }
 
+/// Convert FFmpeg AVPixelFormat back to ff-format PixelFormat.
+fn from_av_pixel_format(fmt: AVPixelFormat) -> ff_format::PixelFormat {
+    use ff_format::PixelFormat;
+    if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P {
+        PixelFormat::Yuv420p
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P {
+        PixelFormat::Yuv422p
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P {
+        PixelFormat::Yuv444p
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24 {
+        PixelFormat::Rgb24
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24 {
+        PixelFormat::Bgr24
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA {
+        PixelFormat::Rgba
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA {
+        PixelFormat::Bgra
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8 {
+        PixelFormat::Gray8
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_NV12 {
+        PixelFormat::Nv12
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_NV21 {
+        PixelFormat::Nv21
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE {
+        PixelFormat::Yuv420p10le
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE {
+        PixelFormat::Yuv422p10le
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE {
+        PixelFormat::Yuv444p10le
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE {
+        PixelFormat::Yuva444p10le
+    } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE {
+        PixelFormat::P010le
+    } else {
+        log::warn!(
+            "pixel_format unsupported, falling back to Yuv420p requested={fmt} fallback=Yuv420p"
+        );
+        PixelFormat::Yuv420p
+    }
+}
+
 // SAFETY: VideoEncoderInner owns all FFmpeg contexts exclusively.
 //         These contexts are not accessed from multiple threads simultaneously;
 //         all access is serialized by whichever thread holds the VideoEncoder.
@@ -3155,6 +3221,52 @@ mod tests {
         assert_eq!(
             pixel_format_to_av(ff_format::PixelFormat::Other(999)),
             ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P
+        );
+
+        // 10-bit formats
+        assert_eq!(
+            pixel_format_to_av(ff_format::PixelFormat::Yuv420p10le),
+            ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE
+        );
+        assert_eq!(
+            pixel_format_to_av(ff_format::PixelFormat::Yuv422p10le),
+            ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE
+        );
+        assert_eq!(
+            pixel_format_to_av(ff_format::PixelFormat::Yuv444p10le),
+            ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE
+        );
+    }
+
+    #[test]
+    fn from_av_pixel_format_yuv420p10le_should_return_yuv420p10le() {
+        assert_eq!(
+            from_av_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE),
+            ff_format::PixelFormat::Yuv420p10le
+        );
+    }
+
+    #[test]
+    fn from_av_pixel_format_yuv422p10le_should_return_yuv422p10le() {
+        assert_eq!(
+            from_av_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE),
+            ff_format::PixelFormat::Yuv422p10le
+        );
+    }
+
+    #[test]
+    fn from_av_pixel_format_yuv444p10le_should_return_yuv444p10le() {
+        assert_eq!(
+            from_av_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE),
+            ff_format::PixelFormat::Yuv444p10le
+        );
+    }
+
+    #[test]
+    fn from_av_pixel_format_unknown_should_fall_back_to_yuv420p() {
+        assert_eq!(
+            from_av_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_NONE),
+            ff_format::PixelFormat::Yuv420p
         );
     }
 

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -17,6 +17,7 @@ use ff_encode::{
     H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier, Preset, ProResOptions,
     ProResProfile, SvtAv1Options, VideoCodec, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
+use ff_format::PixelFormat;
 use fixtures::{
     FileGuard, assert_valid_output_file, create_black_frame, get_file_size, test_output_path,
 };
@@ -1084,6 +1085,83 @@ fn dnxhd_invalid_resolution_should_return_error() {
         matches!(result, Err(EncodeError::InvalidOption { .. })),
         "Expected InvalidOption error for DNxHD with non-standard resolution"
     );
+}
+
+// ============================================================================
+// 10-bit Pixel Format Tests
+// ============================================================================
+
+#[test]
+fn h265_main10_with_explicit_yuv420p10le_should_produce_valid_output() {
+    let output_path = test_output_path("h265_main10_yuv420p10le.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H265)
+        .bitrate_mode(BitrateMode::Crf(28))
+        .preset(Preset::Ultrafast)
+        .pixel_format(PixelFormat::Yuv420p10le)
+        .codec_options(VideoCodecOptions::H265(H265Options {
+            profile: H265Profile::Main10,
+            tier: H265Tier::Main,
+            level: None,
+            ..H265Options::default()
+        }))
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping h265_main10_yuv420p10le test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(640, 480);
+    for _ in 0..10 {
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("h265_main10_yuv420p10le: codec={codec_name}");
+}
+
+#[test]
+fn pixel_format_yuv420p10le_on_h264_should_be_accepted() {
+    let output_path = test_output_path("h264_yuv420p10le.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .pixel_format(PixelFormat::Yuv420p10le)
+        .build();
+
+    // The builder must not return InvalidOption — 10-bit formats are always accepted.
+    assert!(
+        !matches!(result, Err(EncodeError::InvalidOption { .. })),
+        "pixel_format(Yuv420p10le) must not return InvalidOption"
+    );
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping pixel_format_yuv420p10le_on_h264 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(640, 480);
+    for _ in 0..5 {
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds complete 10-bit pixel format support across the encoder and decoder stack. The `PixelFormat` variants were already defined; this PR wires them end-to-end with a new `VideoEncoderBuilder::pixel_format()` setter, H.265 Main10 auto-selection of `yuv420p10le`, a `from_av_pixel_format()` reverse mapping, and 10-bit coverage in the ff-decode conversion functions.

## Changes

- `builder.rs`: add `pixel_format(PixelFormat)` setter and `pixel_format` field on `VideoEncoderBuilder` / `VideoEncoderConfig`
- `encoder_inner.rs`: thread `pixel_format` through `init_video_encoder` and `init_pass2_codec_ctx`; H.265 `Main10` auto-selects `yuv420p10le` in `apply_codec_options`; explicit `pixel_format()` override takes priority, applied after codec-option auto-select; add `from_av_pixel_format()` reverse mapping used in "codec opened" log; 4 new unit tests + extended `test_pixel_format_to_av` for 10-bit
- `decoder_inner.rs` (ff-decode): extend `convert_pixel_format()` with `Yuv420p10le/422/444/P010le`; extend `pixel_format_to_av()` with all 5 10-bit variants; 4 new unit tests; update stale test that expected `Yuv420p10le` to fall back
- `video_encoder_tests.rs`: 2 new integration tests: `h265_main10_with_explicit_yuv420p10le_should_produce_valid_output` and `pixel_format_yuv420p10le_on_h264_should_be_accepted`

## Related Issues

Closes #205

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes