### PR TITLE
refactor(ff-probe): split info.rs into probe/builder.rs + probe/probe_inner.rs

### DIFF
--- a/crates/ff-probe/src/lib.rs
+++ b/crates/ff-probe/src/lib.rs
@@ -9,7 +9,7 @@
 //! ## Module Structure
 //!
 //! - `error` - Error types ([`ProbeError`])
-//! - `info` - Media info extraction ([`open`])
+//! - `probe` - Media info extraction ([`open`])
 //!
 //! ## Quick Start
 //!
@@ -128,7 +128,7 @@
 #![warn(clippy::pedantic)]
 
 mod error;
-mod info;
+mod probe;
 
 // Re-export types from ff-format for convenience
 pub use ff_format::{
@@ -140,7 +140,7 @@ pub use ff_format::{
 pub use error::ProbeError;
 
 // Re-export the open function at the crate level
-pub use info::open;
+pub use probe::open;
 
 /// Prelude module for convenient imports.
 ///

--- a/crates/ff-probe/src/probe/builder.rs
+++ b/crates/ff-probe/src/probe/builder.rs
@@ -1,0 +1,168 @@
+//! Safe public API for media file probing.
+//!
+//! This module provides the [`open`] function for extracting metadata from media files
+//! using `FFmpeg`. It creates a [`MediaInfo`] struct containing all relevant information
+//! about the media file, including container format, duration, file size, and stream details.
+//!
+//! # Examples
+//!
+//! ## Basic Usage
+//!
+//! ```no_run
+//! use ff_probe::open;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let info = open("video.mp4")?;
+//!
+//!     println!("Format: {}", info.format());
+//!     println!("Duration: {:?}", info.duration());
+//!
+//!     // Access video stream information
+//!     if let Some(video) = info.primary_video() {
+//!         println!("Video: {} {}x{} @ {:.2} fps",
+//!             video.codec_name(),
+//!             video.width(),
+//!             video.height(),
+//!             video.fps()
+//!         );
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Checking for Video vs Audio-Only Files
+//!
+//! ```no_run
+//! use ff_probe::open;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let info = open("media_file.mp4")?;
+//!
+//!     if info.has_video() {
+//!         println!("This is a video file");
+//!     } else if info.has_audio() {
+//!         println!("This is an audio-only file");
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+
+use std::path::Path;
+
+use ff_format::MediaInfo;
+
+use crate::error::ProbeError;
+
+use super::probe_inner;
+
+/// Opens a media file and extracts its metadata.
+///
+/// This function opens the file at the given path using `FFmpeg`, reads the container
+/// format information, and returns a [`MediaInfo`] struct containing all extracted
+/// metadata.
+///
+/// # Arguments
+///
+/// * `path` - Path to the media file to probe. Accepts anything that can be converted
+///   to a [`Path`], including `&str`, `String`, `PathBuf`, etc.
+///
+/// # Returns
+///
+/// Returns `Ok(MediaInfo)` on success, or a [`ProbeError`] on failure.
+///
+/// # Errors
+///
+/// - [`ProbeError::FileNotFound`] if the file does not exist
+/// - [`ProbeError::CannotOpen`] if `FFmpeg` cannot open the file
+/// - [`ProbeError::InvalidMedia`] if stream information cannot be read
+/// - [`ProbeError::Io`] if there's an I/O error accessing the file
+///
+/// # Examples
+///
+/// ## Opening a Video File
+///
+/// ```no_run
+/// use ff_probe::open;
+/// use std::path::Path;
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     // Open by string path
+///     let info = open("video.mp4")?;
+///
+///     // Or by Path
+///     let path = Path::new("/path/to/video.mkv");
+///     let info = open(path)?;
+///
+///     if let Some(video) = info.primary_video() {
+///         println!("Resolution: {}x{}", video.width(), video.height());
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Handling Errors
+///
+/// ```
+/// use ff_probe::{open, ProbeError};
+///
+/// // Non-existent file returns FileNotFound
+/// let result = open("/this/file/does/not/exist.mp4");
+/// assert!(matches!(result, Err(ProbeError::FileNotFound { .. })));
+/// ```
+pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
+    let path = path.as_ref();
+
+    log::debug!("probing media file path={}", path.display());
+
+    // Check if file exists
+    if !path.exists() {
+        return Err(ProbeError::FileNotFound {
+            path: path.to_path_buf(),
+        });
+    }
+
+    // Get file size - propagate error since file may exist but be inaccessible (permission denied, etc.)
+    let file_size = std::fs::metadata(path).map(|m| m.len())?;
+
+    probe_inner::probe_file(path, file_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_should_return_file_not_found_for_nonexistent_path() {
+        let result = open("/nonexistent/path/to/video.mp4");
+        assert!(result.is_err());
+        match result {
+            Err(ProbeError::FileNotFound { path }) => {
+                assert!(path.to_string_lossy().contains("video.mp4"));
+            }
+            _ => panic!("Expected FileNotFound error"),
+        }
+    }
+
+    #[test]
+    fn open_should_return_error_for_invalid_media() {
+        // Create a temporary file with invalid content
+        let temp_dir = std::env::temp_dir();
+        let temp_file = temp_dir.join("ff_probe_test_invalid.mp4");
+        std::fs::write(&temp_file, b"not a valid video file").ok();
+
+        let result = open(&temp_file);
+
+        // Clean up
+        std::fs::remove_file(&temp_file).ok();
+
+        // FFmpeg should fail to open this as a valid media file
+        assert!(result.is_err());
+        match result {
+            Err(ProbeError::CannotOpen { .. }) | Err(ProbeError::InvalidMedia { .. }) => {}
+            _ => panic!("Expected CannotOpen or InvalidMedia error"),
+        }
+    }
+}

--- a/crates/ff-probe/src/probe/mod.rs
+++ b/crates/ff-probe/src/probe/mod.rs
@@ -1,0 +1,6 @@
+//! Probe module — media file metadata extraction.
+
+mod builder;
+pub(crate) mod probe_inner;
+
+pub use builder::open;

--- a/crates/ff-probe/src/probe/probe_inner.rs
+++ b/crates/ff-probe/src/probe/probe_inner.rs
@@ -1,55 +1,9 @@
-//! Media file information extraction.
+//! Unsafe `FFmpeg` calls for media file probing.
 //!
-//! This module provides the [`open`] function for extracting metadata from media files
-//! using `FFmpeg`. It creates a [`MediaInfo`] struct containing all relevant information
-//! about the media file, including container format, duration, file size, and stream details.
-//!
-//! # Examples
-//!
-//! ## Basic Usage
-//!
-//! ```no_run
-//! use ff_probe::open;
-//!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let info = open("video.mp4")?;
-//!
-//!     println!("Format: {}", info.format());
-//!     println!("Duration: {:?}", info.duration());
-//!
-//!     // Access video stream information
-//!     if let Some(video) = info.primary_video() {
-//!         println!("Video: {} {}x{} @ {:.2} fps",
-//!             video.codec_name(),
-//!             video.width(),
-//!             video.height(),
-//!             video.fps()
-//!         );
-//!     }
-//!
-//!     Ok(())
-//! }
-//! ```
-//!
-//! ## Checking for Video vs Audio-Only Files
-//!
-//! ```no_run
-//! use ff_probe::open;
-//!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let info = open("media_file.mp4")?;
-//!
-//!     if info.has_video() {
-//!         println!("This is a video file");
-//!     } else if info.has_audio() {
-//!         println!("This is an audio-only file");
-//!     }
-//!
-//!     Ok(())
-//! }
-//! ```
+//! All `unsafe` blocks in `ff-probe` are concentrated here. The only public
+//! symbol is [`probe_file`], which is called exclusively by [`super::builder::open`]
+//! after all safe preconditions (file exists, file size readable) are satisfied.
 
-// This module requires unsafe code for FFmpeg FFI interactions
 #![allow(unsafe_code)]
 
 use std::collections::HashMap;
@@ -69,76 +23,14 @@ use crate::error::ProbeError;
 /// `AV_TIME_BASE` constant from `FFmpeg` (microseconds per second).
 const AV_TIME_BASE: i64 = 1_000_000;
 
-/// Opens a media file and extracts its metadata.
+/// Opens, probes, and closes a media file, returning fully-populated [`MediaInfo`].
 ///
-/// This function opens the file at the given path using `FFmpeg`, reads the container
-/// format information, and returns a [`MediaInfo`] struct containing all extracted
-/// metadata.
+/// # Safety invariant
 ///
-/// # Arguments
-///
-/// * `path` - Path to the media file to probe. Accepts anything that can be converted
-///   to a [`Path`], including `&str`, `String`, `PathBuf`, etc.
-///
-/// # Returns
-///
-/// Returns `Ok(MediaInfo)` on success, or a [`ProbeError`] on failure.
-///
-/// # Errors
-///
-/// - [`ProbeError::FileNotFound`] if the file does not exist
-/// - [`ProbeError::CannotOpen`] if `FFmpeg` cannot open the file
-/// - [`ProbeError::InvalidMedia`] if stream information cannot be read
-/// - [`ProbeError::Io`] if there's an I/O error accessing the file
-///
-/// # Examples
-///
-/// ## Opening a Video File
-///
-/// ```no_run
-/// use ff_probe::open;
-/// use std::path::Path;
-///
-/// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Open by string path
-///     let info = open("video.mp4")?;
-///
-///     // Or by Path
-///     let path = Path::new("/path/to/video.mkv");
-///     let info = open(path)?;
-///
-///     if let Some(video) = info.primary_video() {
-///         println!("Resolution: {}x{}", video.width(), video.height());
-///     }
-///
-///     Ok(())
-/// }
-/// ```
-///
-/// ## Handling Errors
-///
-/// ```
-/// use ff_probe::{open, ProbeError};
-///
-/// // Non-existent file returns FileNotFound
-/// let result = open("/this/file/does/not/exist.mp4");
-/// assert!(matches!(result, Err(ProbeError::FileNotFound { .. })));
-/// ```
-pub fn open(path: impl AsRef<Path>) -> Result<MediaInfo, ProbeError> {
-    let path = path.as_ref();
-
-    log::debug!("probing media file path={}", path.display());
-
-    // Check if file exists
-    if !path.exists() {
-        return Err(ProbeError::FileNotFound {
-            path: path.to_path_buf(),
-        });
-    }
-
-    // Get file size - propagate error since file may exist but be inaccessible (permission denied, etc.)
-    let file_size = std::fs::metadata(path).map(|m| m.len())?;
-
+/// The caller (`builder::open`) has already verified that `path` exists and that
+/// `file_size` was read successfully. `probe_file` itself performs no file-system
+/// checks — it delegates those to the `FFmpeg` API.
+pub(crate) fn probe_file(path: &Path, file_size: u64) -> Result<MediaInfo, ProbeError> {
     // Open file with FFmpeg
     // SAFETY: We verified the file exists, and we properly close the context on all paths
     let ctx = unsafe { ff_sys::avformat::open_input(path) }.map_err(|err_code| {
@@ -1420,38 +1312,6 @@ unsafe fn extract_chapter_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_open_nonexistent_file() {
-        let result = open("/nonexistent/path/to/video.mp4");
-        assert!(result.is_err());
-        match result {
-            Err(ProbeError::FileNotFound { path }) => {
-                assert!(path.to_string_lossy().contains("video.mp4"));
-            }
-            _ => panic!("Expected FileNotFound error"),
-        }
-    }
-
-    #[test]
-    fn test_open_invalid_file() {
-        // Create a temporary file with invalid content
-        let temp_dir = std::env::temp_dir();
-        let temp_file = temp_dir.join("ff_probe_test_invalid.mp4");
-        std::fs::write(&temp_file, b"not a valid video file").ok();
-
-        let result = open(&temp_file);
-
-        // Clean up
-        std::fs::remove_file(&temp_file).ok();
-
-        // FFmpeg should fail to open this as a valid media file
-        assert!(result.is_err());
-        match result {
-            Err(ProbeError::CannotOpen { .. }) | Err(ProbeError::InvalidMedia { .. }) => {}
-            _ => panic!("Expected CannotOpen or InvalidMedia error"),
-        }
-    }
 
     #[test]
     fn test_av_time_base_constant() {


### PR DESCRIPTION
## Summary

Splits the monolithic `crates/ff-probe/src/info.rs` (1889 lines) into the standard three-file module layout already used by `ff-decode` and `ff-encode`. No behavior or public API changes.

## Changes

- `probe/mod.rs`: new — re-exports only
- `probe/builder.rs`: new — safe `pub fn open()` with file-existence and file-size checks; `open()` tests
- `probe/probe_inner.rs`: new — all `unsafe` FFmpeg calls behind `pub(crate) fn probe_file(path, file_size)`; all mapping/pts/constant tests
- `lib.rs`: `mod info` → `mod probe`; `pub use info::open` → `pub use probe::open`
- `info.rs`: deleted

## Related Issues

Resolves #707

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes