### PR TITLE
feat(ff-encode): add add_attachment() for MKV binary attachment muxing

### DIFF
--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -55,6 +55,8 @@ pub struct VideoEncoderBuilder {
     pub(crate) color_space: Option<ff_format::ColorSpace>,
     pub(crate) color_transfer: Option<ff_format::ColorTransfer>,
     pub(crate) color_primaries: Option<ff_format::ColorPrimaries>,
+    /// Binary attachments: (raw data, MIME type, filename).
+    pub(crate) attachments: Vec<(Vec<u8>, String, String)>,
 }
 
 impl std::fmt::Debug for VideoEncoderBuilder {
@@ -87,6 +89,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             .field("color_space", &self.color_space)
             .field("color_transfer", &self.color_transfer)
             .field("color_primaries", &self.color_primaries)
+            .field("attachments_count", &self.attachments.len())
             .finish()
     }
 }
@@ -118,6 +121,7 @@ impl VideoEncoderBuilder {
             color_space: None,
             color_transfer: None,
             color_primaries: None,
+            attachments: Vec::new(),
         }
     }
 
@@ -351,6 +355,28 @@ impl VideoEncoderBuilder {
         self
     }
 
+    // === Attachments ===
+
+    /// Embed a binary attachment in the output container.
+    ///
+    /// Attachments are supported in MKV/WebM containers and are used for
+    /// fonts (required by ASS/SSA subtitle rendering), cover art, or other
+    /// binary files that consumers of the file may need.
+    ///
+    /// - `data` — raw bytes of the attachment
+    /// - `mime_type` — MIME type string (e.g. `"application/x-truetype-font"`,
+    ///   `"image/jpeg"`)
+    /// - `filename` — the name reported inside the container (e.g. `"Arial.ttf"`)
+    ///
+    /// Multiple calls accumulate entries; each attachment becomes its own stream
+    /// with `AVMEDIA_TYPE_ATTACHMENT` codec parameters.
+    #[must_use]
+    pub fn add_attachment(mut self, data: Vec<u8>, mime_type: &str, filename: &str) -> Self {
+        self.attachments
+            .push((data, mime_type.to_string(), filename.to_string()));
+        self
+    }
+
     // === Build ===
 
     /// Validate builder state and open the output file.
@@ -558,6 +584,7 @@ impl VideoEncoder {
             color_space: builder.color_space,
             color_transfer: builder.color_transfer,
             color_primaries: builder.color_primaries,
+            attachments: builder.attachments,
         };
 
         let inner = if config.video_width.is_some() {
@@ -807,6 +834,7 @@ mod tests {
                 color_space: None,
                 color_transfer: None,
                 color_primaries: None,
+                attachments: Vec::new(),
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,
@@ -1004,5 +1032,25 @@ mod tests {
                 "is_hw for {codec_name}"
             );
         }
+    }
+
+    #[test]
+    fn add_attachment_should_accumulate_entries() {
+        let builder = VideoEncoder::create("output.mkv")
+            .video(320, 240, 30.0)
+            .add_attachment(vec![1, 2, 3], "application/x-truetype-font", "font.ttf")
+            .add_attachment(vec![4, 5, 6], "image/jpeg", "cover.jpg");
+        assert_eq!(builder.attachments.len(), 2);
+        assert_eq!(builder.attachments[0].0, vec![1u8, 2, 3]);
+        assert_eq!(builder.attachments[0].1, "application/x-truetype-font");
+        assert_eq!(builder.attachments[0].2, "font.ttf");
+        assert_eq!(builder.attachments[1].1, "image/jpeg");
+        assert_eq!(builder.attachments[1].2, "cover.jpg");
+    }
+
+    #[test]
+    fn add_attachment_with_no_attachments_should_start_empty() {
+        let builder = VideoEncoder::create("output.mkv").video(320, 240, 30.0);
+        assert!(builder.attachments.is_empty());
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -200,6 +200,8 @@ pub(super) struct VideoEncoderConfig {
     pub(super) color_space: Option<ff_format::ColorSpace>,
     pub(super) color_transfer: Option<ff_format::ColorTransfer>,
     pub(super) color_primaries: Option<ff_format::ColorPrimaries>,
+    /// Binary attachments: (raw data, MIME type, filename).
+    pub(super) attachments: Vec<(Vec<u8>, String, String)>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -963,6 +965,11 @@ impl VideoEncoderInner {
             // Register subtitle passthrough stream (must happen before avformat_write_header).
             if let Some((ref path, stream_index)) = config.subtitle_passthrough {
                 encoder.init_subtitle_passthrough(path, stream_index);
+            }
+
+            // Register attachment streams (must happen before avformat_write_header).
+            if !config.attachments.is_empty() {
+                encoder.init_attachments(&config.attachments);
             }
 
             // For two-pass encoding the output file is opened in run_pass2() after
@@ -2799,6 +2806,80 @@ impl VideoEncoderInner {
     /// stream with copied codec parameters, and close the source.
     ///
     /// Stores `(source_path, source_stream_index, output_stream_index)` in
+    /// Register binary attachment streams in the output container.
+    ///
+    /// Each attachment is stored as an `AVMEDIA_TYPE_ATTACHMENT` stream with
+    /// `AV_CODEC_ID_BIN_DATA`. The attachment data is placed in `extradata`
+    /// so the MKV muxer can write it into the container's `Attachments` element.
+    ///
+    /// Failures per entry are non-fatal: a warning is logged and the entry is
+    /// skipped so the rest of encoding can continue.
+    ///
+    /// # Safety
+    ///
+    /// `self.format_ctx` must be a valid, non-null `AVFormatContext` pointer.
+    /// Must be called before `avformat_write_header`.
+    unsafe fn init_attachments(&mut self, attachments: &[(Vec<u8>, String, String)]) {
+        for (data, mime_type, filename) in attachments {
+            // Create a new stream for the attachment.
+            // SAFETY: format_ctx is valid; null codec means the muxer selects a default.
+            let out_stream = avformat_new_stream(self.format_ctx, std::ptr::null());
+            if out_stream.is_null() {
+                log::warn!("attachment: avformat_new_stream failed, skipping filename={filename}");
+                continue;
+            }
+
+            let codecpar = (*out_stream).codecpar;
+            (*codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_ATTACHMENT;
+            (*codecpar).codec_id = ff_sys::AVCodecID_AV_CODEC_ID_BIN_DATA;
+
+            // Allocate extradata with FFmpeg's allocator so it can be freed by
+            // avcodec_parameters_free. The padding bytes are zeroed by av_mallocz.
+            let alloc_size = data.len() + ff_sys::AV_INPUT_BUFFER_PADDING_SIZE as usize;
+            let extradata = ff_sys::av_mallocz(alloc_size) as *mut u8;
+            if extradata.is_null() {
+                log::warn!(
+                    "attachment: av_mallocz failed for extradata, skipping filename={filename}"
+                );
+                continue;
+            }
+            // SAFETY: extradata has at least `data.len()` bytes; data slice is valid.
+            std::ptr::copy_nonoverlapping(data.as_ptr(), extradata, data.len());
+            (*codecpar).extradata = extradata;
+            (*codecpar).extradata_size = data.len() as i32;
+
+            // Set stream metadata so the muxer records the filename and MIME type.
+            let Ok(c_filename) = std::ffi::CString::new(filename.as_str()) else {
+                log::warn!("attachment: filename contains null byte, skipping filename={filename}");
+                continue;
+            };
+            let Ok(c_mime) = std::ffi::CString::new(mime_type.as_str()) else {
+                log::warn!(
+                    "attachment: mime_type contains null byte, skipping filename={filename}"
+                );
+                continue;
+            };
+            // SAFETY: out_stream->metadata pointer is valid (initialized by avformat_new_stream).
+            ff_sys::av_dict_set(
+                &mut (*out_stream).metadata,
+                b"filename\0".as_ptr() as *const i8,
+                c_filename.as_ptr(),
+                0,
+            );
+            ff_sys::av_dict_set(
+                &mut (*out_stream).metadata,
+                b"mimetype\0".as_ptr() as *const i8,
+                c_mime.as_ptr(),
+                0,
+            );
+
+            log::info!(
+                "attachment: registered filename={filename} mime={mime_type} size={}",
+                data.len()
+            );
+        }
+    }
+
     /// `self.subtitle_passthrough` on success. On any failure it logs a warning and returns
     /// without modifying state, so encoding can continue without subtitles.
     ///

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -1943,3 +1943,82 @@ fn color_transfer_bt709_on_h264_should_produce_valid_output() {
     assert_valid_output_file(&output_path);
     println!("BT.709 H264: codec={codec_name}");
 }
+
+// ============================================================================
+// Attachment Tests
+// ============================================================================
+
+#[test]
+fn attachment_embedding_mkv_should_produce_valid_output() {
+    let output_path = test_output_path("attachment_mkv.mkv");
+    let _guard = FileGuard::new(output_path.clone());
+
+    // Minimal synthetic font bytes (not a real font, just binary data for testing).
+    let font_data = vec![0x00u8; 512];
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .add_attachment(font_data, "application/x-truetype-font", "test_font.ttf")
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping attachment_embedding test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
+fn attachment_embedding_with_multiple_attachments_should_produce_valid_output() {
+    let output_path = test_output_path("attachment_multi_mkv.mkv");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let font_data = vec![0xFFu8; 256];
+    let image_data = vec![0xABu8; 128];
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .add_attachment(font_data, "application/x-truetype-font", "font.ttf")
+        .add_attachment(image_data, "image/jpeg", "cover.jpg")
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping multi-attachment test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..5 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
+fn attachment_builder_setter_should_not_panic() {
+    // Verify that add_attachment() is chainable and does not panic.
+    // Field-level assertions live in the crate's unit tests.
+    let _builder = VideoEncoder::create("output.mkv")
+        .video(320, 240, 30.0)
+        .add_attachment(vec![1, 2, 3], "application/octet-stream", "data.bin")
+        .add_attachment(vec![4, 5, 6], "image/png", "icon.png");
+}

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -95,6 +95,8 @@ pub struct AVCodecParameters {
     pub codec_type: AVMediaType,
     pub codec_id: AVCodecID,
     pub codec_tag: c_uint,
+    pub extradata: *mut u8,
+    pub extradata_size: c_int,
     pub format: c_int,
     pub bit_rate: i64,
     pub width: c_int,
@@ -194,8 +196,11 @@ pub const AV_TIME_BASE: u32 = 1_000_000;
 pub const AVMediaType_AVMEDIA_TYPE_VIDEO: AVMediaType = 0;
 pub const AVMediaType_AVMEDIA_TYPE_AUDIO: AVMediaType = 1;
 pub const AVMediaType_AVMEDIA_TYPE_SUBTITLE: AVMediaType = 3;
+pub const AVMediaType_AVMEDIA_TYPE_ATTACHMENT: AVMediaType = 4;
 
 pub const AV_DISPOSITION_FORCED: u32 = 0x0040;
+pub const AV_DISPOSITION_ATTACHED_PIC: u32 = 0x0400;
+pub const AV_INPUT_BUFFER_PADDING_SIZE: u32 = 64;
 
 pub const AVChannelOrder_AV_CHANNEL_ORDER_UNSPEC: AVChannelOrder = 0;
 pub const AVChannelOrder_AV_CHANNEL_ORDER_NATIVE: AVChannelOrder = 1;
@@ -228,6 +233,9 @@ pub const AVCodecID_AV_CODEC_ID_SRT: AVCodecID = 94216;
 pub const AVCodecID_AV_CODEC_ID_SUBRIP: AVCodecID = 94248;
 pub const AVCodecID_AV_CODEC_ID_WEBVTT: AVCodecID = 94249;
 pub const AVCodecID_AV_CODEC_ID_ASS: AVCodecID = 94253;
+
+// AVCodecID — attachment / data
+pub const AVCodecID_AV_CODEC_ID_BIN_DATA: AVCodecID = 98314;
 
 // AVCodecID — audio
 pub const AVCodecID_AV_CODEC_ID_PCM_S16LE: AVCodecID = 65536;
@@ -526,6 +534,16 @@ pub unsafe fn av_channel_layout_uninit(_ch_layout: *mut AVChannelLayout) {}
 
 pub unsafe fn av_mallocz(_size: usize) -> *mut c_void {
     std::ptr::null_mut()
+}
+
+pub unsafe fn av_malloc(_size: usize) -> *mut c_void {
+    std::ptr::null_mut()
+}
+
+pub unsafe fn av_free(_ptr: *mut c_void) {}
+
+pub unsafe fn av_new_packet(_pkt: *mut AVPacket, _size: c_int) -> c_int {
+    -1
 }
 
 pub unsafe fn avcodec_parameters_copy(


### PR DESCRIPTION
## Summary

Adds `VideoEncoderBuilder::add_attachment(data, mime_type, filename)` to embed binary attachments (fonts for ASS/SSA subtitles, cover art, or arbitrary files) into output containers. The MKV/Matroska muxer stores these in its `Attachments` element. Multiple calls to `add_attachment()` accumulate entries, each becoming its own `AVMEDIA_TYPE_ATTACHMENT` stream in the output.

## Changes

- `ff-encode/src/video/builder.rs`: add `attachments: Vec<(Vec<u8>, String, String)>` field, `add_attachment()` consuming setter, `Debug` impl update, `from_builder()` forwarding, and unit tests for accumulation behavior
- `ff-encode/src/video/encoder_inner.rs`: add `attachments` to `VideoEncoderConfig`; add `init_attachments()` unsafe method that creates `AVMEDIA_TYPE_ATTACHMENT` streams with `AV_CODEC_ID_BIN_DATA`, allocates `codecpar->extradata` via `av_mallocz` (FFmpeg-managed memory), and sets `filename`/`mimetype` stream metadata; called before `avformat_write_header`
- `ff-sys/src/docsrs_stubs.rs`: add `extradata`/`extradata_size` fields to `AVCodecParameters`; add `AVMediaType_AVMEDIA_TYPE_ATTACHMENT`, `AVCodecID_AV_CODEC_ID_BIN_DATA`, `AV_INPUT_BUFFER_PADDING_SIZE`, `AV_DISPOSITION_ATTACHED_PIC` constants; add `av_malloc`, `av_free`, `av_new_packet` stubs
- Integration tests: `attachment_embedding_mkv_should_produce_valid_output`, `attachment_embedding_with_multiple_attachments_should_produce_valid_output`, `attachment_builder_setter_should_not_panic`

## Related Issues

Closes #208

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes