### PR TITLE
feat(ff-encode,ff-format): add image sequence encode via image2 muxer

### DIFF
--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -461,6 +461,22 @@ impl VideoEncoderBuilder {
             }
         }
 
+        // Image-sequence paths contain '%' (e.g. "frames/frame%04d.png").
+        // Auto-select codec from the extension that follows the pattern.
+        let is_image_sequence = self.path.to_str().is_some_and(|s| s.contains('%'));
+        if is_image_sequence && !self.video_codec_explicit {
+            let ext = self
+                .path
+                .to_str()
+                .and_then(|s| s.rfind('.').map(|i| &s[i + 1..]))
+                .unwrap_or("");
+            if ext.eq_ignore_ascii_case("png") {
+                self.video_codec = VideoCodec::Png;
+            } else if ext.eq_ignore_ascii_case("jpg") || ext.eq_ignore_ascii_case("jpeg") {
+                self.video_codec = VideoCodec::Mjpeg;
+            }
+        }
+
         self
     }
 
@@ -490,16 +506,27 @@ impl VideoEncoderBuilder {
             }
         }
 
+        // Image-sequence paths (containing '%') do not support audio streams.
+        let is_image_sequence = self.path.to_str().is_some_and(|s| s.contains('%'));
+        if is_image_sequence && has_audio {
+            return Err(EncodeError::InvalidConfig {
+                reason: "Image sequence output does not support audio streams".to_string(),
+            });
+        }
+
+        // PNG supports odd dimensions; all other codecs require even width/height.
+        let requires_even_dims = !matches!(self.video_codec, VideoCodec::Png);
+
         if has_video {
             if let Some(width) = self.video_width
-                && (width == 0 || width % 2 != 0)
+                && (width == 0 || (requires_even_dims && width % 2 != 0))
             {
                 return Err(EncodeError::InvalidConfig {
                     reason: format!("Video width must be non-zero and even, got {width}"),
                 });
             }
             if let Some(height) = self.video_height
-                && (height == 0 || height % 2 != 0)
+                && (height == 0 || (requires_even_dims && height % 2 != 0))
             {
                 return Err(EncodeError::InvalidConfig {
                     reason: format!("Video height must be non-zero and even, got {height}"),

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -18,10 +18,10 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC,
     AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
     AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS,
-    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PRORES,
-    AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9,
-    AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
-    AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG,
+    AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8,
+    AVCodecID_AV_CODEC_ID_VP9, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_SUBTITLE,
+    AVPacket, AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
     AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext, SwsContext, av_frame_alloc, av_frame_free,
     av_interleaved_write_frame, av_mallocz, av_packet_alloc, av_packet_free,
@@ -881,11 +881,20 @@ impl VideoEncoderInner {
                 path: config.path.clone(),
             })?;
 
+            // For image-sequence outputs (path contains '%'), use the `image2`
+            // muxer explicitly. The `image2` muxer manages I/O internally
+            // (AVFMT_NOFILE), so we must not call avio_open on it.
+            let is_image_sequence = config.path.to_str().is_some_and(|s| s.contains('%'));
+
             let mut format_ctx: *mut AVFormatContext = ptr::null_mut();
             let ret = avformat_alloc_output_context2(
                 &mut format_ctx,
                 ptr::null_mut(),
-                ptr::null(),
+                if is_image_sequence {
+                    b"image2\0".as_ptr() as *const i8
+                } else {
+                    ptr::null()
+                },
                 c_path.as_ptr(),
             );
 
@@ -974,17 +983,21 @@ impl VideoEncoderInner {
 
             // For two-pass encoding the output file is opened in run_pass2() after
             // pass-1 statistics have been collected.  Single-pass opens it now.
+            // Image-sequence output (path contains '%') uses the `image2` muxer which
+            // manages I/O internally (AVFMT_NOFILE) — skip avio_open in that case.
             if !config.two_pass {
-                match ff_sys::avformat::open_output(
-                    &config.path,
-                    ff_sys::avformat::avio_flags::WRITE,
-                ) {
-                    Ok(pb) => (*format_ctx).pb = pb,
-                    Err(_) => {
-                        encoder.cleanup();
-                        return Err(EncodeError::CannotCreateFile {
-                            path: config.path.clone(),
-                        });
+                if !is_image_sequence {
+                    match ff_sys::avformat::open_output(
+                        &config.path,
+                        ff_sys::avformat::avio_flags::WRITE,
+                    ) {
+                        Ok(pb) => (*format_ctx).pb = pb,
+                        Err(_) => {
+                            encoder.cleanup();
+                            return Err(EncodeError::CannotCreateFile {
+                                path: config.path.clone(),
+                            });
+                        }
                     }
                 }
 
@@ -1259,6 +1272,7 @@ impl VideoEncoderInner {
             VideoCodec::Vp8 => vec!["libvpx"],
             VideoCodec::Mpeg2 => vec!["mpeg2video"],
             VideoCodec::Mjpeg => vec!["mjpeg"],
+            VideoCodec::Png => vec!["png"],
             _ => vec![],
         };
 
@@ -3157,6 +3171,7 @@ fn codec_to_id(codec: VideoCodec) -> AVCodecID {
         VideoCodec::Vp8 => AVCodecID_AV_CODEC_ID_VP8,
         VideoCodec::Mpeg2 => AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
         VideoCodec::Mjpeg => AVCodecID_AV_CODEC_ID_MJPEG,
+        VideoCodec::Png => AVCodecID_AV_CODEC_ID_PNG,
         _ => AVCodecID_AV_CODEC_ID_NONE,
     }
 }

--- a/crates/ff-encode/tests/image_sequence_encoder_tests.rs
+++ b/crates/ff-encode/tests/image_sequence_encoder_tests.rs
@@ -1,0 +1,207 @@
+//! Integration tests for image-sequence encoding via the `image2` muxer.
+
+mod fixtures;
+
+use ff_encode::{VideoCodec, VideoEncoder};
+use fixtures::{create_black_frame, test_output_dir};
+use std::path::{Path, PathBuf};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// RAII guard that deletes a directory tree on drop.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(name: &str) -> Self {
+        let dir = test_output_dir().join(name);
+        std::fs::create_dir_all(&dir).expect("failed to create temp dir");
+        Self(dir)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn image_sequence_png_should_encode_all_frames() {
+    let tmp = TempDir::new("img_seq_enc_png");
+    let pattern = tmp.path().join("frame%04d.png");
+
+    let mut encoder = match VideoEncoder::create(&pattern)
+        .video(64, 64, 25.0)
+        .video_codec(VideoCodec::Png)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..3 {
+        let frame = create_black_frame(64, 64);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: {e}");
+        return;
+    }
+
+    // Three PNG files should have been produced.
+    for i in 1..=3u32 {
+        let file = tmp.path().join(format!("frame{i:04}.png"));
+        assert!(file.exists(), "expected {file:?} to exist");
+    }
+}
+
+#[test]
+fn image_sequence_jpeg_should_encode_all_frames() {
+    let tmp = TempDir::new("img_seq_enc_jpg");
+    let pattern = tmp.path().join("frame%04d.jpg");
+
+    let mut encoder = match VideoEncoder::create(&pattern)
+        .video(64, 64, 25.0)
+        .video_codec(VideoCodec::Mjpeg)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    for _ in 0..2 {
+        let frame = create_black_frame(64, 64);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: {e}");
+        return;
+    }
+
+    for i in 1..=2u32 {
+        let file = tmp.path().join(format!("frame{i:04}.jpg"));
+        assert!(file.exists(), "expected {file:?} to exist");
+    }
+}
+
+#[test]
+fn image_sequence_png_auto_codec_from_extension_should_work() {
+    // No explicit .video_codec() — the builder should auto-select Png from ".png".
+    let tmp = TempDir::new("img_seq_enc_auto_png");
+    let pattern = tmp.path().join("frame%04d.png");
+
+    let mut encoder = match VideoEncoder::create(&pattern).video(64, 64, 25.0).build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    if let Err(e) = encoder.push_video(&frame) {
+        println!("Skipping: {e}");
+        return;
+    }
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: {e}");
+        return;
+    }
+
+    assert!(
+        tmp.path().join("frame0001.png").exists(),
+        "expected frame0001.png to exist"
+    );
+}
+
+#[test]
+fn image_sequence_jpeg_auto_codec_from_extension_should_work() {
+    // No explicit .video_codec() — the builder should auto-select Mjpeg from ".jpg".
+    let tmp = TempDir::new("img_seq_enc_auto_jpg");
+    let pattern = tmp.path().join("frame%04d.jpg");
+
+    let mut encoder = match VideoEncoder::create(&pattern).video(64, 64, 25.0).build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let frame = create_black_frame(64, 64);
+    if let Err(e) = encoder.push_video(&frame) {
+        println!("Skipping: {e}");
+        return;
+    }
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: {e}");
+        return;
+    }
+
+    assert!(
+        tmp.path().join("frame0001.jpg").exists(),
+        "expected frame0001.jpg to exist"
+    );
+}
+
+#[test]
+fn image_sequence_with_audio_should_return_error() {
+    // Audio streams are not supported in image-sequence output.
+    let tmp = TempDir::new("img_seq_enc_audio_err");
+    let pattern = tmp.path().join("frame%04d.png");
+
+    let result = VideoEncoder::create(&pattern)
+        .video(64, 64, 25.0)
+        .audio(44100, 2)
+        .video_codec(VideoCodec::Png)
+        .build();
+
+    assert!(
+        result.is_err(),
+        "expected an error when audio is configured for image-sequence output"
+    );
+}
+
+#[test]
+fn non_sequence_path_should_not_be_affected() {
+    // Regression guard: a regular .mp4 path must not be treated as an image sequence.
+    let tmp = TempDir::new("img_seq_enc_regression");
+    let output = tmp.path().join("output.mp4");
+
+    let result = VideoEncoder::create(&output)
+        .video(64, 64, 25.0)
+        .video_codec(VideoCodec::H264)
+        .build();
+
+    // Either succeeds or fails with an encoder error — but not with
+    // InvalidConfig about image sequences.
+    match result {
+        Ok(_) => {}
+        Err(ff_encode::EncodeError::InvalidConfig { ref reason })
+            if reason.contains("image sequence") =>
+        {
+            panic!("regular path incorrectly treated as image sequence: {reason}");
+        }
+        Err(_) => {}
+    }
+}

--- a/crates/ff-format/src/codec.rs
+++ b/crates/ff-format/src/codec.rs
@@ -59,6 +59,8 @@ pub enum VideoCodec {
     Mpeg2,
     /// MJPEG - Motion JPEG, used by some cameras
     Mjpeg,
+    /// PNG - lossless image codec, used for image sequence output
+    Png,
     /// Unknown or unsupported codec
     Unknown,
 }
@@ -87,6 +89,7 @@ impl VideoCodec {
             Self::Mpeg4 => "mpeg4",
             Self::Mpeg2 => "mpeg2video",
             Self::Mjpeg => "mjpeg",
+            Self::Png => "png",
             Self::Unknown => "unknown",
         }
     }
@@ -115,6 +118,7 @@ impl VideoCodec {
             Self::Mpeg4 => "MPEG-4 Part 2",
             Self::Mpeg2 => "MPEG-2",
             Self::Mjpeg => "Motion JPEG",
+            Self::Png => "PNG",
             Self::Unknown => "Unknown",
         }
     }


### PR DESCRIPTION
## Summary

Adds image sequence encoding to `VideoEncoder`: when the output path contains `%` (e.g. `frame%04d.png`), the encoder automatically uses FFmpeg's `image2` muxer, which writes one numbered file per frame. A new `VideoCodec::Png` variant is added to `ff-format` for lossless PNG output; MJPEG sequences are already supported via the existing `VideoCodec::Mjpeg`.

## Changes

- **`ff-format/src/codec.rs`**: Add `VideoCodec::Png` with `name() = "png"` and `display_name() = "PNG"`
- **`ff-encode/src/video/builder.rs`**:
  - `apply_container_defaults()` detects `%` in path and auto-selects `VideoCodec::Png` for `.png` extension, `VideoCodec::Mjpeg` for `.jpg`/`.jpeg`
  - `validate()` rejects audio streams on image-sequence paths (image2 muxer produces no container for audio)
  - Even-dimension requirement is relaxed for `VideoCodec::Png`
- **`ff-encode/src/video/encoder_inner.rs`**:
  - Wire `VideoCodec::Png` → `AVCodecID_AV_CODEC_ID_PNG` and encoder candidate `"png"`
  - Detect `%` in path → pass `"image2"` as the format name to `avformat_alloc_output_context2`
  - Skip `avio_open` for image-sequence paths (`image2` has `AVFMT_NOFILE` and manages per-frame I/O internally)
- **`crates/ff-encode/tests/image_sequence_encoder_tests.rs`**: 6 new integration tests covering PNG sequence, JPEG sequence, auto-codec from extension, audio rejection, and regression guard for regular video paths

## Related Issues

Closes #213

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes