### PR TITLE
feat(ff-decode): add auto-reconnect with exponential backoff for live streams

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -276,6 +276,12 @@ pub(crate) struct AudioDecoderInner {
     packet: *mut AVPacket,
     /// Reusable frame for decoding
     frame: *mut AVFrame,
+    /// URL used to open this source — `None` for file-path sources.
+    url: Option<String>,
+    /// Network options used for the initial open (timeouts, reconnect config).
+    network_opts: NetworkOptions,
+    /// Number of successful reconnects so far (for logging).
+    reconnect_count: u32,
 }
 
 impl AudioDecoderInner {
@@ -308,6 +314,13 @@ impl AudioDecoderInner {
 
         let path_str = path.to_str().unwrap_or("");
         let is_network_url = crate::network::is_url(path_str);
+
+        let url = if is_network_url {
+            Some(path_str.to_owned())
+        } else {
+            None
+        };
+        let stored_network_opts = network_opts.clone().unwrap_or_default();
 
         // Verify SRT availability before attempting to open (feature + runtime check).
         if is_network_url {
@@ -430,6 +443,9 @@ impl AudioDecoderInner {
                 position: Duration::ZERO,
                 packet: packet_guard.into_raw(),
                 frame: frame_guard.into_raw(),
+                url,
+                network_opts: stored_network_opts,
+                reconnect_count: 0,
             },
             stream_info,
             container_info,
@@ -668,12 +684,29 @@ impl AudioDecoderInner {
 
     /// Decodes the next audio frame.
     ///
+    /// Transparently reconnects on `StreamInterrupted` when
+    /// `NetworkOptions::reconnect_on_error` is enabled.
+    ///
     /// # Returns
     ///
     /// - `Ok(Some(frame))` - Successfully decoded a frame
     /// - `Ok(None)` - End of stream reached
     /// - `Err(_)` - Decoding error occurred
     pub(crate) fn decode_one(&mut self) -> Result<Option<AudioFrame>, DecodeError> {
+        loop {
+            match self.decode_one_inner() {
+                Ok(frame) => return Ok(frame),
+                Err(DecodeError::StreamInterrupted { .. })
+                    if self.url.is_some() && self.network_opts.reconnect_on_error =>
+                {
+                    self.attempt_reconnect()?;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn decode_one_inner(&mut self) -> Result<Option<AudioFrame>, DecodeError> {
         if self.eof {
             return Ok(None);
         }
@@ -709,12 +742,20 @@ impl AudioDecoderInner {
                         self.eof = true;
                         continue;
                     } else if read_ret < 0 {
-                        return Err(DecodeError::Ffmpeg {
-                            code: read_ret,
-                            message: format!(
-                                "Failed to read frame: {}",
-                                ff_sys::av_error_string(read_ret)
-                            ),
+                        return Err(if let Some(url) = &self.url {
+                            // Network source: map to typed variant so reconnect can detect it.
+                            crate::network::map_network_error(
+                                read_ret,
+                                crate::network::sanitize_url(url),
+                            )
+                        } else {
+                            DecodeError::Ffmpeg {
+                                code: read_ret,
+                                message: format!(
+                                    "Failed to read frame: {}",
+                                    ff_sys::av_error_string(read_ret)
+                                ),
+                            }
                         });
                     }
 
@@ -1205,6 +1246,99 @@ impl AudioDecoderInner {
             ff_sys::avcodec::flush_buffers(self.codec_ctx);
         }
         self.eof = false;
+    }
+
+    // ── Reconnect helpers ─────────────────────────────────────────────────────
+
+    /// Attempts to reconnect to the stream URL using exponential backoff.
+    ///
+    /// Called from `decode_one()` when `StreamInterrupted` is received and
+    /// `NetworkOptions::reconnect_on_error` is `true`. After all attempts fail,
+    /// returns a `StreamInterrupted` error.
+    fn attempt_reconnect(&mut self) -> Result<(), DecodeError> {
+        let url = match self.url.as_deref() {
+            Some(u) => u.to_owned(),
+            None => return Ok(()), // file-path source: no reconnect
+        };
+        let max = self.network_opts.max_reconnect_attempts;
+
+        for attempt in 1..=max {
+            let backoff_ms = 100u64 * (1u64 << (attempt - 1).min(10));
+            log::warn!(
+                "reconnecting attempt={attempt} url={} backoff_ms={backoff_ms}",
+                crate::network::sanitize_url(&url)
+            );
+            std::thread::sleep(Duration::from_millis(backoff_ms));
+            match self.reopen(&url) {
+                Ok(()) => {
+                    self.reconnect_count += 1;
+                    log::info!(
+                        "reconnected attempt={attempt} url={} total_reconnects={}",
+                        crate::network::sanitize_url(&url),
+                        self.reconnect_count
+                    );
+                    return Ok(());
+                }
+                Err(e) => log::warn!("reconnect attempt={attempt} failed err={e}"),
+            }
+        }
+
+        Err(DecodeError::StreamInterrupted {
+            code: 0,
+            endpoint: crate::network::sanitize_url(&url),
+            message: format!("stream did not recover after {max} attempts"),
+        })
+    }
+
+    /// Closes the current `AVFormatContext`, re-opens the URL, re-reads stream info,
+    /// re-finds the audio stream, and flushes the codec.
+    fn reopen(&mut self, url: &str) -> Result<(), DecodeError> {
+        // Close the current format context. `avformat_close_input` sets the pointer
+        // to null — this matches the null check in Drop so no double-free occurs.
+        // SAFETY: self.format_ctx is valid and owned exclusively by self.
+        unsafe {
+            ff_sys::avformat::close_input(std::ptr::addr_of_mut!(self.format_ctx));
+        }
+
+        // Re-open the URL with the stored network timeouts.
+        // SAFETY: url is a valid UTF-8 network URL string.
+        self.format_ctx = unsafe {
+            ff_sys::avformat::open_input_url(
+                url,
+                self.network_opts.connect_timeout,
+                self.network_opts.read_timeout,
+            )
+            .map_err(|e| crate::network::map_network_error(e, crate::network::sanitize_url(url)))?
+        };
+
+        // Re-read stream information.
+        // SAFETY: self.format_ctx is valid and freshly opened.
+        unsafe {
+            ff_sys::avformat::find_stream_info(self.format_ctx).map_err(|e| {
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "reconnect find_stream_info failed: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                }
+            })?;
+        }
+
+        // Re-find the audio stream (index may differ in theory after reconnect).
+        // SAFETY: self.format_ctx is valid.
+        let (stream_index, _) = unsafe { Self::find_audio_stream(self.format_ctx) }
+            .ok_or_else(|| DecodeError::NoAudioStream { path: url.into() })?;
+        self.stream_index = stream_index as i32;
+
+        // Flush codec buffers to discard stale decoded state from before the drop.
+        // SAFETY: self.codec_ctx is valid and has not been freed.
+        unsafe {
+            ff_sys::avcodec::flush_buffers(self.codec_ctx);
+        }
+
+        self.eof = false;
+        Ok(())
     }
 }
 

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -309,6 +309,12 @@ pub(crate) struct VideoDecoderInner {
     active_hw_accel: HardwareAccel,
     /// Optional frame pool for memory reuse
     frame_pool: Option<Arc<dyn FramePool>>,
+    /// URL used to open this source — `None` for file-path and image-sequence sources.
+    url: Option<String>,
+    /// Network options used for the initial open (timeouts, reconnect config).
+    network_opts: NetworkOptions,
+    /// Number of successful reconnects so far (for logging).
+    reconnect_count: u32,
 }
 
 impl VideoDecoderInner {
@@ -565,6 +571,13 @@ impl VideoDecoderInner {
         let is_image_sequence = path_str.contains('%');
         let is_network_url = crate::network::is_url(path_str);
 
+        let url = if is_network_url {
+            Some(path_str.to_owned())
+        } else {
+            None
+        };
+        let stored_network_opts = network_opts.clone().unwrap_or_default();
+
         // Verify SRT availability before attempting to open (feature + runtime check).
         if is_network_url {
             crate::network::check_srt_url(path_str)?;
@@ -722,6 +735,9 @@ impl VideoDecoderInner {
                 hw_device_ctx,
                 active_hw_accel,
                 frame_pool,
+                url,
+                network_opts: stored_network_opts,
+                reconnect_count: 0,
             },
             stream_info,
             container_info,
@@ -1003,12 +1019,29 @@ impl VideoDecoderInner {
 
     /// Decodes the next video frame.
     ///
+    /// Transparently reconnects on `StreamInterrupted` when
+    /// `NetworkOptions::reconnect_on_error` is enabled.
+    ///
     /// # Returns
     ///
     /// - `Ok(Some(frame))` - Successfully decoded a frame
     /// - `Ok(None)` - End of stream reached
     /// - `Err(_)` - Decoding error occurred
     pub(crate) fn decode_one(&mut self) -> Result<Option<VideoFrame>, DecodeError> {
+        loop {
+            match self.decode_one_inner() {
+                Ok(frame) => return Ok(frame),
+                Err(DecodeError::StreamInterrupted { .. })
+                    if self.url.is_some() && self.network_opts.reconnect_on_error =>
+                {
+                    self.attempt_reconnect()?;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn decode_one_inner(&mut self) -> Result<Option<VideoFrame>, DecodeError> {
         if self.eof {
             return Ok(None);
         }
@@ -1047,12 +1080,20 @@ impl VideoDecoderInner {
                         self.eof = true;
                         continue;
                     } else if read_ret < 0 {
-                        return Err(DecodeError::Ffmpeg {
-                            code: read_ret,
-                            message: format!(
-                                "Failed to read frame: {}",
-                                ff_sys::av_error_string(read_ret)
-                            ),
+                        return Err(if let Some(url) = &self.url {
+                            // Network source: map to typed variant so reconnect can detect it.
+                            crate::network::map_network_error(
+                                read_ret,
+                                crate::network::sanitize_url(url),
+                            )
+                        } else {
+                            DecodeError::Ffmpeg {
+                                code: read_ret,
+                                message: format!(
+                                    "Failed to read frame: {}",
+                                    ff_sys::av_error_string(read_ret)
+                                ),
+                            }
                         });
                     }
 
@@ -2028,6 +2069,99 @@ impl VideoDecoderInner {
 
             Ok(video_frame)
         }
+    }
+
+    // ── Reconnect helpers ─────────────────────────────────────────────────────
+
+    /// Attempts to reconnect to the stream URL using exponential backoff.
+    ///
+    /// Called from `decode_one()` when `StreamInterrupted` is received and
+    /// `NetworkOptions::reconnect_on_error` is `true`. After all attempts fail,
+    /// returns a `StreamInterrupted` error.
+    fn attempt_reconnect(&mut self) -> Result<(), DecodeError> {
+        let url = match self.url.as_deref() {
+            Some(u) => u.to_owned(),
+            None => return Ok(()), // file-path source: no reconnect
+        };
+        let max = self.network_opts.max_reconnect_attempts;
+
+        for attempt in 1..=max {
+            let backoff_ms = 100u64 * (1u64 << (attempt - 1).min(10));
+            log::warn!(
+                "reconnecting attempt={attempt} url={} backoff_ms={backoff_ms}",
+                crate::network::sanitize_url(&url)
+            );
+            std::thread::sleep(Duration::from_millis(backoff_ms));
+            match self.reopen(&url) {
+                Ok(()) => {
+                    self.reconnect_count += 1;
+                    log::info!(
+                        "reconnected attempt={attempt} url={} total_reconnects={}",
+                        crate::network::sanitize_url(&url),
+                        self.reconnect_count
+                    );
+                    return Ok(());
+                }
+                Err(e) => log::warn!("reconnect attempt={attempt} failed err={e}"),
+            }
+        }
+
+        Err(DecodeError::StreamInterrupted {
+            code: 0,
+            endpoint: crate::network::sanitize_url(&url),
+            message: format!("stream did not recover after {max} attempts"),
+        })
+    }
+
+    /// Closes the current `AVFormatContext`, re-opens the URL, re-reads stream info,
+    /// re-finds the video stream, and flushes the codec.
+    fn reopen(&mut self, url: &str) -> Result<(), DecodeError> {
+        // Close the current format context. `avformat_close_input` sets the pointer
+        // to null — this matches the null check in Drop so no double-free occurs.
+        // SAFETY: self.format_ctx is valid and owned exclusively by self.
+        unsafe {
+            ff_sys::avformat::close_input(std::ptr::addr_of_mut!(self.format_ctx));
+        }
+
+        // Re-open the URL with the stored network timeouts.
+        // SAFETY: url is a valid UTF-8 network URL string.
+        self.format_ctx = unsafe {
+            ff_sys::avformat::open_input_url(
+                url,
+                self.network_opts.connect_timeout,
+                self.network_opts.read_timeout,
+            )
+            .map_err(|e| crate::network::map_network_error(e, crate::network::sanitize_url(url)))?
+        };
+
+        // Re-read stream information.
+        // SAFETY: self.format_ctx is valid and freshly opened.
+        unsafe {
+            ff_sys::avformat::find_stream_info(self.format_ctx).map_err(|e| {
+                DecodeError::Ffmpeg {
+                    code: e,
+                    message: format!(
+                        "reconnect find_stream_info failed: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                }
+            })?;
+        }
+
+        // Re-find the video stream (index may differ in theory after reconnect).
+        // SAFETY: self.format_ctx is valid.
+        let (stream_index, _) = unsafe { Self::find_video_stream(self.format_ctx) }
+            .ok_or_else(|| DecodeError::NoVideoStream { path: url.into() })?;
+        self.stream_index = stream_index as i32;
+
+        // Flush codec buffers to discard stale decoded state from before the drop.
+        // SAFETY: self.codec_ctx is valid and has not been freed.
+        unsafe {
+            ff_sys::avcodec::flush_buffers(self.codec_ctx);
+        }
+
+        self.eof = false;
+        Ok(())
     }
 }
 

--- a/crates/ff-decode/tests/reconnect_tests.rs
+++ b/crates/ff-decode/tests/reconnect_tests.rs
@@ -1,0 +1,148 @@
+//! Integration tests for auto-reconnect on error (issue #226).
+//!
+//! Tests that require a live network source that drops connections are skipped
+//! gracefully when no such server is available (see #235).
+
+mod fixtures;
+use fixtures::*;
+
+use ff_decode::{DecodeError, VideoDecoder};
+use ff_format::NetworkOptions;
+
+// ── File-backed decoders are not subject to reconnect ─────────────────────────
+
+#[test]
+fn file_decoder_should_decode_all_frames_without_reconnect() {
+    // Regression guard: reconnect logic must not interfere with file decoders.
+    let mut decoder = VideoDecoder::open(test_video_path())
+        .build()
+        .expect("Failed to open test video");
+
+    let mut frame_count = 0u32;
+    loop {
+        match decoder.decode_one() {
+            Ok(Some(_)) => frame_count += 1,
+            Ok(None) => break,
+            Err(e) => panic!("Unexpected error during file decode: {e}"),
+        }
+    }
+    assert!(frame_count > 0, "Expected at least one decoded frame");
+}
+
+#[test]
+fn file_decoder_with_reconnect_enabled_should_reach_eof() {
+    // A file decoder with reconnect_on_error=true must still reach EOF normally
+    // without looping forever (EOF is never a StreamInterrupted error).
+    let mut decoder = VideoDecoder::open(test_video_path())
+        .network(NetworkOptions {
+            reconnect_on_error: true,
+            max_reconnect_attempts: 5,
+            ..Default::default()
+        })
+        .build()
+        .expect("Failed to open test video");
+
+    let mut frame_count = 0u32;
+    loop {
+        match decoder.decode_one() {
+            Ok(Some(_)) => frame_count += 1,
+            Ok(None) => break,
+            Err(e) => panic!("Unexpected error with reconnect enabled on file: {e}"),
+        }
+    }
+    assert!(frame_count > 0, "Expected at least one frame");
+}
+
+// ── NetworkOptions defaults ───────────────────────────────────────────────────
+
+#[test]
+fn network_options_should_default_reconnect_on_error_to_false() {
+    let opts = NetworkOptions::default();
+    assert!(
+        !opts.reconnect_on_error,
+        "reconnect_on_error must default to false to avoid unexpected overhead"
+    );
+}
+
+#[test]
+fn network_options_should_default_max_reconnect_attempts_to_three() {
+    let opts = NetworkOptions::default();
+    assert_eq!(
+        opts.max_reconnect_attempts, 3,
+        "max_reconnect_attempts default should be 3"
+    );
+}
+
+// ── Backoff formula ───────────────────────────────────────────────────────────
+
+#[test]
+fn backoff_ms_should_double_each_attempt_up_to_cap() {
+    // Formula: 100 * 2^min(attempt-1, 10)
+    let backoff = |attempt: u32| -> u64 { 100u64 * (1u64 << (attempt - 1).min(10)) };
+
+    assert_eq!(backoff(1), 100);
+    assert_eq!(backoff(2), 200);
+    assert_eq!(backoff(3), 400);
+    assert_eq!(backoff(4), 800);
+    assert_eq!(backoff(10), 51200);
+    assert_eq!(backoff(11), 102400); // capped at 2^10
+    assert_eq!(backoff(12), 102400); // still capped
+}
+
+// ── Unreachable network URL: reconnect_on_error=false propagates error ────────
+
+#[test]
+fn http_url_with_reconnect_disabled_should_not_reconnect() {
+    // When reconnect_on_error=false (default), any network error propagates immediately.
+    let result = VideoDecoder::open("http://127.0.0.1:65535/stream.ts")
+        .network(NetworkOptions {
+            reconnect_on_error: false,
+            ..Default::default()
+        })
+        .build();
+    // The result must not be FileNotFound (URL skips existence check).
+    if let Err(DecodeError::FileNotFound { path }) = result {
+        panic!("http:// URL must not produce FileNotFound; path={path:?}");
+    }
+    // Any other error (ConnectionFailed, Ffmpeg, etc.) is acceptable.
+}
+
+// ── Live stream reconnect (requires a server that drops connections) ──────────
+
+/// Validates reconnect behavior on a live stream that intentionally drops.
+///
+/// Skipped gracefully when no such server is available (see #235).
+#[test]
+fn live_stream_decoder_with_reconnect_should_survive_interruption() {
+    let mut decoder = match VideoDecoder::open("http://127.0.0.1:9999/drop-after-1s.ts")
+        .network(NetworkOptions {
+            reconnect_on_error: true,
+            max_reconnect_attempts: 2,
+            ..Default::default()
+        })
+        .build()
+    {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: no drop-test server available ({e})");
+            return;
+        }
+    };
+
+    // Attempt to decode a few frames — the decoder should survive the interruption.
+    let mut frames = 0u32;
+    for _ in 0..10 {
+        match decoder.decode_one() {
+            Ok(Some(_)) => frames += 1,
+            Ok(None) => break,
+            Err(e) => {
+                println!("Skipping: stream error before reconnect test ({e})");
+                return;
+            }
+        }
+    }
+    assert!(
+        frames > 0,
+        "Expected at least one frame from reconnecting decoder"
+    );
+}


### PR DESCRIPTION
## Summary

Implements transparent auto-reconnect for `VideoDecoder` and `AudioDecoder` on live network streams. When `NetworkOptions::reconnect_on_error = true` and `av_read_frame` returns an I/O error (mapped to `StreamInterrupted`), the decoder re-opens the stream URL using exponential backoff instead of propagating the error to the caller. File-backed and image-sequence decoders are entirely unaffected.

## Changes

- `video/decoder_inner.rs` and `audio/decoder_inner.rs`:
  - Added `url: Option<String>`, `network_opts: NetworkOptions`, and `reconnect_count: u32` fields to both inners (set when opened via URL, ignored for files)
  - Split `decode_one()` into a public reconnect wrapper and a private `decode_one_inner()`; the wrapper retries on `StreamInterrupted` when `reconnect_on_error` is enabled
  - Updated `read_ret < 0` branch in `decode_one_inner()` to map errors from URL sources through `map_network_error()` (EIO → `StreamInterrupted`, etc.) so the reconnect guard can detect them
  - Added `attempt_reconnect()`: exponential backoff loop `100ms × 2^min(attempt-1, 10)`, logs `warn!` per attempt and `info!` on success; propagates `StreamInterrupted` after exhausting `max_reconnect_attempts`
  - Added `reopen()`: closes current `AVFormatContext`, re-opens URL with stored timeouts, re-reads stream info, re-finds stream index, flushes codec buffers
- `tests/reconnect_tests.rs`: 7 tests covering file-decoder regression, reconnect-enabled file decoder reaches EOF normally, `NetworkOptions` defaults, backoff formula correctness, error propagation when disabled, and graceful-skip live stream test

## Related Issues

Closes #226

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes