### PR TITLE
chore(ff-filter, ff-probe): document read-only tests need no temp file cleanup

### DIFF
--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1,3 +1,12 @@
+//! Integration tests for ff-filter push/pull frame processing.
+//!
+//! # Temporary file cleanup
+//!
+//! These tests are read-only with respect to the filesystem: they push frames
+//! through in-memory filter graphs and inspect the resulting `VideoFrame` /
+//! `AudioFrame` values. No output files are written, so no
+//! `fixtures/mod.rs` with `FileGuard`/`DirGuard` is needed.
+
 #![allow(clippy::unwrap_used)]
 
 use std::time::Duration;

--- a/crates/ff-probe/tests/integration_tests.rs
+++ b/crates/ff-probe/tests/integration_tests.rs
@@ -2,6 +2,12 @@
 //!
 //! These tests verify that ff-probe correctly extracts metadata from
 //! actual media files in the assets directory.
+//!
+//! # Temporary file cleanup
+//!
+//! These tests are read-only: they call `ff_probe::open()` to inspect existing
+//! media files and do not produce any temporary output files. No
+//! `fixtures/mod.rs` with `FileGuard`/`DirGuard` is needed.
 
 use std::path::PathBuf;
 use std::time::Duration;

--- a/crates/ff-probe/tests/performance_validation_tests.rs
+++ b/crates/ff-probe/tests/performance_validation_tests.rs
@@ -3,6 +3,12 @@
 //! These tests validate that metadata extraction meets the performance target:
 //! - Metadata extraction: 20-30ms (same as legacy ffmpeg-next)
 //!
+//! # Temporary file cleanup
+//!
+//! These tests are read-only: they call `ff_probe::open()` to inspect existing
+//! media files and do not produce any temporary output files. No
+//! `fixtures/mod.rs` with `FileGuard`/`DirGuard` is needed.
+//!
 //! Note: These tests use relaxed thresholds to account for CI environment variability.
 
 // Tests are allowed to use unwrap() for simplicity


### PR DESCRIPTION
## Summary

Verifies that ff-filter and ff-probe integration tests do not produce temporary output files, and documents this explicitly in each test module's doc comment. Both crates operate entirely in memory or on existing asset files, so no `fixtures/mod.rs` with `FileGuard`/`DirGuard` is required.

## Changes

- `crates/ff-filter/tests/push_pull_tests.rs`: added module-level doc comment with "Temporary file cleanup" section noting tests are read-only
- `crates/ff-probe/tests/integration_tests.rs`: same
- `crates/ff-probe/tests/performance_validation_tests.rs`: same

## Related Issues

Closes #720

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes