### PR TITLE
feat(ff-filter): extend rotate step with configurable fill color

### DIFF
--- a/crates/avio/examples/filter/video_effects.rs
+++ b/crates/avio/examples/filter/video_effects.rs
@@ -144,7 +144,7 @@ fn main() {
             println!("Input:   {in_name}");
             println!("Effect:  rotate  (angle={angle}°)");
             println!("Output:  {out_name}");
-            FilterGraphBuilder::new().rotate(angle).build()
+            FilterGraphBuilder::new().rotate(angle, "black").build()
         }
         "crop" => {
             let w = crop_w.unwrap_or_else(|| {

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -118,8 +118,11 @@ pub(crate) enum FilterStep {
     FadeIn(Duration),
     /// Fade-out to black over `duration`.
     FadeOut(Duration),
-    /// Rotate clockwise by `degrees`.
-    Rotate(f64),
+    /// Rotate clockwise by `angle_degrees`, filling exposed areas with `fill_color`.
+    Rotate {
+        angle_degrees: f64,
+        fill_color: String,
+    },
     /// HDR-to-SDR tone mapping.
     ToneMap(ToneMap),
     /// Adjust audio volume (in dB; negative = quieter).
@@ -204,7 +207,7 @@ impl FilterStep {
             Self::Crop { .. } => "crop",
             Self::Overlay { .. } => "overlay",
             Self::FadeIn(_) | Self::FadeOut(_) => "fade",
-            Self::Rotate(_) => "rotate",
+            Self::Rotate { .. } => "rotate",
             Self::ToneMap(_) => "tonemap",
             Self::Volume(_) => "volume",
             Self::Amix(_) => "amix",
@@ -236,8 +239,14 @@ impl FilterStep {
             Self::Overlay { x, y } => format!("x={x}:y={y}"),
             Self::FadeIn(d) => format!("type=in:duration={}", d.as_secs_f64()),
             Self::FadeOut(d) => format!("type=out:duration={}", d.as_secs_f64()),
-            Self::Rotate(degrees) => {
-                format!("angle={}", degrees.to_radians())
+            Self::Rotate {
+                angle_degrees,
+                fill_color,
+            } => {
+                format!(
+                    "angle={}:fillcolor={fill_color}",
+                    angle_degrees.to_radians()
+                )
             }
             Self::ToneMap(algorithm) => format!("tonemap={}", algorithm.as_str()),
             Self::Volume(db) => format!("volume={db}dB"),
@@ -394,10 +403,18 @@ impl FilterGraphBuilder {
         self
     }
 
-    /// Rotate the video clockwise by `degrees`.
+    /// Rotate the video clockwise by `angle_degrees`, filling exposed corners
+    /// with `fill_color`.
+    ///
+    /// `fill_color` accepts any color string understood by `FFmpeg` — for example
+    /// `"black"`, `"white"`, `"0x00000000"` (transparent), or `"gray"`.
+    /// Pass `"black"` to reproduce the classic solid-background rotation.
     #[must_use]
-    pub fn rotate(mut self, degrees: f64) -> Self {
-        self.steps.push(FilterStep::Rotate(degrees));
+    pub fn rotate(mut self, angle_degrees: f64, fill_color: &str) -> Self {
+        self.steps.push(FilterStep::Rotate {
+            angle_degrees,
+            fill_color: fill_color.to_owned(),
+        });
         self
     }
 
@@ -946,9 +963,29 @@ mod tests {
 
     #[test]
     fn filter_step_rotate_should_produce_correct_args() {
-        let step = FilterStep::Rotate(90.0);
+        let step = FilterStep::Rotate {
+            angle_degrees: 90.0,
+            fill_color: "black".to_owned(),
+        };
         assert_eq!(step.filter_name(), "rotate");
-        assert_eq!(step.args(), format!("angle={}", 90_f64.to_radians()));
+        assert_eq!(
+            step.args(),
+            format!("angle={}:fillcolor=black", 90_f64.to_radians())
+        );
+    }
+
+    #[test]
+    fn filter_step_rotate_transparent_fill_should_produce_correct_args() {
+        let step = FilterStep::Rotate {
+            angle_degrees: 45.0,
+            fill_color: "0x00000000".to_owned(),
+        };
+        assert_eq!(step.filter_name(), "rotate");
+        let args = step.args();
+        assert!(
+            args.contains("fillcolor=0x00000000"),
+            "args should contain transparent fill: {args}"
+        );
     }
 
     #[test]

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -340,7 +340,7 @@ fn push_video_through_fade_out_should_return_frame_with_same_dimensions() {
 
 #[test]
 fn push_video_through_rotate_should_return_frame() {
-    let mut graph = match FilterGraph::builder().rotate(90.0).build() {
+    let mut graph = match FilterGraph::builder().rotate(90.0, "black").build() {
         Ok(g) => g,
         Err(e) => {
             println!("Skipping: {e}");


### PR DESCRIPTION
## Summary

Extends `FilterStep::Rotate` and `FilterGraphBuilder::rotate` to accept a `fill_color` parameter that controls how FFmpeg fills the exposed corners after rotation. Passing `"black"` reproduces the previous default behaviour; other values such as `"white"` or `"0x00000000"` (transparent) are also accepted. This is a breaking change to the builder signature.

## Changes

- `crates/ff-filter/src/graph.rs`: changed `FilterStep::Rotate(f64)` to `FilterStep::Rotate { angle_degrees: f64, fill_color: String }`; updated `args()` to emit `fillcolor=<color>`; updated builder method to `rotate(angle_degrees: f64, fill_color: &str)`; updated existing unit test; added new unit test for transparent fill (`"0x00000000"`)
- `crates/ff-filter/tests/push_pull_tests.rs`: updated integration test call to `rotate(90.0, "black")`
- `crates/avio/examples/filter/video_effects.rs`: updated example call to `rotate(angle, "black")`

## Related Issues

Closes #247

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes