### PR TITLE
feat(ff-encode,ff-format): add HDR10 static metadata embedding

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -198,9 +198,9 @@
 // in from ff-format anyway).
 pub use ff_format::{
     AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder,
-    ColorPrimaries, ColorRange, ColorSpace, ContainerInfo, MediaInfo, MediaInfoBuilder,
-    PixelFormat, Rational, SampleFormat, SubtitleCodec, SubtitleStreamInfo, Timestamp, VideoCodec,
-    VideoFrame, VideoStreamInfo,
+    ColorPrimaries, ColorRange, ColorSpace, ContainerInfo, Hdr10Metadata, MasteringDisplay,
+    MediaInfo, MediaInfoBuilder, PixelFormat, Rational, SampleFormat, SubtitleCodec,
+    SubtitleStreamInfo, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
 };
 
 // ── probe feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -51,6 +51,7 @@ pub struct VideoEncoderBuilder {
     pub(crate) subtitle_passthrough: Option<(String, usize)>,
     pub(crate) codec_options: Option<VideoCodecOptions>,
     pub(crate) pixel_format: Option<ff_format::PixelFormat>,
+    pub(crate) hdr10_metadata: Option<ff_format::Hdr10Metadata>,
 }
 
 impl std::fmt::Debug for VideoEncoderBuilder {
@@ -79,6 +80,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             .field("subtitle_passthrough", &self.subtitle_passthrough)
             .field("codec_options", &self.codec_options)
             .field("pixel_format", &self.pixel_format)
+            .field("hdr10_metadata", &self.hdr10_metadata)
             .finish()
     }
 }
@@ -106,6 +108,7 @@ impl VideoEncoderBuilder {
             subtitle_passthrough: None,
             codec_options: None,
             pixel_format: None,
+            hdr10_metadata: None,
         }
     }
 
@@ -282,6 +285,26 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn pixel_format(mut self, fmt: ff_format::PixelFormat) -> Self {
         self.pixel_format = Some(fmt);
+        self
+    }
+
+    // === HDR metadata ===
+
+    /// Embed HDR10 static metadata in the output.
+    ///
+    /// Sets `color_primaries = BT.2020`, `color_trc = SMPTE ST 2084 (PQ)`,
+    /// and `colorspace = BT.2020 NCL` on the codec context, then attaches
+    /// `AV_PKT_DATA_CONTENT_LIGHT_LEVEL` and
+    /// `AV_PKT_DATA_MASTERING_DISPLAY_METADATA` packet side data to every
+    /// keyframe.
+    ///
+    /// Pair with [`codec_options`](Self::codec_options) using
+    /// `H265Options { profile: H265Profile::Main10, .. }`
+    /// and [`pixel_format(PixelFormat::Yuv420p10le)`](Self::pixel_format) for a
+    /// complete HDR10 pipeline.
+    #[must_use]
+    pub fn hdr10_metadata(mut self, meta: ff_format::Hdr10Metadata) -> Self {
+        self.hdr10_metadata = Some(meta);
         self
     }
 
@@ -488,6 +511,7 @@ impl VideoEncoder {
             subtitle_passthrough: builder.subtitle_passthrough,
             codec_options: builder.codec_options,
             pixel_format: builder.pixel_format,
+            hdr10_metadata: builder.hdr10_metadata,
         };
 
         let inner = if config.video_width.is_some() {
@@ -711,6 +735,7 @@ mod tests {
                 two_pass_config: None,
                 stats_in_cstr: None,
                 subtitle_passthrough: None,
+                hdr10_metadata: None,
             }),
             _config: VideoEncoderConfig {
                 path: "test.mp4".into(),
@@ -732,6 +757,7 @@ mod tests {
                 subtitle_passthrough: None,
                 codec_options: None,
                 pixel_format: None,
+                hdr10_metadata: None,
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -20,14 +20,50 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS,
     AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS,
     AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9, AVFormatContext, AVFrame,
-    AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext,
-    SwsContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_mallocz,
-    av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer, avcodec,
+    AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
+    AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+    AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext, SwsContext, av_frame_alloc, av_frame_free,
+    av_interleaved_write_frame, av_mallocz, av_packet_alloc, av_packet_free,
+    av_packet_new_side_data, av_packet_unref, av_write_trailer, avcodec,
     avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
     avformat_write_header, swresample, swscale,
 };
 use std::ffi::CString;
 use std::ptr;
+
+/// FFmpeg `AVContentLightMetadata` — matches the C struct layout.
+///
+/// Not exposed by bindgen, so defined here with field order/types matching
+/// the FFmpeg 7.x header `libavutil/mastering_display_metadata.h`.
+#[repr(C)]
+struct AvContentLightMetadata {
+    /// Maximum Content Light Level (nits). Corresponds to `MaxCLL` in C.
+    max_cll: u32,
+    /// Maximum Frame-Average Light Level (nits). Corresponds to `MaxFALL` in C.
+    max_fall: u32,
+}
+
+/// FFmpeg `AVMasteringDisplayMetadata` — matches the C struct layout.
+///
+/// Not exposed by bindgen, so defined here with the exact field names and
+/// types from the FFmpeg 7.x header `libavutil/mastering_display_metadata.h`.
+#[repr(C)]
+struct AvMasteringDisplayMetadata {
+    /// Chromaticity coordinates of the source primaries:
+    /// `display_primaries[R=0/G=1/B=2][x=0/y=1]`.
+    display_primaries: [[ff_sys::AVRational; 2]; 3],
+    /// White point chromaticity: `white_point[x=0/y=1]`.
+    white_point: [ff_sys::AVRational; 2],
+    /// Minimum display luminance (AVRational with denominator 10000).
+    min_luminance: ff_sys::AVRational,
+    /// Maximum display luminance (AVRational with denominator 10000).
+    max_luminance: ff_sys::AVRational,
+    /// Flag: 1 if `display_primaries` is set, 0 otherwise.
+    has_primaries: std::os::raw::c_int,
+    /// Flag: 1 if `min_luminance`/`max_luminance` are set, 0 otherwise.
+    has_luminance: std::os::raw::c_int,
+}
 
 /// Maximum number of planes in AVFrame data/linesize arrays.
 ///
@@ -131,6 +167,11 @@ pub(super) struct VideoEncoderInner {
     /// Set by `init_subtitle_passthrough`; read by `write_subtitle_packets`.
     /// `None` if no subtitle passthrough was requested.
     pub(super) subtitle_passthrough: Option<(String, usize, i32)>,
+
+    /// HDR10 static metadata to embed in keyframe packets.
+    ///
+    /// `None` if no HDR metadata was requested.
+    pub(super) hdr10_metadata: Option<ff_format::Hdr10Metadata>,
 }
 
 /// VideoEncoder configuration (stored from builder).
@@ -155,6 +196,7 @@ pub(super) struct VideoEncoderConfig {
     pub(super) subtitle_passthrough: Option<(String, usize)>,
     pub(super) codec_options: Option<crate::video::codec_options::VideoCodecOptions>,
     pub(super) pixel_format: Option<ff_format::PixelFormat>,
+    pub(super) hdr10_metadata: Option<ff_format::Hdr10Metadata>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -874,6 +916,7 @@ impl VideoEncoderInner {
                 two_pass_config: None,
                 stats_in_cstr: None,
                 subtitle_passthrough: None,
+                hdr10_metadata: config.hdr10_metadata.clone(),
             };
 
             // Initialize video encoder if configured
@@ -1068,6 +1111,14 @@ impl VideoEncoderInner {
         if let Some(fmt) = pixel_format {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
             (*codec_ctx).pix_fmt = pixel_format_to_av(*fmt);
+        }
+
+        // Apply HDR10 color context: BT.2020 primaries, PQ transfer, BT.2020 NCL colorspace.
+        if self.hdr10_metadata.is_some() {
+            // SAFETY: codec_ctx is valid and allocated; direct field writes are safe.
+            (*codec_ctx).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
+            (*codec_ctx).color_trc = ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
+            (*codec_ctx).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
         }
 
         // For two-pass, set the pass-1 flag before opening the codec.
@@ -1915,6 +1966,14 @@ impl VideoEncoderInner {
             // Set stream index
             (*packet).stream_index = self.video_stream_index;
 
+            // Attach HDR10 side data to keyframe packets.
+            if let Some(ref meta) = self.hdr10_metadata {
+                const AV_PKT_FLAG_KEY: i32 = 1;
+                if (*packet).flags & AV_PKT_FLAG_KEY != 0 {
+                    self.attach_hdr10_side_data(packet, meta);
+                }
+            }
+
             // Write packet
             let write_ret = av_interleaved_write_frame(self.format_ctx, packet);
             if write_ret < 0 {
@@ -1932,6 +1991,88 @@ impl VideoEncoderInner {
 
         av_packet_free(&mut packet as *mut *mut _);
         Ok(())
+    }
+
+    /// Attach HDR10 static metadata as packet side data to a keyframe packet.
+    ///
+    /// Attaches `AV_PKT_DATA_CONTENT_LIGHT_LEVEL` (MaxCLL/MaxFALL) and
+    /// `AV_PKT_DATA_MASTERING_DISPLAY_METADATA` to `pkt`.  Called from
+    /// `receive_packets` for every keyframe when `hdr10_metadata` is set.
+    ///
+    /// # Safety
+    ///
+    /// `pkt` must be a valid, non-null pointer to an allocated `AVPacket`.
+    unsafe fn attach_hdr10_side_data(&self, pkt: *mut AVPacket, meta: &ff_format::Hdr10Metadata) {
+        // ── Content light level (MaxCLL / MaxFALL) ──────────────────────────
+        let cll_ptr = av_packet_new_side_data(
+            pkt,
+            AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+            std::mem::size_of::<AvContentLightMetadata>(),
+        );
+        if cll_ptr.is_null() {
+            log::warn!(
+                "hdr10 side_data allocation failed, skipping MaxCLL/MaxFALL type=content_light_level"
+            );
+        } else {
+            // SAFETY: av_packet_new_side_data returns memory allocated for exactly
+            // sizeof(AvContentLightMetadata) bytes with alignment suitable for the
+            // data type. We use ptr::write to avoid creating a reference to
+            // potentially-unaligned memory (ptr::write handles any alignment).
+            let cll_value = AvContentLightMetadata {
+                max_cll: u32::from(meta.max_cll),
+                max_fall: u32::from(meta.max_fall),
+            };
+            // SAFETY: write_unaligned does not require the pointer to be aligned;
+            // it copies bytes. FFmpeg's av_packet_new_side_data returns
+            // malloc-aligned memory in practice, but write_unaligned is correct
+            // regardless of alignment.
+            std::ptr::write_unaligned(cll_ptr.cast::<AvContentLightMetadata>(), cll_value);
+        }
+
+        // ── Mastering display colour volume ─────────────────────────────────
+        let md_ptr = av_packet_new_side_data(
+            pkt,
+            AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
+            std::mem::size_of::<AvMasteringDisplayMetadata>(),
+        );
+        if md_ptr.is_null() {
+            log::warn!(
+                "hdr10 side_data allocation failed, skipping mastering display type=mastering_display_metadata"
+            );
+        } else {
+            let d = &meta.mastering_display;
+            let r = |n: u16| ff_sys::AVRational {
+                num: i32::from(n),
+                den: 50000,
+            };
+            let lum = |n: u32| ff_sys::AVRational {
+                num: i32::try_from(n).unwrap_or(i32::MAX),
+                den: 10000,
+            };
+            // SAFETY: av_packet_new_side_data returns memory allocated for exactly
+            // sizeof(AvMasteringDisplayMetadata) bytes. We use ptr::write to safely
+            // write the struct without creating a potentially-unaligned reference.
+            let md_value = AvMasteringDisplayMetadata {
+                // Chromaticity coordinates: denominator = 50000 (CIE 1931 xy).
+                // Order: [R, G, B][x, y]
+                display_primaries: [
+                    [r(d.red_x), r(d.red_y)],
+                    [r(d.green_x), r(d.green_y)],
+                    [r(d.blue_x), r(d.blue_y)],
+                ],
+                white_point: [r(d.white_x), r(d.white_y)],
+                // Luminance: denominator = 10000.
+                min_luminance: lum(d.min_luminance),
+                max_luminance: lum(d.max_luminance),
+                has_primaries: 1,
+                has_luminance: 1,
+            };
+            // SAFETY: write_unaligned does not require the pointer to be aligned;
+            // it copies bytes. FFmpeg's av_packet_new_side_data returns
+            // malloc-aligned memory in practice, but write_unaligned is correct
+            // regardless of alignment.
+            std::ptr::write_unaligned(md_ptr.cast::<AvMasteringDisplayMetadata>(), md_value);
+        }
     }
 
     /// Push an audio frame for encoding.
@@ -2462,6 +2603,14 @@ impl VideoEncoderInner {
         if let Some(fmt) = config.pixel_format.as_ref() {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
             (*codec_ctx).pix_fmt = pixel_format_to_av(*fmt);
+        }
+
+        // Apply HDR10 color context for pass 2 (mirrors pass 1).
+        if config.hdr10_metadata.is_some() {
+            // SAFETY: codec_ctx is valid and allocated; direct field writes are safe.
+            (*codec_ctx).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
+            (*codec_ctx).color_trc = ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
+            (*codec_ctx).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
         }
 
         // Set the pass-2 flag and provide stats_in.
@@ -3317,6 +3466,7 @@ mod tests {
             two_pass_config: None,
             stats_in_cstr: None,
             subtitle_passthrough: None,
+            hdr10_metadata: None,
         }
     }
 }

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -1758,3 +1758,113 @@ fn h264_zerolatency_tune_should_produce_valid_output() {
         get_file_size(&output_path)
     );
 }
+
+// ============================================================================
+// HDR10 Metadata Tests
+// ============================================================================
+
+#[test]
+fn hdr10_metadata_on_h265_main10_should_produce_valid_output() {
+    use ff_format::hdr::{Hdr10Metadata, MasteringDisplay};
+
+    let output_path = test_output_path("hdr10_h265_main10.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let hdr = Hdr10Metadata {
+        max_cll: 1000,
+        max_fall: 400,
+        mastering_display: MasteringDisplay {
+            red_x: 17000,
+            red_y: 8500,
+            green_x: 13250,
+            green_y: 34500,
+            blue_x: 7500,
+            blue_y: 3000,
+            white_x: 15635,
+            white_y: 16450,
+            min_luminance: 50,
+            max_luminance: 10_000_000,
+        },
+    };
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H265)
+        .bitrate_mode(BitrateMode::Crf(28))
+        .preset(Preset::Ultrafast)
+        .pixel_format(PixelFormat::Yuv420p10le)
+        .codec_options(VideoCodecOptions::H265(H265Options {
+            profile: H265Profile::Main10,
+            ..H265Options::default()
+        }))
+        .hdr10_metadata(hdr)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..15 {
+        let frame = create_black_frame(640, 480);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("HDR10 H265 Main10: codec={codec_name}");
+}
+
+#[test]
+fn hdr10_metadata_on_h264_should_produce_valid_output() {
+    use ff_format::hdr::{Hdr10Metadata, MasteringDisplay};
+
+    let output_path = test_output_path("hdr10_h264.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let hdr = Hdr10Metadata {
+        max_cll: 500,
+        max_fall: 200,
+        mastering_display: MasteringDisplay {
+            red_x: 17000,
+            red_y: 8500,
+            green_x: 13250,
+            green_y: 34500,
+            blue_x: 7500,
+            blue_y: 3000,
+            white_x: 15635,
+            white_y: 16450,
+            min_luminance: 50,
+            max_luminance: 5_000_000,
+        },
+    };
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .hdr10_metadata(hdr)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("HDR10 H264: codec={codec_name}");
+}

--- a/crates/ff-format/src/hdr.rs
+++ b/crates/ff-format/src/hdr.rs
@@ -1,0 +1,71 @@
+//! HDR metadata types for high-dynamic-range video.
+//!
+//! This module provides [`Hdr10Metadata`] and [`MasteringDisplay`] for HDR10
+//! static metadata embedding.
+
+/// HDR10 static metadata (`MaxCLL` + `MaxFALL` + mastering display).
+///
+/// Pass to `VideoEncoderBuilder::hdr10_metadata` (in `ff-encode`) to embed
+/// HDR10 static metadata in the encoded output using
+/// `AV_PKT_DATA_CONTENT_LIGHT_LEVEL` and
+/// `AV_PKT_DATA_MASTERING_DISPLAY_METADATA` packet side data.
+///
+/// Setting this automatically configures the codec context with:
+/// - `color_primaries = BT.2020`
+/// - `color_trc = SMPTE ST 2084 (PQ)`
+/// - `colorspace = BT.2020 NCL`
+#[derive(Debug, Clone)]
+pub struct Hdr10Metadata {
+    /// Maximum Content Light Level in nits (e.g. 1000).
+    pub max_cll: u16,
+    /// Maximum Frame-Average Light Level in nits (e.g. 400).
+    pub max_fall: u16,
+    /// Mastering display colour volume (SMPTE ST 2086).
+    pub mastering_display: MasteringDisplay,
+}
+
+/// Mastering display colour volume (SMPTE ST 2086).
+///
+/// Chromaticity coordinates use a denominator of 50000 (each value represents
+/// `n / 50000` in CIE 1931 xy).  Luminance values use a denominator of 10000
+/// (each value represents `n / 10000` nits).
+///
+/// # Examples
+///
+/// BT.2020 D65 primaries / 1000 nit peak / 0.005 nit black:
+///
+/// ```
+/// use ff_format::hdr::MasteringDisplay;
+///
+/// let md = MasteringDisplay {
+///     red_x: 17000,   red_y: 8500,
+///     green_x: 13250, green_y: 34500,
+///     blue_x: 7500,   blue_y: 3000,
+///     white_x: 15635, white_y: 16450,
+///     min_luminance: 50,          // 0.005 nits
+///     max_luminance: 10_000_000,  // 1000 nits
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct MasteringDisplay {
+    /// Red primary x coordinate (×50000).
+    pub red_x: u16,
+    /// Red primary y coordinate (×50000).
+    pub red_y: u16,
+    /// Green primary x coordinate (×50000).
+    pub green_x: u16,
+    /// Green primary y coordinate (×50000).
+    pub green_y: u16,
+    /// Blue primary x coordinate (×50000).
+    pub blue_x: u16,
+    /// Blue primary y coordinate (×50000).
+    pub blue_y: u16,
+    /// White point x coordinate (×50000).
+    pub white_x: u16,
+    /// White point y coordinate (×50000).
+    pub white_y: u16,
+    /// Minimum display luminance (×10000, in nits).
+    pub min_luminance: u32,
+    /// Maximum display luminance (×10000, in nits).
+    pub max_luminance: u32,
+}

--- a/crates/ff-format/src/lib.rs
+++ b/crates/ff-format/src/lib.rs
@@ -15,6 +15,7 @@
 //! - `container` - Container info ([`ContainerInfo`])
 //! - `media` - Media container info ([`MediaInfo`])
 //! - `color` - Color space definitions ([`ColorSpace`], [`ColorRange`], [`ColorPrimaries`])
+//! - `hdr` - HDR metadata types ([`Hdr10Metadata`], [`MasteringDisplay`])
 //! - `codec` - Codec definitions ([`VideoCodec`], [`AudioCodec`])
 //! - `channel` - Channel layout definitions ([`ChannelLayout`])
 //! - `chapter` - Chapter information ([`ChapterInfo`])
@@ -58,6 +59,7 @@ pub mod color;
 pub mod container;
 pub mod error;
 pub mod frame;
+pub mod hdr;
 pub mod media;
 pub mod pixel;
 pub mod sample;
@@ -72,6 +74,7 @@ pub use container::{ContainerInfo, ContainerInfoBuilder};
 pub use error::{FormatError, FrameError};
 pub use ff_common::PooledBuffer;
 pub use frame::{AudioFrame, VideoFrame};
+pub use hdr::{Hdr10Metadata, MasteringDisplay};
 pub use media::{MediaInfo, MediaInfoBuilder};
 pub use pixel::PixelFormat;
 pub use sample::SampleFormat;

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -159,6 +159,8 @@ pub struct AVPacket {
     pub duration: i64,
 }
 
+pub type AVColorTransferCharacteristic = c_uint;
+
 pub struct AVCodecContext {
     pub codec_id: AVCodecID,
     pub bit_rate: i64,
@@ -178,6 +180,9 @@ pub struct AVCodecContext {
     pub hw_device_ctx: *mut AVBufferRef,
     pub hw_frames_ctx: *mut AVBufferRef,
     pub priv_data: *mut c_void,
+    pub color_primaries: AVColorPrimaries,
+    pub color_trc: AVColorTransferCharacteristic,
+    pub colorspace: AVColorSpace,
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -314,6 +319,14 @@ pub const AVColorSpace_AVCOL_SPC_SMPTE170M: AVColorSpace = 6;
 pub const AVColorSpace_AVCOL_SPC_BT2020_NCL: AVColorSpace = 9;
 pub const AVColorSpace_AVCOL_SPC_BT2020_CL: AVColorSpace = 10;
 
+// AVColorTransferCharacteristic
+pub const AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084: AVColorTransferCharacteristic = 16;
+
+// AVPacketSideDataType
+pub type AVPacketSideDataType = c_uint;
+pub const AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA: AVPacketSideDataType = 20;
+pub const AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL: AVPacketSideDataType = 22;
+
 // AVHWDeviceType
 pub const AVHWDeviceType_AV_HWDEVICE_TYPE_CUDA: AVHWDeviceType = 2;
 pub const AVHWDeviceType_AV_HWDEVICE_TYPE_VAAPI: AVHWDeviceType = 4;
@@ -374,6 +387,14 @@ pub unsafe fn av_packet_alloc() -> *mut AVPacket {
 pub unsafe fn av_packet_free(_pkt: *mut *mut AVPacket) {}
 
 pub unsafe fn av_packet_unref(_pkt: *mut AVPacket) {}
+
+pub unsafe fn av_packet_new_side_data(
+    _pkt: *mut AVPacket,
+    _type_: AVPacketSideDataType,
+    _size: usize,
+) -> *mut u8 {
+    std::ptr::null_mut()
+}
 
 pub unsafe fn av_buffer_ref(_buf: *mut AVBufferRef) -> *mut AVBufferRef {
     std::ptr::null_mut()


### PR DESCRIPTION
## Summary

Adds HDR10 static metadata embedding support to the video encoder. When `hdr10_metadata()` is set on the builder, the encoder automatically configures the codec context with BT.2020 primaries, SMPTE ST 2084 (PQ) transfer characteristic, and BT.2020 NCL colorspace, and attaches `AV_PKT_DATA_CONTENT_LIGHT_LEVEL` and `AV_PKT_DATA_MASTERING_DISPLAY_METADATA` packet side data to every keyframe using `av_packet_new_side_data`.

## Changes

- **`ff-format/src/hdr.rs`** (new): `Hdr10Metadata` struct (`max_cll`, `max_fall`, `mastering_display`) and `MasteringDisplay` struct with CIE 1931 xy chromaticity (×50000 denominator) and luminance fields (×10000 denominator)
- **`ff-format/src/lib.rs`**: expose `pub mod hdr` and re-export `Hdr10Metadata`, `MasteringDisplay`
- **`ff-encode/src/video/builder.rs`**: `hdr10_metadata: Option<ff_format::Hdr10Metadata>` field and `hdr10_metadata()` consuming setter
- **`ff-encode/src/video/encoder_inner.rs`**: local `#[repr(C)]` structs `AvContentLightMetadata` / `AvMasteringDisplayMetadata` (not exposed by bindgen); `hdr10_metadata` field on `VideoEncoderConfig` and `VideoEncoderInner`; color context setup in `init_video_encoder` and `init_pass2_codec_ctx`; `attach_hdr10_side_data()` helper called from `receive_packets` on keyframes
- **`ff-sys/src/docsrs_stubs.rs`**: add `AVColorTransferCharacteristic` type + `AVCOL_TRC_SMPTEST2084` constant; `AVPacketSideDataType` + two side-data constants; `av_packet_new_side_data` stub; `color_primaries`/`color_trc`/`colorspace` fields on `AVCodecContext`
- **`avio/src/lib.rs`**: re-export `Hdr10Metadata` and `MasteringDisplay`
- **`ff-encode/tests/video_encoder_tests.rs`**: two integration tests — HDR10 on H265 Main10 with `yuv420p10le`, and HDR10 on H264

## Related Issues

Closes #206

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes