### PR TITLE
feat(ff-encode,ff-format): add FLAC and OGG audio container support

### DIFF
--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -35,6 +35,7 @@ pub struct AudioEncoderBuilder {
     pub(crate) audio_codec: AudioCodec,
     pub(crate) audio_bitrate: Option<u64>,
     pub(crate) codec_options: Option<AudioCodecOptions>,
+    pub(crate) audio_codec_explicit: bool,
 }
 
 impl AudioEncoderBuilder {
@@ -47,6 +48,7 @@ impl AudioEncoderBuilder {
             audio_codec: AudioCodec::default(),
             audio_bitrate: None,
             codec_options: None,
+            audio_codec_explicit: false,
         }
     }
 
@@ -62,6 +64,7 @@ impl AudioEncoderBuilder {
     #[must_use]
     pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
         self.audio_codec = codec;
+        self.audio_codec_explicit = true;
         self
     }
 
@@ -87,6 +90,34 @@ impl AudioEncoderBuilder {
     pub fn codec_options(mut self, opts: AudioCodecOptions) -> Self {
         self.codec_options = Some(opts);
         self
+    }
+
+    fn apply_container_defaults(&mut self) {
+        let is_flac = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("flac"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Flac);
+        if is_flac && !self.audio_codec_explicit {
+            self.audio_codec = AudioCodec::Flac;
+        }
+
+        let is_ogg = self
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("ogg"))
+            || self
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Ogg);
+        if is_ogg && !self.audio_codec_explicit {
+            self.audio_codec = AudioCodec::Vorbis;
+        }
     }
 
     /// Validate builder state and open the output file.
@@ -130,7 +161,45 @@ impl AudioEncoder {
         AudioEncoderBuilder::new(path.as_ref().to_path_buf())
     }
 
-    pub(crate) fn from_builder(builder: AudioEncoderBuilder) -> Result<Self, EncodeError> {
+    pub(crate) fn from_builder(mut builder: AudioEncoderBuilder) -> Result<Self, EncodeError> {
+        builder.apply_container_defaults();
+
+        // Enforce FLAC container codec allowlist.
+        let is_flac = builder
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("flac"))
+            || builder
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Flac);
+        if is_flac && !matches!(builder.audio_codec, AudioCodec::Flac) {
+            return Err(EncodeError::UnsupportedContainerCodecCombination {
+                container: "flac".to_string(),
+                codec: builder.audio_codec.name().to_string(),
+                hint: "FLAC container only supports the FLAC codec".to_string(),
+            });
+        }
+
+        // Enforce OGG container codec allowlist.
+        let is_ogg = builder
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("ogg"))
+            || builder
+                .container
+                .as_ref()
+                .is_some_and(|c| *c == Container::Ogg);
+        if is_ogg && !matches!(builder.audio_codec, AudioCodec::Vorbis | AudioCodec::Opus) {
+            return Err(EncodeError::UnsupportedContainerCodecCombination {
+                container: "ogg".to_string(),
+                codec: builder.audio_codec.name().to_string(),
+                hint: "OGG container supports Vorbis and Opus".to_string(),
+            });
+        }
+
         // Validate per-codec options before constructing the inner encoder.
         if let Some(AudioCodecOptions::Opus(ref opts)) = builder.codec_options
             && let Some(dur) = opts.frame_duration_ms
@@ -265,5 +334,113 @@ mod tests {
     fn build_without_sample_rate_should_return_error() {
         let result = AudioEncoder::create("output.m4a").build();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn flac_extension_without_explicit_codec_should_default_to_flac() {
+        let builder = AudioEncoder::create("output.flac").audio(44100, 2);
+        let mut b = builder;
+        b.apply_container_defaults();
+        assert_eq!(b.audio_codec, AudioCodec::Flac);
+    }
+
+    #[test]
+    fn ogg_extension_without_explicit_codec_should_default_to_vorbis() {
+        let builder = AudioEncoder::create("output.ogg").audio(44100, 2);
+        let mut b = builder;
+        b.apply_container_defaults();
+        assert_eq!(b.audio_codec, AudioCodec::Vorbis);
+    }
+
+    #[test]
+    fn flac_extension_with_explicit_codec_should_not_override() {
+        let builder = AudioEncoder::create("output.flac")
+            .audio(44100, 2)
+            .audio_codec(AudioCodec::Flac);
+        let mut b = builder;
+        b.apply_container_defaults();
+        assert_eq!(b.audio_codec, AudioCodec::Flac);
+    }
+
+    #[test]
+    fn flac_container_enum_without_explicit_codec_should_default_to_flac() {
+        let builder = AudioEncoder::create("output.audio")
+            .audio(44100, 2)
+            .container(Container::Flac);
+        let mut b = builder;
+        b.apply_container_defaults();
+        assert_eq!(b.audio_codec, AudioCodec::Flac);
+    }
+
+    #[test]
+    fn ogg_container_enum_without_explicit_codec_should_default_to_vorbis() {
+        let builder = AudioEncoder::create("output.audio")
+            .audio(44100, 2)
+            .container(Container::Ogg);
+        let mut b = builder;
+        b.apply_container_defaults();
+        assert_eq!(b.audio_codec, AudioCodec::Vorbis);
+    }
+
+    #[test]
+    fn flac_extension_with_incompatible_codec_should_return_error() {
+        let result = AudioEncoder::create("output.flac")
+            .audio(44100, 2)
+            .audio_codec(AudioCodec::Mp3)
+            .build();
+        assert!(
+            matches!(
+                result,
+                Err(EncodeError::UnsupportedContainerCodecCombination {
+                    ref container,
+                    ..
+                }) if container == "flac"
+            ),
+            "expected UnsupportedContainerCodecCombination for flac"
+        );
+    }
+
+    #[test]
+    fn ogg_extension_with_incompatible_codec_should_return_error() {
+        let result = AudioEncoder::create("output.ogg")
+            .audio(44100, 2)
+            .audio_codec(AudioCodec::Mp3)
+            .build();
+        assert!(
+            matches!(
+                result,
+                Err(EncodeError::UnsupportedContainerCodecCombination {
+                    ref container,
+                    ..
+                }) if container == "ogg"
+            ),
+            "expected UnsupportedContainerCodecCombination for ogg"
+        );
+    }
+
+    #[test]
+    fn ogg_with_opus_should_pass_validation() {
+        // Opus is a valid OGG codec — validation should not reject it.
+        // (build() will fail due to missing sample-rate check, but not with
+        // UnsupportedContainerCodecCombination.)
+        let result = AudioEncoder::create("output.ogg")
+            .audio_codec(AudioCodec::Opus)
+            .build();
+        assert!(!matches!(
+            result,
+            Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn non_flac_ogg_extension_should_not_enforce_container_codecs() {
+        // A plain .mp3 path should not trigger FLAC/OGG enforcement.
+        let result = AudioEncoder::create("output.mp3")
+            .audio_codec(AudioCodec::Flac)
+            .build();
+        assert!(!matches!(
+            result,
+            Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
     }
 }

--- a/crates/ff-encode/src/container.rs
+++ b/crates/ff-encode/src/container.rs
@@ -21,6 +21,12 @@ pub enum Container {
 
     /// MOV
     Mov,
+
+    /// FLAC (lossless audio container)
+    Flac,
+
+    /// OGG (audio container for Vorbis/Opus)
+    Ogg,
 }
 
 impl Container {
@@ -33,6 +39,8 @@ impl Container {
             Self::Mkv => "matroska",
             Self::Avi => "avi",
             Self::Mov => "mov",
+            Self::Flac => "flac",
+            Self::Ogg => "ogg",
         }
     }
 
@@ -45,6 +53,8 @@ impl Container {
             Self::Mkv => "mkv",
             Self::Avi => "avi",
             Self::Mov => "mov",
+            Self::Flac => "flac",
+            Self::Ogg => "ogg",
         }
     }
 }
@@ -65,5 +75,17 @@ mod tests {
         assert_eq!(Container::Mp4.default_extension(), "mp4");
         assert_eq!(Container::WebM.default_extension(), "webm");
         assert_eq!(Container::Mkv.default_extension(), "mkv");
+        assert_eq!(Container::Flac.default_extension(), "flac");
+        assert_eq!(Container::Ogg.default_extension(), "ogg");
+    }
+
+    #[test]
+    fn flac_as_str_should_return_flac() {
+        assert_eq!(Container::Flac.as_str(), "flac");
+    }
+
+    #[test]
+    fn ogg_as_str_should_return_ogg() {
+        assert_eq!(Container::Ogg.as_str(), "ogg");
     }
 }

--- a/crates/ff-encode/tests/audio_encoder_tests.rs
+++ b/crates/ff-encode/tests/audio_encoder_tests.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use ff_decode::AudioDecoder;
 use ff_encode::{
-    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioEncoder, EncodeError, FlacOptions,
-    Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
+    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioEncoder, Container, EncodeError,
+    FlacOptions, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
 };
 use ff_format::{AudioFrame, SampleFormat};
 
@@ -616,4 +616,177 @@ fn flac_level_0_should_produce_larger_file_than_level_12() {
         size_0 >= size_12,
         "expected level 0 file ({size_0} bytes) to be >= level 12 file ({size_12} bytes)"
     );
+}
+
+// ── FLAC Container Tests ──────────────────────────────────────────────────────
+
+#[test]
+fn flac_auto_default_codec_should_not_return_container_codec_error() {
+    // No explicit audio_codec — builder should auto-select FLAC.
+    // Omit .audio() so build() fails with InvalidConfig (missing sample rate),
+    // not UnsupportedContainerCodecCombination.
+    let result = AudioEncoder::create("output.flac").build();
+    assert!(!matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn flac_with_incompatible_codec_should_return_error() {
+    let result = AudioEncoder::create("output.flac")
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Mp3)
+        .build();
+    assert!(
+        matches!(
+            result,
+            Err(EncodeError::UnsupportedContainerCodecCombination {
+                ref container, ..
+            }) if container == "flac"
+        ),
+        "expected UnsupportedContainerCodecCombination for flac container"
+    );
+}
+
+#[test]
+fn flac_container_enum_with_incompatible_codec_should_return_error() {
+    let result = AudioEncoder::create("output.audio")
+        .audio(44100, 2)
+        .container(Container::Flac)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+    assert!(
+        matches!(
+            result,
+            Err(EncodeError::UnsupportedContainerCodecCombination {
+                ref container, ..
+            }) if container == "flac"
+        ),
+        "expected UnsupportedContainerCodecCombination for flac container enum"
+    );
+}
+
+#[test]
+fn flac_flac_codec_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("flac_container_test.flac"));
+
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Flac)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(4096, 2, 44100, SampleFormat::F32p).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+// ── OGG Container Tests ───────────────────────────────────────────────────────
+
+#[test]
+fn ogg_auto_default_codec_should_not_return_container_codec_error() {
+    // No explicit audio_codec — builder should auto-select Vorbis.
+    // Omit .audio() so build() fails with InvalidConfig (missing sample rate),
+    // not UnsupportedContainerCodecCombination.
+    let result = AudioEncoder::create("output.ogg").build();
+    assert!(!matches!(
+        result,
+        Err(EncodeError::UnsupportedContainerCodecCombination { .. })
+    ));
+}
+
+#[test]
+fn ogg_with_incompatible_codec_should_return_error() {
+    let result = AudioEncoder::create("output.ogg")
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Mp3)
+        .build();
+    assert!(
+        matches!(
+            result,
+            Err(EncodeError::UnsupportedContainerCodecCombination {
+                ref container, ..
+            }) if container == "ogg"
+        ),
+        "expected UnsupportedContainerCodecCombination for ogg container"
+    );
+}
+
+#[test]
+fn ogg_container_enum_with_incompatible_codec_should_return_error() {
+    let result = AudioEncoder::create("output.audio")
+        .audio(44100, 2)
+        .container(Container::Ogg)
+        .audio_codec(AudioCodec::Flac)
+        .build();
+    assert!(
+        matches!(
+            result,
+            Err(EncodeError::UnsupportedContainerCodecCombination {
+                ref container, ..
+            }) if container == "ogg"
+        ),
+        "expected UnsupportedContainerCodecCombination for ogg container enum"
+    );
+}
+
+#[test]
+fn ogg_vorbis_codec_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("ogg_vorbis_container_test.ogg"));
+
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(44100, 2)
+        .audio_codec(AudioCodec::Vorbis)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(4096, 2, 44100, SampleFormat::F32p).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
+}
+
+#[test]
+fn ogg_opus_codec_should_produce_valid_output() {
+    let output = FileGuard::new(test_output_path("ogg_opus_container_test.ogg"));
+
+    let mut encoder = match AudioEncoder::create(output.path())
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Opus)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..10 {
+        let frame = AudioFrame::empty(960, 2, 48000, SampleFormat::F32).unwrap();
+        encoder.push(&frame).expect("Failed to push audio frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(output.path());
 }


### PR DESCRIPTION
## Summary

Adds FLAC and OGG as first-class standalone audio container targets in `AudioEncoderBuilder`. The builder auto-selects `AudioCodec::Flac` for `.flac` output and `AudioCodec::Vorbis` for `.ogg` output when no codec is explicitly set. Incompatible codec/container combinations are rejected with `UnsupportedContainerCodecCombination`, consistent with the pattern established for WebM, AVI, and MOV.

## Changes

- `Container::Flac` and `Container::Ogg`: added `default_extension()` arms (`"flac"` / `"ogg"`) and new unit tests
- `AudioEncoderBuilder`: added `audio_codec_explicit: bool` field; `audio_codec()` setter sets it `true`; new `apply_container_defaults()` auto-selects FLAC for `.flac`/`Container::Flac` and Vorbis for `.ogg`/`Container::Ogg`
- `AudioEncoder::from_builder()`: calls `apply_container_defaults()` then enforces FLAC-only and OGG (Vorbis/Opus) allowlists before opening the output file
- 9 new unit tests in `audio/builder.rs` covering default selection, explicit-codec preservation, enum-based detection, and rejection paths
- 9 new integration tests in `audio_encoder_tests.rs` covering valid encoding (`flac`, `ogg` with Vorbis and Opus) and incompatible codec rejection

## Related Issues

Closes #211

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes