### PR TITLE
feat(ff-encode,ff-stream): add fMP4/CMAF container support

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -269,8 +269,8 @@ pub use ff_pipeline::{
 // Enabling `stream` also enables `pipeline` (and transitively `filter`).
 #[cfg(feature = "stream")]
 pub use ff_stream::{
-    AbrLadder, AbrRendition, DashOutput, FanoutOutput, HlsOutput, LiveAbrFormat, LiveAbrLadder,
-    LiveDashOutput, LiveHlsOutput, Rendition, RtmpOutput, StreamError, StreamOutput,
+    AbrLadder, AbrRendition, DashOutput, FanoutOutput, HlsOutput, HlsSegmentFormat, LiveAbrFormat,
+    LiveAbrLadder, LiveDashOutput, LiveHlsOutput, Rendition, RtmpOutput, StreamError, StreamOutput,
 };
 
 #[cfg(test)]

--- a/crates/ff-encode/src/container.rs
+++ b/crates/ff-encode/src/container.rs
@@ -10,6 +10,14 @@ pub enum Container {
     /// MP4 / `QuickTime`
     Mp4,
 
+    /// Fragmented MP4 — CMAF-compatible streaming container.
+    ///
+    /// Uses the same `mp4` `FFmpeg` muxer as [`Container::Mp4`] but with
+    /// `movflags=+frag_keyframe+empty_moov+default_base_moof` applied before
+    /// writing the header. Required for HTTP Live Streaming fMP4 segments
+    /// (CMAF) and MPEG-DASH.
+    FMp4,
+
     /// `WebM`
     WebM,
 
@@ -34,7 +42,7 @@ impl Container {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::Mp4 => "mp4",
+            Self::Mp4 | Self::FMp4 => "mp4",
             Self::WebM => "webm",
             Self::Mkv => "matroska",
             Self::Avi => "avi",
@@ -48,7 +56,7 @@ impl Container {
     #[must_use]
     pub const fn default_extension(self) -> &'static str {
         match self {
-            Self::Mp4 => "mp4",
+            Self::Mp4 | Self::FMp4 => "mp4",
             Self::WebM => "webm",
             Self::Mkv => "mkv",
             Self::Avi => "avi",
@@ -56,6 +64,16 @@ impl Container {
             Self::Flac => "flac",
             Self::Ogg => "ogg",
         }
+    }
+
+    /// Returns `true` if this container is fragmented MP4.
+    ///
+    /// When `true`, the encoder applies
+    /// `movflags=+frag_keyframe+empty_moov+default_base_moof` before writing
+    /// the file header, enabling CMAF-compatible streaming output.
+    #[must_use]
+    pub const fn is_fragmented(self) -> bool {
+        matches!(self, Self::FMp4)
     }
 }
 
@@ -87,5 +105,22 @@ mod tests {
     #[test]
     fn ogg_as_str_should_return_ogg() {
         assert_eq!(Container::Ogg.as_str(), "ogg");
+    }
+
+    #[test]
+    fn fmp4_as_str_should_return_mp4() {
+        assert_eq!(Container::FMp4.as_str(), "mp4");
+    }
+
+    #[test]
+    fn fmp4_extension_should_return_mp4() {
+        assert_eq!(Container::FMp4.default_extension(), "mp4");
+    }
+
+    #[test]
+    fn fmp4_is_fragmented_should_return_true() {
+        assert!(Container::FMp4.is_fragmented());
+        assert!(!Container::Mp4.is_fragmented());
+        assert!(!Container::Mkv.is_fragmented());
     }
 }

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -717,6 +717,26 @@ impl VideoEncoderBuilder {
             }
         }
 
+        // fMP4 container codec enforcement.
+        let is_fmp4 = self
+            .container
+            .as_ref()
+            .is_some_and(|c| *c == Container::FMp4);
+
+        if is_fmp4 {
+            let fmp4_video_ok = !matches!(
+                self.video_codec,
+                VideoCodec::Mpeg2 | VideoCodec::Mpeg4 | VideoCodec::Mjpeg
+            );
+            if !fmp4_video_ok {
+                return Err(EncodeError::UnsupportedContainerCodecCombination {
+                    container: "fMP4".to_string(),
+                    codec: self.video_codec.name().to_string(),
+                    hint: "fMP4 supports H.264, H.265, VP9, AV1".to_string(),
+                });
+            }
+        }
+
         if has_audio {
             if let Some(rate) = self.audio_sample_rate
                 && rate == 0
@@ -795,6 +815,7 @@ impl VideoEncoder {
             color_transfer: builder.color_transfer,
             color_primaries: builder.color_primaries,
             attachments: builder.attachments,
+            container: builder.container,
         };
 
         let inner = if config.video_width.is_some() {
@@ -1045,6 +1066,7 @@ mod tests {
                 color_transfer: None,
                 color_primaries: None,
                 attachments: Vec::new(),
+                container: None,
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,
@@ -1482,6 +1504,49 @@ mod tests {
             Err(crate::EncodeError::UnsupportedContainerCodecCombination {
                 ref container, ..
             }) if container == "avi" || container == "mov"
+        ));
+    }
+
+    #[test]
+    fn fmp4_container_with_h264_should_pass_validation() {
+        let result = VideoEncoder::create("output.mp4")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::H264)
+            .container(Container::FMp4)
+            .build();
+        assert!(!matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination { .. })
+        ));
+    }
+
+    #[test]
+    fn fmp4_container_with_mpeg4_should_return_error() {
+        let result = VideoEncoder::create("output.mp4")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Mpeg4)
+            .container(Container::FMp4)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination {
+                ref container, ..
+            }) if container == "fMP4"
+        ));
+    }
+
+    #[test]
+    fn fmp4_container_with_mjpeg_should_return_error() {
+        let result = VideoEncoder::create("output.mp4")
+            .video(640, 480, 30.0)
+            .video_codec(VideoCodec::Mjpeg)
+            .container(Container::FMp4)
+            .build();
+        assert!(matches!(
+            result,
+            Err(crate::EncodeError::UnsupportedContainerCodecCombination {
+                ref container, ..
+            }) if container == "fMP4"
         ));
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -202,6 +202,7 @@ pub(super) struct VideoEncoderConfig {
     pub(super) color_primaries: Option<ff_format::ColorPrimaries>,
     /// Binary attachments: (raw data, MIME type, filename).
     pub(super) attachments: Vec<(Vec<u8>, String, String)>,
+    pub(super) container: Option<crate::Container>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -234,6 +235,38 @@ impl VideoEncoderInner {
                 log::warn!(
                     "av_dict_set failed for metadata entry, skipping \
                      key={key} error={}",
+                    ff_sys::av_error_string(ret)
+                );
+            }
+        }
+    }
+
+    /// Apply `movflags` for fMP4 containers before `avformat_write_header`.
+    ///
+    /// When `container` is [`crate::Container::FMp4`], sets
+    /// `movflags=+frag_keyframe+empty_moov+default_base_moof` via `av_opt_set`
+    /// on the format context's `priv_data`. This enables CMAF-compatible
+    /// fragmented output required for HLS fMP4 segments and MPEG-DASH.
+    ///
+    /// # Safety
+    /// `format_ctx` must be a valid non-null pointer to an allocated `AVFormatContext`
+    /// whose `priv_data` is non-null. Must be called before `avformat_write_header`.
+    unsafe fn apply_movflags(
+        format_ctx: *mut ff_sys::AVFormatContext,
+        container: Option<crate::Container>,
+    ) {
+        if container.is_some_and(|c| c.is_fragmented()) {
+            // SAFETY: format_ctx and priv_data are non-null; string literals are
+            // static and NUL-terminated. av_opt_set does not retain the pointers.
+            let ret = ff_sys::av_opt_set(
+                (*format_ctx).priv_data,
+                c"movflags".as_ptr(),
+                c"+frag_keyframe+empty_moov+default_base_moof".as_ptr(),
+                0,
+            );
+            if ret < 0 {
+                log::warn!(
+                    "av_opt_set movflags failed for fMP4 container error={}",
                     ff_sys::av_error_string(ret)
                 );
             }
@@ -1001,6 +1034,7 @@ impl VideoEncoderInner {
                     }
                 }
 
+                Self::apply_movflags(format_ctx, config.container);
                 Self::apply_metadata(format_ctx, &config.metadata);
                 Self::apply_chapters(format_ctx, &config.chapters);
                 let ret = avformat_write_header(format_ctx, ptr::null_mut());
@@ -2487,6 +2521,7 @@ impl VideoEncoderInner {
             }
         }
 
+        Self::apply_movflags(self.format_ctx, config.container);
         Self::apply_metadata(self.format_ctx, &config.metadata);
         Self::apply_chapters(self.format_ctx, &config.chapters);
         let ret = avformat_write_header(self.format_ctx, ptr::null_mut());

--- a/crates/ff-stream/src/hls.rs
+++ b/crates/ff-stream/src/hls.rs
@@ -8,6 +8,21 @@ use std::time::Duration;
 
 use crate::error::StreamError;
 
+/// Container format for individual HLS segments.
+///
+/// Passed to [`HlsOutput::segment_format`] and
+/// [`LiveHlsOutput::segment_format`](crate::live_hls::LiveHlsOutput::segment_format).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HlsSegmentFormat {
+    /// Legacy MPEG-TS segments (`.ts`). This is the default.
+    #[default]
+    Ts,
+    /// fMP4 / CMAF segments (`.m4s`) with a separate initialization segment
+    /// (`init.mp4`). The `.m3u8` playlist includes an `#EXT-X-MAP:URI="init.mp4"`
+    /// tag written automatically by the `FFmpeg` HLS muxer.
+    Fmp4,
+}
+
 /// Builds and writes an HLS segmented output.
 ///
 /// `HlsOutput` follows the consuming-builder pattern: each setter takes `self`
@@ -34,6 +49,7 @@ pub struct HlsOutput {
     keyframe_interval: u32,
     target_bitrate: Option<u64>,
     target_video_size: Option<(u32, u32)>,
+    segment_format: HlsSegmentFormat,
 }
 
 impl HlsOutput {
@@ -53,6 +69,7 @@ impl HlsOutput {
             keyframe_interval: 48,
             target_bitrate: None,
             target_video_size: None,
+            segment_format: HlsSegmentFormat::Ts,
         }
     }
 
@@ -103,6 +120,17 @@ impl HlsOutput {
     #[must_use]
     pub fn keyframe_interval(mut self, frames: u32) -> Self {
         self.keyframe_interval = frames;
+        self
+    }
+
+    /// Set the HLS segment container format (default: [`HlsSegmentFormat::Ts`]).
+    ///
+    /// Use [`HlsSegmentFormat::Fmp4`] to produce CMAF-compatible fMP4 segments
+    /// (`.m4s`) with an `init.mp4` initialization segment. The playlist will
+    /// contain an `#EXT-X-MAP:URI="init.mp4"` tag automatically.
+    #[must_use]
+    pub fn segment_format(mut self, fmt: HlsSegmentFormat) -> Self {
+        self.segment_format = fmt;
         self
     }
 
@@ -182,6 +210,7 @@ impl HlsOutput {
             target_bitrate,
             target_width,
             target_height,
+            self.segment_format,
         )
     }
 }
@@ -231,6 +260,18 @@ mod tests {
     fn build_with_valid_config_should_succeed() {
         let result = HlsOutput::new("/tmp/hls").input("/src/video.mp4").build();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn segment_format_default_should_be_ts() {
+        let h = HlsOutput::new("/tmp/hls");
+        assert_eq!(h.segment_format, HlsSegmentFormat::Ts);
+    }
+
+    #[test]
+    fn segment_format_setter_should_store_fmp4() {
+        let h = HlsOutput::new("/tmp/hls").segment_format(HlsSegmentFormat::Fmp4);
+        assert_eq!(h.segment_format, HlsSegmentFormat::Fmp4);
     }
 
     #[test]

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -49,6 +49,7 @@ use crate::error::StreamError;
 ///
 /// Returns [`StreamError::Ffmpeg`] when any `FFmpeg` operation fails, or
 /// [`StreamError::Io`] when directory creation fails.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn write_hls(
     input_path: &str,
     output_dir: &str,
@@ -57,6 +58,7 @@ pub(crate) fn write_hls(
     target_bitrate: i64,
     target_width: i32,
     target_height: i32,
+    segment_format: crate::hls::HlsSegmentFormat,
 ) -> Result<(), StreamError> {
     std::fs::create_dir_all(output_dir)?;
     // SAFETY: All FFmpeg resources are allocated and freed within this call.
@@ -69,6 +71,7 @@ pub(crate) fn write_hls(
             target_bitrate,
             target_width,
             target_height,
+            segment_format,
         )
     }
 }
@@ -77,6 +80,7 @@ pub(crate) fn write_hls(
 // Unsafe implementation
 // ============================================================================
 
+#[allow(clippy::too_many_arguments)]
 unsafe fn write_hls_unsafe(
     input_path: &str,
     output_dir: &str,
@@ -85,6 +89,7 @@ unsafe fn write_hls_unsafe(
     target_bitrate: i64,
     target_width: i32,
     target_height: i32,
+    segment_format: crate::hls::HlsSegmentFormat,
 ) -> Result<(), StreamError> {
     ff_sys::ensure_initialized();
 
@@ -211,7 +216,9 @@ unsafe fn write_hls_unsafe(
 
     // ── 7. Set HLS muxer options ──────────────────────────────────────────────
     let seg_time_str = format!("{}", segment_duration_secs as u32);
-    let seg_filename = format!("{output_dir}/segment%03d.ts");
+    let use_fmp4 = segment_format == crate::hls::HlsSegmentFormat::Fmp4;
+    let seg_ext = if use_fmp4 { "m4s" } else { "ts" };
+    let seg_filename = format!("{output_dir}/segment%03d.{seg_ext}");
     if let (Ok(c_seg_time), Ok(c_seg_file)) = (
         CString::new(seg_time_str.as_str()),
         CString::new(seg_filename.as_str()),
@@ -241,6 +248,20 @@ unsafe fn write_hls_unsafe(
                  requested={seg_filename} error={}",
                 ff_sys::av_error_string(ret)
             );
+        }
+        if use_fmp4 {
+            let ret = av_opt_set(
+                (*out_ctx).priv_data,
+                c"hls_segment_type".as_ptr(),
+                c"fmp4".as_ptr(),
+                0,
+            );
+            if ret < 0 {
+                log::warn!(
+                    "hls_segment_type fmp4 option not supported error={}",
+                    ff_sys::av_error_string(ret)
+                );
+            }
         }
     }
 

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -91,7 +91,7 @@ pub use abr::{AbrLadder, Rendition};
 pub use dash::DashOutput;
 pub use error::StreamError;
 pub use fanout::FanoutOutput;
-pub use hls::HlsOutput;
+pub use hls::{HlsOutput, HlsSegmentFormat};
 pub use live_abr::{AbrRendition, LiveAbrFormat, LiveAbrLadder};
 pub use live_dash::LiveDashOutput;
 pub use live_hls::LiveHlsOutput;

--- a/crates/ff-stream/src/live_hls.rs
+++ b/crates/ff-stream/src/live_hls.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 use ff_format::{AudioCodec, AudioFrame, VideoCodec, VideoFrame};
 
 use crate::error::StreamError;
+use crate::hls::HlsSegmentFormat;
 use crate::live_hls_inner::LiveHlsInner;
 use crate::output::StreamOutput;
 
@@ -61,6 +62,7 @@ pub struct LiveHlsOutput {
     fps: Option<f64>,
     sample_rate: Option<u32>,
     channels: Option<u32>,
+    segment_format: HlsSegmentFormat,
     inner: Option<LiveHlsInner>,
     finished: bool,
 }
@@ -92,6 +94,7 @@ impl LiveHlsOutput {
             fps: None,
             sample_rate: None,
             channels: None,
+            segment_format: HlsSegmentFormat::Ts,
             inner: None,
             finished: false,
         }
@@ -172,6 +175,16 @@ impl LiveHlsOutput {
         self
     }
 
+    /// Set the HLS segment container format (default: [`HlsSegmentFormat::Ts`]).
+    ///
+    /// Use [`HlsSegmentFormat::Fmp4`] to produce CMAF-compatible fMP4 segments
+    /// (`.m4s`) with an `init.mp4` initialization segment.
+    #[must_use]
+    pub fn segment_format(mut self, fmt: HlsSegmentFormat) -> Self {
+        self.segment_format = fmt;
+        self
+    }
+
     /// Open all `FFmpeg` contexts and write the HLS header.
     ///
     /// # Errors
@@ -230,6 +243,7 @@ impl LiveHlsOutput {
             fps_int,
             self.video_bitrate,
             audio_params,
+            self.segment_format,
         )?;
 
         self.inner = Some(inner);
@@ -319,5 +333,17 @@ mod tests {
     fn playlist_size_default_should_be_five() {
         let out = LiveHlsOutput::new("/tmp/x");
         assert_eq!(out.playlist_size, 5);
+    }
+
+    #[test]
+    fn segment_format_default_should_be_ts() {
+        let out = LiveHlsOutput::new("/tmp/x");
+        assert_eq!(out.segment_format, HlsSegmentFormat::Ts);
+    }
+
+    #[test]
+    fn segment_format_setter_should_store_fmp4() {
+        let out = LiveHlsOutput::new("/tmp/x").segment_format(HlsSegmentFormat::Fmp4);
+        assert_eq!(out.segment_format, HlsSegmentFormat::Fmp4);
     }
 }

--- a/crates/ff-stream/src/live_hls_inner.rs
+++ b/crates/ff-stream/src/live_hls_inner.rs
@@ -142,6 +142,7 @@ impl LiveHlsInner {
         fps_int: i32,
         video_bitrate: u64,
         audio: Option<(i32, i32, i64)>,
+        segment_format: crate::hls::HlsSegmentFormat,
     ) -> Result<Self, StreamError> {
         // SAFETY: All FFmpeg resources are managed within this function; the
         // returned LiveHlsInner takes exclusive ownership of every pointer.
@@ -155,6 +156,7 @@ impl LiveHlsInner {
                 fps_int,
                 video_bitrate,
                 audio,
+                segment_format,
             )
         }
     }
@@ -196,6 +198,7 @@ impl LiveHlsInner {
         fps_int: i32,
         video_bitrate: u64,
         audio: Option<(i32, i32, i64)>,
+        segment_format: crate::hls::HlsSegmentFormat,
     ) -> Result<Self, StreamError> {
         ff_sys::ensure_initialized();
 
@@ -218,7 +221,9 @@ impl LiveHlsInner {
         // ── 2. Set HLS muxer options ──────────────────────────────────────────
         let seg_time_str = format!("{segment_secs}");
         let list_size_str = format!("{playlist_size}");
-        let seg_filename = format!("{output_dir}/segment%03d.ts");
+        let use_fmp4 = segment_format == crate::hls::HlsSegmentFormat::Fmp4;
+        let seg_ext = if use_fmp4 { "m4s" } else { "ts" };
+        let seg_filename = format!("{output_dir}/segment%03d.{seg_ext}");
 
         if let (Ok(c_seg_time), Ok(c_list_size), Ok(c_seg_file)) = (
             CString::new(seg_time_str.as_str()),
@@ -275,6 +280,20 @@ impl LiveHlsInner {
                      requested={seg_filename} error={}",
                     ff_sys::av_error_string(ret)
                 );
+            }
+            if use_fmp4 {
+                let ret = av_opt_set(
+                    (*out_ctx).priv_data,
+                    c"hls_segment_type".as_ptr(),
+                    c"fmp4".as_ptr(),
+                    0,
+                );
+                if ret < 0 {
+                    log::warn!(
+                        "live_hls hls_segment_type fmp4 option not supported error={}",
+                        ff_sys::av_error_string(ret)
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Adds `Container::FMp4` to `ff-encode` and `HlsSegmentFormat` to `ff-stream`, enabling CMAF-compatible fragmented MP4 output for both standalone video encoding and HLS streaming. When `Container::FMp4` is set, the encoder applies `movflags=+frag_keyframe+empty_moov+default_base_moof` before writing the file header. `HlsOutput` and `LiveHlsOutput` gain a `.segment_format(HlsSegmentFormat::Fmp4)` setter that switches the HLS muxer to produce `.m4s` segments with an `init.mp4` initialization segment.

## Changes

- `ff-encode/src/container.rs`: Added `Container::FMp4` variant with `as_str() = "mp4"`, `default_extension() = "mp4"`, and `is_fragmented()` helper
- `ff-encode/src/video/encoder_inner.rs`: Added `apply_movflags()` helper; called before `avformat_write_header` in both single-pass and two-pass paths; added `container` field to `VideoEncoderConfig`
- `ff-encode/src/video/builder.rs`: Propagates `container` into `VideoEncoderConfig`; rejects `Mpeg2`, `Mpeg4`, `Mjpeg` codecs with fMP4 via `UnsupportedContainerCodecCombination`
- `ff-stream/src/hls.rs`: Added `HlsSegmentFormat { Ts, Fmp4 }` enum and `.segment_format()` setter on `HlsOutput`
- `ff-stream/src/hls_inner.rs`: Passes `hls_segment_type=fmp4` and `.m4s` segment pattern when `HlsSegmentFormat::Fmp4`
- `ff-stream/src/live_hls.rs`: Added `.segment_format()` setter on `LiveHlsOutput`
- `ff-stream/src/live_hls_inner.rs`: Same fMP4 options as `hls_inner`
- `ff-stream/src/lib.rs`, `avio/src/lib.rs`: Re-export `HlsSegmentFormat`

## Related Issues

Closes #678

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes