### PR TITLE
feat(ff-decode): document DASH/MPD support and integration tests

### DIFF
--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -189,10 +189,12 @@ impl AudioDecoderBuilder {
     ///
     /// # DRM Limitation
     ///
-    /// DRM-protected HLS streams (`FairPlay`, Widevine, AES-128 with external
-    /// key servers) are **not** supported. `FFmpeg` can parse the playlist and
-    /// fetch segments, but key delivery to a DRM license server is outside
-    /// the scope of this API.
+    /// DRM-protected streams are **not** supported:
+    /// - HLS: `FairPlay`, Widevine, AES-128 with external key servers
+    /// - DASH: CENC, `PlayReady`, Widevine
+    ///
+    /// `FFmpeg` can parse the manifest and fetch segments, but key delivery
+    /// to a DRM license server is outside the scope of this API.
     ///
     /// # Examples
     ///

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -402,6 +402,28 @@ impl VideoDecoderBuilder {
     ///     .build()?;
     /// ```
     ///
+    /// # DASH / MPD Streams
+    ///
+    /// MPEG-DASH manifests (`.mpd`) are detected automatically by `FFmpeg`'s
+    /// built-in `dash` demuxer. The demuxer downloads the manifest, selects the
+    /// highest-quality representation, and fetches segments automatically:
+    ///
+    /// ```ignore
+    /// use ff_decode::VideoDecoder;
+    /// use ff_format::NetworkOptions;
+    ///
+    /// let decoder = VideoDecoder::open("https://example.com/dash/manifest.mpd")
+    ///     .network(NetworkOptions::default())
+    ///     .build()?;
+    /// ```
+    ///
+    /// **Multi-period caveat**: multi-period DASH streams are supported by
+    /// `FFmpeg` but period boundaries may trigger an internal decoder reset,
+    /// which can cause a brief gap in decoded frames.
+    ///
+    /// **Adaptive bitrate**: representation selection (ABR switching) is handled
+    /// internally by `FFmpeg` and is not exposed through this API.
+    ///
     /// # Credentials
     ///
     /// HTTP basic-auth credentials must be embedded directly in the URL:
@@ -410,10 +432,12 @@ impl VideoDecoderBuilder {
     ///
     /// # DRM Limitation
     ///
-    /// DRM-protected HLS streams (`FairPlay`, Widevine, AES-128 with external
-    /// key servers) are **not** supported. `FFmpeg` can parse the playlist and
-    /// fetch segments, but key delivery to a DRM license server is outside
-    /// the scope of this API.
+    /// DRM-protected streams are **not** supported:
+    /// - HLS: `FairPlay`, Widevine, AES-128 with external key servers
+    /// - DASH: CENC, `PlayReady`, Widevine
+    ///
+    /// `FFmpeg` can parse the manifest and fetch segments, but key delivery
+    /// to a DRM license server is outside the scope of this API.
     ///
     /// # Examples
     ///

--- a/crates/ff-decode/tests/dash_stream_tests.rs
+++ b/crates/ff-decode/tests/dash_stream_tests.rs
@@ -1,0 +1,91 @@
+//! Integration tests for MPEG-DASH / MPD network stream support (issue #223).
+//!
+//! Tests that require a reachable DASH server are skipped gracefully when the
+//! server is unavailable (e.g. in CI without a local test server — see #235).
+
+mod fixtures;
+use fixtures::*;
+
+use ff_decode::{DecodeError, SeekMode, VideoDecoder};
+use ff_format::NetworkOptions;
+
+// ── File-backed decoder is not a DASH live stream ────────────────────────────
+
+#[test]
+fn file_video_decoder_should_not_be_live_dash() {
+    // Re-verify the baseline: a file-backed decoder never reports is_live=true,
+    // even after the DASH demuxer detection logic was added.
+    let decoder = VideoDecoder::open(test_video_path())
+        .build()
+        .expect("Failed to open test video");
+    assert!(
+        !decoder.is_live(),
+        "File-backed VideoDecoder must report is_live=false (DASH regression guard)"
+    );
+}
+
+// ── MPD URL does not produce FileNotFound ────────────────────────────────────
+
+#[test]
+fn dash_mpd_open_should_not_return_file_not_found() {
+    // Use an unreachable loopback address. The important assertion is that the
+    // file-existence guard is bypassed for HTTP URLs regardless of extension.
+    let result = VideoDecoder::open("http://127.0.0.1:65535/nonexistent/manifest.mpd")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("HTTP MPD URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+// ── Live DASH stream detection (requires reachable DASH server) ──────────────
+
+/// Validates that a live DASH stream (`type="dynamic"` MPD) is detected as live.
+///
+/// Skipped gracefully when no local DASH test server is reachable (see #235).
+#[test]
+fn dash_live_decoder_should_report_is_live() {
+    let decoder = match VideoDecoder::open("http://localhost:8080/dash/live/manifest.mpd")
+        .network(NetworkOptions::default())
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: no live DASH server available ({e})");
+            return;
+        }
+    };
+
+    assert!(
+        decoder.is_live(),
+        "Live DASH (type=dynamic) must report is_live=true"
+    );
+}
+
+/// Validates that `seek()` on a live DASH decoder returns `SeekNotSupported`.
+///
+/// Skipped gracefully when no local DASH test server is reachable (see #235).
+#[test]
+fn dash_live_decoder_seek_should_return_seek_not_supported() {
+    let mut decoder = match VideoDecoder::open("http://localhost:8080/dash/live/manifest.mpd")
+        .network(NetworkOptions::default())
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: no live DASH server available ({e})");
+            return;
+        }
+    };
+
+    if !decoder.is_live() {
+        println!("Skipping: decoder did not detect live DASH source (VOD manifest?)");
+        return;
+    }
+
+    let result = decoder.seek(std::time::Duration::from_secs(5), SeekMode::Keyframe);
+    assert!(
+        matches!(result, Err(DecodeError::SeekNotSupported)),
+        "Expected SeekNotSupported on live DASH stream, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Documents and validates MPEG-DASH (`.mpd`) input support for `VideoDecoder`. No new runtime code is required — `FFmpeg`'s built-in `dash` demuxer handles manifest parsing and segment fetching automatically, and `is_live()` detection via `AVFMT_TS_DISCONT` (added in #222) already covers DASH live streams.

## Changes

- `video/builder.rs`: add `# DASH / MPD Streams` section to `.network()` documenting `.mpd` auto-detection, multi-period caveat, and ABR note; expand `# DRM Limitation` to cover both HLS and DASH (CENC, `PlayReady`, Widevine)
- `audio/builder.rs`: same DRM limitation expansion
- `tests/dash_stream_tests.rs` (new): 4 integration tests — regression guard for file-backed decoders, `FileNotFound` bypass check for `.mpd` URLs, and two gracefully-skipped live-server tests for `is_live()` and seek guard

## Related Issues

Closes #223

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes