### PR TITLE
feat(ff-filter): add hqdn3d filter step for video noise reduction

### DIFF
--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -253,6 +253,20 @@ pub(crate) enum FilterStep {
         /// Chroma (colour) sharpening/blurring amount. Range: −1.5 – 1.5.
         chroma_strength: f32,
     },
+    /// High Quality 3D noise reduction (`hqdn3d`).
+    ///
+    /// Typical values: `luma_spatial=4.0`, `chroma_spatial=3.0`,
+    /// `luma_tmp=6.0`, `chroma_tmp=4.5`. All values must be ≥ 0.0.
+    Hqdn3d {
+        /// Spatial luma noise reduction strength. Must be ≥ 0.0.
+        luma_spatial: f32,
+        /// Spatial chroma noise reduction strength. Must be ≥ 0.0.
+        chroma_spatial: f32,
+        /// Temporal luma noise reduction strength. Must be ≥ 0.0.
+        luma_tmp: f32,
+        /// Temporal chroma noise reduction strength. Must be ≥ 0.0.
+        chroma_tmp: f32,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -312,6 +326,7 @@ impl FilterStep {
             Self::FitToAspect { .. } => "scale",
             Self::GBlur { .. } => "gblur",
             Self::Unsharp { .. } => "unsharp",
+            Self::Hqdn3d { .. } => "hqdn3d",
         }
     }
 
@@ -425,6 +440,12 @@ impl FilterStep {
                 "luma_msize_x=5:luma_msize_y=5:luma_amount={luma_strength}:\
                  chroma_msize_x=5:chroma_msize_y=5:chroma_amount={chroma_strength}"
             ),
+            Self::Hqdn3d {
+                luma_spatial,
+                chroma_spatial,
+                luma_tmp,
+                chroma_tmp,
+            } => format!("{luma_spatial}:{chroma_spatial}:{luma_tmp}:{chroma_tmp}"),
             Self::FitToAspect { width, height, .. } => {
                 // Scale to fit within the target dimensions, preserving the source
                 // aspect ratio.  The accompanying pad filter (inserted by
@@ -817,6 +838,32 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Apply High Quality 3D (`hqdn3d`) noise reduction.
+    ///
+    /// Typical values: `luma_spatial=4.0`, `chroma_spatial=3.0`,
+    /// `luma_tmp=6.0`, `chroma_tmp=4.5`. All values must be ≥ 0.0.
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if any
+    /// value is negative.
+    #[must_use]
+    pub fn hqdn3d(
+        mut self,
+        luma_spatial: f32,
+        chroma_spatial: f32,
+        luma_tmp: f32,
+        chroma_tmp: f32,
+    ) -> Self {
+        self.steps.push(FilterStep::Hqdn3d {
+            luma_spatial,
+            chroma_spatial,
+            luma_tmp,
+            chroma_tmp,
+        });
+        self
+    }
+
     // ── Audio filters ─────────────────────────────────────────────────────────
 
     /// Adjust audio volume by `gain_db` decibels (negative = quieter).
@@ -1034,6 +1081,26 @@ impl FilterGraphBuilder {
                             "unsharp chroma_strength {chroma_strength} out of range [-1.5, 1.5]"
                         ),
                     });
+                }
+            }
+            if let FilterStep::Hqdn3d {
+                luma_spatial,
+                chroma_spatial,
+                luma_tmp,
+                chroma_tmp,
+            } = step
+            {
+                for (name, val) in [
+                    ("luma_spatial", luma_spatial),
+                    ("chroma_spatial", chroma_spatial),
+                    ("luma_tmp", luma_tmp),
+                    ("chroma_tmp", chroma_tmp),
+                ] {
+                    if *val < 0.0 {
+                        return Err(FilterError::InvalidConfig {
+                            reason: format!("hqdn3d {name} {val} must be >= 0.0"),
+                        });
+                    }
                 }
             }
         }
@@ -2344,5 +2411,87 @@ mod tests {
                 "reason should mention chroma_strength: {reason}"
             );
         }
+    }
+
+    #[test]
+    fn filter_step_hqdn3d_should_produce_correct_filter_name() {
+        let step = FilterStep::Hqdn3d {
+            luma_spatial: 4.0,
+            chroma_spatial: 3.0,
+            luma_tmp: 6.0,
+            chroma_tmp: 4.5,
+        };
+        assert_eq!(step.filter_name(), "hqdn3d");
+    }
+
+    #[test]
+    fn filter_step_hqdn3d_should_produce_correct_args() {
+        let step = FilterStep::Hqdn3d {
+            luma_spatial: 4.0,
+            chroma_spatial: 3.0,
+            luma_tmp: 6.0,
+            chroma_tmp: 4.5,
+        };
+        assert_eq!(step.args(), "4:3:6:4.5");
+    }
+
+    #[test]
+    fn builder_hqdn3d_with_valid_params_should_succeed() {
+        let result = FilterGraph::builder().hqdn3d(4.0, 3.0, 6.0, 4.5).build();
+        assert!(
+            result.is_ok(),
+            "hqdn3d(4.0, 3.0, 6.0, 4.5) must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_hqdn3d_with_zero_params_should_succeed() {
+        let result = FilterGraph::builder().hqdn3d(0.0, 0.0, 0.0, 0.0).build();
+        assert!(
+            result.is_ok(),
+            "hqdn3d(0.0, 0.0, 0.0, 0.0) must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_hqdn3d_with_negative_luma_spatial_should_return_invalid_config() {
+        let result = FilterGraph::builder().hqdn3d(-1.0, 3.0, 6.0, 4.5).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for negative luma_spatial, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("luma_spatial"),
+                "reason should mention luma_spatial: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_hqdn3d_with_negative_chroma_spatial_should_return_invalid_config() {
+        let result = FilterGraph::builder().hqdn3d(4.0, -1.0, 6.0, 4.5).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for negative chroma_spatial, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_hqdn3d_with_negative_luma_tmp_should_return_invalid_config() {
+        let result = FilterGraph::builder().hqdn3d(4.0, 3.0, -1.0, 4.5).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for negative luma_tmp, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_hqdn3d_with_negative_chroma_tmp_should_return_invalid_config() {
+        let result = FilterGraph::builder().hqdn3d(4.0, 3.0, 6.0, -1.0).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for negative chroma_tmp, got {result:?}"
+        );
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -952,3 +952,26 @@ fn push_video_through_unsharp_sharpen_should_return_frame_with_same_dimensions()
     assert_eq!(out.width(), 64, "width should be unchanged after unsharp");
     assert_eq!(out.height(), 64, "height should be unchanged after unsharp");
 }
+
+#[test]
+fn push_video_through_hqdn3d_should_return_frame_with_same_dimensions() {
+    let mut graph = match FilterGraph::builder().hqdn3d(4.0, 3.0, 6.0, 4.5).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after hqdn3d push");
+    assert_eq!(out.width(), 64, "width should be unchanged after hqdn3d");
+    assert_eq!(out.height(), 64, "height should be unchanged after hqdn3d");
+}


### PR DESCRIPTION
## Summary

Adds `hqdn3d` (High Quality 3D) noise reduction as a new `FilterStep` variant and corresponding `FilterGraphBuilder::hqdn3d()` builder method. The filter exposes all four standard hqdn3d parameters — luma spatial, chroma spatial, luma temporal, and chroma temporal — with validation rejecting negative values.

## Changes

- Added `FilterStep::Hqdn3d { luma_spatial, chroma_spatial, luma_tmp, chroma_tmp }` variant with `filter_name()` → `"hqdn3d"` and `args()` → `"{ls}:{cs}:{lt}:{ct}"`
- Added `FilterGraphBuilder::hqdn3d(luma_spatial, chroma_spatial, luma_tmp, chroma_tmp)` builder method
- Added `build()` validation: all four parameters must be `>= 0.0`, returning `FilterError::InvalidConfig` otherwise
- Added 8 unit tests covering filter name, args format, valid builds, and rejection of each negative parameter
- Added 1 integration test verifying a 64×64 frame passes through the filter unchanged in dimensions

## Related Issues

Closes #254

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes