### PR TITLE
feat(avio): add SVT-AV1 (SvtAv1Options) to codec_options example

### DIFF
--- a/crates/avio/examples/codec_options.rs
+++ b/crates/avio/examples/codec_options.rs
@@ -7,6 +7,8 @@
 //!   B-frames, GOP, refs, and libx264 `preset` / `tune`
 //! - `H265Options` — profile (`main` / `main10`), tier, libx265 `preset`
 //! - `Av1Options` — `cpu_used` (0 = best, 8 = fastest), tile layout, usage
+//! - `SvtAv1Options` — SVT-AV1 (`libsvtav1`) preset (0–13), tile layout,
+//!   raw `svtav1_params` string; skips gracefully when libsvtav1 is absent
 //! - `Vp9Options` — `cpu_used`, constrained-quality (`cq_level`), tile layout
 //!
 //! All options are applied via `av_opt_set` / direct field assignment before
@@ -19,15 +21,15 @@
 //! cargo run --example codec_options --features "decode encode" -- \
 //!   --input   input.mp4   \
 //!   --output  output.mp4  \
-//!   --codec   h264        # h264 | h265 | av1 | vp9  (default: h264)
+//!   --codec   h264        # h264 | h265 | av1 | svt-av1 | vp9  (default: h264)
 //! ```
 
 use std::{path::Path, process};
 
 use avio::{
     Av1Options, Av1Usage, BitrateMode, H264Options, H264Preset, H264Profile, H265Options,
-    H265Profile, PixelFormat, VideoCodec, VideoCodecOptions, VideoDecoder, VideoEncoder,
-    Vp9Options,
+    H265Profile, PixelFormat, SvtAv1Options, VideoCodec, VideoCodecOptions, VideoDecoder,
+    VideoEncoder, Vp9Options,
 };
 
 fn main() {
@@ -51,7 +53,7 @@ fn main() {
     let input = input.unwrap_or_else(|| {
         eprintln!(
             "Usage: codec_options --input <file> --output <file> \
-             [--codec h264|h265|av1|vp9]"
+             [--codec h264|h265|av1|svt-av1|vp9]"
         );
         process::exit(1);
     });
@@ -142,6 +144,31 @@ fn main() {
                     "AV1 (libaom), cpu_used=6, 2×2 tiles, VoD mode",
                 )
             }
+            "svt-av1" => {
+                // SvtAv1Options: preset controls the speed/quality tradeoff.
+                //   0  = best quality / slowest encode
+                //   13 = fastest encode / lowest quality
+                //
+                // tile_rows / tile_cols are log2 counts (0 = 1 tile, 1 = 2, 2 = 4, …).
+                //
+                // svtav1_params allows passing raw key=value pairs from the
+                // libsvtav1 parameter interface (e.g. "fast-decode=1").
+                //
+                // Requires an FFmpeg build with --enable-libsvtav1.
+                // build() returns EncodeError::EncoderUnavailable if absent.
+                let opts = SvtAv1Options {
+                    preset: 8, // balanced speed/quality
+                    tile_rows: 1,
+                    tile_cols: 1,
+                    svtav1_params: None,
+                };
+                (
+                    VideoCodec::Av1Svt,
+                    VideoCodecOptions::Av1Svt(opts),
+                    None,
+                    "AV1 (SVT-AV1 / libsvtav1), preset=8, 2×2 tiles",
+                )
+            }
             "vp9" => {
                 // Vp9Options: cpu_used, constrained-quality mode (cq_level),
                 // and tile configuration.
@@ -160,7 +187,7 @@ fn main() {
                 )
             }
             other => {
-                eprintln!("Unknown codec '{other}' (try h264, h265, av1, vp9)");
+                eprintln!("Unknown codec '{other}' (try h264, h265, av1, svt-av1, vp9)");
                 process::exit(1);
             }
         };


### PR DESCRIPTION
## Summary

Extends the `codec_options` example with a `--codec svt-av1` option that demonstrates `SvtAv1Options` and `VideoCodecOptions::Av1Svt`. The example was the only place in the v0.7.0 example set where SVT-AV1 was absent despite the encoder being fully implemented in #196.

## Changes

- Added `"svt-av1"` arm to the codec match in `codec_options.rs` demonstrating `SvtAv1Options { preset, tile_rows, tile_cols, svtav1_params }`
- Updated usage string and doc comment to list `svt-av1` alongside the other codecs
- Imported `SvtAv1Options` from `avio`

The example skips gracefully (via `EncodeError::EncoderUnavailable`) when the FFmpeg build does not include `--enable-libsvtav1`.

## Related Issues

Closes #196

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes