### PR TITLE
feat(ff-format): add NetworkOptions struct for network-backed sources

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -199,8 +199,9 @@
 pub use ff_format::{
     AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ChapterInfo, ChapterInfoBuilder,
     ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, ContainerInfo, Hdr10Metadata,
-    MasteringDisplay, MediaInfo, MediaInfoBuilder, PixelFormat, Rational, SampleFormat,
-    SubtitleCodec, SubtitleStreamInfo, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
+    MasteringDisplay, MediaInfo, MediaInfoBuilder, NetworkOptions, PixelFormat, Rational,
+    SampleFormat, SubtitleCodec, SubtitleStreamInfo, Timestamp, VideoCodec, VideoFrame,
+    VideoStreamInfo,
 };
 
 // ── probe feature ─────────────────────────────────────────────────────────────
@@ -288,6 +289,7 @@ mod tests {
         let _: Rational = Rational::default();
         let _: Timestamp = Timestamp::default();
         let _: MediaInfo = MediaInfo::default();
+        let _: NetworkOptions = NetworkOptions::default();
     }
 
     // ── probe feature ─────────────────────────────────────────────────────────

--- a/crates/ff-format/src/lib.rs
+++ b/crates/ff-format/src/lib.rs
@@ -16,6 +16,7 @@
 //! - `media` - Media container info ([`MediaInfo`])
 //! - `color` - Color space definitions ([`ColorSpace`], [`ColorRange`], [`ColorPrimaries`])
 //! - `hdr` - HDR metadata types ([`Hdr10Metadata`], [`MasteringDisplay`])
+//! - `network` - Network configuration ([`NetworkOptions`])
 //! - `codec` - Codec definitions ([`VideoCodec`], [`AudioCodec`])
 //! - `channel` - Channel layout definitions ([`ChannelLayout`])
 //! - `chapter` - Chapter information ([`ChapterInfo`])
@@ -61,6 +62,7 @@ pub mod error;
 pub mod frame;
 pub mod hdr;
 pub mod media;
+pub mod network;
 pub mod pixel;
 pub mod sample;
 pub mod stream;
@@ -76,6 +78,7 @@ pub use ff_common::PooledBuffer;
 pub use frame::{AudioFrame, VideoFrame};
 pub use hdr::{Hdr10Metadata, MasteringDisplay};
 pub use media::{MediaInfo, MediaInfoBuilder};
+pub use network::NetworkOptions;
 pub use pixel::PixelFormat;
 pub use sample::SampleFormat;
 pub use stream::{
@@ -94,8 +97,8 @@ pub use time::{Rational, Timestamp};
 pub mod prelude {
     pub use crate::{
         AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ChapterInfo, ColorPrimaries,
-        ColorRange, ColorSpace, FormatError, FrameError, MediaInfo, PixelFormat, PooledBuffer,
-        Rational, SampleFormat, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
+        ColorRange, ColorSpace, FormatError, FrameError, MediaInfo, NetworkOptions, PixelFormat,
+        PooledBuffer, Rational, SampleFormat, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
     };
 }
 
@@ -123,6 +126,7 @@ mod tests {
         let _video_stream: VideoStreamInfo = VideoStreamInfo::default();
         let _audio_stream: AudioStreamInfo = AudioStreamInfo::default();
         let _media_info: MediaInfo = MediaInfo::default();
+        let _network_opts: NetworkOptions = NetworkOptions::default();
     }
 
     #[test]

--- a/crates/ff-format/src/network.rs
+++ b/crates/ff-format/src/network.rs
@@ -1,0 +1,123 @@
+//! Network configuration types for network-backed sources and outputs.
+//!
+//! This module provides [`NetworkOptions`] — shared connection and reconnect
+//! settings consumed by network-aware decoders (e.g., RTMP, SRT, HLS ingest)
+//! and live streaming outputs.
+//!
+//! # `FFmpeg` key mapping
+//!
+//! | Field             | `FFmpeg` option key | Unit         |
+//! |-------------------|-------------------|--------------|
+//! | `connect_timeout` | `timeout`         | microseconds |
+//! | `read_timeout`    | `rw_timeout`      | microseconds |
+//!
+//! # Examples
+//!
+//! ```
+//! use ff_format::network::NetworkOptions;
+//! use std::time::Duration;
+//!
+//! let opts = NetworkOptions {
+//!     connect_timeout: Duration::from_secs(5),
+//!     read_timeout: Duration::from_secs(15),
+//!     reconnect_on_error: true,
+//!     max_reconnect_attempts: 5,
+//! };
+//! assert_eq!(opts.connect_timeout.as_micros(), 5_000_000);
+//! ```
+
+use std::time::Duration;
+
+/// Shared network configuration for network-backed decoders and live outputs.
+///
+/// These settings map directly to `FFmpeg` `AVFormatContext` options that control
+/// connection and read timeouts, and to application-level reconnection logic.
+///
+/// # `FFmpeg` option keys
+///
+/// Pass the converted microsecond values via `av_dict_set` on the
+/// `AVFormatContext` before opening the stream:
+///
+/// - `connect_timeout` → key `"timeout"`, value `connect_timeout.as_micros()`
+/// - `read_timeout` → key `"rw_timeout"`, value `read_timeout.as_micros()`
+///
+/// # Defaults
+///
+/// ```
+/// use ff_format::network::NetworkOptions;
+/// use std::time::Duration;
+///
+/// let opts = NetworkOptions::default();
+/// assert_eq!(opts.connect_timeout, Duration::from_secs(10));
+/// assert_eq!(opts.read_timeout, Duration::from_secs(30));
+/// assert!(!opts.reconnect_on_error);
+/// assert_eq!(opts.max_reconnect_attempts, 3);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct NetworkOptions {
+    /// Maximum time to wait when establishing a connection.
+    ///
+    /// Maps to the `FFmpeg` `"timeout"` option key (value in microseconds).
+    /// Default: 10 seconds.
+    pub connect_timeout: Duration,
+
+    /// Maximum time to wait for data after the connection is open.
+    ///
+    /// Maps to the `FFmpeg` `"rw_timeout"` option key (value in microseconds).
+    /// Default: 30 seconds.
+    pub read_timeout: Duration,
+
+    /// Whether to attempt reconnection when a read error occurs.
+    ///
+    /// When `false`, `max_reconnect_attempts` is ignored.
+    /// Default: `false`.
+    pub reconnect_on_error: bool,
+
+    /// Maximum number of reconnection attempts before giving up.
+    ///
+    /// Ignored when `reconnect_on_error` is `false`.
+    /// Default: `3`.
+    pub max_reconnect_attempts: u32,
+}
+
+impl Default for NetworkOptions {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Duration::from_secs(10),
+            read_timeout: Duration::from_secs(30),
+            reconnect_on_error: false,
+            max_reconnect_attempts: 3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_should_have_correct_timeout_values() {
+        let opts = NetworkOptions::default();
+        assert_eq!(opts.connect_timeout, Duration::from_secs(10));
+        assert_eq!(opts.read_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn default_should_disable_reconnect() {
+        let opts = NetworkOptions::default();
+        assert!(!opts.reconnect_on_error);
+        assert_eq!(opts.max_reconnect_attempts, 3);
+    }
+
+    #[test]
+    fn connect_timeout_microseconds_should_match_duration() {
+        let opts = NetworkOptions::default();
+        assert_eq!(opts.connect_timeout.as_micros(), 10_000_000);
+    }
+
+    #[test]
+    fn read_timeout_microseconds_should_match_duration() {
+        let opts = NetworkOptions::default();
+        assert_eq!(opts.read_timeout.as_micros(), 30_000_000);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `NetworkOptions` in `ff-format/src/network.rs` — the shared configuration type for all network-backed decoders and live stream outputs. Placing it in `ff-format` allows both `ff-decode` (input) and `ff-stream` (output) to depend on it without circular dependencies, and exposes it from `avio` without any feature flag.

## Changes

- Add `crates/ff-format/src/network.rs` with `NetworkOptions` struct (`connect_timeout`, `read_timeout`, `reconnect_on_error`, `max_reconnect_attempts`) and a manual `Default` impl (10 s / 30 s / false / 3)
- Re-export `NetworkOptions` from `ff-format::lib` and the `ff-format::prelude` module
- Re-export `NetworkOptions` from `avio` in the always-available `pub use ff_format::{}` block (no feature flag)
- 4 unit tests covering default values and microsecond conversion (`as_micros()`)

## Related Issues

Closes #219

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes