### PR TITLE
fix(ff-sys): add missing docsrs_stubs symbols for v0.7.0

### DIFF
--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -29,12 +29,12 @@ pub type AVPictureType = c_int;
 // ── Opaque types (only ever used behind raw pointers) ─────────────────────────
 
 pub struct AVDictionary(());
-pub struct AVCodec(());
 pub struct SwsContext(());
 pub struct SwrContext(());
 pub struct AVBufferRef(());
 pub struct AVIOContext(());
 pub struct AVOutputFormat(());
+pub struct AVAudioFifo(());
 
 pub struct AVInputFormat {
     pub name: *const c_char,
@@ -185,6 +185,20 @@ pub struct AVCodecContext {
     pub color_primaries: AVColorPrimaries,
     pub color_trc: AVColorTransferCharacteristic,
     pub colorspace: AVColorSpace,
+    // Fields added for v0.7.0 feature coverage
+    pub frame_size: c_int,
+    pub color_range: AVColorRange,
+    pub refs: c_int,
+    pub rc_max_rate: i64,
+    pub rc_buffer_size: c_int,
+    pub flags: c_int,
+    pub stats_out: *mut c_char,
+    pub stats_in: *mut c_char,
+}
+
+pub struct AVCodec {
+    pub sample_fmts: *const AVSampleFormat,
+    pub capabilities: c_int,
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -275,6 +289,8 @@ pub const AVPixelFormat_AV_PIX_FMT_NV21: AVPixelFormat = 24;
 pub const AVPixelFormat_AV_PIX_FMT_RGBA: AVPixelFormat = 26;
 pub const AVPixelFormat_AV_PIX_FMT_BGRA: AVPixelFormat = 28;
 pub const AVPixelFormat_AV_PIX_FMT_YUVJ420P: AVPixelFormat = 12;
+pub const AVPixelFormat_AV_PIX_FMT_YUVJ422P: AVPixelFormat = 13;
+pub const AVPixelFormat_AV_PIX_FMT_YUVJ444P: AVPixelFormat = 14;
 pub const AVPixelFormat_AV_PIX_FMT_VAAPI: AVPixelFormat = 51;
 pub const AVPixelFormat_AV_PIX_FMT_DXVA2_VLD: AVPixelFormat = 53;
 pub const AV_OPT_SEARCH_CHILDREN: u32 = 1;
@@ -576,8 +592,11 @@ pub unsafe fn av_packet_rescale_ts(
 // ── libavfilter opaque types ──────────────────────────────────────────────────
 
 pub struct AVFilterGraph(());
-pub struct AVFilterContext(());
 pub struct AVFilter(());
+
+pub struct AVFilterContext {
+    pub hw_device_ctx: *mut AVBufferRef,
+}
 
 // ── libavfilter constants ─────────────────────────────────────────────────────
 
@@ -898,6 +917,43 @@ pub mod swresample {
         }
         pub fn is_native_order(_ch_layout: &AVChannelLayout) -> bool {
             false
+        }
+    }
+
+    pub mod audio_fifo {
+        use std::ffi::c_void;
+        use std::os::raw::c_int;
+
+        use super::super::{AVAudioFifo, AVSampleFormat};
+
+        pub unsafe fn alloc(
+            _sample_fmt: AVSampleFormat,
+            _channels: c_int,
+            _nb_samples: c_int,
+        ) -> Result<*mut AVAudioFifo, c_int> {
+            Err(-1)
+        }
+
+        pub unsafe fn free(_fifo: *mut AVAudioFifo) {}
+
+        pub unsafe fn write(
+            _fifo: *mut AVAudioFifo,
+            _data: *const *mut c_void,
+            _nb_samples: c_int,
+        ) -> Result<c_int, c_int> {
+            Err(-1)
+        }
+
+        pub unsafe fn read(
+            _fifo: *mut AVAudioFifo,
+            _data: *const *mut c_void,
+            _nb_samples: c_int,
+        ) -> Result<c_int, c_int> {
+            Err(-1)
+        }
+
+        pub unsafe fn size(_fifo: *mut AVAudioFifo) -> c_int {
+            0
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes docs.rs build failures for `ff-encode`, `ff-pipeline`, `ff-stream`, and `avio` at v0.7.0 by adding all symbols referenced in code added during the v0.7.0 milestone that were absent from `ff-sys/src/docsrs_stubs.rs`.

## Root Cause

docs.rs builds `ff-sys` with `DOCS_RS=1`, which substitutes `docsrs_stubs.rs` for the real bindgen bindings. Several new FFmpeg symbols added in v0.7.0 were not mirrored into the stubs file, causing compile errors cascading through every crate that depends on `ff-sys`.

## Missing Symbols Added

| Symbol | Used by | Error |
|---|---|---|
| `AVAudioFifo` struct | `ff-encode` audio encoder | `unresolved import ff_sys::AVAudioFifo` |
| `swresample::audio_fifo` module (`alloc`, `free`, `write`, `read`, `size`) | `ff-encode` audio encoder | `cannot find audio_fifo in swresample` |
| `AVCodec.sample_fmts` / `.capabilities` | `ff-encode` audio encoder | `no field sample_fmts on type AVCodec` |
| `AVFilterContext.hw_device_ctx` | `ff-filter` | `no field hw_device_ctx on type AVFilterContext` |
| `AVCodecContext.frame_size` | `ff-encode` audio encoder | `no field frame_size on type AVCodecContext` |
| `AVCodecContext.color_range` | `ff-encode` image encoder | `no field color_range on type AVCodecContext` |
| `AVCodecContext.refs` | `ff-encode` H.264 options | `no field refs on type AVCodecContext` |
| `AVCodecContext.rc_max_rate` / `.rc_buffer_size` | `ff-encode` VBR | missing fields |
| `AVCodecContext.flags` | `ff-encode` two-pass | `no field flags on type AVCodecContext` |
| `AVCodecContext.stats_out` / `.stats_in` | `ff-encode` two-pass | missing fields |
| `AVPixelFormat_AV_PIX_FMT_YUVJ422P` / `YUVJ444P` | `ff-decode` / `ff-encode` | `cannot find value YUVJ422P` |

## Verification

```bash
DOCS_RS=1 cargo build -p ff-encode -p ff-pipeline -p ff-stream -p avio
# → Finished with no errors
```

## Test Plan

- [x] `DOCS_RS=1 cargo build -p ff-sys -p ff-encode -p ff-pipeline -p ff-stream -p avio` passes
- [x] `cargo build --workspace` passes (normal build unaffected)
- [x] `cargo clippy -p ff-sys -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes