### PR TITLE
feat(ff-decode,ff-sys): image sequence decode via image2 demuxer

### DIFF
--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -140,6 +140,8 @@ pub struct VideoDecoderBuilder {
     thread_count: usize,
     /// Optional frame pool for memory reuse
     frame_pool: Option<Arc<dyn FramePool>>,
+    /// Frame rate override for image sequences (default 25 fps when path contains `%`).
+    frame_rate: Option<u32>,
 }
 
 impl VideoDecoderBuilder {
@@ -154,6 +156,7 @@ impl VideoDecoderBuilder {
             hardware_accel: HardwareAccel::Auto,
             thread_count: 0,
             frame_pool: None,
+            frame_rate: None,
         }
     }
 
@@ -354,6 +357,26 @@ impl VideoDecoderBuilder {
         self
     }
 
+    /// Sets the frame rate for image sequence decoding.
+    ///
+    /// Only used when the path contains `%` (e.g. `"frames/frame%04d.png"`).
+    /// Defaults to 25 fps when not set.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_decode::VideoDecoder;
+    ///
+    /// let decoder = VideoDecoder::open("frames/frame%04d.png")?
+    ///     .frame_rate(30)
+    ///     .build()?;
+    /// ```
+    #[must_use]
+    pub fn frame_rate(mut self, fps: u32) -> Self {
+        self.frame_rate = Some(fps);
+        self
+    }
+
     /// Sets a frame pool for memory reuse.
     ///
     /// Using a frame pool can significantly reduce allocation overhead
@@ -468,8 +491,9 @@ impl VideoDecoderBuilder {
             }
         }
 
-        // Verify the file exists
-        if !self.path.exists() {
+        // Image-sequence patterns contain '%' — the literal path does not exist.
+        let is_image_sequence = self.path.to_str().is_some_and(|s| s.contains('%'));
+        if !is_image_sequence && !self.path.exists() {
             return Err(DecodeError::FileNotFound {
                 path: self.path.clone(),
             });
@@ -490,6 +514,7 @@ impl VideoDecoderBuilder {
             self.output_scale,
             self.hardware_accel,
             self.thread_count,
+            self.frame_rate,
             self.frame_pool.clone(),
         )?;
 

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -83,6 +83,27 @@ impl AvFormatContextGuard {
         std::mem::forget(self);
         ptr
     }
+
+    /// Opens an image sequence using the `image2` demuxer.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure FFmpeg is initialized and path is valid.
+    unsafe fn new_image_sequence(path: &Path, framerate: u32) -> Result<Self, DecodeError> {
+        // SAFETY: Caller ensures FFmpeg is initialized and path is a valid image-sequence pattern
+        let format_ctx = unsafe {
+            ff_sys::avformat::open_input_image_sequence(path, framerate).map_err(|e| {
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "Failed to open image sequence: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                }
+            })?
+        };
+        Ok(Self(format_ctx))
+    }
 }
 
 impl Drop for AvFormatContextGuard {
@@ -512,14 +533,24 @@ impl VideoDecoderInner {
         output_scale: Option<OutputScale>,
         hardware_accel: HardwareAccel,
         thread_count: usize,
+        frame_rate: Option<u32>,
         frame_pool: Option<Arc<dyn FramePool>>,
     ) -> Result<(Self, VideoStreamInfo, ContainerInfo), DecodeError> {
         // Ensure FFmpeg is initialized (thread-safe and idempotent)
         ff_sys::ensure_initialized();
 
-        // Open the input file (with RAII guard)
+        // Open the input file (with RAII guard).
+        // Image-sequence patterns contain '%'; use the image2 demuxer in that case.
+        let is_image_sequence = path.to_str().is_some_and(|s| s.contains('%'));
         // SAFETY: Path is valid, AvFormatContextGuard ensures cleanup
-        let format_ctx_guard = unsafe { AvFormatContextGuard::new(path)? };
+        let format_ctx_guard = unsafe {
+            if is_image_sequence {
+                let fps = frame_rate.unwrap_or(25);
+                AvFormatContextGuard::new_image_sequence(path, fps)?
+            } else {
+                AvFormatContextGuard::new(path)?
+            }
+        };
         let format_ctx = format_ctx_guard.as_ptr();
 
         // Read stream information

--- a/crates/ff-decode/tests/image_sequence_tests.rs
+++ b/crates/ff-decode/tests/image_sequence_tests.rs
@@ -1,0 +1,176 @@
+//! Integration tests for image-sequence decoding via the `image2` demuxer.
+
+use std::path::{Path, PathBuf};
+
+use ff_decode::{HardwareAccel, VideoDecoder};
+
+mod fixtures;
+use fixtures::assets_dir;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// RAII guard that deletes a directory tree on drop.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(name: &str) -> Self {
+        let dir = std::env::temp_dir().join(name);
+        std::fs::create_dir_all(&dir).expect("failed to create temp dir");
+        Self(dir)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Returns the path to the test PNG image.
+fn test_png_path() -> PathBuf {
+    assets_dir().join("img/hello-triangle.png")
+}
+
+/// Returns the path to the test JPEG image.
+fn test_jpeg_path() -> PathBuf {
+    assets_dir().join("img/hello-triangle.jpg")
+}
+
+/// Creates a numbered image sequence in `dir` by copying `src` `count` times.
+///
+/// Files are named `frame0001.ext`, `frame0002.ext`, …
+/// Returns the printf-style pattern path (e.g. `dir/frame%04d.png`).
+fn make_image_sequence(dir: &Path, src: &Path, count: usize) -> PathBuf {
+    let ext = src.extension().and_then(|e| e.to_str()).unwrap_or("png");
+    for i in 1..=count {
+        let dst = dir.join(format!("frame{i:04}.{ext}"));
+        std::fs::copy(src, &dst).expect("failed to copy image file");
+    }
+    dir.join(format!("frame%04d.{ext}"))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn image_sequence_png_should_decode_all_frames() {
+    let tmp = TempDir::new("ff_decode_img_seq_png");
+    let pattern = make_image_sequence(tmp.path(), &test_png_path(), 3);
+
+    let mut decoder = match VideoDecoder::open(&pattern)
+        .hardware_accel(HardwareAccel::None)
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let mut count = 0usize;
+    loop {
+        match decoder.decode_one() {
+            Ok(Some(_)) => count += 1,
+            Ok(None) => break,
+            Err(e) => panic!("decode error: {e}"),
+        }
+    }
+
+    assert_eq!(count, 3, "expected 3 frames from a 3-image PNG sequence");
+}
+
+#[test]
+fn image_sequence_with_frame_rate_override_should_succeed() {
+    let tmp = TempDir::new("ff_decode_img_seq_fps");
+    let pattern = make_image_sequence(tmp.path(), &test_png_path(), 2);
+
+    let mut decoder = match VideoDecoder::open(&pattern)
+        .hardware_accel(HardwareAccel::None)
+        .frame_rate(30)
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let mut count = 0usize;
+    loop {
+        match decoder.decode_one() {
+            Ok(Some(_)) => count += 1,
+            Ok(None) => break,
+            Err(e) => panic!("decode error: {e}"),
+        }
+    }
+
+    assert_eq!(
+        count, 2,
+        "expected 2 frames from a 2-image sequence at 30 fps"
+    );
+}
+
+#[test]
+fn image_sequence_jpeg_should_decode_successfully() {
+    let tmp = TempDir::new("ff_decode_img_seq_jpg");
+    let pattern = make_image_sequence(tmp.path(), &test_jpeg_path(), 2);
+
+    let mut decoder = match VideoDecoder::open(&pattern)
+        .hardware_accel(HardwareAccel::None)
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let mut count = 0usize;
+    loop {
+        match decoder.decode_one() {
+            Ok(Some(_)) => count += 1,
+            Ok(None) => break,
+            Err(e) => panic!("decode error: {e}"),
+        }
+    }
+
+    assert_eq!(count, 2, "expected 2 frames from a 2-image JPEG sequence");
+}
+
+#[test]
+fn non_sequence_path_should_open_normally() {
+    // Regression guard: a regular video path (no '%') must still work.
+    let video_path = assets_dir().join("video/gameplay.mp4");
+    let result = VideoDecoder::open(&video_path)
+        .hardware_accel(HardwareAccel::None)
+        .build();
+    // If the test asset is present the decoder opens successfully.
+    // FileNotFound is also acceptable if the asset is missing.
+    match result {
+        Ok(_) => {}
+        Err(ff_decode::DecodeError::FileNotFound { .. }) => {}
+        Err(e) => panic!("unexpected error for regular video path: {e}"),
+    }
+}
+
+#[test]
+fn image_sequence_missing_files_should_return_error() {
+    // Pattern points to a directory that contains no matching files.
+    let tmp = TempDir::new("ff_decode_img_seq_empty");
+    let pattern = tmp.path().join("frame%04d.png");
+
+    let result = VideoDecoder::open(&pattern)
+        .hardware_accel(HardwareAccel::None)
+        .build();
+
+    assert!(
+        result.is_err(),
+        "expected an error when no matching files exist for the pattern"
+    );
+}

--- a/crates/ff-sys/src/avformat.rs
+++ b/crates/ff-sys/src/avformat.rs
@@ -156,6 +156,66 @@ pub unsafe fn open_input(path: &Path) -> Result<*mut AVFormatContext, c_int> {
     Ok(ctx)
 }
 
+/// Open an image sequence using the `image2` demuxer.
+///
+/// Sets `framerate` in the demuxer options so FFmpeg assigns the correct PTS
+/// to each frame. The returned pointer must be freed using [`close_input()`].
+///
+/// # Errors
+///
+/// Returns a negative error code if the path is invalid, the sequence cannot
+/// be opened, or the `image2` demuxer is unavailable.
+///
+/// # Safety
+///
+/// The caller must call `close_input()` on the returned context when done.
+pub unsafe fn open_input_image_sequence(
+    path: &Path,
+    framerate: u32,
+) -> Result<*mut AVFormatContext, c_int> {
+    ensure_initialized();
+
+    let path_str = match path.to_str() {
+        Some(s) => s,
+        None => return Err(crate::error_codes::EINVAL),
+    };
+    let c_path = match CString::new(path_str) {
+        Ok(s) => s,
+        Err(_) => return Err(crate::error_codes::EINVAL),
+    };
+
+    // Locate the image2 demuxer.  Always present in standard FFmpeg builds;
+    // passing null falls back to FFmpeg's auto-detection from file extension.
+    // SAFETY: string literal has no null bytes
+    let image2_name = CString::new("image2").unwrap();
+    let input_fmt = crate::av_find_input_format(image2_name.as_ptr());
+
+    // Build options dictionary: framerate=<n>
+    let mut opts: *mut crate::AVDictionary = ptr::null_mut();
+    // SAFETY: string literals have no null bytes
+    let framerate_key = CString::new("framerate").unwrap();
+    let framerate_str = CString::new(framerate.to_string()).unwrap();
+    crate::av_dict_set(
+        ptr::addr_of_mut!(opts),
+        framerate_key.as_ptr(),
+        framerate_str.as_ptr(),
+        0,
+    );
+
+    let mut ctx: *mut AVFormatContext = ptr::null_mut();
+    let ret = ffi_avformat_open_input(&mut ctx, c_path.as_ptr(), input_fmt, &mut opts);
+
+    // Free any options that FFmpeg did not consume.
+    if !opts.is_null() {
+        crate::av_dict_free(ptr::addr_of_mut!(opts));
+    }
+
+    if ret < 0 {
+        return Err(ret);
+    }
+    Ok(ctx)
+}
+
 /// Close an opened media file and free its resources.
 ///
 /// This function closes the input file, frees the format context and all its

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -376,6 +376,12 @@ pub unsafe fn av_dict_set(
     0
 }
 
+pub unsafe fn av_dict_free(_m: *mut *mut AVDictionary) {}
+
+pub unsafe fn av_find_input_format(_short_name: *const c_char) -> *const AVInputFormat {
+    std::ptr::null()
+}
+
 pub unsafe fn avcodec_get_name(_id: AVCodecID) -> *const c_char {
     std::ptr::null()
 }
@@ -643,6 +649,13 @@ pub mod avformat {
     use super::{AVFormatContext, AVIOContext, AVPacket};
 
     pub unsafe fn open_input(_path: &Path) -> Result<*mut AVFormatContext, c_int> {
+        Err(-1)
+    }
+
+    pub unsafe fn open_input_image_sequence(
+        _path: &Path,
+        _framerate: u32,
+    ) -> Result<*mut AVFormatContext, c_int> {
         Err(-1)
     }
 


### PR DESCRIPTION
## Summary

Adds image sequence decoding to `VideoDecoder` using FFmpeg's `image2` demuxer. When the path passed to `VideoDecoder::open()` contains a `%` character (e.g. `frames/frame%04d.png`), the decoder automatically selects the `image2` demuxer with a default 25 fps frame rate. An optional `frame_rate()` setter on `VideoDecoderBuilder` allows overriding the rate. No new public API types are needed — the existing builder and decoder API just work.

## Changes

- `ff-sys/src/avformat.rs`: Added `open_input_image_sequence(path, framerate)` — calls `av_find_input_format("image2")`, sets `framerate` in an `AVDictionary`, and opens the input with `avformat_open_input`
- `ff-sys/src/docsrs_stubs.rs`: Added `av_find_input_format`, `av_dict_free` top-level stubs; added `open_input_image_sequence` to the `avformat` module stub
- `ff-decode/src/video/builder.rs`: Added `frame_rate: Option<u32>` field and `frame_rate()` setter; the file-existence check now skips paths containing `%` (sequence patterns don't have a literal on-disk match)
- `ff-decode/src/video/decoder_inner.rs`: Added `frame_rate: Option<u32>` parameter to `new()`; added `AvFormatContextGuard::new_image_sequence()`; branches on `%` in path to use the image2 open path
- `ff-decode/tests/image_sequence_tests.rs`: 5 new integration tests — PNG sequence (3 frames), frame-rate override (30 fps), JPEG sequence, regression guard for regular video paths, error on empty directory

## Related Issues

Closes #212

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes