### PR TITLE
fix(ff-sys): add av_rescale_q and AVPictureType constants to docsrs_stubs

### DIFF
--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -366,6 +366,10 @@ pub const AVHWDeviceType_AV_HWDEVICE_TYPE_QSV: AVHWDeviceType = 5;
 pub const AVHWDeviceType_AV_HWDEVICE_TYPE_VIDEOTOOLBOX: AVHWDeviceType = 7;
 pub const AVHWDeviceType_AV_HWDEVICE_TYPE_D3D11VA: AVHWDeviceType = 8;
 
+// AVPictureType constants
+pub const AVPictureType_AV_PICTURE_TYPE_NONE: AVPictureType = 0;
+pub const AVPictureType_AV_PICTURE_TYPE_I: AVPictureType = 1;
+
 // ── Raw FFmpeg functions (bindgen-generated counterparts) ─────────────────────
 //
 // These mirror what bindgen would emit from the real FFmpeg headers.
@@ -555,6 +559,10 @@ pub unsafe fn swr_init(_s: *mut SwrContext) -> c_int {
 pub unsafe fn av_channel_layout_default(_ch_layout: *mut AVChannelLayout, _nb_channels: c_int) {}
 
 pub unsafe fn av_channel_layout_uninit(_ch_layout: *mut AVChannelLayout) {}
+
+pub unsafe fn av_rescale_q(_a: i64, _bq: AVRational, _cq: AVRational) -> i64 {
+    0
+}
 
 pub unsafe fn av_mallocz(_size: usize) -> *mut c_void {
     std::ptr::null_mut()


### PR DESCRIPTION
## Summary

Fixes the remaining docs.rs build failure for `ff-stream` (discovered after v0.7.1 fixed the other crates).

## Root Cause

`ff-stream`'s `hls_inner.rs`, `dash_inner.rs`, and `codec_utils.rs` reference three `ff-sys` symbols that were absent from `docsrs_stubs.rs`:

| Symbol | Type | Used in |
|---|---|---|
| `av_rescale_q` | `fn(i64, AVRational, AVRational) -> i64` | PTS rescaling in HLS/DASH encoders |
| `AVPictureType_AV_PICTURE_TYPE_NONE` | `AVPictureType = 0` | Frame type tagging |
| `AVPictureType_AV_PICTURE_TYPE_I` | `AVPictureType = 1` | IDR/keyframe tagging |

## Verification

```bash
DOCS_RS=1 cargo build -p ff-stream  # → Finished with no errors
DOCS_RS=1 cargo build --workspace   # → Finished with no errors
```

## Test Plan

- [x] `DOCS_RS=1 cargo build --workspace` passes
- [x] `cargo build --workspace` passes
- [x] `cargo clippy -p ff-sys -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes