### PR TITLE
feat(ff-format,ff-stream): LiveHlsOutput integration test (#236)

### DIFF
--- a/crates/ff-format/src/frame/audio.rs
+++ b/crates/ff-format/src/frame/audio.rs
@@ -200,6 +200,34 @@ impl AudioFrame {
         })
     }
 
+    /// Creates a silent audio frame with 1024 zero-filled samples.
+    ///
+    /// `pts_ms` is the presentation timestamp in milliseconds.
+    /// Both planar formats (one plane per channel) and packed formats (single
+    /// interleaved plane) are supported.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn new_silent(sample_rate: u32, channels: u32, format: SampleFormat, pts_ms: i64) -> Self {
+        let samples = 1024usize;
+        let bps = format.bytes_per_sample();
+        let planes = if format.is_planar() {
+            (0..channels as usize)
+                .map(|_| vec![0u8; samples * bps])
+                .collect()
+        } else {
+            vec![vec![0u8; samples * channels as usize * bps]]
+        };
+        let timestamp = Timestamp::from_millis(pts_ms, crate::Rational::new(1, 1000));
+        Self {
+            planes,
+            samples,
+            channels,
+            sample_rate,
+            format,
+            timestamp,
+        }
+    }
+
     /// Allocates planes for the given parameters.
     fn allocate_planes(samples: usize, channels: u32, format: SampleFormat) -> Vec<Vec<u8>> {
         let bytes_per_sample = format.bytes_per_sample();

--- a/crates/ff-format/src/frame/video.rs
+++ b/crates/ff-format/src/frame/video.rs
@@ -198,6 +198,36 @@ impl VideoFrame {
         })
     }
 
+    /// Creates a black YUV420P video frame.
+    ///
+    /// The Y plane is filled with `0x00`; U and V planes are filled with `0x80`
+    /// (neutral chroma). `pts_ms` is the presentation timestamp in milliseconds.
+    ///
+    /// The `format` parameter is accepted for call-site clarity; always pass
+    /// [`PixelFormat::Yuv420p`].
+    #[doc(hidden)]
+    #[must_use]
+    pub fn new_black(width: u32, height: u32, format: PixelFormat, pts_ms: i64) -> Self {
+        let y_w = width as usize;
+        let y_h = height as usize;
+        let uv_w = (width as usize).div_ceil(2);
+        let uv_h = (height as usize).div_ceil(2);
+        let timestamp = Timestamp::from_millis(pts_ms, crate::Rational::new(1, 1000));
+        Self {
+            planes: vec![
+                PooledBuffer::standalone(vec![0u8; y_w * y_h]),
+                PooledBuffer::standalone(vec![0x80u8; uv_w * uv_h]),
+                PooledBuffer::standalone(vec![0x80u8; uv_w * uv_h]),
+            ],
+            strides: vec![y_w, uv_w, uv_w],
+            width,
+            height,
+            format,
+            timestamp,
+            key_frame: true,
+        }
+    }
+
     /// Allocates planes and strides for the given dimensions and format.
     #[allow(clippy::too_many_lines)]
     fn allocate_planes(

--- a/crates/ff-stream/Cargo.toml
+++ b/crates/ff-stream/Cargo.toml
@@ -23,5 +23,8 @@ ff-pipeline = { workspace = true }
 thiserror   = { workspace = true }
 log         = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/crates/ff-stream/tests/live_hls_tests.rs
+++ b/crates/ff-stream/tests/live_hls_tests.rs
@@ -1,0 +1,101 @@
+//! Integration tests for `LiveHlsOutput` (issue #236).
+//!
+//! Pushes synthetic video and audio frames through a `LiveHlsOutput` and verifies
+//! that the resulting `index.m3u8` playlist and `.ts` segment files are correctly
+//! structured.  All tests skip gracefully when the required encoder is unavailable.
+
+// Tests are allowed to use unwrap() / expect() for simplicity.
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
+mod fixtures;
+use fixtures::DirGuard;
+
+use ff_format::{AudioFrame, PixelFormat, SampleFormat, VideoFrame};
+use ff_stream::{LiveHlsOutput, StreamOutput};
+use std::time::Duration;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn make_video_frame(pts_ms: i64, width: u32, height: u32) -> VideoFrame {
+    VideoFrame::new_black(width, height, PixelFormat::Yuv420p, pts_ms)
+}
+
+fn make_audio_frame(pts_ms: i64, sample_rate: u32, channels: u32) -> AudioFrame {
+    AudioFrame::new_silent(sample_rate, channels, SampleFormat::F32p, pts_ms)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn live_hls_output_should_generate_valid_m3u8_and_segments() {
+    let out_dir = tempfile::tempdir().expect("temp dir");
+    let _guard = DirGuard(out_dir.path().to_path_buf());
+
+    let mut hls = match LiveHlsOutput::new(out_dir.path())
+        .segment_duration(Duration::from_secs(2))
+        .playlist_size(3)
+        .video(640, 360, 30.0)
+        .audio(44100, 2)
+        .build()
+    {
+        Ok(h) => h,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+
+    // Push 30 seconds of synthetic frames (30 fps × 30 s = 900 video frames).
+    // One audio frame is pushed per video-second.
+    for frame_idx in 0..900_u64 {
+        let pts_ms = (frame_idx * 1000 / 30) as i64;
+        hls.push_video(&make_video_frame(pts_ms, 640, 360))
+            .expect("push_video");
+        if frame_idx % 30 == 0 {
+            hls.push_audio(&make_audio_frame(pts_ms, 44100, 2))
+                .expect("push_audio");
+        }
+    }
+    Box::new(hls).finish().expect("finish");
+
+    // ── assertions ──────────────────────────────────────────────────────────
+    let playlist = out_dir.path().join("index.m3u8");
+    assert!(playlist.exists(), "index.m3u8 must exist after finish()");
+
+    let content = std::fs::read_to_string(&playlist).unwrap();
+    assert!(content.contains("#EXTM3U"), "m3u8 must start with #EXTM3U");
+    assert!(
+        content.contains("#EXT-X-ENDLIST") || content.contains("#EXTINF"),
+        "m3u8 must contain segment entries"
+    );
+
+    // Sliding window: at most 3 segment references in the playlist.
+    let segment_count = content.lines().filter(|l| l.ends_with(".ts")).count();
+    assert!(
+        segment_count <= 3,
+        "sliding window must not exceed playlist_size=3 (got {segment_count})"
+    );
+    assert!(segment_count >= 1, "at least one segment must be present");
+
+    // The HLS muxer deletes old segments on rotation (when a new segment is
+    // started).  The final `av_write_trailer` closes the last segment without
+    // triggering one more rotation, so the segment just before the sliding
+    // window may still be present on disk.  Allow playlist_size + 1 files.
+    let ts_files: Vec<_> = std::fs::read_dir(out_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |x| x == "ts"))
+        .collect();
+    let playlist_size = 3;
+    assert!(
+        ts_files.len() <= playlist_size + 1,
+        "at most {} .ts files should remain on disk (got {})",
+        playlist_size + 1,
+        ts_files.len()
+    );
+}


### PR DESCRIPTION
## Summary

Adds an integration test for `LiveHlsOutput` that pushes synthetic video and audio frames and verifies the resulting `index.m3u8` playlist and `.ts` segment files are correctly structured. Also adds two `#[doc(hidden)]` frame constructors to `ff-format` so integration tests in other crates can generate synthetic frames without depending on FFmpeg decode paths.

## Changes

- **`crates/ff-format/src/frame/video.rs`**: adds `VideoFrame::new_black(width, height, format, pts_ms)` — allocates a YUV420P frame with Y=`0x00`, U/V=`0x80` (neutral chroma) and a millisecond-precision timestamp
- **`crates/ff-format/src/frame/audio.rs`**: adds `AudioFrame::new_silent(sample_rate, channels, format, pts_ms)` — allocates 1024 zero-filled samples, handling both planar and packed formats
- **`crates/ff-stream/Cargo.toml`**: adds `tempfile = "3"` dev-dependency
- **`crates/ff-stream/tests/live_hls_tests.rs`** (new): pushes 900 video frames + 30 audio frames through `LiveHlsOutput` with `segment_duration=2s`, `playlist_size=3`; asserts `index.m3u8` exists with valid HLS tags and the sliding window does not exceed 3 playlist entries; skips gracefully when the encoder is unavailable

## Related Issues

Closes #236

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes