### PR TITLE
feat(ff-encode,ff-format): AVI/MOV container codec enforcement + Pcm16/Pcm24

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -17,10 +17,10 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_DTS,
     AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3,
     AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
-    AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame, SwrContext, av_frame_alloc,
-    av_frame_free, av_interleaved_write_frame, av_packet_alloc, av_packet_free, av_packet_unref,
-    av_write_trailer, avcodec, avformat_alloc_output_context2, avformat_free_context,
-    avformat_new_stream, avformat_write_header, swresample,
+    AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame,
+    SwrContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc,
+    av_packet_free, av_packet_unref, av_write_trailer, avcodec, avformat_alloc_output_context2,
+    avformat_free_context, avformat_new_stream, avformat_write_header, swresample,
 };
 use std::ffi::{CString, c_void};
 use std::ptr;
@@ -202,8 +202,10 @@ impl AudioEncoderInner {
                 AudioCodec::Aac => 192_000,
                 AudioCodec::Opus => 128_000,
                 AudioCodec::Mp3 => 192_000,
-                AudioCodec::Flac => 0, // Lossless
-                AudioCodec::Pcm => 0,  // Uncompressed
+                AudioCodec::Flac => 0,  // Lossless
+                AudioCodec::Pcm => 0,   // Uncompressed
+                AudioCodec::Pcm16 => 0, // Uncompressed
+                AudioCodec::Pcm24 => 0, // Uncompressed
                 AudioCodec::Vorbis => 192_000,
                 AudioCodec::Ac3 => 192_000,
                 AudioCodec::Eac3 => 192_000,
@@ -420,6 +422,8 @@ impl AudioEncoderInner {
             AudioCodec::Mp3 => vec!["libmp3lame", "mp3"],
             AudioCodec::Flac => vec!["flac"],
             AudioCodec::Pcm => vec!["pcm_s16le"],
+            AudioCodec::Pcm16 => vec!["pcm_s16le"],
+            AudioCodec::Pcm24 => vec!["pcm_s24le"],
             AudioCodec::Vorbis => vec!["libvorbis", "vorbis"],
             AudioCodec::Ac3 => vec!["ac3"],
             AudioCodec::Eac3 => vec!["eac3"],
@@ -899,6 +903,8 @@ fn codec_to_id(codec: AudioCodec) -> AVCodecID {
         AudioCodec::Mp3 => AVCodecID_AV_CODEC_ID_MP3,
         AudioCodec::Flac => AVCodecID_AV_CODEC_ID_FLAC,
         AudioCodec::Pcm => AVCodecID_AV_CODEC_ID_PCM_S16LE,
+        AudioCodec::Pcm16 => AVCodecID_AV_CODEC_ID_PCM_S16LE,
+        AudioCodec::Pcm24 => AVCodecID_AV_CODEC_ID_PCM_S24LE,
         AudioCodec::Vorbis => AVCodecID_AV_CODEC_ID_VORBIS,
         AudioCodec::Ac3 => AVCodecID_AV_CODEC_ID_AC3,
         AudioCodec::Eac3 => AVCodecID_AV_CODEC_ID_EAC3,

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -423,6 +423,44 @@ impl VideoEncoderBuilder {
             }
         }
 
+        let is_avi = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("avi"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Avi);
+
+        if is_avi {
+            if !self.video_codec_explicit {
+                self.video_codec = VideoCodec::H264;
+            }
+            if !self.audio_codec_explicit {
+                self.audio_codec = AudioCodec::Mp3;
+            }
+        }
+
+        let is_mov = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("mov"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Mov);
+
+        if is_mov {
+            if !self.video_codec_explicit {
+                self.video_codec = VideoCodec::H264;
+            }
+            if !self.audio_codec_explicit {
+                self.audio_codec = AudioCodec::Aac;
+            }
+        }
+
         self
     }
 
@@ -573,6 +611,81 @@ impl VideoEncoderBuilder {
                     container: "webm".to_string(),
                     codec: self.audio_codec.name().to_string(),
                     hint: "WebM supports VP9, AV1 (video) and Vorbis, Opus (audio)".to_string(),
+                });
+            }
+        }
+
+        // AVI container codec enforcement.
+        let is_avi = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("avi"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Avi);
+
+        if is_avi {
+            let avi_video_ok = matches!(self.video_codec, VideoCodec::H264 | VideoCodec::Mpeg4);
+            if !avi_video_ok {
+                return Err(EncodeError::UnsupportedContainerCodecCombination {
+                    container: "avi".to_string(),
+                    codec: self.video_codec.name().to_string(),
+                    hint: "AVI supports H264 and MPEG-4 (video); MP3, AAC, and PCM 16-bit (audio)"
+                        .to_string(),
+                });
+            }
+
+            let avi_audio_ok = matches!(
+                self.audio_codec,
+                AudioCodec::Mp3 | AudioCodec::Aac | AudioCodec::Pcm | AudioCodec::Pcm16
+            );
+            if !avi_audio_ok {
+                return Err(EncodeError::UnsupportedContainerCodecCombination {
+                    container: "avi".to_string(),
+                    codec: self.audio_codec.name().to_string(),
+                    hint: "AVI supports H264 and MPEG-4 (video); MP3, AAC, and PCM 16-bit (audio)"
+                        .to_string(),
+                });
+            }
+        }
+
+        // MOV container codec enforcement.
+        let is_mov = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("mov"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Mov);
+
+        if is_mov {
+            let mov_video_ok = matches!(
+                self.video_codec,
+                VideoCodec::H264 | VideoCodec::H265 | VideoCodec::ProRes
+            );
+            if !mov_video_ok {
+                return Err(EncodeError::UnsupportedContainerCodecCombination {
+                    container: "mov".to_string(),
+                    codec: self.video_codec.name().to_string(),
+                    hint: "MOV supports H264, H265, and ProRes (video); AAC and PCM (audio)"
+                        .to_string(),
+                });
+            }
+
+            let mov_audio_ok = matches!(
+                self.audio_codec,
+                AudioCodec::Aac | AudioCodec::Pcm | AudioCodec::Pcm16 | AudioCodec::Pcm24
+            );
+            if !mov_audio_ok {
+                return Err(EncodeError::UnsupportedContainerCodecCombination {
+                    container: "mov".to_string(),
+                    codec: self.audio_codec.name().to_string(),
+                    hint: "MOV supports H264, H265, and ProRes (video); AAC and PCM (audio)"
+                        .to_string(),
                 });
             }
         }
@@ -1204,6 +1317,144 @@ mod tests {
         assert!(!matches!(
             result,
             Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn avi_extension_without_explicit_codec_should_default_to_h264_mp3() {
+        let builder = VideoEncoder::create("output.avi").video(640, 480, 30.0);
+        let normalized = builder.apply_container_defaults();
+        assert_eq!(normalized.video_codec, VideoCodec::H264);
+        assert_eq!(normalized.audio_codec, AudioCodec::Mp3);
+    }
+
+    #[test]
+    fn mov_extension_without_explicit_codec_should_default_to_h264_aac() {
+        let builder = VideoEncoder::create("output.mov").video(640, 480, 30.0);
+        let normalized = builder.apply_container_defaults();
+        assert_eq!(normalized.video_codec, VideoCodec::H264);
+        assert_eq!(normalized.audio_codec, AudioCodec::Aac);
+    }
+
+    #[test]
+    fn avi_with_incompatible_video_codec_should_return_error() {
+        let result = VideoEncoder::create("output.avi")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Vp9)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn avi_with_incompatible_audio_codec_should_return_error() {
+        let result = VideoEncoder::create("output.avi")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H264)
+            .audio(48000, 2)
+            .audio_codec(AudioCodec::Opus)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn mov_with_incompatible_video_codec_should_return_error() {
+        let result = VideoEncoder::create("output.mov")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Vp9)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn mov_with_incompatible_audio_codec_should_return_error() {
+        let result = VideoEncoder::create("output.mov")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H264)
+            .audio(48000, 2)
+            .audio_codec(AudioCodec::Opus)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn avi_container_enum_with_incompatible_codec_should_return_error() {
+        let result = VideoEncoder::create("output.mp4")
+            .video(640, 480, 30.0)
+            .container(Container::Avi)
+            .video_codec(VideoCodec::Vp9)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn mov_container_enum_with_incompatible_codec_should_return_error() {
+        let result = VideoEncoder::create("output.mp4")
+            .video(640, 480, 30.0)
+            .container(Container::Mov)
+            .video_codec(VideoCodec::Vp9)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn avi_with_pcm_audio_should_pass_validation() {
+        // AudioCodec::Pcm (backward-compat alias for 16-bit PCM) must be accepted in AVI.
+        let result = VideoEncoder::create("output.avi")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H264)
+            .audio(48000, 2)
+            .audio_codec(AudioCodec::Pcm)
+            .build();
+        assert!(!matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn mov_with_pcm24_audio_should_pass_validation() {
+        let result = VideoEncoder::create("output.mov")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H264)
+            .audio(48000, 2)
+            .audio_codec(AudioCodec::Pcm24)
+            .build();
+        assert!(!matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn non_avi_mov_extension_should_not_enforce_avi_mov_codecs() {
+        // Vp9 on .webm should not trigger AVI/MOV validation
+        let result = VideoEncoder::create("output.webm")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Vp9)
+            .build();
+        assert!(!matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination {
+                ref container, ..
+            }) if container == "avi" || container == "mov"
         ));
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -18,9 +18,9 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC,
     AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
     AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS,
-    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS,
-    AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9, AVFormatContext, AVFrame,
-    AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
+    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PRORES,
+    AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9,
+    AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
     AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
     AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext, SwsContext, av_frame_alloc, av_frame_free,
@@ -1443,8 +1443,10 @@ impl VideoEncoderInner {
                 AudioCodec::Aac => 192_000,
                 AudioCodec::Opus => 128_000,
                 AudioCodec::Mp3 => 192_000,
-                AudioCodec::Flac => 0, // Lossless
-                AudioCodec::Pcm => 0,  // Uncompressed
+                AudioCodec::Flac => 0,  // Lossless
+                AudioCodec::Pcm => 0,   // Uncompressed
+                AudioCodec::Pcm16 => 0, // Uncompressed
+                AudioCodec::Pcm24 => 0, // Uncompressed
                 AudioCodec::Vorbis => 192_000,
                 AudioCodec::Ac3 => 192_000,
                 AudioCodec::Eac3 => 192_000,
@@ -1502,6 +1504,8 @@ impl VideoEncoderInner {
             AudioCodec::Mp3 => vec!["libmp3lame", "mp3"],
             AudioCodec::Flac => vec!["flac"],
             AudioCodec::Pcm => vec!["pcm_s16le"],
+            AudioCodec::Pcm16 => vec!["pcm_s16le"],
+            AudioCodec::Pcm24 => vec!["pcm_s24le"],
             AudioCodec::Vorbis => vec!["libvorbis", "vorbis"],
             AudioCodec::Ac3 => vec!["ac3"],
             AudioCodec::Eac3 => vec!["eac3"],
@@ -3178,6 +3182,8 @@ fn audio_codec_to_id(codec: AudioCodec) -> AVCodecID {
         AudioCodec::Mp3 => AVCodecID_AV_CODEC_ID_MP3,
         AudioCodec::Flac => AVCodecID_AV_CODEC_ID_FLAC,
         AudioCodec::Pcm => AVCodecID_AV_CODEC_ID_PCM_S16LE,
+        AudioCodec::Pcm16 => AVCodecID_AV_CODEC_ID_PCM_S16LE,
+        AudioCodec::Pcm24 => AVCodecID_AV_CODEC_ID_PCM_S24LE,
         AudioCodec::Vorbis => AVCodecID_AV_CODEC_ID_VORBIS,
         AudioCodec::Ac3 => AVCodecID_AV_CODEC_ID_AC3,
         AudioCodec::Eac3 => AVCodecID_AV_CODEC_ID_EAC3,

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -2124,3 +2124,177 @@ fn container_enum_webm_with_incompatible_codec_should_return_error() {
         Err(EncodeError::UnsupportedContainerCodecCombination { .. })
     ));
 }
+
+// ============================================================================
+// AVI Container Tests
+// ============================================================================
+
+#[test]
+fn avi_h264_mp3_should_produce_valid_output() {
+    let output_path = test_output_path("avi_h264_mp3.avi");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .preset(Preset::Ultrafast)
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Mp3)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping avi_h264_mp3 test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("avi_h264_mp3: codec={codec_name}");
+}
+
+#[test]
+fn avi_auto_default_codec_should_not_return_container_codec_error() {
+    let output_path = test_output_path("avi_auto_default.avi");
+    let _guard = FileGuard::new(output_path.clone());
+
+    // Without calling video_codec() or audio_codec(), .avi should auto-select H264+MP3.
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .build();
+
+    assert!(!matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn avi_with_incompatible_video_codec_should_return_error() {
+    let output_path = test_output_path("avi_vp9_error.avi");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Vp9)
+        .build();
+
+    assert!(matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn avi_with_incompatible_audio_codec_should_return_error() {
+    let output_path = test_output_path("avi_opus_error.avi");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Opus)
+        .build();
+
+    assert!(matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+// ============================================================================
+// MOV Container Tests
+// ============================================================================
+
+#[test]
+fn mov_h264_aac_should_produce_valid_output() {
+    let output_path = test_output_path("mov_h264_aac.mov");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))
+        .preset(Preset::Ultrafast)
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping mov_h264_aac test: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("Failed to push frame");
+    }
+
+    let codec_name = encoder.actual_video_codec().to_string();
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+    println!("mov_h264_aac: codec={codec_name}");
+}
+
+#[test]
+fn mov_auto_default_codec_should_not_return_container_codec_error() {
+    let output_path = test_output_path("mov_auto_default.mov");
+    let _guard = FileGuard::new(output_path.clone());
+
+    // Without calling video_codec() or audio_codec(), .mov should auto-select H264+AAC.
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .build();
+
+    assert!(!matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn mov_with_incompatible_video_codec_should_return_error() {
+    let output_path = test_output_path("mov_vp9_error.mov");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Vp9)
+        .build();
+
+    assert!(matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn mov_with_incompatible_audio_codec_should_return_error() {
+    let output_path = test_output_path("mov_opus_error.mov");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::H264)
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Opus)
+        .build();
+
+    assert!(matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}

--- a/crates/ff-format/src/codec.rs
+++ b/crates/ff-format/src/codec.rs
@@ -245,6 +245,10 @@ pub enum AudioCodec {
     Flac,
     /// PCM (Pulse Code Modulation) - uncompressed audio
     Pcm,
+    /// PCM signed 16-bit little-endian — uncompressed, explicit bit depth
+    Pcm16,
+    /// PCM signed 24-bit little-endian — uncompressed, professional audio
+    Pcm24,
     /// Vorbis - open lossy codec, used in Ogg containers
     Vorbis,
     /// AC3 (Dolby Digital) - surround sound codec
@@ -278,6 +282,8 @@ impl AudioCodec {
             Self::Opus => "opus",
             Self::Flac => "flac",
             Self::Pcm => "pcm",
+            Self::Pcm16 => "pcm_s16le",
+            Self::Pcm24 => "pcm_s24le",
             Self::Vorbis => "vorbis",
             Self::Ac3 => "ac3",
             Self::Eac3 => "eac3",
@@ -305,6 +311,8 @@ impl AudioCodec {
             Self::Opus => "Opus",
             Self::Flac => "FLAC",
             Self::Pcm => "PCM",
+            Self::Pcm16 => "PCM 16-bit",
+            Self::Pcm24 => "PCM 24-bit",
             Self::Vorbis => "Vorbis",
             Self::Ac3 => "Dolby Digital (AC-3)",
             Self::Eac3 => "Dolby Digital Plus (E-AC-3)",
@@ -351,7 +359,10 @@ impl AudioCodec {
     /// ```
     #[must_use]
     pub const fn is_lossless(&self) -> bool {
-        matches!(self, Self::Flac | Self::Pcm | Self::Alac)
+        matches!(
+            self,
+            Self::Flac | Self::Pcm | Self::Pcm16 | Self::Pcm24 | Self::Alac
+        )
     }
 
     /// Returns `true` if this is a surround sound codec.
@@ -791,6 +802,28 @@ mod tests {
             assert!(AudioCodec::Dts.is_surround());
             assert!(!AudioCodec::Aac.is_surround());
             assert!(!AudioCodec::Flac.is_surround());
+        }
+
+        #[test]
+        fn pcm16_name_should_return_pcm_s16le() {
+            assert_eq!(AudioCodec::Pcm16.name(), "pcm_s16le");
+        }
+
+        #[test]
+        fn pcm24_name_should_return_pcm_s24le() {
+            assert_eq!(AudioCodec::Pcm24.name(), "pcm_s24le");
+        }
+
+        #[test]
+        fn pcm16_should_be_lossless() {
+            assert!(AudioCodec::Pcm16.is_lossless());
+            assert!(!AudioCodec::Pcm16.is_lossy());
+        }
+
+        #[test]
+        fn pcm24_should_be_lossless() {
+            assert!(AudioCodec::Pcm24.is_lossless());
+            assert!(!AudioCodec::Pcm24.is_lossy());
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Extends the container codec validation pattern introduced in #209 (WebM) to cover `.avi` and `.mov` output paths. Adds `AudioCodec::Pcm16` (`pcm_s16le`) and `AudioCodec::Pcm24` (`pcm_s24le`) to `ff-format` alongside the existing `Pcm` variant, which is preserved for backwards compatibility. When the output path ends in `.avi` or `.mov` (or the matching `Container` enum is set), the builder auto-selects default codecs and rejects incompatible ones with `EncodeError::UnsupportedContainerCodecCombination`.

## Changes

- `ff-format/src/codec.rs`: added `AudioCodec::Pcm16` (→ `pcm_s16le`) and `AudioCodec::Pcm24` (→ `pcm_s24le`); updated `name()`, `display_name()`, `is_lossless()`; 4 new unit tests
- `ff-encode/src/video/encoder_inner.rs` + `audio/encoder_inner.rs`: wired `Pcm16`/`Pcm24` into codec ID mapping, encoder selection, and default bitrate; added `AVCodecID_AV_CODEC_ID_PCM_S24LE` import
- `ff-encode/src/video/builder.rs`: `apply_container_defaults()` sets H264+MP3 for AVI, H264+AAC for MOV when no codec explicitly chosen; `validate()` enforces AVI (H264/MPEG4 video; MP3/AAC/PCM audio) and MOV (H264/H265/ProRes video; AAC/PCM audio) allowlists; 11 new unit tests
- `ff-encode/tests/video_encoder_tests.rs`: 8 new integration tests covering AVI and MOV encode, auto-default behavior, and incompatible codec rejection

## Related Issues

Closes #210

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes