### PR TITLE
feat(ff-stream): RtmpOutput frame-push RTMP encoder

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -269,8 +269,8 @@ pub use ff_pipeline::{
 // Enabling `stream` also enables `pipeline` (and transitively `filter`).
 #[cfg(feature = "stream")]
 pub use ff_stream::{
-    AbrLadder, DashOutput, HlsOutput, LiveDashOutput, LiveHlsOutput, Rendition, StreamError,
-    StreamOutput,
+    AbrLadder, DashOutput, HlsOutput, LiveDashOutput, LiveHlsOutput, Rendition, RtmpOutput,
+    StreamError, StreamOutput,
 };
 
 #[cfg(test)]

--- a/crates/ff-stream/src/error.rs
+++ b/crates/ff-stream/src/error.rs
@@ -42,6 +42,18 @@ pub enum StreamError {
         reason: String,
     },
 
+    /// The requested codec is not supported by the output format.
+    ///
+    /// For example, RTMP/FLV requires H.264 video and AAC audio; requesting
+    /// any other codec returns this error from `build()`.
+    #[error("unsupported codec: {codec} — {reason}")]
+    UnsupportedCodec {
+        /// Name of the codec that was rejected.
+        codec: String,
+        /// Human-readable explanation of the constraint.
+        reason: String,
+    },
+
     /// An `FFmpeg` runtime error occurred during muxing or transcoding.
     ///
     /// `code` is the raw `FFmpeg` negative error value returned by the failing
@@ -89,6 +101,17 @@ mod tests {
         let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied");
         let err: StreamError = io.into();
         assert!(err.to_string().contains("access denied"), "got: {err}");
+    }
+
+    #[test]
+    fn unsupported_codec_should_display_codec_and_reason() {
+        let err = StreamError::UnsupportedCodec {
+            codec: "Vp9".into(),
+            reason: "RTMP/FLV requires H.264 video".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Vp9"), "got: {msg}");
+        assert!(msg.contains("H.264"), "got: {msg}");
     }
 
     #[test]

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -82,6 +82,8 @@ pub(crate) mod live_dash_inner;
 pub mod live_hls;
 pub(crate) mod live_hls_inner;
 pub mod output;
+pub mod rtmp;
+pub(crate) mod rtmp_inner;
 
 pub use abr::{AbrLadder, Rendition};
 pub use dash::DashOutput;
@@ -90,3 +92,4 @@ pub use hls::HlsOutput;
 pub use live_dash::LiveDashOutput;
 pub use live_hls::LiveHlsOutput;
 pub use output::StreamOutput;
+pub use rtmp::RtmpOutput;

--- a/crates/ff-stream/src/rtmp.rs
+++ b/crates/ff-stream/src/rtmp.rs
@@ -1,0 +1,324 @@
+//! Frame-push RTMP output.
+//!
+//! [`RtmpOutput`] receives pre-decoded [`VideoFrame`] / [`AudioFrame`] values
+//! from the caller, encodes them with H.264/AAC, and pushes the stream to an
+//! RTMP ingest endpoint using `FFmpeg`'s built-in RTMP support.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use ff_stream::{RtmpOutput, StreamOutput};
+//!
+//! let mut out = RtmpOutput::new("rtmp://ingest.example.com/live/stream_key")
+//!     .video(1920, 1080, 30.0)
+//!     .audio(44100, 2)
+//!     .video_bitrate(4_000_000)
+//!     .audio_bitrate(128_000)
+//!     .build()?;
+//!
+//! // for each decoded frame:
+//! out.push_video(&video_frame)?;
+//! out.push_audio(&audio_frame)?;
+//!
+//! // when done:
+//! Box::new(out).finish()?;
+//! ```
+
+use ff_format::{AudioCodec, AudioFrame, VideoCodec, VideoFrame};
+
+use crate::error::StreamError;
+use crate::output::StreamOutput;
+use crate::rtmp_inner::RtmpInner;
+
+// ============================================================================
+// RtmpOutput — safe builder + StreamOutput impl
+// ============================================================================
+
+/// Live RTMP output: encodes frames and pushes them to an RTMP ingest endpoint.
+///
+/// Build with [`RtmpOutput::new`], chain setter methods, then call
+/// [`build`](Self::build) to open the `FFmpeg` context and establish the
+/// RTMP connection. After `build()`:
+///
+/// - [`push_video`](Self::push_video) and [`push_audio`](Self::push_audio) encode and
+///   transmit frames in real time.
+/// - [`StreamOutput::finish`] flushes all encoders, sends the FLV end-of-stream
+///   marker, and closes the RTMP connection.
+///
+/// RTMP/FLV requires H.264 video and AAC audio; [`build`](Self::build) returns
+/// [`StreamError::UnsupportedCodec`] for any other codec selection.
+pub struct RtmpOutput {
+    url: String,
+    video_width: Option<u32>,
+    video_height: Option<u32>,
+    fps: Option<f64>,
+    sample_rate: u32,
+    channels: u32,
+    video_codec: VideoCodec,
+    audio_codec: AudioCodec,
+    video_bitrate: u64,
+    audio_bitrate: u64,
+    inner: Option<RtmpInner>,
+    finished: bool,
+}
+
+impl RtmpOutput {
+    /// Create a new builder that streams to the given RTMP URL.
+    ///
+    /// The URL must begin with `rtmp://`; [`build`](Self::build) returns
+    /// [`StreamError::InvalidConfig`] otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use ff_stream::RtmpOutput;
+    ///
+    /// let out = RtmpOutput::new("rtmp://ingest.example.com/live/key");
+    /// ```
+    #[must_use]
+    pub fn new(url: &str) -> Self {
+        Self {
+            url: url.to_owned(),
+            video_width: None,
+            video_height: None,
+            fps: None,
+            sample_rate: 44100,
+            channels: 2,
+            video_codec: VideoCodec::H264,
+            audio_codec: AudioCodec::Aac,
+            video_bitrate: 4_000_000,
+            audio_bitrate: 128_000,
+            inner: None,
+            finished: false,
+        }
+    }
+
+    /// Set the video encoding parameters.
+    ///
+    /// This method **must** be called before [`build`](Self::build).
+    #[must_use]
+    pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
+        self.video_width = Some(width);
+        self.video_height = Some(height);
+        self.fps = Some(fps);
+        self
+    }
+
+    /// Set the audio sample rate and channel count.
+    ///
+    /// Defaults: 44 100 Hz, 2 channels (stereo).
+    #[must_use]
+    pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
+        self.sample_rate = sample_rate;
+        self.channels = channels;
+        self
+    }
+
+    /// Set the video codec.
+    ///
+    /// Default: [`VideoCodec::H264`]. Only `H264` is accepted by
+    /// [`build`](Self::build); any other value returns
+    /// [`StreamError::UnsupportedCodec`].
+    #[must_use]
+    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
+        self.video_codec = codec;
+        self
+    }
+
+    /// Set the audio codec.
+    ///
+    /// Default: [`AudioCodec::Aac`]. Only `Aac` is accepted by
+    /// [`build`](Self::build); any other value returns
+    /// [`StreamError::UnsupportedCodec`].
+    #[must_use]
+    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
+        self.audio_codec = codec;
+        self
+    }
+
+    /// Set the video encoder target bit rate in bits/s.
+    ///
+    /// Default: 4 000 000 (4 Mbit/s).
+    #[must_use]
+    pub fn video_bitrate(mut self, bitrate: u64) -> Self {
+        self.video_bitrate = bitrate;
+        self
+    }
+
+    /// Set the audio encoder target bit rate in bits/s.
+    ///
+    /// Default: 128 000 (128 kbit/s).
+    #[must_use]
+    pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
+        self.audio_bitrate = bitrate;
+        self
+    }
+
+    /// Open the `FFmpeg` context and establish the RTMP connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StreamError::InvalidConfig`] when:
+    /// - The URL does not start with `rtmp://`.
+    /// - [`video`](Self::video) was not called before `build`.
+    ///
+    /// Returns [`StreamError::UnsupportedCodec`] when:
+    /// - The video codec is not [`VideoCodec::H264`].
+    /// - The audio codec is not [`AudioCodec::Aac`].
+    ///
+    /// Returns [`StreamError::Ffmpeg`] when any `FFmpeg` operation fails
+    /// (including network connection errors).
+    pub fn build(mut self) -> Result<Self, StreamError> {
+        if !self.url.starts_with("rtmp://") {
+            return Err(StreamError::InvalidConfig {
+                reason: "RtmpOutput URL must start with rtmp://".into(),
+            });
+        }
+
+        let (Some(width), Some(height), Some(fps)) =
+            (self.video_width, self.video_height, self.fps)
+        else {
+            return Err(StreamError::InvalidConfig {
+                reason: "video parameters not set; call .video(width, height, fps) before .build()"
+                    .into(),
+            });
+        };
+
+        if self.video_codec != VideoCodec::H264 {
+            return Err(StreamError::UnsupportedCodec {
+                codec: format!("{:?}", self.video_codec),
+                reason: "RTMP/FLV requires H.264 video".into(),
+            });
+        }
+
+        if self.audio_codec != AudioCodec::Aac {
+            return Err(StreamError::UnsupportedCodec {
+                codec: format!("{:?}", self.audio_codec),
+                reason: "RTMP/FLV requires AAC audio".into(),
+            });
+        }
+
+        #[allow(clippy::cast_possible_truncation)]
+        let fps_int = fps.round().max(1.0) as i32;
+
+        let inner = RtmpInner::open(
+            &self.url,
+            width.cast_signed(),
+            height.cast_signed(),
+            fps_int,
+            self.video_bitrate,
+            self.sample_rate.cast_signed(),
+            self.channels.cast_signed(),
+            self.audio_bitrate.cast_signed(),
+        )?;
+
+        self.inner = Some(inner);
+        Ok(self)
+    }
+}
+
+// ============================================================================
+// StreamOutput impl
+// ============================================================================
+
+impl StreamOutput for RtmpOutput {
+    fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
+        if self.finished {
+            return Err(StreamError::InvalidConfig {
+                reason: "push_video called after finish()".into(),
+            });
+        }
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| StreamError::InvalidConfig {
+                reason: "push_video called before build()".into(),
+            })?;
+        inner.push_video(frame)
+    }
+
+    fn push_audio(&mut self, frame: &AudioFrame) -> Result<(), StreamError> {
+        if self.finished {
+            return Err(StreamError::InvalidConfig {
+                reason: "push_audio called after finish()".into(),
+            });
+        }
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| StreamError::InvalidConfig {
+                reason: "push_audio called before build()".into(),
+            })?;
+        inner.push_audio(frame);
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) -> Result<(), StreamError> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| StreamError::InvalidConfig {
+                reason: "finish() called before build()".into(),
+            })?;
+        inner.flush_and_close();
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_without_rtmp_scheme_should_return_invalid_config() {
+        let result = RtmpOutput::new("http://example.com/live")
+            .video(1280, 720, 30.0)
+            .build();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn build_without_video_should_return_invalid_config() {
+        let result = RtmpOutput::new("rtmp://localhost/live/key").build();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn build_with_non_h264_video_codec_should_return_unsupported_codec() {
+        let result = RtmpOutput::new("rtmp://localhost/live/key")
+            .video(1280, 720, 30.0)
+            .video_codec(VideoCodec::Vp9)
+            .build();
+        assert!(matches!(result, Err(StreamError::UnsupportedCodec { .. })));
+    }
+
+    #[test]
+    fn build_with_non_aac_audio_codec_should_return_unsupported_codec() {
+        let result = RtmpOutput::new("rtmp://localhost/live/key")
+            .video(1280, 720, 30.0)
+            .audio_codec(AudioCodec::Mp3)
+            .build();
+        assert!(matches!(result, Err(StreamError::UnsupportedCodec { .. })));
+    }
+
+    #[test]
+    fn video_bitrate_default_should_be_four_megabits() {
+        let out = RtmpOutput::new("rtmp://localhost/live/key");
+        assert_eq!(out.video_bitrate, 4_000_000);
+    }
+
+    #[test]
+    fn audio_defaults_should_be_44100hz_stereo() {
+        let out = RtmpOutput::new("rtmp://localhost/live/key");
+        assert_eq!(out.sample_rate, 44100);
+        assert_eq!(out.channels, 2);
+    }
+}

--- a/crates/ff-stream/src/rtmp_inner.rs
+++ b/crates/ff-stream/src/rtmp_inner.rs
@@ -1,0 +1,766 @@
+//! Internal RTMP state — all `unsafe` `FFmpeg` calls live here.
+//!
+//! [`RtmpInner`] owns all raw `FFmpeg` contexts and the RTMP network
+//! connection. It is created by [`crate::rtmp::RtmpOutput::build`] and driven
+//! by the safe wrappers in [`crate::rtmp`].
+//!
+//! Unlike the HLS/DASH muxers, the RTMP connection (`out_ctx->pb`) is kept
+//! open for the entire session and is only closed after [`av_write_trailer`]
+//! in [`RtmpInner::flush_and_close`].
+
+// This module is intentionally unsafe — it drives the FFmpeg C API directly.
+#![allow(unsafe_code)]
+#![allow(clippy::ptr_as_ptr)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::ref_as_ptr)]
+#![allow(clippy::too_many_lines)]
+
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr;
+
+use ff_format::{AudioFrame, PixelFormat, SampleFormat, VideoFrame};
+use ff_sys::{
+    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, SwrContext, SwsContext,
+    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref, av_rescale_q,
+    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat_write_header,
+};
+
+use crate::codec_utils::{drain_encoder, ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
+use crate::error::StreamError;
+
+// ============================================================================
+// Pixel-format conversion (local — ff-format has no FFmpeg dependency)
+// ============================================================================
+
+fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
+    match fmt {
+        PixelFormat::Yuv420p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P,
+        PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
+        PixelFormat::Yuv444p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P,
+        PixelFormat::Rgb24 => ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24,
+        PixelFormat::Bgr24 => ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24,
+        PixelFormat::Rgba => ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA,
+        PixelFormat::Bgra => ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA,
+        PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
+        PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
+        PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
+        PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
+        PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
+        PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
+        PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
+        PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
+        PixelFormat::Gbrpf32le => ff_sys::AVPixelFormat_AV_PIX_FMT_GBRPF32LE,
+        PixelFormat::Other(_) | _ => AVPixelFormat_AV_PIX_FMT_NONE,
+    }
+}
+
+fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
+    match fmt {
+        SampleFormat::U8 => ff_sys::swresample::sample_format::U8,
+        SampleFormat::I16 => ff_sys::swresample::sample_format::S16,
+        SampleFormat::I32 => ff_sys::swresample::sample_format::S32,
+        SampleFormat::F32 => ff_sys::swresample::sample_format::FLT,
+        SampleFormat::F64 => ff_sys::swresample::sample_format::DBL,
+        SampleFormat::U8p => ff_sys::swresample::sample_format::U8P,
+        SampleFormat::I16p => ff_sys::swresample::sample_format::S16P,
+        SampleFormat::I32p => ff_sys::swresample::sample_format::S32P,
+        SampleFormat::F32p => ff_sys::swresample::sample_format::FLTP,
+        SampleFormat::F64p => ff_sys::swresample::sample_format::DBLP,
+        SampleFormat::Other(_) | _ => ff_sys::swresample::sample_format::NONE,
+    }
+}
+
+// ============================================================================
+// RtmpInner
+// ============================================================================
+
+/// Owns all raw `FFmpeg` contexts and the RTMP network connection.
+///
+/// Created by [`RtmpInner::open`]; consumed by [`RtmpInner::flush_and_close`].
+/// After `flush_and_close` returns, calling any other method is undefined behaviour;
+/// the safe wrapper in `rtmp.rs` prevents this via the `finished` guard.
+pub(crate) struct RtmpInner {
+    out_ctx: *mut AVFormatContext,
+    vid_enc_ctx: *mut AVCodecContext,
+    aud_enc_ctx: *mut AVCodecContext,
+    /// Null until first `push_audio` call; recreated if input format changes.
+    swr_ctx: *mut SwrContext,
+    /// Null until swscale is needed; recreated if source dimensions/format change.
+    sws_ctx: *mut SwsContext,
+    vid_enc_frame: *mut AVFrame,
+    aud_enc_frame: *mut AVFrame,
+    vid_out_stream_idx: i32,
+    aud_out_stream_idx: i32,
+    video_frame_count: u64,
+    audio_pts: i64,
+    fps_int: i32,
+    enc_width: i32,
+    enc_height: i32,
+    /// AAC encoder `frame_size` (typically 1024); set after `avcodec_open2`.
+    aud_frame_size: i32,
+    aud_sample_rate: i32,
+    url: String,
+    /// Tracks the last swscale source so we can detect changes.
+    last_sws_src_fmt: Option<AVPixelFormat>,
+    last_sws_src_w: Option<i32>,
+    last_sws_src_h: Option<i32>,
+    /// Tracks the last swr input so we can detect format changes.
+    last_swr_in_fmt: Option<AVSampleFormat>,
+    last_swr_in_rate: Option<i32>,
+    last_swr_in_channels: Option<i32>,
+}
+
+// SAFETY: RtmpInner exclusively owns all FFmpeg contexts.
+// FFmpeg contexts are not safe for concurrent access, but ownership transfer
+// between threads is safe (there is no shared state).
+unsafe impl Send for RtmpInner {}
+
+impl RtmpInner {
+    /// Open the `FFmpeg` context and establish the RTMP connection.
+    ///
+    /// # Parameters
+    ///
+    /// - `url`: RTMP ingest URL (e.g. `rtmp://ingest.example.com/live/key`).
+    /// - `enc_width`, `enc_height`, `fps_int`: video encoder dimensions and frame rate.
+    /// - `video_bitrate`: video encoder bit rate in bits/s.
+    /// - `aud_sample_rate`, `aud_channels`, `aud_bitrate`: audio encoder parameters.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn open(
+        url: &str,
+        enc_width: i32,
+        enc_height: i32,
+        fps_int: i32,
+        video_bitrate: u64,
+        aud_sample_rate: i32,
+        aud_channels: i32,
+        aud_bitrate: i64,
+    ) -> Result<Self, StreamError> {
+        // SAFETY: All FFmpeg resources are managed within this function; the
+        // returned RtmpInner takes exclusive ownership of every pointer.
+        unsafe {
+            Self::open_unsafe(
+                url,
+                enc_width,
+                enc_height,
+                fps_int,
+                video_bitrate,
+                aud_sample_rate,
+                aud_channels,
+                aud_bitrate,
+            )
+        }
+    }
+
+    /// Encode and mux one video frame.
+    pub(crate) fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
+        // SAFETY: self was initialised by open() and is not yet finished.
+        unsafe { self.push_video_unsafe(frame) }
+    }
+
+    /// Encode and mux one audio frame.
+    pub(crate) fn push_audio(&mut self, frame: &AudioFrame) {
+        // SAFETY: self was initialised by open() and is not yet finished.
+        unsafe {
+            self.push_audio_unsafe(frame);
+        }
+    }
+
+    /// Flush both encoders, write the FLV trailer, and close the RTMP connection.
+    /// Consumes `self`.
+    pub(crate) fn flush_and_close(mut self) {
+        // SAFETY: self was initialised by open(); flush_and_close is called once.
+        unsafe {
+            self.flush_and_close_unsafe();
+        }
+    }
+
+    // ── Private unsafe implementations ───────────────────────────────────────
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn open_unsafe(
+        url: &str,
+        enc_width: i32,
+        enc_height: i32,
+        fps_int: i32,
+        video_bitrate: u64,
+        aud_sample_rate: i32,
+        aud_channels: i32,
+        aud_bitrate: i64,
+    ) -> Result<Self, StreamError> {
+        ff_sys::ensure_initialized();
+
+        // ── 1. Allocate FLV output context with RTMP URL ───────────────────
+        let c_url = CString::new(url).map_err(|_| ffmpeg_err_msg("RTMP URL contains null byte"))?;
+
+        let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
+        let ret = avformat_alloc_output_context2(
+            &mut out_ctx,
+            ptr::null_mut(),
+            c"flv".as_ptr(),
+            c_url.as_ptr(),
+        );
+        if ret < 0 || out_ctx.is_null() {
+            return Err(ffmpeg_err(ret));
+        }
+
+        // ── 2. Open H.264 video encoder ────────────────────────────────────
+        let vid_enc_codec = crate::codec_utils::select_h264_encoder("rtmp").ok_or_else(|| {
+            avformat_free_context(out_ctx);
+            ffmpeg_err_msg(
+                "no H.264 encoder available \
+                     (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)",
+            )
+        })?;
+
+        let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+            avformat_free_context(out_ctx);
+            ffmpeg_err(e)
+        })?;
+
+        (*vid_enc_ctx).width = enc_width;
+        (*vid_enc_ctx).height = enc_height;
+        (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*vid_enc_ctx).time_base.num = 1;
+        (*vid_enc_ctx).time_base.den = fps_int;
+        (*vid_enc_ctx).framerate.num = fps_int;
+        (*vid_enc_ctx).framerate.den = 1;
+        // GOP size of 2 s gives a reasonable keyframe interval for RTMP.
+        (*vid_enc_ctx).gop_size = fps_int * 2;
+        (*vid_enc_ctx).bit_rate = video_bitrate as i64;
+
+        ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            ffmpeg_err(e)
+        })?;
+
+        // ── 3. Add video output stream ─────────────────────────────────────
+        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+        if vid_out_stream.is_null() {
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err_msg("cannot create video output stream"));
+        }
+        (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+        let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+
+        // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
+        ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
+            |e| {
+                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e)
+            },
+        )?;
+
+        // ── 4. Open AAC audio encoder ──────────────────────────────────────
+        let mut aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "rtmp")
+            .inspect_err(|_| {
+                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+                avformat_free_context(out_ctx);
+            })?;
+
+        let aud_frame_size = if (*aud_enc_ctx).frame_size > 0 {
+            (*aud_enc_ctx).frame_size
+        } else {
+            1024
+        };
+
+        // ── 5. Add audio output stream ─────────────────────────────────────
+        let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+        if aud_out_stream.is_null() {
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err_msg("cannot create audio output stream"));
+        }
+        (*aud_out_stream).time_base.num = 1;
+        (*aud_out_stream).time_base.den = aud_sample_rate;
+        let aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+
+        // SAFETY: aud_out_stream and aud_enc_ctx are valid.
+        if ff_sys::avcodec::parameters_from_context((*aud_out_stream).codecpar, aud_enc_ctx)
+            .is_err()
+        {
+            log::warn!("rtmp audio stream codecpar copy failed");
+        }
+
+        // ── 6. Allocate encoder frames ─────────────────────────────────────
+        let vid_enc_frame = av_frame_alloc();
+        let aud_enc_frame = av_frame_alloc();
+
+        if vid_enc_frame.is_null() || aud_enc_frame.is_null() {
+            if !vid_enc_frame.is_null() {
+                av_frame_free(&mut (vid_enc_frame as *mut _));
+            }
+            if !aud_enc_frame.is_null() {
+                av_frame_free(&mut (aud_enc_frame as *mut _));
+            }
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err_msg("cannot allocate encoder frames"));
+        }
+
+        // ── 7. Open RTMP connection and write FLV header ───────────────────
+        // Unlike HLS/DASH, RTMP uses a persistent network connection.
+        // We use avio_open via avformat::open_output with the URL as the path.
+        // SAFETY: url is a valid null-terminated C string (validated above).
+        let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
+            .map_err(|e| {
+                av_frame_free(&mut (aud_enc_frame as *mut _));
+                av_frame_free(&mut (vid_enc_frame as *mut _));
+                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e)
+            })?;
+        (*out_ctx).pb = pb;
+
+        let ret = avformat_write_header(out_ctx, ptr::null_mut());
+        if ret < 0 {
+            ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+            av_frame_free(&mut (aud_enc_frame as *mut _));
+            av_frame_free(&mut (vid_enc_frame as *mut _));
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err(ret));
+        }
+
+        // NOTE: pb is intentionally kept open. RTMP is a persistent TCP connection;
+        // closing pb here would terminate the stream.
+
+        log::info!(
+            "rtmp output opened url={url} video={enc_width}x{enc_height}@{fps_int}fps \
+             bitrate={video_bitrate}bps"
+        );
+
+        Ok(Self {
+            out_ctx,
+            vid_enc_ctx,
+            aud_enc_ctx,
+            swr_ctx: ptr::null_mut(),
+            sws_ctx: ptr::null_mut(),
+            vid_enc_frame,
+            aud_enc_frame,
+            vid_out_stream_idx,
+            aud_out_stream_idx,
+            video_frame_count: 0,
+            audio_pts: 0,
+            fps_int,
+            enc_width,
+            enc_height,
+            aud_frame_size,
+            aud_sample_rate,
+            url: url.to_owned(),
+            last_sws_src_fmt: None,
+            last_sws_src_w: None,
+            last_sws_src_h: None,
+            last_swr_in_fmt: None,
+            last_swr_in_rate: None,
+            last_swr_in_channels: None,
+        })
+    }
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn push_video_unsafe(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
+        let src_fmt = pixel_format_to_av(frame.format());
+        let src_w = frame.width() as i32;
+        let src_h = frame.height() as i32;
+        let needs_conversion = src_fmt != AVPixelFormat_AV_PIX_FMT_YUV420P
+            || src_w != self.enc_width
+            || src_h != self.enc_height
+            || src_fmt == AVPixelFormat_AV_PIX_FMT_NONE;
+
+        if needs_conversion {
+            // (Re)create SwsContext when source properties change.
+            if self.last_sws_src_fmt != Some(src_fmt)
+                || self.last_sws_src_w != Some(src_w)
+                || self.last_sws_src_h != Some(src_h)
+            {
+                if !self.sws_ctx.is_null() {
+                    ff_sys::swscale::free_context(self.sws_ctx);
+                    self.sws_ctx = ptr::null_mut();
+                }
+                match ff_sys::swscale::get_context(
+                    src_w,
+                    src_h,
+                    src_fmt,
+                    self.enc_width,
+                    self.enc_height,
+                    AVPixelFormat_AV_PIX_FMT_YUV420P,
+                    ff_sys::swscale::scale_flags::BILINEAR,
+                ) {
+                    Ok(ctx) => {
+                        self.sws_ctx = ctx;
+                        self.last_sws_src_fmt = Some(src_fmt);
+                        self.last_sws_src_w = Some(src_w);
+                        self.last_sws_src_h = Some(src_h);
+                    }
+                    Err(_) => {
+                        return Err(ffmpeg_err_msg(
+                            "rtmp swscale context creation failed for video frame",
+                        ));
+                    }
+                }
+            }
+
+            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
+            (*self.vid_enc_frame).width = self.enc_width;
+            (*self.vid_enc_frame).height = self.enc_height;
+            self.set_vid_enc_pts();
+
+            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
+            if buf_ret < 0 {
+                av_frame_unref(self.vid_enc_frame);
+                return Err(ffmpeg_err(buf_ret));
+            }
+
+            // Build source plane/linesize arrays from the VideoFrame.
+            let planes = frame.planes();
+            let strides = frame.strides();
+            let mut src_data = [ptr::null::<u8>(); 8];
+            let mut src_linesize = [0i32; 8];
+            for (i, (plane, &stride)) in planes.iter().zip(strides.iter()).enumerate().take(8) {
+                src_data[i] = plane.as_ref().as_ptr();
+                src_linesize[i] = stride as i32;
+            }
+
+            ff_sys::swscale::scale(
+                self.sws_ctx,
+                src_data.as_ptr(),
+                src_linesize.as_ptr(),
+                0,
+                src_h,
+                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
+                (*self.vid_enc_frame).linesize.as_mut_ptr(),
+            )
+            .map_err(|_| ffmpeg_err_msg("rtmp swscale conversion failed"))?;
+        } else {
+            // Same format and dimensions — copy planes directly.
+            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
+            (*self.vid_enc_frame).width = self.enc_width;
+            (*self.vid_enc_frame).height = self.enc_height;
+            self.set_vid_enc_pts();
+
+            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
+            if buf_ret < 0 {
+                av_frame_unref(self.vid_enc_frame);
+                return Err(ffmpeg_err(buf_ret));
+            }
+
+            // Copy Y/U/V planes line-by-line.
+            let planes = frame.planes();
+            let strides = frame.strides();
+            for (plane_idx, (src_plane, &src_stride)) in
+                planes.iter().zip(strides.iter()).enumerate().take(3)
+            {
+                let dst_stride = (*self.vid_enc_frame).linesize[plane_idx] as usize;
+                let dst_ptr = (*self.vid_enc_frame).data[plane_idx];
+                if dst_ptr.is_null() {
+                    continue;
+                }
+                let rows = if plane_idx == 0 {
+                    self.enc_height as usize
+                } else {
+                    (self.enc_height as usize).div_ceil(2)
+                };
+                let copy_width = dst_stride.min(src_stride);
+                let src_bytes: &[u8] = src_plane.as_ref();
+                for row in 0..rows {
+                    let src_off = row * src_stride;
+                    let dst_off = row * dst_stride;
+                    if src_off + copy_width > src_bytes.len() {
+                        break;
+                    }
+                    // SAFETY: dst_ptr + dst_off is within the allocated frame buffer.
+                    ptr::copy_nonoverlapping(
+                        src_bytes.as_ptr().add(src_off),
+                        dst_ptr.add(dst_off),
+                        copy_width,
+                    );
+                }
+            }
+        }
+
+        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
+            // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
+            drain_encoder(
+                self.vid_enc_ctx,
+                self.out_ctx,
+                self.vid_out_stream_idx,
+                "rtmp",
+                AVRational {
+                    num: 1,
+                    den: self.fps_int,
+                },
+            );
+        }
+
+        av_frame_unref(self.vid_enc_frame);
+        self.video_frame_count += 1;
+        Ok(())
+    }
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
+        let in_fmt = sample_format_to_av(frame.format());
+        let in_rate = frame.sample_rate() as i32;
+        let in_channels = frame.channels() as i32;
+
+        // (Re)create SwrContext when input parameters change.
+        if self.last_swr_in_fmt != Some(in_fmt)
+            || self.last_swr_in_rate != Some(in_rate)
+            || self.last_swr_in_channels != Some(in_channels)
+        {
+            if !self.swr_ctx.is_null() {
+                let mut swr_tmp = self.swr_ctx;
+                ff_sys::swresample::free(&mut swr_tmp);
+                self.swr_ctx = ptr::null_mut();
+            }
+
+            let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
+            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
+
+            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
+                enc_ch_layout,
+                ff_sys::swresample::sample_format::FLTP,
+                self.aud_sample_rate,
+                &in_layout,
+                in_fmt,
+                in_rate,
+            ) {
+                if ff_sys::swresample::init(ctx).is_ok() {
+                    self.swr_ctx = ctx;
+                    self.last_swr_in_fmt = Some(in_fmt);
+                    self.last_swr_in_rate = Some(in_rate);
+                    self.last_swr_in_channels = Some(in_channels);
+                } else {
+                    let mut swr_tmp = ctx;
+                    ff_sys::swresample::free(&mut swr_tmp);
+                    log::warn!("rtmp swr init failed, dropping audio frame");
+                    return;
+                }
+            } else {
+                log::warn!("rtmp swr alloc failed, dropping audio frame");
+                return;
+            }
+        }
+
+        // Prepare the encoder frame.
+        (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
+        (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
+        (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
+        let _ = ff_sys::swresample::channel_layout::copy(
+            &mut (*self.aud_enc_frame).ch_layout,
+            &(*self.aud_enc_ctx).ch_layout,
+        );
+
+        let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
+        if buf_ret < 0 {
+            av_frame_unref(self.aud_enc_frame);
+            return;
+        }
+
+        // Build input plane pointers from the AudioFrame.
+        let planes = frame.planes();
+        let mut in_data = [ptr::null::<u8>(); 8];
+        for (i, plane) in planes.iter().enumerate().take(8) {
+            in_data[i] = plane.as_ptr();
+        }
+
+        let samples_out = ff_sys::swresample::convert(
+            self.swr_ctx,
+            (*self.aud_enc_frame).data.as_mut_ptr(),
+            self.aud_frame_size,
+            in_data.as_ptr(),
+            frame.samples() as i32,
+        );
+
+        if let Ok(n) = samples_out
+            && n > 0
+        {
+            (*self.aud_enc_frame).nb_samples = n;
+            (*self.aud_enc_frame).pts = self.audio_pts;
+            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
+                let aud_frame_period = AVRational {
+                    num: (*self.aud_enc_ctx).frame_size,
+                    den: (*self.aud_enc_ctx).sample_rate,
+                };
+                // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
+                drain_encoder(
+                    self.aud_enc_ctx,
+                    self.out_ctx,
+                    self.aud_out_stream_idx,
+                    "rtmp",
+                    aud_frame_period,
+                );
+            }
+            self.audio_pts += i64::from(n);
+        }
+
+        av_frame_unref(self.aud_enc_frame);
+    }
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn flush_and_close_unsafe(&mut self) {
+        // ── Flush video encoder ───────────────────────────────────────────────
+        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
+        drain_encoder(
+            self.vid_enc_ctx,
+            self.out_ctx,
+            self.vid_out_stream_idx,
+            "rtmp",
+            AVRational {
+                num: 1,
+                den: self.fps_int,
+            },
+        );
+
+        // ── Flush audio encoder ───────────────────────────────────────────────
+        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
+            // Drain any remaining resampler buffered samples.
+            if !self.swr_ctx.is_null() {
+                (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
+                (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
+                (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
+                let _ = ff_sys::swresample::channel_layout::copy(
+                    &mut (*self.aud_enc_frame).ch_layout,
+                    &(*self.aud_enc_ctx).ch_layout,
+                );
+
+                if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
+                    if let Ok(n) = ff_sys::swresample::convert(
+                        self.swr_ctx,
+                        (*self.aud_enc_frame).data.as_mut_ptr(),
+                        self.aud_frame_size,
+                        ptr::null(),
+                        0,
+                    ) && n > 0
+                    {
+                        (*self.aud_enc_frame).nb_samples = n;
+                        (*self.aud_enc_frame).pts = self.audio_pts;
+                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
+                        {
+                            let aud_frame_period = AVRational {
+                                num: (*self.aud_enc_ctx).frame_size,
+                                den: (*self.aud_enc_ctx).sample_rate,
+                            };
+                            drain_encoder(
+                                self.aud_enc_ctx,
+                                self.out_ctx,
+                                self.aud_out_stream_idx,
+                                "rtmp",
+                                aud_frame_period,
+                            );
+                        }
+                    }
+                    av_frame_unref(self.aud_enc_frame);
+                }
+            }
+
+            // Flush the AAC encoder itself.
+            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
+            let aud_frame_period = AVRational {
+                num: (*self.aud_enc_ctx).frame_size,
+                den: (*self.aud_enc_ctx).sample_rate,
+            };
+            drain_encoder(
+                self.aud_enc_ctx,
+                self.out_ctx,
+                self.aud_out_stream_idx,
+                "rtmp",
+                aud_frame_period,
+            );
+        }
+
+        // ── Write FLV trailer ─────────────────────────────────────────────────
+        av_write_trailer(self.out_ctx);
+
+        // Close the RTMP connection. Unlike HLS/DASH, pb was kept open throughout
+        // the session and must be explicitly closed after av_write_trailer.
+        if !(*self.out_ctx).pb.is_null() {
+            ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
+        }
+
+        log::info!("rtmp output finished url={}", self.url);
+
+        // Zero all pointers so Drop does not double-free.
+        self.free_all();
+    }
+
+    // SAFETY: Callers must ensure self is not used again after this call.
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn set_vid_enc_pts(&mut self) {
+        (*self.vid_enc_frame).pts = av_rescale_q(
+            self.video_frame_count as i64,
+            AVRational {
+                num: 1,
+                den: self.fps_int,
+            },
+            (*self.vid_enc_ctx).time_base,
+        );
+    }
+
+    /// Free all owned `FFmpeg` contexts and zero the pointers.
+    ///
+    /// # Safety
+    ///
+    /// Each pointer is checked for null before freeing. After this call all
+    /// pointers are null, so a second call is a no-op.
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn free_all(&mut self) {
+        if !self.sws_ctx.is_null() {
+            ff_sys::swscale::free_context(self.sws_ctx);
+            self.sws_ctx = ptr::null_mut();
+        }
+        if !self.swr_ctx.is_null() {
+            let mut swr_tmp = self.swr_ctx;
+            ff_sys::swresample::free(&mut swr_tmp);
+            self.swr_ctx = ptr::null_mut();
+        }
+        if !self.vid_enc_frame.is_null() {
+            av_frame_free(&mut (self.vid_enc_frame as *mut _));
+            self.vid_enc_frame = ptr::null_mut();
+        }
+        if !self.aud_enc_frame.is_null() {
+            av_frame_free(&mut (self.aud_enc_frame as *mut _));
+            self.aud_enc_frame = ptr::null_mut();
+        }
+        if !self.aud_enc_ctx.is_null() {
+            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
+            self.aud_enc_ctx = ptr::null_mut();
+        }
+        if !self.vid_enc_ctx.is_null() {
+            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
+            self.vid_enc_ctx = ptr::null_mut();
+        }
+        if !self.out_ctx.is_null() {
+            // Close pb if still open (Drop path, flush_and_close was not called).
+            if !(*self.out_ctx).pb.is_null() {
+                ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
+            }
+            avformat_free_context(self.out_ctx);
+            self.out_ctx = ptr::null_mut();
+        }
+    }
+}
+
+impl Drop for RtmpInner {
+    fn drop(&mut self) {
+        // SAFETY: free_all checks each pointer for null before freeing.
+        // flush_and_close already zeroed all pointers on the success path,
+        // so this is a safe no-op in the normal case.
+        unsafe {
+            self.free_all();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements `RtmpOutput`, a frame-push RTMP encoder for the `ff-stream` crate. It encodes pre-decoded `VideoFrame`/`AudioFrame` values with H.264/AAC via FFmpeg's FLV muxer and pushes them to an RTMP ingest endpoint over a persistent TCP connection. Unlike the HLS/DASH muxers, the RTMP connection (`pb`) is kept open for the entire session. Also adds `StreamError::UnsupportedCodec` to reject non-H.264/AAC codec selections at `build()` time, since RTMP/FLV mandates those formats.

## Changes

- `crates/ff-stream/src/rtmp.rs` (new): `RtmpOutput` consuming builder with `video`, `audio`, `video_codec`, `audio_codec`, `video_bitrate`, `audio_bitrate` setters; codec constraints validated in `build()`; implements `StreamOutput`
- `crates/ff-stream/src/rtmp_inner.rs` (new): `RtmpInner` — FLV/RTMP muxer setup, H.264+AAC encoders, lazy swscale/swresample; pb kept open across the session and closed after `av_write_trailer` in `flush_and_close`
- `crates/ff-stream/src/error.rs`: added `UnsupportedCodec { codec, reason }` variant with display impl and unit test
- `crates/ff-stream/src/lib.rs`: added `rtmp` / `rtmp_inner` module declarations and `RtmpOutput` re-export
- `crates/avio/src/lib.rs`: added `RtmpOutput` under `#[cfg(feature = "stream")]`

## Related Issues

Closes #231

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes