### PR TITLE
feat(ff-decode): add SRT protocol input support behind srt feature flag

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -21,6 +21,7 @@ stream   = ["dep:ff-stream", "pipeline"]
 tokio    = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio"]
 gpl      = ["ff-encode/gpl"]
 hwaccel  = ["ff-encode/hwaccel"]
+srt      = ["ff-decode/srt"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/ff-decode/Cargo.toml
+++ b/crates/ff-decode/Cargo.toml
@@ -33,6 +33,7 @@ winapi = { workspace = true, features = ["processthreadsapi", "psapi"] }
 default = ["hwaccel"]
 hwaccel = []  # Hardware acceleration
 tokio = ["dep:tokio", "dep:futures"]
+srt = []      # SRT (Secure Reliable Transport) protocol input
 
 [[bench]]
 name = "decode_bench"

--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -192,6 +192,30 @@ impl AudioDecoderBuilder {
     /// | `buffer_size` | `65536` | Enlarges the UDP receive buffer |
     /// | `overrun_nonfatal` | `1` | Discards excess data instead of erroring |
     ///
+    /// # SRT (Secure Reliable Transport)
+    ///
+    /// SRT URLs (`srt://host:port`) require the `srt` feature flag **and** a
+    /// libsrt-enabled `FFmpeg` build.  Enable the feature in `Cargo.toml`:
+    ///
+    /// ```toml
+    /// [dependencies]
+    /// ff-decode = { version = "*", features = ["srt"] }
+    /// ```
+    ///
+    /// Without the `srt` feature, opening an `srt://` URL returns
+    /// [`DecodeError::ConnectionFailed`]. If the feature is enabled but the
+    /// linked `FFmpeg` was not built with `--enable-libsrt`, the same error is
+    /// returned with a message directing you to rebuild `FFmpeg`.
+    ///
+    /// ```ignore
+    /// use ff_decode::AudioDecoder;
+    /// use ff_format::NetworkOptions;
+    ///
+    /// let decoder = AudioDecoder::open("srt://ingest.example.com:4200")
+    ///     .network(NetworkOptions::default())
+    ///     .build()?;
+    /// ```
+    ///
     /// # Credentials
     ///
     /// HTTP basic-auth credentials must be embedded directly in the URL:

--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -309,6 +309,11 @@ impl AudioDecoderInner {
         let path_str = path.to_str().unwrap_or("");
         let is_network_url = crate::network::is_url(path_str);
 
+        // Verify SRT availability before attempting to open (feature + runtime check).
+        if is_network_url {
+            crate::network::check_srt_url(path_str)?;
+        }
+
         // Open the input source (with RAII guard)
         // SAFETY: Path is valid, AvFormatContextGuard ensures cleanup
         let format_ctx_guard = unsafe {

--- a/crates/ff-decode/src/network.rs
+++ b/crates/ff-decode/src/network.rs
@@ -75,6 +75,45 @@ pub(crate) fn sanitize_url(url: &str) -> String {
     }
 }
 
+/// Checks whether `url` can be opened as an SRT source.
+///
+/// Returns `Ok(())` immediately when `url` does not start with `srt://`.
+///
+/// For `srt://` URLs:
+/// - Without the `srt` feature flag: always returns [`DecodeError::ConnectionFailed`]
+///   with an instruction to recompile with `features = ["srt"]`.
+/// - With the `srt` feature flag: checks at runtime whether the linked `FFmpeg`
+///   was built with libsrt and returns [`DecodeError::ConnectionFailed`] if not.
+pub(crate) fn check_srt_url(url: &str) -> Result<(), DecodeError> {
+    if !url.starts_with("srt://") {
+        return Ok(());
+    }
+    check_srt_available(url)
+}
+
+#[cfg(not(feature = "srt"))]
+fn check_srt_available(url: &str) -> Result<(), DecodeError> {
+    Err(DecodeError::ConnectionFailed {
+        code: 0,
+        endpoint: sanitize_url(url),
+        message: "SRT protocol is not enabled; recompile with feature = \"srt\"".to_string(),
+    })
+}
+
+#[cfg(feature = "srt")]
+fn check_srt_available(url: &str) -> Result<(), DecodeError> {
+    if !ff_sys::avformat::srt_available() {
+        return Err(DecodeError::ConnectionFailed {
+            code: 0,
+            endpoint: sanitize_url(url),
+            message: "SRT protocol is not available in the linked FFmpeg build; \
+                      recompile FFmpeg with --enable-libsrt"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Maps an `FFmpeg` network error code to the most specific [`DecodeError`] variant.
 ///
 /// The `endpoint` string must already be sanitized (no password, no query string).

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -444,6 +444,30 @@ impl VideoDecoderBuilder {
     ///     .build()?;
     /// ```
     ///
+    /// # SRT (Secure Reliable Transport)
+    ///
+    /// SRT URLs (`srt://host:port`) require the `srt` feature flag **and** a
+    /// libsrt-enabled `FFmpeg` build.  Enable the feature in `Cargo.toml`:
+    ///
+    /// ```toml
+    /// [dependencies]
+    /// ff-decode = { version = "*", features = ["srt"] }
+    /// ```
+    ///
+    /// Without the `srt` feature, opening an `srt://` URL returns
+    /// [`DecodeError::ConnectionFailed`]. If the feature is enabled but the
+    /// linked `FFmpeg` was not built with `--enable-libsrt`, the same error is
+    /// returned with a message directing you to rebuild `FFmpeg`.
+    ///
+    /// ```ignore
+    /// use ff_decode::VideoDecoder;
+    /// use ff_format::NetworkOptions;
+    ///
+    /// let decoder = VideoDecoder::open("srt://ingest.example.com:4200")
+    ///     .network(NetworkOptions::default())
+    ///     .build()?;
+    /// ```
+    ///
     /// # Credentials
     ///
     /// HTTP basic-auth credentials must be embedded directly in the URL:

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -565,6 +565,11 @@ impl VideoDecoderInner {
         let is_image_sequence = path_str.contains('%');
         let is_network_url = crate::network::is_url(path_str);
 
+        // Verify SRT availability before attempting to open (feature + runtime check).
+        if is_network_url {
+            crate::network::check_srt_url(path_str)?;
+        }
+
         // Open the input (with RAII guard for cleanup on error).
         // SAFETY: Path/URL is valid; AvFormatContextGuard ensures cleanup.
         let format_ctx_guard = unsafe {

--- a/crates/ff-decode/tests/srt_stream_tests.rs
+++ b/crates/ff-decode/tests/srt_stream_tests.rs
@@ -1,0 +1,94 @@
+//! Integration tests for SRT (Secure Reliable Transport) stream input support (issue #225).
+//!
+//! The `srt` feature flag enables the SRT code path. Tests that require a reachable
+//! SRT server are skipped gracefully when none is available (e.g. in CI — see #235).
+
+mod fixtures;
+use fixtures::*;
+
+use ff_decode::{DecodeError, VideoDecoder};
+use ff_format::NetworkOptions;
+
+// ── File-backed decoder is not an SRT source ─────────────────────────────────
+
+#[test]
+fn file_video_decoder_should_not_be_live_srt() {
+    // Regression guard: the SRT check must not affect file decoders.
+    let decoder = VideoDecoder::open(test_video_path())
+        .build()
+        .expect("Failed to open test video");
+    assert!(
+        !decoder.is_live(),
+        "File-backed VideoDecoder must report is_live=false (SRT regression guard)"
+    );
+}
+
+// ── Without the srt feature, srt:// returns ConnectionFailed ─────────────────
+
+#[cfg(not(feature = "srt"))]
+#[test]
+fn srt_url_without_feature_should_return_connection_failed() {
+    let result = VideoDecoder::open("srt://127.0.0.1:4200")
+        .network(NetworkOptions::default())
+        .build();
+    match result {
+        Err(DecodeError::ConnectionFailed { message, .. }) => {
+            assert!(
+                message.contains("srt"),
+                "ConnectionFailed message must mention the srt feature; got: {message}"
+            );
+        }
+        Err(other) => panic!("Expected ConnectionFailed for srt:// without feature, got: {other}"),
+        Ok(_) => panic!("Expected an error for unreachable SRT endpoint without feature"),
+    }
+}
+
+// ── With the srt feature, srt:// bypasses file-existence check ───────────────
+
+#[cfg(feature = "srt")]
+#[test]
+fn srt_url_open_should_not_return_file_not_found() {
+    // Use an unreachable loopback port. The assertion is that the
+    // file-existence guard is bypassed for srt:// URLs.
+    let result = VideoDecoder::open("srt://127.0.0.1:65535")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("srt:// URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+// ── Non-SRT URLs are not affected by the SRT check ───────────────────────────
+
+#[test]
+fn http_url_open_should_not_be_affected_by_srt_check() {
+    // Ensure the SRT-specific check does not interfere with HTTP URLs.
+    let result = VideoDecoder::open("http://127.0.0.1:65535/stream.ts")
+        .network(NetworkOptions::default())
+        .build();
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("http:// URL must not produce FileNotFound; path={path:?}");
+    }
+}
+
+// ── Live SRT stream (requires reachable SRT server) ──────────────────────────
+
+/// Validates that a live SRT stream is detected as live.
+///
+/// Skipped gracefully when no SRT server is reachable (see #235).
+#[cfg(feature = "srt")]
+#[test]
+fn srt_live_decoder_should_report_is_live() {
+    let decoder = match VideoDecoder::open("srt://127.0.0.1:4200")
+        .network(NetworkOptions::default())
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: no SRT server available ({e})");
+            return;
+        }
+    };
+
+    assert!(decoder.is_live(), "SRT source must report is_live=true");
+}

--- a/crates/ff-sys/src/avformat.rs
+++ b/crates/ff-sys/src/avformat.rs
@@ -248,6 +248,18 @@ pub unsafe fn open_input_url(
     Ok(ctx)
 }
 
+/// Returns `true` when the `libsrt` protocol is available in the linked FFmpeg build.
+///
+/// Calls `av_find_input_format("libsrt")` at runtime. When FFmpeg was built
+/// without libsrt support this returns `false`.
+pub fn srt_available() -> bool {
+    ensure_initialized();
+    // SAFETY: string literal has no interior null bytes.
+    let name = CString::new("libsrt").unwrap();
+    let fmt = unsafe { crate::av_find_input_format(name.as_ptr()) };
+    !fmt.is_null()
+}
+
 /// Open an image sequence using the `image2` demuxer.
 ///
 /// Sets `framerate` in the demuxer options so FFmpeg assigns the correct PTS

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -679,6 +679,10 @@ pub mod avformat {
 
     use super::{AVFormatContext, AVIOContext, AVPacket};
 
+    pub fn srt_available() -> bool {
+        false
+    }
+
     pub unsafe fn open_input(_path: &Path) -> Result<*mut AVFormatContext, c_int> {
         Err(-1)
     }


### PR DESCRIPTION
## Summary

Adds SRT (Secure Reliable Transport) input support to `VideoDecoder` and `AudioDecoder` behind an optional `srt` feature flag. Without the flag, opening an `srt://` URL returns a clear `ConnectionFailed` error. With the flag, a runtime check via `av_find_input_format("libsrt")` verifies that the linked FFmpeg was built with libsrt before delegating to the existing `open_input_url` path.

## Changes

- `ff-decode/Cargo.toml`: added `srt = []` feature flag
- `avio/Cargo.toml`: added `srt = ["ff-decode/srt"]` feature flag
- `ff-sys/src/avformat.rs`: added `srt_available()` — wraps `av_find_input_format("libsrt")`
- `ff-sys/src/docsrs_stubs.rs`: added `srt_available()` stub returning `false`
- `ff-decode/src/network.rs`: added `check_srt_url()` with `#[cfg(not(feature = "srt"))]` / `#[cfg(feature = "srt")]` variants
- `ff-decode/src/video/decoder_inner.rs`: call `check_srt_url()` before `open_input_url` for network URLs
- `ff-decode/src/audio/decoder_inner.rs`: same
- `ff-decode/src/video/builder.rs`: added SRT section to `.network()` doc comment
- `ff-decode/src/audio/builder.rs`: same
- `ff-decode/tests/srt_stream_tests.rs`: integration tests covering feature-gating, file-existence bypass, and graceful skip when no server is reachable

## Related Issues

Closes #225

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes