### PR TITLE
feat(ff-encode,ff-format): add HLG color transfer and color space tagging

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -198,9 +198,9 @@
 // in from ff-format anyway).
 pub use ff_format::{
     AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder,
-    ColorPrimaries, ColorRange, ColorSpace, ContainerInfo, Hdr10Metadata, MasteringDisplay,
-    MediaInfo, MediaInfoBuilder, PixelFormat, Rational, SampleFormat, SubtitleCodec,
-    SubtitleStreamInfo, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
+    ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, ContainerInfo, Hdr10Metadata,
+    MasteringDisplay, MediaInfo, MediaInfoBuilder, PixelFormat, Rational, SampleFormat,
+    SubtitleCodec, SubtitleStreamInfo, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
 };
 
 // ── probe feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -52,6 +52,9 @@ pub struct VideoEncoderBuilder {
     pub(crate) codec_options: Option<VideoCodecOptions>,
     pub(crate) pixel_format: Option<ff_format::PixelFormat>,
     pub(crate) hdr10_metadata: Option<ff_format::Hdr10Metadata>,
+    pub(crate) color_space: Option<ff_format::ColorSpace>,
+    pub(crate) color_transfer: Option<ff_format::ColorTransfer>,
+    pub(crate) color_primaries: Option<ff_format::ColorPrimaries>,
 }
 
 impl std::fmt::Debug for VideoEncoderBuilder {
@@ -81,6 +84,9 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             .field("codec_options", &self.codec_options)
             .field("pixel_format", &self.pixel_format)
             .field("hdr10_metadata", &self.hdr10_metadata)
+            .field("color_space", &self.color_space)
+            .field("color_transfer", &self.color_transfer)
+            .field("color_primaries", &self.color_primaries)
             .finish()
     }
 }
@@ -109,6 +115,9 @@ impl VideoEncoderBuilder {
             codec_options: None,
             pixel_format: None,
             hdr10_metadata: None,
+            color_space: None,
+            color_transfer: None,
+            color_primaries: None,
         }
     }
 
@@ -305,6 +314,40 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn hdr10_metadata(mut self, meta: ff_format::Hdr10Metadata) -> Self {
         self.hdr10_metadata = Some(meta);
+        self
+    }
+
+    // === Color tagging ===
+
+    /// Override the color space (matrix coefficients) written to the codec context.
+    ///
+    /// When omitted the encoder uses the FFmpeg default. HDR10 metadata, if set
+    /// via [`hdr10_metadata()`](Self::hdr10_metadata), automatically selects
+    /// BT.2020 NCL — this setter takes priority over that automatic choice.
+    #[must_use]
+    pub fn color_space(mut self, cs: ff_format::ColorSpace) -> Self {
+        self.color_space = Some(cs);
+        self
+    }
+
+    /// Override the color transfer characteristic (gamma curve) written to the codec context.
+    ///
+    /// When omitted the encoder uses the FFmpeg default. HDR10 metadata
+    /// automatically selects PQ (SMPTE ST 2084) — this setter takes priority.
+    /// Use [`ColorTransfer::Hlg`](ff_format::ColorTransfer::Hlg) for HLG broadcast HDR.
+    #[must_use]
+    pub fn color_transfer(mut self, trc: ff_format::ColorTransfer) -> Self {
+        self.color_transfer = Some(trc);
+        self
+    }
+
+    /// Override the color primaries written to the codec context.
+    ///
+    /// When omitted the encoder uses the FFmpeg default. HDR10 metadata
+    /// automatically selects BT.2020 — this setter takes priority.
+    #[must_use]
+    pub fn color_primaries(mut self, cp: ff_format::ColorPrimaries) -> Self {
+        self.color_primaries = Some(cp);
         self
     }
 
@@ -512,6 +555,9 @@ impl VideoEncoder {
             codec_options: builder.codec_options,
             pixel_format: builder.pixel_format,
             hdr10_metadata: builder.hdr10_metadata,
+            color_space: builder.color_space,
+            color_transfer: builder.color_transfer,
+            color_primaries: builder.color_primaries,
         };
 
         let inner = if config.video_width.is_some() {
@@ -758,6 +804,9 @@ mod tests {
                 codec_options: None,
                 pixel_format: None,
                 hdr10_metadata: None,
+                color_space: None,
+                color_transfer: None,
+                color_primaries: None,
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -197,6 +197,9 @@ pub(super) struct VideoEncoderConfig {
     pub(super) codec_options: Option<crate::video::codec_options::VideoCodecOptions>,
     pub(super) pixel_format: Option<ff_format::PixelFormat>,
     pub(super) hdr10_metadata: Option<ff_format::Hdr10Metadata>,
+    pub(super) color_space: Option<ff_format::ColorSpace>,
+    pub(super) color_transfer: Option<ff_format::ColorTransfer>,
+    pub(super) color_primaries: Option<ff_format::ColorPrimaries>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -934,6 +937,9 @@ impl VideoEncoderInner {
                     config.two_pass,
                     config.codec_options.as_ref(),
                     config.pixel_format.as_ref(),
+                    config.color_space,
+                    config.color_transfer,
+                    config.color_primaries,
                 )?;
             }
 
@@ -1008,6 +1014,9 @@ impl VideoEncoderInner {
         two_pass: bool,
         codec_options: Option<&crate::video::codec_options::VideoCodecOptions>,
         pixel_format: Option<&ff_format::PixelFormat>,
+        color_space: Option<ff_format::ColorSpace>,
+        color_transfer: Option<ff_format::ColorTransfer>,
+        color_primaries: Option<ff_format::ColorPrimaries>,
     ) -> Result<(), EncodeError> {
         use crate::BitrateMode;
         // Select encoder based on codec and availability
@@ -1119,6 +1128,20 @@ impl VideoEncoderInner {
             (*codec_ctx).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
             (*codec_ctx).color_trc = ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
             (*codec_ctx).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
+        }
+
+        // Apply explicit color overrides (take priority over HDR10 automatic defaults).
+        if let Some(cs) = color_space {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).colorspace = color_space_to_av(cs);
+        }
+        if let Some(trc) = color_transfer {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).color_trc = color_transfer_to_av(trc);
+        }
+        if let Some(cp) = color_primaries {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).color_primaries = color_primaries_to_av(cp);
         }
 
         // For two-pass, set the pass-1 flag before opening the codec.
@@ -2613,6 +2636,20 @@ impl VideoEncoderInner {
             (*codec_ctx).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
         }
 
+        // Apply explicit color overrides for pass 2 (mirrors pass 1; take priority over HDR10).
+        if let Some(cs) = config.color_space {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).colorspace = color_space_to_av(cs);
+        }
+        if let Some(trc) = config.color_transfer {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).color_trc = color_transfer_to_av(trc);
+        }
+        if let Some(cp) = config.color_primaries {
+            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
+            (*codec_ctx).color_primaries = color_primaries_to_av(cp);
+        }
+
         // Set the pass-2 flag and provide stats_in.
         // SAFETY: codec_ctx is a valid allocated (but not yet opened) context.
         (*codec_ctx).flags |= AV_CODEC_FLAG_PASS2;
@@ -3166,6 +3203,46 @@ fn from_av_pixel_format(fmt: AVPixelFormat) -> ff_format::PixelFormat {
     }
 }
 
+/// Convert ff-format ColorSpace to the FFmpeg AVColorSpace constant.
+fn color_space_to_av(cs: ff_format::ColorSpace) -> ff_sys::AVColorSpace {
+    use ff_format::ColorSpace;
+    match cs {
+        ColorSpace::Bt709 => ff_sys::AVColorSpace_AVCOL_SPC_BT709,
+        ColorSpace::Bt601 => ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M,
+        ColorSpace::Bt2020 => ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL,
+        ColorSpace::DciP3 | ColorSpace::Srgb => ff_sys::AVColorSpace_AVCOL_SPC_RGB,
+        ColorSpace::Unknown => ff_sys::AVColorSpace_AVCOL_SPC_UNSPECIFIED,
+        _ => ff_sys::AVColorSpace_AVCOL_SPC_UNSPECIFIED,
+    }
+}
+
+/// Convert ff-format ColorTransfer to the FFmpeg AVColorTransferCharacteristic constant.
+fn color_transfer_to_av(trc: ff_format::ColorTransfer) -> ff_sys::AVColorTransferCharacteristic {
+    use ff_format::ColorTransfer;
+    match trc {
+        ColorTransfer::Bt709 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_BT709,
+        ColorTransfer::Bt2020_10 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_BT2020_10,
+        ColorTransfer::Bt2020_12 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_BT2020_12,
+        ColorTransfer::Hlg => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_ARIB_STD_B67,
+        ColorTransfer::Pq => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084,
+        ColorTransfer::Linear => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_LINEAR,
+        ColorTransfer::Unknown => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_UNSPECIFIED,
+        _ => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_UNSPECIFIED,
+    }
+}
+
+/// Convert ff-format ColorPrimaries to the FFmpeg AVColorPrimaries constant.
+fn color_primaries_to_av(cp: ff_format::ColorPrimaries) -> ff_sys::AVColorPrimaries {
+    use ff_format::ColorPrimaries;
+    match cp {
+        ColorPrimaries::Bt709 => ff_sys::AVColorPrimaries_AVCOL_PRI_BT709,
+        ColorPrimaries::Bt601 => ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M,
+        ColorPrimaries::Bt2020 => ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020,
+        ColorPrimaries::Unknown => ff_sys::AVColorPrimaries_AVCOL_PRI_UNSPECIFIED,
+        _ => ff_sys::AVColorPrimaries_AVCOL_PRI_UNSPECIFIED,
+    }
+}
+
 // SAFETY: VideoEncoderInner owns all FFmpeg contexts exclusively.
 //         These contexts are not accessed from multiple threads simultaneously;
 //         all access is serialized by whichever thread holds the VideoEncoder.
@@ -3416,6 +3493,70 @@ mod tests {
         assert_eq!(
             from_av_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_NONE),
             ff_format::PixelFormat::Yuv420p
+        );
+    }
+
+    #[test]
+    fn color_space_to_av_bt709_should_return_bt709() {
+        assert_eq!(
+            color_space_to_av(ff_format::ColorSpace::Bt709),
+            ff_sys::AVColorSpace_AVCOL_SPC_BT709
+        );
+    }
+
+    #[test]
+    fn color_space_to_av_bt2020_should_return_bt2020_ncl() {
+        assert_eq!(
+            color_space_to_av(ff_format::ColorSpace::Bt2020),
+            ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL
+        );
+    }
+
+    #[test]
+    fn color_space_to_av_dcip3_should_return_rgb() {
+        assert_eq!(
+            color_space_to_av(ff_format::ColorSpace::DciP3),
+            ff_sys::AVColorSpace_AVCOL_SPC_RGB
+        );
+    }
+
+    #[test]
+    fn color_transfer_to_av_hlg_should_return_arib_std_b67() {
+        assert_eq!(
+            color_transfer_to_av(ff_format::ColorTransfer::Hlg),
+            ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_ARIB_STD_B67
+        );
+    }
+
+    #[test]
+    fn color_transfer_to_av_pq_should_return_smptest2084() {
+        assert_eq!(
+            color_transfer_to_av(ff_format::ColorTransfer::Pq),
+            ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084
+        );
+    }
+
+    #[test]
+    fn color_transfer_to_av_bt709_should_return_bt709() {
+        assert_eq!(
+            color_transfer_to_av(ff_format::ColorTransfer::Bt709),
+            ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_BT709
+        );
+    }
+
+    #[test]
+    fn color_primaries_to_av_bt2020_should_return_bt2020() {
+        assert_eq!(
+            color_primaries_to_av(ff_format::ColorPrimaries::Bt2020),
+            ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020
+        );
+    }
+
+    #[test]
+    fn color_primaries_to_av_bt709_should_return_bt709() {
+        assert_eq!(
+            color_primaries_to_av(ff_format::ColorPrimaries::Bt709),
+            ff_sys::AVColorPrimaries_AVCOL_PRI_BT709
         );
     }
 

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -1868,3 +1868,78 @@ fn hdr10_metadata_on_h264_should_produce_valid_output() {
     assert_valid_output_file(&output_path);
     println!("HDR10 H264: codec={codec_name}");
 }
+
+// ============================================================================
+// Color Tagging Tests
+// ============================================================================
+
+#[test]
+fn hlg_color_transfer_on_h265_should_produce_valid_output() {
+    use ff_format::{ColorPrimaries, ColorSpace, ColorTransfer};
+
+    let output_path = test_output_path("hlg_h265.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H265)
+        .bitrate_mode(BitrateMode::Crf(28))
+        .preset(Preset::Ultrafast)
+        .color_space(ColorSpace::Bt2020)
+        .color_transfer(ColorTransfer::Hlg)
+        .color_primaries(ColorPrimaries::Bt2020)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("HLG H265: codec={codec_name}");
+}
+
+#[test]
+fn color_transfer_bt709_on_h264_should_produce_valid_output() {
+    use ff_format::{ColorPrimaries, ColorSpace, ColorTransfer};
+
+    let output_path = test_output_path("bt709_h264.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .color_space(ColorSpace::Bt709)
+        .color_transfer(ColorTransfer::Bt709)
+        .color_primaries(ColorPrimaries::Bt709)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(640, 480);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("BT.709 H264: codec={codec_name}");
+}

--- a/crates/ff-format/src/color.rs
+++ b/crates/ff-format/src/color.rs
@@ -40,6 +40,8 @@ pub enum ColorSpace {
     Bt601,
     /// ITU-R BT.2020 - UHD/HDR television standard
     Bt2020,
+    /// DCI-P3 - digital cinema wide color gamut
+    DciP3,
     /// sRGB color space - computer graphics and web
     Srgb,
     /// Color space is not specified or unknown
@@ -63,6 +65,7 @@ impl ColorSpace {
             Self::Bt709 => "bt709",
             Self::Bt601 => "bt601",
             Self::Bt2020 => "bt2020",
+            Self::DciP3 => "dcip3",
             Self::Srgb => "srgb",
             Self::Unknown => "unknown",
         }
@@ -111,6 +114,21 @@ impl ColorSpace {
     #[must_use]
     pub const fn is_uhd(&self) -> bool {
         matches!(self, Self::Bt2020)
+    }
+
+    /// Returns `true` if this is a cinema/DCI color space (DCI-P3).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::color::ColorSpace;
+    ///
+    /// assert!(ColorSpace::DciP3.is_cinema());
+    /// assert!(!ColorSpace::Bt709.is_cinema());
+    /// ```
+    #[must_use]
+    pub const fn is_cinema(&self) -> bool {
+        matches!(self, Self::DciP3)
     }
 
     /// Returns `true` if the color space is unknown.
@@ -347,6 +365,132 @@ impl fmt::Display for ColorPrimaries {
     }
 }
 
+/// Color transfer characteristic (opto-electronic transfer function).
+///
+/// The transfer characteristic defines how scene luminance maps to the signal
+/// level stored in the video bitstream. Different HDR and SDR standards use
+/// different curves.
+///
+/// # Common Usage
+///
+/// - **`Bt709`**: Standard SDR video (HD television)
+/// - **`Pq`**: HDR10 and Dolby Vision (SMPTE ST 2084 / Perceptual Quantizer)
+/// - **`Hlg`**: Hybrid Log-Gamma — broadcast-compatible HDR (ARIB STD-B67)
+/// - **`Bt2020_10`** / **`Bt2020_12`**: BT.2020 SDR at 10/12-bit depth
+/// - **`Linear`**: Linear light, no gamma applied
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum ColorTransfer {
+    /// ITU-R BT.709 transfer characteristic (standard SDR)
+    #[default]
+    Bt709,
+    /// ITU-R BT.2020 for 10-bit content
+    Bt2020_10,
+    /// ITU-R BT.2020 for 12-bit content
+    Bt2020_12,
+    /// Hybrid Log-Gamma (ARIB STD-B67) — broadcast HDR
+    Hlg,
+    /// Perceptual Quantizer / SMPTE ST 2084 — HDR10
+    Pq,
+    /// Linear light transfer (no gamma)
+    Linear,
+    /// Transfer characteristic is not specified or unknown
+    Unknown,
+}
+
+impl ColorTransfer {
+    /// Returns the name of the color transfer characteristic as a string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::color::ColorTransfer;
+    ///
+    /// assert_eq!(ColorTransfer::Bt709.name(), "bt709");
+    /// assert_eq!(ColorTransfer::Hlg.name(), "hlg");
+    /// assert_eq!(ColorTransfer::Pq.name(), "pq");
+    /// ```
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::Bt709 => "bt709",
+            Self::Bt2020_10 => "bt2020-10",
+            Self::Bt2020_12 => "bt2020-12",
+            Self::Hlg => "hlg",
+            Self::Pq => "pq",
+            Self::Linear => "linear",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Returns `true` if this is an HDR transfer characteristic (`Pq` or `Hlg`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::color::ColorTransfer;
+    ///
+    /// assert!(ColorTransfer::Pq.is_hdr());
+    /// assert!(ColorTransfer::Hlg.is_hdr());
+    /// assert!(!ColorTransfer::Bt709.is_hdr());
+    /// ```
+    #[must_use]
+    pub const fn is_hdr(&self) -> bool {
+        matches!(self, Self::Pq | Self::Hlg)
+    }
+
+    /// Returns `true` if this is Hybrid Log-Gamma (HLG).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::color::ColorTransfer;
+    ///
+    /// assert!(ColorTransfer::Hlg.is_hlg());
+    /// assert!(!ColorTransfer::Pq.is_hlg());
+    /// ```
+    #[must_use]
+    pub const fn is_hlg(&self) -> bool {
+        matches!(self, Self::Hlg)
+    }
+
+    /// Returns `true` if this is Perceptual Quantizer / SMPTE ST 2084 (PQ).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::color::ColorTransfer;
+    ///
+    /// assert!(ColorTransfer::Pq.is_pq());
+    /// assert!(!ColorTransfer::Hlg.is_pq());
+    /// ```
+    #[must_use]
+    pub const fn is_pq(&self) -> bool {
+        matches!(self, Self::Pq)
+    }
+
+    /// Returns `true` if the transfer characteristic is unknown.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_format::color::ColorTransfer;
+    ///
+    /// assert!(ColorTransfer::Unknown.is_unknown());
+    /// assert!(!ColorTransfer::Bt709.is_unknown());
+    /// ```
+    #[must_use]
+    pub const fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+}
+
+impl fmt::Display for ColorTransfer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -359,6 +503,7 @@ mod tests {
             assert_eq!(ColorSpace::Bt709.name(), "bt709");
             assert_eq!(ColorSpace::Bt601.name(), "bt601");
             assert_eq!(ColorSpace::Bt2020.name(), "bt2020");
+            assert_eq!(ColorSpace::DciP3.name(), "dcip3");
             assert_eq!(ColorSpace::Srgb.name(), "srgb");
             assert_eq!(ColorSpace::Unknown.name(), "unknown");
         }
@@ -387,6 +532,13 @@ mod tests {
             assert!(!ColorSpace::Bt2020.is_hd());
             assert!(!ColorSpace::Bt2020.is_sd());
             assert!(ColorSpace::Bt2020.is_uhd());
+        }
+
+        #[test]
+        fn dcip3_is_cinema_should_return_true() {
+            assert!(ColorSpace::DciP3.is_cinema());
+            assert!(!ColorSpace::Bt709.is_cinema());
+            assert!(!ColorSpace::Bt2020.is_cinema());
         }
 
         #[test]
@@ -533,6 +685,76 @@ mod tests {
             set.insert(ColorPrimaries::Bt2020);
             assert!(set.contains(&ColorPrimaries::Bt709));
             assert!(!set.contains(&ColorPrimaries::Bt601));
+        }
+    }
+
+    mod color_transfer_tests {
+        use super::*;
+
+        #[test]
+        fn test_names() {
+            assert_eq!(ColorTransfer::Bt709.name(), "bt709");
+            assert_eq!(ColorTransfer::Bt2020_10.name(), "bt2020-10");
+            assert_eq!(ColorTransfer::Bt2020_12.name(), "bt2020-12");
+            assert_eq!(ColorTransfer::Hlg.name(), "hlg");
+            assert_eq!(ColorTransfer::Pq.name(), "pq");
+            assert_eq!(ColorTransfer::Linear.name(), "linear");
+            assert_eq!(ColorTransfer::Unknown.name(), "unknown");
+        }
+
+        #[test]
+        fn test_display() {
+            assert_eq!(format!("{}", ColorTransfer::Hlg), "hlg");
+            assert_eq!(format!("{}", ColorTransfer::Pq), "pq");
+            assert_eq!(format!("{}", ColorTransfer::Bt709), "bt709");
+        }
+
+        #[test]
+        fn test_default() {
+            assert_eq!(ColorTransfer::default(), ColorTransfer::Bt709);
+        }
+
+        #[test]
+        fn hlg_is_hdr_should_return_true() {
+            assert!(ColorTransfer::Hlg.is_hdr());
+            assert!(ColorTransfer::Hlg.is_hlg());
+            assert!(!ColorTransfer::Hlg.is_pq());
+        }
+
+        #[test]
+        fn pq_is_hdr_should_return_true() {
+            assert!(ColorTransfer::Pq.is_hdr());
+            assert!(ColorTransfer::Pq.is_pq());
+            assert!(!ColorTransfer::Pq.is_hlg());
+        }
+
+        #[test]
+        fn sdr_transfers_are_not_hdr() {
+            assert!(!ColorTransfer::Bt709.is_hdr());
+            assert!(!ColorTransfer::Bt2020_10.is_hdr());
+            assert!(!ColorTransfer::Bt2020_12.is_hdr());
+            assert!(!ColorTransfer::Linear.is_hdr());
+        }
+
+        #[test]
+        fn is_unknown_should_only_match_unknown() {
+            assert!(ColorTransfer::Unknown.is_unknown());
+            assert!(!ColorTransfer::Bt709.is_unknown());
+            assert!(!ColorTransfer::Hlg.is_unknown());
+        }
+
+        #[test]
+        fn test_equality_and_hash() {
+            use std::collections::HashSet;
+
+            assert_eq!(ColorTransfer::Hlg, ColorTransfer::Hlg);
+            assert_ne!(ColorTransfer::Hlg, ColorTransfer::Pq);
+
+            let mut set = HashSet::new();
+            set.insert(ColorTransfer::Hlg);
+            set.insert(ColorTransfer::Pq);
+            assert!(set.contains(&ColorTransfer::Hlg));
+            assert!(!set.contains(&ColorTransfer::Bt709));
         }
     }
 }

--- a/crates/ff-format/src/lib.rs
+++ b/crates/ff-format/src/lib.rs
@@ -69,7 +69,7 @@ pub mod time;
 pub use channel::ChannelLayout;
 pub use chapter::{ChapterInfo, ChapterInfoBuilder};
 pub use codec::{AudioCodec, SubtitleCodec, VideoCodec};
-pub use color::{ColorPrimaries, ColorRange, ColorSpace};
+pub use color::{ColorPrimaries, ColorRange, ColorSpace, ColorTransfer};
 pub use container::{ContainerInfo, ContainerInfoBuilder};
 pub use error::{FormatError, FrameError};
 pub use ff_common::PooledBuffer;

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -320,7 +320,13 @@ pub const AVColorSpace_AVCOL_SPC_BT2020_NCL: AVColorSpace = 9;
 pub const AVColorSpace_AVCOL_SPC_BT2020_CL: AVColorSpace = 10;
 
 // AVColorTransferCharacteristic
+pub const AVColorTransferCharacteristic_AVCOL_TRC_BT709: AVColorTransferCharacteristic = 1;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_UNSPECIFIED: AVColorTransferCharacteristic = 2;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_LINEAR: AVColorTransferCharacteristic = 8;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_BT2020_10: AVColorTransferCharacteristic = 14;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_BT2020_12: AVColorTransferCharacteristic = 15;
 pub const AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084: AVColorTransferCharacteristic = 16;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_ARIB_STD_B67: AVColorTransferCharacteristic = 18;
 
 // AVPacketSideDataType
 pub type AVPacketSideDataType = c_uint;


### PR DESCRIPTION
## Summary

Adds `ColorTransfer` enum to `ff-format` covering HLG (ARIB STD-B67), PQ (SMPTE ST 2084), BT.709, BT.2020 10/12-bit, Linear, and Unknown. Adds `DciP3` to the `ColorSpace` enum. Exposes `color_space()`, `color_transfer()`, and `color_primaries()` builder setters on `VideoEncoderBuilder` that write `colorspace`, `color_trc`, and `color_primaries` onto the `AVCodecContext` during encoder init. Explicit setters take priority over the automatic defaults set by `hdr10_metadata()`.

## Changes

- `ff-format/src/color.rs`: add `ColorTransfer` enum (`Bt709`, `Bt2020_10`, `Bt2020_12`, `Hlg`, `Pq`, `Linear`, `Unknown`) with `name()`, `is_hdr()`, `is_hlg()`, `is_pq()`, `is_unknown()`, and `Display`; add `DciP3` variant to `ColorSpace` with `is_cinema()` method
- `ff-format/src/lib.rs`: re-export `ColorTransfer`
- `ff-encode/src/video/builder.rs`: add `color_space`, `color_transfer`, `color_primaries` fields and consuming setters; forward to `VideoEncoderConfig`
- `ff-encode/src/video/encoder_inner.rs`: add fields to `VideoEncoderConfig`; add `color_space_to_av()`, `color_transfer_to_av()`, `color_primaries_to_av()` conversion functions; apply in `init_video_encoder` and `init_pass2_codec_ctx` after HDR10 defaults
- `ff-sys/src/docsrs_stubs.rs`: add `AVCOL_TRC_BT709`, `AVCOL_TRC_UNSPECIFIED`, `AVCOL_TRC_LINEAR`, `AVCOL_TRC_BT2020_10`, `AVCOL_TRC_BT2020_12`, `AVCOL_TRC_ARIB_STD_B67` constants
- `avio/src/lib.rs`: re-export `ColorTransfer`
- Integration tests: `hlg_color_transfer_on_h265_should_produce_valid_output`, `color_transfer_bt709_on_h264_should_produce_valid_output`
- Unit tests in `color.rs` and `encoder_inner.rs` for new types and mapping functions

## Related Issues

Closes #207

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes