### PR TITLE
feat(ff-filter): add fit_to_aspect for auto letterbox/pillarbox

### DIFF
--- a/crates/ff-filter/src/filter_inner.rs
+++ b/crates/ff-filter/src/filter_inner.rs
@@ -354,6 +354,21 @@ impl FilterGraphInner {
                 };
             }
 
+            // FitToAspect is a compound step: the scale filter (added by
+            // add_and_link_step above) preserves the source aspect ratio; the
+            // pad filter added here centres the scaled frame on the target canvas.
+            if let FilterStep::FitToAspect {
+                width,
+                height,
+                color,
+            } = step
+            {
+                prev_ctx = match add_fit_to_aspect_pad(graph, prev_ctx, *width, *height, color, i) {
+                    Ok(ctx) => ctx,
+                    Err(e) => bail!(e),
+                };
+            }
+
             // Overlay consumes a second input on pad 1.
             if matches!(step, FilterStep::Overlay { .. })
                 && let Some(Some(extra_src)) = src_ctxs.get(1)
@@ -992,6 +1007,54 @@ unsafe fn add_setpts_after_trim(
         return Err(FilterError::BuildFailed);
     }
     log::debug!("filter added name=setpts args=PTS-STARTPTS");
+
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+    Ok(ctx)
+}
+
+/// Add a `pad` filter that centres the scaled frame on the target `width × height`
+/// canvas, completing the scale-then-pad compound step for [`FilterStep::FitToAspect`].
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+unsafe fn add_fit_to_aspect_pad(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    width: u32,
+    height: u32,
+    color: &str,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let pad_filter = ff_sys::avfilter_get_by_name(c"pad".as_ptr());
+    if pad_filter.is_null() {
+        log::warn!("filter not found name=pad (fit_to_aspect)");
+        return Err(FilterError::BuildFailed);
+    }
+
+    let name =
+        std::ffi::CString::new(format!("fitpad{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let args_str = format!("width={width}:height={height}:x=(ow-iw)/2:y=(oh-ih)/2:color={color}");
+    let args = std::ffi::CString::new(args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+
+    let mut ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut ctx,
+        pad_filter,
+        name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=pad args={args_str}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=pad args={args_str} index={index}");
 
     let ret = ff_sys::avfilter_link(prev_ctx, 0, ctx, 0);
     if ret < 0 {

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -222,6 +222,19 @@ pub(crate) enum FilterStep {
         /// Fill color (any `FFmpeg` color string, e.g. `"black"`, `"0x000000"`).
         color: String,
     },
+    /// Scale (preserving aspect ratio) then centre-pad to fill target dimensions
+    /// (letterbox or pillarbox as required).
+    ///
+    /// Implemented as a `scale` filter with `force_original_aspect_ratio=decrease`
+    /// followed by a `pad` filter that centres the scaled frame on the canvas.
+    FitToAspect {
+        /// Target canvas width in pixels.
+        width: u32,
+        /// Target canvas height in pixels.
+        height: u32,
+        /// Fill color for the bars (any `FFmpeg` color string, e.g. `"black"`).
+        color: String,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -275,6 +288,10 @@ impl FilterStep {
             Self::HFlip => "hflip",
             Self::VFlip => "vflip",
             Self::Pad { .. } => "pad",
+            // FitToAspect is implemented as scale + pad; "scale" is validated at
+            // build time.  The pad filter is inserted by filter_inner at graph
+            // construction time.
+            Self::FitToAspect { .. } => "scale",
         }
     }
 
@@ -380,6 +397,13 @@ impl FilterStep {
                 )
             }
             Self::HFlip | Self::VFlip => String::new(),
+            Self::FitToAspect { width, height, .. } => {
+                // Scale to fit within the target dimensions, preserving the source
+                // aspect ratio.  The accompanying pad filter (inserted by
+                // filter_inner after this scale filter) centres the result on the
+                // target canvas.
+                format!("w={width}:h={height}:force_original_aspect_ratio=decrease")
+            }
             Self::Pad {
                 width,
                 height,
@@ -705,6 +729,30 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Scale the source frame to fit within `width × height` while preserving its
+    /// aspect ratio, then centre it on a `width × height` canvas filled with
+    /// `color` (letterbox / pillarbox).
+    ///
+    /// Wide sources (wider aspect ratio than the target) get horizontal black bars
+    /// (*letterbox*); tall sources get vertical bars (*pillarbox*).
+    ///
+    /// `color` accepts any color string understood by `FFmpeg` — for example
+    /// `"black"`, `"white"`, `"0x000000"`.
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `width` or `height` is zero.
+    #[must_use]
+    pub fn fit_to_aspect(mut self, width: u32, height: u32, color: &str) -> Self {
+        self.steps.push(FilterStep::FitToAspect {
+            width,
+            height,
+            color: color.to_owned(),
+        });
+        self
+    }
+
     // ── Audio filters ─────────────────────────────────────────────────────────
 
     /// Adjust audio volume by `gain_db` decibels (negative = quieter).
@@ -888,6 +936,13 @@ impl FilterGraphBuilder {
             {
                 return Err(FilterError::InvalidConfig {
                     reason: "pad width and height must be > 0".to_string(),
+                });
+            }
+            if let FilterStep::FitToAspect { width, height, .. } = step
+                && (*width == 0 || *height == 0)
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: "fit_to_aspect width and height must be > 0".to_string(),
                 });
             }
         }
@@ -1989,6 +2044,73 @@ mod tests {
     #[test]
     fn builder_pad_with_zero_height_should_return_invalid_config() {
         let result = FilterGraph::builder().pad(1920, 0, -1, -1, "black").build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for height=0, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn filter_step_fit_to_aspect_should_produce_correct_filter_name() {
+        let step = FilterStep::FitToAspect {
+            width: 1920,
+            height: 1080,
+            color: "black".to_owned(),
+        };
+        assert_eq!(step.filter_name(), "scale");
+    }
+
+    #[test]
+    fn filter_step_fit_to_aspect_should_produce_scale_args_with_force_original_aspect_ratio() {
+        let step = FilterStep::FitToAspect {
+            width: 1920,
+            height: 1080,
+            color: "black".to_owned(),
+        };
+        let args = step.args();
+        assert!(
+            args.contains("w=1920") && args.contains("h=1080"),
+            "args must contain target dimensions: {args}"
+        );
+        assert!(
+            args.contains("force_original_aspect_ratio=decrease"),
+            "args must request aspect-ratio-preserving scale: {args}"
+        );
+    }
+
+    #[test]
+    fn builder_fit_to_aspect_with_valid_params_should_succeed() {
+        let result = FilterGraph::builder()
+            .fit_to_aspect(1920, 1080, "black")
+            .build();
+        assert!(
+            result.is_ok(),
+            "fit_to_aspect with valid params must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_fit_to_aspect_with_zero_width_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .fit_to_aspect(0, 1080, "black")
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for width=0, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("fit_to_aspect width and height must be > 0"),
+                "reason should mention fit_to_aspect dimensions: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_fit_to_aspect_with_zero_height_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .fit_to_aspect(1920, 0, "black")
+            .build();
         assert!(
             matches!(result, Err(FilterError::InvalidConfig { .. })),
             "expected InvalidConfig for height=0, got {result:?}"

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -832,3 +832,77 @@ fn push_720p_frame_through_pad_1920_1080_centred_should_return_1080p_frame() {
     assert_eq!(out.width(), 1920, "width should be padded to 1920");
     assert_eq!(out.height(), 1080, "height should be padded to 1080");
 }
+
+#[test]
+fn push_4x3_frame_through_fit_to_aspect_16x9_should_return_target_dimensions() {
+    // 64×48 is 4:3; fitting into 128×72 (16:9) should produce pillarbox bars.
+    // Scale factor = min(128/64, 72/48) = min(2.0, 1.5) = 1.5
+    // Scaled: 64×1.5=96, 48×1.5=72 → pad to 128×72 with (128-96)/2=16px bars each side.
+    let mut graph = match FilterGraph::builder()
+        .fit_to_aspect(128, 72, "black")
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 48);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after fit_to_aspect push");
+    assert_eq!(
+        out.width(),
+        128,
+        "width should match target after fit_to_aspect"
+    );
+    assert_eq!(
+        out.height(),
+        72,
+        "height should match target after fit_to_aspect"
+    );
+}
+
+#[test]
+fn push_wide_frame_through_fit_to_aspect_should_produce_letterbox() {
+    // 128×54 is ~2.37:1; fitting into 128×72 (16:9) should produce letterbox bars.
+    // Scale factor = min(128/128, 72/54) = min(1.0, 1.33) = 1.0 (no scale needed)
+    // Pad 128×72 with (72-54)/2=9px bars top and bottom.
+    let mut graph = match FilterGraph::builder()
+        .fit_to_aspect(128, 72, "black")
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(128, 54);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after fit_to_aspect letterbox push");
+    assert_eq!(
+        out.width(),
+        128,
+        "width should match target after letterbox fit"
+    );
+    assert_eq!(
+        out.height(),
+        72,
+        "height should match target after letterbox fit"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `fit_to_aspect` step to `FilterGraphBuilder` that automatically letterboxes or pillarboxes a source frame to a target resolution without distortion. Wide sources receive horizontal bars (letterbox); tall sources receive vertical bars (pillarbox). The step is implemented as a `scale` filter with `force_original_aspect_ratio=decrease` followed by a centred `pad` filter, both inserted by `filter_inner` during graph construction.

## Changes

- Added `FilterStep::FitToAspect { width, height, color }` variant
- `filter_name()` → `"scale"` (validated at build time); `args()` returns the aspect-ratio-preserving scale args
- New `add_fit_to_aspect_pad` helper in `filter_inner.rs` inserts the `pad` filter after the scale step (mirrors the `add_setpts_after_trim` pattern)
- `FilterGraphBuilder::fit_to_aspect(width, height, color) -> Self` builder method
- `build()` validates that `width` and `height` are > 0
- 5 new unit tests (filter name, args format, valid build, zero-dimension rejection)
- 2 new integration tests: pillarbox (4:3 source → 16:9 target) and letterbox (2.37:1 source → 16:9 target)

## Related Issues

Closes #251

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes