### PR TITLE
feat(ff-decode): HLS/M3U8 support, is_live() detection, and seek guard

### DIFF
--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -162,8 +162,37 @@ impl AudioDecoderBuilder {
 
     /// Sets network options for URL-based audio sources (HTTP, RTSP, RTMP, etc.).
     ///
-    /// This option is only relevant when the path is a network URL. For local
-    /// files it is silently ignored.
+    /// When set, the builder skips the file-existence check and passes connect
+    /// and read timeouts to `avformat_open_input` via an `AVDictionary`.
+    /// Call this before `.build()` when opening `rtmp://`, `rtsp://`, `http://`,
+    /// `https://`, `udp://`, `srt://`, or `rtp://` URLs.
+    ///
+    /// # HLS / M3U8 Playlists
+    ///
+    /// Audio-only HLS playlists (`.m3u8` pointing to AAC or MP3 segments) are
+    /// detected automatically by `FFmpeg`. Pass the full HTTP(S) URL:
+    ///
+    /// ```ignore
+    /// use ff_decode::AudioDecoder;
+    /// use ff_format::NetworkOptions;
+    ///
+    /// let decoder = AudioDecoder::open("https://example.com/audio/index.m3u8")
+    ///     .network(NetworkOptions::default())
+    ///     .build()?;
+    /// ```
+    ///
+    /// # Credentials
+    ///
+    /// HTTP basic-auth credentials must be embedded directly in the URL:
+    /// `https://user:password@cdn.example.com/audio/index.m3u8`.
+    /// The password is redacted in log output.
+    ///
+    /// # DRM Limitation
+    ///
+    /// DRM-protected HLS streams (`FairPlay`, Widevine, AES-128 with external
+    /// key servers) are **not** supported. `FFmpeg` can parse the playlist and
+    /// fetch segments, but key delivery to a DRM license server is outside
+    /// the scope of this API.
     ///
     /// # Examples
     ///
@@ -172,7 +201,7 @@ impl AudioDecoderBuilder {
     /// use ff_format::NetworkOptions;
     /// use std::time::Duration;
     ///
-    /// let decoder = AudioDecoder::open("http://stream.example.com/audio.aac")?
+    /// let decoder = AudioDecoder::open("http://stream.example.com/audio.aac")
     ///     .network(NetworkOptions {
     ///         connect_timeout: Duration::from_secs(5),
     ///         ..Default::default()
@@ -640,7 +669,21 @@ impl AudioDecoder {
     /// }
     /// ```
     pub fn seek(&mut self, position: Duration, mode: crate::SeekMode) -> Result<(), DecodeError> {
+        if self.inner.is_live() {
+            return Err(DecodeError::SeekNotSupported);
+        }
         self.inner.seek(position, mode)
+    }
+
+    /// Returns `true` if the source is a live or streaming input.
+    ///
+    /// Live sources (HLS live playlists, RTMP, RTSP, MPEG-TS) have the
+    /// `AVFMT_TS_DISCONT` flag set on their `AVInputFormat`. Seeking is not
+    /// supported on live sources — [`AudioDecoder::seek`] will return
+    /// [`DecodeError::SeekNotSupported`].
+    #[must_use]
+    pub fn is_live(&self) -> bool {
+        self.inner.is_live()
     }
 
     /// Flushes the decoder's internal buffers.

--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -266,6 +266,8 @@ pub(crate) struct AudioDecoderInner {
     output_sample_rate: Option<u32>,
     /// Target output channel count (if remixing is needed)
     output_channels: Option<u32>,
+    /// Whether the source is a live/streaming input (seeking is not supported)
+    is_live: bool,
     /// Whether end of file has been reached
     eof: bool,
     /// Current playback position
@@ -333,6 +335,14 @@ impl AudioDecoderInner {
                 message: format!("Failed to find stream info: {}", ff_sys::av_error_string(e)),
             })?;
         }
+
+        // Detect live/streaming source via the AVFMT_TS_DISCONT flag on AVInputFormat.
+        // SAFETY: format_ctx is valid and non-null; iformat is set by avformat_open_input
+        //         and is non-null for all successfully opened formats.
+        let is_live = unsafe {
+            let iformat = (*format_ctx).iformat;
+            !iformat.is_null() && ((*iformat).flags & ff_sys::AVFMT_TS_DISCONT) != 0
+        };
 
         // Find the audio stream
         // SAFETY: format_ctx is valid
@@ -410,6 +420,7 @@ impl AudioDecoderInner {
                 output_format,
                 output_sample_rate,
                 output_channels,
+                is_live,
                 eof: false,
                 position: Duration::ZERO,
                 packet: packet_guard.into_raw(),
@@ -1069,6 +1080,14 @@ impl AudioDecoderInner {
     /// Returns whether end of file has been reached.
     pub(crate) fn is_eof(&self) -> bool {
         self.eof
+    }
+
+    /// Returns whether the source is a live or streaming input.
+    ///
+    /// Live sources have the `AVFMT_TS_DISCONT` flag set on their `AVInputFormat`.
+    /// Seeking is not meaningful on live sources.
+    pub(crate) fn is_live(&self) -> bool {
+        self.is_live
     }
 
     /// Converts a `Duration` to a presentation timestamp (PTS) in stream time_base units.

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -387,6 +387,34 @@ impl VideoDecoderBuilder {
     /// Call this before `.build()` when opening `rtmp://`, `rtsp://`, `http://`,
     /// `https://`, `udp://`, `srt://`, or `rtp://` URLs.
     ///
+    /// # HLS / M3U8 Playlists
+    ///
+    /// HLS playlists (`.m3u8`) are detected automatically by `FFmpeg` — no extra
+    /// configuration is required beyond calling `.network()`. Pass the full
+    /// HTTP(S) URL of the master or media playlist:
+    ///
+    /// ```ignore
+    /// use ff_decode::VideoDecoder;
+    /// use ff_format::NetworkOptions;
+    ///
+    /// let decoder = VideoDecoder::open("https://example.com/live/index.m3u8")
+    ///     .network(NetworkOptions::default())
+    ///     .build()?;
+    /// ```
+    ///
+    /// # Credentials
+    ///
+    /// HTTP basic-auth credentials must be embedded directly in the URL:
+    /// `https://user:password@cdn.example.com/live/index.m3u8`.
+    /// The password is redacted in log output.
+    ///
+    /// # DRM Limitation
+    ///
+    /// DRM-protected HLS streams (`FairPlay`, Widevine, AES-128 with external
+    /// key servers) are **not** supported. `FFmpeg` can parse the playlist and
+    /// fetch segments, but key delivery to a DRM license server is outside
+    /// the scope of this API.
+    ///
     /// # Examples
     ///
     /// ```ignore
@@ -983,7 +1011,21 @@ impl VideoDecoder {
     /// }
     /// ```
     pub fn seek(&mut self, position: Duration, mode: crate::SeekMode) -> Result<(), DecodeError> {
+        if self.inner.is_live() {
+            return Err(DecodeError::SeekNotSupported);
+        }
         self.inner.seek(position, mode)
+    }
+
+    /// Returns `true` if the source is a live or streaming input.
+    ///
+    /// Live sources (HLS live playlists, RTMP, RTSP, MPEG-TS) have the
+    /// `AVFMT_TS_DISCONT` flag set on their `AVInputFormat`. Seeking is not
+    /// supported on live sources — [`VideoDecoder::seek`] will return
+    /// [`DecodeError::SeekNotSupported`].
+    #[must_use]
+    pub fn is_live(&self) -> bool {
+        self.inner.is_live()
     }
 
     /// Flushes the decoder's internal buffers.

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -289,6 +289,8 @@ pub(crate) struct VideoDecoderInner {
     output_format: Option<PixelFormat>,
     /// Requested output scale (if resizing is needed)
     output_scale: Option<OutputScale>,
+    /// Whether the source is a live/streaming input (seeking is not supported)
+    is_live: bool,
     /// Whether end of file has been reached
     eof: bool,
     /// Current playback position
@@ -593,6 +595,14 @@ impl VideoDecoderInner {
             })?;
         }
 
+        // Detect live/streaming source via the AVFMT_TS_DISCONT flag on AVInputFormat.
+        // SAFETY: format_ctx is valid and non-null; iformat is set by avformat_open_input
+        //         and is non-null for all successfully opened formats.
+        let is_live = unsafe {
+            let iformat = (*format_ctx).iformat;
+            !iformat.is_null() && ((*iformat).flags & ff_sys::AVFMT_TS_DISCONT) != 0
+        };
+
         // Find the video stream
         // SAFETY: format_ctx is valid
         let (stream_index, codec_id) =
@@ -697,6 +707,7 @@ impl VideoDecoderInner {
                 sws_cache_key: None,
                 output_format,
                 output_scale,
+                is_live,
                 eof: false,
                 position: Duration::ZERO,
                 packet: packet_guard.into_raw(),
@@ -1548,6 +1559,14 @@ impl VideoDecoderInner {
     /// Returns whether end of file has been reached.
     pub(crate) fn is_eof(&self) -> bool {
         self.eof
+    }
+
+    /// Returns whether the source is a live or streaming input.
+    ///
+    /// Live sources have the `AVFMT_TS_DISCONT` flag set on their `AVInputFormat`.
+    /// Seeking is not meaningful on live sources.
+    pub(crate) fn is_live(&self) -> bool {
+        self.is_live
     }
 
     /// Converts a `Duration` to a presentation timestamp (PTS) in stream time_base units.

--- a/crates/ff-decode/tests/hls_stream_tests.rs
+++ b/crates/ff-decode/tests/hls_stream_tests.rs
@@ -1,0 +1,114 @@
+//! Integration tests for HLS / M3U8 network stream support (issue #222).
+//!
+//! Tests that require a reachable HLS server are skipped gracefully when the
+//! server is unavailable (e.g. in CI without a local test server — see #235).
+
+mod fixtures;
+use fixtures::*;
+
+use ff_decode::{AudioDecoder, DecodeError, SeekMode, VideoDecoder};
+use ff_format::NetworkOptions;
+
+// ── is_live detection on file-backed decoders ────────────────────────────────
+
+#[test]
+fn file_video_decoder_should_not_be_live() {
+    let decoder = VideoDecoder::open(test_video_path())
+        .build()
+        .expect("Failed to open test video");
+    assert!(
+        !decoder.is_live(),
+        "File-backed VideoDecoder must report is_live=false"
+    );
+}
+
+#[test]
+fn file_audio_decoder_should_not_be_live() {
+    let decoder = AudioDecoder::open(test_audio_path())
+        .build()
+        .expect("Failed to open test audio");
+    assert!(
+        !decoder.is_live(),
+        "File-backed AudioDecoder must report is_live=false"
+    );
+}
+
+// ── Seek is allowed on file-backed decoders ──────────────────────────────────
+
+#[test]
+fn file_video_decoder_seek_should_not_return_seek_not_supported() {
+    let mut decoder = VideoDecoder::open(test_video_path())
+        .build()
+        .expect("Failed to open test video");
+    let result = decoder.seek(std::time::Duration::from_millis(100), SeekMode::Keyframe);
+    assert!(
+        !matches!(result, Err(DecodeError::SeekNotSupported)),
+        "File-backed seek must not return SeekNotSupported, got: {result:?}"
+    );
+}
+
+#[test]
+fn file_audio_decoder_seek_should_not_return_seek_not_supported() {
+    let mut decoder = AudioDecoder::open(test_audio_path())
+        .build()
+        .expect("Failed to open test audio");
+    let result = decoder.seek(std::time::Duration::from_millis(100), SeekMode::Keyframe);
+    assert!(
+        !matches!(result, Err(DecodeError::SeekNotSupported)),
+        "File-backed audio seek must not return SeekNotSupported, got: {result:?}"
+    );
+}
+
+// ── Network URL does not produce FileNotFound ────────────────────────────────
+
+#[test]
+fn hls_video_open_should_not_return_file_not_found() {
+    // Use an unreachable loopback address — the important assertion is that
+    // the file-existence guard is bypassed for HTTP URLs.
+    let result = VideoDecoder::open("http://127.0.0.1:65535/nonexistent/index.m3u8")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("HTTP URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+#[test]
+fn hls_audio_open_should_not_return_file_not_found() {
+    let result = AudioDecoder::open("http://127.0.0.1:65535/nonexistent/audio.m3u8")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("HTTP URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+// ── Seek guard on live decoder (requires reachable HLS server) ──────────────
+
+/// Validates that `seek()` on a live HLS decoder returns `SeekNotSupported`.
+///
+/// Skipped gracefully when no local HLS test server is reachable (see #235).
+#[test]
+fn hls_live_decoder_seek_should_return_seek_not_supported() {
+    let mut decoder = match VideoDecoder::open("http://localhost:8080/live/index.m3u8")
+        .network(NetworkOptions::default())
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: no live HLS server available ({e})");
+            return;
+        }
+    };
+
+    if !decoder.is_live() {
+        println!("Skipping: decoder did not detect live source (VOD playlist?)");
+        return;
+    }
+
+    let result = decoder.seek(std::time::Duration::from_secs(5), SeekMode::Keyframe);
+    assert!(
+        matches!(result, Err(DecodeError::SeekNotSupported)),
+        "Expected SeekNotSupported on live HLS stream, got: {result:?}"
+    );
+}

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -39,6 +39,7 @@ pub struct AVAudioFifo(());
 pub struct AVInputFormat {
     pub name: *const c_char,
     pub long_name: *const c_char,
+    pub flags: c_int,
 }
 
 // ── Structs with field-level access ───────────────────────────────────────────

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -171,6 +171,13 @@ pub mod error_codes {
 /// This constant indicates that a frame or packet does not have a valid presentation timestamp.
 pub const AV_NOPTS_VALUE: i64 = i64::MIN;
 
+/// `AVFMT_TS_DISCONT` — `AVInputFormat` flag indicating discontinuous timestamps.
+///
+/// Set for live/streaming formats such as HLS (live playlists), RTMP, RTSP,
+/// MPEG-TS (UDP/SRT), and similar sources. Used to detect live streams after
+/// `avformat_find_stream_info` has been called.
+pub const AVFMT_TS_DISCONT: i32 = 0x0200;
+
 /// `AV_BUFFERSRC_FLAG_KEEP_REF` normalized to `i32` for cross-platform use.
 ///
 /// bindgen generates `AV_BUFFERSRC_FLAG_KEEP_REF` as `u32` on Linux/macOS


### PR DESCRIPTION
## Summary

Completes HLS stream (`.m3u8`) input support for `VideoDecoder` and `AudioDecoder`. No new FFmpeg demuxer code is required — FFmpeg auto-detects HLS URLs. The main additions are live-stream detection via the `AVFMT_TS_DISCONT` flag on `AVInputFormat`, a public `is_live()` API, and a seek guard that returns `DecodeError::SeekNotSupported` on live sources.

## Changes

- `ff-sys/src/lib.rs`: add `AVFMT_TS_DISCONT: i32 = 0x0200` constant
- `ff-sys/src/docsrs_stubs.rs`: add `flags: c_int` to `AVInputFormat` stub so docs.rs builds compile
- `video/decoder_inner.rs` + `audio/decoder_inner.rs`: add `is_live: bool` field; detect live mode by checking `iformat->flags & AVFMT_TS_DISCONT` after `avformat_find_stream_info`; add `pub(crate) fn is_live()` accessor
- `video/builder.rs` + `audio/builder.rs`: add `pub fn is_live() -> bool`; guard `seek()` to return `DecodeError::SeekNotSupported` when live; expand `.network()` doc comment with HLS/M3U8 section, credentials note, and DRM limitation
- `tests/hls_stream_tests.rs` (new): 7 integration tests covering `is_live=false` on file decoders, seek-allowed on files, `FileNotFound` bypass for HTTP URLs, and a gracefully-skipped live-seek guard test

## Related Issues

Closes #222

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes