### PR TITLE
fix(ff-sys): add priv_data field to AVFormatContext in docsrs_stubs

### DIFF
--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -131,6 +131,7 @@ pub struct AVFormatContext {
     pub iformat: *mut AVInputFormat,
     pub bit_rate: i64,
     pub pb: *mut AVIOContext,
+    pub priv_data: *mut c_void,
 }
 
 pub struct AVFrame {


### PR DESCRIPTION
## Summary

`AVFormatContext::priv_data` is accessed in `ff-stream`'s `hls_inner.rs` and `dash_inner.rs` via `av_opt_set`, but the field was missing from the `docsrs_stubs` definition. This caused `DOCS_RS=1` builds to fail with `E0609`.

## Changes

- Add `priv_data: *mut libc::c_void` field to `AVFormatContext` in `crates/ff-sys/src/docsrs_stubs.rs`

## Related Issues

Resolves #232

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes