### PR TITLE
feat(ff-filter): add crop validation for zero dimensions and out-of-bounds

### DIFF
--- a/crates/ff-filter/src/filter_inner.rs
+++ b/crates/ff-filter/src/filter_inner.rs
@@ -386,6 +386,21 @@ impl FilterGraphInner {
         let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
         if ret < 0 {
             log::warn!("avfilter_graph_config failed code={ret}");
+            // If there is a crop step the most likely cause is the rectangle
+            // extending beyond the source frame dimensions.
+            if let Some(FilterStep::Crop {
+                x,
+                y,
+                width,
+                height,
+            }) = steps.iter().find(|s| matches!(s, FilterStep::Crop { .. }))
+            {
+                bail!(FilterError::InvalidConfig {
+                    reason: format!(
+                        "crop rect {x},{y}+{width}x{height} exceeds source frame dimensions"
+                    ),
+                });
+            }
             bail!(ffmpeg_err(ret));
         }
 

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -616,6 +616,13 @@ impl FilterGraphBuilder {
         // (e.g. a watermark larger than the video). Catch it early with a
         // descriptive error rather than silently producing invisible output.
         for step in &self.steps {
+            if let FilterStep::Crop { width, height, .. } = step
+                && (*width == 0 || *height == 0)
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: "crop width and height must be > 0".to_string(),
+                });
+            }
             if let FilterStep::Overlay { x, y } = step
                 && (*x < 0 || *y < 0)
             {
@@ -1635,6 +1642,39 @@ mod tests {
         assert!(
             matches!(result, Err(FilterError::InvalidConfig { .. })),
             "expected InvalidConfig for angle < 0.0, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_crop_with_zero_width_should_return_invalid_config() {
+        let result = FilterGraph::builder().crop(0, 0, 0, 100).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for width=0, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("crop width and height must be > 0"),
+                "reason should mention crop dimensions: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_crop_with_zero_height_should_return_invalid_config() {
+        let result = FilterGraph::builder().crop(0, 0, 100, 0).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for height=0, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_crop_with_valid_dimensions_should_succeed() {
+        let result = FilterGraph::builder().crop(0, 0, 64, 64).build();
+        assert!(
+            result.is_ok(),
+            "crop with valid dimensions must build successfully, got {result:?}"
         );
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -226,6 +226,30 @@ fn push_video_through_crop_should_return_cropped_frame() {
 }
 
 #[test]
+fn push_1080p_frame_through_crop_100_100_1720_880_should_return_cropped_frame() {
+    // Crop a 1920×1080 frame to a 1720×880 rectangle starting at (100, 100).
+    let mut graph = match FilterGraph::builder().crop(100, 100, 1720, 880).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(1920, 1080);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after crop push");
+    assert_eq!(out.width(), 1720, "width should be 1720 after crop");
+    assert_eq!(out.height(), 880, "height should be 880 after crop");
+}
+
+#[test]
 fn push_video_through_overlay_should_return_composited_frame() {
     let mut graph = match FilterGraph::builder().overlay(0, 0).build() {
         Ok(g) => g,


### PR DESCRIPTION
## Summary

Adds two layers of validation to the existing `crop` filter step. At `build()` time, zero width or height is rejected with a descriptive `FilterError::InvalidConfig`. At graph-configuration time, if `avfilter_graph_config` fails while a `Crop` step is present, the generic FFmpeg error is replaced with an `InvalidConfig` message that includes the rectangle coordinates, making it clear the crop rect exceeds the source frame dimensions.

## Changes

- `crates/ff-filter/src/graph.rs`: added `build()` guard rejecting `width == 0` or `height == 0`; added 3 unit tests (`crop(0,0,0,100)`, `crop(0,0,100,0)`, and a valid-dimensions success case)
- `crates/ff-filter/src/filter_inner.rs`: in `build_video_graph`, after `avfilter_graph_config` failure, check for a `Crop` step and return `FilterError::InvalidConfig` with the rect coordinates instead of a raw FFmpeg error code
- `crates/ff-filter/tests/push_pull_tests.rs`: added integration test cropping a 1920×1080 frame to 1720×880 at offset (100, 100) and asserting the output dimensions

## Related Issues

Closes #246

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes