### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.3] - 2026-03-22
+
+### Fixed
+
+#### ff-sys
+- `docsrs_stubs`: add `AVFormatContext.priv_data` field, fixing the docs.rs build failure for `ff-stream` (used by `av_opt_set` calls in `hls_inner.rs` and `dash_inner.rs`)
+
+### Changed
+
+#### CI
+- Add `docsrs-stubs` job (`DOCS_RS=1 cargo build --workspace`) to catch missing `ff-sys` stub symbols before publishing
+
+---
+
 ## [0.7.2] - 2026-03-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.7.2" }
-ff-common   = { path = "crates/ff-common",   version = "0.7.2" }
-ff-format   = { path = "crates/ff-format",   version = "0.7.2" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.7.2" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.7.2" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.7.2" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.7.2" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.7.2" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.7.2" }
-avio        = { path = "crates/avio",        version = "0.7.2" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.7.3" }
+ff-common   = { path = "crates/ff-common",   version = "0.7.3" }
+ff-format   = { path = "crates/ff-format",   version = "0.7.3" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.7.3" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.7.3" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.7.3" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.7.3" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.7.3" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.7.3" }
+avio        = { path = "crates/avio",        version = "0.7.3" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.7.2 to 0.7.3 and documents all changes in CHANGELOG.md.

## Changes

- `Cargo.toml`: workspace version 0.7.2 → 0.7.3; intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.7.3]` entry
- `crates/ff-sys/src/docsrs_stubs.rs`: add `AVFormatContext.priv_data` field (PR #671)
- `.github/workflows/ci.yml`: add `docsrs-stubs` CI job (PR #671)

## Related Issues

Fixes docs.rs build failure for `ff-stream` in v0.7.2 (`AVFormatContext::priv_data` missing from stubs).

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `DOCS_RS=1 cargo build --workspace` passes (new CI job)