### PR TITLE
refactor(ff-decode): remove dead DecoderConfig structs and #[allow(dead_code)] items

### DIFF
--- a/crates/ff-decode/src/audio/builder.rs
+++ b/crates/ff-decode/src/audio/builder.rs
@@ -11,19 +11,6 @@ use ff_format::{AudioFrame, AudioStreamInfo, ContainerInfo, NetworkOptions, Samp
 use crate::audio::decoder_inner::AudioDecoderInner;
 use crate::error::DecodeError;
 
-/// Internal configuration for the audio decoder.
-#[derive(Debug, Clone, Default)]
-#[allow(clippy::struct_field_names)]
-#[allow(dead_code)] // Fields will be used when SwResample is fully implemented
-pub(crate) struct AudioDecoderConfig {
-    /// Output sample format (None = use source format)
-    pub output_format: Option<SampleFormat>,
-    /// Output sample rate (None = use source sample rate)
-    pub output_sample_rate: Option<u32>,
-    /// Output channel count (None = use source channel count)
-    pub output_channels: Option<u32>,
-}
-
 /// Builder for configuring and constructing an [`AudioDecoder`].
 ///
 /// This struct provides a fluent interface for setting up decoder options
@@ -311,13 +298,6 @@ impl AudioDecoderBuilder {
             });
         }
 
-        // Build the internal configuration
-        let config = AudioDecoderConfig {
-            output_format: self.output_format,
-            output_sample_rate: self.output_sample_rate,
-            output_channels: self.output_channels,
-        };
-
         // Create the decoder inner
         let (inner, stream_info, container_info) = AudioDecoderInner::new(
             &self.path,
@@ -329,7 +309,6 @@ impl AudioDecoderBuilder {
 
         Ok(AudioDecoder {
             path: self.path,
-            config,
             inner,
             stream_info,
             container_info,
@@ -387,9 +366,6 @@ impl AudioDecoderBuilder {
 pub struct AudioDecoder {
     /// Path to the media file
     path: PathBuf,
-    /// Decoder configuration
-    #[allow(dead_code)]
-    config: AudioDecoderConfig,
     /// Internal decoder state
     inner: AudioDecoderInner,
     /// Audio stream information
@@ -822,15 +798,6 @@ mod tests {
             Err(e) => panic!("Expected FileNotFound error, got: {e:?}"),
             Ok(_) => panic!("Expected error, got Ok"),
         }
-    }
-
-    #[test]
-    fn test_decoder_config_default() {
-        let config = AudioDecoderConfig::default();
-
-        assert!(config.output_format.is_none());
-        assert!(config.output_sample_rate.is_none());
-        assert!(config.output_channels.is_none());
     }
 
     #[test]

--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -226,16 +226,6 @@ impl Drop for AvFrameGuard {
 /// RAII guard for `SwrContext` to ensure proper cleanup.
 struct SwrContextGuard(*mut SwrContext);
 
-impl SwrContextGuard {
-    /// Consumes the guard and returns the raw pointer without dropping.
-    #[allow(dead_code)]
-    fn into_raw(self) -> *mut SwrContext {
-        let ptr = self.0;
-        std::mem::forget(self);
-        ptr
-    }
-}
-
 impl Drop for SwrContextGuard {
     fn drop(&mut self) {
         if !self.0.is_null() {

--- a/crates/ff-decode/src/video/builder.rs
+++ b/crates/ff-decode/src/video/builder.rs
@@ -50,34 +50,6 @@ pub(crate) enum OutputScale {
     FitHeight(u32),
 }
 
-/// Internal configuration for the decoder.
-///
-/// NOTE: Fields are currently unused but will be used when `FFmpeg` integration
-/// is implemented in a future issue.
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub(crate) struct VideoDecoderConfig {
-    /// Output pixel format (None = use source format)
-    pub output_format: Option<PixelFormat>,
-    /// Output scale (None = use source dimensions)
-    pub output_scale: Option<OutputScale>,
-    /// Hardware acceleration setting
-    pub hardware_accel: HardwareAccel,
-    /// Number of decoding threads (0 = auto)
-    pub thread_count: usize,
-}
-
-impl Default for VideoDecoderConfig {
-    fn default() -> Self {
-        Self {
-            output_format: None,
-            output_scale: None,
-            hardware_accel: HardwareAccel::Auto,
-            thread_count: 0, // Auto-detect
-        }
-    }
-}
-
 /// Builder for configuring and constructing a [`VideoDecoder`].
 ///
 /// This struct provides a fluent interface for setting up decoder options
@@ -624,14 +596,6 @@ impl VideoDecoderBuilder {
             });
         }
 
-        // Build the internal configuration
-        let config = VideoDecoderConfig {
-            output_format: self.output_format,
-            output_scale: self.output_scale,
-            hardware_accel: self.hardware_accel,
-            thread_count: self.thread_count,
-        };
-
         // Create the decoder inner
         let (inner, stream_info, container_info) = VideoDecoderInner::new(
             &self.path,
@@ -646,7 +610,6 @@ impl VideoDecoderBuilder {
 
         Ok(VideoDecoder {
             path: self.path,
-            config,
             frame_pool: self.frame_pool,
             inner,
             stream_info,
@@ -708,12 +671,6 @@ impl VideoDecoderBuilder {
 pub struct VideoDecoder {
     /// Path to the media file
     path: PathBuf,
-    /// Decoder configuration
-    ///
-    /// NOTE: Currently unused but will be used when `FFmpeg` integration
-    /// is implemented in a future issue.
-    #[allow(dead_code)]
-    config: VideoDecoderConfig,
     /// Optional frame pool for memory reuse
     frame_pool: Option<Arc<dyn FramePool>>,
     /// Internal decoder state
@@ -1453,15 +1410,6 @@ mod tests {
                     || matches!(e, DecodeError::Ffmpeg { .. })
             );
         }
-    }
-
-    #[test]
-    fn test_decoder_config_default() {
-        let config = VideoDecoderConfig::default();
-
-        assert!(config.output_format.is_none());
-        assert_eq!(config.hardware_accel, HardwareAccel::Auto);
-        assert_eq!(config.thread_count, 0);
     }
 
     #[test]

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -200,12 +200,6 @@ impl AvPacketGuard {
         Ok(Self(packet))
     }
 
-    /// Returns the raw pointer.
-    #[allow(dead_code)]
-    const fn as_ptr(&self) -> *mut AVPacket {
-        self.0
-    }
-
     /// Consumes the guard and returns the raw pointer without dropping.
     fn into_raw(self) -> *mut AVPacket {
         let ptr = self.0;
@@ -1657,23 +1651,6 @@ impl VideoDecoderInner {
     /// # Safety
     ///
     /// Caller must ensure that `format_ctx` and `stream_index` are valid.
-    ///
-    /// # Note
-    ///
-    /// Currently unused but kept for potential future use in more advanced seeking scenarios.
-    #[allow(dead_code)]
-    fn pts_to_duration(&self, pts: i64) -> Duration {
-        // SAFETY: Caller ensures format_ctx and stream_index are valid
-        unsafe {
-            let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
-            let time_base = (*(*stream)).time_base;
-
-            // Convert PTS to duration
-            let duration_secs = pts as f64 * time_base.num as f64 / time_base.den as f64;
-            Duration::from_secs_f64(duration_secs)
-        }
-    }
-
     /// Seeks to a specified position in the video stream.
     ///
     /// This method performs efficient seeking without reopening the file.


### PR DESCRIPTION
## Summary

Removes `AudioDecoderConfig` and `VideoDecoderConfig` — placeholder structs whose fields duplicated values already stored directly in the inner decoder types. The `config` field in each decoder struct was populated in `build()` but never read afterwards, making it pure dead code. Also removes three dead helper methods that were suppressed with `#[allow(dead_code)]`.

## Changes

- `audio/builder.rs`: remove `AudioDecoderConfig` struct, `config` field from `AudioDecoder`, its construction in `build()`, and the `test_decoder_config_default` unit test
- `video/builder.rs`: remove `VideoDecoderConfig` struct + `Default` impl, `config` field from `VideoDecoder`, its construction in `build()`, and the `test_decoder_config_default` unit test
- `audio/decoder_inner.rs`: remove `SwrContextGuard::into_raw` (unused; `Drop` impl and guard usage are preserved)
- `video/decoder_inner.rs`: remove `AvPacketGuard::as_ptr` and `VideoDecoderInner::pts_to_duration`

SwResample integration is unaffected — the conversion path lives in `AudioDecoderInner` and is controlled by `output_format`/`output_sample_rate`/`output_channels` fields that flow directly from the builder setters.

## Related Issues

Resolves #706

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes