### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.1] - 2026-03-22
+
+### Fixed
+
+#### ff-sys
+- `docsrs_stubs`: add all symbols referenced by v0.7.0 feature additions that were missing, causing docs.rs build failures for `ff-encode`, `ff-pipeline`, `ff-stream`, and `avio`:
+  - `AVAudioFifo` opaque struct and `swresample::audio_fifo` module (`alloc`, `free`, `write`, `read`, `size`)
+  - `AVCodec.sample_fmts` and `AVCodec.capabilities` fields (struct was previously opaque)
+  - `AVFilterContext.hw_device_ctx` field (struct was previously opaque)
+  - `AVCodecContext` fields: `frame_size`, `color_range`, `refs`, `rc_max_rate`, `rc_buffer_size`, `flags`, `stats_out`, `stats_in`
+  - `AVPixelFormat_AV_PIX_FMT_YUVJ422P` and `AVPixelFormat_AV_PIX_FMT_YUVJ444P` pixel format constants
+
+---
+
 ## [0.7.0] - 2026-03-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.7.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.7.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.7.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.7.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.7.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.7.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.7.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.7.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.7.0" }
-avio        = { path = "crates/avio",        version = "0.7.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.7.1" }
+ff-common   = { path = "crates/ff-common",   version = "0.7.1" }
+ff-format   = { path = "crates/ff-format",   version = "0.7.1" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.7.1" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.7.1" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.7.1" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.7.1" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.7.1" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.7.1" }
+avio        = { path = "crates/avio",        version = "0.7.1" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Patch release fixing docs.rs build failures for `ff-encode`, `ff-pipeline`, `ff-stream`, and `avio` introduced in v0.7.0.

## Changes

- `Cargo.toml`: workspace version `0.7.0` → `0.7.1`; intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.7.1]` entry

## Root Cause

The `ff-sys/src/docsrs_stubs.rs` file was missing several symbols referenced by code added in the v0.7.0 milestone. docs.rs substitutes this stub file for the real bindgen bindings, so any unreferenced symbol causes a compile error cascading to all dependent crates.

## Related Issues

Closes #667 (via PR #667, already merged to main)

## Test Plan

- [x] `DOCS_RS=1 cargo build -p ff-sys -p ff-encode -p ff-pipeline -p ff-stream -p avio` passes
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes