### PR TITLE
refactor(ff-stream): extract MuxerCore to eliminate ~2000 lines of duplication

### DIFF
--- a/crates/ff-stream/src/codec_utils.rs
+++ b/crates/ff-stream/src/codec_utils.rs
@@ -17,9 +17,12 @@
 #![allow(clippy::ref_as_ptr)]
 
 use ff_sys::{
-    AVCodec, AVCodecContext, AVFormatContext, AVRational, av_interleaved_write_frame,
-    av_packet_alloc, av_packet_free, av_packet_rescale_ts, av_packet_unref, av_rescale_q,
+    AVCodec, AVCodecContext, AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
+    AVRational, AVSampleFormat, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
+    av_packet_rescale_ts, av_packet_unref, av_rescale_q,
 };
+
+use ff_format::{PixelFormat, SampleFormat};
 
 use crate::error::StreamError;
 
@@ -111,6 +114,54 @@ pub(crate) unsafe fn open_aac_encoder(
          sample_rate={sample_rate} channels={nb_channels} bit_rate={bit_rate}"
     );
     Ok(ctx)
+}
+
+// ============================================================================
+// Format conversion helpers
+// ============================================================================
+
+/// Map a [`PixelFormat`] to the corresponding `AVPixelFormat` constant.
+///
+/// Returns `AV_PIX_FMT_NONE` for unknown or `Other(_)` variants.
+pub(crate) fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
+    match fmt {
+        PixelFormat::Yuv420p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P,
+        PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
+        PixelFormat::Yuv444p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P,
+        PixelFormat::Rgb24 => ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24,
+        PixelFormat::Bgr24 => ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24,
+        PixelFormat::Rgba => ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA,
+        PixelFormat::Bgra => ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA,
+        PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
+        PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
+        PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
+        PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
+        PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
+        PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
+        PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
+        PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
+        PixelFormat::Gbrpf32le => ff_sys::AVPixelFormat_AV_PIX_FMT_GBRPF32LE,
+        PixelFormat::Other(_) | _ => AVPixelFormat_AV_PIX_FMT_NONE,
+    }
+}
+
+/// Map a [`SampleFormat`] to the corresponding `AVSampleFormat` constant.
+///
+/// Returns `AV_SAMPLE_FMT_NONE` for unknown or `Other(_)` variants.
+pub(crate) fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
+    match fmt {
+        SampleFormat::U8 => ff_sys::swresample::sample_format::U8,
+        SampleFormat::I16 => ff_sys::swresample::sample_format::S16,
+        SampleFormat::I32 => ff_sys::swresample::sample_format::S32,
+        SampleFormat::F32 => ff_sys::swresample::sample_format::FLT,
+        SampleFormat::F64 => ff_sys::swresample::sample_format::DBL,
+        SampleFormat::U8p => ff_sys::swresample::sample_format::U8P,
+        SampleFormat::I16p => ff_sys::swresample::sample_format::S16P,
+        SampleFormat::I32p => ff_sys::swresample::sample_format::S32P,
+        SampleFormat::F32p => ff_sys::swresample::sample_format::FLTP,
+        SampleFormat::F64p => ff_sys::swresample::sample_format::DBLP,
+        SampleFormat::Other(_) | _ => ff_sys::swresample::sample_format::NONE,
+    }
 }
 
 /// Drain all available encoded packets from `enc_ctx` into `out_ctx`.

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -83,6 +83,7 @@ pub mod live_dash;
 pub(crate) mod live_dash_inner;
 pub mod live_hls;
 pub(crate) mod live_hls_inner;
+pub(crate) mod muxer_core;
 pub mod output;
 pub mod rtmp;
 pub(crate) mod rtmp_inner;

--- a/crates/ff-stream/src/live_dash_inner.rs
+++ b/crates/ff-stream/src/live_dash_inner.rs
@@ -1,11 +1,11 @@
 //! Internal live DASH state — all `unsafe` `FFmpeg` calls live here.
 //!
-//! [`LiveDashInner`] owns all raw `FFmpeg` contexts. It is created by
-//! [`crate::live_dash::LiveDashOutput::build`] and driven by the safe wrappers
-//! in [`crate::live_dash`].
+//! [`LiveDashInner`] owns a [`MuxerCore`] and the DASH segment duration. It is
+//! created by [`crate::live_dash::LiveDashOutput::build`] and driven by the
+//! safe wrappers in [`crate::live_dash`].
 //!
-//! Public methods on `LiveDashInner` are safe; all raw `FFmpeg` calls are confined
-//! to `unsafe {}` blocks inside this file.
+//! Public methods on `LiveDashInner` are safe; all raw `FFmpeg` calls are
+//! confined to `unsafe {}` blocks inside this file.
 
 // This module is intentionally unsafe — it drives the FFmpeg C API directly.
 #![allow(unsafe_code)]
@@ -21,103 +21,30 @@ use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
-use ff_format::{AudioFrame, PixelFormat, SampleFormat, VideoFrame};
+use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, SwrContext, SwsContext,
-    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref, av_opt_set, av_rescale_q,
-    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header,
+    AVCodecContext, AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
+    avformat_free_context, avformat_new_stream, avformat_write_header,
 };
 
-use crate::codec_utils::{drain_encoder, ffmpeg_err, ffmpeg_err_msg};
+use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
 use crate::error::StreamError;
-
-// ============================================================================
-// Pixel-format conversion (local — ff-format has no FFmpeg dependency)
-// ============================================================================
-
-fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
-    match fmt {
-        PixelFormat::Yuv420p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P,
-        PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
-        PixelFormat::Yuv444p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P,
-        PixelFormat::Rgb24 => ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24,
-        PixelFormat::Bgr24 => ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24,
-        PixelFormat::Rgba => ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA,
-        PixelFormat::Bgra => ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA,
-        PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
-        PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
-        PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
-        PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
-        PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
-        PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
-        PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
-        PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
-        PixelFormat::Gbrpf32le => ff_sys::AVPixelFormat_AV_PIX_FMT_GBRPF32LE,
-        PixelFormat::Other(_) | _ => AVPixelFormat_AV_PIX_FMT_NONE,
-    }
-}
-
-fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
-    match fmt {
-        SampleFormat::U8 => ff_sys::swresample::sample_format::U8,
-        SampleFormat::I16 => ff_sys::swresample::sample_format::S16,
-        SampleFormat::I32 => ff_sys::swresample::sample_format::S32,
-        SampleFormat::F32 => ff_sys::swresample::sample_format::FLT,
-        SampleFormat::F64 => ff_sys::swresample::sample_format::DBL,
-        SampleFormat::U8p => ff_sys::swresample::sample_format::U8P,
-        SampleFormat::I16p => ff_sys::swresample::sample_format::S16P,
-        SampleFormat::I32p => ff_sys::swresample::sample_format::S32P,
-        SampleFormat::F32p => ff_sys::swresample::sample_format::FLTP,
-        SampleFormat::F64p => ff_sys::swresample::sample_format::DBLP,
-        SampleFormat::Other(_) | _ => ff_sys::swresample::sample_format::NONE,
-    }
-}
+use crate::muxer_core::MuxerCore;
 
 // ============================================================================
 // LiveDashInner
 // ============================================================================
 
-/// Owns all raw `FFmpeg` contexts for a live DASH output session.
+/// Owns the shared `FFmpeg` muxer state for a live DASH output session.
 ///
 /// Created by [`LiveDashInner::open`]; consumed by [`LiveDashInner::flush_and_close`].
 /// After `flush_and_close` returns, calling any other method is undefined behaviour;
 /// the safe wrapper in `live_dash.rs` prevents this via the `finished` guard.
 pub(crate) struct LiveDashInner {
-    out_ctx: *mut AVFormatContext,
-    vid_enc_ctx: *mut AVCodecContext,
-    /// Null when no audio output was configured.
-    aud_enc_ctx: *mut AVCodecContext,
-    /// Null until first `push_audio` call; recreated if input format changes.
-    swr_ctx: *mut SwrContext,
-    /// Null until swscale is needed; recreated if source dimensions/format change.
-    sws_ctx: *mut SwsContext,
-    vid_enc_frame: *mut AVFrame,
-    aud_enc_frame: *mut AVFrame,
-    vid_out_stream_idx: i32,
-    aud_out_stream_idx: i32,
-    video_frame_count: u64,
-    audio_pts: i64,
-    fps_int: i32,
-    enc_width: i32,
-    enc_height: i32,
-    /// AAC encoder `frame_size` (typically 1024); set after `avcodec_open2`.
-    aud_frame_size: i32,
-    aud_sample_rate: i32,
-    /// Tracks the last swscale source so we can detect changes.
-    last_sws_src_fmt: Option<AVPixelFormat>,
-    last_sws_src_w: Option<i32>,
-    last_sws_src_h: Option<i32>,
-    /// Tracks the last swr input so we can detect format changes.
-    last_swr_in_fmt: Option<AVSampleFormat>,
-    last_swr_in_rate: Option<i32>,
-    last_swr_in_channels: Option<i32>,
+    core: MuxerCore,
 }
 
-// SAFETY: LiveDashInner exclusively owns all FFmpeg contexts.
-// FFmpeg contexts are not safe for concurrent access, but ownership transfer
-// between threads is safe (there is no shared state).
+// SAFETY: LiveDashInner exclusively owns all FFmpeg contexts via MuxerCore.
 unsafe impl Send for LiveDashInner {}
 
 impl LiveDashInner {
@@ -158,7 +85,7 @@ impl LiveDashInner {
     /// Encode and mux one video frame.
     pub(crate) fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
         // SAFETY: self was initialised by open() and is not yet finished.
-        unsafe { self.push_video_unsafe(frame) }
+        unsafe { self.core.push_video_unsafe(frame) }
     }
 
     /// Encode and mux one audio frame.
@@ -167,7 +94,7 @@ impl LiveDashInner {
     pub(crate) fn push_audio(&mut self, frame: &AudioFrame) {
         // SAFETY: self was initialised by open() and is not yet finished.
         unsafe {
-            self.push_audio_unsafe(frame);
+            self.core.push_audio_unsafe(frame);
         }
     }
 
@@ -175,7 +102,7 @@ impl LiveDashInner {
     pub(crate) fn flush_and_close(mut self) {
         // SAFETY: self was initialised by open(); flush_and_close is called once.
         unsafe {
-            self.flush_and_close_unsafe();
+            self.core.flush_and_close_unsafe();
         }
     }
 
@@ -199,7 +126,7 @@ impl LiveDashInner {
         let c_manifest = CString::new(manifest_path.as_str())
             .map_err(|_| ffmpeg_err_msg("manifest path contains null byte"))?;
 
-        let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
+        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
         let ret = avformat_alloc_output_context2(
             &mut out_ctx,
             ptr::null_mut(),
@@ -362,33 +289,12 @@ impl LiveDashInner {
             }
         }
 
-        // ── 6. Allocate encoder frames ────────────────────────────────────────
-        let vid_enc_frame = av_frame_alloc();
-        let aud_enc_frame = av_frame_alloc();
-
-        if vid_enc_frame.is_null() || aud_enc_frame.is_null() {
-            if !vid_enc_frame.is_null() {
-                av_frame_free(&mut (vid_enc_frame as *mut _));
-            }
-            if !aud_enc_frame.is_null() {
-                av_frame_free(&mut (aud_enc_frame as *mut _));
-            }
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err_msg("cannot allocate encoder frames"));
-        }
-
-        // ── 7. Open output file and write header ──────────────────────────────
+        // ── 6. Open output file and write header ──────────────────────────────
         let pb = ff_sys::avformat::open_output(
             Path::new(&manifest_path),
             ff_sys::avformat::avio_flags::WRITE,
         )
         .map_err(|e| {
-            av_frame_free(&mut (aud_enc_frame as *mut _));
-            av_frame_free(&mut (vid_enc_frame as *mut _));
             if !aud_enc_ctx.is_null() {
                 ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             }
@@ -401,8 +307,6 @@ impl LiveDashInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            av_frame_free(&mut (aud_enc_frame as *mut _));
-            av_frame_free(&mut (vid_enc_frame as *mut _));
             if !aud_enc_ctx.is_null() {
                 ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             }
@@ -422,418 +326,29 @@ impl LiveDashInner {
             aud_out_stream_idx >= 0
         );
 
-        Ok(Self {
+        // ── 7. Build MuxerCore ────────────────────────────────────────────────
+        let core = MuxerCore::new(
             out_ctx,
             vid_enc_ctx,
             aud_enc_ctx,
-            swr_ctx: ptr::null_mut(),
-            sws_ctx: ptr::null_mut(),
-            vid_enc_frame,
-            aud_enc_frame,
             vid_out_stream_idx,
             aud_out_stream_idx,
-            video_frame_count: 0,
-            audio_pts: 0,
             fps_int,
             enc_width,
             enc_height,
             aud_frame_size,
             aud_sample_rate,
-            last_sws_src_fmt: None,
-            last_sws_src_w: None,
-            last_sws_src_h: None,
-            last_swr_in_fmt: None,
-            last_swr_in_rate: None,
-            last_swr_in_channels: None,
-        })
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_video_unsafe(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        let src_fmt = pixel_format_to_av(frame.format());
-        let src_w = frame.width() as i32;
-        let src_h = frame.height() as i32;
-        let needs_conversion = src_fmt != AVPixelFormat_AV_PIX_FMT_YUV420P
-            || src_w != self.enc_width
-            || src_h != self.enc_height
-            || src_fmt == AVPixelFormat_AV_PIX_FMT_NONE;
-
-        if needs_conversion {
-            // (Re)create SwsContext when source properties change.
-            if self.last_sws_src_fmt != Some(src_fmt)
-                || self.last_sws_src_w != Some(src_w)
-                || self.last_sws_src_h != Some(src_h)
-            {
-                if !self.sws_ctx.is_null() {
-                    ff_sys::swscale::free_context(self.sws_ctx);
-                    self.sws_ctx = ptr::null_mut();
-                }
-                match ff_sys::swscale::get_context(
-                    src_w,
-                    src_h,
-                    src_fmt,
-                    self.enc_width,
-                    self.enc_height,
-                    AVPixelFormat_AV_PIX_FMT_YUV420P,
-                    ff_sys::swscale::scale_flags::BILINEAR,
-                ) {
-                    Ok(ctx) => {
-                        self.sws_ctx = ctx;
-                        self.last_sws_src_fmt = Some(src_fmt);
-                        self.last_sws_src_w = Some(src_w);
-                        self.last_sws_src_h = Some(src_h);
-                    }
-                    Err(_) => {
-                        return Err(ffmpeg_err_msg(
-                            "live_dash swscale context creation failed for video frame",
-                        ));
-                    }
-                }
-            }
-
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Build source plane/linesize arrays from the VideoFrame.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            let mut src_data = [ptr::null::<u8>(); 8];
-            let mut src_linesize = [0i32; 8];
-            for (i, (plane, &stride)) in planes.iter().zip(strides.iter()).enumerate().take(8) {
-                src_data[i] = plane.as_ref().as_ptr();
-                src_linesize[i] = stride as i32;
-            }
-
-            ff_sys::swscale::scale(
-                self.sws_ctx,
-                src_data.as_ptr(),
-                src_linesize.as_ptr(),
-                0,
-                src_h,
-                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
-                (*self.vid_enc_frame).linesize.as_mut_ptr(),
-            )
-            .map_err(|_| ffmpeg_err_msg("live_dash swscale conversion failed"))?;
-        } else {
-            // Same format and dimensions — copy planes directly.
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Copy Y/U/V planes line-by-line.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            for (plane_idx, (src_plane, &src_stride)) in
-                planes.iter().zip(strides.iter()).enumerate().take(3)
-            {
-                let dst_stride = (*self.vid_enc_frame).linesize[plane_idx] as usize;
-                let dst_ptr = (*self.vid_enc_frame).data[plane_idx];
-                if dst_ptr.is_null() {
-                    continue;
-                }
-                let rows = if plane_idx == 0 {
-                    self.enc_height as usize
-                } else {
-                    (self.enc_height as usize).div_ceil(2)
-                };
-                let copy_width = dst_stride.min(src_stride);
-                let src_bytes: &[u8] = src_plane.as_ref();
-                for row in 0..rows {
-                    let src_off = row * src_stride;
-                    let dst_off = row * dst_stride;
-                    if src_off + copy_width > src_bytes.len() {
-                        break;
-                    }
-                    // SAFETY: dst_ptr + dst_off is within the allocated frame buffer.
-                    ptr::copy_nonoverlapping(
-                        src_bytes.as_ptr().add(src_off),
-                        dst_ptr.add(dst_off),
-                        copy_width,
-                    );
-                }
-            }
-        }
-
-        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
-            // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
-            drain_encoder(
-                self.vid_enc_ctx,
-                self.out_ctx,
-                self.vid_out_stream_idx,
-                "live_dash",
-                AVRational {
-                    num: 1,
-                    den: self.fps_int,
-                },
-            );
-        }
-
-        av_frame_unref(self.vid_enc_frame);
-        self.video_frame_count += 1;
-        Ok(())
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
-        if self.aud_enc_ctx.is_null() || self.aud_out_stream_idx < 0 {
-            return; // audio not configured
-        }
-
-        let in_fmt = sample_format_to_av(frame.format());
-        let in_rate = frame.sample_rate() as i32;
-        let in_channels = frame.channels() as i32;
-
-        // (Re)create SwrContext when input parameters change.
-        if self.last_swr_in_fmt != Some(in_fmt)
-            || self.last_swr_in_rate != Some(in_rate)
-            || self.last_swr_in_channels != Some(in_channels)
-        {
-            if !self.swr_ctx.is_null() {
-                let mut swr_tmp = self.swr_ctx;
-                ff_sys::swresample::free(&mut swr_tmp);
-                self.swr_ctx = ptr::null_mut();
-            }
-
-            let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
-            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
-
-            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
-                enc_ch_layout,
-                ff_sys::swresample::sample_format::FLTP,
-                self.aud_sample_rate,
-                &in_layout,
-                in_fmt,
-                in_rate,
-            ) {
-                if ff_sys::swresample::init(ctx).is_ok() {
-                    self.swr_ctx = ctx;
-                    self.last_swr_in_fmt = Some(in_fmt);
-                    self.last_swr_in_rate = Some(in_rate);
-                    self.last_swr_in_channels = Some(in_channels);
-                } else {
-                    let mut swr_tmp = ctx;
-                    ff_sys::swresample::free(&mut swr_tmp);
-                    log::warn!("live_dash swr init failed, dropping audio frame");
-                    return;
-                }
-            } else {
-                log::warn!("live_dash swr alloc failed, dropping audio frame");
-                return;
-            }
-        }
-
-        // Prepare the encoder frame.
-        (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-        (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-        (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-        let _ = ff_sys::swresample::channel_layout::copy(
-            &mut (*self.aud_enc_frame).ch_layout,
-            &(*self.aud_enc_ctx).ch_layout,
-        );
-
-        let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
-        if buf_ret < 0 {
-            av_frame_unref(self.aud_enc_frame);
-            return;
-        }
-
-        // Build input plane pointers from the AudioFrame.
-        let planes = frame.planes();
-        let mut in_data = [ptr::null::<u8>(); 8];
-        for (i, plane) in planes.iter().enumerate().take(8) {
-            in_data[i] = plane.as_ptr();
-        }
-
-        let samples_out = ff_sys::swresample::convert(
-            self.swr_ctx,
-            (*self.aud_enc_frame).data.as_mut_ptr(),
-            self.aud_frame_size,
-            in_data.as_ptr(),
-            frame.samples() as i32,
-        );
-
-        if let Ok(n) = samples_out
-            && n > 0
-        {
-            (*self.aud_enc_frame).nb_samples = n;
-            (*self.aud_enc_frame).pts = self.audio_pts;
-            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
-                let aud_frame_period = AVRational {
-                    num: (*self.aud_enc_ctx).frame_size,
-                    den: (*self.aud_enc_ctx).sample_rate,
-                };
-                // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
-                drain_encoder(
-                    self.aud_enc_ctx,
-                    self.out_ctx,
-                    self.aud_out_stream_idx,
-                    "live_dash",
-                    aud_frame_period,
-                );
-            }
-            self.audio_pts += i64::from(n);
-        }
-
-        av_frame_unref(self.aud_enc_frame);
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn flush_and_close_unsafe(&mut self) {
-        // ── Flush video encoder ───────────────────────────────────────────────
-        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
-        drain_encoder(
-            self.vid_enc_ctx,
-            self.out_ctx,
-            self.vid_out_stream_idx,
             "live_dash",
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-        );
-
-        // ── Flush audio encoder ───────────────────────────────────────────────
-        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
-            // Drain any remaining resampler buffered samples.
-            if !self.swr_ctx.is_null() {
-                (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-                (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-                (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-                let _ = ff_sys::swresample::channel_layout::copy(
-                    &mut (*self.aud_enc_frame).ch_layout,
-                    &(*self.aud_enc_ctx).ch_layout,
-                );
-
-                if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
-                    if let Ok(n) = ff_sys::swresample::convert(
-                        self.swr_ctx,
-                        (*self.aud_enc_frame).data.as_mut_ptr(),
-                        self.aud_frame_size,
-                        ptr::null(),
-                        0,
-                    ) && n > 0
-                    {
-                        (*self.aud_enc_frame).nb_samples = n;
-                        (*self.aud_enc_frame).pts = self.audio_pts;
-                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
-                        {
-                            let aud_frame_period = AVRational {
-                                num: (*self.aud_enc_ctx).frame_size,
-                                den: (*self.aud_enc_ctx).sample_rate,
-                            };
-                            drain_encoder(
-                                self.aud_enc_ctx,
-                                self.out_ctx,
-                                self.aud_out_stream_idx,
-                                "live_dash",
-                                aud_frame_period,
-                            );
-                        }
-                    }
-                    av_frame_unref(self.aud_enc_frame);
-                }
+            false, // close_pb_after_trailer: pb already closed after header write
+        )
+        .inspect_err(|_| {
+            if !aud_enc_ctx.is_null() {
+                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             }
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+        })?;
 
-            // Flush the AAC encoder itself.
-            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
-            let aud_frame_period = AVRational {
-                num: (*self.aud_enc_ctx).frame_size,
-                den: (*self.aud_enc_ctx).sample_rate,
-            };
-            drain_encoder(
-                self.aud_enc_ctx,
-                self.out_ctx,
-                self.aud_out_stream_idx,
-                "live_dash",
-                aud_frame_period,
-            );
-        }
-
-        // ── Write trailer ─────────────────────────────────────────────────────
-        // pb was already closed after avformat_write_header; skip double-close.
-        av_write_trailer(self.out_ctx);
-
-        log::info!("live_dash finished");
-
-        // Zero all pointers so Drop does not double-free.
-        self.free_all();
-    }
-
-    // SAFETY: Callers must ensure self is not used again after this call.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn set_vid_enc_pts(&mut self) {
-        (*self.vid_enc_frame).pts = av_rescale_q(
-            self.video_frame_count as i64,
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-            (*self.vid_enc_ctx).time_base,
-        );
-    }
-
-    /// Free all owned `FFmpeg` contexts and zero the pointers.
-    ///
-    /// # Safety
-    ///
-    /// Each pointer is checked for null before freeing. After this call all
-    /// pointers are null, so a second call is a no-op.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn free_all(&mut self) {
-        if !self.sws_ctx.is_null() {
-            ff_sys::swscale::free_context(self.sws_ctx);
-            self.sws_ctx = ptr::null_mut();
-        }
-        if !self.swr_ctx.is_null() {
-            let mut swr_tmp = self.swr_ctx;
-            ff_sys::swresample::free(&mut swr_tmp);
-            self.swr_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_frame.is_null() {
-            av_frame_free(&mut (self.vid_enc_frame as *mut _));
-            self.vid_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_frame.is_null() {
-            av_frame_free(&mut (self.aud_enc_frame as *mut _));
-            self.aud_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
-            self.aud_enc_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
-            self.vid_enc_ctx = ptr::null_mut();
-        }
-        if !self.out_ctx.is_null() {
-            avformat_free_context(self.out_ctx);
-            self.out_ctx = ptr::null_mut();
-        }
-    }
-}
-
-impl Drop for LiveDashInner {
-    fn drop(&mut self) {
-        // SAFETY: free_all checks each pointer for null before freeing.
-        // flush_and_close already zeroed all pointers on the success path,
-        // so this is a safe no-op in the normal case.
-        unsafe {
-            self.free_all();
-        }
+        Ok(Self { core })
     }
 }

--- a/crates/ff-stream/src/live_hls_inner.rs
+++ b/crates/ff-stream/src/live_hls_inner.rs
@@ -1,11 +1,11 @@
 //! Internal live HLS state — all `unsafe` `FFmpeg` calls live here.
 //!
-//! [`LiveHlsInner`] owns all raw `FFmpeg` contexts. It is created by
-//! [`crate::live_hls::LiveHlsOutput::build`] and driven by the safe wrappers
-//! in [`crate::live_hls`].
+//! [`LiveHlsInner`] owns a [`MuxerCore`] and the HLS segment duration. It is
+//! created by [`crate::live_hls::LiveHlsOutput::build`] and driven by the
+//! safe wrappers in [`crate::live_hls`].
 //!
-//! Public methods on `LiveHlsInner` are safe; all raw `FFmpeg` calls are confined
-//! to `unsafe {}` blocks inside this file.
+//! Public methods on `LiveHlsInner` are safe; all raw `FFmpeg` calls are
+//! confined to `unsafe {}` blocks inside this file.
 
 // This module is intentionally unsafe — it drives the FFmpeg C API directly.
 #![allow(unsafe_code)]
@@ -21,104 +21,30 @@ use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
-use ff_format::{AudioFrame, PixelFormat, SampleFormat, VideoFrame};
+use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, SwrContext, SwsContext,
-    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref, av_opt_set, av_rescale_q,
-    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header,
+    AVCodecContext, AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
+    avformat_free_context, avformat_new_stream, avformat_write_header,
 };
 
-use crate::codec_utils::{drain_encoder, ffmpeg_err, ffmpeg_err_msg};
+use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
 use crate::error::StreamError;
-
-// ============================================================================
-// Pixel-format conversion (local — ff-format has no FFmpeg dependency)
-// ============================================================================
-
-fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
-    match fmt {
-        PixelFormat::Yuv420p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P,
-        PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
-        PixelFormat::Yuv444p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P,
-        PixelFormat::Rgb24 => ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24,
-        PixelFormat::Bgr24 => ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24,
-        PixelFormat::Rgba => ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA,
-        PixelFormat::Bgra => ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA,
-        PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
-        PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
-        PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
-        PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
-        PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
-        PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
-        PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
-        PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
-        PixelFormat::Gbrpf32le => ff_sys::AVPixelFormat_AV_PIX_FMT_GBRPF32LE,
-        PixelFormat::Other(_) | _ => AVPixelFormat_AV_PIX_FMT_NONE,
-    }
-}
-
-fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
-    match fmt {
-        SampleFormat::U8 => ff_sys::swresample::sample_format::U8,
-        SampleFormat::I16 => ff_sys::swresample::sample_format::S16,
-        SampleFormat::I32 => ff_sys::swresample::sample_format::S32,
-        SampleFormat::F32 => ff_sys::swresample::sample_format::FLT,
-        SampleFormat::F64 => ff_sys::swresample::sample_format::DBL,
-        SampleFormat::U8p => ff_sys::swresample::sample_format::U8P,
-        SampleFormat::I16p => ff_sys::swresample::sample_format::S16P,
-        SampleFormat::I32p => ff_sys::swresample::sample_format::S32P,
-        SampleFormat::F32p => ff_sys::swresample::sample_format::FLTP,
-        SampleFormat::F64p => ff_sys::swresample::sample_format::DBLP,
-        SampleFormat::Other(_) | _ => ff_sys::swresample::sample_format::NONE,
-    }
-}
+use crate::muxer_core::MuxerCore;
 
 // ============================================================================
 // LiveHlsInner
 // ============================================================================
 
-/// Owns all raw `FFmpeg` contexts for a live HLS output session.
+/// Owns the shared `FFmpeg` muxer state for a live HLS output session.
 ///
 /// Created by [`LiveHlsInner::open`]; consumed by [`LiveHlsInner::flush_and_close`].
 /// After `flush_and_close` returns, calling any other method is undefined behaviour;
 /// the safe wrapper in `live_hls.rs` prevents this via the `finished` guard.
 pub(crate) struct LiveHlsInner {
-    out_ctx: *mut AVFormatContext,
-    vid_enc_ctx: *mut AVCodecContext,
-    /// Null when no audio output was configured.
-    aud_enc_ctx: *mut AVCodecContext,
-    /// Null until first `push_audio` call; recreated if input format changes.
-    swr_ctx: *mut SwrContext,
-    /// Null until swscale is needed; recreated if source dimensions/format change.
-    sws_ctx: *mut SwsContext,
-    vid_enc_frame: *mut AVFrame,
-    aud_enc_frame: *mut AVFrame,
-    vid_out_stream_idx: i32,
-    aud_out_stream_idx: i32,
-    video_frame_count: u64,
-    audio_pts: i64,
-    fps_int: i32,
-    enc_width: i32,
-    enc_height: i32,
-    /// AAC encoder `frame_size` (typically 1024); set after `avcodec_open2`.
-    aud_frame_size: i32,
-    aud_sample_rate: i32,
-    segment_secs: u32,
-    /// Tracks the last swscale source so we can detect changes.
-    last_sws_src_fmt: Option<AVPixelFormat>,
-    last_sws_src_w: Option<i32>,
-    last_sws_src_h: Option<i32>,
-    /// Tracks the last swr input so we can detect format changes.
-    last_swr_in_fmt: Option<AVSampleFormat>,
-    last_swr_in_rate: Option<i32>,
-    last_swr_in_channels: Option<i32>,
+    core: MuxerCore,
 }
 
-// SAFETY: LiveHlsInner exclusively owns all FFmpeg contexts.
-// FFmpeg contexts are not safe for concurrent access, but ownership transfer
-// between threads is safe (there is no shared state).
+// SAFETY: LiveHlsInner exclusively owns all FFmpeg contexts via MuxerCore.
 unsafe impl Send for LiveHlsInner {}
 
 impl LiveHlsInner {
@@ -164,7 +90,7 @@ impl LiveHlsInner {
     /// Encode and mux one video frame.
     pub(crate) fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
         // SAFETY: self was initialised by open() and is not yet finished.
-        unsafe { self.push_video_unsafe(frame) }
+        unsafe { self.core.push_video_unsafe(frame) }
     }
 
     /// Encode and mux one audio frame.
@@ -173,7 +99,7 @@ impl LiveHlsInner {
     pub(crate) fn push_audio(&mut self, frame: &AudioFrame) {
         // SAFETY: self was initialised by open() and is not yet finished.
         unsafe {
-            self.push_audio_unsafe(frame);
+            self.core.push_audio_unsafe(frame);
         }
     }
 
@@ -181,7 +107,7 @@ impl LiveHlsInner {
     pub(crate) fn flush_and_close(mut self) {
         // SAFETY: self was initialised by open(); flush_and_close is called once.
         unsafe {
-            self.flush_and_close_unsafe();
+            self.core.flush_and_close_unsafe();
         }
     }
 
@@ -207,7 +133,7 @@ impl LiveHlsInner {
         let c_playlist = CString::new(playlist_path.as_str())
             .map_err(|_| ffmpeg_err_msg("playlist path contains null byte"))?;
 
-        let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
+        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
         let ret = avformat_alloc_output_context2(
             &mut out_ctx,
             ptr::null_mut(),
@@ -391,33 +317,12 @@ impl LiveHlsInner {
             }
         }
 
-        // ── 6. Allocate encoder frames ────────────────────────────────────────
-        let vid_enc_frame = av_frame_alloc();
-        let aud_enc_frame = av_frame_alloc();
-
-        if vid_enc_frame.is_null() || aud_enc_frame.is_null() {
-            if !vid_enc_frame.is_null() {
-                av_frame_free(&mut (vid_enc_frame as *mut _));
-            }
-            if !aud_enc_frame.is_null() {
-                av_frame_free(&mut (aud_enc_frame as *mut _));
-            }
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err_msg("cannot allocate encoder frames"));
-        }
-
-        // ── 7. Open output file and write header ──────────────────────────────
+        // ── 6. Open output file and write header ──────────────────────────────
         let pb = ff_sys::avformat::open_output(
             Path::new(&playlist_path),
             ff_sys::avformat::avio_flags::WRITE,
         )
         .map_err(|e| {
-            av_frame_free(&mut (aud_enc_frame as *mut _));
-            av_frame_free(&mut (vid_enc_frame as *mut _));
             if !aud_enc_ctx.is_null() {
                 ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             }
@@ -430,8 +335,6 @@ impl LiveHlsInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            av_frame_free(&mut (aud_enc_frame as *mut _));
-            av_frame_free(&mut (vid_enc_frame as *mut _));
             if !aud_enc_ctx.is_null() {
                 ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             }
@@ -452,424 +355,29 @@ impl LiveHlsInner {
             aud_out_stream_idx >= 0
         );
 
-        Ok(Self {
+        // ── 7. Build MuxerCore ────────────────────────────────────────────────
+        let core = MuxerCore::new(
             out_ctx,
             vid_enc_ctx,
             aud_enc_ctx,
-            swr_ctx: ptr::null_mut(),
-            sws_ctx: ptr::null_mut(),
-            vid_enc_frame,
-            aud_enc_frame,
             vid_out_stream_idx,
             aud_out_stream_idx,
-            video_frame_count: 0,
-            audio_pts: 0,
             fps_int,
             enc_width,
             enc_height,
             aud_frame_size,
             aud_sample_rate,
-            segment_secs,
-            last_sws_src_fmt: None,
-            last_sws_src_w: None,
-            last_sws_src_h: None,
-            last_swr_in_fmt: None,
-            last_swr_in_rate: None,
-            last_swr_in_channels: None,
-        })
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_video_unsafe(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        let src_fmt = pixel_format_to_av(frame.format());
-        let src_w = frame.width() as i32;
-        let src_h = frame.height() as i32;
-        let needs_conversion = src_fmt != AVPixelFormat_AV_PIX_FMT_YUV420P
-            || src_w != self.enc_width
-            || src_h != self.enc_height
-            || src_fmt == AVPixelFormat_AV_PIX_FMT_NONE;
-
-        if needs_conversion {
-            // (Re)create SwsContext when source properties change.
-            if self.last_sws_src_fmt != Some(src_fmt)
-                || self.last_sws_src_w != Some(src_w)
-                || self.last_sws_src_h != Some(src_h)
-            {
-                if !self.sws_ctx.is_null() {
-                    ff_sys::swscale::free_context(self.sws_ctx);
-                    self.sws_ctx = ptr::null_mut();
-                }
-                match ff_sys::swscale::get_context(
-                    src_w,
-                    src_h,
-                    src_fmt,
-                    self.enc_width,
-                    self.enc_height,
-                    AVPixelFormat_AV_PIX_FMT_YUV420P,
-                    ff_sys::swscale::scale_flags::BILINEAR,
-                ) {
-                    Ok(ctx) => {
-                        self.sws_ctx = ctx;
-                        self.last_sws_src_fmt = Some(src_fmt);
-                        self.last_sws_src_w = Some(src_w);
-                        self.last_sws_src_h = Some(src_h);
-                    }
-                    Err(_) => {
-                        return Err(ffmpeg_err_msg(
-                            "live_hls swscale context creation failed for video frame",
-                        ));
-                    }
-                }
-            }
-
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Build source plane/linesize arrays from the VideoFrame.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            let mut src_data = [ptr::null::<u8>(); 8];
-            let mut src_linesize = [0i32; 8];
-            for (i, (plane, &stride)) in planes.iter().zip(strides.iter()).enumerate().take(8) {
-                src_data[i] = plane.as_ref().as_ptr();
-                src_linesize[i] = stride as i32;
-            }
-
-            ff_sys::swscale::scale(
-                self.sws_ctx,
-                src_data.as_ptr(),
-                src_linesize.as_ptr(),
-                0,
-                src_h,
-                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
-                (*self.vid_enc_frame).linesize.as_mut_ptr(),
-            )
-            .map_err(|_| ffmpeg_err_msg("live_hls swscale conversion failed"))?;
-        } else {
-            // Same format and dimensions — copy planes directly.
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Copy Y/U/V planes line-by-line.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            for (plane_idx, (src_plane, &src_stride)) in
-                planes.iter().zip(strides.iter()).enumerate().take(3)
-            {
-                let dst_stride = (*self.vid_enc_frame).linesize[plane_idx] as usize;
-                let dst_ptr = (*self.vid_enc_frame).data[plane_idx];
-                if dst_ptr.is_null() {
-                    continue;
-                }
-                let rows = if plane_idx == 0 {
-                    self.enc_height as usize
-                } else {
-                    (self.enc_height as usize).div_ceil(2)
-                };
-                let copy_width = dst_stride.min(src_stride);
-                let src_bytes: &[u8] = src_plane.as_ref();
-                for row in 0..rows {
-                    let src_off = row * src_stride;
-                    let dst_off = row * dst_stride;
-                    if src_off + copy_width > src_bytes.len() {
-                        break;
-                    }
-                    // SAFETY: dst_ptr + dst_off is within the allocated frame buffer.
-                    ptr::copy_nonoverlapping(
-                        src_bytes.as_ptr().add(src_off),
-                        dst_ptr.add(dst_off),
-                        copy_width,
-                    );
-                }
-            }
-        }
-
-        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
-            // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
-            drain_encoder(
-                self.vid_enc_ctx,
-                self.out_ctx,
-                self.vid_out_stream_idx,
-                "live_hls",
-                AVRational {
-                    num: 1,
-                    den: self.fps_int,
-                },
-            );
-        }
-
-        av_frame_unref(self.vid_enc_frame);
-        self.video_frame_count += 1;
-        Ok(())
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
-        if self.aud_enc_ctx.is_null() || self.aud_out_stream_idx < 0 {
-            return; // audio not configured
-        }
-
-        let in_fmt = sample_format_to_av(frame.format());
-        let in_rate = frame.sample_rate() as i32;
-        let in_channels = frame.channels() as i32;
-
-        // (Re)create SwrContext when input parameters change.
-        if self.last_swr_in_fmt != Some(in_fmt)
-            || self.last_swr_in_rate != Some(in_rate)
-            || self.last_swr_in_channels != Some(in_channels)
-        {
-            if !self.swr_ctx.is_null() {
-                let mut swr_tmp = self.swr_ctx;
-                ff_sys::swresample::free(&mut swr_tmp);
-                self.swr_ctx = ptr::null_mut();
-            }
-
-            let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
-            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
-
-            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
-                enc_ch_layout,
-                ff_sys::swresample::sample_format::FLTP,
-                self.aud_sample_rate,
-                &in_layout,
-                in_fmt,
-                in_rate,
-            ) {
-                if ff_sys::swresample::init(ctx).is_ok() {
-                    self.swr_ctx = ctx;
-                    self.last_swr_in_fmt = Some(in_fmt);
-                    self.last_swr_in_rate = Some(in_rate);
-                    self.last_swr_in_channels = Some(in_channels);
-                } else {
-                    let mut swr_tmp = ctx;
-                    ff_sys::swresample::free(&mut swr_tmp);
-                    log::warn!("live_hls swr init failed, dropping audio frame");
-                    return;
-                }
-            } else {
-                log::warn!("live_hls swr alloc failed, dropping audio frame");
-                return;
-            }
-        }
-
-        // Prepare the encoder frame.
-        (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-        (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-        (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-        let _ = ff_sys::swresample::channel_layout::copy(
-            &mut (*self.aud_enc_frame).ch_layout,
-            &(*self.aud_enc_ctx).ch_layout,
-        );
-
-        let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
-        if buf_ret < 0 {
-            av_frame_unref(self.aud_enc_frame);
-            return;
-        }
-
-        // Build input plane pointers from the AudioFrame.
-        let planes = frame.planes();
-        let mut in_data = [ptr::null::<u8>(); 8];
-        for (i, plane) in planes.iter().enumerate().take(8) {
-            in_data[i] = plane.as_ptr();
-        }
-
-        let samples_out = ff_sys::swresample::convert(
-            self.swr_ctx,
-            (*self.aud_enc_frame).data.as_mut_ptr(),
-            self.aud_frame_size,
-            in_data.as_ptr(),
-            frame.samples() as i32,
-        );
-
-        if let Ok(n) = samples_out
-            && n > 0
-        {
-            (*self.aud_enc_frame).nb_samples = n;
-            (*self.aud_enc_frame).pts = self.audio_pts;
-            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
-                let aud_frame_period = AVRational {
-                    num: (*self.aud_enc_ctx).frame_size,
-                    den: (*self.aud_enc_ctx).sample_rate,
-                };
-                // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
-                drain_encoder(
-                    self.aud_enc_ctx,
-                    self.out_ctx,
-                    self.aud_out_stream_idx,
-                    "live_hls",
-                    aud_frame_period,
-                );
-            }
-            self.audio_pts += i64::from(n);
-        }
-
-        av_frame_unref(self.aud_enc_frame);
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn flush_and_close_unsafe(&mut self) {
-        // ── Flush video encoder ───────────────────────────────────────────────
-        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
-        drain_encoder(
-            self.vid_enc_ctx,
-            self.out_ctx,
-            self.vid_out_stream_idx,
             "live_hls",
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-        );
-
-        // ── Flush audio encoder ───────────────────────────────────────────────
-        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
-            // Drain any remaining resampler buffered samples.
-            if !self.swr_ctx.is_null() {
-                (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-                (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-                (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-                let _ = ff_sys::swresample::channel_layout::copy(
-                    &mut (*self.aud_enc_frame).ch_layout,
-                    &(*self.aud_enc_ctx).ch_layout,
-                );
-
-                if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
-                    if let Ok(n) = ff_sys::swresample::convert(
-                        self.swr_ctx,
-                        (*self.aud_enc_frame).data.as_mut_ptr(),
-                        self.aud_frame_size,
-                        ptr::null(),
-                        0,
-                    ) && n > 0
-                    {
-                        (*self.aud_enc_frame).nb_samples = n;
-                        (*self.aud_enc_frame).pts = self.audio_pts;
-                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
-                        {
-                            let aud_frame_period = AVRational {
-                                num: (*self.aud_enc_ctx).frame_size,
-                                den: (*self.aud_enc_ctx).sample_rate,
-                            };
-                            drain_encoder(
-                                self.aud_enc_ctx,
-                                self.out_ctx,
-                                self.aud_out_stream_idx,
-                                "live_hls",
-                                aud_frame_period,
-                            );
-                        }
-                    }
-                    av_frame_unref(self.aud_enc_frame);
-                }
+            false, // close_pb_after_trailer: pb already closed after header write
+        )
+        .inspect_err(|_| {
+            if !aud_enc_ctx.is_null() {
+                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             }
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+        })?;
 
-            // Flush the AAC encoder itself.
-            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
-            let aud_frame_period = AVRational {
-                num: (*self.aud_enc_ctx).frame_size,
-                den: (*self.aud_enc_ctx).sample_rate,
-            };
-            drain_encoder(
-                self.aud_enc_ctx,
-                self.out_ctx,
-                self.aud_out_stream_idx,
-                "live_hls",
-                aud_frame_period,
-            );
-        }
-
-        // ── Write trailer ─────────────────────────────────────────────────────
-        // pb was already closed after avformat_write_header; skip double-close.
-        av_write_trailer(self.out_ctx);
-
-        log::info!(
-            "live_hls finished segments_written approx={}",
-            self.video_frame_count
-                / u64::from(self.fps_int.max(1) as u32)
-                / u64::from(self.segment_secs.max(1))
-        );
-
-        // Zero all pointers so Drop does not double-free.
-        self.free_all();
-    }
-
-    // SAFETY: Callers must ensure self is not used again after this call.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn set_vid_enc_pts(&mut self) {
-        (*self.vid_enc_frame).pts = av_rescale_q(
-            self.video_frame_count as i64,
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-            (*self.vid_enc_ctx).time_base,
-        );
-    }
-
-    /// Free all owned `FFmpeg` contexts and zero the pointers.
-    ///
-    /// # Safety
-    ///
-    /// Each pointer is checked for null before freeing. After this call all
-    /// pointers are null, so a second call is a no-op.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn free_all(&mut self) {
-        if !self.sws_ctx.is_null() {
-            ff_sys::swscale::free_context(self.sws_ctx);
-            self.sws_ctx = ptr::null_mut();
-        }
-        if !self.swr_ctx.is_null() {
-            let mut swr_tmp = self.swr_ctx;
-            ff_sys::swresample::free(&mut swr_tmp);
-            self.swr_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_frame.is_null() {
-            av_frame_free(&mut (self.vid_enc_frame as *mut _));
-            self.vid_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_frame.is_null() {
-            av_frame_free(&mut (self.aud_enc_frame as *mut _));
-            self.aud_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
-            self.aud_enc_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
-            self.vid_enc_ctx = ptr::null_mut();
-        }
-        if !self.out_ctx.is_null() {
-            avformat_free_context(self.out_ctx);
-            self.out_ctx = ptr::null_mut();
-        }
-    }
-}
-
-impl Drop for LiveHlsInner {
-    fn drop(&mut self) {
-        // SAFETY: free_all checks each pointer for null before freeing.
-        // flush_and_close already zeroed all pointers on the success path,
-        // so this is a safe no-op in the normal case.
-        unsafe {
-            self.free_all();
-        }
+        Ok(Self { core })
     }
 }

--- a/crates/ff-stream/src/muxer_core.rs
+++ b/crates/ff-stream/src/muxer_core.rs
@@ -1,0 +1,597 @@
+//! Shared `FFmpeg` muxer state for all streaming outputs.
+//!
+//! [`MuxerCore`] owns all raw `FFmpeg` contexts (video/audio encoder, resampler,
+//! scaler, output format context). The four protocol-specific inner types
+//! (`RtmpInner`, `SrtInner`, `LiveHlsInner`, `LiveDashInner`) each hold a
+//! `MuxerCore` and delegate every method except `open_unsafe` to it.
+
+// This module is intentionally unsafe — it drives the FFmpeg C API directly.
+#![allow(unsafe_code)]
+// Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
+#![allow(unsafe_op_in_unsafe_fn)]
+#![allow(clippy::ptr_as_ptr)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::ref_as_ptr)]
+
+use std::ptr;
+
+use ff_format::{AudioFrame, VideoFrame};
+use ff_sys::{
+    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P,
+    AVRational, AVSampleFormat, SwrContext, SwsContext, av_frame_alloc, av_frame_free,
+    av_frame_get_buffer, av_frame_unref, av_rescale_q, av_write_trailer, avformat_free_context,
+};
+
+use crate::codec_utils::{
+    drain_encoder, ffmpeg_err, ffmpeg_err_msg, pixel_format_to_av, sample_format_to_av,
+};
+use crate::error::StreamError;
+
+// ============================================================================
+// MuxerCore
+// ============================================================================
+
+/// Shared `FFmpeg` context owner for all streaming outputs.
+///
+/// Created by each inner type's `open_unsafe` via [`MuxerCore::new`] after the
+/// format context, encoder contexts, and streams are fully configured.
+/// Consumed by [`MuxerCore::flush_and_close_unsafe`].
+///
+/// After `flush_and_close_unsafe` returns all pointers are zeroed; subsequent
+/// calls to any method are safe no-ops (Drop will be a no-op too).
+pub(crate) struct MuxerCore {
+    pub(crate) out_ctx: *mut AVFormatContext,
+    pub(crate) vid_enc_ctx: *mut AVCodecContext,
+    /// Null when audio is not configured (optional for HLS/DASH).
+    pub(crate) aud_enc_ctx: *mut AVCodecContext,
+    /// Null until first `push_audio_unsafe` call; recreated if input format changes.
+    pub(crate) swr_ctx: *mut SwrContext,
+    /// Null until swscale is needed; recreated if source dimensions/format change.
+    pub(crate) sws_ctx: *mut SwsContext,
+    pub(crate) vid_enc_frame: *mut AVFrame,
+    pub(crate) aud_enc_frame: *mut AVFrame,
+    pub(crate) vid_out_stream_idx: i32,
+    /// `-1` when audio is not configured.
+    pub(crate) aud_out_stream_idx: i32,
+    pub(crate) video_frame_count: u64,
+    pub(crate) audio_pts: i64,
+    pub(crate) fps_int: i32,
+    pub(crate) enc_width: i32,
+    pub(crate) enc_height: i32,
+    /// AAC encoder `frame_size` (typically 1024); set after `avcodec_open2`.
+    pub(crate) aud_frame_size: i32,
+    pub(crate) aud_sample_rate: i32,
+    /// Tracks the last swscale source so we can detect changes.
+    pub(crate) last_sws_src_fmt: Option<AVPixelFormat>,
+    pub(crate) last_sws_src_w: Option<i32>,
+    pub(crate) last_sws_src_h: Option<i32>,
+    /// Tracks the last swr input so we can detect format changes.
+    pub(crate) last_swr_in_fmt: Option<AVSampleFormat>,
+    pub(crate) last_swr_in_rate: Option<i32>,
+    pub(crate) last_swr_in_channels: Option<i32>,
+    /// Human-readable protocol prefix used in log messages (e.g. `"rtmp"`, `"live_hls"`).
+    pub(crate) log_prefix: &'static str,
+    /// When `true`, `flush_and_close_unsafe` and `free_all` close `out_ctx.pb`
+    /// before freeing the format context.
+    ///
+    /// Set to `true` for RTMP/SRT (pb is kept open for streaming after the header
+    /// write). Set to `false` for LiveHLS/LiveDASH (pb is closed immediately after
+    /// `avformat_write_header` so the muxer can manage its own avio handles).
+    pub(crate) close_pb_after_trailer: bool,
+}
+
+// SAFETY: MuxerCore exclusively owns all raw FFmpeg pointers. FFmpeg contexts
+// are not safe for concurrent access, but transferring ownership between threads
+// is safe (no shared state).
+unsafe impl Send for MuxerCore {}
+
+impl MuxerCore {
+    /// Allocate encoder frames and initialise tracking state.
+    ///
+    /// Called by each inner `open_unsafe` after the format context, encoder
+    /// contexts, and output streams are fully configured.
+    ///
+    /// # Safety
+    ///
+    /// - `out_ctx` and `vid_enc_ctx` must be non-null and valid.
+    /// - `aud_enc_ctx` may be null (audio is optional for HLS/DASH outputs).
+    /// - On `Err` the caller is responsible for freeing its own contexts;
+    ///   `MuxerCore` does not free them in this case.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) unsafe fn new(
+        out_ctx: *mut AVFormatContext,
+        vid_enc_ctx: *mut AVCodecContext,
+        aud_enc_ctx: *mut AVCodecContext,
+        vid_out_stream_idx: i32,
+        aud_out_stream_idx: i32,
+        fps_int: i32,
+        enc_width: i32,
+        enc_height: i32,
+        aud_frame_size: i32,
+        aud_sample_rate: i32,
+        log_prefix: &'static str,
+        close_pb_after_trailer: bool,
+    ) -> Result<Self, StreamError> {
+        let vid_enc_frame = av_frame_alloc();
+        let aud_enc_frame = av_frame_alloc();
+
+        if vid_enc_frame.is_null() || aud_enc_frame.is_null() {
+            if !vid_enc_frame.is_null() {
+                av_frame_free(&mut (vid_enc_frame as *mut _));
+            }
+            if !aud_enc_frame.is_null() {
+                av_frame_free(&mut (aud_enc_frame as *mut _));
+            }
+            return Err(ffmpeg_err_msg("cannot allocate encoder frames"));
+        }
+
+        Ok(Self {
+            out_ctx,
+            vid_enc_ctx,
+            aud_enc_ctx,
+            swr_ctx: ptr::null_mut(),
+            sws_ctx: ptr::null_mut(),
+            vid_enc_frame,
+            aud_enc_frame,
+            vid_out_stream_idx,
+            aud_out_stream_idx,
+            video_frame_count: 0,
+            audio_pts: 0,
+            fps_int,
+            enc_width,
+            enc_height,
+            aud_frame_size,
+            aud_sample_rate,
+            last_sws_src_fmt: None,
+            last_sws_src_w: None,
+            last_sws_src_h: None,
+            last_swr_in_fmt: None,
+            last_swr_in_rate: None,
+            last_swr_in_channels: None,
+            log_prefix,
+            close_pb_after_trailer,
+        })
+    }
+
+    /// Encode and mux one video frame.
+    ///
+    /// # Safety
+    ///
+    /// `self` must have been initialised by the enclosing inner type's
+    /// `open_unsafe` and must not yet be finished.
+    pub(crate) unsafe fn push_video_unsafe(
+        &mut self,
+        frame: &VideoFrame,
+    ) -> Result<(), StreamError> {
+        let src_fmt = pixel_format_to_av(frame.format());
+        let src_w = frame.width() as i32;
+        let src_h = frame.height() as i32;
+        let needs_conversion = src_fmt != AVPixelFormat_AV_PIX_FMT_YUV420P
+            || src_w != self.enc_width
+            || src_h != self.enc_height
+            || src_fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_NONE;
+
+        if needs_conversion {
+            // (Re)create SwsContext when source properties change.
+            if self.last_sws_src_fmt != Some(src_fmt)
+                || self.last_sws_src_w != Some(src_w)
+                || self.last_sws_src_h != Some(src_h)
+            {
+                if !self.sws_ctx.is_null() {
+                    ff_sys::swscale::free_context(self.sws_ctx);
+                    self.sws_ctx = ptr::null_mut();
+                }
+                match ff_sys::swscale::get_context(
+                    src_w,
+                    src_h,
+                    src_fmt,
+                    self.enc_width,
+                    self.enc_height,
+                    AVPixelFormat_AV_PIX_FMT_YUV420P,
+                    ff_sys::swscale::scale_flags::BILINEAR,
+                ) {
+                    Ok(ctx) => {
+                        self.sws_ctx = ctx;
+                        self.last_sws_src_fmt = Some(src_fmt);
+                        self.last_sws_src_w = Some(src_w);
+                        self.last_sws_src_h = Some(src_h);
+                    }
+                    Err(_) => {
+                        return Err(ffmpeg_err_msg(&format!(
+                            "{} swscale context creation failed for video frame",
+                            self.log_prefix
+                        )));
+                    }
+                }
+            }
+
+            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
+            (*self.vid_enc_frame).width = self.enc_width;
+            (*self.vid_enc_frame).height = self.enc_height;
+            self.set_vid_enc_pts();
+
+            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
+            if buf_ret < 0 {
+                av_frame_unref(self.vid_enc_frame);
+                return Err(ffmpeg_err(buf_ret));
+            }
+
+            // Build source plane/linesize arrays from the VideoFrame.
+            let planes = frame.planes();
+            let strides = frame.strides();
+            let mut src_data = [ptr::null::<u8>(); 8];
+            let mut src_linesize = [0i32; 8];
+            for (i, (plane, &stride)) in planes.iter().zip(strides.iter()).enumerate().take(8) {
+                src_data[i] = plane.as_ref().as_ptr();
+                src_linesize[i] = stride as i32;
+            }
+
+            ff_sys::swscale::scale(
+                self.sws_ctx,
+                src_data.as_ptr(),
+                src_linesize.as_ptr(),
+                0,
+                src_h,
+                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
+                (*self.vid_enc_frame).linesize.as_mut_ptr(),
+            )
+            .map_err(|_| {
+                ffmpeg_err_msg(&format!("{} swscale conversion failed", self.log_prefix))
+            })?;
+        } else {
+            // Same format and dimensions — copy planes directly.
+            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
+            (*self.vid_enc_frame).width = self.enc_width;
+            (*self.vid_enc_frame).height = self.enc_height;
+            self.set_vid_enc_pts();
+
+            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
+            if buf_ret < 0 {
+                av_frame_unref(self.vid_enc_frame);
+                return Err(ffmpeg_err(buf_ret));
+            }
+
+            // Copy Y/U/V planes line-by-line.
+            let planes = frame.planes();
+            let strides = frame.strides();
+            for (plane_idx, (src_plane, &src_stride)) in
+                planes.iter().zip(strides.iter()).enumerate().take(3)
+            {
+                let dst_stride = (*self.vid_enc_frame).linesize[plane_idx] as usize;
+                let dst_ptr = (*self.vid_enc_frame).data[plane_idx];
+                if dst_ptr.is_null() {
+                    continue;
+                }
+                let rows = if plane_idx == 0 {
+                    self.enc_height as usize
+                } else {
+                    (self.enc_height as usize).div_ceil(2)
+                };
+                let copy_width = dst_stride.min(src_stride);
+                let src_bytes: &[u8] = src_plane.as_ref();
+                for row in 0..rows {
+                    let src_off = row * src_stride;
+                    let dst_off = row * dst_stride;
+                    if src_off + copy_width > src_bytes.len() {
+                        break;
+                    }
+                    // SAFETY: dst_ptr + dst_off is within the allocated frame buffer.
+                    ptr::copy_nonoverlapping(
+                        src_bytes.as_ptr().add(src_off),
+                        dst_ptr.add(dst_off),
+                        copy_width,
+                    );
+                }
+            }
+        }
+
+        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
+            // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
+            drain_encoder(
+                self.vid_enc_ctx,
+                self.out_ctx,
+                self.vid_out_stream_idx,
+                self.log_prefix,
+                AVRational {
+                    num: 1,
+                    den: self.fps_int,
+                },
+            );
+        }
+
+        av_frame_unref(self.vid_enc_frame);
+        self.video_frame_count += 1;
+        Ok(())
+    }
+
+    /// Encode and mux one audio frame.
+    ///
+    /// Silently returns when audio is not configured (`aud_enc_ctx` is null or
+    /// `aud_out_stream_idx < 0`), making this safe to call for all output types.
+    ///
+    /// # Safety
+    ///
+    /// `self` must have been initialised by the enclosing inner type's
+    /// `open_unsafe` and must not yet be finished.
+    pub(crate) unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
+        if self.aud_enc_ctx.is_null() || self.aud_out_stream_idx < 0 {
+            return; // audio not configured
+        }
+
+        let in_fmt = sample_format_to_av(frame.format());
+        let in_rate = frame.sample_rate() as i32;
+        let in_channels = frame.channels() as i32;
+
+        // (Re)create SwrContext when input parameters change.
+        if self.last_swr_in_fmt != Some(in_fmt)
+            || self.last_swr_in_rate != Some(in_rate)
+            || self.last_swr_in_channels != Some(in_channels)
+        {
+            if !self.swr_ctx.is_null() {
+                let mut swr_tmp = self.swr_ctx;
+                ff_sys::swresample::free(&mut swr_tmp);
+                self.swr_ctx = ptr::null_mut();
+            }
+
+            let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
+            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
+
+            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
+                enc_ch_layout,
+                ff_sys::swresample::sample_format::FLTP,
+                self.aud_sample_rate,
+                &in_layout,
+                in_fmt,
+                in_rate,
+            ) {
+                if ff_sys::swresample::init(ctx).is_ok() {
+                    self.swr_ctx = ctx;
+                    self.last_swr_in_fmt = Some(in_fmt);
+                    self.last_swr_in_rate = Some(in_rate);
+                    self.last_swr_in_channels = Some(in_channels);
+                } else {
+                    let mut swr_tmp = ctx;
+                    ff_sys::swresample::free(&mut swr_tmp);
+                    log::warn!("{} swr init failed, dropping audio frame", self.log_prefix);
+                    return;
+                }
+            } else {
+                log::warn!("{} swr alloc failed, dropping audio frame", self.log_prefix);
+                return;
+            }
+        }
+
+        // Prepare the encoder frame.
+        (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
+        (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
+        (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
+        let _ = ff_sys::swresample::channel_layout::copy(
+            &mut (*self.aud_enc_frame).ch_layout,
+            &(*self.aud_enc_ctx).ch_layout,
+        );
+
+        let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
+        if buf_ret < 0 {
+            av_frame_unref(self.aud_enc_frame);
+            return;
+        }
+
+        // Build input plane pointers from the AudioFrame.
+        let planes = frame.planes();
+        let mut in_data = [ptr::null::<u8>(); 8];
+        for (i, plane) in planes.iter().enumerate().take(8) {
+            in_data[i] = plane.as_ptr();
+        }
+
+        let samples_out = ff_sys::swresample::convert(
+            self.swr_ctx,
+            (*self.aud_enc_frame).data.as_mut_ptr(),
+            self.aud_frame_size,
+            in_data.as_ptr(),
+            frame.samples() as i32,
+        );
+
+        if let Ok(n) = samples_out
+            && n > 0
+        {
+            (*self.aud_enc_frame).nb_samples = n;
+            (*self.aud_enc_frame).pts = self.audio_pts;
+            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
+                let aud_frame_period = AVRational {
+                    num: (*self.aud_enc_ctx).frame_size,
+                    den: (*self.aud_enc_ctx).sample_rate,
+                };
+                // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
+                drain_encoder(
+                    self.aud_enc_ctx,
+                    self.out_ctx,
+                    self.aud_out_stream_idx,
+                    self.log_prefix,
+                    aud_frame_period,
+                );
+            }
+            self.audio_pts += i64::from(n);
+        }
+
+        av_frame_unref(self.aud_enc_frame);
+    }
+
+    /// Flush both encoders, write the container trailer, and release all resources.
+    ///
+    /// For RTMP/SRT (`close_pb_after_trailer = true`) the persistent network
+    /// connection (`out_ctx.pb`) is closed after `av_write_trailer`.
+    /// For HLS/DASH (`close_pb_after_trailer = false`) `pb` was already closed
+    /// after the header write, so this is skipped.
+    ///
+    /// All pointers are zeroed after this call so that [`Drop`] is a no-op.
+    ///
+    /// # Safety
+    ///
+    /// `self` must have been initialised by the enclosing inner type's
+    /// `open_unsafe`. This method must be called at most once.
+    pub(crate) unsafe fn flush_and_close_unsafe(&mut self) {
+        // ── Flush video encoder ───────────────────────────────────────────────
+        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
+        drain_encoder(
+            self.vid_enc_ctx,
+            self.out_ctx,
+            self.vid_out_stream_idx,
+            self.log_prefix,
+            AVRational {
+                num: 1,
+                den: self.fps_int,
+            },
+        );
+
+        // ── Flush audio encoder ───────────────────────────────────────────────
+        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
+            // Drain any remaining resampler buffered samples.
+            if !self.swr_ctx.is_null() {
+                (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
+                (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
+                (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
+                let _ = ff_sys::swresample::channel_layout::copy(
+                    &mut (*self.aud_enc_frame).ch_layout,
+                    &(*self.aud_enc_ctx).ch_layout,
+                );
+
+                if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
+                    if let Ok(n) = ff_sys::swresample::convert(
+                        self.swr_ctx,
+                        (*self.aud_enc_frame).data.as_mut_ptr(),
+                        self.aud_frame_size,
+                        ptr::null(),
+                        0,
+                    ) && n > 0
+                    {
+                        (*self.aud_enc_frame).nb_samples = n;
+                        (*self.aud_enc_frame).pts = self.audio_pts;
+                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
+                        {
+                            let aud_frame_period = AVRational {
+                                num: (*self.aud_enc_ctx).frame_size,
+                                den: (*self.aud_enc_ctx).sample_rate,
+                            };
+                            drain_encoder(
+                                self.aud_enc_ctx,
+                                self.out_ctx,
+                                self.aud_out_stream_idx,
+                                self.log_prefix,
+                                aud_frame_period,
+                            );
+                        }
+                    }
+                    av_frame_unref(self.aud_enc_frame);
+                }
+            }
+
+            // Flush the AAC encoder itself.
+            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
+            let aud_frame_period = AVRational {
+                num: (*self.aud_enc_ctx).frame_size,
+                den: (*self.aud_enc_ctx).sample_rate,
+            };
+            drain_encoder(
+                self.aud_enc_ctx,
+                self.out_ctx,
+                self.aud_out_stream_idx,
+                self.log_prefix,
+                aud_frame_period,
+            );
+        }
+
+        // ── Write trailer ─────────────────────────────────────────────────────
+        av_write_trailer(self.out_ctx);
+
+        // For RTMP/SRT the connection (pb) was kept open throughout the session
+        // and must be closed now. For HLS/DASH pb was already closed after the
+        // header write, so closing it here would be a double-close.
+        if self.close_pb_after_trailer && !(*self.out_ctx).pb.is_null() {
+            ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
+        }
+
+        log::info!("{} output finished", self.log_prefix);
+
+        // Zero all pointers so Drop does not double-free.
+        self.free_all();
+    }
+
+    /// Set the PTS on `vid_enc_frame` from `video_frame_count` and `fps_int`.
+    ///
+    /// # Safety
+    ///
+    /// `vid_enc_frame` and `vid_enc_ctx` must be valid non-null pointers.
+    unsafe fn set_vid_enc_pts(&mut self) {
+        (*self.vid_enc_frame).pts = av_rescale_q(
+            self.video_frame_count as i64,
+            AVRational {
+                num: 1,
+                den: self.fps_int,
+            },
+            (*self.vid_enc_ctx).time_base,
+        );
+    }
+
+    /// Free all owned `FFmpeg` contexts and zero the pointers.
+    ///
+    /// Each pointer is checked for null before freeing. After this call all
+    /// pointers are null, so a second call is a no-op.
+    ///
+    /// For RTMP/SRT (`close_pb_after_trailer = true`) closes `out_ctx.pb`
+    /// before freeing `out_ctx` — handles the abnormal Drop path where
+    /// `flush_and_close_unsafe` was never called.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called when no other reference to the contained pointers exists.
+    unsafe fn free_all(&mut self) {
+        if !self.sws_ctx.is_null() {
+            ff_sys::swscale::free_context(self.sws_ctx);
+            self.sws_ctx = ptr::null_mut();
+        }
+        if !self.swr_ctx.is_null() {
+            let mut swr_tmp = self.swr_ctx;
+            ff_sys::swresample::free(&mut swr_tmp);
+            self.swr_ctx = ptr::null_mut();
+        }
+        if !self.vid_enc_frame.is_null() {
+            av_frame_free(&mut (self.vid_enc_frame as *mut _));
+            self.vid_enc_frame = ptr::null_mut();
+        }
+        if !self.aud_enc_frame.is_null() {
+            av_frame_free(&mut (self.aud_enc_frame as *mut _));
+            self.aud_enc_frame = ptr::null_mut();
+        }
+        if !self.aud_enc_ctx.is_null() {
+            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
+            self.aud_enc_ctx = ptr::null_mut();
+        }
+        if !self.vid_enc_ctx.is_null() {
+            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
+            self.vid_enc_ctx = ptr::null_mut();
+        }
+        if !self.out_ctx.is_null() {
+            // For RTMP/SRT: close pb if still open (Drop path where
+            // flush_and_close_unsafe was not called).
+            if self.close_pb_after_trailer && !(*self.out_ctx).pb.is_null() {
+                ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
+            }
+            avformat_free_context(self.out_ctx);
+            self.out_ctx = ptr::null_mut();
+        }
+    }
+}
+
+impl Drop for MuxerCore {
+    fn drop(&mut self) {
+        // SAFETY: free_all checks each pointer for null before freeing.
+        // flush_and_close_unsafe already zeroed all pointers on the success path,
+        // so this is a safe no-op in the normal case.
+        unsafe {
+            self.free_all();
+        }
+    }
+}

--- a/crates/ff-stream/src/rtmp_inner.rs
+++ b/crates/ff-stream/src/rtmp_inner.rs
@@ -1,8 +1,8 @@
 //! Internal RTMP state — all `unsafe` `FFmpeg` calls live here.
 //!
-//! [`RtmpInner`] owns all raw `FFmpeg` contexts and the RTMP network
-//! connection. It is created by [`crate::rtmp::RtmpOutput::build`] and driven
-//! by the safe wrappers in [`crate::rtmp`].
+//! [`RtmpInner`] owns a [`MuxerCore`] and the RTMP URL. It is created by
+//! [`crate::rtmp::RtmpOutput::build`] and driven by the safe wrappers in
+//! [`crate::rtmp`].
 //!
 //! Unlike the HLS/DASH muxers, the RTMP connection (`out_ctx->pb`) is kept
 //! open for the entire session and is only closed after [`av_write_trailer`]
@@ -22,103 +22,30 @@ use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
-use ff_format::{AudioFrame, PixelFormat, SampleFormat, VideoFrame};
+use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, SwrContext, SwsContext,
-    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref, av_rescale_q,
-    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_alloc_output_context2, avformat_free_context,
+    avformat_new_stream, avformat_write_header,
 };
 
-use crate::codec_utils::{drain_encoder, ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
+use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
 use crate::error::StreamError;
-
-// ============================================================================
-// Pixel-format conversion (local — ff-format has no FFmpeg dependency)
-// ============================================================================
-
-fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
-    match fmt {
-        PixelFormat::Yuv420p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P,
-        PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
-        PixelFormat::Yuv444p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P,
-        PixelFormat::Rgb24 => ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24,
-        PixelFormat::Bgr24 => ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24,
-        PixelFormat::Rgba => ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA,
-        PixelFormat::Bgra => ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA,
-        PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
-        PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
-        PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
-        PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
-        PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
-        PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
-        PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
-        PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
-        PixelFormat::Gbrpf32le => ff_sys::AVPixelFormat_AV_PIX_FMT_GBRPF32LE,
-        PixelFormat::Other(_) | _ => AVPixelFormat_AV_PIX_FMT_NONE,
-    }
-}
-
-fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
-    match fmt {
-        SampleFormat::U8 => ff_sys::swresample::sample_format::U8,
-        SampleFormat::I16 => ff_sys::swresample::sample_format::S16,
-        SampleFormat::I32 => ff_sys::swresample::sample_format::S32,
-        SampleFormat::F32 => ff_sys::swresample::sample_format::FLT,
-        SampleFormat::F64 => ff_sys::swresample::sample_format::DBL,
-        SampleFormat::U8p => ff_sys::swresample::sample_format::U8P,
-        SampleFormat::I16p => ff_sys::swresample::sample_format::S16P,
-        SampleFormat::I32p => ff_sys::swresample::sample_format::S32P,
-        SampleFormat::F32p => ff_sys::swresample::sample_format::FLTP,
-        SampleFormat::F64p => ff_sys::swresample::sample_format::DBLP,
-        SampleFormat::Other(_) | _ => ff_sys::swresample::sample_format::NONE,
-    }
-}
+use crate::muxer_core::MuxerCore;
 
 // ============================================================================
 // RtmpInner
 // ============================================================================
 
-/// Owns all raw `FFmpeg` contexts and the RTMP network connection.
+/// Owns the shared `FFmpeg` muxer state for the RTMP output session.
 ///
 /// Created by [`RtmpInner::open`]; consumed by [`RtmpInner::flush_and_close`].
 /// After `flush_and_close` returns, calling any other method is undefined behaviour;
 /// the safe wrapper in `rtmp.rs` prevents this via the `finished` guard.
 pub(crate) struct RtmpInner {
-    out_ctx: *mut AVFormatContext,
-    vid_enc_ctx: *mut AVCodecContext,
-    aud_enc_ctx: *mut AVCodecContext,
-    /// Null until first `push_audio` call; recreated if input format changes.
-    swr_ctx: *mut SwrContext,
-    /// Null until swscale is needed; recreated if source dimensions/format change.
-    sws_ctx: *mut SwsContext,
-    vid_enc_frame: *mut AVFrame,
-    aud_enc_frame: *mut AVFrame,
-    vid_out_stream_idx: i32,
-    aud_out_stream_idx: i32,
-    video_frame_count: u64,
-    audio_pts: i64,
-    fps_int: i32,
-    enc_width: i32,
-    enc_height: i32,
-    /// AAC encoder `frame_size` (typically 1024); set after `avcodec_open2`.
-    aud_frame_size: i32,
-    aud_sample_rate: i32,
-    url: String,
-    /// Tracks the last swscale source so we can detect changes.
-    last_sws_src_fmt: Option<AVPixelFormat>,
-    last_sws_src_w: Option<i32>,
-    last_sws_src_h: Option<i32>,
-    /// Tracks the last swr input so we can detect format changes.
-    last_swr_in_fmt: Option<AVSampleFormat>,
-    last_swr_in_rate: Option<i32>,
-    last_swr_in_channels: Option<i32>,
+    core: MuxerCore,
 }
 
-// SAFETY: RtmpInner exclusively owns all FFmpeg contexts.
-// FFmpeg contexts are not safe for concurrent access, but ownership transfer
-// between threads is safe (there is no shared state).
+// SAFETY: RtmpInner exclusively owns all FFmpeg contexts via MuxerCore.
 unsafe impl Send for RtmpInner {}
 
 impl RtmpInner {
@@ -160,14 +87,14 @@ impl RtmpInner {
     /// Encode and mux one video frame.
     pub(crate) fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
         // SAFETY: self was initialised by open() and is not yet finished.
-        unsafe { self.push_video_unsafe(frame) }
+        unsafe { self.core.push_video_unsafe(frame) }
     }
 
     /// Encode and mux one audio frame.
     pub(crate) fn push_audio(&mut self, frame: &AudioFrame) {
         // SAFETY: self was initialised by open() and is not yet finished.
         unsafe {
-            self.push_audio_unsafe(frame);
+            self.core.push_audio_unsafe(frame);
         }
     }
 
@@ -176,7 +103,7 @@ impl RtmpInner {
     pub(crate) fn flush_and_close(mut self) {
         // SAFETY: self was initialised by open(); flush_and_close is called once.
         unsafe {
-            self.flush_and_close_unsafe();
+            self.core.flush_and_close_unsafe();
         }
     }
 
@@ -199,7 +126,7 @@ impl RtmpInner {
         // ── 1. Allocate FLV output context with RTMP URL ───────────────────
         let c_url = CString::new(url).map_err(|_| ffmpeg_err_msg("RTMP URL contains null byte"))?;
 
-        let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
+        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
         let ret = avformat_alloc_output_context2(
             &mut out_ctx,
             ptr::null_mut(),
@@ -292,31 +219,12 @@ impl RtmpInner {
             log::warn!("rtmp audio stream codecpar copy failed");
         }
 
-        // ── 6. Allocate encoder frames ─────────────────────────────────────
-        let vid_enc_frame = av_frame_alloc();
-        let aud_enc_frame = av_frame_alloc();
-
-        if vid_enc_frame.is_null() || aud_enc_frame.is_null() {
-            if !vid_enc_frame.is_null() {
-                av_frame_free(&mut (vid_enc_frame as *mut _));
-            }
-            if !aud_enc_frame.is_null() {
-                av_frame_free(&mut (aud_enc_frame as *mut _));
-            }
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err_msg("cannot allocate encoder frames"));
-        }
-
-        // ── 7. Open RTMP connection and write FLV header ───────────────────
+        // ── 6. Open RTMP connection and write FLV header ───────────────────
         // Unlike HLS/DASH, RTMP uses a persistent network connection.
         // We use avio_open via avformat::open_output with the URL as the path.
         // SAFETY: url is a valid null-terminated C string (validated above).
         let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
             .map_err(|e| {
-                av_frame_free(&mut (aud_enc_frame as *mut _));
-                av_frame_free(&mut (vid_enc_frame as *mut _));
                 ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
                 ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
                 avformat_free_context(out_ctx);
@@ -327,8 +235,6 @@ impl RtmpInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            av_frame_free(&mut (aud_enc_frame as *mut _));
-            av_frame_free(&mut (vid_enc_frame as *mut _));
             ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
@@ -343,424 +249,27 @@ impl RtmpInner {
              bitrate={video_bitrate}bps"
         );
 
-        Ok(Self {
+        // ── 7. Build MuxerCore ─────────────────────────────────────────────
+        let core = MuxerCore::new(
             out_ctx,
             vid_enc_ctx,
             aud_enc_ctx,
-            swr_ctx: ptr::null_mut(),
-            sws_ctx: ptr::null_mut(),
-            vid_enc_frame,
-            aud_enc_frame,
             vid_out_stream_idx,
             aud_out_stream_idx,
-            video_frame_count: 0,
-            audio_pts: 0,
             fps_int,
             enc_width,
             enc_height,
             aud_frame_size,
             aud_sample_rate,
-            url: url.to_owned(),
-            last_sws_src_fmt: None,
-            last_sws_src_w: None,
-            last_sws_src_h: None,
-            last_swr_in_fmt: None,
-            last_swr_in_rate: None,
-            last_swr_in_channels: None,
-        })
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_video_unsafe(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        let src_fmt = pixel_format_to_av(frame.format());
-        let src_w = frame.width() as i32;
-        let src_h = frame.height() as i32;
-        let needs_conversion = src_fmt != AVPixelFormat_AV_PIX_FMT_YUV420P
-            || src_w != self.enc_width
-            || src_h != self.enc_height
-            || src_fmt == AVPixelFormat_AV_PIX_FMT_NONE;
-
-        if needs_conversion {
-            // (Re)create SwsContext when source properties change.
-            if self.last_sws_src_fmt != Some(src_fmt)
-                || self.last_sws_src_w != Some(src_w)
-                || self.last_sws_src_h != Some(src_h)
-            {
-                if !self.sws_ctx.is_null() {
-                    ff_sys::swscale::free_context(self.sws_ctx);
-                    self.sws_ctx = ptr::null_mut();
-                }
-                match ff_sys::swscale::get_context(
-                    src_w,
-                    src_h,
-                    src_fmt,
-                    self.enc_width,
-                    self.enc_height,
-                    AVPixelFormat_AV_PIX_FMT_YUV420P,
-                    ff_sys::swscale::scale_flags::BILINEAR,
-                ) {
-                    Ok(ctx) => {
-                        self.sws_ctx = ctx;
-                        self.last_sws_src_fmt = Some(src_fmt);
-                        self.last_sws_src_w = Some(src_w);
-                        self.last_sws_src_h = Some(src_h);
-                    }
-                    Err(_) => {
-                        return Err(ffmpeg_err_msg(
-                            "rtmp swscale context creation failed for video frame",
-                        ));
-                    }
-                }
-            }
-
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Build source plane/linesize arrays from the VideoFrame.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            let mut src_data = [ptr::null::<u8>(); 8];
-            let mut src_linesize = [0i32; 8];
-            for (i, (plane, &stride)) in planes.iter().zip(strides.iter()).enumerate().take(8) {
-                src_data[i] = plane.as_ref().as_ptr();
-                src_linesize[i] = stride as i32;
-            }
-
-            ff_sys::swscale::scale(
-                self.sws_ctx,
-                src_data.as_ptr(),
-                src_linesize.as_ptr(),
-                0,
-                src_h,
-                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
-                (*self.vid_enc_frame).linesize.as_mut_ptr(),
-            )
-            .map_err(|_| ffmpeg_err_msg("rtmp swscale conversion failed"))?;
-        } else {
-            // Same format and dimensions — copy planes directly.
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Copy Y/U/V planes line-by-line.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            for (plane_idx, (src_plane, &src_stride)) in
-                planes.iter().zip(strides.iter()).enumerate().take(3)
-            {
-                let dst_stride = (*self.vid_enc_frame).linesize[plane_idx] as usize;
-                let dst_ptr = (*self.vid_enc_frame).data[plane_idx];
-                if dst_ptr.is_null() {
-                    continue;
-                }
-                let rows = if plane_idx == 0 {
-                    self.enc_height as usize
-                } else {
-                    (self.enc_height as usize).div_ceil(2)
-                };
-                let copy_width = dst_stride.min(src_stride);
-                let src_bytes: &[u8] = src_plane.as_ref();
-                for row in 0..rows {
-                    let src_off = row * src_stride;
-                    let dst_off = row * dst_stride;
-                    if src_off + copy_width > src_bytes.len() {
-                        break;
-                    }
-                    // SAFETY: dst_ptr + dst_off is within the allocated frame buffer.
-                    ptr::copy_nonoverlapping(
-                        src_bytes.as_ptr().add(src_off),
-                        dst_ptr.add(dst_off),
-                        copy_width,
-                    );
-                }
-            }
-        }
-
-        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
-            // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
-            drain_encoder(
-                self.vid_enc_ctx,
-                self.out_ctx,
-                self.vid_out_stream_idx,
-                "rtmp",
-                AVRational {
-                    num: 1,
-                    den: self.fps_int,
-                },
-            );
-        }
-
-        av_frame_unref(self.vid_enc_frame);
-        self.video_frame_count += 1;
-        Ok(())
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
-        let in_fmt = sample_format_to_av(frame.format());
-        let in_rate = frame.sample_rate() as i32;
-        let in_channels = frame.channels() as i32;
-
-        // (Re)create SwrContext when input parameters change.
-        if self.last_swr_in_fmt != Some(in_fmt)
-            || self.last_swr_in_rate != Some(in_rate)
-            || self.last_swr_in_channels != Some(in_channels)
-        {
-            if !self.swr_ctx.is_null() {
-                let mut swr_tmp = self.swr_ctx;
-                ff_sys::swresample::free(&mut swr_tmp);
-                self.swr_ctx = ptr::null_mut();
-            }
-
-            let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
-            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
-
-            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
-                enc_ch_layout,
-                ff_sys::swresample::sample_format::FLTP,
-                self.aud_sample_rate,
-                &in_layout,
-                in_fmt,
-                in_rate,
-            ) {
-                if ff_sys::swresample::init(ctx).is_ok() {
-                    self.swr_ctx = ctx;
-                    self.last_swr_in_fmt = Some(in_fmt);
-                    self.last_swr_in_rate = Some(in_rate);
-                    self.last_swr_in_channels = Some(in_channels);
-                } else {
-                    let mut swr_tmp = ctx;
-                    ff_sys::swresample::free(&mut swr_tmp);
-                    log::warn!("rtmp swr init failed, dropping audio frame");
-                    return;
-                }
-            } else {
-                log::warn!("rtmp swr alloc failed, dropping audio frame");
-                return;
-            }
-        }
-
-        // Prepare the encoder frame.
-        (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-        (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-        (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-        let _ = ff_sys::swresample::channel_layout::copy(
-            &mut (*self.aud_enc_frame).ch_layout,
-            &(*self.aud_enc_ctx).ch_layout,
-        );
-
-        let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
-        if buf_ret < 0 {
-            av_frame_unref(self.aud_enc_frame);
-            return;
-        }
-
-        // Build input plane pointers from the AudioFrame.
-        let planes = frame.planes();
-        let mut in_data = [ptr::null::<u8>(); 8];
-        for (i, plane) in planes.iter().enumerate().take(8) {
-            in_data[i] = plane.as_ptr();
-        }
-
-        let samples_out = ff_sys::swresample::convert(
-            self.swr_ctx,
-            (*self.aud_enc_frame).data.as_mut_ptr(),
-            self.aud_frame_size,
-            in_data.as_ptr(),
-            frame.samples() as i32,
-        );
-
-        if let Ok(n) = samples_out
-            && n > 0
-        {
-            (*self.aud_enc_frame).nb_samples = n;
-            (*self.aud_enc_frame).pts = self.audio_pts;
-            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
-                let aud_frame_period = AVRational {
-                    num: (*self.aud_enc_ctx).frame_size,
-                    den: (*self.aud_enc_ctx).sample_rate,
-                };
-                // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
-                drain_encoder(
-                    self.aud_enc_ctx,
-                    self.out_ctx,
-                    self.aud_out_stream_idx,
-                    "rtmp",
-                    aud_frame_period,
-                );
-            }
-            self.audio_pts += i64::from(n);
-        }
-
-        av_frame_unref(self.aud_enc_frame);
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn flush_and_close_unsafe(&mut self) {
-        // ── Flush video encoder ───────────────────────────────────────────────
-        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
-        drain_encoder(
-            self.vid_enc_ctx,
-            self.out_ctx,
-            self.vid_out_stream_idx,
             "rtmp",
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-        );
+            true, // close_pb_after_trailer: pb stays open for streaming
+        )
+        .inspect_err(|_| {
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+        })?;
 
-        // ── Flush audio encoder ───────────────────────────────────────────────
-        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
-            // Drain any remaining resampler buffered samples.
-            if !self.swr_ctx.is_null() {
-                (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-                (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-                (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-                let _ = ff_sys::swresample::channel_layout::copy(
-                    &mut (*self.aud_enc_frame).ch_layout,
-                    &(*self.aud_enc_ctx).ch_layout,
-                );
-
-                if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
-                    if let Ok(n) = ff_sys::swresample::convert(
-                        self.swr_ctx,
-                        (*self.aud_enc_frame).data.as_mut_ptr(),
-                        self.aud_frame_size,
-                        ptr::null(),
-                        0,
-                    ) && n > 0
-                    {
-                        (*self.aud_enc_frame).nb_samples = n;
-                        (*self.aud_enc_frame).pts = self.audio_pts;
-                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
-                        {
-                            let aud_frame_period = AVRational {
-                                num: (*self.aud_enc_ctx).frame_size,
-                                den: (*self.aud_enc_ctx).sample_rate,
-                            };
-                            drain_encoder(
-                                self.aud_enc_ctx,
-                                self.out_ctx,
-                                self.aud_out_stream_idx,
-                                "rtmp",
-                                aud_frame_period,
-                            );
-                        }
-                    }
-                    av_frame_unref(self.aud_enc_frame);
-                }
-            }
-
-            // Flush the AAC encoder itself.
-            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
-            let aud_frame_period = AVRational {
-                num: (*self.aud_enc_ctx).frame_size,
-                den: (*self.aud_enc_ctx).sample_rate,
-            };
-            drain_encoder(
-                self.aud_enc_ctx,
-                self.out_ctx,
-                self.aud_out_stream_idx,
-                "rtmp",
-                aud_frame_period,
-            );
-        }
-
-        // ── Write FLV trailer ─────────────────────────────────────────────────
-        av_write_trailer(self.out_ctx);
-
-        // Close the RTMP connection. Unlike HLS/DASH, pb was kept open throughout
-        // the session and must be explicitly closed after av_write_trailer.
-        if !(*self.out_ctx).pb.is_null() {
-            ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
-        }
-
-        log::info!("rtmp output finished url={}", self.url);
-
-        // Zero all pointers so Drop does not double-free.
-        self.free_all();
-    }
-
-    // SAFETY: Callers must ensure self is not used again after this call.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn set_vid_enc_pts(&mut self) {
-        (*self.vid_enc_frame).pts = av_rescale_q(
-            self.video_frame_count as i64,
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-            (*self.vid_enc_ctx).time_base,
-        );
-    }
-
-    /// Free all owned `FFmpeg` contexts and zero the pointers.
-    ///
-    /// # Safety
-    ///
-    /// Each pointer is checked for null before freeing. After this call all
-    /// pointers are null, so a second call is a no-op.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn free_all(&mut self) {
-        if !self.sws_ctx.is_null() {
-            ff_sys::swscale::free_context(self.sws_ctx);
-            self.sws_ctx = ptr::null_mut();
-        }
-        if !self.swr_ctx.is_null() {
-            let mut swr_tmp = self.swr_ctx;
-            ff_sys::swresample::free(&mut swr_tmp);
-            self.swr_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_frame.is_null() {
-            av_frame_free(&mut (self.vid_enc_frame as *mut _));
-            self.vid_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_frame.is_null() {
-            av_frame_free(&mut (self.aud_enc_frame as *mut _));
-            self.aud_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
-            self.aud_enc_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
-            self.vid_enc_ctx = ptr::null_mut();
-        }
-        if !self.out_ctx.is_null() {
-            // Close pb if still open (Drop path, flush_and_close was not called).
-            if !(*self.out_ctx).pb.is_null() {
-                ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
-            }
-            avformat_free_context(self.out_ctx);
-            self.out_ctx = ptr::null_mut();
-        }
-    }
-}
-
-impl Drop for RtmpInner {
-    fn drop(&mut self) {
-        // SAFETY: free_all checks each pointer for null before freeing.
-        // flush_and_close already zeroed all pointers on the success path,
-        // so this is a safe no-op in the normal case.
-        unsafe {
-            self.free_all();
-        }
+        Ok(Self { core })
     }
 }

--- a/crates/ff-stream/src/srt_output_inner.rs
+++ b/crates/ff-stream/src/srt_output_inner.rs
@@ -1,8 +1,8 @@
 //! Internal SRT state — all `unsafe` `FFmpeg` calls live here.
 //!
-//! [`SrtInner`] owns all raw `FFmpeg` contexts and the SRT network
-//! connection. It is created by [`crate::srt_output::SrtOutput::build`] and
-//! driven by the safe wrappers in [`crate::srt_output`].
+//! [`SrtInner`] owns a [`MuxerCore`] and the SRT URL. It is created by
+//! [`crate::srt_output::SrtOutput::build`] and driven by the safe wrappers in
+//! [`crate::srt_output`].
 //!
 //! The MPEG-TS muxer writes to the SRT URL via `avio_open2`. The connection
 //! (`out_ctx->pb`) is kept open for the entire session and closed after
@@ -22,104 +22,31 @@ use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
-use ff_format::{AudioFrame, PixelFormat, SampleFormat, VideoFrame};
+use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, SwrContext, SwsContext,
-    av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref, av_rescale_q,
-    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_alloc_output_context2, avformat_free_context,
+    avformat_new_stream, avformat_write_header,
 };
 
-use crate::codec_utils::{drain_encoder, ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
+use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
 use crate::error::StreamError;
-
-// ============================================================================
-// Pixel-format and sample-format conversion
-// ============================================================================
-
-fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
-    match fmt {
-        PixelFormat::Yuv420p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P,
-        PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
-        PixelFormat::Yuv444p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P,
-        PixelFormat::Rgb24 => ff_sys::AVPixelFormat_AV_PIX_FMT_RGB24,
-        PixelFormat::Bgr24 => ff_sys::AVPixelFormat_AV_PIX_FMT_BGR24,
-        PixelFormat::Rgba => ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA,
-        PixelFormat::Bgra => ff_sys::AVPixelFormat_AV_PIX_FMT_BGRA,
-        PixelFormat::Nv12 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV12,
-        PixelFormat::Nv21 => ff_sys::AVPixelFormat_AV_PIX_FMT_NV21,
-        PixelFormat::Yuv420p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE,
-        PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
-        PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
-        PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
-        PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
-        PixelFormat::Gray8 => ff_sys::AVPixelFormat_AV_PIX_FMT_GRAY8,
-        PixelFormat::Gbrpf32le => ff_sys::AVPixelFormat_AV_PIX_FMT_GBRPF32LE,
-        PixelFormat::Other(_) | _ => AVPixelFormat_AV_PIX_FMT_NONE,
-    }
-}
-
-fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
-    match fmt {
-        SampleFormat::U8 => ff_sys::swresample::sample_format::U8,
-        SampleFormat::I16 => ff_sys::swresample::sample_format::S16,
-        SampleFormat::I32 => ff_sys::swresample::sample_format::S32,
-        SampleFormat::F32 => ff_sys::swresample::sample_format::FLT,
-        SampleFormat::F64 => ff_sys::swresample::sample_format::DBL,
-        SampleFormat::U8p => ff_sys::swresample::sample_format::U8P,
-        SampleFormat::I16p => ff_sys::swresample::sample_format::S16P,
-        SampleFormat::I32p => ff_sys::swresample::sample_format::S32P,
-        SampleFormat::F32p => ff_sys::swresample::sample_format::FLTP,
-        SampleFormat::F64p => ff_sys::swresample::sample_format::DBLP,
-        SampleFormat::Other(_) | _ => ff_sys::swresample::sample_format::NONE,
-    }
-}
+use crate::muxer_core::MuxerCore;
 
 // ============================================================================
 // SrtInner
 // ============================================================================
 
-/// Owns all raw `FFmpeg` contexts and the SRT network connection.
+/// Owns the shared `FFmpeg` muxer state for the SRT output session.
 ///
 /// Created by [`SrtInner::open`]; consumed by [`SrtInner::flush_and_close`].
 /// After `flush_and_close` returns, calling any other method is undefined
 /// behaviour; the safe wrapper in `srt_output.rs` prevents this via the
 /// `finished` guard.
 pub(crate) struct SrtInner {
-    out_ctx: *mut AVFormatContext,
-    vid_enc_ctx: *mut AVCodecContext,
-    aud_enc_ctx: *mut AVCodecContext,
-    /// Null until first `push_audio` call; recreated if input format changes.
-    swr_ctx: *mut SwrContext,
-    /// Null until swscale is needed; recreated if source dimensions/format change.
-    sws_ctx: *mut SwsContext,
-    vid_enc_frame: *mut AVFrame,
-    aud_enc_frame: *mut AVFrame,
-    vid_out_stream_idx: i32,
-    aud_out_stream_idx: i32,
-    video_frame_count: u64,
-    audio_pts: i64,
-    fps_int: i32,
-    enc_width: i32,
-    enc_height: i32,
-    /// AAC encoder `frame_size` (typically 1024); set after `avcodec_open2`.
-    aud_frame_size: i32,
-    aud_sample_rate: i32,
-    url: String,
-    /// Tracks the last swscale source so we can detect changes.
-    last_sws_src_fmt: Option<AVPixelFormat>,
-    last_sws_src_w: Option<i32>,
-    last_sws_src_h: Option<i32>,
-    /// Tracks the last swr input so we can detect format changes.
-    last_swr_in_fmt: Option<AVSampleFormat>,
-    last_swr_in_rate: Option<i32>,
-    last_swr_in_channels: Option<i32>,
+    core: MuxerCore,
 }
 
-// SAFETY: SrtInner exclusively owns all FFmpeg contexts.
-// FFmpeg contexts are not safe for concurrent access, but ownership transfer
-// between threads is safe (there is no shared state).
+// SAFETY: SrtInner exclusively owns all FFmpeg contexts via MuxerCore.
 unsafe impl Send for SrtInner {}
 
 impl SrtInner {
@@ -161,14 +88,14 @@ impl SrtInner {
     /// Encode and mux one video frame.
     pub(crate) fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
         // SAFETY: self was initialised by open() and is not yet finished.
-        unsafe { self.push_video_unsafe(frame) }
+        unsafe { self.core.push_video_unsafe(frame) }
     }
 
     /// Encode and mux one audio frame.
     pub(crate) fn push_audio(&mut self, frame: &AudioFrame) {
         // SAFETY: self was initialised by open() and is not yet finished.
         unsafe {
-            self.push_audio_unsafe(frame);
+            self.core.push_audio_unsafe(frame);
         }
     }
 
@@ -177,7 +104,7 @@ impl SrtInner {
     pub(crate) fn flush_and_close(mut self) {
         // SAFETY: self was initialised by open(); flush_and_close is called once.
         unsafe {
-            self.flush_and_close_unsafe();
+            self.core.flush_and_close_unsafe();
         }
     }
 
@@ -200,7 +127,7 @@ impl SrtInner {
         // ── 1. Allocate MPEG-TS output context with SRT URL ────────────────
         let c_url = CString::new(url).map_err(|_| ffmpeg_err_msg("SRT URL contains null byte"))?;
 
-        let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
+        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
         let ret = avformat_alloc_output_context2(
             &mut out_ctx,
             ptr::null_mut(),
@@ -293,31 +220,12 @@ impl SrtInner {
             log::warn!("srt audio stream codecpar copy failed");
         }
 
-        // ── 6. Allocate encoder frames ─────────────────────────────────────
-        let vid_enc_frame = av_frame_alloc();
-        let aud_enc_frame = av_frame_alloc();
-
-        if vid_enc_frame.is_null() || aud_enc_frame.is_null() {
-            if !vid_enc_frame.is_null() {
-                av_frame_free(&mut (vid_enc_frame as *mut _));
-            }
-            if !aud_enc_frame.is_null() {
-                av_frame_free(&mut (aud_enc_frame as *mut _));
-            }
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err_msg("cannot allocate encoder frames"));
-        }
-
-        // ── 7. Open SRT connection and write MPEG-TS header ────────────────
+        // ── 6. Open SRT connection and write MPEG-TS header ────────────────
         // SRT uses a persistent network connection like RTMP.
         // We use avio_open via avformat::open_output with the URL as the path.
         // SAFETY: url is a valid null-terminated C string (validated above).
         let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
             .map_err(|e| {
-                av_frame_free(&mut (aud_enc_frame as *mut _));
-                av_frame_free(&mut (vid_enc_frame as *mut _));
                 ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
                 ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
                 avformat_free_context(out_ctx);
@@ -328,8 +236,6 @@ impl SrtInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            av_frame_free(&mut (aud_enc_frame as *mut _));
-            av_frame_free(&mut (vid_enc_frame as *mut _));
             ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
             ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
@@ -344,424 +250,27 @@ impl SrtInner {
              bitrate={video_bitrate}bps"
         );
 
-        Ok(Self {
+        // ── 7. Build MuxerCore ─────────────────────────────────────────────
+        let core = MuxerCore::new(
             out_ctx,
             vid_enc_ctx,
             aud_enc_ctx,
-            swr_ctx: ptr::null_mut(),
-            sws_ctx: ptr::null_mut(),
-            vid_enc_frame,
-            aud_enc_frame,
             vid_out_stream_idx,
             aud_out_stream_idx,
-            video_frame_count: 0,
-            audio_pts: 0,
             fps_int,
             enc_width,
             enc_height,
             aud_frame_size,
             aud_sample_rate,
-            url: url.to_owned(),
-            last_sws_src_fmt: None,
-            last_sws_src_w: None,
-            last_sws_src_h: None,
-            last_swr_in_fmt: None,
-            last_swr_in_rate: None,
-            last_swr_in_channels: None,
-        })
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_video_unsafe(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        let src_fmt = pixel_format_to_av(frame.format());
-        let src_w = frame.width() as i32;
-        let src_h = frame.height() as i32;
-        let needs_conversion = src_fmt != AVPixelFormat_AV_PIX_FMT_YUV420P
-            || src_w != self.enc_width
-            || src_h != self.enc_height
-            || src_fmt == AVPixelFormat_AV_PIX_FMT_NONE;
-
-        if needs_conversion {
-            // (Re)create SwsContext when source properties change.
-            if self.last_sws_src_fmt != Some(src_fmt)
-                || self.last_sws_src_w != Some(src_w)
-                || self.last_sws_src_h != Some(src_h)
-            {
-                if !self.sws_ctx.is_null() {
-                    ff_sys::swscale::free_context(self.sws_ctx);
-                    self.sws_ctx = ptr::null_mut();
-                }
-                match ff_sys::swscale::get_context(
-                    src_w,
-                    src_h,
-                    src_fmt,
-                    self.enc_width,
-                    self.enc_height,
-                    AVPixelFormat_AV_PIX_FMT_YUV420P,
-                    ff_sys::swscale::scale_flags::BILINEAR,
-                ) {
-                    Ok(ctx) => {
-                        self.sws_ctx = ctx;
-                        self.last_sws_src_fmt = Some(src_fmt);
-                        self.last_sws_src_w = Some(src_w);
-                        self.last_sws_src_h = Some(src_h);
-                    }
-                    Err(_) => {
-                        return Err(ffmpeg_err_msg(
-                            "srt swscale context creation failed for video frame",
-                        ));
-                    }
-                }
-            }
-
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Build source plane/linesize arrays from the VideoFrame.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            let mut src_data = [ptr::null::<u8>(); 8];
-            let mut src_linesize = [0i32; 8];
-            for (i, (plane, &stride)) in planes.iter().zip(strides.iter()).enumerate().take(8) {
-                src_data[i] = plane.as_ref().as_ptr();
-                src_linesize[i] = stride as i32;
-            }
-
-            ff_sys::swscale::scale(
-                self.sws_ctx,
-                src_data.as_ptr(),
-                src_linesize.as_ptr(),
-                0,
-                src_h,
-                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
-                (*self.vid_enc_frame).linesize.as_mut_ptr(),
-            )
-            .map_err(|_| ffmpeg_err_msg("srt swscale conversion failed"))?;
-        } else {
-            // Same format and dimensions — copy planes directly.
-            (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-            (*self.vid_enc_frame).width = self.enc_width;
-            (*self.vid_enc_frame).height = self.enc_height;
-            self.set_vid_enc_pts();
-
-            let buf_ret = av_frame_get_buffer(self.vid_enc_frame, 0);
-            if buf_ret < 0 {
-                av_frame_unref(self.vid_enc_frame);
-                return Err(ffmpeg_err(buf_ret));
-            }
-
-            // Copy Y/U/V planes line-by-line.
-            let planes = frame.planes();
-            let strides = frame.strides();
-            for (plane_idx, (src_plane, &src_stride)) in
-                planes.iter().zip(strides.iter()).enumerate().take(3)
-            {
-                let dst_stride = (*self.vid_enc_frame).linesize[plane_idx] as usize;
-                let dst_ptr = (*self.vid_enc_frame).data[plane_idx];
-                if dst_ptr.is_null() {
-                    continue;
-                }
-                let rows = if plane_idx == 0 {
-                    self.enc_height as usize
-                } else {
-                    (self.enc_height as usize).div_ceil(2)
-                };
-                let copy_width = dst_stride.min(src_stride);
-                let src_bytes: &[u8] = src_plane.as_ref();
-                for row in 0..rows {
-                    let src_off = row * src_stride;
-                    let dst_off = row * dst_stride;
-                    if src_off + copy_width > src_bytes.len() {
-                        break;
-                    }
-                    // SAFETY: dst_ptr + dst_off is within the allocated frame buffer.
-                    ptr::copy_nonoverlapping(
-                        src_bytes.as_ptr().add(src_off),
-                        dst_ptr.add(dst_off),
-                        copy_width,
-                    );
-                }
-            }
-        }
-
-        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
-            // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
-            drain_encoder(
-                self.vid_enc_ctx,
-                self.out_ctx,
-                self.vid_out_stream_idx,
-                "srt",
-                AVRational {
-                    num: 1,
-                    den: self.fps_int,
-                },
-            );
-        }
-
-        av_frame_unref(self.vid_enc_frame);
-        self.video_frame_count += 1;
-        Ok(())
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
-        let in_fmt = sample_format_to_av(frame.format());
-        let in_rate = frame.sample_rate() as i32;
-        let in_channels = frame.channels() as i32;
-
-        // (Re)create SwrContext when input parameters change.
-        if self.last_swr_in_fmt != Some(in_fmt)
-            || self.last_swr_in_rate != Some(in_rate)
-            || self.last_swr_in_channels != Some(in_channels)
-        {
-            if !self.swr_ctx.is_null() {
-                let mut swr_tmp = self.swr_ctx;
-                ff_sys::swresample::free(&mut swr_tmp);
-                self.swr_ctx = ptr::null_mut();
-            }
-
-            let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
-            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
-
-            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
-                enc_ch_layout,
-                ff_sys::swresample::sample_format::FLTP,
-                self.aud_sample_rate,
-                &in_layout,
-                in_fmt,
-                in_rate,
-            ) {
-                if ff_sys::swresample::init(ctx).is_ok() {
-                    self.swr_ctx = ctx;
-                    self.last_swr_in_fmt = Some(in_fmt);
-                    self.last_swr_in_rate = Some(in_rate);
-                    self.last_swr_in_channels = Some(in_channels);
-                } else {
-                    let mut swr_tmp = ctx;
-                    ff_sys::swresample::free(&mut swr_tmp);
-                    log::warn!("srt swr init failed, dropping audio frame");
-                    return;
-                }
-            } else {
-                log::warn!("srt swr alloc failed, dropping audio frame");
-                return;
-            }
-        }
-
-        // Prepare the encoder frame.
-        (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-        (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-        (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-        let _ = ff_sys::swresample::channel_layout::copy(
-            &mut (*self.aud_enc_frame).ch_layout,
-            &(*self.aud_enc_ctx).ch_layout,
-        );
-
-        let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
-        if buf_ret < 0 {
-            av_frame_unref(self.aud_enc_frame);
-            return;
-        }
-
-        // Build input plane pointers from the AudioFrame.
-        let planes = frame.planes();
-        let mut in_data = [ptr::null::<u8>(); 8];
-        for (i, plane) in planes.iter().enumerate().take(8) {
-            in_data[i] = plane.as_ptr();
-        }
-
-        let samples_out = ff_sys::swresample::convert(
-            self.swr_ctx,
-            (*self.aud_enc_frame).data.as_mut_ptr(),
-            self.aud_frame_size,
-            in_data.as_ptr(),
-            frame.samples() as i32,
-        );
-
-        if let Ok(n) = samples_out
-            && n > 0
-        {
-            (*self.aud_enc_frame).nb_samples = n;
-            (*self.aud_enc_frame).pts = self.audio_pts;
-            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
-                let aud_frame_period = AVRational {
-                    num: (*self.aud_enc_ctx).frame_size,
-                    den: (*self.aud_enc_ctx).sample_rate,
-                };
-                // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
-                drain_encoder(
-                    self.aud_enc_ctx,
-                    self.out_ctx,
-                    self.aud_out_stream_idx,
-                    "srt",
-                    aud_frame_period,
-                );
-            }
-            self.audio_pts += i64::from(n);
-        }
-
-        av_frame_unref(self.aud_enc_frame);
-    }
-
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn flush_and_close_unsafe(&mut self) {
-        // ── Flush video encoder ───────────────────────────────────────────────
-        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
-        drain_encoder(
-            self.vid_enc_ctx,
-            self.out_ctx,
-            self.vid_out_stream_idx,
             "srt",
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-        );
+            true, // close_pb_after_trailer: pb stays open for streaming
+        )
+        .inspect_err(|_| {
+            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            avformat_free_context(out_ctx);
+        })?;
 
-        // ── Flush audio encoder ───────────────────────────────────────────────
-        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
-            // Drain any remaining resampler buffered samples.
-            if !self.swr_ctx.is_null() {
-                (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
-                (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
-                (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
-                let _ = ff_sys::swresample::channel_layout::copy(
-                    &mut (*self.aud_enc_frame).ch_layout,
-                    &(*self.aud_enc_ctx).ch_layout,
-                );
-
-                if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
-                    if let Ok(n) = ff_sys::swresample::convert(
-                        self.swr_ctx,
-                        (*self.aud_enc_frame).data.as_mut_ptr(),
-                        self.aud_frame_size,
-                        ptr::null(),
-                        0,
-                    ) && n > 0
-                    {
-                        (*self.aud_enc_frame).nb_samples = n;
-                        (*self.aud_enc_frame).pts = self.audio_pts;
-                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
-                        {
-                            let aud_frame_period = AVRational {
-                                num: (*self.aud_enc_ctx).frame_size,
-                                den: (*self.aud_enc_ctx).sample_rate,
-                            };
-                            drain_encoder(
-                                self.aud_enc_ctx,
-                                self.out_ctx,
-                                self.aud_out_stream_idx,
-                                "srt",
-                                aud_frame_period,
-                            );
-                        }
-                    }
-                    av_frame_unref(self.aud_enc_frame);
-                }
-            }
-
-            // Flush the AAC encoder itself.
-            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
-            let aud_frame_period = AVRational {
-                num: (*self.aud_enc_ctx).frame_size,
-                den: (*self.aud_enc_ctx).sample_rate,
-            };
-            drain_encoder(
-                self.aud_enc_ctx,
-                self.out_ctx,
-                self.aud_out_stream_idx,
-                "srt",
-                aud_frame_period,
-            );
-        }
-
-        // ── Write MPEG-TS trailer ─────────────────────────────────────────────
-        av_write_trailer(self.out_ctx);
-
-        // Close the SRT connection. Like RTMP, pb was kept open throughout
-        // the session and must be explicitly closed after av_write_trailer.
-        if !(*self.out_ctx).pb.is_null() {
-            ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
-        }
-
-        log::info!("srt output finished url={}", self.url);
-
-        // Zero all pointers so Drop does not double-free.
-        self.free_all();
-    }
-
-    // SAFETY: Callers must ensure self is not used again after this call.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn set_vid_enc_pts(&mut self) {
-        (*self.vid_enc_frame).pts = av_rescale_q(
-            self.video_frame_count as i64,
-            AVRational {
-                num: 1,
-                den: self.fps_int,
-            },
-            (*self.vid_enc_ctx).time_base,
-        );
-    }
-
-    /// Free all owned `FFmpeg` contexts and zero the pointers.
-    ///
-    /// # Safety
-    ///
-    /// Each pointer is checked for null before freeing. After this call all
-    /// pointers are null, so a second call is a no-op.
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn free_all(&mut self) {
-        if !self.sws_ctx.is_null() {
-            ff_sys::swscale::free_context(self.sws_ctx);
-            self.sws_ctx = ptr::null_mut();
-        }
-        if !self.swr_ctx.is_null() {
-            let mut swr_tmp = self.swr_ctx;
-            ff_sys::swresample::free(&mut swr_tmp);
-            self.swr_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_frame.is_null() {
-            av_frame_free(&mut (self.vid_enc_frame as *mut _));
-            self.vid_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_frame.is_null() {
-            av_frame_free(&mut (self.aud_enc_frame as *mut _));
-            self.aud_enc_frame = ptr::null_mut();
-        }
-        if !self.aud_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
-            self.aud_enc_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
-            self.vid_enc_ctx = ptr::null_mut();
-        }
-        if !self.out_ctx.is_null() {
-            // Close pb if still open (Drop path, flush_and_close was not called).
-            if !(*self.out_ctx).pb.is_null() {
-                ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
-            }
-            avformat_free_context(self.out_ctx);
-            self.out_ctx = ptr::null_mut();
-        }
-    }
-}
-
-impl Drop for SrtInner {
-    fn drop(&mut self) {
-        // SAFETY: free_all checks each pointer for null before freeing.
-        // flush_and_close already zeroed all pointers on the success path,
-        // so this is a safe no-op in the normal case.
-        unsafe {
-            self.free_all();
-        }
+        Ok(Self { core })
     }
 }


### PR DESCRIPTION
## Summary

Introduces `MuxerCore`, a single shared struct that owns all FFmpeg pointer fields and implements the push/flush/free logic that was previously copy-pasted verbatim across `RtmpInner`, `SrtInner`, `LiveHlsInner`, and `LiveDashInner`. Each inner type is now reduced to its protocol-specific `open_unsafe` plus one-line delegation calls. Also moves the duplicated `pixel_format_to_av` / `sample_format_to_av` helpers into `codec_utils.rs`.

## Changes

- **`muxer_core.rs`** (new): `MuxerCore` struct owns 22 shared FFmpeg fields; implements `push_video_unsafe`, `push_audio_unsafe`, `flush_and_close_unsafe`, `free_all`, `Drop`. A `close_pb_after_trailer: bool` field handles the RTMP/SRT (persistent connection) vs HLS/DASH (pb closed after header write) difference without branching in call sites.
- **`codec_utils.rs`**: add `pub(crate) pixel_format_to_av` and `sample_format_to_av`; remove four identical copies from inner files.
- **`rtmp_inner.rs`**: 766 → ~240 lines; retains only `open_unsafe`.
- **`srt_output_inner.rs`**: 767 → ~240 lines; retains only `open_unsafe`.
- **`live_hls_inner.rs`**: 875 → ~390 lines; retains only `open_unsafe` (HLS muxer options, optional audio).
- **`live_dash_inner.rs`**: 839 → ~355 lines; retains only `open_unsafe` (DASH muxer options, optional audio).
- Net: **−2071 lines / +164 lines** across six source files; new `muxer_core.rs` adds ~580 lines.

## Related Issues

Resolves #702

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes