### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.2] - 2026-03-22
+
+### Fixed
+
+#### ff-sys
+- `docsrs_stubs`: add `av_rescale_q`, `AVPictureType_AV_PICTURE_TYPE_NONE`, and `AVPictureType_AV_PICTURE_TYPE_I`, fixing the docs.rs build failure for `ff-stream`
+
+---
+
 ## [0.7.1] - 2026-03-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.7.1" }
-ff-common   = { path = "crates/ff-common",   version = "0.7.1" }
-ff-format   = { path = "crates/ff-format",   version = "0.7.1" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.7.1" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.7.1" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.7.1" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.7.1" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.7.1" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.7.1" }
-avio        = { path = "crates/avio",        version = "0.7.1" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.7.2" }
+ff-common   = { path = "crates/ff-common",   version = "0.7.2" }
+ff-format   = { path = "crates/ff-format",   version = "0.7.2" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.7.2" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.7.2" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.7.2" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.7.2" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.7.2" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.7.2" }
+avio        = { path = "crates/avio",        version = "0.7.2" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Patch release fixing the remaining docs.rs build failure for `ff-stream` introduced in v0.7.0.

## Changes

- `Cargo.toml`: workspace version `0.7.1` → `0.7.2`; intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.7.2]` entry

## Related Issues

Closes #669 (already merged to main)

## Test Plan

- [x] `DOCS_RS=1 cargo build --workspace` passes
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes