### PR TITLE
refactor(ff-encode): rename Container to OutputContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### ff-encode — breaking
+- `Container` renamed to `OutputContainer` to avoid confusion with `ff_format::ContainerInfo` ([#716](https://github.com/itsakeyfut/avio/issues/716))
+
+#### avio — breaking
+- Re-export updated: `Container` → `OutputContainer` under the `encode` feature
+
 ---
 
 ## [0.8.0] - 2026-03-24

--- a/crates/avio/examples/audio_codec_options.rs
+++ b/crates/avio/examples/audio_codec_options.rs
@@ -4,16 +4,16 @@
 //! structs added in v0.7.0:
 //!
 //! - `OpusOptions` — application mode (`Voip` / `Audio` / `LowDelay`),
-//!   frame duration; stored in an OGG container via `Container::Ogg`
+//!   frame duration; stored in an OGG container via `OutputContainer::Ogg`
 //! - `AacOptions` — profile (`LC` / `HE` / `HEv2`), VBR quality mode
 //! - `Mp3Options` — VBR quality (`V0`–`V9`) or fixed bitrate
 //! - `FlacOptions` — compression level (`0` = fastest / largest …
 //!   `12` = slowest / smallest); stored in a FLAC container via
-//!   `Container::Flac`
+//!   `OutputContainer::Flac`
 //!
 //! Also demonstrates `AudioEncoder::create().container()` — explicit
-//! container selection for audio-only formats (`Container::Flac`,
-//! `Container::Ogg`).
+//! container selection for audio-only formats (`OutputContainer::Flac`,
+//! `OutputContainer::Ogg`).
 //!
 //! # Usage
 //!
@@ -27,8 +27,8 @@
 use std::{path::Path, process};
 
 use avio::{
-    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioDecoder, AudioEncoder, Container,
-    FlacOptions, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
+    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioDecoder, AudioEncoder, FlacOptions,
+    Mp3Options, Mp3Quality, OpusApplication, OpusOptions, OutputContainer,
 };
 
 fn main() {
@@ -92,8 +92,8 @@ fn main() {
 
     // Each arm returns (codec, options, bitrate, container, description).
     // container — Some(c) sets the muxer explicitly; None infers from the
-    //   output file extension.  Audio-only containers (Container::Flac,
-    //   Container::Ogg) are typically paired with their native codec.
+    //   output file extension.  Audio-only containers (OutputContainer::Flac,
+    //   OutputContainer::Ogg) are typically paired with their native codec.
     let (audio_codec, codec_options, bitrate, container, description) =
         match codec_str.to_lowercase().as_str() {
             "opus" => {
@@ -103,7 +103,7 @@ fn main() {
                 //   LowDelay — minimal algorithmic delay
                 //
                 // Opus is stored natively in an OGG container.
-                // Container::Ogg is set explicitly here so that the muxer is
+                // OutputContainer::Ogg is set explicitly here so that the muxer is
                 // always correct regardless of the output file extension.
                 let opts = OpusOptions {
                     application: OpusApplication::Audio,
@@ -113,7 +113,7 @@ fn main() {
                     AudioCodec::Opus,
                     AudioCodecOptions::Opus(opts),
                     128_000u64,
-                    Some(Container::Ogg),
+                    Some(OutputContainer::Ogg),
                     "Opus, Audio application, 128 kbps, 20 ms frames, OGG container",
                 )
             }
@@ -154,9 +154,9 @@ fn main() {
                 // through 12 (slowest encode, smallest lossless file).
                 // Default is 5 — a good balance for most use cases.
                 //
-                // FLAC has a dedicated container (Container::Flac) that wraps
+                // FLAC has a dedicated container (OutputContainer::Flac) that wraps
                 // the raw FLAC stream — the same format produced by a standalone
-                // FLAC encoder.  Container::Ogg can also hold FLAC streams in
+                // FLAC encoder.  OutputContainer::Ogg can also hold FLAC streams in
                 // an Ogg wrapper, but the native FLAC container is more common.
                 let opts = FlacOptions {
                     compression_level: 6,
@@ -165,7 +165,7 @@ fn main() {
                     AudioCodec::Flac,
                     AudioCodecOptions::Flac(opts),
                     0u64, // lossless — bitrate is determined by content
-                    Some(Container::Flac),
+                    Some(OutputContainer::Flac),
                     "FLAC, compression level 6, FLAC container",
                 )
             }

--- a/crates/avio/examples/container_format.rs
+++ b/crates/avio/examples/container_format.rs
@@ -1,11 +1,11 @@
 //! Encode video with an explicitly selected output container format.
 //!
 //! Demonstrates:
-//! - `Container` enum — full set of supported muxers:
+//! - `OutputContainer` enum — full set of supported muxers:
 //!   - **Video** containers: `Mp4`, `Mkv`, `WebM`, `Avi`, `Mov`
 //!   - **Audio** containers: `Flac` (lossless), `Ogg` (Vorbis/Opus)
-//! - `Container::as_str()` — `FFmpeg` format name
-//! - `Container::default_extension()` — canonical file extension
+//! - `OutputContainer::as_str()` — `FFmpeg` format name
+//! - `OutputContainer::default_extension()` — canonical file extension
 //! - `VideoEncoder::create().container()` — override the container inferred
 //!   from the output file extension
 //!
@@ -13,8 +13,8 @@
 //! Use `container()` when the extension does not match the desired format
 //! or when you need to guarantee a specific muxer regardless of the path.
 //!
-//! Audio-only containers (`Container::Flac`, `Container::Ogg`) are used the
-//! same way with `AudioEncoder::create().container(Container::Flac)`.
+//! Audio-only containers (`OutputContainer::Flac`, `OutputContainer::Ogg`) are used the
+//! same way with `AudioEncoder::create().container(OutputContainer::Flac)`.
 //! See the `audio_codec_options` example for a complete audio encoding
 //! workflow that demonstrates explicit container selection.
 //!
@@ -29,7 +29,7 @@
 
 use std::{path::Path, process};
 
-use avio::{Container, VideoCodec, VideoDecoder, VideoEncoder};
+use avio::{OutputContainer, VideoCodec, VideoDecoder, VideoEncoder};
 
 fn main() {
     let mut args = std::env::args().skip(1);
@@ -61,16 +61,16 @@ fn main() {
         process::exit(1);
     });
 
-    // ── Parse Container variant ───────────────────────────────────────────────
+    // ── Parse OutputContainer variant ───────────────────────────────────────────────
 
     let container = container_str
         .as_deref()
         .map(|s| match s.to_lowercase().as_str() {
-            "mp4" => Container::Mp4,
-            "mkv" | "matroska" => Container::Mkv,
-            "webm" => Container::WebM,
-            "avi" => Container::Avi,
-            "mov" => Container::Mov,
+            "mp4" => OutputContainer::Mp4,
+            "mkv" | "matroska" => OutputContainer::Mkv,
+            "webm" => OutputContainer::WebM,
+            "avi" => OutputContainer::Avi,
+            "mov" => OutputContainer::Mov,
             other => {
                 eprintln!("Unknown container '{other}' (try mp4, mkv, webm, avi, mov)");
                 process::exit(1);
@@ -105,11 +105,11 @@ fn main() {
 
     match container {
         Some(c) => println!(
-            "Container: {c:?} (format='{}')  default_ext='{}'",
+            "OutputContainer: {c:?} (format='{}')  default_ext='{}'",
             c.as_str(),
             c.default_extension()
         ),
-        None => println!("Container: (inferred from output extension)"),
+        None => println!("OutputContainer: (inferred from output extension)"),
     }
 
     println!("Output: {out_name}");

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -232,11 +232,11 @@ pub use ff_decode::{
 #[cfg(feature = "encode")]
 pub use ff_encode::{
     AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode,
-    CRF_MAX, Container, DnxhdOptions, DnxhdVariant, EncodeError, EncodeProgress,
-    EncodeProgressCallback, FlacOptions, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality,
-    OpusApplication, OpusOptions, Preset, ProResOptions, ProResProfile, SvtAv1Options,
-    VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    CRF_MAX, DnxhdOptions, DnxhdVariant, EncodeError, EncodeProgress, EncodeProgressCallback,
+    FlacOptions, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
+    H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
+    OutputContainer, Preset, ProResOptions, ProResProfile, SvtAv1Options, VideoCodecEncodeExt,
+    VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -10,7 +10,7 @@ use ff_format::AudioFrame;
 
 use super::codec_options::{AudioCodecOptions, Mp3Quality};
 use super::encoder_inner::{AudioEncoderConfig, AudioEncoderInner};
-use crate::{AudioCodec, Container, EncodeError};
+use crate::{AudioCodec, EncodeError, OutputContainer};
 
 /// Builder for constructing an [`AudioEncoder`].
 ///
@@ -29,7 +29,7 @@ use crate::{AudioCodec, Container, EncodeError};
 /// ```
 pub struct AudioEncoderBuilder {
     pub(crate) path: PathBuf,
-    pub(crate) container: Option<Container>,
+    pub(crate) container: Option<OutputContainer>,
     pub(crate) audio_sample_rate: Option<u32>,
     pub(crate) audio_channels: Option<u32>,
     pub(crate) audio_codec: AudioCodec,
@@ -77,7 +77,7 @@ impl AudioEncoderBuilder {
 
     /// Set container format explicitly (usually auto-detected from file extension).
     #[must_use]
-    pub fn container(mut self, container: Container) -> Self {
+    pub fn container(mut self, container: OutputContainer) -> Self {
         self.container = Some(container);
         self
     }
@@ -101,7 +101,7 @@ impl AudioEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Flac);
+                .is_some_and(|c| *c == OutputContainer::Flac);
         if is_flac && !self.audio_codec_explicit {
             self.audio_codec = AudioCodec::Flac;
         }
@@ -114,7 +114,7 @@ impl AudioEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Ogg);
+                .is_some_and(|c| *c == OutputContainer::Ogg);
         if is_ogg && !self.audio_codec_explicit {
             self.audio_codec = AudioCodec::Vorbis;
         }
@@ -173,7 +173,7 @@ impl AudioEncoder {
             || builder
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Flac);
+                .is_some_and(|c| *c == OutputContainer::Flac);
         if is_flac && !matches!(builder.audio_codec, AudioCodec::Flac) {
             return Err(EncodeError::UnsupportedContainerCodecCombination {
                 container: "flac".to_string(),
@@ -191,7 +191,7 @@ impl AudioEncoder {
             || builder
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Ogg);
+                .is_some_and(|c| *c == OutputContainer::Ogg);
         if is_ogg && !matches!(builder.audio_codec, AudioCodec::Vorbis | AudioCodec::Opus) {
             return Err(EncodeError::UnsupportedContainerCodecCombination {
                 container: "ogg".to_string(),
@@ -364,7 +364,7 @@ mod tests {
     fn flac_container_enum_without_explicit_codec_should_default_to_flac() {
         let builder = AudioEncoder::create("output.audio")
             .audio(44100, 2)
-            .container(Container::Flac);
+            .container(OutputContainer::Flac);
         let mut b = builder;
         b.apply_container_defaults();
         assert_eq!(b.audio_codec, AudioCodec::Flac);
@@ -374,7 +374,7 @@ mod tests {
     fn ogg_container_enum_without_explicit_codec_should_default_to_vorbis() {
         let builder = AudioEncoder::create("output.audio")
             .audio(44100, 2)
-            .container(Container::Ogg);
+            .container(OutputContainer::Ogg);
         let mut b = builder;
         b.apply_container_defaults();
         assert_eq!(b.audio_codec, AudioCodec::Vorbis);

--- a/crates/ff-encode/src/container.rs
+++ b/crates/ff-encode/src/container.rs
@@ -1,18 +1,21 @@
 //! Container format definitions.
 
-/// Container format for output file.
+/// Output container format for encoding.
 ///
 /// The container format is usually auto-detected from the file extension,
 /// but can be explicitly specified if needed.
+///
+/// Named `OutputContainer` (rather than `Container`) to avoid confusion with
+/// `ff_format::ContainerInfo`, which describes a container *read* from a probed file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum Container {
+pub enum OutputContainer {
     /// MP4 / `QuickTime`
     Mp4,
 
     /// Fragmented MP4 — CMAF-compatible streaming container.
     ///
-    /// Uses the same `mp4` `FFmpeg` muxer as [`Container::Mp4`] but with
+    /// Uses the same `mp4` `FFmpeg` muxer as [`OutputContainer::Mp4`] but with
     /// `movflags=+frag_keyframe+empty_moov+default_base_moof` applied before
     /// writing the header. Required for HTTP Live Streaming fMP4 segments
     /// (CMAF) and MPEG-DASH.
@@ -37,7 +40,7 @@ pub enum Container {
     Ogg,
 }
 
-impl Container {
+impl OutputContainer {
     /// Get `FFmpeg` format name.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
@@ -83,44 +86,44 @@ mod tests {
 
     #[test]
     fn test_container_as_str() {
-        assert_eq!(Container::Mp4.as_str(), "mp4");
-        assert_eq!(Container::WebM.as_str(), "webm");
-        assert_eq!(Container::Mkv.as_str(), "matroska");
+        assert_eq!(OutputContainer::Mp4.as_str(), "mp4");
+        assert_eq!(OutputContainer::WebM.as_str(), "webm");
+        assert_eq!(OutputContainer::Mkv.as_str(), "matroska");
     }
 
     #[test]
     fn test_container_extension() {
-        assert_eq!(Container::Mp4.default_extension(), "mp4");
-        assert_eq!(Container::WebM.default_extension(), "webm");
-        assert_eq!(Container::Mkv.default_extension(), "mkv");
-        assert_eq!(Container::Flac.default_extension(), "flac");
-        assert_eq!(Container::Ogg.default_extension(), "ogg");
+        assert_eq!(OutputContainer::Mp4.default_extension(), "mp4");
+        assert_eq!(OutputContainer::WebM.default_extension(), "webm");
+        assert_eq!(OutputContainer::Mkv.default_extension(), "mkv");
+        assert_eq!(OutputContainer::Flac.default_extension(), "flac");
+        assert_eq!(OutputContainer::Ogg.default_extension(), "ogg");
     }
 
     #[test]
     fn flac_as_str_should_return_flac() {
-        assert_eq!(Container::Flac.as_str(), "flac");
+        assert_eq!(OutputContainer::Flac.as_str(), "flac");
     }
 
     #[test]
     fn ogg_as_str_should_return_ogg() {
-        assert_eq!(Container::Ogg.as_str(), "ogg");
+        assert_eq!(OutputContainer::Ogg.as_str(), "ogg");
     }
 
     #[test]
     fn fmp4_as_str_should_return_mp4() {
-        assert_eq!(Container::FMp4.as_str(), "mp4");
+        assert_eq!(OutputContainer::FMp4.as_str(), "mp4");
     }
 
     #[test]
     fn fmp4_extension_should_return_mp4() {
-        assert_eq!(Container::FMp4.default_extension(), "mp4");
+        assert_eq!(OutputContainer::FMp4.default_extension(), "mp4");
     }
 
     #[test]
     fn fmp4_is_fragmented_should_return_true() {
-        assert!(Container::FMp4.is_fragmented());
-        assert!(!Container::Mp4.is_fragmented());
-        assert!(!Container::Mkv.is_fragmented());
+        assert!(OutputContainer::FMp4.is_fragmented());
+        assert!(!OutputContainer::Mp4.is_fragmented());
+        assert!(!OutputContainer::Mkv.is_fragmented());
     }
 }

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -209,7 +209,7 @@ pub use audio::{
 };
 pub use bitrate::{BitrateMode, CRF_MAX};
 pub use codec::{AudioCodec, VideoCodec, VideoCodecEncodeExt};
-pub use container::Container;
+pub use container::OutputContainer;
 pub use error::EncodeError;
 pub use hardware::HardwareEncoder;
 pub use image::{ImageEncoder, ImageEncoderBuilder};

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -11,7 +11,8 @@ use ff_format::{AudioFrame, VideoFrame};
 use super::codec_options::VideoCodecOptions;
 use super::encoder_inner::{VideoEncoderConfig, VideoEncoderInner, preset_to_string};
 use crate::{
-    AudioCodec, Container, EncodeError, EncodeProgressCallback, HardwareEncoder, Preset, VideoCodec,
+    AudioCodec, EncodeError, EncodeProgressCallback, HardwareEncoder, OutputContainer, Preset,
+    VideoCodec,
 };
 
 /// Builder for constructing a [`VideoEncoder`].
@@ -32,7 +33,7 @@ use crate::{
 /// ```
 pub struct VideoEncoderBuilder {
     pub(crate) path: PathBuf,
-    pub(crate) container: Option<Container>,
+    pub(crate) container: Option<OutputContainer>,
     pub(crate) video_width: Option<u32>,
     pub(crate) video_height: Option<u32>,
     pub(crate) video_fps: Option<f64>,
@@ -196,11 +197,11 @@ impl VideoEncoderBuilder {
         self
     }
 
-    // === Container settings ===
+    // === OutputContainer settings ===
 
     /// Set container format explicitly (usually auto-detected from file extension).
     #[must_use]
-    pub fn container(mut self, container: Container) -> Self {
+    pub fn container(mut self, container: OutputContainer) -> Self {
         self.container = Some(container);
         self
     }
@@ -412,7 +413,7 @@ impl VideoEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::WebM);
+                .is_some_and(|c| *c == OutputContainer::WebM);
 
         if is_webm {
             if !self.video_codec_explicit {
@@ -431,7 +432,7 @@ impl VideoEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Avi);
+                .is_some_and(|c| *c == OutputContainer::Avi);
 
         if is_avi {
             if !self.video_codec_explicit {
@@ -450,7 +451,7 @@ impl VideoEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Mov);
+                .is_some_and(|c| *c == OutputContainer::Mov);
 
         if is_mov {
             if !self.video_codec_explicit {
@@ -617,7 +618,7 @@ impl VideoEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::WebM);
+                .is_some_and(|c| *c == OutputContainer::WebM);
 
         if is_webm {
             let webm_video_ok = matches!(
@@ -651,7 +652,7 @@ impl VideoEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Avi);
+                .is_some_and(|c| *c == OutputContainer::Avi);
 
         if is_avi {
             let avi_video_ok = matches!(self.video_codec, VideoCodec::H264 | VideoCodec::Mpeg4);
@@ -687,7 +688,7 @@ impl VideoEncoderBuilder {
             || self
                 .container
                 .as_ref()
-                .is_some_and(|c| *c == Container::Mov);
+                .is_some_and(|c| *c == OutputContainer::Mov);
 
         if is_mov {
             let mov_video_ok = matches!(
@@ -721,7 +722,7 @@ impl VideoEncoderBuilder {
         let is_fmp4 = self
             .container
             .as_ref()
-            .is_some_and(|c| *c == Container::FMp4);
+            .is_some_and(|c| *c == OutputContainer::FMp4);
 
         if is_fmp4 {
             let fmp4_video_ok = !matches!(
@@ -1123,8 +1124,8 @@ mod tests {
     fn builder_container_should_be_stored() {
         let builder = VideoEncoder::create("output.mp4")
             .video(1920, 1080, 30.0)
-            .container(Container::Mp4);
-        assert_eq!(builder.container, Some(Container::Mp4));
+            .container(OutputContainer::Mp4);
+        assert_eq!(builder.container, Some(OutputContainer::Mp4));
     }
 
     #[test]
@@ -1343,7 +1344,7 @@ mod tests {
     fn webm_container_enum_with_incompatible_codec_should_return_error() {
         let result = VideoEncoder::create("output.mkv")
             .video(640, 480, 30.0)
-            .container(Container::WebM)
+            .container(OutputContainer::WebM)
             .video_codec(VideoCodec::H264)
             .build();
         assert!(matches!(
@@ -1438,7 +1439,7 @@ mod tests {
     fn avi_container_enum_with_incompatible_codec_should_return_error() {
         let result = VideoEncoder::create("output.mp4")
             .video(640, 480, 30.0)
-            .container(Container::Avi)
+            .container(OutputContainer::Avi)
             .video_codec(VideoCodec::Vp9)
             .build();
         assert!(matches!(
@@ -1451,7 +1452,7 @@ mod tests {
     fn mov_container_enum_with_incompatible_codec_should_return_error() {
         let result = VideoEncoder::create("output.mp4")
             .video(640, 480, 30.0)
-            .container(Container::Mov)
+            .container(OutputContainer::Mov)
             .video_codec(VideoCodec::Vp9)
             .build();
         assert!(matches!(
@@ -1509,7 +1510,7 @@ mod tests {
         let result = VideoEncoder::create("output.mp4")
             .video(640, 480, 30.0)
             .video_codec(VideoCodec::H264)
-            .container(Container::FMp4)
+            .container(OutputContainer::FMp4)
             .build();
         assert!(!matches!(
             result,
@@ -1522,7 +1523,7 @@ mod tests {
         let result = VideoEncoder::create("output.mp4")
             .video(640, 480, 30.0)
             .video_codec(VideoCodec::Mpeg4)
-            .container(Container::FMp4)
+            .container(OutputContainer::FMp4)
             .build();
         assert!(matches!(
             result,
@@ -1537,7 +1538,7 @@ mod tests {
         let result = VideoEncoder::create("output.mp4")
             .video(640, 480, 30.0)
             .video_codec(VideoCodec::Mjpeg)
-            .container(Container::FMp4)
+            .container(OutputContainer::FMp4)
             .build();
         assert!(matches!(
             result,

--- a/crates/ff-encode/src/video/encoder_inner.rs
+++ b/crates/ff-encode/src/video/encoder_inner.rs
@@ -202,7 +202,7 @@ pub(super) struct VideoEncoderConfig {
     pub(super) color_primaries: Option<ff_format::ColorPrimaries>,
     /// Binary attachments: (raw data, MIME type, filename).
     pub(super) attachments: Vec<(Vec<u8>, String, String)>,
-    pub(super) container: Option<crate::Container>,
+    pub(super) container: Option<crate::OutputContainer>,
 }
 impl VideoEncoderInner {
     /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
@@ -243,7 +243,7 @@ impl VideoEncoderInner {
 
     /// Apply `movflags` for fMP4 containers before `avformat_write_header`.
     ///
-    /// When `container` is [`crate::Container::FMp4`], sets
+    /// When `container` is [`crate::OutputContainer::FMp4`], sets
     /// `movflags=+frag_keyframe+empty_moov+default_base_moof` via `av_opt_set`
     /// on the format context's `priv_data`. This enables CMAF-compatible
     /// fragmented output required for HLS fMP4 segments and MPEG-DASH.
@@ -253,7 +253,7 @@ impl VideoEncoderInner {
     /// whose `priv_data` is non-null. Must be called before `avformat_write_header`.
     unsafe fn apply_movflags(
         format_ctx: *mut ff_sys::AVFormatContext,
-        container: Option<crate::Container>,
+        container: Option<crate::OutputContainer>,
     ) {
         if container.is_some_and(|c| c.is_fragmented()) {
             // SAFETY: format_ctx and priv_data are non-null; string literals are

--- a/crates/ff-encode/tests/audio_encoder_tests.rs
+++ b/crates/ff-encode/tests/audio_encoder_tests.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use ff_decode::AudioDecoder;
 use ff_encode::{
-    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioEncoder, Container, EncodeError,
-    FlacOptions, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
+    AacOptions, AacProfile, AudioCodec, AudioCodecOptions, AudioEncoder, EncodeError, FlacOptions,
+    Mp3Options, Mp3Quality, OpusApplication, OpusOptions, OutputContainer,
 };
 use ff_format::{AudioFrame, SampleFormat};
 
@@ -618,7 +618,7 @@ fn flac_level_0_should_produce_larger_file_than_level_12() {
     );
 }
 
-// ── FLAC Container Tests ──────────────────────────────────────────────────────
+// ── FLAC OutputContainer Tests ──────────────────────────────────────────────────────
 
 #[test]
 fn flac_auto_default_codec_should_not_return_container_codec_error() {
@@ -653,7 +653,7 @@ fn flac_with_incompatible_codec_should_return_error() {
 fn flac_container_enum_with_incompatible_codec_should_return_error() {
     let result = AudioEncoder::create("output.audio")
         .audio(44100, 2)
-        .container(Container::Flac)
+        .container(OutputContainer::Flac)
         .audio_codec(AudioCodec::Aac)
         .build();
     assert!(
@@ -692,7 +692,7 @@ fn flac_flac_codec_should_produce_valid_output() {
     assert_valid_output_file(output.path());
 }
 
-// ── OGG Container Tests ───────────────────────────────────────────────────────
+// ── OGG OutputContainer Tests ───────────────────────────────────────────────────────
 
 #[test]
 fn ogg_auto_default_codec_should_not_return_container_codec_error() {
@@ -727,7 +727,7 @@ fn ogg_with_incompatible_codec_should_return_error() {
 fn ogg_container_enum_with_incompatible_codec_should_return_error() {
     let result = AudioEncoder::create("output.audio")
         .audio(44100, 2)
-        .container(Container::Ogg)
+        .container(OutputContainer::Ogg)
         .audio_codec(AudioCodec::Flac)
         .build();
     assert!(

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -13,10 +13,10 @@
 mod fixtures;
 
 use ff_encode::{
-    AudioCodec, Av1Options, Av1Usage, BitrateMode, Container, DnxhdOptions, DnxhdVariant,
-    EncodeError, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
-    H265Tier, Preset, ProResOptions, ProResProfile, SvtAv1Options, VideoCodec, VideoCodecOptions,
-    VideoEncoder, Vp9Options,
+    AudioCodec, Av1Options, Av1Usage, BitrateMode, DnxhdOptions, DnxhdVariant, EncodeError,
+    H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier,
+    OutputContainer, Preset, ProResOptions, ProResProfile, SvtAv1Options, VideoCodec,
+    VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 use ff_format::PixelFormat;
 use fixtures::{
@@ -2025,7 +2025,7 @@ fn attachment_builder_setter_should_not_panic() {
 }
 
 // ============================================================================
-// WebM Container Tests
+// WebM OutputContainer Tests
 // ============================================================================
 
 #[test]
@@ -2115,7 +2115,7 @@ fn webm_with_incompatible_audio_codec_should_return_error() {
 fn container_enum_webm_with_incompatible_codec_should_return_error() {
     let result = VideoEncoder::create("output.mkv")
         .video(640, 480, 30.0)
-        .container(Container::WebM)
+        .container(OutputContainer::WebM)
         .video_codec(VideoCodec::H265)
         .build();
 
@@ -2126,7 +2126,7 @@ fn container_enum_webm_with_incompatible_codec_should_return_error() {
 }
 
 // ============================================================================
-// AVI Container Tests
+// AVI OutputContainer Tests
 // ============================================================================
 
 #[test]
@@ -2213,7 +2213,7 @@ fn avi_with_incompatible_audio_codec_should_return_error() {
 }
 
 // ============================================================================
-// MOV Container Tests
+// MOV OutputContainer Tests
 // ============================================================================
 
 #[test]


### PR DESCRIPTION
## Summary

Renames `ff_encode::Container` to `OutputContainer` to eliminate the naming ambiguity with `ff_format::ContainerInfo`. Both types appeared side-by-side in IDE autocomplete, making it unclear which described a container read from a probed file (`ContainerInfo`) versus a container format chosen for encoding output (`OutputContainer`).

## Changes

- `ff-encode/src/container.rs` — enum renamed to `OutputContainer`; doc comment updated to explain the naming rationale
- `ff-encode/src/lib.rs` — re-export updated to `OutputContainer`
- `ff-encode/src/video/builder.rs` — all `Container` references replaced with `OutputContainer`
- `ff-encode/src/video/encoder_inner.rs` — `crate::Container` → `crate::OutputContainer`
- `ff-encode/src/audio/builder.rs` — all `Container` references replaced with `OutputContainer`
- `ff-encode/tests/video_encoder_tests.rs` — import and usage updated
- `ff-encode/tests/audio_encoder_tests.rs` — import and usage updated
- `avio/src/lib.rs` — re-export updated to `OutputContainer`
- `avio/examples/container_format.rs` — all usage updated
- `avio/examples/audio_codec_options.rs` — all usage updated
- `CHANGELOG.md` — breaking change documented under `[Unreleased]`

Note: `EncodeError::UnsupportedContainerCodecCombination` is intentionally left unchanged — it is an error variant name, not a type name, and renaming it would provide no clarity benefit.

## Related Issues

Resolves #716

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes