### PR TITLE
docs: v0.7.0 release prep — READMEs, examples, and GPL/LGPL fixes

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "multimedia", "codec"]
 categories = ["multimedia::video", "multimedia::audio", "multimedia::encoding"]
 
 [features]
-default = ["probe", "decode", "encode"]
+default = ["probe", "decode", "encode", "hwaccel"]
 probe    = ["dep:ff-probe"]
 decode   = ["dep:ff-decode"]
 encode   = ["dep:ff-encode"]
@@ -19,6 +19,8 @@ filter   = ["dep:ff-filter"]
 pipeline = ["dep:ff-pipeline", "filter"]
 stream   = ["dep:ff-stream", "pipeline"]
 tokio    = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio"]
+gpl      = ["ff-encode/gpl"]
+hwaccel  = ["ff-encode/hwaccel"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -208,6 +210,10 @@ required-features = ["decode", "encode"]
 [[example]]
 name = "image_sequence"
 required-features = ["decode", "encode"]
+
+[[example]]
+name = "openexr_sequence"
+required-features = ["decode"]
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -12,16 +12,16 @@ to only the capabilities you need via feature flags.
 ```toml
 [dependencies]
 # Default: probe + decode + encode
-avio = "0.6"
+avio = "0.7"
 
 # Add filtering
-avio = { version = "0.6", features = ["filter"] }
+avio = { version = "0.7", features = ["filter"] }
 
 # Full stack (implies filter + pipeline)
-avio = { version = "0.6", features = ["stream"] }
+avio = { version = "0.7", features = ["stream"] }
 
 # Async decode/encode (requires tokio runtime)
-avio = { version = "0.6", features = ["tokio"] }
+avio = { version = "0.7", features = ["tokio"] }
 ```
 
 ## Feature Flags
@@ -59,7 +59,7 @@ let mut vdec = VideoDecoder::open("video.mp4")
     .output_format(PixelFormat::Rgb24)
     .build()?;
 while let Some(frame) = vdec.decode_one()? {
-    // frame.data contains raw pixel bytes
+    // frame.data() contains raw pixel bytes
 }
 
 // Audio — resample to f32 at 44.1 kHz
@@ -68,8 +68,29 @@ let mut adec = AudioDecoder::open("audio.flac")
     .output_sample_rate(44_100)
     .build()?;
 while let Some(frame) = adec.decode_one()? {
-    // frame.data contains audio samples
+    // frame.to_f32_interleaved() returns interleaved f32 samples
 }
+```
+
+### Image Sequences
+
+A `%`-pattern path (e.g. `frame%04d.png`) automatically selects the `image2`
+demuxer for decode and muxer for encode:
+
+```rust
+use avio::{VideoDecoder, VideoEncoder, VideoCodec, HardwareAccel};
+
+// Decode numbered PNGs → video
+let mut decoder = VideoDecoder::open("frames/frame%04d.png")
+    .hardware_accel(HardwareAccel::None)
+    .frame_rate(25)
+    .build()?;
+
+// Encode video → numbered PNGs
+let mut encoder = VideoEncoder::create("out/frame%04d.png")
+    .video(1920, 1080, 25.0)
+    .video_codec(VideoCodec::Png)
+    .build()?;
 ```
 
 ### Encode
@@ -89,6 +110,103 @@ for frame in &video_frames {
     encoder.push_video(frame)?;
 }
 encoder.finish()?;
+```
+
+### Per-Codec Options
+
+`VideoCodecOptions` and `AudioCodecOptions` provide typed, per-codec
+configuration applied before the codec is opened:
+
+```rust
+use avio::{
+    VideoEncoder, VideoCodec, VideoCodecOptions,
+    H264Options, H264Profile, H264Preset,
+    BitrateMode,
+};
+
+let opts = VideoCodecOptions::H264(H264Options {
+    profile: H264Profile::High,
+    level: Some(41),
+    bframes: 2,
+    gop_size: 250,
+    refs: 3,
+    preset: Some(H264Preset::Fast),
+    tune: None,
+});
+
+let mut encoder = VideoEncoder::create("output.mp4")
+    .video(1920, 1080, 30.0)
+    .video_codec(VideoCodec::H264)
+    .bitrate_mode(BitrateMode::Crf(23))
+    .codec_options(opts)
+    .build()?;
+```
+
+Available option structs: `H264Options`, `H265Options`, `Av1Options`,
+`SvtAv1Options`, `Vp9Options`, `ProResOptions`, `DnxhdOptions`,
+`OpusOptions`, `AacOptions`, `Mp3Options`, `FlacOptions`.
+
+### Professional Formats
+
+```rust
+use avio::{
+    VideoEncoder, VideoCodec, VideoCodecOptions,
+    ProResOptions, ProResProfile, PixelFormat,
+};
+
+let mut encoder = VideoEncoder::create("output.mov")
+    .video(1920, 1080, 25.0)
+    .video_codec(VideoCodec::ProRes)
+    .pixel_format(PixelFormat::Yuv422p10le)
+    .codec_options(VideoCodecOptions::ProRes(ProResOptions {
+        profile: ProResProfile::Hq,
+        vendor: None,
+    }))
+    .build()?;
+```
+
+### HDR Metadata
+
+```rust
+use avio::{
+    VideoEncoder, VideoCodec, VideoCodecOptions,
+    H265Options, H265Profile, PixelFormat, BitrateMode,
+    Hdr10Metadata, MasteringDisplay, ColorTransfer,
+};
+
+// HDR10 — PQ transfer + MaxCLL/MaxFALL side data
+let mut encoder = VideoEncoder::create("output.mkv")
+    .video(3840, 2160, 24.0)
+    .video_codec(VideoCodec::H265)
+    .bitrate_mode(BitrateMode::Crf(22))
+    .pixel_format(PixelFormat::Yuv420p10le)
+    .codec_options(VideoCodecOptions::H265(H265Options {
+        profile: H265Profile::Main10,
+        ..H265Options::default()
+    }))
+    .hdr10_metadata(Hdr10Metadata {
+        max_cll: 1000, max_fall: 400,
+        mastering_display: MasteringDisplay {
+            red_x: 17000, red_y: 8500,
+            green_x: 13250, green_y: 34500,
+            blue_x: 7500, blue_y: 3000,
+            white_x: 15635, white_y: 16450,
+            min_luminance: 50,
+            max_luminance: 10_000_000,
+        },
+    })
+    .build()?;
+
+// HLG — broadcast HDR without MaxCLL/MaxFALL
+use avio::{ColorSpace, ColorPrimaries};
+let mut encoder = VideoEncoder::create("output.mkv")
+    .video(1920, 1080, 50.0)
+    .video_codec(VideoCodec::H265)
+    .pixel_format(PixelFormat::Yuv420p10le)
+    .color_transfer(ColorTransfer::Hlg)
+    .color_space(ColorSpace::Bt2020)
+    .color_primaries(ColorPrimaries::Bt2020)
+    .build()?;
 ```
 
 ### Async (tokio feature)

--- a/crates/avio/examples/audio_codec_options.rs
+++ b/crates/avio/examples/audio_codec_options.rs
@@ -3,12 +3,17 @@
 //! Demonstrates the `AudioCodecOptions` enum and the codec-specific option
 //! structs added in v0.7.0:
 //!
-//! - `OpusOptions` — application mode (`Voip` / `Audio` / `LowDelay`), bitrate,
-//!   frame duration
+//! - `OpusOptions` — application mode (`Voip` / `Audio` / `LowDelay`),
+//!   frame duration; stored in an OGG container via `Container::Ogg`
 //! - `AacOptions` — profile (`LC` / `HE` / `HEv2`), VBR quality mode
 //! - `Mp3Options` — VBR quality (`V0`–`V9`) or fixed bitrate
 //! - `FlacOptions` — compression level (`0` = fastest / largest …
-//!   `12` = slowest / smallest)
+//!   `12` = slowest / smallest); stored in a FLAC container via
+//!   `Container::Flac`
+//!
+//! Also demonstrates `AudioEncoder::create().container()` — explicit
+//! container selection for audio-only formats (`Container::Flac`,
+//! `Container::Ogg`).
 //!
 //! # Usage
 //!
@@ -22,8 +27,8 @@
 use std::{path::Path, process};
 
 use avio::{
-    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioDecoder, AudioEncoder, FlacOptions,
-    Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
+    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioDecoder, AudioEncoder, Container,
+    FlacOptions, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
 };
 
 fn main() {
@@ -85,73 +90,90 @@ fn main() {
     // AudioCodecOptions is the v0.7.0 API for per-codec audio configuration.
     // Each variant holds a typed options struct specific to that codec.
 
-    let (audio_codec, codec_options, bitrate, description) = match codec_str.to_lowercase().as_str()
-    {
-        "opus" => {
-            // OpusOptions: application mode controls the psychoacoustic model.
-            //   Audio    — general music and voice (default)
-            //   Voip     — optimised for low-latency voice
-            //   LowDelay — minimal algorithmic delay
-            let opts = OpusOptions {
-                application: OpusApplication::Audio,
-                frame_duration_ms: Some(20),
-            };
-            (
-                AudioCodec::Opus,
-                AudioCodecOptions::Opus(opts),
-                128_000u64,
-                "Opus, Audio application, 128 kbps, 20 ms frames",
-            )
-        }
-        "aac" => {
-            // AacOptions: profile selects the AAC variant.
-            //   Lc   — Low Complexity, compatible with all devices (default)
-            //   He   — HE-AAC v1 (SBR) — better quality at low bitrates
-            //   Hev2 — HE-AAC v2 (SBR + PS) — stereo only, very low bitrates
-            let opts = AacOptions {
-                profile: AacProfile::Lc,
-                vbr_quality: None, // None = CBR at the specified bitrate
-            };
-            (
-                AudioCodec::Aac,
-                AudioCodecOptions::Aac(opts),
-                192_000u64,
-                "AAC-LC, CBR 192 kbps",
-            )
-        }
-        "mp3" => {
-            // Mp3Options: VBR quality scale 0 (best) … 9 (smallest).
-            // Vbr(2) corresponds to libmp3lame -V2, ~190 kbps average.
-            // Use Mp3Quality::Cbr(bitrate) for a fixed bitrate instead.
-            let opts = Mp3Options {
-                quality: Mp3Quality::Vbr(2), // ~190 kbps average
-            };
-            (
-                AudioCodec::Mp3,
-                AudioCodecOptions::Mp3(opts),
-                0u64, // irrelevant in VBR mode
-                "MP3, VBR quality V2 (~190 kbps average)",
-            )
-        }
-        "flac" => {
-            // FlacOptions: compression level 0 (fastest encode, largest file)
-            // through 12 (slowest encode, smallest lossless file).
-            // Default is 5 — a good balance for most use cases.
-            let opts = FlacOptions {
-                compression_level: 6,
-            };
-            (
-                AudioCodec::Flac,
-                AudioCodecOptions::Flac(opts),
-                0u64, // lossless — bitrate is determined by content
-                "FLAC, compression level 6",
-            )
-        }
-        other => {
-            eprintln!("Unknown codec '{other}' (try opus, aac, mp3, flac)");
-            process::exit(1);
-        }
-    };
+    // Each arm returns (codec, options, bitrate, container, description).
+    // container — Some(c) sets the muxer explicitly; None infers from the
+    //   output file extension.  Audio-only containers (Container::Flac,
+    //   Container::Ogg) are typically paired with their native codec.
+    let (audio_codec, codec_options, bitrate, container, description) =
+        match codec_str.to_lowercase().as_str() {
+            "opus" => {
+                // OpusOptions: application mode controls the psychoacoustic model.
+                //   Audio    — general music and voice (default)
+                //   Voip     — optimised for low-latency voice
+                //   LowDelay — minimal algorithmic delay
+                //
+                // Opus is stored natively in an OGG container.
+                // Container::Ogg is set explicitly here so that the muxer is
+                // always correct regardless of the output file extension.
+                let opts = OpusOptions {
+                    application: OpusApplication::Audio,
+                    frame_duration_ms: Some(20),
+                };
+                (
+                    AudioCodec::Opus,
+                    AudioCodecOptions::Opus(opts),
+                    128_000u64,
+                    Some(Container::Ogg),
+                    "Opus, Audio application, 128 kbps, 20 ms frames, OGG container",
+                )
+            }
+            "aac" => {
+                // AacOptions: profile selects the AAC variant.
+                //   Lc   — Low Complexity, compatible with all devices (default)
+                //   He   — HE-AAC v1 (SBR) — better quality at low bitrates
+                //   Hev2 — HE-AAC v2 (SBR + PS) — stereo only, very low bitrates
+                let opts = AacOptions {
+                    profile: AacProfile::Lc,
+                    vbr_quality: None, // None = CBR at the specified bitrate
+                };
+                (
+                    AudioCodec::Aac,
+                    AudioCodecOptions::Aac(opts),
+                    192_000u64,
+                    None, // infer container from extension (e.g. .m4a, .mp4)
+                    "AAC-LC, CBR 192 kbps",
+                )
+            }
+            "mp3" => {
+                // Mp3Options: VBR quality scale 0 (best) … 9 (smallest).
+                // Vbr(2) corresponds to libmp3lame -V2, ~190 kbps average.
+                // Use Mp3Quality::Cbr(bitrate) for a fixed bitrate instead.
+                let opts = Mp3Options {
+                    quality: Mp3Quality::Vbr(2), // ~190 kbps average
+                };
+                (
+                    AudioCodec::Mp3,
+                    AudioCodecOptions::Mp3(opts),
+                    0u64, // irrelevant in VBR mode
+                    None, // infer container from .mp3 extension
+                    "MP3, VBR quality V2 (~190 kbps average)",
+                )
+            }
+            "flac" => {
+                // FlacOptions: compression level 0 (fastest encode, largest file)
+                // through 12 (slowest encode, smallest lossless file).
+                // Default is 5 — a good balance for most use cases.
+                //
+                // FLAC has a dedicated container (Container::Flac) that wraps
+                // the raw FLAC stream — the same format produced by a standalone
+                // FLAC encoder.  Container::Ogg can also hold FLAC streams in
+                // an Ogg wrapper, but the native FLAC container is more common.
+                let opts = FlacOptions {
+                    compression_level: 6,
+                };
+                (
+                    AudioCodec::Flac,
+                    AudioCodecOptions::Flac(opts),
+                    0u64, // lossless — bitrate is determined by content
+                    Some(Container::Flac),
+                    "FLAC, compression level 6, FLAC container",
+                )
+            }
+            other => {
+                eprintln!("Unknown codec '{other}' (try opus, aac, mp3, flac)");
+                process::exit(1);
+            }
+        };
 
     println!("Codec:  {description}");
     println!("Output: {out_name}");
@@ -161,15 +183,20 @@ fn main() {
     //
     // .codec_options() applies the per-codec option struct.
     // .audio_bitrate() sets the target bitrate (ignored by lossless codecs and
-    // VBR-quality modes such as Mp3Quality::V2).
+    // VBR-quality modes such as Mp3Quality::Vbr).
+    // .container() overrides the muxer; None lets FFmpeg infer from the path.
 
-    let mut encoder = match AudioEncoder::create(&output)
+    let mut enc_builder = AudioEncoder::create(&output)
         .audio(sample_rate, channels)
         .audio_codec(audio_codec)
         .audio_bitrate(bitrate)
-        .codec_options(codec_options)
-        .build()
-    {
+        .codec_options(codec_options);
+
+    if let Some(c) = container {
+        enc_builder = enc_builder.container(c);
+    }
+
+    let mut encoder = match enc_builder.build() {
         Ok(e) => e,
         Err(e) => {
             eprintln!("Error building encoder: {e}");

--- a/crates/avio/examples/container_format.rs
+++ b/crates/avio/examples/container_format.rs
@@ -1,7 +1,9 @@
 //! Encode video with an explicitly selected output container format.
 //!
 //! Demonstrates:
-//! - `Container` enum — `Mp4`, `Mkv`, `WebM`, `Avi`, `Mov`
+//! - `Container` enum — full set of supported muxers:
+//!   - **Video** containers: `Mp4`, `Mkv`, `WebM`, `Avi`, `Mov`
+//!   - **Audio** containers: `Flac` (lossless), `Ogg` (Vorbis/Opus)
 //! - `Container::as_str()` — `FFmpeg` format name
 //! - `Container::default_extension()` — canonical file extension
 //! - `VideoEncoder::create().container()` — override the container inferred
@@ -10,6 +12,11 @@
 //! By default the container is auto-detected from the output extension.
 //! Use `container()` when the extension does not match the desired format
 //! or when you need to guarantee a specific muxer regardless of the path.
+//!
+//! Audio-only containers (`Container::Flac`, `Container::Ogg`) are used the
+//! same way with `AudioEncoder::create().container(Container::Flac)`.
+//! See the `audio_codec_options` example for a complete audio encoding
+//! workflow that demonstrates explicit container selection.
 //!
 //! # Usage
 //!

--- a/crates/avio/examples/openexr_sequence.rs
+++ b/crates/avio/examples/openexr_sequence.rs
@@ -1,0 +1,141 @@
+//! Decode an `OpenEXR` image sequence to individual frames.
+//!
+//! Demonstrates `OpenEXR` sequence support added in v0.7.0:
+//!
+//! - `VideoDecoder::open()` with a printf-style `%` pattern (e.g.
+//!   `frames/frame%04d.exr`) uses the `image2` demuxer automatically.
+//! - `HardwareAccel::None` — hardware decoders do not support EXR; software
+//!   decoding is mandatory.
+//! - `PixelFormat::Gbrpf32le` — EXR files decode to three 32-bit float planes
+//!   ordered G, B, R (matching the EXR channel naming convention).
+//! - `VideoFrame::plane()` — access individual colour planes by index.
+//! - `VideoFrame::num_planes()` — returns `3` for `gbrpf32le` frames.
+//!
+//! The example skips gracefully when the EXR decoder is absent from the
+//! `FFmpeg` build (`--enable-decoder=exr` is an optional configure flag).
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example openexr_sequence --features "decode" -- \
+//!   --input "frames/frame%04d.exr"  \
+//!   [--fps 24]
+//! ```
+//!
+//! # Creating a test sequence
+//!
+//! If you have `ffmpeg` on your PATH, you can generate a 3-frame EXR sequence
+//! from any image (requires `--enable-encoder=exr` in your `FFmpeg` build):
+//!
+//! ```bash
+//! mkdir -p /tmp/exr_seq
+//! ffmpeg -loop 1 -i input.png -vf "format=gbrpf32le" \
+//!        -frames:v 3 "/tmp/exr_seq/frame%04d.exr"
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{HardwareAccel, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut fps: u32 = 24;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--fps" => {
+                let v = args.next().unwrap_or_default();
+                fps = v.parse().unwrap_or(24);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: openexr_sequence --input \"frame%04d.exr\" [--fps 24]");
+        process::exit(1);
+    });
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:  {in_name}  fps={fps}");
+    println!();
+
+    // ── Open the EXR sequence ─────────────────────────────────────────────────
+    //
+    // VideoDecoder::open() detects the `%` in the path and uses the `image2`
+    // demuxer automatically.  .frame_rate() overrides the default 25 fps.
+    //
+    // .hardware_accel(HardwareAccel::None) is required because hardware
+    // decoders do not support the EXR codec.
+    let mut decoder = match VideoDecoder::open(&input)
+        .hardware_accel(HardwareAccel::None)
+        .frame_rate(fps)
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error opening EXR sequence: {e}");
+            eprintln!(
+                "Note: EXR decoding requires FFmpeg built with \
+                 --enable-decoder=exr"
+            );
+            process::exit(1);
+        }
+    };
+
+    let width = decoder.width();
+    let height = decoder.height();
+    let actual_fps = decoder.frame_rate();
+
+    println!("Sequence: {width}×{height}  actual_fps={actual_fps:.2}");
+
+    // ── Decode loop ───────────────────────────────────────────────────────────
+    //
+    // EXR frames decode as gbrpf32le (32-bit float, planar, G/B/R order).
+    // Each plane holds one colour channel; plane(0)=G, plane(1)=B, plane(2)=R.
+
+    let mut frames: u64 = 0;
+
+    loop {
+        let frame = match decoder.decode_one() {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Decode error at frame {frames}: {e}");
+                process::exit(1);
+            }
+        };
+
+        // Report the pixel format and plane layout for the first frame.
+        if frames == 0 {
+            println!(
+                "Frame 0: format={:?}  planes={}",
+                frame.format(),
+                frame.num_planes(),
+            );
+            for i in 0..frame.num_planes() {
+                if let Some(plane) = frame.plane(i) {
+                    let float_count = plane.len() / 4; // 4 bytes per f32
+                    println!(
+                        "  plane[{i}]: {} bytes ({float_count} f32 values)",
+                        plane.len()
+                    );
+                }
+            }
+        }
+
+        frames += 1;
+    }
+
+    println!();
+    println!("Done. {frames} EXR frames decoded from '{in_name}'");
+}

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -1,13 +1,13 @@
 # ff-decode
 
-Decode video and audio frames without managing codec contexts, packet queues, or timestamp conversions. Open a file, call `decode_frame` in a loop, and receive `VideoFrame` objects with their position already expressed as a `Duration`.
+Decode video and audio frames without managing codec contexts, packet queues, or timestamp conversions. Open a file, call `decode_one` in a loop, and receive `VideoFrame` objects with their position already expressed as a `Timestamp`.
 
 ## Installation
 
 ```toml
 [dependencies]
-ff-decode = "0.6"
-ff-format = "0.6"
+ff-decode = "0.7"
+ff-format = "0.7"
 ```
 
 ## Video Decoding
@@ -16,15 +16,26 @@ ff-format = "0.6"
 use ff_decode::VideoDecoder;
 use ff_format::PixelFormat;
 
-let mut decoder = VideoDecoder::open("video.mp4")?
+let mut decoder = VideoDecoder::open("video.mp4")
     .output_format(PixelFormat::Rgba)
     .build()?;
 
-while let Some(frame) = decoder.decode_frame()? {
+while let Some(frame) = decoder.decode_one()? {
     // frame.data()      — raw pixel bytes in RGBA order
     // frame.width()     — frame width in pixels
     // frame.height()    — frame height in pixels
-    // frame.timestamp() — position as std::time::Duration
+    // frame.timestamp() — position as Timestamp
+    process(&frame);
+}
+```
+
+### Iterator API
+
+`VideoDecoder` and `AudioDecoder` implement `Iterator` and `FusedIterator`:
+
+```rust
+for frame in decoder {
+    let frame = frame?;   // Iterator<Item = Result<VideoFrame, DecodeError>>
     process(&frame);
 }
 ```
@@ -33,20 +44,92 @@ while let Some(frame) = decoder.decode_frame()? {
 
 ```rust
 use ff_decode::AudioDecoder;
-use ff_format::{SampleFormat, ChannelLayout};
+use ff_format::SampleFormat;
 
-let mut decoder = AudioDecoder::open("audio.flac")?
+let mut decoder = AudioDecoder::open("audio.flac")
     .output_format(SampleFormat::Fltp)
     .output_sample_rate(44_100)
-    .output_channel_layout(ChannelLayout::Stereo)
+    .output_channels(2)   // downmix to stereo
     .build()?;
 
-while let Some(frame) = decoder.decode_frame()? {
-    // frame.data()        — interleaved or planar sample bytes
-    // frame.sample_rate() — samples per second
-    // frame.timestamp()   — position as std::time::Duration
+while let Some(frame) = decoder.decode_one()? {
+    // frame.to_f32_interleaved() — interleaved f32 samples
     process(&frame);
 }
+```
+
+## Image Sequence Decoding
+
+When a path contains `%` (printf-style pattern), `VideoDecoder` automatically
+uses the `image2` demuxer. Supported extensions: `.png`, `.jpg`, `.bmp`, `.tiff`.
+
+```rust
+use ff_decode::{VideoDecoder, HardwareAccel};
+
+// Decode a numbered PNG sequence at 25 fps.
+let mut decoder = VideoDecoder::open("frames/frame%04d.png")
+    .hardware_accel(HardwareAccel::None)  // recommended for still images
+    .frame_rate(25)
+    .build()?;
+
+while let Some(frame) = decoder.decode_one()? {
+    process(&frame);
+}
+```
+
+## OpenEXR Sequence Decoding
+
+OpenEXR sequences use the same `%`-pattern mechanism. EXR frames decode as
+`gbrpf32le` (32-bit float, three planes ordered G/B/R):
+
+```rust
+use ff_decode::{VideoDecoder, HardwareAccel};
+use ff_format::PixelFormat;
+
+// Hardware decoders do not support EXR; always use HardwareAccel::None.
+let mut decoder = VideoDecoder::open("frames/frame%04d.exr")
+    .hardware_accel(HardwareAccel::None)
+    .frame_rate(24)
+    .build()?;  // returns DecodeError::DecoderUnavailable if --enable-decoder=exr
+                // was omitted from the FFmpeg build
+
+while let Some(frame) = decoder.decode_one()? {
+    assert_eq!(frame.format(), PixelFormat::Gbrpf32le);
+    // Access individual colour planes: plane(0)=G, plane(1)=B, plane(2)=R
+    let green_plane = frame.plane(0).unwrap();
+    // Each element is a 4-byte IEEE 754 f32 in native byte order.
+}
+```
+
+## 10-bit and High-Bit-Depth Formats
+
+HDR and professional content often uses 10-bit pixel formats. Request conversion
+via `.output_format()` or leave unset to receive frames in the native format:
+
+```rust
+use ff_format::PixelFormat;
+
+// Receive frames in the native 10-bit format (no conversion).
+let mut decoder = VideoDecoder::open("hdr.mkv").build()?;
+
+// Or convert to a specific format for processing.
+let mut decoder = VideoDecoder::open("hdr.mkv")
+    .output_format(PixelFormat::Yuv420p10le)
+    .build()?;
+```
+
+Common 10-bit formats: `Yuv420p10le`, `Yuv422p10le`, `Yuv444p10le`, `P010Le`.
+
+## Scaled Output
+
+```rust
+use ff_decode::VideoDecoder;
+use ff_format::PixelFormat;
+
+let mut decoder = VideoDecoder::open("4k.mp4")
+    .output_format(PixelFormat::Rgb24)
+    .output_size(1280, 720)   // scale + pixel-format conversion in one pass
+    .build()?;
 ```
 
 ## Seeking
@@ -55,7 +138,7 @@ while let Some(frame) = decoder.decode_frame()? {
 use ff_decode::{VideoDecoder, SeekMode};
 use std::time::Duration;
 
-let mut decoder = VideoDecoder::open("video.mp4")?.build()?;
+let mut decoder = VideoDecoder::open("video.mp4").build()?;
 
 // Jump to the nearest keyframe at or before 30 seconds.
 decoder.seek(Duration::from_secs(30), SeekMode::Keyframe)?;
@@ -71,7 +154,7 @@ Seeking does not re-open the file. The existing codec context is flushed and reu
 ```rust
 use ff_decode::{VideoDecoder, HardwareAccel};
 
-let mut decoder = VideoDecoder::open("video.mp4")?
+let mut decoder = VideoDecoder::open("video.mp4")
     .hardware_accel(HardwareAccel::Auto)
     .build()?;
 ```
@@ -80,21 +163,23 @@ let mut decoder = VideoDecoder::open("video.mp4")?
 
 ## Error Handling
 
-| Variant                          | When it occurs                                   |
-|----------------------------------|--------------------------------------------------|
-| `DecodeError::FileNotFound`      | The input path does not exist                    |
-| `DecodeError::CannotOpen`        | FFmpeg could not open the container or codec     |
-| `DecodeError::UnsupportedCodec`  | No decoder available for the stream's codec      |
-| `DecodeError::InvalidConfig`     | Builder options are inconsistent or unsupported  |
-| `DecodeError::Io`                | Read error on the underlying file                |
+| Variant                              | When it occurs                                   |
+|--------------------------------------|--------------------------------------------------|
+| `DecodeError::FileNotFound`          | The input path does not exist                    |
+| `DecodeError::CannotOpen`            | FFmpeg could not open the container or codec     |
+| `DecodeError::UnsupportedCodec`      | No decoder available for the stream's codec      |
+| `DecodeError::DecoderUnavailable`    | Codec is known but not compiled into FFmpeg      |
+| `DecodeError::InvalidConfig`         | Builder options are inconsistent or unsupported  |
+| `DecodeError::Io`                    | Read error on the underlying file                |
 
 ## What the Crate Handles for You
 
 - Codec context allocation and lifetime
-- PTS-to-`Duration` conversion using the stream's time base
+- PTS-to-`Timestamp` conversion using the stream's time base
 - Packet queue management and buffering
 - EOF signalled as `Ok(None)` rather than a special error variant
 - Pixel format and sample format negotiation via `swscale` / `swresample`
+- `image2` demuxer selection for `%`-pattern paths (image sequences)
 
 ## Feature Flags
 
@@ -104,7 +189,7 @@ let mut decoder = VideoDecoder::open("video.mp4")?
 
 ```toml
 [dependencies]
-ff-decode = { version = "0.6", features = ["tokio"] }
+ff-decode = { version = "0.7", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoDecoder` and `AudioDecoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -6,12 +6,12 @@ Encode video and audio to any format with a builder chain. The encoder validates
 
 ```toml
 [dependencies]
-ff-encode = "0.6"
-ff-format = "0.6"
+ff-encode = "0.7"
+ff-format = "0.7"
 
 # Enable GPL-licensed encoders (libx264, libx265).
 # Requires GPL compliance or MPEG LA licensing in your project.
-# ff-encode = { version = "0.6", features = ["gpl"] }
+# ff-encode = { version = "0.7", features = ["gpl"] }
 ```
 
 By default, only LGPL-compatible encoders are enabled.
@@ -19,13 +19,12 @@ By default, only LGPL-compatible encoders are enabled.
 ## Quick Start
 
 ```rust
-use ff_encode::{VideoEncoder, VideoCodec, AudioCodec, BitrateMode, Preset};
+use ff_encode::{VideoEncoder, VideoCodec, AudioCodec, BitrateMode};
 
 let mut encoder = VideoEncoder::create("output.mp4")
     .video(1920, 1080, 30.0)          // width, height, fps
     .video_codec(VideoCodec::H264)
     .bitrate_mode(BitrateMode::Cbr(4_000_000))
-    .preset(Preset::Medium)
     .audio(48_000, 2)                 // sample_rate, channels
     .audio_codec(AudioCodec::Aac)
     .audio_bitrate(192_000)
@@ -51,6 +50,220 @@ encoder.finish()?;
 
 // Variable bitrate — target average with hard ceiling.
 .bitrate_mode(BitrateMode::Vbr { target: 3_000_000, max: 6_000_000 })
+```
+
+## Per-Codec Video Options
+
+`VideoCodecOptions` provides typed configuration for each codec. Options are
+applied via `av_opt_set` before `avcodec_open2`; unsupported values are logged
+as warnings and skipped — `build()` never fails due to an unsupported option.
+
+```rust
+use ff_encode::{
+    VideoEncoder, VideoCodec, VideoCodecOptions,
+    H264Options, H264Profile, H264Preset,
+    H265Options, H265Profile,
+    Av1Options, Av1Usage,
+    SvtAv1Options,
+    Vp9Options,
+};
+
+// H.264 — profile, level, B-frames, GOP, refs, preset, tune
+let opts = VideoCodecOptions::H264(H264Options {
+    profile: H264Profile::High,
+    level: Some(41),       // 4.1 — supports 1080p30
+    bframes: 2,
+    gop_size: 250,
+    refs: 3,
+    preset: Some(H264Preset::Fast),
+    tune: None,
+});
+
+// H.265 — profile (Main / Main10 for 10-bit HDR), preset
+let opts = VideoCodecOptions::H265(H265Options {
+    profile: H265Profile::Main10,
+    preset: Some("fast".to_string()),
+    ..H265Options::default()
+});
+
+// AV1 (libaom) — cpu_used, tile layout, usage mode
+let opts = VideoCodecOptions::Av1(Av1Options {
+    cpu_used: 6,
+    tile_rows: 1,   // 2^1 = 2 rows
+    tile_cols: 1,   // 2^1 = 2 columns
+    usage: Av1Usage::VoD,
+});
+
+// AV1 (SVT-AV1 / libsvtav1) — preset 0–13, tiles, raw params
+// Requires FFmpeg built with --enable-libsvtav1.
+let opts = VideoCodecOptions::Av1Svt(SvtAv1Options {
+    preset: 8,
+    tile_rows: 1,
+    tile_cols: 1,
+    svtav1_params: None,
+});
+
+// VP9 — cpu_used, constrained quality, row-based multithreading
+let opts = VideoCodecOptions::Vp9(Vp9Options {
+    cpu_used: 4,
+    cq_level: Some(33),
+    tile_columns: 1,
+    tile_rows: 0,
+    row_mt: true,
+});
+
+let mut encoder = VideoEncoder::create("output.mp4")
+    .video(1920, 1080, 30.0)
+    .video_codec(VideoCodec::H264)
+    .bitrate_mode(BitrateMode::Crf(23))
+    .codec_options(opts)
+    .build()?;
+```
+
+## Per-Codec Audio Options
+
+`AudioCodecOptions` provides typed configuration for Opus, AAC, MP3, and FLAC.
+
+```rust
+use ff_encode::{
+    AudioEncoder, AudioCodec, AudioCodecOptions,
+    OpusOptions, OpusApplication,
+    AacOptions, AacProfile,
+    Mp3Options, Mp3Quality,
+    FlacOptions,
+    Container,
+};
+
+// Opus — application mode + frame duration, OGG container
+let opts = AudioCodecOptions::Opus(OpusOptions {
+    application: OpusApplication::Audio,
+    frame_duration_ms: Some(20),
+});
+let mut encoder = AudioEncoder::create("output.ogg")
+    .audio(48_000, 2)
+    .audio_codec(AudioCodec::Opus)
+    .audio_bitrate(128_000)
+    .container(Container::Ogg)
+    .codec_options(opts)
+    .build()?;
+
+// AAC — profile (LC / HE / HEv2), optional VBR quality
+let opts = AudioCodecOptions::Aac(AacOptions {
+    profile: AacProfile::Lc,
+    vbr_quality: None,  // None = CBR
+});
+
+// MP3 — VBR quality scale 0 (best) … 9 (smallest)
+let opts = AudioCodecOptions::Mp3(Mp3Options {
+    quality: Mp3Quality::Vbr(2),  // ~190 kbps
+});
+
+// FLAC — compression level 0–12, native FLAC container
+let opts = AudioCodecOptions::Flac(FlacOptions {
+    compression_level: 6,
+});
+let mut encoder = AudioEncoder::create("output.flac")
+    .audio(44_100, 2)
+    .audio_codec(AudioCodec::Flac)
+    .container(Container::Flac)
+    .codec_options(opts)
+    .build()?;
+```
+
+## Professional Formats
+
+ProRes and DNxHD/DNxHR require specific pixel formats and FFmpeg encoder
+support (`prores_ks` and `dnxhd` respectively).
+
+```rust
+use ff_encode::{
+    VideoEncoder, VideoCodec, VideoCodecOptions,
+    ProResOptions, ProResProfile,
+    DnxhdOptions, DnxhdVariant,
+    PixelFormat,
+};
+
+// Apple ProRes HQ — yuv422p10le, .mov container
+let opts = VideoCodecOptions::ProRes(ProResOptions {
+    profile: ProResProfile::Hq,
+    vendor: None,
+});
+let mut encoder = VideoEncoder::create("output.mov")
+    .video(1920, 1080, 25.0)
+    .video_codec(VideoCodec::ProRes)
+    .pixel_format(PixelFormat::Yuv422p10le)
+    .codec_options(opts)
+    .build()?;
+
+// Avid DNxHR SQ — yuv422p, any resolution
+let opts = VideoCodecOptions::Dnxhd(DnxhdOptions {
+    variant: DnxhdVariant::DnxhrSq,
+});
+let mut encoder = VideoEncoder::create("output.mxf")
+    .video(1920, 1080, 25.0)
+    .video_codec(VideoCodec::DnxHd)
+    .codec_options(opts)
+    .build()?;
+```
+
+| ProRes Profile | Pixel Format | Notes |
+|---|---|---|
+| `Proxy`, `Lt`, `Standard`, `Hq` | `yuv422p10le` | 422 chroma |
+| `P4444`, `P4444Xq` | `yuva444p10le` | 444 chroma + alpha |
+
+| DNxHD/HR Variant | Pixel Format | Notes |
+|---|---|---|
+| `Dnxhd115`, `Dnxhd145`, `Dnxhd220` | `yuv422p` | Fixed bitrate, 1080p only |
+| `Dnxhd220x`, `DnxhrHqx` | `yuv422p10le` | 10-bit |
+| `DnxhrLb`, `DnxhrSq`, `DnxhrHq`, `DnxhrR444` | `yuv422p` | Any resolution |
+
+## HDR Metadata
+
+```rust
+use ff_encode::{
+    VideoEncoder, VideoCodec, VideoCodecOptions,
+    H265Options, H265Profile,
+    Hdr10Metadata, MasteringDisplay,
+    ColorTransfer, ColorSpace, ColorPrimaries,
+    PixelFormat, BitrateMode,
+};
+
+// HDR10 — static metadata (MaxCLL, MaxFALL, mastering display)
+// hdr10_metadata() automatically sets BT.2020 primaries, PQ transfer,
+// and BT.2020 NCL colour matrix on the codec context.
+let meta = Hdr10Metadata {
+    max_cll: 1000,   // nits
+    max_fall: 400,   // nits
+    mastering_display: MasteringDisplay {
+        red_x: 17000, red_y: 8500,
+        green_x: 13250, green_y: 34500,
+        blue_x: 7500, blue_y: 3000,
+        white_x: 15635, white_y: 16450,
+        min_luminance: 50,
+        max_luminance: 10_000_000,
+    },
+};
+let mut encoder = VideoEncoder::create("output.mkv")
+    .video(3840, 2160, 24.0)
+    .video_codec(VideoCodec::H265)
+    .bitrate_mode(BitrateMode::Crf(22))
+    .pixel_format(PixelFormat::Yuv420p10le)
+    .codec_options(VideoCodecOptions::H265(H265Options {
+        profile: H265Profile::Main10,
+        ..H265Options::default()
+    }))
+    .hdr10_metadata(meta)
+    .build()?;
+
+// HLG — broadcast HDR without MaxCLL/MaxFALL side data
+let mut encoder = VideoEncoder::create("output.mkv")
+    .video(1920, 1080, 50.0)
+    .video_codec(VideoCodec::H265)
+    .pixel_format(PixelFormat::Yuv420p10le)
+    .color_transfer(ColorTransfer::Hlg)
+    .color_space(ColorSpace::Bt2020)
+    .color_primaries(ColorPrimaries::Bt2020)
+    .build()?;
 ```
 
 ## Hardware Encoding
@@ -111,7 +324,7 @@ Enable the `gpl` feature to add libx264 and libx265. This changes the license te
 
 ```toml
 [dependencies]
-ff-encode = { version = "0.6", features = ["tokio"] }
+ff-encode = { version = "0.7", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoEncoder`, `AudioEncoder`, and `ImageEncoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/src/codec.rs
+++ b/crates/ff-encode/src/codec.rs
@@ -45,6 +45,7 @@ impl VideoCodecEncodeExt for VideoCodec {
             self,
             VideoCodec::Vp9
                 | VideoCodec::Av1
+                | VideoCodec::Av1Svt
                 | VideoCodec::Mpeg4
                 | VideoCodec::ProRes
                 | VideoCodec::DnxHd

--- a/crates/ff-format/README.md
+++ b/crates/ff-format/README.md
@@ -4,19 +4,62 @@ Shared data types for the ff-* crate family. No FFmpeg dependency — these type
 
 ## Key Types
 
-| Type           | Description                                                     |
-|----------------|-----------------------------------------------------------------|
-| `PixelFormat`  | Enumeration of supported pixel formats (Yuv420p, Rgba, …)       |
-| `SampleFormat` | Audio sample formats (Fltp, S16, …)                             |
-| `ChannelLayout`| Mono, Stereo, Surround51, and others                            |
-| `ColorSpace`   | BT.601, BT.709, BT.2020, and others                             |
-| `VideoCodec`   | H264, H265, Vp9, Av1, ProRes, and others                        |
-| `AudioCodec`   | Aac, Opus, Mp3, Flac, and others                                |
-| `VideoFrame`   | Decoded video frame with pixel data and associated `Timestamp`  |
-| `AudioFrame`   | Decoded audio frame with sample data and associated `Timestamp` |
-| `Timestamp`    | Media position expressed as a `Rational` fraction of seconds    |
+| Type              | Description                                                          |
+|-------------------|----------------------------------------------------------------------|
+| `PixelFormat`     | Enumeration of pixel formats (`Yuv420p`, `Rgba`, `Yuv420p10le`, `Yuv422p10le`, `Gbrpf32le`, …) |
+| `SampleFormat`    | Audio sample formats (`Fltp`, `S16`, …)                              |
+| `ChannelLayout`   | `Mono`, `Stereo`, `Surround51`, and others                           |
+| `ColorSpace`      | `Bt601`, `Bt709`, `Bt2020`, and others                               |
+| `ColorRange`      | `Limited` (studio swing) or `Full` (PC swing)                        |
+| `ColorPrimaries`  | `Bt709`, `Bt2020`, `DciP3`, and others                               |
+| `ColorTransfer`   | OETF tag: `Bt709`, `Pq` (HDR10 / SMPTE ST 2084), `Hlg` (BT.2100), … |
+| `Hdr10Metadata`   | `MaxCLL` + `MaxFALL` + `MasteringDisplay` for HDR10 static metadata  |
+| `MasteringDisplay`| SMPTE ST 2086 mastering display colour volume (chromaticity + luminance) |
+| `VideoCodec`      | `H264`, `H265`, `Vp9`, `Av1`, `Av1Svt`, `ProRes`, `DnxHd`, and others |
+| `AudioCodec`      | `Aac`, `Opus`, `Mp3`, `Flac`, `Vorbis`, and others                  |
+| `VideoFrame`      | Decoded video frame with pixel data and associated `Timestamp`       |
+| `AudioFrame`      | Decoded audio frame with sample data and associated `Timestamp`      |
+| `Timestamp`       | Media position expressed as a `Rational` fraction of seconds         |
 
 These are the types `ff-decode` hands back when you decode a frame, and the types `ff-encode` expects when you push a frame.
+
+## Color Science Types
+
+HDR and colour-space metadata is represented as pure-Rust enums — no FFmpeg dependency required:
+
+```rust
+use ff_format::{ColorTransfer, ColorSpace, ColorPrimaries, ColorRange};
+
+// Tag a stream as HLG broadcast HDR.
+let transfer  = ColorTransfer::Hlg;
+let space     = ColorSpace::Bt2020;
+let primaries = ColorPrimaries::Bt2020;
+let range     = ColorRange::Limited;
+
+// Tag a stream as HDR10 (PQ transfer + BT.2020 primaries).
+let transfer  = ColorTransfer::Pq;
+```
+
+`Hdr10Metadata` and `MasteringDisplay` carry HDR10 static metadata that is
+embedded as side data on key-frame packets:
+
+```rust
+use ff_format::{Hdr10Metadata, MasteringDisplay};
+
+// BT.2020 D65 primaries, coordinates × 50000; luminance × 10000 nits.
+let meta = Hdr10Metadata {
+    max_cll: 1000,    // MaxCLL in nits
+    max_fall: 400,    // MaxFALL in nits
+    mastering_display: MasteringDisplay {
+        red_x: 17000, red_y: 8500,
+        green_x: 13250, green_y: 34500,
+        blue_x: 7500, blue_y: 3000,
+        white_x: 15635, white_y: 16450,
+        min_luminance: 50,           // 0.005 nit deep black
+        max_luminance: 10_000_000,   // 1000 nit peak
+    },
+};
+```
 
 ## Example
 


### PR DESCRIPTION
## Summary

Prepares the repository for the v0.7.0 release by updating all crate READMEs to document the new APIs, adding a missing `openexr_sequence` example, fixing two example bugs, and correcting two GPL/LGPL feature-flag bugs that were silently preventing users of the `avio` facade from enabling GPL codecs or hardware acceleration.

## Changes

### READMEs

- **avio**: add Image Sequences, Per-Codec Options, Professional Formats, and HDR Metadata sections with complete code examples
- **ff-decode**: fix `decode_one()` API name (was `decode_frame()`); remove erroneous `?` after builder `open()` calls; fix `output_channels()` (was `output_channel_layout()`); add Iterator API, Image Sequence, OpenEXR Sequence, 10-bit formats, Scaled Output, and Seeking sections; add `DecoderUnavailable` to error table; update version strings to `0.7`
- **ff-encode**: add Per-Codec Video Options (H264/H265/AV1/SVT-AV1/VP9), Per-Codec Audio Options (Opus/AAC/MP3/FLAC with `Container`), Professional Formats tables with pixel format requirements, HDR Metadata section; update version strings to `0.7`
- **ff-format**: add `ColorRange`, `ColorPrimaries`, `ColorTransfer`, `Hdr10Metadata`, `MasteringDisplay`, `Av1Svt` to Key Types table; add Color Science Types section with `HLG` and `HDR10` examples

### New example

- **`openexr_sequence`**: demonstrates OpenEXR image sequence decoding using `HardwareAccel::None`, `.frame_rate()`, and `gbrpf32le` plane access (`plane(0)=G`, `plane(1)=B`, `plane(2)=R`)

### Example fixes

- **`audio_codec_options`**: add `Container::Ogg` for Opus and `Container::Flac` for FLAC encoders; fix `Mp3Options` field name (`quality` not `vbr_quality`); remove non-existent `bitrate` field from `OpusOptions`
- **`container_format`**: document `Container::Flac` and `Container::Ogg` as audio-only container variants

### GPL/LGPL bug fixes

- **`ff-encode/src/codec.rs`**: add `VideoCodec::Av1Svt` to `is_lgpl_compatible()` — libsvtav1 is BSD-3-Clause and is LGPL-compatible; the static method was returning `false` while the runtime check correctly identified it as compliant
- **`avio/Cargo.toml`**: expose `gpl = ["ff-encode/gpl"]` and `hwaccel = ["ff-encode/hwaccel"]` features so users of the `avio` facade can enable GPL codecs (libx264/libx265) and hardware acceleration; add `hwaccel` to `default` features to match `ff-encode`'s own defaults

## Related Issues

Closes #212

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes