### PR TITLE
feat(ff-filter): add hflip and vflip filter steps

### DIFF
--- a/crates/ff-filter/src/filter_inner.rs
+++ b/crates/ff-filter/src/filter_inner.rs
@@ -1278,13 +1278,27 @@ unsafe fn av_frame_to_video_frame(raw_frame: *const AVFrame) -> Result<VideoFram
         if src_ptr.is_null() {
             return Err(());
         }
-        let stride = (*raw_frame).linesize[i] as usize;
+        let linesize_raw = (*raw_frame).linesize[i];
+        // Some filters (e.g. `vflip`) produce frames with a negative linesize to
+        // indicate a bottom-up scan order. `data[i]` then points to the last row,
+        // and each successive row is at a lower address. We take the absolute
+        // stride, seek back to the first row, and copy the contiguous data block.
+        let stride = linesize_raw.unsigned_abs() as usize;
         let rows = plane_height(format, i, height as usize);
         let byte_count = stride * rows;
+        let data_ptr = if linesize_raw < 0 {
+            // SAFETY: The full plane is `stride * rows` bytes.  With a negative
+            // linesize `data[i]` sits at the start of the *last* row; offsetting
+            // by `linesize_raw * (rows - 1)` steps back to the first row so we
+            // can read the whole block in one contiguous slice.
+            src_ptr.offset(linesize_raw as isize * (rows as isize - 1))
+        } else {
+            src_ptr
+        };
 
         // SAFETY: `av_frame_get_buffer` / `av_buffersink_get_frame` guarantees
-        // at least `linesize[i] * rows` bytes per plane pointer.
-        let data = std::slice::from_raw_parts(src_ptr, byte_count).to_vec();
+        // at least `stride * rows` bytes starting at `data_ptr`.
+        let data = std::slice::from_raw_parts(data_ptr, byte_count).to_vec();
         planes.push(PooledBuffer::standalone(data));
         strides.push(stride);
     }

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -170,6 +170,10 @@ pub(crate) enum FilterStep {
         /// Vertical centre of the vignette. `0.0` maps to `h/2`.
         y0: f32,
     },
+    /// Horizontal flip (mirror left-right).
+    HFlip,
+    /// Vertical flip (mirror top-bottom).
+    VFlip,
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -220,6 +224,8 @@ impl FilterStep {
             Self::Gamma { .. } => "eq",
             Self::ThreeWayCC { .. } => "curves",
             Self::Vignette { .. } => "vignette",
+            Self::HFlip => "hflip",
+            Self::VFlip => "vflip",
         }
     }
 
@@ -320,6 +326,7 @@ impl FilterStep {
                     curve(lift.b, gamma.b, gain.b),
                 )
             }
+            Self::HFlip | Self::VFlip => String::new(),
         }
     }
 }
@@ -575,6 +582,20 @@ impl FilterGraphBuilder {
     #[must_use]
     pub fn vignette(mut self, angle: f32, x0: f32, y0: f32) -> Self {
         self.steps.push(FilterStep::Vignette { angle, x0, y0 });
+        self
+    }
+
+    /// Flip the video horizontally (mirror left–right) using `FFmpeg`'s `hflip` filter.
+    #[must_use]
+    pub fn hflip(mut self) -> Self {
+        self.steps.push(FilterStep::HFlip);
+        self
+    }
+
+    /// Flip the video vertically (mirror top–bottom) using `FFmpeg`'s `vflip` filter.
+    #[must_use]
+    pub fn vflip(mut self) -> Self {
+        self.steps.push(FilterStep::VFlip);
         self
     }
 
@@ -1712,6 +1733,47 @@ mod tests {
         assert!(
             result.is_ok(),
             "crop with valid dimensions must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn filter_step_hflip_should_produce_correct_filter_name_and_empty_args() {
+        let step = FilterStep::HFlip;
+        assert_eq!(step.filter_name(), "hflip");
+        assert_eq!(step.args(), "");
+    }
+
+    #[test]
+    fn filter_step_vflip_should_produce_correct_filter_name_and_empty_args() {
+        let step = FilterStep::VFlip;
+        assert_eq!(step.filter_name(), "vflip");
+        assert_eq!(step.args(), "");
+    }
+
+    #[test]
+    fn builder_hflip_should_succeed() {
+        let result = FilterGraph::builder().hflip().build();
+        assert!(
+            result.is_ok(),
+            "hflip must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_vflip_should_succeed() {
+        let result = FilterGraph::builder().vflip().build();
+        assert!(
+            result.is_ok(),
+            "vflip must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_hflip_twice_should_succeed() {
+        let result = FilterGraph::builder().hflip().hflip().build();
+        assert!(
+            result.is_ok(),
+            "double hflip (round-trip) must build successfully, got {result:?}"
         );
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -751,3 +751,49 @@ fn push_video_through_vignette_should_return_frame_with_same_dimensions() {
         "height should be unchanged after vignette"
     );
 }
+
+#[test]
+fn push_video_through_hflip_should_return_frame_with_same_dimensions() {
+    let mut graph = match FilterGraph::builder().hflip().build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after hflip push");
+    assert_eq!(out.width(), 64, "width should be unchanged after hflip");
+    assert_eq!(out.height(), 64, "height should be unchanged after hflip");
+}
+
+#[test]
+fn push_video_through_vflip_should_return_frame_with_same_dimensions() {
+    let mut graph = match FilterGraph::builder().vflip().build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after vflip push");
+    assert_eq!(out.width(), 64, "width should be unchanged after vflip");
+    assert_eq!(out.height(), 64, "height should be unchanged after vflip");
+}


### PR DESCRIPTION
## Summary

Adds `FilterStep::HFlip` and `FilterStep::VFlip` variants backed by FFmpeg's `hflip` and `vflip` filters, along with the corresponding `FilterGraphBuilder::hflip()` and `vflip()` builder methods. Also fixes a pre-existing panic in `av_frame_to_video_frame` where negative `linesize` values (used by `vflip` and other bottom-up filters) were incorrectly cast to `usize`, causing a multiplication overflow at runtime.

## Changes

- `crates/ff-filter/src/graph.rs`: added `FilterStep::HFlip` and `FilterStep::VFlip` variants; `filter_name()` → `"hflip"` / `"vflip"`, `args()` → empty string; added builder methods `hflip()` and `vflip()`; added 5 unit tests
- `crates/ff-filter/src/filter_inner.rs`: fixed `av_frame_to_video_frame` to handle negative `linesize` by using `unsigned_abs()` for the stride and offsetting the data pointer back to the first row before reading the plane
- `crates/ff-filter/tests/push_pull_tests.rs`: added integration tests for both `hflip` and `vflip` verifying output dimensions are preserved

## Related Issues

Closes #248

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes