### PR TITLE
feat(avio): add v0.7.0 example programs for advanced codec and HDR APIs

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -189,6 +189,26 @@ required-features = ["tokio"]
 name = "async_transcode"
 required-features = ["tokio"]
 
+[[example]]
+name = "codec_options"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "audio_codec_options"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "professional_formats"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "hdr10_encode"
+required-features = ["decode", "encode"]
+
+[[example]]
+name = "image_sequence"
+required-features = ["decode", "encode"]
+
 [dev-dependencies]
 futures = { workspace = true }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/avio/examples/audio_codec_options.rs
+++ b/crates/avio/examples/audio_codec_options.rs
@@ -1,0 +1,224 @@
+//! Encode audio with per-codec options via `AudioCodecOptions`.
+//!
+//! Demonstrates the `AudioCodecOptions` enum and the codec-specific option
+//! structs added in v0.7.0:
+//!
+//! - `OpusOptions` — application mode (`Voip` / `Audio` / `LowDelay`), bitrate,
+//!   frame duration
+//! - `AacOptions` — profile (`LC` / `HE` / `HEv2`), VBR quality mode
+//! - `Mp3Options` — VBR quality (`V0`–`V9`) or fixed bitrate
+//! - `FlacOptions` — compression level (`0` = fastest / largest …
+//!   `12` = slowest / smallest)
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example audio_codec_options --features "decode encode" -- \
+//!   --input   input.mp3   \
+//!   --output  output.opus  \
+//!   --codec   opus          # opus | aac | mp3 | flac  (default: opus)
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{
+    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioDecoder, AudioEncoder, FlacOptions,
+    Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
+};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut codec_str = "opus".to_string();
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--codec" | "-c" => codec_str = args.next().unwrap_or_else(|| "opus".to_string()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: audio_codec_options --input <file> --output <file> \
+             [--codec opus|aac|mp3|flac]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match AudioDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+    let sample_rate = probe.sample_rate();
+    let channels = probe.channels();
+    drop(probe);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}  {sample_rate} Hz  {channels} ch");
+
+    // ── Select codec + AudioCodecOptions ─────────────────────────────────────
+    //
+    // AudioCodecOptions is the v0.7.0 API for per-codec audio configuration.
+    // Each variant holds a typed options struct specific to that codec.
+
+    let (audio_codec, codec_options, bitrate, description) = match codec_str.to_lowercase().as_str()
+    {
+        "opus" => {
+            // OpusOptions: application mode controls the psychoacoustic model.
+            //   Audio    — general music and voice (default)
+            //   Voip     — optimised for low-latency voice
+            //   LowDelay — minimal algorithmic delay
+            let opts = OpusOptions {
+                application: OpusApplication::Audio,
+                frame_duration_ms: Some(20),
+            };
+            (
+                AudioCodec::Opus,
+                AudioCodecOptions::Opus(opts),
+                128_000u64,
+                "Opus, Audio application, 128 kbps, 20 ms frames",
+            )
+        }
+        "aac" => {
+            // AacOptions: profile selects the AAC variant.
+            //   Lc   — Low Complexity, compatible with all devices (default)
+            //   He   — HE-AAC v1 (SBR) — better quality at low bitrates
+            //   Hev2 — HE-AAC v2 (SBR + PS) — stereo only, very low bitrates
+            let opts = AacOptions {
+                profile: AacProfile::Lc,
+                vbr_quality: None, // None = CBR at the specified bitrate
+            };
+            (
+                AudioCodec::Aac,
+                AudioCodecOptions::Aac(opts),
+                192_000u64,
+                "AAC-LC, CBR 192 kbps",
+            )
+        }
+        "mp3" => {
+            // Mp3Options: VBR quality scale 0 (best) … 9 (smallest).
+            // Vbr(2) corresponds to libmp3lame -V2, ~190 kbps average.
+            // Use Mp3Quality::Cbr(bitrate) for a fixed bitrate instead.
+            let opts = Mp3Options {
+                quality: Mp3Quality::Vbr(2), // ~190 kbps average
+            };
+            (
+                AudioCodec::Mp3,
+                AudioCodecOptions::Mp3(opts),
+                0u64, // irrelevant in VBR mode
+                "MP3, VBR quality V2 (~190 kbps average)",
+            )
+        }
+        "flac" => {
+            // FlacOptions: compression level 0 (fastest encode, largest file)
+            // through 12 (slowest encode, smallest lossless file).
+            // Default is 5 — a good balance for most use cases.
+            let opts = FlacOptions {
+                compression_level: 6,
+            };
+            (
+                AudioCodec::Flac,
+                AudioCodecOptions::Flac(opts),
+                0u64, // lossless — bitrate is determined by content
+                "FLAC, compression level 6",
+            )
+        }
+        other => {
+            eprintln!("Unknown codec '{other}' (try opus, aac, mp3, flac)");
+            process::exit(1);
+        }
+    };
+
+    println!("Codec:  {description}");
+    println!("Output: {out_name}");
+    println!();
+
+    // ── Build encoder ─────────────────────────────────────────────────────────
+    //
+    // .codec_options() applies the per-codec option struct.
+    // .audio_bitrate() sets the target bitrate (ignored by lossless codecs and
+    // VBR-quality modes such as Mp3Quality::V2).
+
+    let mut encoder = match AudioEncoder::create(&output)
+        .audio(sample_rate, channels)
+        .audio_codec(audio_codec)
+        .audio_bitrate(bitrate)
+        .codec_options(codec_options)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Decode + encode loop ──────────────────────────────────────────────────
+
+    let mut decoder = match AudioDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut chunks: u64 = 0;
+
+    loop {
+        let chunk = match decoder.decode_one() {
+            Ok(Some(c)) => c,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push(&chunk) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        chunks += 1;
+    }
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let kb = std::fs::metadata(&output).map_or(0, |m| m.len()) as f64 / 1024.0;
+    let size_str = if kb < 1024.0 {
+        format!("{kb:.0} KB")
+    } else {
+        format!("{:.1} MB", kb / 1024.0)
+    };
+
+    println!("Done. {out_name}  {size_str}  {chunks} audio chunks");
+}

--- a/crates/avio/examples/codec_options.rs
+++ b/crates/avio/examples/codec_options.rs
@@ -1,0 +1,244 @@
+//! Encode video with per-codec options via `VideoCodecOptions`.
+//!
+//! Demonstrates the `VideoCodecOptions` enum and the codec-specific option
+//! structs added in v0.7.0:
+//!
+//! - `H264Options` — profile (`baseline` / `main` / `high` / `high10`), level,
+//!   B-frames, GOP, refs, and libx264 `preset` / `tune`
+//! - `H265Options` — profile (`main` / `main10`), tier, libx265 `preset`
+//! - `Av1Options` — `cpu_used` (0 = best, 8 = fastest), tile layout, usage
+//! - `Vp9Options` — `cpu_used`, constrained-quality (`cq_level`), tile layout
+//!
+//! All options are applied via `av_opt_set` / direct field assignment before
+//! `avcodec_open2`.  Unsupported options are logged as warnings and skipped —
+//! `build()` never fails because of an unsupported option value.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example codec_options --features "decode encode" -- \
+//!   --input   input.mp4   \
+//!   --output  output.mp4  \
+//!   --codec   h264        # h264 | h265 | av1 | vp9  (default: h264)
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{
+    Av1Options, Av1Usage, BitrateMode, H264Options, H264Preset, H264Profile, H265Options,
+    H265Profile, PixelFormat, VideoCodec, VideoCodecOptions, VideoDecoder, VideoEncoder,
+    Vp9Options,
+};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut codec_str = "h264".to_string();
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--codec" | "-c" => codec_str = args.next().unwrap_or_else(|| "h264".to_string()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: codec_options --input <file> --output <file> \
+             [--codec h264|h265|av1|vp9]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+    let width = probe.width();
+    let height = probe.height();
+    let fps = probe.frame_rate();
+    drop(probe);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}  {width}×{height}  {fps:.2} fps");
+
+    // ── Select codec + VideoCodecOptions ─────────────────────────────────────
+    //
+    // VideoCodecOptions is the main v0.7.0 API for per-codec configuration.
+    // Each variant holds a typed options struct specific to that codec.
+
+    let (video_codec, codec_options, pixel_format, description) =
+        match codec_str.to_lowercase().as_str() {
+            "h264" => {
+                // H264Options: profile, level, B-frames, GOP size, reference frames,
+                // libx264 preset and tune.
+                let opts = H264Options {
+                    profile: H264Profile::High,
+                    level: Some(41), // 4.1 — supports 1080p30
+                    bframes: 2,
+                    gop_size: 250,
+                    refs: 3,
+                    preset: Some(H264Preset::Fast),
+                    tune: None,
+                };
+                (
+                    VideoCodec::H264,
+                    VideoCodecOptions::H264(opts),
+                    None,
+                    "H.264 High@4.1, fast preset, 2 B-frames",
+                )
+            }
+            "h265" => {
+                // H265Options: profile (Main or Main10), tier, libx265 preset.
+                // Main10 with yuv420p10le enables 10-bit HDR-capable output.
+                let opts = H265Options {
+                    profile: H265Profile::Main10,
+                    preset: Some("fast".to_string()),
+                    ..H265Options::default()
+                };
+                (
+                    VideoCodec::H265,
+                    VideoCodecOptions::H265(opts),
+                    Some(PixelFormat::Yuv420p10le),
+                    "H.265 Main10 (10-bit), fast preset",
+                )
+            }
+            "av1" => {
+                // Av1Options: cpu_used (0=slowest/best, 8=fastest/lowest),
+                // tile layout for parallelism, and usage mode.
+                let opts = Av1Options {
+                    cpu_used: 6,  // balanced speed/quality
+                    tile_rows: 1, // 2^1 = 2 tile rows
+                    tile_cols: 1, // 2^1 = 2 tile columns
+                    usage: Av1Usage::VoD,
+                };
+                (
+                    VideoCodec::Av1,
+                    VideoCodecOptions::Av1(opts),
+                    None,
+                    "AV1 (libaom), cpu_used=6, 2×2 tiles, VoD mode",
+                )
+            }
+            "vp9" => {
+                // Vp9Options: cpu_used, constrained-quality mode (cq_level),
+                // and tile configuration.
+                let opts = Vp9Options {
+                    cpu_used: 4,
+                    cq_level: Some(33), // CQ mode: quality-governed VBR
+                    tile_columns: 1,
+                    tile_rows: 0,
+                    row_mt: true,
+                };
+                (
+                    VideoCodec::Vp9,
+                    VideoCodecOptions::Vp9(opts),
+                    None,
+                    "VP9 (libvpx-vp9), cpu_used=4, CQ=33, row-MT enabled",
+                )
+            }
+            other => {
+                eprintln!("Unknown codec '{other}' (try h264, h265, av1, vp9)");
+                process::exit(1);
+            }
+        };
+
+    println!("Codec:  {description}");
+    println!("Output: {out_name}");
+    println!();
+
+    // ── Build encoder ─────────────────────────────────────────────────────────
+    //
+    // .codec_options() applies the per-codec option struct.
+    // .pixel_format() overrides the default pixel format when needed (e.g. 10-bit).
+
+    let mut enc_builder = VideoEncoder::create(&output)
+        .video(width, height, fps)
+        .video_codec(video_codec)
+        .bitrate_mode(BitrateMode::Crf(26))
+        .codec_options(codec_options);
+
+    if let Some(fmt) = pixel_format {
+        enc_builder = enc_builder.pixel_format(fmt);
+    }
+
+    let mut encoder = match enc_builder.build() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!(
+        "Encoder opened: actual_codec={}",
+        encoder.actual_video_codec()
+    );
+
+    // ── Decode + encode loop ──────────────────────────────────────────────────
+
+    let mut decoder = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push_video(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let kb = std::fs::metadata(&output).map_or(0, |m| m.len()) as f64 / 1024.0;
+    let size_str = if kb < 1024.0 {
+        format!("{kb:.0} KB")
+    } else {
+        format!("{:.1} MB", kb / 1024.0)
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+}

--- a/crates/avio/examples/hdr10_encode.rs
+++ b/crates/avio/examples/hdr10_encode.rs
@@ -1,0 +1,242 @@
+//! Embed HDR10 static metadata and HLG colour transfer tags when encoding.
+//!
+//! Demonstrates the HDR and colour-tagging APIs added in v0.7.0:
+//!
+//! - `Hdr10Metadata` — `MaxCLL` + `MaxFALL` + mastering display (SMPTE ST 2086)
+//! - `MasteringDisplay` — chromaticity coordinates (×50000) + luminance (×10000)
+//! - `VideoEncoderBuilder::hdr10_metadata()` — attach HDR10 side data to key-
+//!   frame packets (`AV_PKT_DATA_CONTENT_LIGHT_LEVEL` +
+//!   `AV_PKT_DATA_MASTERING_DISPLAY_METADATA`)
+//! - `VideoEncoderBuilder::color_transfer()` — override the OETF tag
+//!   (`ColorTransfer::Pq` for HDR10, `ColorTransfer::Hlg` for HLG broadcast)
+//! - `VideoEncoderBuilder::color_space()` / `color_primaries()` — BT.2020 tags
+//!
+//! Setting `hdr10_metadata()` automatically applies BT.2020 primaries, PQ
+//! transfer, and BT.2020 NCL colour matrix to the codec context.
+//! Use `color_transfer(ColorTransfer::Hlg)` instead to tag HLG content without
+//! MaxCLL/MaxFALL side data.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example hdr10_encode --features "decode encode" -- \
+//!   --input    input.mp4     \
+//!   --output   output.mkv    \
+//!   [--max-cll  1000]        # MaxCLL in nits  (default: 1000)
+//!   [--max-fall 400]         # MaxFALL in nits (default: 400)
+//!   [--hlg]                  # tag HLG transfer instead of HDR10
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{
+    BitrateMode, ColorPrimaries, ColorSpace, ColorTransfer, H265Options, H265Profile,
+    Hdr10Metadata, MasteringDisplay, PixelFormat, Preset, VideoCodec, VideoCodecOptions,
+    VideoDecoder, VideoEncoder,
+};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut max_cll: u16 = 1000;
+    let mut max_fall: u16 = 400;
+    let mut hlg = false;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--max-cll" => {
+                let v = args.next().unwrap_or_default();
+                max_cll = v.parse().unwrap_or(1000);
+            }
+            "--max-fall" => {
+                let v = args.next().unwrap_or_default();
+                max_fall = v.parse().unwrap_or(400);
+            }
+            "--hlg" => hlg = true,
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: hdr10_encode --input <file> --output <file> \
+             [--max-cll N] [--max-fall N] [--hlg]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+    let width = probe.width();
+    let height = probe.height();
+    let fps = probe.frame_rate();
+    drop(probe);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}  {width}×{height}  {fps:.2} fps");
+
+    // ── Build encoder with HDR metadata ──────────────────────────────────────
+
+    let mut enc_builder = VideoEncoder::create(&output)
+        .video(width, height, fps)
+        .video_codec(VideoCodec::H265)
+        .bitrate_mode(BitrateMode::Crf(22))
+        .preset(Preset::Fast)
+        // yuv420p10le is the canonical 10-bit pixel format for HDR content.
+        .pixel_format(PixelFormat::Yuv420p10le)
+        .codec_options(VideoCodecOptions::H265(H265Options {
+            profile: H265Profile::Main10,
+            ..H265Options::default()
+        }));
+
+    if hlg {
+        // ── HLG (Hybrid Log-Gamma) colour tags ───────────────────────────────
+        //
+        // HLG is a broadcast-compatible HDR standard (ARIB STD-B67 / BT.2100).
+        // It does not use MaxCLL/MaxFALL side data — instead the OETF tag on
+        // the stream signals the display how to render the content.
+        //
+        // .color_transfer()  sets the OETF (ColorTransfer::Hlg).
+        // .color_space()     sets the matrix coefficients (BT.2020 NCL).
+        // .color_primaries() sets the chromaticity primaries (BT.2020).
+        println!("Mode:   HLG colour tags (no MaxCLL/MaxFALL side data)");
+        enc_builder = enc_builder
+            .color_transfer(ColorTransfer::Hlg)
+            .color_space(ColorSpace::Bt2020)
+            .color_primaries(ColorPrimaries::Bt2020);
+    } else {
+        // ── HDR10 static metadata ─────────────────────────────────────────────
+        //
+        // Hdr10Metadata combines:
+        //   max_cll   — Maximum Content Light Level (nits)
+        //   max_fall  — Maximum Frame-Average Light Level (nits)
+        //   mastering_display — SMPTE ST 2086 mastering display colour volume
+        //
+        // MasteringDisplay chromaticity coordinates use a denominator of 50000
+        // (value = n / 50000 in CIE 1931 xy).  The BT.2020 primaries below are
+        // the standard values for reference HDR monitors.
+        //
+        // Luminance uses a denominator of 10000 nits:
+        //   min_luminance = 50   → 0.005 nit (deep black)
+        //   max_luminance = 10_000_000 → 1000 nit peak
+        //
+        // hdr10_metadata() also automatically sets:
+        //   color_primaries = BT.2020
+        //   color_trc       = SMPTE ST 2084 (PQ)
+        //   colorspace      = BT.2020 NCL
+        println!("Mode:   HDR10  MaxCLL={max_cll} nits  MaxFALL={max_fall} nits");
+        let meta = Hdr10Metadata {
+            max_cll,
+            max_fall,
+            mastering_display: MasteringDisplay {
+                // BT.2020 D65 primaries (×50000)
+                red_x: 17000,
+                red_y: 8500,
+                green_x: 13250,
+                green_y: 34500,
+                blue_x: 7500,
+                blue_y: 3000,
+                // D65 white point (×50000)
+                white_x: 15635,
+                white_y: 16450,
+                // Luminance (×10000 nits)
+                min_luminance: 50,
+                max_luminance: 10_000_000,
+            },
+        };
+        enc_builder = enc_builder.hdr10_metadata(meta);
+    }
+
+    println!("Codec:  H.265 Main10, yuv420p10le");
+    println!("Output: {out_name}");
+    println!();
+
+    let mut encoder = match enc_builder.build() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!(
+        "Encoder opened: actual_codec={}",
+        encoder.actual_video_codec()
+    );
+    println!("Encoding...");
+
+    // ── Decode + encode loop ──────────────────────────────────────────────────
+
+    let mut decoder = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push_video(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let kb = std::fs::metadata(&output).map_or(0, |m| m.len()) as f64 / 1024.0;
+    let size_str = if kb < 1024.0 {
+        format!("{kb:.0} KB")
+    } else {
+        format!("{:.1} MB", kb / 1024.0)
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+    if !hlg {
+        println!(
+            "Verify with: ffprobe -show_streams {out_name} | grep -E 'max_content|max_average'"
+        );
+    }
+}

--- a/crates/avio/examples/image_sequence.rs
+++ b/crates/avio/examples/image_sequence.rs
@@ -1,0 +1,272 @@
+//! Decode an image sequence to video, or extract video frames to an image sequence.
+//!
+//! Demonstrates the image-sequence support added in v0.7.0:
+//!
+//! **Decode mode** (`--decode`): a printf-style pattern such as
+//! `frames/frame%04d.png` is opened with the `image2` demuxer and decoded
+//! frame-by-frame.  An optional `--fps` override sets the frame rate assigned
+//! to each image (default: 25).
+//!
+//! **Encode mode** (`--encode`): a printf-style output pattern such as
+//! `output/frame%04d.png` selects the `image2` muxer automatically.  Each
+//! video frame is written as a separate file.  Supported extensions:
+//! `.png`, `.jpg` / `.jpeg`.
+//!
+//! The `%` character in the path is what triggers the image-sequence path in
+//! `VideoDecoder` / `VideoEncoder`.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Assemble PNGs into a video
+//! cargo run --example image_sequence --features "decode encode" -- \
+//!   --decode "frames/frame%04d.png" \
+//!   --output output.mp4 \
+//!   [--fps 25]
+//!
+//! # Extract video frames to PNGs
+//! cargo run --example image_sequence --features "decode encode" -- \
+//!   --encode input.mp4 \
+//!   --output "frames/frame%04d.png"
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{HardwareAccel, VideoCodec, VideoDecoder, VideoEncoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut decode_pattern = None::<String>;
+    let mut encode_input = None::<String>;
+    let mut output = None::<String>;
+    let mut fps: u32 = 25;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--decode" => decode_pattern = Some(args.next().unwrap_or_default()),
+            "--encode" => encode_input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--fps" => {
+                let v = args.next().unwrap_or_default();
+                fps = v.parse().unwrap_or(25);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let output = output.unwrap_or_else(|| {
+        eprintln!(
+            "Usage:\n\
+             Decode: image_sequence --decode \"frame%04d.png\" --output video.mp4 [--fps 25]\n\
+             Encode: image_sequence --encode input.mp4 --output \"frame%04d.png\""
+        );
+        process::exit(1);
+    });
+
+    match (decode_pattern, encode_input) {
+        (Some(pattern), None) => decode_sequence(&pattern, &output, fps),
+        (None, Some(input)) => encode_sequence(&input, &output),
+        _ => {
+            eprintln!("Provide exactly one of --decode <pattern> or --encode <input>");
+            process::exit(1);
+        }
+    }
+}
+
+// ── Decode mode: image sequence → video ──────────────────────────────────────
+
+fn decode_sequence(pattern: &str, output: &str, fps: u32) {
+    let out_name = Path::new(output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(output);
+
+    println!("Decode: image sequence pattern='{pattern}'  fps={fps}");
+    println!("Output: {out_name}");
+    println!();
+
+    // VideoDecoder::open() detects the `%` in the path and uses the `image2`
+    // demuxer automatically.  .frame_rate() overrides the default 25 fps.
+    //
+    // .hardware_accel(HardwareAccel::None) avoids hardware decoder selection
+    // for still-image formats, which is rarely supported.
+    let mut decoder = match VideoDecoder::open(pattern)
+        .hardware_accel(HardwareAccel::None)
+        .frame_rate(fps)
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening image sequence: {e}");
+            process::exit(1);
+        }
+    };
+
+    let width = decoder.width();
+    let height = decoder.height();
+    let actual_fps = decoder.frame_rate();
+
+    println!("Sequence: {width}×{height}  actual_fps={actual_fps:.2}");
+
+    // Encode decoded frames to a video file.
+    let mut encoder = match VideoEncoder::create(output)
+        .video(width, height, actual_fps)
+        .video_codec(VideoCodec::H264)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building video encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error at frame {frames}: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push_video(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let kb = std::fs::metadata(output).map_or(0, |m| m.len()) as f64 / 1024.0;
+    let size_str = if kb < 1024.0 {
+        format!("{kb:.0} KB")
+    } else {
+        format!("{:.1} MB", kb / 1024.0)
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames assembled");
+}
+
+// ── Encode mode: video → image sequence ──────────────────────────────────────
+
+fn encode_sequence(input: &str, pattern: &str) {
+    let in_name = Path::new(input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(input);
+
+    println!("Encode: {in_name} → image sequence pattern='{pattern}'");
+    println!();
+
+    // Ensure the output directory exists.
+    if let Some(parent) = Path::new(pattern)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).unwrap_or_else(|e| {
+            eprintln!("Cannot create output directory '{}': {e}", parent.display());
+            process::exit(1);
+        });
+    }
+
+    // Probe the source to get dimensions and frame rate.
+    let probe = match VideoDecoder::open(input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+    let width = probe.width();
+    let height = probe.height();
+    let fps = probe.frame_rate();
+    drop(probe);
+
+    println!("Source: {width}×{height}  {fps:.2} fps");
+
+    // VideoEncoder::create() detects `%` in the output path and uses the
+    // `image2` muxer.  The codec is selected automatically from the extension:
+    //   .png  → VideoCodec::Png
+    //   .jpg  → VideoCodec::Mjpeg
+    //
+    // Explicitly setting the codec avoids ambiguity.
+    let ext = Path::new(pattern)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    let codec = match ext.as_str() {
+        "png" => VideoCodec::Png,
+        "jpg" | "jpeg" => VideoCodec::Mjpeg,
+        other => {
+            eprintln!("Unsupported image extension '.{other}' (try .png or .jpg)");
+            process::exit(1);
+        }
+    };
+
+    let mut encoder = match VideoEncoder::create(pattern)
+        .video(width, height, fps)
+        .video_codec(codec)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building image encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut decoder = match VideoDecoder::open(input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error at frame {frames}: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push_video(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    println!("Done. {frames} frames written to '{pattern}'");
+    println!(
+        "Files: {}  through  {}",
+        pattern.replace("%04d", &format!("{:04}", 1)),
+        pattern.replace("%04d", &format!("{:04}", frames))
+    );
+}

--- a/crates/avio/examples/professional_formats.rs
+++ b/crates/avio/examples/professional_formats.rs
@@ -1,0 +1,238 @@
+//! Encode video to Apple `ProRes` or Avid `DNxHD`/`DNxHR` professional formats.
+//!
+//! Demonstrates:
+//! - `ProResOptions` + `ProResProfile` — 422 Proxy / LT / Standard / HQ / 4444 / 4444 XQ
+//! - `DnxhdOptions` + `DnxhdVariant` — legacy `DNxHD` (fixed bitrate, 1920×1080) and
+//!   resolution-agnostic `DNxHR` (LB / SQ / HQ / HQX / R444)
+//! - Pixel format requirements:
+//!   - `ProRes` 422 profiles → `yuv422p10le`
+//!   - `ProRes` 4444 profiles → `yuva444p10le`
+//!   - `DNxHD` / `DNxHR` 8-bit profiles → `yuv422p`
+//!   - `DNxHD` 220x / `DNxHR` HQX → `yuv422p10le`
+//!
+//! Both codecs skip gracefully when the required encoder (`prores_ks` or
+//! `dnxhd`) is absent from the `FFmpeg` build.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example professional_formats --features "decode encode" -- \
+//!   --input   input.mp4       \
+//!   --output  output.mov      \
+//!   --codec   prores          # prores | dnxhd  (default: prores)
+//!   [--profile hq]            # ProRes: proxy|lt|standard|hq|4444|4444xq
+//!                             # DNxHD:  dnxhd115|dnxhd145|dnxhd220|dnxhr_sq|dnxhr_hq|...
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{
+    DnxhdOptions, DnxhdVariant, ProResOptions, ProResProfile, VideoCodec, VideoCodecOptions,
+    VideoDecoder, VideoEncoder,
+};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut codec_str = "prores".to_string();
+    let mut profile_str = "hq".to_string();
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--codec" | "-c" => codec_str = args.next().unwrap_or_else(|| "prores".to_string()),
+            "--profile" => profile_str = args.next().unwrap_or_else(|| "hq".to_string()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: professional_formats --input <file> --output <file> \
+             [--codec prores|dnxhd] [--profile <profile>]\n\
+             ProRes profiles: proxy | lt | standard | hq | 4444 | 4444xq\n\
+             DNxHD profiles:  dnxhd115 | dnxhd145 | dnxhd220 | dnxhd220x |\n\
+                              dnxhr_lb | dnxhr_sq | dnxhr_hq | dnxhr_hqx | dnxhr_444"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Probe source ──────────────────────────────────────────────────────────
+
+    let probe = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening input: {e}");
+            process::exit(1);
+        }
+    };
+    let width = probe.width();
+    let height = probe.height();
+    let fps = probe.frame_rate();
+    drop(probe);
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+    let out_name = Path::new(&output)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&output);
+
+    println!("Input:  {in_name}  {width}×{height}  {fps:.2} fps");
+
+    // ── Select codec + VideoCodecOptions ─────────────────────────────────────
+
+    let (video_codec, codec_options, description) = match codec_str.to_lowercase().as_str() {
+        "prores" => {
+            // ProResProfile controls quality and chroma sampling:
+            //   Proxy    (0) — lowest bitrate, offline editing
+            //   Lt       (1) — lightweight proxy
+            //   Standard (2) — production quality (default)
+            //   Hq       (3) — high quality, mastering
+            //   P4444    (4) — full chroma, supports alpha
+            //   P4444Xq  (5) — maximum quality 4444
+            //
+            // 422 profiles store yuv422p10le; 4444 profiles store yuva444p10le.
+            let profile = match profile_str.to_lowercase().as_str() {
+                "proxy" => ProResProfile::Proxy,
+                "lt" => ProResProfile::Lt,
+                "standard" => ProResProfile::Standard,
+                "hq" => ProResProfile::Hq,
+                "4444" => ProResProfile::P4444,
+                "4444xq" => ProResProfile::P4444Xq,
+                other => {
+                    eprintln!(
+                        "Unknown ProRes profile '{other}' \
+                         (try proxy, lt, standard, hq, 4444, 4444xq)"
+                    );
+                    process::exit(1);
+                }
+            };
+            let desc = format!("Apple ProRes {profile:?}");
+            let opts = ProResOptions {
+                profile,
+                vendor: None,
+            };
+            (VideoCodec::ProRes, VideoCodecOptions::ProRes(opts), desc)
+        }
+
+        "dnxhd" => {
+            // DnxhdVariant: legacy DNxHD variants (Dnxhd*) require 1920×1080 or
+            // 1280×720 and apply a fixed bitrate automatically.
+            // DNxHR variants (Dnxhr*) work at any resolution.
+            let variant = match profile_str.to_lowercase().as_str() {
+                "dnxhd115" => DnxhdVariant::Dnxhd115,
+                "dnxhd145" => DnxhdVariant::Dnxhd145,
+                "dnxhd220" => DnxhdVariant::Dnxhd220,
+                "dnxhd220x" => DnxhdVariant::Dnxhd220x,
+                "dnxhr_lb" => DnxhdVariant::DnxhrLb,
+                "dnxhr_sq" | "sq" => DnxhdVariant::DnxhrSq,
+                "dnxhr_hq" | "hq" => DnxhdVariant::DnxhrHq,
+                "dnxhr_hqx" | "hqx" => DnxhdVariant::DnxhrHqx,
+                "dnxhr_444" | "444" => DnxhdVariant::DnxhrR444,
+                other => {
+                    eprintln!(
+                        "Unknown DNxHD profile '{other}' \
+                         (try dnxhd115, dnxhd145, dnxhd220, dnxhr_sq, dnxhr_hq, …)"
+                    );
+                    process::exit(1);
+                }
+            };
+            let desc = format!("Avid DNxHD/HR {variant:?}");
+            (
+                VideoCodec::DnxHd,
+                VideoCodecOptions::Dnxhd(DnxhdOptions { variant }),
+                desc,
+            )
+        }
+
+        other => {
+            eprintln!("Unknown codec '{other}' (try prores, dnxhd)");
+            process::exit(1);
+        }
+    };
+
+    println!("Codec:  {description}");
+    println!("Output: {out_name}");
+    println!();
+
+    // ── Build encoder ─────────────────────────────────────────────────────────
+
+    let mut encoder = match VideoEncoder::create(&output)
+        .video(width, height, fps)
+        .video_codec(video_codec)
+        .codec_options(codec_options)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error building encoder: {e}");
+            eprintln!(
+                "Note: ProRes requires 'prores_ks'; DNxHD requires 'dnxhd' in your FFmpeg build."
+            );
+            process::exit(1);
+        }
+    };
+
+    println!(
+        "Encoder opened: actual_codec={}",
+        encoder.actual_video_codec()
+    );
+    println!("Encoding...");
+
+    // ── Decode + encode loop ──────────────────────────────────────────────────
+
+    let mut decoder = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        };
+
+        if let Err(e) = encoder.push_video(&frame) {
+            eprintln!("Encode error: {e}");
+            process::exit(1);
+        }
+
+        frames += 1;
+    }
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("Error finalising output: {e}");
+        process::exit(1);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let kb = std::fs::metadata(&output).map_or(0, |m| m.len()) as f64 / 1024.0;
+    let size_str = if kb < 1024.0 {
+        format!("{kb:.0} KB")
+    } else {
+        format!("{:.1} MB", kb / 1024.0)
+    };
+
+    println!("Done. {out_name}  {size_str}  {frames} frames");
+}


### PR DESCRIPTION
## Summary

Adds five self-contained CLI example programs that demonstrate the major APIs introduced in the v0.7.0 milestone (issues #190–#212). Each example can be run with `cargo run --example <name> --features "decode encode"` and prints usage to stderr if arguments are missing.

## Changes

- **`codec_options`** — demonstrates `VideoCodecOptions` with H.264 (`H264Options`, `H264Profile`, `H264Preset`), H.265 (`H265Options`, `H265Profile`), AV1 (`Av1Options`, `Av1Usage`), and VP9 (`Vp9Options`)
- **`audio_codec_options`** — demonstrates `AudioCodecOptions` with Opus (`OpusOptions`, `OpusApplication`), AAC (`AacOptions`, `AacProfile`), MP3 (`Mp3Options`, `Mp3Quality`), and FLAC (`FlacOptions`)
- **`professional_formats`** — demonstrates Apple `ProRes` (`ProResOptions`, `ProResProfile`) and Avid `DNxHD`/`DNxHR` (`DnxhdOptions`, `DnxhdVariant`) encode
- **`hdr10_encode`** — demonstrates `Hdr10Metadata` + `MasteringDisplay` for HDR10 static metadata embedding and `ColorTransfer::Hlg` / `ColorSpace::Bt2020` / `ColorPrimaries::Bt2020` for HLG colour tagging
- **`image_sequence`** — demonstrates image2 demuxer/muxer for numbered JPEG/PNG frame sequences via `VideoDecoder::frame_rate()` and `%`-pattern paths
- **`crates/avio/Cargo.toml`** — five new `[[example]]` entries with `required-features = ["decode", "encode"]`

## Related Issues

Closes #190
Closes #191
Closes #193
Closes #198
Closes #199
Closes #200
Closes #201
Closes #202
Closes #203
Closes #204
Closes #206
Closes #207
Closes #212

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes