### PR TITLE
feat(ff-decode): add network URL support to AudioDecoder

### DIFF
--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ff_format::{AudioFrame, AudioStreamInfo, ContainerInfo, SampleFormat};
+use ff_format::{AudioFrame, AudioStreamInfo, ContainerInfo, NetworkOptions, SampleFormat};
 
 use crate::audio::decoder_inner::AudioDecoderInner;
 use crate::error::DecodeError;
@@ -61,6 +61,8 @@ pub struct AudioDecoderBuilder {
     output_sample_rate: Option<u32>,
     /// Output channel count (None = use source channel count)
     output_channels: Option<u32>,
+    /// Network options for URL-based sources (None = use defaults)
+    network_opts: Option<NetworkOptions>,
 }
 
 impl AudioDecoderBuilder {
@@ -73,6 +75,7 @@ impl AudioDecoderBuilder {
             output_format: None,
             output_sample_rate: None,
             output_channels: None,
+            network_opts: None,
         }
     }
 
@@ -157,6 +160,31 @@ impl AudioDecoderBuilder {
         self
     }
 
+    /// Sets network options for URL-based audio sources (HTTP, RTSP, RTMP, etc.).
+    ///
+    /// This option is only relevant when the path is a network URL. For local
+    /// files it is silently ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_decode::AudioDecoder;
+    /// use ff_format::NetworkOptions;
+    /// use std::time::Duration;
+    ///
+    /// let decoder = AudioDecoder::open("http://stream.example.com/audio.aac")?
+    ///     .network(NetworkOptions {
+    ///         connect_timeout: Duration::from_secs(5),
+    ///         ..Default::default()
+    ///     })
+    ///     .build()?;
+    /// ```
+    #[must_use]
+    pub fn network(mut self, opts: NetworkOptions) -> Self {
+        self.network_opts = Some(opts);
+        self
+    }
+
     /// Returns the configured file path.
     #[must_use]
     pub fn path(&self) -> &Path {
@@ -209,8 +237,9 @@ impl AudioDecoderBuilder {
     /// }
     /// ```
     pub fn build(self) -> Result<AudioDecoder, DecodeError> {
-        // Verify the file exists
-        if !self.path.exists() {
+        // Network URLs skip the file-existence check (literal path does not exist).
+        let is_network_url = self.path.to_str().is_some_and(crate::network::is_url);
+        if !is_network_url && !self.path.exists() {
             return Err(DecodeError::FileNotFound {
                 path: self.path.clone(),
             });
@@ -229,6 +258,7 @@ impl AudioDecoderBuilder {
             self.output_format,
             self.output_sample_rate,
             self.output_channels,
+            self.network_opts,
         )?;
 
         Ok(AudioDecoder {
@@ -721,5 +751,25 @@ mod tests {
         assert!(config.output_format.is_none());
         assert!(config.output_sample_rate.is_none());
         assert!(config.output_channels.is_none());
+    }
+
+    #[test]
+    fn network_setter_should_store_options() {
+        let opts = NetworkOptions::default();
+        let builder = AudioDecoderBuilder::new(PathBuf::from("test.mp3")).network(opts.clone());
+        assert_eq!(builder.network_opts, Some(opts));
+    }
+
+    #[test]
+    fn build_should_bypass_file_existence_check_for_network_url() {
+        // A network URL that clearly does not exist locally should not return
+        // FileNotFound — it will return a different error (or succeed) from
+        // FFmpeg's network layer. The important thing is that FileNotFound is
+        // NOT returned.
+        let result = AudioDecoder::open("http://192.0.2.1/nonexistent.aac").build();
+        assert!(
+            !matches!(result, Err(DecodeError::FileNotFound { .. })),
+            "FileNotFound must not be returned for network URLs"
+        );
     }
 }

--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -31,7 +31,7 @@ use ff_format::channel::ChannelLayout;
 use ff_format::codec::AudioCodec;
 use ff_format::container::ContainerInfo;
 use ff_format::time::{Rational, Timestamp};
-use ff_format::{AudioFrame, AudioStreamInfo, SampleFormat};
+use ff_format::{AudioFrame, AudioStreamInfo, NetworkOptions, SampleFormat};
 use ff_sys::{
     AVCodecContext, AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_AUDIO, AVPacket,
     AVSampleFormat, SwrContext,
@@ -55,6 +55,22 @@ impl AvFormatContextGuard {
                 code: e,
                 message: format!("Failed to open file: {}", ff_sys::av_error_string(e)),
             })?
+        };
+        Ok(Self(format_ctx))
+    }
+
+    /// Opens a network URL using the supplied network options.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure FFmpeg is initialized and URL is valid.
+    unsafe fn new_url(url: &str, network: &NetworkOptions) -> Result<Self, DecodeError> {
+        // SAFETY: Caller ensures FFmpeg is initialized and URL is valid
+        let format_ctx = unsafe {
+            ff_sys::avformat::open_input_url(url, network.connect_timeout, network.read_timeout)
+                .map_err(|e| {
+                    crate::network::map_network_error(e, crate::network::sanitize_url(url))
+                })?
         };
         Ok(Self(format_ctx))
     }
@@ -277,18 +293,36 @@ impl AudioDecoderInner {
     /// - No audio stream is found
     /// - The codec is not supported
     /// - Decoder initialization fails
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         path: &Path,
         output_format: Option<SampleFormat>,
         output_sample_rate: Option<u32>,
         output_channels: Option<u32>,
+        network_opts: Option<NetworkOptions>,
     ) -> Result<(Self, AudioStreamInfo, ContainerInfo), DecodeError> {
         // Ensure FFmpeg is initialized (thread-safe and idempotent)
         ff_sys::ensure_initialized();
 
-        // Open the input file (with RAII guard)
+        let path_str = path.to_str().unwrap_or("");
+        let is_network_url = crate::network::is_url(path_str);
+
+        // Open the input source (with RAII guard)
         // SAFETY: Path is valid, AvFormatContextGuard ensures cleanup
-        let format_ctx_guard = unsafe { AvFormatContextGuard::new(path)? };
+        let format_ctx_guard = unsafe {
+            if is_network_url {
+                let network = network_opts.unwrap_or_default();
+                log::info!(
+                    "opening network audio source url={} connect_timeout_ms={} read_timeout_ms={}",
+                    crate::network::sanitize_url(path_str),
+                    network.connect_timeout.as_millis(),
+                    network.read_timeout.as_millis()
+                );
+                AvFormatContextGuard::new_url(path_str, &network)?
+            } else {
+                AvFormatContextGuard::new(path)?
+            }
+        };
         let format_ctx = format_ctx_guard.as_ptr();
 
         // Read stream information


### PR DESCRIPTION
## Summary

Mirrors the `VideoDecoder` network implementation (#220) for `AudioDecoder`. `AudioDecoderBuilder` gains a `.network(NetworkOptions)` setter so callers can tune connect/read timeouts. The file-existence check in `.build()` is bypassed for recognised URL schemes, and network-specific FFmpeg errno values are mapped to the typed `DecodeError` variants introduced in #228 (`NetworkTimeout`, `ConnectionFailed`, `StreamInterrupted`).

## Changes

- `audio/builder.rs`: add `network_opts: Option<NetworkOptions>` field and `.network()` setter; skip file-existence check for network URLs in `build()`; pass `network_opts` to `AudioDecoderInner::new()`
- `audio/decoder_inner.rs`: add `AvFormatContextGuard::new_url()` calling `ff_sys::avformat::open_input_url`; add `network_opts` parameter to `AudioDecoderInner::new()`; log `url=`, `connect_timeout_ms=`, `read_timeout_ms=` at `info` level when opening a network source
- Unit tests: `network_setter_should_store_options`, `build_should_bypass_file_existence_check_for_network_url`

## Related Issues

Closes #221

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes