### PR TITLE
feat(ff-decode): UDP/MPEG-TS buffer options and live-mode docs

### DIFF
--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -181,6 +181,17 @@ impl AudioDecoderBuilder {
     ///     .build()?;
     /// ```
     ///
+    /// # UDP / MPEG-TS
+    ///
+    /// `udp://` URLs are always live — `is_live()` returns `true` and seeking
+    /// is not supported. Two extra `AVDictionary` options are set automatically
+    /// to reduce packet loss on high-bitrate streams:
+    ///
+    /// | Option | Value | Reason |
+    /// |---|---|---|
+    /// | `buffer_size` | `65536` | Enlarges the UDP receive buffer |
+    /// | `overrun_nonfatal` | `1` | Discards excess data instead of erroring |
+    ///
     /// # Credentials
     ///
     /// HTTP basic-auth credentials must be embedded directly in the URL:

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -424,6 +424,26 @@ impl VideoDecoderBuilder {
     /// **Adaptive bitrate**: representation selection (ABR switching) is handled
     /// internally by `FFmpeg` and is not exposed through this API.
     ///
+    /// # UDP / MPEG-TS
+    ///
+    /// `udp://` URLs are always live — `is_live()` returns `true` and seeking
+    /// is not supported. Two extra `AVDictionary` options are set automatically
+    /// to reduce packet loss on high-bitrate streams:
+    ///
+    /// | Option | Value | Reason |
+    /// |---|---|---|
+    /// | `buffer_size` | `65536` | Enlarges the UDP receive buffer |
+    /// | `overrun_nonfatal` | `1` | Discards excess data instead of erroring |
+    ///
+    /// ```ignore
+    /// use ff_decode::VideoDecoder;
+    /// use ff_format::NetworkOptions;
+    ///
+    /// let decoder = VideoDecoder::open("udp://224.0.0.1:1234")
+    ///     .network(NetworkOptions::default())
+    ///     .build()?;
+    /// ```
+    ///
     /// # Credentials
     ///
     /// HTTP basic-auth credentials must be embedded directly in the URL:

--- a/crates/ff-decode/tests/udp_stream_tests.rs
+++ b/crates/ff-decode/tests/udp_stream_tests.rs
@@ -1,0 +1,86 @@
+//! Integration tests for UDP/MPEG-TS stream input support (issue #224).
+//!
+//! Tests that require a reachable UDP multicast source are skipped gracefully
+//! when unavailable (e.g. in CI without a local IPTV feed — see #235).
+
+mod fixtures;
+use fixtures::*;
+
+use ff_decode::{DecodeError, VideoDecoder};
+use ff_format::NetworkOptions;
+
+// ── File-backed decoder is unaffected by UDP changes ────────────────────────
+
+#[test]
+fn file_video_decoder_should_not_be_live_udp_regression() {
+    // Regression guard: the UDP buffer-size logic must not affect file decoders.
+    let decoder = VideoDecoder::open(test_video_path())
+        .build()
+        .expect("Failed to open test video");
+    assert!(
+        !decoder.is_live(),
+        "File-backed VideoDecoder must report is_live=false (UDP regression guard)"
+    );
+}
+
+// ── UDP URL bypasses file-existence check ────────────────────────────────────
+
+#[test]
+fn udp_url_open_should_not_return_file_not_found() {
+    // Use an unreachable loopback port. The assertion is that the
+    // file-existence guard is bypassed for udp:// URLs.
+    let result = VideoDecoder::open("udp://127.0.0.1:65535")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("udp:// URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+#[test]
+fn udp_multicast_url_open_should_not_return_file_not_found() {
+    // Common IPTV multicast address format — must not trigger FileNotFound.
+    let result = VideoDecoder::open("udp://224.0.0.1:1234")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("udp:// multicast URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+// ── Non-UDP URLs are not affected ────────────────────────────────────────────
+
+#[test]
+fn http_url_open_should_not_return_file_not_found() {
+    // Ensure the UDP-specific logic does not break other schemes.
+    let result = VideoDecoder::open("http://127.0.0.1:65535/stream.ts")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("http:// URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+// ── Live UDP stream (requires reachable source) ──────────────────────────────
+
+/// Validates that a live UDP/MPEG-TS stream is detected as live.
+///
+/// Skipped gracefully when no multicast source is reachable (see #235).
+#[test]
+fn udp_live_decoder_should_report_is_live() {
+    let decoder = match VideoDecoder::open("udp://224.0.0.1:1234")
+        .network(NetworkOptions::default())
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: no UDP multicast source available ({e})");
+            return;
+        }
+    };
+
+    assert!(
+        decoder.is_live(),
+        "UDP/MPEG-TS source must report is_live=true"
+    );
+}

--- a/crates/ff-sys/src/avformat.rs
+++ b/crates/ff-sys/src/avformat.rs
@@ -208,6 +208,28 @@ pub unsafe fn open_input_url(
             rw_timeout_val.as_ptr(),
             0,
         );
+
+        // UDP-specific options: enlarge the receive buffer and suppress
+        // overrun errors so that high-bitrate MPEG-TS streams do not drop
+        // entire frames due to transient kernel-buffer exhaustion.
+        if url.starts_with("udp://") {
+            let buf_key = CString::new("buffer_size").expect("no null in literal");
+            let buf_val = CString::new("65536").expect("no null in literal");
+            let overrun_key = CString::new("overrun_nonfatal").expect("no null in literal");
+            let overrun_val = CString::new("1").expect("no null in literal");
+            crate::av_dict_set(
+                ptr::addr_of_mut!(opts),
+                buf_key.as_ptr(),
+                buf_val.as_ptr(),
+                0,
+            );
+            crate::av_dict_set(
+                ptr::addr_of_mut!(opts),
+                overrun_key.as_ptr(),
+                overrun_val.as_ptr(),
+                0,
+            );
+        }
     }
 
     let mut ctx: *mut AVFormatContext = ptr::null_mut();


### PR DESCRIPTION
## Summary

Adds UDP-specific `AVDictionary` options (`buffer_size=65536`, `overrun_nonfatal=1`) to `open_input_url` in `ff-sys` for `udp://` URLs, reducing packet loss on high-bitrate MPEG-TS streams. Non-UDP URLs are completely unaffected. Documents UDP behaviour (`is_live=true`, no seeking) in the `.network()` doc comment on both builder types.

## Changes

- `ff-sys/src/avformat.rs`: in `open_input_url`, detect `udp://` prefix and append `buffer_size` and `overrun_nonfatal` to the `AVDictionary` alongside the existing timeout options
- `video/builder.rs`: add `# UDP / MPEG-TS` section to `.network()` doc with option table and usage example
- `audio/builder.rs`: same UDP doc section
- `tests/udp_stream_tests.rs` (new): 5 integration tests — regression guard for file decoders, `FileNotFound` bypass for unicast and multicast `udp://` URLs, regression guard for `http://` scheme, and a gracefully-skipped live-source `is_live()` test

## Related Issues

Closes #224

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes