### PR TITLE
feat(avio): add v0.8.0 live streaming and network examples

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -224,6 +224,30 @@ required-features = ["decode", "encode"]
 name = "gpl_encode"
 required-features = ["decode", "encode"]
 
+[[example]]
+name = "decode_from_url"
+required-features = ["decode"]
+
+[[example]]
+name = "live_hls_output"
+required-features = ["stream"]
+
+[[example]]
+name = "live_dash_output"
+required-features = ["stream"]
+
+[[example]]
+name = "rtmp_output"
+required-features = ["stream"]
+
+[[example]]
+name = "fanout_output"
+required-features = ["stream"]
+
+[[example]]
+name = "live_abr_ladder"
+required-features = ["stream"]
+
 [dev-dependencies]
 futures = { workspace = true }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/avio/examples/decode_from_url.rs
+++ b/crates/avio/examples/decode_from_url.rs
@@ -1,0 +1,133 @@
+//! Decode video frames from an HTTP, HLS, RTMP, or SRT URL.
+//!
+//! Demonstrates:
+//! - `VideoDecoder::open(url)` — open a network source
+//! - `.network(NetworkOptions)` — configure connection and read timeouts
+//! - `.is_live()` — detect live vs. VOD streams
+//! - `decode_one()` — pull frames from a remote source
+//!
+//! The example opens the URL, prints stream metadata, and decodes up to
+//! `--max-frames` video frames (default: 30), reporting wall-clock throughput.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example decode_from_url --features decode -- \
+//!   --url   http://example.com/video.mp4   \
+//!   [--max-frames 30]                      \
+//!   [--connect-timeout 10]                 \
+//!   [--read-timeout 30]
+//! ```
+
+use std::{process, time::Duration};
+
+use avio::{NetworkOptions, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut url = None::<String>;
+    let mut max_frames: u64 = 30;
+    let mut connect_timeout_secs: u64 = 10;
+    let mut read_timeout_secs: u64 = 30;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--url" | "-u" => url = Some(args.next().unwrap_or_default()),
+            "--max-frames" | "-n" => {
+                let v = args.next().unwrap_or_default();
+                max_frames = v.parse().unwrap_or(30);
+            }
+            "--connect-timeout" => {
+                let v = args.next().unwrap_or_default();
+                connect_timeout_secs = v.parse().unwrap_or(10);
+            }
+            "--read-timeout" => {
+                let v = args.next().unwrap_or_default();
+                read_timeout_secs = v.parse().unwrap_or(30);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let url = url.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: decode_from_url --url <URL> \
+             [--max-frames N] [--connect-timeout N] [--read-timeout N]"
+        );
+        eprintln!();
+        eprintln!("Examples:");
+        eprintln!("  --url http://example.com/video.mp4");
+        eprintln!("  --url rtmp://ingest.example.com/live/key");
+        eprintln!("  --url srt://source.example.com:9000");
+        process::exit(1);
+    });
+
+    let network = NetworkOptions {
+        connect_timeout: Duration::from_secs(connect_timeout_secs),
+        read_timeout: Duration::from_secs(read_timeout_secs),
+        reconnect_on_error: false,
+        max_reconnect_attempts: 0,
+    };
+
+    println!("URL:             {url}");
+    println!("Connect timeout: {connect_timeout_secs} s");
+    println!("Read timeout:    {read_timeout_secs} s");
+    println!("Max frames:      {max_frames}");
+    println!();
+    println!("Opening...");
+
+    let mut decoder = match VideoDecoder::open(&url).network(network).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!(
+        "Stream:  {}×{}  {:.2} fps",
+        decoder.width(),
+        decoder.height(),
+        decoder.frame_rate()
+    );
+    println!("Live:    {}", decoder.is_live());
+    println!();
+    println!("Decoding up to {max_frames} frames...");
+    println!();
+
+    let start = std::time::Instant::now();
+    let mut decoded: u64 = 0;
+
+    loop {
+        if decoded >= max_frames {
+            break;
+        }
+
+        match decoder.decode_one() {
+            Ok(Some(frame)) => {
+                decoded += 1;
+                let pts = frame.timestamp().as_millis();
+                if decoded <= 5 || decoded.is_multiple_of(10) {
+                    println!("  frame {decoded:>4}  pts={pts} ms");
+                }
+            }
+            Ok(None) => {
+                println!("End of stream after {decoded} frames.");
+                break;
+            }
+            Err(e) => {
+                eprintln!("Decode error: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    #[allow(clippy::cast_precision_loss)]
+    let fps = decoded as f64 / elapsed.max(0.001);
+    println!();
+    println!("Decoded {decoded} frames in {elapsed:.2} s  ({fps:.1} fps)");
+}

--- a/crates/avio/examples/fanout_output.rs
+++ b/crates/avio/examples/fanout_output.rs
@@ -1,0 +1,198 @@
+//! Fan a video source out to multiple outputs simultaneously.
+//!
+//! Demonstrates:
+//! - `FanoutOutput` — deliver frames to multiple `StreamOutput` targets at once
+//! - Combining `LiveHlsOutput` and `LiveDashOutput` targets in one fan-out
+//! - Graceful error reporting: all targets still receive each frame even when
+//!   one fails, and errors are aggregated into `StreamError::FanoutFailure`
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example fanout_output --features stream -- \
+//!   --input     input.mp4    \
+//!   --hls-dir   ./fanout-hls/ \
+//!   --dash-dir  ./fanout-dash/ \
+//!   [--segment  6]            \
+//!   [--bitrate  2000000]
+//! ```
+//!
+//! Both output directories will be populated in a single pass through the
+//! source file. You can extend the example by adding an `RtmpOutput` target
+//! to simultaneously push to a live ingest endpoint.
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{AudioDecoder, FanoutOutput, LiveDashOutput, LiveHlsOutput, StreamOutput, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut hls_dir = None::<String>;
+    let mut dash_dir = None::<String>;
+    let mut segment_secs: u64 = 6;
+    let mut bitrate: u64 = 2_000_000;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--hls-dir" => hls_dir = Some(args.next().unwrap_or_default()),
+            "--dash-dir" => dash_dir = Some(args.next().unwrap_or_default()),
+            "--segment" | "-s" => {
+                let v = args.next().unwrap_or_default();
+                segment_secs = v.parse().unwrap_or(6);
+            }
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().unwrap_or(2_000_000);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: fanout_output --input <file> --hls-dir <dir> --dash-dir <dir> \
+             [--segment N] [--bitrate N]"
+        );
+        process::exit(1);
+    });
+    let hls_dir = hls_dir.unwrap_or_else(|| {
+        eprintln!("--hls-dir is required");
+        process::exit(1);
+    });
+    let dash_dir = dash_dir.unwrap_or_else(|| {
+        eprintln!("--dash-dir is required");
+        process::exit(1);
+    });
+
+    // ── Open source decoders ──────────────────────────────────────────────────
+
+    let mut video_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open video decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut audio_dec = AudioDecoder::open(&input).build().ok();
+
+    let width = video_dec.width();
+    let height = video_dec.height();
+    let fps = video_dec.frame_rate();
+    let fps_display = if fps > 0.0 { fps } else { 30.0 };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:    {in_name}  ({width}×{height}  {fps_display:.2} fps)");
+    println!("HLS out:  {hls_dir}");
+    println!("DASH out: {dash_dir}");
+    println!("Segment:  {segment_secs} s");
+    println!("Bitrate:  {bitrate} bps");
+    println!();
+
+    // ── Build individual targets ──────────────────────────────────────────────
+
+    let has_audio = audio_dec.is_some();
+    let seg_dur = Duration::from_secs(segment_secs);
+
+    let mut hls_builder = LiveHlsOutput::new(&hls_dir)
+        .video(width, height, fps_display)
+        .segment_duration(seg_dur)
+        .video_bitrate(bitrate);
+    if has_audio {
+        hls_builder = hls_builder.audio(44100, 2);
+    }
+    let hls = match hls_builder.build() {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Error: cannot open LiveHlsOutput: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut dash_builder = LiveDashOutput::new(&dash_dir)
+        .video(width, height, fps_display)
+        .segment_duration(seg_dur)
+        .video_bitrate(bitrate);
+    if has_audio {
+        dash_builder = dash_builder.audio(44100, 2);
+    }
+    let dash = match dash_builder.build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open LiveDashOutput: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Wrap in FanoutOutput ──────────────────────────────────────────────────
+
+    let mut fanout = FanoutOutput::new(vec![Box::new(hls), Box::new(dash)]);
+
+    // ── Frame loop ────────────────────────────────────────────────────────────
+
+    println!("Encoding and fanning out...");
+    let start = std::time::Instant::now();
+    let mut video_frames: u64 = 0;
+    let mut audio_frames: u64 = 0;
+
+    loop {
+        match video_dec.decode_one() {
+            Ok(Some(frame)) => {
+                video_frames += 1;
+                if let Err(e) = fanout.push_video(&frame) {
+                    eprintln!("Error: push_video: {e}");
+                    process::exit(1);
+                }
+                if video_frames.is_multiple_of(300) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    println!("  {video_frames} video frames  ({elapsed:.1} s elapsed)");
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error: video decode: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    if let Some(ref mut adec) = audio_dec {
+        loop {
+            match adec.decode_one() {
+                Ok(Some(frame)) => {
+                    audio_frames += 1;
+                    if let Err(e) = fanout.push_audio(&frame) {
+                        eprintln!("Error: push_audio: {e}");
+                        process::exit(1);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Error: audio decode: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = Box::new(fanout).finish() {
+        eprintln!("Error: finish: {e}");
+        process::exit(1);
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    println!();
+    println!("Done in {elapsed:.2} s — {video_frames} video frames, {audio_frames} audio frames");
+    println!();
+    println!("HLS:  npx serve {hls_dir}  (open http://localhost:3000/index.m3u8)");
+    println!("DASH: npx serve {dash_dir}  (open http://localhost:3000/manifest.mpd)");
+}

--- a/crates/avio/examples/live_abr_ladder.rs
+++ b/crates/avio/examples/live_abr_ladder.rs
@@ -1,0 +1,263 @@
+//! Encode a video file into a live multi-rendition ABR ladder.
+//!
+//! Demonstrates:
+//! - `LiveAbrLadder` — fan decoded frames to multiple encoders at different
+//!   resolutions and bitrates in one pass
+//! - `AbrRendition` — per-rendition width, height, and bitrate settings
+//! - `LiveAbrFormat` — choose HLS (`index.m3u8` per rendition + `master.m3u8`)
+//!   or DASH (`manifest.mpd` per rendition + top-level `manifest.mpd`)
+//! - `StreamOutput::finish()` — flush all encoders and write the master playlist
+//!
+//! Each rendition is placed in a subdirectory named after its resolution
+//! (`{width}x{height}` by default). The master playlist at the root of the
+//! output directory references all renditions.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example live_abr_ladder --features stream -- \
+//!   --input   input.mp4  \
+//!   --output  ./abr-live/ \
+//!   [--format hls]        \
+//!   [--segment 6]         \
+//!   [--ladder 1080,4000000:720,2000000:480,1000000]
+//! ```
+//!
+//! Serve with:
+//!
+//! ```bash
+//! npx serve ./abr-live/
+//! # HLS:  open http://localhost:3000/master.m3u8
+//! # DASH: open http://localhost:3000/manifest.mpd
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{AbrRendition, AudioDecoder, LiveAbrFormat, LiveAbrLadder, StreamOutput, VideoDecoder};
+
+/// Parse `"H,BPS:H,BPS:..."` into `Vec<(height, bitrate)>`.
+fn parse_ladder(s: &str) -> Result<Vec<(u32, u64)>, String> {
+    s.split(':')
+        .map(|pair| {
+            let mut parts = pair.splitn(2, ',');
+            let height: u32 = parts
+                .next()
+                .ok_or_else(|| format!("missing height in '{pair}'"))?
+                .parse()
+                .map_err(|_| format!("invalid height in '{pair}'"))?;
+            let bitrate: u64 = parts
+                .next()
+                .ok_or_else(|| format!("missing bitrate in '{pair}'"))?
+                .parse()
+                .map_err(|_| format!("invalid bitrate in '{pair}'"))?;
+            Ok((height, bitrate))
+        })
+        .collect()
+}
+
+const DEFAULT_LADDER: &[(u32, u64)] = &[(1080, 4_000_000), (720, 2_000_000), (480, 1_000_000)];
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut format_str = "hls".to_string();
+    let mut segment_secs: u64 = 6;
+    let mut ladder_str = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--format" | "-f" => format_str = args.next().unwrap_or_else(|| "hls".to_string()),
+            "--segment" | "-s" => {
+                let v = args.next().unwrap_or_default();
+                segment_secs = v.parse().unwrap_or(6);
+            }
+            "--ladder" => ladder_str = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: live_abr_ladder --input <file> --output <dir> \
+             [--format hls|dash] [--segment N] [--ladder H,BPS:H,BPS]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    let format_lower = format_str.to_lowercase();
+    if format_lower != "hls" && format_lower != "dash" {
+        eprintln!("Error: --format must be 'hls' or 'dash'");
+        process::exit(1);
+    }
+
+    let ladder_pairs = match ladder_str {
+        Some(ref s) => parse_ladder(s).unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }),
+        None => DEFAULT_LADDER.to_vec(),
+    };
+
+    // ── Open source decoders ──────────────────────────────────────────────────
+
+    let mut video_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open video decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut audio_dec = AudioDecoder::open(&input).build().ok();
+
+    let src_width = video_dec.width();
+    let src_height = video_dec.height();
+    let fps = video_dec.frame_rate();
+    let fps_display = if fps > 0.0 { fps } else { 30.0 };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:   {in_name}  ({src_width}×{src_height}  {fps_display:.2} fps)");
+    println!("Output:  {output}");
+    println!("Format:  {}", format_lower.to_uppercase());
+    println!("Segment: {segment_secs} s");
+    println!();
+
+    // ── Build rendition list ──────────────────────────────────────────────────
+
+    let aspect = if src_height > 0 {
+        f64::from(src_width) / f64::from(src_height)
+    } else {
+        16.0 / 9.0
+    };
+
+    println!("Renditions:");
+    let mut renditions = Vec::new();
+    for (i, &(height, video_bitrate)) in ladder_pairs.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let width = ((f64::from(height) * aspect).round() as u32 / 2) * 2; // ensure even
+        let audio_bitrate = if video_bitrate >= 4_000_000 {
+            192_000
+        } else {
+            128_000
+        };
+        println!("  #{i}  {width}×{height}  video={video_bitrate} bps  audio={audio_bitrate} bps");
+        renditions.push(AbrRendition {
+            width,
+            height,
+            video_bitrate,
+            audio_bitrate,
+            name: None,
+        });
+    }
+    println!();
+
+    // ── Open LiveAbrLadder ────────────────────────────────────────────────────
+
+    let fmt = if format_lower == "dash" {
+        LiveAbrFormat::Dash
+    } else {
+        LiveAbrFormat::Hls
+    };
+
+    let mut builder = LiveAbrLadder::new(&output)
+        .fps(fps_display)
+        .segment_duration(Duration::from_secs(segment_secs))
+        .format(fmt);
+
+    for r in renditions {
+        builder = builder.add_rendition(r);
+    }
+
+    if audio_dec.is_some() {
+        builder = builder.audio(44100, 2);
+    }
+
+    let mut ladder = match builder.build() {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Error: cannot open LiveAbrLadder: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Frame loop ────────────────────────────────────────────────────────────
+
+    println!("Encoding...");
+    let start = std::time::Instant::now();
+    let mut video_frames: u64 = 0;
+    let mut audio_frames: u64 = 0;
+
+    loop {
+        match video_dec.decode_one() {
+            Ok(Some(frame)) => {
+                video_frames += 1;
+                if let Err(e) = ladder.push_video(&frame) {
+                    eprintln!("Error: push_video: {e}");
+                    process::exit(1);
+                }
+                if video_frames.is_multiple_of(300) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    println!("  {video_frames} video frames  ({elapsed:.1} s elapsed)");
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error: video decode: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    if let Some(ref mut adec) = audio_dec {
+        loop {
+            match adec.decode_one() {
+                Ok(Some(frame)) => {
+                    audio_frames += 1;
+                    if let Err(e) = ladder.push_audio(&frame) {
+                        eprintln!("Error: push_audio: {e}");
+                        process::exit(1);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Error: audio decode: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = Box::new(ladder).finish() {
+        eprintln!("Error: finish: {e}");
+        process::exit(1);
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    println!();
+    println!("Done in {elapsed:.2} s — {video_frames} video frames, {audio_frames} audio frames");
+    println!();
+
+    // ── Show master playlist location ─────────────────────────────────────────
+
+    if format_lower == "hls" {
+        println!("Master playlist: {output}/master.m3u8");
+        println!("Serve with: npx serve {output}  (open http://localhost:3000/master.m3u8)");
+    } else {
+        println!("Manifest: {output}/manifest.mpd");
+        println!("Serve with: npx serve {output}  (open http://localhost:3000/manifest.mpd)");
+    }
+}

--- a/crates/avio/examples/live_dash_output.rs
+++ b/crates/avio/examples/live_dash_output.rs
@@ -1,0 +1,204 @@
+//! Ingest a local video file and publish it as a live DASH stream.
+//!
+//! Demonstrates:
+//! - `VideoDecoder` — decode frames from a source file
+//! - `LiveDashOutput` — accept decoded frames and write a `manifest.mpd`
+//!   backed by `.m4s` segment files
+//! - `StreamOutput::finish()` — flush encoders and write the DASH trailer
+//!
+//! `LiveDashOutput` is intended for sources where frames arrive one at a time
+//! (camera, network ingest, synthetic generator). For transcoding a file to
+//! a static DASH package, use `DashOutput` instead.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example live_dash_output --features stream -- \
+//!   --input    input.mp4    \
+//!   --output   ./live-dash/ \
+//!   [--segment 4]           \
+//!   [--bitrate  2000000]
+//! ```
+//!
+//! Serve the output directory with any HTTP server, for example:
+//!
+//! ```bash
+//! npx serve ./live-dash/
+//! # open http://localhost:3000/manifest.mpd in a DASH-capable player
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{AudioDecoder, LiveDashOutput, StreamOutput, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut segment_secs: u64 = 4;
+    let mut bitrate: u64 = 2_000_000;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--segment" | "-s" => {
+                let v = args.next().unwrap_or_default();
+                segment_secs = v.parse().unwrap_or(4);
+            }
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().unwrap_or(2_000_000);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: live_dash_output --input <file> --output <dir> \
+             [--segment N] [--bitrate N]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Open source decoders ──────────────────────────────────────────────────
+
+    let mut video_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open video decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut audio_dec = AudioDecoder::open(&input).build().ok();
+
+    let width = video_dec.width();
+    let height = video_dec.height();
+    let fps = video_dec.frame_rate();
+    let fps_display = if fps > 0.0 { fps } else { 30.0 };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:    {in_name}  ({width}×{height}  {fps_display:.2} fps)");
+    println!("Output:   {output}");
+    println!("Segment:  {segment_secs} s");
+    println!("Bitrate:  {bitrate} bps");
+    println!();
+
+    // ── Open LiveDashOutput ───────────────────────────────────────────────────
+
+    let mut builder = LiveDashOutput::new(&output)
+        .video(width, height, fps_display)
+        .segment_duration(Duration::from_secs(segment_secs))
+        .video_bitrate(bitrate);
+
+    if audio_dec.is_some() {
+        builder = builder.audio(44100, 2);
+    }
+
+    let mut dash = match builder.build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open LiveDashOutput: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Frame loop ────────────────────────────────────────────────────────────
+
+    println!("Encoding frames...");
+    let start = std::time::Instant::now();
+    let mut video_frames: u64 = 0;
+    let mut audio_frames: u64 = 0;
+
+    loop {
+        match video_dec.decode_one() {
+            Ok(Some(frame)) => {
+                video_frames += 1;
+                if let Err(e) = dash.push_video(&frame) {
+                    eprintln!("Error: push_video: {e}");
+                    process::exit(1);
+                }
+                if video_frames.is_multiple_of(300) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    println!("  {video_frames} video frames  ({elapsed:.1} s elapsed)");
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error: video decode: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    if let Some(ref mut adec) = audio_dec {
+        loop {
+            match adec.decode_one() {
+                Ok(Some(frame)) => {
+                    audio_frames += 1;
+                    if let Err(e) = dash.push_audio(&frame) {
+                        eprintln!("Error: push_audio: {e}");
+                        process::exit(1);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Error: audio decode: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = Box::new(dash).finish() {
+        eprintln!("Error: finish: {e}");
+        process::exit(1);
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    println!();
+    println!("Done in {elapsed:.2} s — {video_frames} video frames, {audio_frames} audio frames");
+    println!();
+
+    // ── List output files ─────────────────────────────────────────────────────
+
+    let entries = match std::fs::read_dir(&output) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Warning: cannot list output: {e}");
+            return;
+        }
+    };
+
+    let mut files: Vec<(String, u64)> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let size = e.metadata().ok()?.len();
+            Some((name, size))
+        })
+        .collect();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    println!("Output directory ({} files):", files.len());
+    for (name, size) in &files {
+        #[allow(clippy::cast_precision_loss)]
+        let kb = *size as f64 / 1024.0;
+        println!("  {name:<40}  ({kb:.1} KB)");
+    }
+    println!();
+    println!("Serve with: npx serve {output}  (open http://localhost:3000/manifest.mpd)");
+}

--- a/crates/avio/examples/live_hls_output.rs
+++ b/crates/avio/examples/live_hls_output.rs
@@ -1,0 +1,213 @@
+//! Ingest a local video file and publish it as a live HLS stream.
+//!
+//! Demonstrates:
+//! - `VideoDecoder` — decode frames from a source file
+//! - `LiveHlsOutput` — accept decoded frames and write a sliding-window
+//!   `index.m3u8` playlist backed by `.ts` segment files
+//! - `StreamOutput::finish()` — flush encoders and write the HLS trailer
+//!
+//! `LiveHlsOutput` is intended for sources where frames arrive one at a time
+//! (camera, network ingest, synthetic generator). For transcoding a file to
+//! a static HLS package, use `HlsOutput` instead.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example live_hls_output --features stream -- \
+//!   --input    input.mp4   \
+//!   --output   ./live-hls/ \
+//!   [--segment 6]          \
+//!   [--playlist-size 5]    \
+//!   [--bitrate  2000000]
+//! ```
+//!
+//! Serve the output directory with any HTTP server that supports byte-range
+//! requests, for example:
+//!
+//! ```bash
+//! npx serve ./live-hls/
+//! # open http://localhost:3000/index.m3u8 in an HLS-capable player
+//! ```
+
+use std::{path::Path, process, time::Duration};
+
+use avio::{AudioDecoder, LiveHlsOutput, StreamOutput, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut output = None::<String>;
+    let mut segment_secs: u64 = 6;
+    let mut playlist_size: u32 = 5;
+    let mut bitrate: u64 = 2_000_000;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--output" | "-o" => output = Some(args.next().unwrap_or_default()),
+            "--segment" | "-s" => {
+                let v = args.next().unwrap_or_default();
+                segment_secs = v.parse().unwrap_or(6);
+            }
+            "--playlist-size" | "-p" => {
+                let v = args.next().unwrap_or_default();
+                playlist_size = v.parse().unwrap_or(5);
+            }
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().unwrap_or(2_000_000);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: live_hls_output --input <file> --output <dir> \
+             [--segment N] [--playlist-size N] [--bitrate N]"
+        );
+        process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("--output is required");
+        process::exit(1);
+    });
+
+    // ── Open source decoders ──────────────────────────────────────────────────
+
+    let mut video_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open video decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut audio_dec = AudioDecoder::open(&input).build().ok();
+
+    let width = video_dec.width();
+    let height = video_dec.height();
+    let fps = video_dec.frame_rate();
+    let fps_display = if fps > 0.0 { fps } else { 30.0 };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:         {in_name}  ({width}×{height}  {fps_display:.2} fps)");
+    println!("Output:        {output}");
+    println!("Segment:       {segment_secs} s");
+    println!("Playlist size: {playlist_size}");
+    println!("Bitrate:       {bitrate} bps");
+    println!();
+
+    // ── Open LiveHlsOutput ────────────────────────────────────────────────────
+
+    let mut builder = LiveHlsOutput::new(&output)
+        .video(width, height, fps_display)
+        .segment_duration(Duration::from_secs(segment_secs))
+        .playlist_size(playlist_size)
+        .video_bitrate(bitrate);
+
+    if audio_dec.is_some() {
+        builder = builder.audio(44100, 2);
+    }
+
+    let mut hls = match builder.build() {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Error: cannot open LiveHlsOutput: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── Frame loop ────────────────────────────────────────────────────────────
+
+    println!("Encoding frames...");
+    let start = std::time::Instant::now();
+    let mut video_frames: u64 = 0;
+    let mut audio_frames: u64 = 0;
+
+    loop {
+        match video_dec.decode_one() {
+            Ok(Some(frame)) => {
+                video_frames += 1;
+                if let Err(e) = hls.push_video(&frame) {
+                    eprintln!("Error: push_video: {e}");
+                    process::exit(1);
+                }
+                if video_frames.is_multiple_of(300) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    println!("  {video_frames} video frames  ({elapsed:.1} s elapsed)");
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error: video decode: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    if let Some(ref mut adec) = audio_dec {
+        loop {
+            match adec.decode_one() {
+                Ok(Some(frame)) => {
+                    audio_frames += 1;
+                    if let Err(e) = hls.push_audio(&frame) {
+                        eprintln!("Error: push_audio: {e}");
+                        process::exit(1);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Error: audio decode: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = Box::new(hls).finish() {
+        eprintln!("Error: finish: {e}");
+        process::exit(1);
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    println!();
+    println!("Done in {elapsed:.2} s — {video_frames} video frames, {audio_frames} audio frames");
+    println!();
+
+    // ── List output files ─────────────────────────────────────────────────────
+
+    let entries = match std::fs::read_dir(&output) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Warning: cannot list output: {e}");
+            return;
+        }
+    };
+
+    let mut files: Vec<(String, u64)> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let size = e.metadata().ok()?.len();
+            Some((name, size))
+        })
+        .collect();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    println!("Output directory ({} files):", files.len());
+    for (name, size) in &files {
+        #[allow(clippy::cast_precision_loss)]
+        let kb = *size as f64 / 1024.0;
+        println!("  {name:<40}  ({kb:.1} KB)");
+    }
+    println!();
+    println!("Serve with: npx serve {output}  (open http://localhost:3000/index.m3u8)");
+}

--- a/crates/avio/examples/rtmp_output.rs
+++ b/crates/avio/examples/rtmp_output.rs
@@ -1,0 +1,168 @@
+//! Push a video file to an RTMP ingest endpoint in real time.
+//!
+//! Demonstrates:
+//! - `VideoDecoder` — decode frames from a source file
+//! - `RtmpOutput` — encode frames and push them to an `rtmp://` URL
+//! - `StreamOutput::finish()` — flush encoders and close the RTMP connection
+//!
+//! RTMP/FLV requires H.264 video and AAC audio. `RtmpOutput` enforces this at
+//! `build()` time and returns `StreamError::UnsupportedCodec` for any other
+//! codec selection.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example rtmp_output --features stream -- \
+//!   --input   input.mp4                              \
+//!   --url     rtmp://ingest.example.com/live/key     \
+//!   [--bitrate 4000000]
+//! ```
+//!
+//! To test locally with a self-hosted RTMP server (e.g. nginx-rtmp or SRS):
+//!
+//! ```bash
+//! # nginx-rtmp on localhost:1935, application "live"
+//! cargo run --example rtmp_output --features stream -- \
+//!   --input input.mp4  --url rtmp://127.0.0.1/live/test
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{AudioDecoder, RtmpOutput, StreamOutput, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut url = None::<String>;
+    let mut bitrate: u64 = 4_000_000;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--url" | "-u" => url = Some(args.next().unwrap_or_default()),
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().unwrap_or(4_000_000);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: rtmp_output --input <file> --url <rtmp://...> [--bitrate N]");
+        process::exit(1);
+    });
+    let url = url.unwrap_or_else(|| {
+        eprintln!("--url is required (must start with rtmp://)");
+        process::exit(1);
+    });
+
+    // ── Open source decoders ──────────────────────────────────────────────────
+
+    let mut video_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open video decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut audio_dec = AudioDecoder::open(&input).build().ok();
+
+    let width = video_dec.width();
+    let height = video_dec.height();
+    let fps = video_dec.frame_rate();
+    let fps_display = if fps > 0.0 { fps } else { 30.0 };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:   {in_name}  ({width}×{height}  {fps_display:.2} fps)");
+    println!("URL:     {url}");
+    println!("Bitrate: {bitrate} bps");
+    println!();
+    println!("Connecting...");
+
+    // ── Open RtmpOutput ───────────────────────────────────────────────────────
+
+    let mut builder = RtmpOutput::new(&url)
+        .video(width, height, fps_display)
+        .video_bitrate(bitrate);
+
+    if audio_dec.is_some() {
+        builder = builder.audio(44100, 2);
+    }
+
+    let mut rtmp = match builder.build() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: cannot open RtmpOutput: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!("Connected. Streaming frames...");
+    println!();
+
+    // ── Frame loop ────────────────────────────────────────────────────────────
+
+    let start = std::time::Instant::now();
+    let mut video_frames: u64 = 0;
+    let mut audio_frames: u64 = 0;
+
+    loop {
+        match video_dec.decode_one() {
+            Ok(Some(frame)) => {
+                video_frames += 1;
+                if let Err(e) = rtmp.push_video(&frame) {
+                    eprintln!("Error: push_video: {e}");
+                    process::exit(1);
+                }
+                if video_frames.is_multiple_of(150) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    println!("  {video_frames} frames sent  ({elapsed:.1} s elapsed)");
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error: video decode: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    if let Some(ref mut adec) = audio_dec {
+        loop {
+            match adec.decode_one() {
+                Ok(Some(frame)) => {
+                    audio_frames += 1;
+                    if let Err(e) = rtmp.push_audio(&frame) {
+                        eprintln!("Error: push_audio: {e}");
+                        process::exit(1);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Error: audio decode: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = Box::new(rtmp).finish() {
+        eprintln!("Error: finish: {e}");
+        process::exit(1);
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    println!();
+    println!(
+        "Done in {elapsed:.2} s — {video_frames} video frames, {audio_frames} audio frames sent"
+    );
+}


### PR DESCRIPTION
## Summary

Adds six runnable examples covering the live streaming and network input features shipped in v0.8.0. All examples follow the established example pattern (CLI flags, graceful error handling, output directory listing), have been run locally against `assets/video/gameplay.mp4`, and pass `clippy -D warnings` and `fmt --check`.

## Changes

- **`decode_from_url`** — open an HTTP, HLS, RTMP, or SRT URL with `VideoDecoder::open(url).network(NetworkOptions)`, print stream metadata, and decode up to N frames; shows `is_live()`, `frame_rate()`, and per-frame PTS
- **`live_hls_output`** — decode a source file frame-by-frame and push each frame to `LiveHlsOutput`; demonstrates `segment_duration`, `playlist_size`, `video_bitrate`, and audio opt-in
- **`live_dash_output`** — same pattern for `LiveDashOutput`, producing `manifest.mpd` backed by `.m4s` segments
- **`rtmp_output`** — push encoded frames to an `rtmp://` ingest endpoint; validates URL scheme before connecting and reports frame count
- **`fanout_output`** — fan frames to a `LiveHlsOutput` and a `LiveDashOutput` simultaneously via `FanoutOutput`; both output directories are written in a single decode pass
- **`live_abr_ladder`** — multi-rendition `LiveAbrLadder` with configurable `--ladder H,BPS:H,BPS` tiers; computes widths from source aspect ratio and writes `master.m3u8` or top-level `manifest.mpd`
- **`crates/avio/Cargo.toml`** — add `[[example]]` entries for all six new examples with `required-features = ["stream"]` (or `["decode"]` for `decode_from_url`)

## Related Issues

Part of v0.8.0 release readiness (network input and live streaming milestone).

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes