### PR TITLE
feat(ff-filter): add yadif deinterlacing filter step

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -253,7 +253,7 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap,
+    FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -122,6 +122,21 @@ impl ScaleAlgorithm {
     }
 }
 
+/// Deinterlacing mode for the `yadif` filter.
+///
+/// Used with [`FilterGraphBuilder::yadif`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum YadifMode {
+    /// Output one frame per frame (progressive output).
+    Frame = 0,
+    /// Output one frame per field (doubles the frame rate).
+    Field = 1,
+    /// Frame mode without spatial interlacing check.
+    FrameNospatial = 2,
+    /// Field mode without spatial interlacing check.
+    FieldNospatial = 3,
+}
+
 // ── FilterStep ────────────────────────────────────────────────────────────────
 
 /// A single step in a filter chain, constructed by the builder methods.
@@ -277,6 +292,11 @@ pub(crate) enum FilterStep {
         /// Denoising strength. Must be in the range [1.0, 30.0].
         strength: f32,
     },
+    /// Deinterlace using the `yadif` filter.
+    Yadif {
+        /// Deinterlacing mode controlling output frame rate and spatial checks.
+        mode: YadifMode,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -338,6 +358,7 @@ impl FilterStep {
             Self::Unsharp { .. } => "unsharp",
             Self::Hqdn3d { .. } => "hqdn3d",
             Self::Nlmeans { .. } => "nlmeans",
+            Self::Yadif { .. } => "yadif",
         }
     }
 
@@ -458,6 +479,7 @@ impl FilterStep {
                 chroma_tmp,
             } => format!("{luma_spatial}:{chroma_spatial}:{luma_tmp}:{chroma_tmp}"),
             Self::Nlmeans { strength } => format!("s={strength}"),
+            Self::Yadif { mode } => format!("mode={}", *mode as i32),
             Self::FitToAspect { width, height, .. } => {
                 // Scale to fit within the target dimensions, preserving the source
                 // aspect ratio.  The accompanying pad filter (inserted by
@@ -885,6 +907,16 @@ impl FilterGraphBuilder {
     #[must_use]
     pub fn nlmeans(mut self, strength: f32) -> Self {
         self.steps.push(FilterStep::Nlmeans { strength });
+        self
+    }
+
+    /// Deinterlace using the `yadif` (Yet Another Deinterlacing Filter).
+    ///
+    /// `mode` controls whether one frame or two fields are emitted per input
+    /// frame and whether the spatial interlacing check is enabled.
+    #[must_use]
+    pub fn yadif(mut self, mode: YadifMode) -> Self {
+        self.steps.push(FilterStep::Yadif { mode });
         self
     }
 
@@ -2591,6 +2623,79 @@ mod tests {
             assert!(
                 reason.contains("strength"),
                 "reason should mention strength: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn yadif_mode_variants_should_have_correct_discriminants() {
+        assert_eq!(YadifMode::Frame as i32, 0);
+        assert_eq!(YadifMode::Field as i32, 1);
+        assert_eq!(YadifMode::FrameNospatial as i32, 2);
+        assert_eq!(YadifMode::FieldNospatial as i32, 3);
+    }
+
+    #[test]
+    fn filter_step_yadif_should_produce_correct_filter_name() {
+        let step = FilterStep::Yadif {
+            mode: YadifMode::Frame,
+        };
+        assert_eq!(step.filter_name(), "yadif");
+    }
+
+    #[test]
+    fn filter_step_yadif_frame_should_produce_mode_0_args() {
+        let step = FilterStep::Yadif {
+            mode: YadifMode::Frame,
+        };
+        assert_eq!(step.args(), "mode=0");
+    }
+
+    #[test]
+    fn filter_step_yadif_field_should_produce_mode_1_args() {
+        let step = FilterStep::Yadif {
+            mode: YadifMode::Field,
+        };
+        assert_eq!(step.args(), "mode=1");
+    }
+
+    #[test]
+    fn filter_step_yadif_frame_nospatial_should_produce_mode_2_args() {
+        let step = FilterStep::Yadif {
+            mode: YadifMode::FrameNospatial,
+        };
+        assert_eq!(step.args(), "mode=2");
+    }
+
+    #[test]
+    fn filter_step_yadif_field_nospatial_should_produce_mode_3_args() {
+        let step = FilterStep::Yadif {
+            mode: YadifMode::FieldNospatial,
+        };
+        assert_eq!(step.args(), "mode=3");
+    }
+
+    #[test]
+    fn builder_yadif_with_frame_mode_should_succeed() {
+        let result = FilterGraph::builder().yadif(YadifMode::Frame).build();
+        assert!(
+            result.is_ok(),
+            "yadif(Frame) must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_yadif_with_all_modes_should_succeed() {
+        for mode in [
+            YadifMode::Frame,
+            YadifMode::Field,
+            YadifMode::FrameNospatial,
+            YadifMode::FieldNospatial,
+        ] {
+            let result = FilterGraph::builder().yadif(mode).build();
+            assert!(
+                result.is_ok(),
+                "yadif({mode:?}) must build successfully, got {result:?}"
             );
         }
     }

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -36,4 +36,6 @@ mod filter_inner;
 pub mod graph;
 
 pub use error::FilterError;
-pub use graph::{FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap};
+pub use graph::{
+    FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap, YadifMode,
+};

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -11,7 +11,7 @@
 
 use std::time::Duration;
 
-use ff_filter::{FilterError, FilterGraph, HwAccel, Rgb, ScaleAlgorithm, ToneMap};
+use ff_filter::{FilterError, FilterGraph, HwAccel, Rgb, ScaleAlgorithm, ToneMap, YadifMode};
 use ff_format::{AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame};
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
@@ -997,4 +997,32 @@ fn push_video_through_nlmeans_should_return_frame_with_same_dimensions() {
     let out = result.expect("expected Some(frame) after nlmeans push");
     assert_eq!(out.width(), 64, "width should be unchanged after nlmeans");
     assert_eq!(out.height(), 64, "height should be unchanged after nlmeans");
+}
+
+#[test]
+fn push_video_through_yadif_frame_mode_should_accept_frames_without_error() {
+    // yadif is a temporal filter; it buffers frames before emitting output.
+    // This test verifies that frames are accepted and pull_video does not error.
+    // A single progressive frame may not produce output (None is acceptable).
+    let mut graph = match FilterGraph::builder().yadif(YadifMode::Frame).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    // pull_video must not error; None is acceptable (frame buffered by yadif).
+    let result = graph.pull_video().expect("pull_video must not fail");
+    if let Some(out) = result {
+        assert_eq!(out.width(), 64, "width should be unchanged after yadif");
+        assert_eq!(out.height(), 64, "height should be unchanged after yadif");
+    }
 }


### PR DESCRIPTION
## Summary

Adds `yadif` (Yet Another Deinterlacing Filter) as a new `FilterStep` variant with a public `YadifMode` enum controlling output frame rate and spatial check behavior. The enum is exported from both `ff-filter` and `avio` so callers can select the appropriate deinterlacing mode.

## Changes

- Added `YadifMode` enum with four variants: `Frame` (0), `Field` (1), `FrameNospatial` (2), `FieldNospatial` (3)
- Added `FilterStep::Yadif { mode: YadifMode }` with `filter_name()` → `"yadif"` and `args()` → `"mode={n}"`
- Added `FilterGraphBuilder::yadif(mode)` builder method
- No validation needed — `YadifMode` enum constrains valid values at compile time
- Exported `YadifMode` from `ff-filter/src/lib.rs` and `avio/src/lib.rs`
- Added 8 unit tests covering discriminant values, filter name, args for each mode, and successful build
- Added 1 integration test verifying push/pull does not error (yadif buffers frames temporally, so `None` output from a single frame is acceptable)

## Related Issues

Closes #256

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes