### PR TITLE
feat(ff-stream): add SrtOutput behind srt feature flag

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -21,7 +21,7 @@ stream   = ["dep:ff-stream", "pipeline"]
 tokio    = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio"]
 gpl      = ["ff-encode/gpl"]
 hwaccel  = ["ff-encode/hwaccel"]
-srt      = ["ff-decode/srt"]
+srt      = ["ff-decode/srt", "ff-stream/srt"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -247,6 +247,10 @@ required-features = ["stream"]
 [[example]]
 name = "live_abr_ladder"
 required-features = ["stream"]
+
+[[example]]
+name = "srt_output"
+required-features = ["stream", "srt"]
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/crates/avio/examples/srt_output.rs
+++ b/crates/avio/examples/srt_output.rs
@@ -1,0 +1,178 @@
+//! Push a video file to an SRT destination as MPEG-TS in real time.
+//!
+//! Demonstrates:
+//! - `SrtOutput` — encode frames and transmit them to an `srt://` URL using
+//!   MPEG-TS as the container
+//! - `StreamError::ProtocolUnavailable` — graceful skip when `FFmpeg` was built
+//!   without libsrt support
+//! - `StreamOutput::finish()` — flush encoders and close the SRT connection
+//!
+//! SRT/MPEG-TS requires H.264 video and AAC audio. `SrtOutput` enforces this
+//! at `build()` time. `build()` also returns `ProtocolUnavailable` when the
+//! linked `FFmpeg` was compiled without libsrt.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example srt_output --features "stream,srt" -- \
+//!   --input   input.mp4                \
+//!   --url     srt://192.168.1.100:9000  \
+//!   [--bitrate 4000000]
+//! ```
+//!
+//! To test locally with a self-hosted SRT receiver (e.g. `srt-live-transmit`
+//! from the libsrt tools):
+//!
+//! ```bash
+//! # In one terminal, start a listener:
+//! srt-live-transmit srt://:9000 file://con > /tmp/output.ts
+//!
+//! # In another terminal, push the stream:
+//! cargo run --example srt_output --features "stream,srt" -- \
+//!   --input input.mp4  --url srt://127.0.0.1:9000
+//! ```
+
+use std::{path::Path, process};
+
+use avio::{AudioDecoder, SrtOutput, StreamError, StreamOutput, VideoDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut url = None::<String>;
+    let mut bitrate: u64 = 4_000_000;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--url" | "-u" => url = Some(args.next().unwrap_or_default()),
+            "--bitrate" => {
+                let v = args.next().unwrap_or_default();
+                bitrate = v.parse().unwrap_or(4_000_000);
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: srt_output --input <file> --url <srt://...> [--bitrate N]");
+        process::exit(1);
+    });
+    let url = url.unwrap_or_else(|| {
+        eprintln!("--url is required (must start with srt://)");
+        process::exit(1);
+    });
+
+    // ── Open source decoders ──────────────────────────────────────────────────
+
+    let mut video_dec = match VideoDecoder::open(&input).build() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: cannot open video decoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    let mut audio_dec = AudioDecoder::open(&input).build().ok();
+
+    let width = video_dec.width();
+    let height = video_dec.height();
+    let fps = video_dec.frame_rate();
+    let fps_display = if fps > 0.0 { fps } else { 30.0 };
+
+    let in_name = Path::new(&input)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&input);
+
+    println!("Input:   {in_name}  ({width}×{height}  {fps_display:.2} fps)");
+    println!("URL:     {url}");
+    println!("Bitrate: {bitrate} bps");
+    println!();
+    println!("Connecting...");
+
+    // ── Open SrtOutput ────────────────────────────────────────────────────────
+
+    let mut builder = SrtOutput::new(&url)
+        .video(width, height, fps_display)
+        .video_bitrate(bitrate);
+
+    if audio_dec.is_some() {
+        builder = builder.audio(44100, 2);
+    }
+
+    let mut srt = match builder.build() {
+        Ok(s) => s,
+        Err(StreamError::ProtocolUnavailable { reason }) => {
+            eprintln!("Skipping: {reason}");
+            return;
+        }
+        Err(e) => {
+            eprintln!("Error: cannot open SrtOutput: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!("Connected. Streaming frames...");
+    println!();
+
+    // ── Frame loop ────────────────────────────────────────────────────────────
+
+    let start = std::time::Instant::now();
+    let mut video_frames: u64 = 0;
+    let mut audio_frames: u64 = 0;
+
+    loop {
+        match video_dec.decode_one() {
+            Ok(Some(frame)) => {
+                video_frames += 1;
+                if let Err(e) = srt.push_video(&frame) {
+                    eprintln!("Error: push_video: {e}");
+                    process::exit(1);
+                }
+                if video_frames.is_multiple_of(150) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    println!("  {video_frames} frames sent  ({elapsed:.1} s elapsed)");
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("Error: video decode: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    if let Some(ref mut adec) = audio_dec {
+        loop {
+            match adec.decode_one() {
+                Ok(Some(frame)) => {
+                    audio_frames += 1;
+                    if let Err(e) = srt.push_audio(&frame) {
+                        eprintln!("Error: push_audio: {e}");
+                        process::exit(1);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Error: audio decode: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    if let Err(e) = Box::new(srt).finish() {
+        eprintln!("Error: finish: {e}");
+        process::exit(1);
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    println!();
+    println!(
+        "Done in {elapsed:.2} s — {video_frames} video frames, {audio_frames} audio frames sent"
+    );
+}

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -273,6 +273,9 @@ pub use ff_stream::{
     LiveAbrLadder, LiveDashOutput, LiveHlsOutput, Rendition, RtmpOutput, StreamError, StreamOutput,
 };
 
+#[cfg(all(feature = "stream", feature = "srt"))]
+pub use ff_stream::SrtOutput;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ff-stream/Cargo.toml
+++ b/crates/ff-stream/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 keywords = ["video", "ffmpeg", "hls", "dash", "streaming"]
 categories = ["multimedia::video", "multimedia::encoding"]
 
+[features]
+srt = []
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/ff-stream/src/error.rs
+++ b/crates/ff-stream/src/error.rs
@@ -69,6 +69,17 @@ pub enum StreamError {
         messages: Vec<String>,
     },
 
+    /// The requested network protocol is not compiled into the linked `FFmpeg` build.
+    ///
+    /// Returned by `build()` when a feature-gated output (e.g. `SrtOutput`)
+    /// is opened but the underlying `FFmpeg` library was built without the
+    /// required protocol support (e.g. libsrt).
+    #[error("protocol unavailable: {reason}")]
+    ProtocolUnavailable {
+        /// Human-readable description of why the protocol is unavailable.
+        reason: String,
+    },
+
     /// An `FFmpeg` runtime error occurred during muxing or transcoding.
     ///
     /// `code` is the raw `FFmpeg` negative error value returned by the failing
@@ -138,6 +149,15 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(msg.contains("1/2"), "got: {msg}");
+    }
+
+    #[test]
+    fn protocol_unavailable_should_display_reason() {
+        let err = StreamError::ProtocolUnavailable {
+            reason: "FFmpeg built without libsrt".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("libsrt"), "got: {msg}");
     }
 
     #[test]

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -86,6 +86,10 @@ pub(crate) mod live_hls_inner;
 pub mod output;
 pub mod rtmp;
 pub(crate) mod rtmp_inner;
+#[cfg(feature = "srt")]
+pub mod srt_output;
+#[cfg(feature = "srt")]
+pub(crate) mod srt_output_inner;
 
 pub use abr::{AbrLadder, Rendition};
 pub use dash::DashOutput;
@@ -97,3 +101,5 @@ pub use live_dash::LiveDashOutput;
 pub use live_hls::LiveHlsOutput;
 pub use output::StreamOutput;
 pub use rtmp::RtmpOutput;
+#[cfg(feature = "srt")]
+pub use srt_output::SrtOutput;

--- a/crates/ff-stream/src/srt_output.rs
+++ b/crates/ff-stream/src/srt_output.rs
@@ -1,0 +1,374 @@
+//! Frame-push SRT output.
+//!
+//! [`SrtOutput`] receives pre-decoded [`VideoFrame`] / [`AudioFrame`] values
+//! from the caller, encodes them with H.264/AAC, and pushes the MPEG-TS
+//! stream to an SRT destination using `FFmpeg`'s built-in SRT support.
+//!
+//! This module is only available when the `srt` feature flag is enabled.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use ff_stream::{SrtOutput, StreamOutput};
+//!
+//! let mut out = SrtOutput::new("srt://192.168.1.100:9000")
+//!     .video(1920, 1080, 30.0)
+//!     .audio(44100, 2)
+//!     .video_bitrate(4_000_000)
+//!     .audio_bitrate(128_000)
+//!     .build()?;
+//!
+//! // for each decoded frame:
+//! out.push_video(&video_frame)?;
+//! out.push_audio(&audio_frame)?;
+//!
+//! // when done:
+//! Box::new(out).finish()?;
+//! ```
+
+use ff_format::{AudioCodec, AudioFrame, VideoCodec, VideoFrame};
+
+use crate::error::StreamError;
+use crate::output::StreamOutput;
+use crate::srt_output_inner::SrtInner;
+
+// ============================================================================
+// SrtOutput — safe builder + StreamOutput impl
+// ============================================================================
+
+/// Live SRT output: encodes frames as MPEG-TS and pushes them to an SRT
+/// destination.
+///
+/// Build with [`SrtOutput::new`], chain setter methods, then call
+/// [`build`](Self::build) to open the `FFmpeg` context and establish the SRT
+/// connection. After `build()`:
+///
+/// - [`push_video`](Self::push_video) and [`push_audio`](Self::push_audio)
+///   encode and transmit frames in real time.
+/// - [`StreamOutput::finish`] flushes all encoders, writes the MPEG-TS
+///   end-of-stream, and closes the SRT connection.
+///
+/// The SRT transport uses MPEG-TS as the container (H.264 video + AAC audio).
+/// [`build`](Self::build) returns [`StreamError::UnsupportedCodec`] for any
+/// other codec selection.
+///
+/// [`build`](Self::build) also performs a runtime check and returns
+/// [`StreamError::ProtocolUnavailable`] when the linked `FFmpeg` library was
+/// built without libsrt support.
+pub struct SrtOutput {
+    url: String,
+    video_width: Option<u32>,
+    video_height: Option<u32>,
+    fps: Option<f64>,
+    sample_rate: u32,
+    channels: u32,
+    video_codec: VideoCodec,
+    audio_codec: AudioCodec,
+    video_bitrate: u64,
+    audio_bitrate: u64,
+    inner: Option<SrtInner>,
+    finished: bool,
+}
+
+impl SrtOutput {
+    /// Create a new builder that streams to the given SRT URL.
+    ///
+    /// The URL must begin with `srt://`; [`build`](Self::build) returns
+    /// [`StreamError::InvalidConfig`] otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use ff_stream::SrtOutput;
+    ///
+    /// let out = SrtOutput::new("srt://192.168.1.100:9000");
+    /// ```
+    #[must_use]
+    pub fn new(url: &str) -> Self {
+        Self {
+            url: url.to_owned(),
+            video_width: None,
+            video_height: None,
+            fps: None,
+            sample_rate: 44100,
+            channels: 2,
+            video_codec: VideoCodec::H264,
+            audio_codec: AudioCodec::Aac,
+            video_bitrate: 4_000_000,
+            audio_bitrate: 128_000,
+            inner: None,
+            finished: false,
+        }
+    }
+
+    /// Set the video encoding parameters.
+    ///
+    /// This method **must** be called before [`build`](Self::build).
+    #[must_use]
+    pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
+        self.video_width = Some(width);
+        self.video_height = Some(height);
+        self.fps = Some(fps);
+        self
+    }
+
+    /// Set the audio sample rate and channel count.
+    ///
+    /// Defaults: 44 100 Hz, 2 channels (stereo).
+    #[must_use]
+    pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
+        self.sample_rate = sample_rate;
+        self.channels = channels;
+        self
+    }
+
+    /// Set the video codec.
+    ///
+    /// Default: [`VideoCodec::H264`]. Only `H264` is accepted by
+    /// [`build`](Self::build); any other value returns
+    /// [`StreamError::UnsupportedCodec`].
+    #[must_use]
+    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
+        self.video_codec = codec;
+        self
+    }
+
+    /// Set the audio codec.
+    ///
+    /// Default: [`AudioCodec::Aac`]. Only `Aac` is accepted by
+    /// [`build`](Self::build); any other value returns
+    /// [`StreamError::UnsupportedCodec`].
+    #[must_use]
+    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
+        self.audio_codec = codec;
+        self
+    }
+
+    /// Set the video encoder target bit rate in bits/s.
+    ///
+    /// Default: 4 000 000 (4 Mbit/s).
+    #[must_use]
+    pub fn video_bitrate(mut self, bitrate: u64) -> Self {
+        self.video_bitrate = bitrate;
+        self
+    }
+
+    /// Set the audio encoder target bit rate in bits/s.
+    ///
+    /// Default: 128 000 (128 kbit/s).
+    #[must_use]
+    pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
+        self.audio_bitrate = bitrate;
+        self
+    }
+
+    /// Open the `FFmpeg` MPEG-TS context and establish the SRT connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StreamError::ProtocolUnavailable`] when the linked `FFmpeg`
+    /// was built without libsrt support.
+    ///
+    /// Returns [`StreamError::InvalidConfig`] when:
+    /// - The URL does not start with `srt://`.
+    /// - [`video`](Self::video) was not called before `build`.
+    ///
+    /// Returns [`StreamError::UnsupportedCodec`] when:
+    /// - The video codec is not [`VideoCodec::H264`].
+    /// - The audio codec is not [`AudioCodec::Aac`].
+    ///
+    /// Returns [`StreamError::Ffmpeg`] when any `FFmpeg` operation fails
+    /// (including network connection errors).
+    pub fn build(mut self) -> Result<Self, StreamError> {
+        if !ff_sys::avformat::srt_available() {
+            return Err(StreamError::ProtocolUnavailable {
+                reason: "FFmpeg was built without libsrt; recompile FFmpeg with --enable-libsrt"
+                    .into(),
+            });
+        }
+
+        if !self.url.starts_with("srt://") {
+            return Err(StreamError::InvalidConfig {
+                reason: "SrtOutput URL must start with srt://".into(),
+            });
+        }
+
+        let (Some(width), Some(height), Some(fps)) =
+            (self.video_width, self.video_height, self.fps)
+        else {
+            return Err(StreamError::InvalidConfig {
+                reason: "video parameters not set; call .video(width, height, fps) before .build()"
+                    .into(),
+            });
+        };
+
+        if self.video_codec != VideoCodec::H264 {
+            return Err(StreamError::UnsupportedCodec {
+                codec: format!("{:?}", self.video_codec),
+                reason: "SRT/MPEG-TS output requires H.264 video".into(),
+            });
+        }
+
+        if self.audio_codec != AudioCodec::Aac {
+            return Err(StreamError::UnsupportedCodec {
+                codec: format!("{:?}", self.audio_codec),
+                reason: "SRT/MPEG-TS output requires AAC audio".into(),
+            });
+        }
+
+        #[allow(clippy::cast_possible_truncation)]
+        let fps_int = fps.round().max(1.0) as i32;
+
+        let inner = SrtInner::open(
+            &self.url,
+            width.cast_signed(),
+            height.cast_signed(),
+            fps_int,
+            self.video_bitrate,
+            self.sample_rate.cast_signed(),
+            self.channels.cast_signed(),
+            self.audio_bitrate.cast_signed(),
+        )?;
+
+        self.inner = Some(inner);
+        Ok(self)
+    }
+}
+
+// ============================================================================
+// StreamOutput impl
+// ============================================================================
+
+impl StreamOutput for SrtOutput {
+    fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
+        if self.finished {
+            return Err(StreamError::InvalidConfig {
+                reason: "push_video called after finish()".into(),
+            });
+        }
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| StreamError::InvalidConfig {
+                reason: "push_video called before build()".into(),
+            })?;
+        inner.push_video(frame)
+    }
+
+    fn push_audio(&mut self, frame: &AudioFrame) -> Result<(), StreamError> {
+        if self.finished {
+            return Err(StreamError::InvalidConfig {
+                reason: "push_audio called after finish()".into(),
+            });
+        }
+        let inner = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| StreamError::InvalidConfig {
+                reason: "push_audio called before build()".into(),
+            })?;
+        inner.push_audio(frame);
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) -> Result<(), StreamError> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| StreamError::InvalidConfig {
+                reason: "finish() called before build()".into(),
+            })?;
+        inner.flush_and_close();
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_without_srt_scheme_should_return_invalid_config() {
+        // Skip if libsrt is not available (ProtocolUnavailable would be returned first).
+        if !ff_sys::avformat::srt_available() {
+            println!("Skipping: libsrt not available in linked FFmpeg");
+            return;
+        }
+        let result = SrtOutput::new("rtmp://example.com/live")
+            .video(1280, 720, 30.0)
+            .build();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn build_without_video_should_return_invalid_config() {
+        if !ff_sys::avformat::srt_available() {
+            println!("Skipping: libsrt not available in linked FFmpeg");
+            return;
+        }
+        let result = SrtOutput::new("srt://127.0.0.1:9000").build();
+        assert!(matches!(result, Err(StreamError::InvalidConfig { .. })));
+    }
+
+    #[test]
+    fn build_with_non_h264_video_codec_should_return_unsupported_codec() {
+        if !ff_sys::avformat::srt_available() {
+            println!("Skipping: libsrt not available in linked FFmpeg");
+            return;
+        }
+        let result = SrtOutput::new("srt://127.0.0.1:9000")
+            .video(1280, 720, 30.0)
+            .video_codec(VideoCodec::Vp9)
+            .build();
+        assert!(matches!(result, Err(StreamError::UnsupportedCodec { .. })));
+    }
+
+    #[test]
+    fn build_with_non_aac_audio_codec_should_return_unsupported_codec() {
+        if !ff_sys::avformat::srt_available() {
+            println!("Skipping: libsrt not available in linked FFmpeg");
+            return;
+        }
+        let result = SrtOutput::new("srt://127.0.0.1:9000")
+            .video(1280, 720, 30.0)
+            .audio_codec(AudioCodec::Mp3)
+            .build();
+        assert!(matches!(result, Err(StreamError::UnsupportedCodec { .. })));
+    }
+
+    #[test]
+    fn build_without_libsrt_should_return_protocol_unavailable() {
+        if ff_sys::avformat::srt_available() {
+            println!("Skipping: libsrt is available; cannot test ProtocolUnavailable path");
+            return;
+        }
+        let result = SrtOutput::new("srt://127.0.0.1:9000")
+            .video(1280, 720, 30.0)
+            .build();
+        assert!(matches!(
+            result,
+            Err(StreamError::ProtocolUnavailable { .. })
+        ));
+    }
+
+    #[test]
+    fn video_bitrate_default_should_be_four_megabits() {
+        let out = SrtOutput::new("srt://127.0.0.1:9000");
+        assert_eq!(out.video_bitrate, 4_000_000);
+    }
+
+    #[test]
+    fn audio_defaults_should_be_44100hz_stereo() {
+        let out = SrtOutput::new("srt://127.0.0.1:9000");
+        assert_eq!(out.sample_rate, 44100);
+        assert_eq!(out.channels, 2);
+    }
+}

--- a/crates/ff-stream/src/srt_output_inner.rs
+++ b/crates/ff-stream/src/srt_output_inner.rs
@@ -1,0 +1,767 @@
+//! Internal SRT state — all `unsafe` `FFmpeg` calls live here.
+//!
+//! [`SrtInner`] owns all raw `FFmpeg` contexts and the SRT network
+//! connection. It is created by [`crate::srt_output::SrtOutput::build`] and
+//! driven by the safe wrappers in [`crate::srt_output`].
+//!
+//! The MPEG-TS muxer writes to the SRT URL via `avio_open2`. The connection
+//! (`out_ctx->pb`) is kept open for the entire session and closed after
+//! [`av_write_trailer`] in [`SrtInner::flush_and_close`].
+
+// This module is intentionally unsafe — it drives the FFmpeg C API directly.
+#![allow(unsafe_code)]
+#![allow(clippy::ptr_as_ptr)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::ref_as_ptr)]
+#![allow(clippy::too_many_lines)]
+
+use std::ffi::CString;
+use std::path::Path;
+use std::ptr;
+
+use ff_format::{AudioFrame, PixelFormat, SampleFormat, VideoFrame};
+use ff_sys::{
+    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, SwrContext, SwsContext,
+    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref, av_rescale_q,
+    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat_write_header,
+};
+
+use crate::codec_utils::{drain_encoder, ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
+use crate::error::StreamError;
+
+// ============================================================================
+// Pixel-format and sample-format conversion
+// ============================================================================
+
+fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
+    match fmt {
+        PixelFormat::Yuv420p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P,
+        PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
+        PixelFormat::Yuv444p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P,
+        PixelFormat::Rgb24 => ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24,
+        PixelFormat::Bgr24 => ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24,
+        PixelFormat::Rgba => ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA,
+        PixelFormat::Bgra => ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA,
+        PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
+        PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
+        PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
+        PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
+        PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
+        PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
+        PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
+        PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
+        PixelFormat::Gbrpf32le => ff_sys::AVPixelFormat_AV_PIX_FMT_GBRPF32LE,
+        PixelFormat::Other(_) | _ => AVPixelFormat_AV_PIX_FMT_NONE,
+    }
+}
+
+fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
+    match fmt {
+        SampleFormat::U8 => ff_sys::swresample::sample_format::U8,
+        SampleFormat::I16 => ff_sys::swresample::sample_format::S16,
+        SampleFormat::I32 => ff_sys::swresample::sample_format::S32,
+        SampleFormat::F32 => ff_sys::swresample::sample_format::FLT,
+        SampleFormat::F64 => ff_sys::swresample::sample_format::DBL,
+        SampleFormat::U8p => ff_sys::swresample::sample_format::U8P,
+        SampleFormat::I16p => ff_sys::swresample::sample_format::S16P,
+        SampleFormat::I32p => ff_sys::swresample::sample_format::S32P,
+        SampleFormat::F32p => ff_sys::swresample::sample_format::FLTP,
+        SampleFormat::F64p => ff_sys::swresample::sample_format::DBLP,
+        SampleFormat::Other(_) | _ => ff_sys::swresample::sample_format::NONE,
+    }
+}
+
+// ============================================================================
+// SrtInner
+// ============================================================================
+
+/// Owns all raw `FFmpeg` contexts and the SRT network connection.
+///
+/// Created by [`SrtInner::open`]; consumed by [`SrtInner::flush_and_close`].
+/// After `flush_and_close` returns, calling any other method is undefined
+/// behaviour; the safe wrapper in `srt_output.rs` prevents this via the
+/// `finished` guard.
+pub(crate) struct SrtInner {
+    out_ctx: *mut AVFormatContext,
+    vid_enc_ctx: *mut AVCodecContext,
+    aud_enc_ctx: *mut AVCodecContext,
+    /// Null until first `push_audio` call; recreated if input format changes.
+    swr_ctx: *mut SwrContext,
+    /// Null until swscale is needed; recreated if source dimensions/format change.
+    sws_ctx: *mut SwsContext,
+    vid_enc_frame: *mut AVFrame,
+    aud_enc_frame: *mut AVFrame,
+    vid_out_stream_idx: i32,
+    aud_out_stream_idx: i32,
+    video_frame_count: u64,
+    audio_pts: i64,
+    fps_int: i32,
+    enc_width: i32,
+    enc_height: i32,
+    /// AAC encoder `frame_size` (typically 1024); set after `avcodec_open2`.
+    aud_frame_size: i32,
+    aud_sample_rate: i32,
+    url: String,
+    /// Tracks the last swscale source so we can detect changes.
+    last_sws_src_fmt: Option<AVPixelFormat>,
+    last_sws_src_w: Option<i32>,
+    last_sws_src_h: Option<i32>,
+    /// Tracks the last swr input so we can detect format changes.
+    last_swr_in_fmt: Option<AVSampleFormat>,
+    last_swr_in_rate: Option<i32>,
+    last_swr_in_channels: Option<i32>,
+}
+
+// SAFETY: SrtInner exclusively owns all FFmpeg contexts.
+// FFmpeg contexts are not safe for concurrent access, but ownership transfer
+// between threads is safe (there is no shared state).
+unsafe impl Send for SrtInner {}
+
+impl SrtInner {
+    /// Open the `FFmpeg` MPEG-TS context and establish the SRT connection.
+    ///
+    /// # Parameters
+    ///
+    /// - `url`: SRT destination URL (e.g. `srt://192.168.1.100:9000`).
+    /// - `enc_width`, `enc_height`, `fps_int`: video encoder dimensions and frame rate.
+    /// - `video_bitrate`: video encoder bit rate in bits/s.
+    /// - `aud_sample_rate`, `aud_channels`, `aud_bitrate`: audio encoder parameters.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn open(
+        url: &str,
+        enc_width: i32,
+        enc_height: i32,
+        fps_int: i32,
+        video_bitrate: u64,
+        aud_sample_rate: i32,
+        aud_channels: i32,
+        aud_bitrate: i64,
+    ) -> Result<Self, StreamError> {
+        // SAFETY: All FFmpeg resources are managed within this function; the
+        // returned SrtInner takes exclusive ownership of every pointer.
+        unsafe {
+            Self::open_unsafe(
+                url,
+                enc_width,
+                enc_height,
+                fps_int,
+                video_bitrate,
+                aud_sample_rate,
+                aud_channels,
+                aud_bitrate,
+            )
+        }
+    }
+
+    /// Encode and mux one video frame.
+    pub(crate) fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
+        // SAFETY: self was initialised by open() and is not yet finished.
+        unsafe { self.push_video_unsafe(frame) }
+    }
+
+    /// Encode and mux one audio frame.
+    pub(crate) fn push_audio(&mut self, frame: &AudioFrame) {
+        // SAFETY: self was initialised by open() and is not yet finished.
+        unsafe {
+            self.push_audio_unsafe(frame);
+        }
+    }
+
+    /// Flush both encoders, write the MPEG-TS trailer, and close the SRT connection.
+    /// Consumes `self`.
+    pub(crate) fn flush_and_close(mut self) {
+        // SAFETY: self was initialised by open(); flush_and_close is called once.
+        unsafe {
+            self.flush_and_close_unsafe();
+        }
+    }
+
+    // ── Private unsafe implementations ───────────────────────────────────────
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn open_unsafe(
+        url: &str,
+        enc_width: i32,
+        enc_height: i32,
+        fps_int: i32,
+        video_bitrate: u64,
+        aud_sample_rate: i32,
+        aud_channels: i32,
+        aud_bitrate: i64,
+    ) -> Result<Self, StreamError> {
+        ff_sys::ensure_initialized();
+
+        // ── 1. Allocate MPEG-TS output context with SRT URL ────────────────
+        let c_url = CString::new(url).map_err(|_| ffmpeg_err_msg("SRT URL contains null byte"))?;
+
+        let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
+        let ret = avformat_alloc_output_context2(
+            &mut out_ctx,
+            ptr::null_mut(),
+            c"mpegts".as_ptr(),
+            c_url.as_ptr(),
+        );
+        if ret < 0 || out_ctx.is_null() {
+            return Err(ffmpeg_err(ret));
+        }
+
+        // ── 2. Open H.264 video encoder ────────────────────────────────────
+        let vid_enc_codec = crate::codec_utils::select_h264_encoder("srt").ok_or_else(|| {
+            avformat_free_context(out_ctx);
+            ffmpeg_err_msg(
+                "no H.264 encoder available \
+                 (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)",
+            )
+        })?;
+
+        let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+            avformat_free_context(out_ctx);
+            ffmpeg_err(e)
+        })?;
+
+        (*vid_enc_ctx).width = enc_width;
+        (*vid_enc_ctx).height = enc_height;
+        (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*vid_enc_ctx).time_base.num = 1;
+        (*vid_enc_ctx).time_base.den = fps_int;
+        (*vid_enc_ctx).framerate.num = fps_int;
+        (*vid_enc_ctx).framerate.den = 1;
+        // GOP size of 2 s gives a reasonable keyframe interval for MPEG-TS/SRT.
+        (*vid_enc_ctx).gop_size = fps_int * 2;
+        (*vid_enc_ctx).bit_rate = video_bitrate as i64;
+
+        ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            ffmpeg_err(e)
+        })?;
+
+        // ── 3. Add video output stream ─────────────────────────────────────
+        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+        if vid_out_stream.is_null() {
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err_msg("cannot create video output stream"));
+        }
+        (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+        let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+
+        // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
+        ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
+            |e| {
+                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e)
+            },
+        )?;
+
+        // ── 4. Open AAC audio encoder ──────────────────────────────────────
+        let mut aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "srt")
+            .inspect_err(|_| {
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+        })?;
+
+        let aud_frame_size = if (*aud_enc_ctx).frame_size > 0 {
+            (*aud_enc_ctx).frame_size
+        } else {
+            1024
+        };
+
+        // ── 5. Add audio output stream ─────────────────────────────────────
+        let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+        if aud_out_stream.is_null() {
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err_msg("cannot create audio output stream"));
+        }
+        (*aud_out_stream).time_base.num = 1;
+        (*aud_out_stream).time_base.den = aud_sample_rate;
+        let aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+
+        // SAFETY: aud_out_stream and aud_enc_ctx are valid.
+        if ff_sys::avcodec::parameters_from_context((*aud_out_stream).codecpar, aud_enc_ctx)
+            .is_err()
+        {
+            log::warn!("srt audio stream codecpar copy failed");
+        }
+
+        // ── 6. Allocate encoder frames ─────────────────────────────────────
+        let vid_enc_frame = av_frame_alloc();
+        let aud_enc_frame = av_frame_alloc();
+
+        if vid_enc_frame.is_null() || aud_enc_frame.is_null() {
+            if !vid_enc_frame.is_null() {
+                av_frame_free(&mut (vid_enc_frame as *mut _));
+            }
+            if !aud_enc_frame.is_null() {
+                av_frame_free(&mut (aud_enc_frame as *mut _));
+            }
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err_msg("cannot allocate encoder frames"));
+        }
+
+        // ── 7. Open SRT connection and write MPEG-TS header ────────────────
+        // SRT uses a persistent network connection like RTMP.
+        // We use avio_open via avformat::open_output with the URL as the path.
+        // SAFETY: url is a valid null-terminated C string (validated above).
+        let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
+            .map_err(|e| {
+                av_frame_free(&mut (aud_enc_frame as *mut _));
+                av_frame_free(&mut (vid_enc_frame as *mut _));
+                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e)
+            })?;
+        (*out_ctx).pb = pb;
+
+        let ret = avformat_write_header(out_ctx, ptr::null_mut());
+        if ret < 0 {
+            ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+            av_frame_free(&mut (aud_enc_frame as *mut _));
+            av_frame_free(&mut (vid_enc_frame as *mut _));
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+            return Err(ffmpeg_err(ret));
+        }
+
+        // NOTE: pb is intentionally kept open. SRT is a persistent connection;
+        // closing pb here would terminate the stream.
+
+        log::info!(
+            "srt output opened url={url} video={enc_width}x{enc_height}@{fps_int}fps \
+             bitrate={video_bitrate}bps"
+        );
+
+        Ok(Self {
+            out_ctx,
+            vid_enc_ctx,
+            aud_enc_ctx,
+            swr_ctx: ptr::null_mut(),
+            sws_ctx: ptr::null_mut(),
+            vid_enc_frame,
+            aud_enc_frame,
+            vid_out_stream_idx,
+            aud_out_stream_idx,
+            video_frame_count: 0,
+            audio_pts: 0,
+            fps_int,
+            enc_width,
+            enc_height,
+            aud_frame_size,
+            aud_sample_rate,
+            url: url.to_owned(),
+            last_sws_src_fmt: None,
+            last_sws_src_w: None,
+            last_sws_src_h: None,
+            last_swr_in_fmt: None,
+            last_swr_in_rate: None,
+            last_swr_in_channels: None,
+        })
+    }
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn push_video_unsafe(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
+        let src_fmt = pixel_format_to_av(frame.format());
+        let src_w = frame.width() as i32;
+        let src_h = frame.height() as i32;
+        let needs_conversion = src_fmt != AVPixelFormat_AV_PIX_FMT_YUV420P
+            || src_w != self.enc_width
+            || src_h != self.enc_height
+            || src_fmt == AVPixelFormat_AV_PIX_FMT_NONE;
+
+        if needs_conversion {
+            // (Re)create SwsContext when source properties change.
+            if self.last_sws_src_fmt != Some(src_fmt)
+                || self.last_sws_src_w != Some(src_w)
+                || self.last_sws_src_h != Some(src_h)
+            {
+                if !self.sws_ctx.is_null() {
+                    ff_sys::swscale::free_context(self.sws_ctx);
+                    self.sws_ctx = ptr::null_mut();
+                }
+                match ff_sys::swscale::get_context(
+                    src_w,
+                    src_h,
+                    src_fmt,
+                    self.enc_width,
+                    self.enc_height,
+                    AVPixelFormat_AV_PIX_FMT_YUV420P,
+                    ff_sys::swscale::scale_flags::BILINEAR,
+                ) {
+                    Ok(ctx) => {
+                        self.sws_ctx = ctx;
+                        self.last_sws_src_fmt = Some(src_fmt);
+                        self.last_sws_src_w = Some(src_w);
+                        self.last_sws_src_h = Some(src_h);
+                    }
+                    Err(_) => {
+                        return Err(ffmpeg_err_msg(
+                            "srt swscale context creation failed for video frame",
+                        ));
+                    }
+                }
+            }
+
+            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
+            (*self.vid_enc_frame).width = self.enc_width;
+            (*self.vid_enc_frame).height = self.enc_height;
+            self.set_vid_enc_pts();
+
+            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
+            if buf_ret < 0 {
+                av_frame_unref(self.vid_enc_frame);
+                return Err(ffmpeg_err(buf_ret));
+            }
+
+            // Build source plane/linesize arrays from the VideoFrame.
+            let planes = frame.planes();
+            let strides = frame.strides();
+            let mut src_data = [ptr::null::<u8>(); 8];
+            let mut src_linesize = [0i32; 8];
+            for (i, (plane, &stride)) in planes.iter().zip(strides.iter()).enumerate().take(8) {
+                src_data[i] = plane.as_ref().as_ptr();
+                src_linesize[i] = stride as i32;
+            }
+
+            ff_sys::swscale::scale(
+                self.sws_ctx,
+                src_data.as_ptr(),
+                src_linesize.as_ptr(),
+                0,
+                src_h,
+                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
+                (*self.vid_enc_frame).linesize.as_mut_ptr(),
+            )
+            .map_err(|_| ffmpeg_err_msg("srt swscale conversion failed"))?;
+        } else {
+            // Same format and dimensions — copy planes directly.
+            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
+            (*self.vid_enc_frame).width = self.enc_width;
+            (*self.vid_enc_frame).height = self.enc_height;
+            self.set_vid_enc_pts();
+
+            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
+            if buf_ret < 0 {
+                av_frame_unref(self.vid_enc_frame);
+                return Err(ffmpeg_err(buf_ret));
+            }
+
+            // Copy Y/U/V planes line-by-line.
+            let planes = frame.planes();
+            let strides = frame.strides();
+            for (plane_idx, (src_plane, &src_stride)) in
+                planes.iter().zip(strides.iter()).enumerate().take(3)
+            {
+                let dst_stride = (*self.vid_enc_frame).linesize[plane_idx] as usize;
+                let dst_ptr = (*self.vid_enc_frame).data[plane_idx];
+                if dst_ptr.is_null() {
+                    continue;
+                }
+                let rows = if plane_idx == 0 {
+                    self.enc_height as usize
+                } else {
+                    (self.enc_height as usize).div_ceil(2)
+                };
+                let copy_width = dst_stride.min(src_stride);
+                let src_bytes: &[u8] = src_plane.as_ref();
+                for row in 0..rows {
+                    let src_off = row * src_stride;
+                    let dst_off = row * dst_stride;
+                    if src_off + copy_width > src_bytes.len() {
+                        break;
+                    }
+                    // SAFETY: dst_ptr + dst_off is within the allocated frame buffer.
+                    ptr::copy_nonoverlapping(
+                        src_bytes.as_ptr().add(src_off),
+                        dst_ptr.add(dst_off),
+                        copy_width,
+                    );
+                }
+            }
+        }
+
+        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
+            // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
+            drain_encoder(
+                self.vid_enc_ctx,
+                self.out_ctx,
+                self.vid_out_stream_idx,
+                "srt",
+                AVRational {
+                    num: 1,
+                    den: self.fps_int,
+                },
+            );
+        }
+
+        av_frame_unref(self.vid_enc_frame);
+        self.video_frame_count += 1;
+        Ok(())
+    }
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
+        let in_fmt = sample_format_to_av(frame.format());
+        let in_rate = frame.sample_rate() as i32;
+        let in_channels = frame.channels() as i32;
+
+        // (Re)create SwrContext when input parameters change.
+        if self.last_swr_in_fmt != Some(in_fmt)
+            || self.last_swr_in_rate != Some(in_rate)
+            || self.last_swr_in_channels != Some(in_channels)
+        {
+            if !self.swr_ctx.is_null() {
+                let mut swr_tmp = self.swr_ctx;
+                ff_sys::swresample::free(&mut swr_tmp);
+                self.swr_ctx = ptr::null_mut();
+            }
+
+            let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
+            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
+
+            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
+                enc_ch_layout,
+                ff_sys::swresample::sample_format::FLTP,
+                self.aud_sample_rate,
+                &in_layout,
+                in_fmt,
+                in_rate,
+            ) {
+                if ff_sys::swresample::init(ctx).is_ok() {
+                    self.swr_ctx = ctx;
+                    self.last_swr_in_fmt = Some(in_fmt);
+                    self.last_swr_in_rate = Some(in_rate);
+                    self.last_swr_in_channels = Some(in_channels);
+                } else {
+                    let mut swr_tmp = ctx;
+                    ff_sys::swresample::free(&mut swr_tmp);
+                    log::warn!("srt swr init failed, dropping audio frame");
+                    return;
+                }
+            } else {
+                log::warn!("srt swr alloc failed, dropping audio frame");
+                return;
+            }
+        }
+
+        // Prepare the encoder frame.
+        (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
+        (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
+        (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
+        let _ = ff_sys::swresample::channel_layout::copy(
+            &mut (*self.aud_enc_frame).ch_layout,
+            &(*self.aud_enc_ctx).ch_layout,
+        );
+
+        let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
+        if buf_ret < 0 {
+            av_frame_unref(self.aud_enc_frame);
+            return;
+        }
+
+        // Build input plane pointers from the AudioFrame.
+        let planes = frame.planes();
+        let mut in_data = [ptr::null::<u8>(); 8];
+        for (i, plane) in planes.iter().enumerate().take(8) {
+            in_data[i] = plane.as_ptr();
+        }
+
+        let samples_out = ff_sys::swresample::convert(
+            self.swr_ctx,
+            (*self.aud_enc_frame).data.as_mut_ptr(),
+            self.aud_frame_size,
+            in_data.as_ptr(),
+            frame.samples() as i32,
+        );
+
+        if let Ok(n) = samples_out
+            && n > 0
+        {
+            (*self.aud_enc_frame).nb_samples = n;
+            (*self.aud_enc_frame).pts = self.audio_pts;
+            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
+                let aud_frame_period = AVRational {
+                    num: (*self.aud_enc_ctx).frame_size,
+                    den: (*self.aud_enc_ctx).sample_rate,
+                };
+                // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
+                drain_encoder(
+                    self.aud_enc_ctx,
+                    self.out_ctx,
+                    self.aud_out_stream_idx,
+                    "srt",
+                    aud_frame_period,
+                );
+            }
+            self.audio_pts += i64::from(n);
+        }
+
+        av_frame_unref(self.aud_enc_frame);
+    }
+
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn flush_and_close_unsafe(&mut self) {
+        // ── Flush video encoder ───────────────────────────────────────────────
+        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
+        drain_encoder(
+            self.vid_enc_ctx,
+            self.out_ctx,
+            self.vid_out_stream_idx,
+            "srt",
+            AVRational {
+                num: 1,
+                den: self.fps_int,
+            },
+        );
+
+        // ── Flush audio encoder ───────────────────────────────────────────────
+        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
+            // Drain any remaining resampler buffered samples.
+            if !self.swr_ctx.is_null() {
+                (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
+                (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
+                (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
+                let _ = ff_sys::swresample::channel_layout::copy(
+                    &mut (*self.aud_enc_frame).ch_layout,
+                    &(*self.aud_enc_ctx).ch_layout,
+                );
+
+                if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
+                    if let Ok(n) = ff_sys::swresample::convert(
+                        self.swr_ctx,
+                        (*self.aud_enc_frame).data.as_mut_ptr(),
+                        self.aud_frame_size,
+                        ptr::null(),
+                        0,
+                    ) && n > 0
+                    {
+                        (*self.aud_enc_frame).nb_samples = n;
+                        (*self.aud_enc_frame).pts = self.audio_pts;
+                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
+                        {
+                            let aud_frame_period = AVRational {
+                                num: (*self.aud_enc_ctx).frame_size,
+                                den: (*self.aud_enc_ctx).sample_rate,
+                            };
+                            drain_encoder(
+                                self.aud_enc_ctx,
+                                self.out_ctx,
+                                self.aud_out_stream_idx,
+                                "srt",
+                                aud_frame_period,
+                            );
+                        }
+                    }
+                    av_frame_unref(self.aud_enc_frame);
+                }
+            }
+
+            // Flush the AAC encoder itself.
+            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
+            let aud_frame_period = AVRational {
+                num: (*self.aud_enc_ctx).frame_size,
+                den: (*self.aud_enc_ctx).sample_rate,
+            };
+            drain_encoder(
+                self.aud_enc_ctx,
+                self.out_ctx,
+                self.aud_out_stream_idx,
+                "srt",
+                aud_frame_period,
+            );
+        }
+
+        // ── Write MPEG-TS trailer ─────────────────────────────────────────────
+        av_write_trailer(self.out_ctx);
+
+        // Close the SRT connection. Like RTMP, pb was kept open throughout
+        // the session and must be explicitly closed after av_write_trailer.
+        if !(*self.out_ctx).pb.is_null() {
+            ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
+        }
+
+        log::info!("srt output finished url={}", self.url);
+
+        // Zero all pointers so Drop does not double-free.
+        self.free_all();
+    }
+
+    // SAFETY: Callers must ensure self is not used again after this call.
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn set_vid_enc_pts(&mut self) {
+        (*self.vid_enc_frame).pts = av_rescale_q(
+            self.video_frame_count as i64,
+            AVRational {
+                num: 1,
+                den: self.fps_int,
+            },
+            (*self.vid_enc_ctx).time_base,
+        );
+    }
+
+    /// Free all owned `FFmpeg` contexts and zero the pointers.
+    ///
+    /// # Safety
+    ///
+    /// Each pointer is checked for null before freeing. After this call all
+    /// pointers are null, so a second call is a no-op.
+    #[allow(unsafe_op_in_unsafe_fn)]
+    unsafe fn free_all(&mut self) {
+        if !self.sws_ctx.is_null() {
+            ff_sys::swscale::free_context(self.sws_ctx);
+            self.sws_ctx = ptr::null_mut();
+        }
+        if !self.swr_ctx.is_null() {
+            let mut swr_tmp = self.swr_ctx;
+            ff_sys::swresample::free(&mut swr_tmp);
+            self.swr_ctx = ptr::null_mut();
+        }
+        if !self.vid_enc_frame.is_null() {
+            av_frame_free(&mut (self.vid_enc_frame as *mut _));
+            self.vid_enc_frame = ptr::null_mut();
+        }
+        if !self.aud_enc_frame.is_null() {
+            av_frame_free(&mut (self.aud_enc_frame as *mut _));
+            self.aud_enc_frame = ptr::null_mut();
+        }
+        if !self.aud_enc_ctx.is_null() {
+            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
+            self.aud_enc_ctx = ptr::null_mut();
+        }
+        if !self.vid_enc_ctx.is_null() {
+            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
+            self.vid_enc_ctx = ptr::null_mut();
+        }
+        if !self.out_ctx.is_null() {
+            // Close pb if still open (Drop path, flush_and_close was not called).
+            if !(*self.out_ctx).pb.is_null() {
+                ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
+            }
+            avformat_free_context(self.out_ctx);
+            self.out_ctx = ptr::null_mut();
+        }
+    }
+}
+
+impl Drop for SrtInner {
+    fn drop(&mut self) {
+        // SAFETY: free_all checks each pointer for null before freeing.
+        // flush_and_close already zeroed all pointers on the success path,
+        // so this is a safe no-op in the normal case.
+        unsafe {
+            self.free_all();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements `SrtOutput` for pushing H.264/AAC streams as MPEG-TS over SRT transport, gated behind the `srt` feature flag in `ff-stream`. The implementation mirrors `RtmpOutput` in structure but uses the `mpegts` muxer and performs a runtime libsrt availability check, returning `StreamError::ProtocolUnavailable` when the linked FFmpeg was built without libsrt.

## Changes

- **`ff-stream/Cargo.toml`** — add `[features] srt = []`
- **`ff-stream/src/error.rs`** — add `ProtocolUnavailable { reason: String }` variant to `StreamError`
- **`ff-stream/src/srt_output_inner.rs`** (new) — `SrtInner`: owns all FFmpeg contexts; opens MPEG-TS output context with SRT URL, encodes H.264+AAC, and maintains a persistent SRT connection
- **`ff-stream/src/srt_output.rs`** (new) — `SrtOutput` builder with `srt://` URL validation, runtime libsrt check via `ff_sys::avformat::srt_available()`, `H264`/`Aac` codec enforcement, `StreamOutput` impl, and 7 unit tests
- **`ff-stream/src/lib.rs`** — wire both new modules under `#[cfg(feature = "srt")]`
- **`avio/Cargo.toml`** — extend `srt = ["ff-decode/srt", "ff-stream/srt"]` (covers both input and output)
- **`avio/src/lib.rs`** — re-export `SrtOutput` under `#[cfg(all(feature = "stream", feature = "srt"))]`
- **`avio/examples/srt_output.rs`** (new) — runnable example; gracefully skips with a message when `ProtocolUnavailable` is returned

## Related Issues

Closes #232

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes