### PR TITLE
refactor(ff-encode): remove unsafe blocks from builder.rs files

### DIFF
--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -284,8 +284,7 @@ impl AudioEncoder {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio encoder not initialized".to_string(),
             })?;
-        // SAFETY: inner is properly initialised and we have exclusive access.
-        unsafe { inner.push_frame(frame)? };
+        inner.push_frame(frame)?;
         Ok(())
     }
 
@@ -296,8 +295,7 @@ impl AudioEncoder {
     /// Returns [`EncodeError`] if finalising fails.
     pub fn finish(mut self) -> Result<(), EncodeError> {
         if let Some(mut inner) = self.inner.take() {
-            // SAFETY: inner is properly initialised and we have exclusive access.
-            unsafe { inner.finish()? };
+            inner.finish()?;
         }
         Ok(())
     }

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -452,88 +452,94 @@ impl AudioEncoderInner {
     }
 
     /// Push an audio frame for encoding.
-    pub(super) unsafe fn push_frame(&mut self, frame: &AudioFrame) -> Result<(), EncodeError> {
-        let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
-            reason: "Audio codec not initialized".to_string(),
-        })?;
-
-        if !self.fifo.is_null() {
-            // Fixed-frame-size path: convert → write into AVAudioFifo → drain
-            // complete frames.  AVAudioFifo manages the ring buffer internally.
-            let mut av_frame = av_frame_alloc();
-            if av_frame.is_null() {
-                return Err(EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Cannot allocate frame".to_string(),
-                });
-            }
-
-            let convert_result = self.convert_audio_frame(frame, av_frame);
-            if let Err(e) = convert_result {
-                av_frame_free(&mut av_frame as *mut *mut _);
-                return Err(e);
-            }
-
-            let nb_samples = (*av_frame).nb_samples;
-
-            // Write converted samples into AVAudioFifo.
-            // SAFETY: av_frame data buffers were allocated by convert_audio_frame
-            let write_result = swresample::audio_fifo::write(
-                self.fifo,
-                (*av_frame).data.as_ptr().cast::<*mut c_void>(),
-                nb_samples,
-            );
-
-            av_frame_free(&mut av_frame as *mut *mut _);
-
-            write_result.map_err(|e| EncodeError::Ffmpeg {
-                code: e,
-                message: format!(
-                    "Failed to write to audio FIFO: {}",
-                    ff_sys::av_error_string(e)
-                ),
+    pub(super) fn push_frame(&mut self, frame: &AudioFrame) -> Result<(), EncodeError> {
+        // SAFETY: self is properly initialised; all raw FFmpeg pointers are valid and exclusively owned.
+        unsafe {
+            let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
+                reason: "Audio codec not initialized".to_string(),
             })?;
 
-            // Drain all complete frames from the FIFO
-            let frame_size = self.frame_size as i32;
-            while swresample::audio_fifo::size(self.fifo) >= frame_size {
-                self.drain_fifo_frame(codec_ctx, frame_size, false)?;
-            }
-        } else {
-            // Direct path: send frame straight to the encoder.
-            let mut av_frame = av_frame_alloc();
-            if av_frame.is_null() {
-                return Err(EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Cannot allocate frame".to_string(),
-                });
-            }
+            if !self.fifo.is_null() {
+                // Fixed-frame-size path: convert → write into AVAudioFifo → drain
+                // complete frames.  AVAudioFifo manages the ring buffer internally.
+                let mut av_frame = av_frame_alloc();
+                if av_frame.is_null() {
+                    return Err(EncodeError::Ffmpeg {
+                        code: 0,
+                        message: "Cannot allocate frame".to_string(),
+                    });
+                }
 
-            let convert_result = self.convert_audio_frame(frame, av_frame);
-            if let Err(e) = convert_result {
+                let convert_result = self.convert_audio_frame(frame, av_frame);
+                if let Err(e) = convert_result {
+                    av_frame_free(&mut av_frame as *mut *mut _);
+                    return Err(e);
+                }
+
+                let nb_samples = (*av_frame).nb_samples;
+
+                // Write converted samples into AVAudioFifo.
+                // SAFETY: av_frame data buffers were allocated by convert_audio_frame
+                let write_result = swresample::audio_fifo::write(
+                    self.fifo,
+                    (*av_frame).data.as_ptr().cast::<*mut c_void>(),
+                    nb_samples,
+                );
+
                 av_frame_free(&mut av_frame as *mut *mut _);
-                return Err(e);
-            }
 
-            (*av_frame).pts = self.sample_count as i64;
-
-            let send_result = avcodec::send_frame(codec_ctx, av_frame);
-            if let Err(e) = send_result {
-                av_frame_free(&mut av_frame as *mut *mut _);
-                return Err(EncodeError::Ffmpeg {
+                write_result.map_err(|e| EncodeError::Ffmpeg {
                     code: e,
-                    message: format!("Failed to send audio frame: {}", ff_sys::av_error_string(e)),
-                });
+                    message: format!(
+                        "Failed to write to audio FIFO: {}",
+                        ff_sys::av_error_string(e)
+                    ),
+                })?;
+
+                // Drain all complete frames from the FIFO
+                let frame_size = self.frame_size as i32;
+                while swresample::audio_fifo::size(self.fifo) >= frame_size {
+                    self.drain_fifo_frame(codec_ctx, frame_size, false)?;
+                }
+            } else {
+                // Direct path: send frame straight to the encoder.
+                let mut av_frame = av_frame_alloc();
+                if av_frame.is_null() {
+                    return Err(EncodeError::Ffmpeg {
+                        code: 0,
+                        message: "Cannot allocate frame".to_string(),
+                    });
+                }
+
+                let convert_result = self.convert_audio_frame(frame, av_frame);
+                if let Err(e) = convert_result {
+                    av_frame_free(&mut av_frame as *mut *mut _);
+                    return Err(e);
+                }
+
+                (*av_frame).pts = self.sample_count as i64;
+
+                let send_result = avcodec::send_frame(codec_ctx, av_frame);
+                if let Err(e) = send_result {
+                    av_frame_free(&mut av_frame as *mut *mut _);
+                    return Err(EncodeError::Ffmpeg {
+                        code: e,
+                        message: format!(
+                            "Failed to send audio frame: {}",
+                            ff_sys::av_error_string(e)
+                        ),
+                    });
+                }
+
+                let receive_result = self.receive_packets();
+                av_frame_free(&mut av_frame as *mut *mut _);
+                receive_result?;
+
+                self.sample_count += frame.samples() as u64;
             }
 
-            let receive_result = self.receive_packets();
-            av_frame_free(&mut av_frame as *mut *mut _);
-            receive_result?;
-
-            self.sample_count += frame.samples() as u64;
-        }
-
-        Ok(())
+            Ok(())
+        } // unsafe
     }
 
     /// Read `frame_size` samples from the FIFO into a new AVFrame and encode it.
@@ -826,33 +832,37 @@ impl AudioEncoderInner {
     }
 
     /// Finish encoding and write trailer.
-    pub(super) unsafe fn finish(&mut self) -> Result<(), EncodeError> {
-        // Flush any remaining samples from the AVAudioFifo (silence-padded to a
-        // full frame so the encoder always receives its required frame_size).
-        if !self.fifo.is_null() && swresample::audio_fifo::size(self.fifo) > 0 {
-            let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
-                reason: "Audio codec not initialized".to_string(),
-            })?;
-            self.drain_fifo_frame(codec_ctx, self.frame_size as i32, true)?;
-        }
+    pub(super) fn finish(&mut self) -> Result<(), EncodeError> {
+        // SAFETY: self is properly initialised; all raw FFmpeg pointers are valid and exclusively owned.
+        unsafe {
+            // Flush any remaining samples from the AVAudioFifo (silence-padded to a
+            // full frame so the encoder always receives its required frame_size).
+            if !self.fifo.is_null() && swresample::audio_fifo::size(self.fifo) > 0 {
+                let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Audio codec not initialized".to_string(),
+                })?;
+                self.drain_fifo_frame(codec_ctx, self.frame_size as i32, true)?;
+            }
 
-        // Flush audio encoder
-        if let Some(codec_ctx) = self.codec_ctx {
-            // Send NULL frame to flush
-            avcodec::send_frame(codec_ctx, ptr::null()).map_err(EncodeError::from_ffmpeg_error)?;
-            self.receive_packets()?;
-        }
+            // Flush audio encoder
+            if let Some(codec_ctx) = self.codec_ctx {
+                // Send NULL frame to flush
+                avcodec::send_frame(codec_ctx, ptr::null())
+                    .map_err(EncodeError::from_ffmpeg_error)?;
+                self.receive_packets()?;
+            }
 
-        // Write trailer
-        let ret = av_write_trailer(self.format_ctx);
-        if ret < 0 {
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
-            });
-        }
+            // Write trailer
+            let ret = av_write_trailer(self.format_ctx);
+            if ret < 0 {
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
+                });
+            }
 
-        Ok(())
+            Ok(())
+        } // unsafe
     }
 
     /// Cleanup FFmpeg resources.

--- a/crates/ff-encode/src/image/builder.rs
+++ b/crates/ff-encode/src/image/builder.rs
@@ -163,9 +163,7 @@ impl ImageEncoder {
             quality: self.quality,
             pixel_format: self.pixel_format,
         };
-        // SAFETY: encode_image manages all FFmpeg resources internally and
-        // frees them before returning, whether on success or error.
-        unsafe { encoder_inner::encode_image(&self.path, frame, &opts) }
+        encoder_inner::encode_image(&self.path, frame, &opts)
     }
 }
 

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -614,35 +614,35 @@ unsafe fn apply_quality(codec_ctx: *mut ff_sys::AVCodecContext, codec_id: AVCode
 /// which frees frame → packet → sws_ctx → codec_ctx → format_ctx regardless
 /// of whether encoding succeeds or fails.
 ///
-/// # Safety
-///
-/// `path` must be a valid UTF-8 file path. The caller must ensure that `opts`
-/// and `frame` are consistent (i.e. non-zero dimensions after fallback).
-pub(super) unsafe fn encode_image(
+pub(super) fn encode_image(
     path: &Path,
     frame: &VideoFrame,
     opts: &ImageEncodeOptions,
 ) -> Result<(), EncodeError> {
-    ff_sys::ensure_initialized();
+    // SAFETY: ImageEncoderInner::open and encode_frame exclusively own all
+    // FFmpeg resources; Drop frees them on every exit path.
+    unsafe {
+        ff_sys::ensure_initialized();
 
-    // Open the encoder; any error here drops `inner` (partially initialised),
-    // which frees whatever was allocated so far.
-    let mut inner = ImageEncoderInner::open(path, opts, frame)?;
+        // Open the encoder; any error here drops `inner` (partially initialised),
+        // which frees whatever was allocated so far.
+        let mut inner = ImageEncoderInner::open(path, opts, frame)?;
 
-    // Encode and finalise the file; on error `inner` is dropped here via `?`,
-    // releasing all remaining FFmpeg resources.
-    inner.encode_frame(frame)?;
+        // Encode and finalise the file; on error `inner` is dropped here via `?`,
+        // releasing all remaining FFmpeg resources.
+        inner.encode_frame(frame)?;
 
-    log::info!(
-        "Image encoded successfully path={} src={}x{} dst={}x{}",
-        path.display(),
-        frame.width(),
-        frame.height(),
-        inner.dst_width,
-        inner.dst_height,
-    );
+        log::info!(
+            "Image encoded successfully path={} src={}x{} dst={}x{}",
+            path.display(),
+            frame.width(),
+            frame.height(),
+            inner.dst_width,
+            inner.dst_height,
+        );
 
-    Ok(())
+        Ok(())
+    } // unsafe
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -919,8 +919,7 @@ impl VideoEncoder {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Video encoder not initialized".to_string(),
             })?;
-        // SAFETY: inner is properly initialised and we have exclusive access.
-        unsafe { inner.push_video_frame(frame)? };
+        inner.push_video_frame(frame)?;
         let progress = self.create_progress_info();
         if let Some(ref mut callback) = self.progress_callback {
             callback.on_progress(&progress);
@@ -945,8 +944,7 @@ impl VideoEncoder {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio encoder not initialized".to_string(),
             })?;
-        // SAFETY: inner is properly initialised and we have exclusive access.
-        unsafe { inner.push_audio_frame(frame)? };
+        inner.push_audio_frame(frame)?;
         let progress = self.create_progress_info();
         if let Some(ref mut callback) = self.progress_callback {
             callback.on_progress(&progress);
@@ -961,8 +959,7 @@ impl VideoEncoder {
     /// Returns [`EncodeError`] if finalising fails.
     pub fn finish(mut self) -> Result<(), EncodeError> {
         if let Some(mut inner) = self.inner.take() {
-            // SAFETY: inner is properly initialised and we have exclusive access.
-            unsafe { inner.finish()? };
+            inner.finish()?;
         }
         Ok(())
     }

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -1586,19 +1586,91 @@ impl VideoEncoderInner {
     /// In two-pass mode the frame is converted to YUV420P via the pass-1 codec
     /// context, the converted data is buffered for pass-2 replay, and the frame
     /// is then sent through the pass-1 encoder (whose output is discarded).
-    pub(super) unsafe fn push_video_frame(
-        &mut self,
-        frame: &VideoFrame,
-    ) -> Result<(), EncodeError> {
-        // ── Two-pass path ────────────────────────────────────────────────────
-        if self.two_pass {
-            let pass1_ctx = self
-                .pass1_codec_ctx
+    pub(super) fn push_video_frame(&mut self, frame: &VideoFrame) -> Result<(), EncodeError> {
+        // SAFETY: self is properly initialised; all raw FFmpeg pointers are valid and exclusively owned.
+        unsafe {
+            // ── Two-pass path ────────────────────────────────────────────────────
+            if self.two_pass {
+                let pass1_ctx = self
+                    .pass1_codec_ctx
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Pass-1 codec context not initialized".to_string(),
+                    })?;
+
+                // Convert the incoming frame to YUV420P (the pass-1 codec's format).
+                let mut av_frame = av_frame_alloc();
+                if av_frame.is_null() {
+                    return Err(EncodeError::Ffmpeg {
+                        code: 0,
+                        message: "Cannot allocate frame".to_string(),
+                    });
+                }
+
+                let convert_result = self.convert_video_frame(frame, av_frame, pass1_ctx);
+                if let Err(e) = convert_result {
+                    av_frame_free(&mut av_frame as *mut *mut _);
+                    return Err(e);
+                }
+
+                // Buffer the converted YUV420P data for pass-2 replay.
+                let width = (*pass1_ctx).width as u32;
+                let height = (*pass1_ctx).height as u32;
+                let uv_height = (height as usize).div_ceil(2);
+
+                let planes: Vec<Vec<u8>> = (0..3)
+                    .map(|i| {
+                        if (*av_frame).data[i].is_null() {
+                            return Vec::new();
+                        }
+                        let stride = (*av_frame).linesize[i] as usize;
+                        let h = if i == 0 { height as usize } else { uv_height };
+                        // SAFETY: data[i] points to a valid buffer of stride * h bytes
+                        // allocated by av_frame_get_buffer inside convert_video_frame.
+                        std::slice::from_raw_parts((*av_frame).data[i], stride * h).to_vec()
+                    })
+                    .collect();
+
+                let strides: Vec<usize> =
+                    (0..3).map(|i| (*av_frame).linesize[i] as usize).collect();
+
+                self.buffered_frames.push(TwoPassFrame {
+                    planes,
+                    strides,
+                    width,
+                    height,
+                    pts: self.frame_count as i64,
+                });
+
+                // Send to pass-1 encoder and discard the encoded output.
+                (*av_frame).pts = self.frame_count as i64;
+                let send_result = avcodec::send_frame(pass1_ctx, av_frame);
+                if let Err(e) = send_result {
+                    av_frame_free(&mut av_frame as *mut *mut _);
+                    return Err(EncodeError::Ffmpeg {
+                        code: e,
+                        message: format!(
+                            "Failed to send frame to pass-1 encoder: {}",
+                            ff_sys::av_error_string(e)
+                        ),
+                    });
+                }
+
+                let drain_result = self.drain_pass1_packets(pass1_ctx);
+                av_frame_free(&mut av_frame as *mut *mut _);
+                drain_result?;
+
+                self.frame_count += 1;
+                return Ok(());
+            }
+
+            // ── Single-pass path ─────────────────────────────────────────────────
+            let codec_ctx = self
+                .video_codec_ctx
                 .ok_or_else(|| EncodeError::InvalidConfig {
-                    reason: "Pass-1 codec context not initialized".to_string(),
+                    reason: "Video codec not initialized".to_string(),
                 })?;
 
-            // Convert the incoming frame to YUV420P (the pass-1 codec's format).
+            // Allocate AVFrame
             let mut av_frame = av_frame_alloc();
             if av_frame.is_null() {
                 return Err(EncodeError::Ffmpeg {
@@ -1607,110 +1679,39 @@ impl VideoEncoderInner {
                 });
             }
 
-            let convert_result = self.convert_video_frame(frame, av_frame, pass1_ctx);
+            // Convert VideoFrame to AVFrame
+            let convert_result = self.convert_video_frame(frame, av_frame, codec_ctx);
             if let Err(e) = convert_result {
                 av_frame_free(&mut av_frame as *mut *mut _);
                 return Err(e);
             }
 
-            // Buffer the converted YUV420P data for pass-2 replay.
-            let width = (*pass1_ctx).width as u32;
-            let height = (*pass1_ctx).height as u32;
-            let uv_height = (height as usize).div_ceil(2);
-
-            let planes: Vec<Vec<u8>> = (0..3)
-                .map(|i| {
-                    if (*av_frame).data[i].is_null() {
-                        return Vec::new();
-                    }
-                    let stride = (*av_frame).linesize[i] as usize;
-                    let h = if i == 0 { height as usize } else { uv_height };
-                    // SAFETY: data[i] points to a valid buffer of stride * h bytes
-                    // allocated by av_frame_get_buffer inside convert_video_frame.
-                    std::slice::from_raw_parts((*av_frame).data[i], stride * h).to_vec()
-                })
-                .collect();
-
-            let strides: Vec<usize> = (0..3).map(|i| (*av_frame).linesize[i] as usize).collect();
-
-            self.buffered_frames.push(TwoPassFrame {
-                planes,
-                strides,
-                width,
-                height,
-                pts: self.frame_count as i64,
-            });
-
-            // Send to pass-1 encoder and discard the encoded output.
+            // Set frame properties
             (*av_frame).pts = self.frame_count as i64;
-            let send_result = avcodec::send_frame(pass1_ctx, av_frame);
+
+            // Send frame to encoder
+            let send_result = avcodec::send_frame(codec_ctx, av_frame);
             if let Err(e) = send_result {
                 av_frame_free(&mut av_frame as *mut *mut _);
                 return Err(EncodeError::Ffmpeg {
                     code: e,
-                    message: format!(
-                        "Failed to send frame to pass-1 encoder: {}",
-                        ff_sys::av_error_string(e)
-                    ),
+                    message: format!("Failed to send frame: {}", ff_sys::av_error_string(e)),
                 });
             }
 
-            let drain_result = self.drain_pass1_packets(pass1_ctx);
+            // Receive packets
+            let receive_result = self.receive_packets();
+
+            // Always cleanup the frame
             av_frame_free(&mut av_frame as *mut *mut _);
-            drain_result?;
+
+            // Check if receiving packets failed
+            receive_result?;
 
             self.frame_count += 1;
-            return Ok(());
-        }
 
-        // ── Single-pass path ─────────────────────────────────────────────────
-        let codec_ctx = self
-            .video_codec_ctx
-            .ok_or_else(|| EncodeError::InvalidConfig {
-                reason: "Video codec not initialized".to_string(),
-            })?;
-
-        // Allocate AVFrame
-        let mut av_frame = av_frame_alloc();
-        if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate frame".to_string(),
-            });
-        }
-
-        // Convert VideoFrame to AVFrame
-        let convert_result = self.convert_video_frame(frame, av_frame, codec_ctx);
-        if let Err(e) = convert_result {
-            av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(e);
-        }
-
-        // Set frame properties
-        (*av_frame).pts = self.frame_count as i64;
-
-        // Send frame to encoder
-        let send_result = avcodec::send_frame(codec_ctx, av_frame);
-        if let Err(e) = send_result {
-            av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(EncodeError::Ffmpeg {
-                code: e,
-                message: format!("Failed to send frame: {}", ff_sys::av_error_string(e)),
-            });
-        }
-
-        // Receive packets
-        let receive_result = self.receive_packets();
-
-        // Always cleanup the frame
-        av_frame_free(&mut av_frame as *mut *mut _);
-
-        // Check if receiving packets failed
-        receive_result?;
-
-        self.frame_count += 1;
-
-        Ok(())
+            Ok(())
+        } // unsafe
     }
 
     /// Drain and discard all pending packets from a codec context.
@@ -2158,57 +2159,57 @@ impl VideoEncoderInner {
     }
 
     /// Push an audio frame for encoding.
-    pub(super) unsafe fn push_audio_frame(
-        &mut self,
-        frame: &AudioFrame,
-    ) -> Result<(), EncodeError> {
-        let codec_ctx = self
-            .audio_codec_ctx
-            .ok_or_else(|| EncodeError::InvalidConfig {
-                reason: "Audio codec not initialized".to_string(),
-            })?;
+    pub(super) fn push_audio_frame(&mut self, frame: &AudioFrame) -> Result<(), EncodeError> {
+        // SAFETY: self is properly initialised; all raw FFmpeg pointers are valid and exclusively owned.
+        unsafe {
+            let codec_ctx = self
+                .audio_codec_ctx
+                .ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Audio codec not initialized".to_string(),
+                })?;
 
-        // Allocate AVFrame
-        let mut av_frame = av_frame_alloc();
-        if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate frame".to_string(),
-            });
-        }
+            // Allocate AVFrame
+            let mut av_frame = av_frame_alloc();
+            if av_frame.is_null() {
+                return Err(EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Cannot allocate frame".to_string(),
+                });
+            }
 
-        // Convert AudioFrame to AVFrame
-        let convert_result = self.convert_audio_frame(frame, av_frame);
-        if let Err(e) = convert_result {
+            // Convert AudioFrame to AVFrame
+            let convert_result = self.convert_audio_frame(frame, av_frame);
+            if let Err(e) = convert_result {
+                av_frame_free(&mut av_frame as *mut *mut _);
+                return Err(e);
+            }
+
+            // Set frame properties
+            (*av_frame).pts = self.audio_sample_count as i64;
+
+            // Send frame to encoder
+            let send_result = avcodec::send_frame(codec_ctx, av_frame);
+            if let Err(e) = send_result {
+                av_frame_free(&mut av_frame as *mut *mut _);
+                return Err(EncodeError::Ffmpeg {
+                    code: e,
+                    message: format!("Failed to send audio frame: {}", ff_sys::av_error_string(e)),
+                });
+            }
+
+            // Receive packets
+            let receive_result = self.receive_audio_packets();
+
+            // Always cleanup the frame
             av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(e);
-        }
 
-        // Set frame properties
-        (*av_frame).pts = self.audio_sample_count as i64;
+            // Check if receiving packets failed
+            receive_result?;
 
-        // Send frame to encoder
-        let send_result = avcodec::send_frame(codec_ctx, av_frame);
-        if let Err(e) = send_result {
-            av_frame_free(&mut av_frame as *mut *mut _);
-            return Err(EncodeError::Ffmpeg {
-                code: e,
-                message: format!("Failed to send audio frame: {}", ff_sys::av_error_string(e)),
-            });
-        }
+            self.audio_sample_count += frame.samples() as u64;
 
-        // Receive packets
-        let receive_result = self.receive_audio_packets();
-
-        // Always cleanup the frame
-        av_frame_free(&mut av_frame as *mut *mut _);
-
-        // Check if receiving packets failed
-        receive_result?;
-
-        self.audio_sample_count += frame.samples() as u64;
-
-        Ok(())
+            Ok(())
+        } // unsafe
     }
 
     /// Convert AudioFrame to AVFrame with resampling if needed.
@@ -2413,39 +2414,44 @@ impl VideoEncoderInner {
     }
 
     /// Finish encoding and write trailer.
-    pub(super) unsafe fn finish(&mut self) -> Result<(), EncodeError> {
-        // For two-pass, run the second pass now (handles flushing + trailer).
-        if self.two_pass {
-            return self.run_pass2();
-        }
+    pub(super) fn finish(&mut self) -> Result<(), EncodeError> {
+        // SAFETY: self is properly initialised; all raw FFmpeg pointers are valid and exclusively owned.
+        unsafe {
+            // For two-pass, run the second pass now (handles flushing + trailer).
+            if self.two_pass {
+                return self.run_pass2();
+            }
 
-        // Single-pass: flush video encoder
-        if let Some(codec_ctx) = self.video_codec_ctx {
-            // Send NULL frame to flush
-            avcodec::send_frame(codec_ctx, ptr::null()).map_err(EncodeError::from_ffmpeg_error)?;
-            self.receive_packets()?;
-        }
+            // Single-pass: flush video encoder
+            if let Some(codec_ctx) = self.video_codec_ctx {
+                // Send NULL frame to flush
+                avcodec::send_frame(codec_ctx, ptr::null())
+                    .map_err(EncodeError::from_ffmpeg_error)?;
+                self.receive_packets()?;
+            }
 
-        // Flush audio encoder
-        if let Some(codec_ctx) = self.audio_codec_ctx {
-            // Send NULL frame to flush
-            avcodec::send_frame(codec_ctx, ptr::null()).map_err(EncodeError::from_ffmpeg_error)?;
-            self.receive_audio_packets()?;
-        }
+            // Flush audio encoder
+            if let Some(codec_ctx) = self.audio_codec_ctx {
+                // Send NULL frame to flush
+                avcodec::send_frame(codec_ctx, ptr::null())
+                    .map_err(EncodeError::from_ffmpeg_error)?;
+                self.receive_audio_packets()?;
+            }
 
-        // Write subtitle passthrough packets before trailer.
-        self.write_subtitle_packets()?;
+            // Write subtitle passthrough packets before trailer.
+            self.write_subtitle_packets()?;
 
-        // Write trailer
-        let ret = av_write_trailer(self.format_ctx);
-        if ret < 0 {
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
-            });
-        }
+            // Write trailer
+            let ret = av_write_trailer(self.format_ctx);
+            if ret < 0 {
+                return Err(EncodeError::Ffmpeg {
+                    code: ret,
+                    message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
+                });
+            }
 
-        Ok(())
+            Ok(())
+        } // unsafe
     }
 
     /// Run the second pass of two-pass encoding.


### PR DESCRIPTION
## Summary

Removes all `unsafe` blocks from the three builder files in `ff-encode` (`video/builder.rs`, `audio/builder.rs`, `image/builder.rs`), which violated the CLAUDE.md convention that builder/`mod.rs` files must be safe Rust and only `*_inner.rs` files may contain `unsafe`. Each delegating call site (`unsafe { inner.push_frame(frame) }`, etc.) has been replaced with a direct safe call.

## Changes

- `video/builder.rs`: removed three `unsafe { ... }` wrappers and their `// SAFETY:` comments from `push_video`, `push_audio`, and `finish`
- `audio/builder.rs`: removed two `unsafe { ... }` wrappers from `push` and `finish`
- `image/builder.rs`: removed one `unsafe { ... }` wrapper from `encode`
- `video/encoder_inner.rs`: changed `push_video_frame`, `push_audio_frame`, and `finish` from `unsafe fn` to safe `fn`; wrapped each body in an internal `unsafe {}` block with a `// SAFETY:` comment
- `audio/encoder_inner.rs`: same treatment for `push_frame` and `finish`
- `image/encoder_inner.rs`: same treatment for `encode_image`; removed the now-obsolete `# Safety` doc section

## Related Issues

Resolves #704

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes