### PR TITLE
feat(ff-filter): add hue filter step for hue rotation

### DIFF
--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -119,6 +119,8 @@ pub(crate) enum FilterStep {
     },
     /// White balance correction via `colorchannelmixer`.
     WhiteBalance { temperature_k: u32, tint: f32 },
+    /// Hue rotation by an arbitrary angle.
+    Hue { degrees: f32 },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -165,6 +167,7 @@ impl FilterStep {
             Self::Eq { .. } => "eq",
             Self::Curves { .. } => "curves",
             Self::WhiteBalance { .. } => "colorchannelmixer",
+            Self::Hue { .. } => "hue",
         }
     }
 
@@ -221,6 +224,7 @@ impl FilterStep {
                 let g_adj = (g + f64::from(*tint)).clamp(0.0, 2.0);
                 format!("rr={r}:gg={g_adj}:bb={b}")
             }
+            Self::Hue { degrees } => format!("h={degrees}"),
         }
     }
 }
@@ -400,6 +404,20 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Rotate hue by `degrees` using `FFmpeg`'s `hue` filter.
+    ///
+    /// Valid range: −360.0–360.0. A value of `0.0` is a no-op.
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `degrees` is outside `[−360.0, 360.0]`.
+    #[must_use]
+    pub fn hue(mut self, degrees: f32) -> Self {
+        self.steps.push(FilterStep::Hue { degrees });
+        self
+    }
+
     // ── Audio filters ─────────────────────────────────────────────────────────
 
     /// Adjust audio volume by `gain_db` decibels (negative = quieter).
@@ -538,6 +556,13 @@ impl FilterGraphBuilder {
                         reason: format!("white_balance tint {tint} out of range [-1.0, 1.0]"),
                     });
                 }
+            }
+            if let FilterStep::Hue { degrees } = step
+                && !(-360.0..=360.0).contains(degrees)
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: format!("hue degrees {degrees} out of range [-360.0, 360.0]"),
+                });
             }
         }
 
@@ -1155,5 +1180,56 @@ mod tests {
                 "reason should mention tint: {reason}"
             );
         }
+    }
+
+    #[test]
+    fn filter_step_hue_should_produce_correct_filter_name() {
+        let step = FilterStep::Hue { degrees: 90.0 };
+        assert_eq!(step.filter_name(), "hue");
+    }
+
+    #[test]
+    fn filter_step_hue_should_produce_correct_args() {
+        let step = FilterStep::Hue { degrees: 180.0 };
+        assert_eq!(step.args(), "h=180");
+    }
+
+    #[test]
+    fn filter_step_hue_zero_should_produce_no_op_args() {
+        let step = FilterStep::Hue { degrees: 0.0 };
+        assert_eq!(step.args(), "h=0");
+    }
+
+    #[test]
+    fn builder_hue_with_valid_degrees_should_succeed() {
+        let result = FilterGraph::builder().hue(0.0).build();
+        assert!(
+            result.is_ok(),
+            "hue(0.0) must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_hue_with_degrees_too_high_should_return_invalid_config() {
+        let result = FilterGraph::builder().hue(400.0).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for degrees > 360.0, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("degrees"),
+                "reason should mention degrees: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_hue_with_degrees_too_low_should_return_invalid_config() {
+        let result = FilterGraph::builder().hue(-400.0).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for degrees < -360.0, got {result:?}"
+        );
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -605,3 +605,35 @@ fn push_video_through_white_balance_should_return_frame_with_same_dimensions() {
         "height should be unchanged after white_balance"
     );
 }
+
+#[test]
+fn push_video_through_hue_180_should_return_frame_with_same_dimensions() {
+    // Rotating hue by 180° inverts the hue; frame dimensions must be preserved.
+    let mut graph = match FilterGraph::builder().hue(180.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after hue push");
+    assert_eq!(
+        out.width(),
+        64,
+        "width should be unchanged after hue rotation"
+    );
+    assert_eq!(
+        out.height(),
+        64,
+        "height should be unchanged after hue rotation"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `FilterGraphBuilder::hue()` to rotate hue by an arbitrary angle
using FFmpeg's `hue` filter. The valid range is −360.0–360.0 (0.0 is a
no-op); values outside this range are rejected at `build()` time.

## Changes

- Added `FilterStep::Hue { degrees: f32 }` variant
- Implemented `filter_name()` → `"hue"` and `args()` → `"h={degrees}"`
- Added `FilterGraphBuilder::hue(degrees: f32) -> Self` builder method
- Added `build()` range validation rejecting degrees outside `[-360.0, 360.0]`
- Added 5 unit tests: filter name, args at 180°, args at 0° (no-op), valid build, and two out-of-range cases
- Added integration test `push_video_through_hue_180_should_return_frame_with_same_dimensions`

## Related Issues

Closes #242

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes