### PR TITLE
feat(ff-encode): WebM container VP9/AV1 + Vorbis/Opus enforcement

### DIFF
--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -90,6 +90,17 @@ pub enum EncodeError {
         reason: String,
     },
 
+    /// Codec is incompatible with the target container format
+    #[error("codec {codec} is not supported by container {container} — {hint}")]
+    UnsupportedContainerCodecCombination {
+        /// Container format name (e.g. `"webm"`)
+        container: String,
+        /// Codec name that was rejected (e.g. `"h264"`)
+        codec: String,
+        /// Human-readable guidance on compatible codecs
+        hint: String,
+    },
+
     /// Encoding cancelled by user
     #[error("Encoding cancelled by user")]
     Cancelled,

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -50,6 +50,8 @@ pub struct VideoEncoderBuilder {
     pub(crate) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(crate) subtitle_passthrough: Option<(String, usize)>,
     pub(crate) codec_options: Option<VideoCodecOptions>,
+    pub(crate) video_codec_explicit: bool,
+    pub(crate) audio_codec_explicit: bool,
     pub(crate) pixel_format: Option<ff_format::PixelFormat>,
     pub(crate) hdr10_metadata: Option<ff_format::Hdr10Metadata>,
     pub(crate) color_space: Option<ff_format::ColorSpace>,
@@ -84,6 +86,8 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             .field("chapters", &self.chapters)
             .field("subtitle_passthrough", &self.subtitle_passthrough)
             .field("codec_options", &self.codec_options)
+            .field("video_codec_explicit", &self.video_codec_explicit)
+            .field("audio_codec_explicit", &self.audio_codec_explicit)
             .field("pixel_format", &self.pixel_format)
             .field("hdr10_metadata", &self.hdr10_metadata)
             .field("color_space", &self.color_space)
@@ -116,6 +120,8 @@ impl VideoEncoderBuilder {
             chapters: Vec::new(),
             subtitle_passthrough: None,
             codec_options: None,
+            video_codec_explicit: false,
+            audio_codec_explicit: false,
             pixel_format: None,
             hdr10_metadata: None,
             color_space: None,
@@ -140,6 +146,7 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn video_codec(mut self, codec: VideoCodec) -> Self {
         self.video_codec = codec;
+        self.video_codec_explicit = true;
         self
     }
 
@@ -178,6 +185,7 @@ impl VideoEncoderBuilder {
     #[must_use]
     pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
         self.audio_codec = codec;
+        self.audio_codec_explicit = true;
         self
     }
 
@@ -386,8 +394,36 @@ impl VideoEncoderBuilder {
     /// Returns [`EncodeError`] if configuration is invalid, the output path
     /// cannot be created, or no suitable encoder is found.
     pub fn build(self) -> Result<VideoEncoder, EncodeError> {
-        self.validate()?;
-        VideoEncoder::from_builder(self)
+        let this = self.apply_container_defaults();
+        this.validate()?;
+        VideoEncoder::from_builder(this)
+    }
+
+    /// Apply container-specific codec defaults before validation.
+    ///
+    /// For WebM paths/containers, default to VP9 + Opus when the caller has
+    /// not explicitly chosen a codec.
+    fn apply_container_defaults(mut self) -> Self {
+        let is_webm = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("webm"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::WebM);
+
+        if is_webm {
+            if !self.video_codec_explicit {
+                self.video_codec = VideoCodec::Vp9;
+            }
+            if !self.audio_codec_explicit {
+                self.audio_codec = AudioCodec::Opus;
+            }
+        }
+
+        self
     }
 
     fn validate(&self) -> Result<(), EncodeError> {
@@ -503,6 +539,40 @@ impl VideoEncoderBuilder {
                 return Err(EncodeError::InvalidOption {
                     name: "variant".to_string(),
                     reason: "DNxHD variants require 1920×1080 or 1280×720 resolution".to_string(),
+                });
+            }
+        }
+
+        // WebM container codec enforcement.
+        let is_webm = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("webm"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::WebM);
+
+        if is_webm {
+            let webm_video_ok = matches!(
+                self.video_codec,
+                VideoCodec::Vp9 | VideoCodec::Av1 | VideoCodec::Av1Svt
+            );
+            if !webm_video_ok {
+                return Err(EncodeError::UnsupportedContainerCodecCombination {
+                    container: "webm".to_string(),
+                    codec: self.video_codec.name().to_string(),
+                    hint: "WebM supports VP9, AV1 (video) and Vorbis, Opus (audio)".to_string(),
+                });
+            }
+
+            let webm_audio_ok = matches!(self.audio_codec, AudioCodec::Opus | AudioCodec::Vorbis);
+            if !webm_audio_ok {
+                return Err(EncodeError::UnsupportedContainerCodecCombination {
+                    container: "webm".to_string(),
+                    codec: self.audio_codec.name().to_string(),
+                    hint: "WebM supports VP9, AV1 (video) and Vorbis, Opus (audio)".to_string(),
                 });
             }
         }
@@ -1052,5 +1122,88 @@ mod tests {
     fn add_attachment_with_no_attachments_should_start_empty() {
         let builder = VideoEncoder::create("output.mkv").video(320, 240, 30.0);
         assert!(builder.attachments.is_empty());
+    }
+
+    #[test]
+    fn webm_extension_with_h264_video_codec_should_return_error() {
+        let result = VideoEncoder::create("output.webm")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H264)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn webm_extension_with_h265_video_codec_should_return_error() {
+        let result = VideoEncoder::create("output.webm")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H265)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn webm_extension_with_incompatible_audio_codec_should_return_error() {
+        let result = VideoEncoder::create("output.webm")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Vp9)
+            .audio(48000, 2)
+            .audio_codec(AudioCodec::Aac)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn webm_extension_without_explicit_codec_should_default_to_vp9_opus() {
+        let builder = VideoEncoder::create("output.webm").video(640, 480, 30.0);
+        let normalized = builder.apply_container_defaults();
+        assert_eq!(normalized.video_codec, VideoCodec::Vp9);
+        assert_eq!(normalized.audio_codec, AudioCodec::Opus);
+    }
+
+    #[test]
+    fn webm_extension_with_explicit_vp9_should_preserve_codec() {
+        let builder = VideoEncoder::create("output.webm")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Vp9);
+        assert!(builder.video_codec_explicit);
+        let normalized = builder.apply_container_defaults();
+        assert_eq!(normalized.video_codec, VideoCodec::Vp9);
+    }
+
+    #[test]
+    fn webm_container_enum_with_incompatible_codec_should_return_error() {
+        let result = VideoEncoder::create("output.mkv")
+            .video(640, 480, 30.0)
+            .container(Container::WebM)
+            .video_codec(VideoCodec::H264)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn non_webm_extension_should_not_enforce_webm_codecs() {
+        // H264 + AAC on .mp4 should not trigger WebM validation
+        let result = VideoEncoder::create("output.mp4")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H264)
+            .build();
+        // Should not fail with UnsupportedContainerCodecCombination
+        assert!(!matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
     }
 }

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -13,9 +13,10 @@
 mod fixtures;
 
 use ff_encode::{
-    Av1Options, Av1Usage, BitrateMode, DnxhdOptions, DnxhdVariant, EncodeError, H264Options,
-    H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier, Preset, ProResOptions,
-    ProResProfile, SvtAv1Options, VideoCodec, VideoCodecOptions, VideoEncoder, Vp9Options,
+    AudioCodec, Av1Options, Av1Usage, BitrateMode, Container, DnxhdOptions, DnxhdVariant,
+    EncodeError, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
+    H265Tier, Preset, ProResOptions, ProResProfile, SvtAv1Options, VideoCodec, VideoCodecOptions,
+    VideoEncoder, Vp9Options,
 };
 use ff_format::PixelFormat;
 use fixtures::{
@@ -2021,4 +2022,105 @@ fn attachment_builder_setter_should_not_panic() {
         .video(320, 240, 30.0)
         .add_attachment(vec![1, 2, 3], "application/octet-stream", "data.bin")
         .add_attachment(vec![4, 5, 6], "image/png", "icon.png");
+}
+
+// ============================================================================
+// WebM Container Tests
+// ============================================================================
+
+#[test]
+fn webm_vp9_should_produce_valid_output() {
+    let output_path = test_output_path("webm_vp9.webm");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Vp9)
+        .bitrate_mode(BitrateMode::Crf(33))
+        .preset(Preset::Ultrafast)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping webm_vp9 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("webm_vp9: codec={codec_name}");
+}
+
+#[test]
+fn webm_auto_default_codec_should_use_vp9_opus() {
+    // When no codec is explicitly set, .webm path should auto-select VP9+Opus.
+    let output_path = test_output_path("webm_auto_default.webm");
+    let _guard = FileGuard::new(output_path.clone());
+
+    // Without calling video_codec() or audio_codec(), build should not fail
+    // with UnsupportedContainerCodecCombination.
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .build();
+
+    assert!(!matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn webm_with_incompatible_video_codec_should_return_error() {
+    let output_path = test_output_path("webm_h264_error.webm");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .build();
+
+    assert!(matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn webm_with_incompatible_audio_codec_should_return_error() {
+    let output_path = test_output_path("webm_aac_error.webm");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Vp9)
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+
+    assert!(matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn container_enum_webm_with_incompatible_codec_should_return_error() {
+    let result = VideoEncoder::create("output.mkv")
+        .video(640, 480, 30.0)
+        .container(Container::WebM)
+        .video_codec(VideoCodec::H265)
+        .build();
+
+    assert!(matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
 }


### PR DESCRIPTION
## Summary

Adds WebM container codec enforcement to `VideoEncoderBuilder`. When the output path ends in `.webm` or `Container::WebM` is explicitly set, the builder validates that the video codec is VP9, AV1, or AV1-SVT and the audio codec is Vorbis or Opus. If an incompatible codec is explicitly chosen, `build()` returns the new `EncodeError::UnsupportedContainerCodecCombination` error. When no codec is explicitly set, the builder auto-defaults to VP9 + Opus before validation runs.

## Changes

- `error.rs`: added `UnsupportedContainerCodecCombination { container, codec, hint }` variant to `EncodeError`
- `builder.rs`: added `video_codec_explicit` / `audio_codec_explicit` tracking fields; added `apply_container_defaults()` for VP9+Opus auto-selection on WebM; added WebM codec validation block in `validate()`; 7 new unit tests
- `video_encoder_tests.rs`: added `AudioCodec` and `Container` imports; 5 new integration tests covering VP9 output, auto-default behavior, and incompatible codec rejection

## Related Issues

Closes #209

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes