### PR TITLE
feat(ff-filter): add ScaleAlgorithm enum to scale filter step

### DIFF
--- a/crates/avio/examples/filter/filter_direct.rs
+++ b/crates/avio/examples/filter/filter_direct.rs
@@ -89,7 +89,7 @@ fn main() {
     // for the audio path on the same graph object.
 
     let mut filter = match FilterGraphBuilder::new()
-        .scale(out_w, out_h)
+        .scale(out_w, out_h, avio::ScaleAlgorithm::Fast)
         .volume(0.8)
         .build()
     {

--- a/crates/avio/examples/transcode/transcode.rs
+++ b/crates/avio/examples/transcode/transcode.rs
@@ -231,7 +231,10 @@ fn main() {
     // ── Build optional scale filter ───────────────────────────────────────────
 
     let filter = match (args.width, args.height) {
-        (Some(w), Some(h)) => match FilterGraphBuilder::new().scale(w, h).build() {
+        (Some(w), Some(h)) => match FilterGraphBuilder::new()
+            .scale(w, h, avio::ScaleAlgorithm::Fast)
+            .build()
+        {
             Ok(fg) => Some(fg),
             Err(e) => {
                 eprintln!("Error: failed to build filter graph: {e}");

--- a/crates/avio/examples/transcode/trim_and_scale.rs
+++ b/crates/avio/examples/transcode/trim_and_scale.rs
@@ -169,7 +169,7 @@ fn main() {
     // Build filter graph: trim → scale (if requested)
     let mut builder = FilterGraphBuilder::new().trim(start, end);
     if let (Some(w), Some(h)) = (width, height) {
-        builder = builder.scale(w, h);
+        builder = builder.scale(w, h, avio::ScaleAlgorithm::Fast);
     }
     let filter = match builder.build() {
         Ok(fg) => fg,

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -252,7 +252,9 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
-pub use ff_filter::{FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ToneMap};
+pub use ff_filter::{
+    FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap,
+};
 
 // ── pipeline feature ──────────────────────────────────────────────────────────
 //

--- a/crates/ff-filter/src/filter_inner.rs
+++ b/crates/ff-filter/src/filter_inner.rs
@@ -1342,6 +1342,7 @@ mod tests {
             vec![FilterStep::Scale {
                 width: 1280,
                 height: 720,
+                algorithm: crate::graph::ScaleAlgorithm::Fast,
             }],
             None,
         );
@@ -1371,6 +1372,7 @@ mod tests {
             vec![FilterStep::Scale {
                 width: 640,
                 height: 360,
+                algorithm: crate::graph::ScaleAlgorithm::Fast,
             }],
             None,
         );
@@ -1450,6 +1452,7 @@ mod tests {
             vec![FilterStep::Scale {
                 width: 1280,
                 height: 720,
+                algorithm: crate::graph::ScaleAlgorithm::Fast,
             }],
             None,
         );
@@ -1475,6 +1478,7 @@ mod tests {
                 FilterStep::Scale {
                     width: 640,
                     height: 360,
+                    algorithm: crate::graph::ScaleAlgorithm::Fast,
                 },
             ],
             None,
@@ -1523,6 +1527,7 @@ mod tests {
         let steps = vec![FilterStep::Scale {
             width: 640,
             height: 360,
+            algorithm: crate::graph::ScaleAlgorithm::Fast,
         }];
         assert!(
             validate_filter_steps(&steps).is_ok(),

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -93,6 +93,35 @@ impl Rgb {
     };
 }
 
+/// Resampling algorithm for the `scale` filter.
+///
+/// Used with [`FilterGraphBuilder::scale`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScaleAlgorithm {
+    /// Fast bilinear interpolation (default). Good balance of speed and quality.
+    Fast,
+    /// Bilinear interpolation. Slightly slower than [`Fast`](Self::Fast) but
+    /// produces smoother results.
+    Bilinear,
+    /// Bicubic interpolation. Higher quality than bilinear with moderate overhead.
+    Bicubic,
+    /// Lanczos interpolation — sharpest output, highest CPU cost.
+    Lanczos,
+}
+
+impl ScaleAlgorithm {
+    /// Returns the `sws_flags` string passed to the `scale` filter.
+    #[must_use]
+    pub const fn as_flags_str(self) -> &'static str {
+        match self {
+            Self::Fast => "fast_bilinear",
+            Self::Bilinear => "bilinear",
+            Self::Bicubic => "bicubic",
+            Self::Lanczos => "lanczos",
+        }
+    }
+}
+
 // ── FilterStep ────────────────────────────────────────────────────────────────
 
 /// A single step in a filter chain, constructed by the builder methods.
@@ -103,8 +132,12 @@ impl Rgb {
 pub(crate) enum FilterStep {
     /// Trim: keep only frames in `[start, end)` seconds.
     Trim { start: f64, end: f64 },
-    /// Scale to a new resolution.
-    Scale { width: u32, height: u32 },
+    /// Scale to a new resolution using the given resampling algorithm.
+    Scale {
+        width: u32,
+        height: u32,
+        algorithm: ScaleAlgorithm,
+    },
     /// Crop a rectangular region.
     Crop {
         x: u32,
@@ -233,7 +266,11 @@ impl FilterStep {
     pub(crate) fn args(&self) -> String {
         match self {
             Self::Trim { start, end } => format!("start={start}:end={end}"),
-            Self::Scale { width, height } => format!("w={width}:h={height}"),
+            Self::Scale {
+                width,
+                height,
+                algorithm,
+            } => format!("w={width}:h={height}:flags={}", algorithm.as_flags_str()),
             Self::Crop {
                 x,
                 y,
@@ -370,10 +407,19 @@ impl FilterGraphBuilder {
         self
     }
 
-    /// Scale the video to `width × height` pixels.
+    /// Scale the video to `width × height` pixels using the given resampling
+    /// `algorithm`.
+    ///
+    /// Use [`ScaleAlgorithm::Fast`] for the best speed/quality trade-off.
+    /// For highest quality use [`ScaleAlgorithm::Lanczos`] at the cost of
+    /// additional CPU time.
     #[must_use]
-    pub fn scale(mut self, width: u32, height: u32) -> Self {
-        self.steps.push(FilterStep::Scale { width, height });
+    pub fn scale(mut self, width: u32, height: u32, algorithm: ScaleAlgorithm) -> Self {
+        self.steps.push(FilterStep::Scale {
+            width,
+            height,
+            algorithm,
+        });
         self
     }
 
@@ -781,7 +827,7 @@ impl FilterGraphBuilder {
 
         crate::filter_inner::validate_filter_steps(&self.steps)?;
         let output_resolution = self.steps.iter().rev().find_map(|s| {
-            if let FilterStep::Scale { width, height } = s {
+            if let FilterStep::Scale { width, height, .. } = s {
                 Some((*width, *height))
             } else {
                 None
@@ -911,9 +957,20 @@ mod tests {
         let step = FilterStep::Scale {
             width: 1280,
             height: 720,
+            algorithm: ScaleAlgorithm::Fast,
         };
         assert_eq!(step.filter_name(), "scale");
-        assert_eq!(step.args(), "w=1280:h=720");
+        assert_eq!(step.args(), "w=1280:h=720:flags=fast_bilinear");
+    }
+
+    #[test]
+    fn filter_step_scale_lanczos_should_produce_lanczos_flags() {
+        let step = FilterStep::Scale {
+            width: 1920,
+            height: 1080,
+            algorithm: ScaleAlgorithm::Lanczos,
+        };
+        assert_eq!(step.args(), "w=1920:h=1080:flags=lanczos");
     }
 
     #[test]
@@ -1037,7 +1094,7 @@ mod tests {
     fn builder_steps_should_accumulate_in_order() {
         let result = FilterGraph::builder()
             .trim(0.0, 5.0)
-            .scale(1280, 720)
+            .scale(1280, 720, ScaleAlgorithm::Fast)
             .volume(-3.0)
             .build();
         assert!(
@@ -1048,7 +1105,9 @@ mod tests {
 
     #[test]
     fn builder_with_valid_steps_should_succeed() {
-        let result = FilterGraph::builder().scale(1280, 720).build();
+        let result = FilterGraph::builder()
+            .scale(1280, 720, ScaleAlgorithm::Fast)
+            .build();
         assert!(
             result.is_ok(),
             "builder with a known filter step must succeed, got {result:?}"
@@ -1057,15 +1116,18 @@ mod tests {
 
     #[test]
     fn output_resolution_should_return_scale_dimensions() {
-        let fg = FilterGraph::builder().scale(1280, 720).build().unwrap();
+        let fg = FilterGraph::builder()
+            .scale(1280, 720, ScaleAlgorithm::Fast)
+            .build()
+            .unwrap();
         assert_eq!(fg.output_resolution(), Some((1280, 720)));
     }
 
     #[test]
     fn output_resolution_should_return_last_scale_when_chained() {
         let fg = FilterGraph::builder()
-            .scale(1920, 1080)
-            .scale(1280, 720)
+            .scale(1920, 1080, ScaleAlgorithm::Fast)
+            .scale(1280, 720, ScaleAlgorithm::Bicubic)
             .build()
             .unwrap();
         assert_eq!(fg.output_resolution(), Some((1280, 720)));

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -36,4 +36,4 @@ mod filter_inner;
 pub mod graph;
 
 pub use error::FilterError;
-pub use graph::{FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ToneMap};
+pub use graph::{FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap};

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -11,7 +11,7 @@
 
 use std::time::Duration;
 
-use ff_filter::{FilterError, FilterGraph, HwAccel, Rgb, ToneMap};
+use ff_filter::{FilterError, FilterGraph, HwAccel, Rgb, ScaleAlgorithm, ToneMap};
 use ff_format::{AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame};
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
@@ -42,7 +42,10 @@ fn make_audio_frame() -> AudioFrame {
 
 #[test]
 fn pull_video_before_push_should_return_none() {
-    let mut graph = match FilterGraph::builder().scale(32, 32).build() {
+    let mut graph = match FilterGraph::builder()
+        .scale(32, 32, ScaleAlgorithm::Fast)
+        .build()
+    {
         Ok(g) => g,
         Err(e) => {
             println!("Skipping: {e}");
@@ -60,7 +63,10 @@ fn pull_video_before_push_should_return_none() {
 
 #[test]
 fn push_video_and_pull_through_scale_should_return_resized_frame() {
-    let mut graph = match FilterGraph::builder().scale(32, 32).build() {
+    let mut graph = match FilterGraph::builder()
+        .scale(32, 32, ScaleAlgorithm::Fast)
+        .build()
+    {
         Ok(g) => g,
         Err(e) => {
             println!("Skipping: {e}");
@@ -83,7 +89,10 @@ fn push_video_and_pull_through_scale_should_return_resized_frame() {
 
 #[test]
 fn push_video_to_invalid_slot_should_return_error() {
-    let mut graph = match FilterGraph::builder().scale(32, 32).build() {
+    let mut graph = match FilterGraph::builder()
+        .scale(32, 32, ScaleAlgorithm::Fast)
+        .build()
+    {
         Ok(g) => g,
         Err(e) => {
             println!("Skipping: {e}");
@@ -448,7 +457,7 @@ fn push_video_through_cuda_scale_should_return_resized_frame_or_skip() {
     // error paths are treated as graceful skips.
     let mut graph = match FilterGraph::builder()
         .hardware(HwAccel::Cuda)
-        .scale(32, 32)
+        .scale(32, 32, ScaleAlgorithm::Fast)
         .build()
     {
         Ok(g) => g,
@@ -481,7 +490,7 @@ fn push_video_through_videotoolbox_scale_should_return_resized_frame_or_skip() {
     // back; avfilter_graph_config failure is also treated as a skip.
     let mut graph = match FilterGraph::builder()
         .hardware(HwAccel::VideoToolbox)
-        .scale(32, 32)
+        .scale(32, 32, ScaleAlgorithm::Fast)
         .build()
     {
         Ok(g) => g,
@@ -514,7 +523,7 @@ fn push_video_through_vaapi_scale_should_return_resized_frame_or_skip() {
     // the VAAPI device and hwdownload brings them back.
     let mut graph = match FilterGraph::builder()
         .hardware(HwAccel::Vaapi)
-        .scale(32, 32)
+        .scale(32, 32, ScaleAlgorithm::Fast)
         .build()
     {
         Ok(g) => g,

--- a/crates/ff-pipeline/tests/pipeline_run_tests.rs
+++ b/crates/ff-pipeline/tests/pipeline_run_tests.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
-use ff_filter::FilterGraph;
+use ff_filter::{FilterGraph, ScaleAlgorithm};
 use ff_pipeline::{EncoderConfig, Pipeline, PipelineError};
 use fixtures::{FileGuard, assets_dir, test_output_path, test_video_path};
 
@@ -190,7 +190,10 @@ fn transcode_with_scale_filter_should_produce_valid_output() {
     let output = test_output_path("pipeline_run_filter.mp4");
     let _guard = FileGuard::new(output.clone());
 
-    let filter = match FilterGraph::builder().scale(160, 120).build() {
+    let filter = match FilterGraph::builder()
+        .scale(160, 120, ScaleAlgorithm::Fast)
+        .build()
+    {
         Ok(f) => f,
         Err(e) => {
             println!("Skipping: filter build failed: {e}");


### PR DESCRIPTION
## Summary

Adds a `ScaleAlgorithm` enum to the `scale` filter step, making the resampling algorithm an explicit parameter rather than a hidden default. The enum variants (`Fast`, `Bilinear`, `Bicubic`, `Lanczos`) map to the corresponding `sws_flags` values in the FFmpeg `scale` filter string.

## Changes

- Added `pub enum ScaleAlgorithm { Fast, Bilinear, Bicubic, Lanczos }` with `as_flags_str()` to `graph.rs`
- Changed `FilterStep::Scale { width, height }` → `Scale { width, height, algorithm: ScaleAlgorithm }`
- Updated `FilterGraphBuilder::scale()` signature: `scale(width, height, algorithm: ScaleAlgorithm)`
- Exported `ScaleAlgorithm` from `ff-filter` and `avio`
- Updated all call sites: examples (`filter_direct`, `transcode`, `trim_and_scale`), `ff-filter` integration tests, and `ff-pipeline` integration tests

## Related Issues

Closes #249

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes