### PR TITLE
feat(ff-filter): add xfade cross-dissolve filter step

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -253,7 +253,8 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap, YadifMode,
+    FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap,
+    XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/filter_inner.rs
+++ b/crates/ff-filter/src/filter_inner.rs
@@ -369,15 +369,15 @@ impl FilterGraphInner {
                 };
             }
 
-            // Overlay consumes a second input on pad 1.
-            if matches!(step, FilterStep::Overlay { .. })
+            // Overlay and xfade both consume a second input on pad 1.
+            if matches!(step, FilterStep::Overlay { .. } | FilterStep::XFade { .. })
                 && let Some(Some(extra_src)) = src_ctxs.get(1)
             {
                 let ret = ff_sys::avfilter_link(extra_src.as_ptr(), 0, prev_ctx, 1);
                 if ret < 0 {
                     bail!(FilterError::BuildFailed);
                 }
-                log::debug!("filter linked extra_input=in1 to overlay pad=1");
+                log::debug!("filter linked extra_input=in1 to two-input filter pad=1");
             }
         }
 
@@ -526,7 +526,7 @@ impl FilterGraphInner {
     /// on slot 0 and a secondary stream on slot 1), 1 otherwise.
     fn video_input_count(&self) -> usize {
         for step in &self.steps {
-            if matches!(step, FilterStep::Overlay { .. }) {
+            if matches!(step, FilterStep::Overlay { .. } | FilterStep::XFade { .. }) {
                 return 2;
             }
         }

--- a/crates/ff-filter/src/graph.rs
+++ b/crates/ff-filter/src/graph.rs
@@ -136,6 +136,65 @@ pub enum YadifMode {
     FieldNospatial = 3,
 }
 
+/// Transition type for the `xfade` cross-dissolve filter.
+///
+/// Used with [`FilterGraphBuilder::xfade`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XfadeTransition {
+    /// Blend frames (cross-dissolve).
+    Dissolve,
+    /// Fade through black.
+    Fade,
+    /// Wipe from right to left.
+    WipeLeft,
+    /// Wipe from left to right.
+    WipeRight,
+    /// Wipe upward.
+    WipeUp,
+    /// Wipe downward.
+    WipeDown,
+    /// Slide from right.
+    SlideLeft,
+    /// Slide from left.
+    SlideRight,
+    /// Slide upward.
+    SlideUp,
+    /// Slide downward.
+    SlideDown,
+    /// Circular iris open.
+    CircleOpen,
+    /// Circular iris close.
+    CircleClose,
+    /// Fade through gray.
+    FadeGrays,
+    /// Pixelize transition.
+    Pixelize,
+}
+
+impl XfadeTransition {
+    /// Returns the `FFmpeg` `xfade` transition name string.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Dissolve => "dissolve",
+            Self::Fade => "fade",
+            Self::WipeLeft => "wipeleft",
+            Self::WipeRight => "wiperight",
+            Self::WipeUp => "wipeup",
+            Self::WipeDown => "wipedown",
+            Self::SlideLeft => "slideleft",
+            Self::SlideRight => "slideright",
+            Self::SlideUp => "slideup",
+            Self::SlideDown => "slidedown",
+            Self::CircleOpen => "circleopen",
+            Self::CircleClose => "circleclose",
+            Self::FadeGrays => "fadegrays",
+            Self::Pixelize => "pixelize",
+        }
+    }
+}
+
 // ── FilterStep ────────────────────────────────────────────────────────────────
 
 /// A single step in a filter chain, constructed by the builder methods.
@@ -300,6 +359,19 @@ pub(crate) enum FilterStep {
         /// Deinterlacing mode controlling output frame rate and spatial checks.
         mode: YadifMode,
     },
+    /// Cross-dissolve transition between two video streams (`xfade`).
+    ///
+    /// Requires two input slots: slot 0 is clip A, slot 1 is clip B.
+    /// `duration` is the overlap length in seconds; `offset` is the PTS
+    /// offset (in seconds) at which clip B begins.
+    XFade {
+        /// Transition style.
+        transition: XfadeTransition,
+        /// Overlap duration in seconds. Must be > 0.0.
+        duration: f64,
+        /// PTS offset (seconds) where clip B starts.
+        offset: f64,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -365,6 +437,7 @@ impl FilterStep {
             Self::Hqdn3d { .. } => "hqdn3d",
             Self::Nlmeans { .. } => "nlmeans",
             Self::Yadif { .. } => "yadif",
+            Self::XFade { .. } => "xfade",
         }
     }
 
@@ -496,6 +569,14 @@ impl FilterStep {
             } => format!("{luma_spatial}:{chroma_spatial}:{luma_tmp}:{chroma_tmp}"),
             Self::Nlmeans { strength } => format!("s={strength}"),
             Self::Yadif { mode } => format!("mode={}", *mode as i32),
+            Self::XFade {
+                transition,
+                duration,
+                offset,
+            } => {
+                let t = transition.as_str();
+                format!("transition={t}:duration={duration}:offset={offset}")
+            }
             Self::FitToAspect { width, height, .. } => {
                 // Scale to fit within the target dimensions, preserving the source
                 // aspect ratio.  The accompanying pad filter (inserted by
@@ -966,6 +1047,25 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Apply a cross-dissolve transition between two video streams using `xfade`.
+    ///
+    /// Requires two input slots: slot 0 is clip A (first clip), slot 1 is clip B
+    /// (second clip). Call [`FilterGraph::push_video`] with slot 0 for clip A
+    /// frames and slot 1 for clip B frames.
+    ///
+    /// - `transition`: the visual transition style.
+    /// - `duration`: length of the overlap in seconds. Must be > 0.0.
+    /// - `offset`: PTS offset (seconds) at which clip B starts playing.
+    #[must_use]
+    pub fn xfade(mut self, transition: XfadeTransition, duration: f64, offset: f64) -> Self {
+        self.steps.push(FilterStep::XFade {
+            transition,
+            duration,
+            offset,
+        });
+        self
+    }
+
     // ── Audio filters ─────────────────────────────────────────────────────────
 
     /// Adjust audio volume by `gain_db` decibels (negative = quieter).
@@ -1036,6 +1136,13 @@ impl FilterGraphBuilder {
             {
                 return Err(FilterError::InvalidConfig {
                     reason: format!("fade duration {duration} must be > 0.0"),
+                });
+            }
+            if let FilterStep::XFade { duration, .. } = step
+                && *duration <= 0.0
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: format!("xfade duration {duration} must be > 0.0"),
                 });
             }
             if let FilterStep::Overlay { x, y } = step
@@ -2908,5 +3015,106 @@ mod tests {
                 "yadif({mode:?}) must build successfully, got {result:?}"
             );
         }
+    }
+
+    #[test]
+    fn xfade_transition_dissolve_should_produce_correct_str() {
+        assert_eq!(XfadeTransition::Dissolve.as_str(), "dissolve");
+    }
+
+    #[test]
+    fn xfade_transition_all_variants_should_produce_unique_strings() {
+        let variants = [
+            (XfadeTransition::Dissolve, "dissolve"),
+            (XfadeTransition::Fade, "fade"),
+            (XfadeTransition::WipeLeft, "wipeleft"),
+            (XfadeTransition::WipeRight, "wiperight"),
+            (XfadeTransition::WipeUp, "wipeup"),
+            (XfadeTransition::WipeDown, "wipedown"),
+            (XfadeTransition::SlideLeft, "slideleft"),
+            (XfadeTransition::SlideRight, "slideright"),
+            (XfadeTransition::SlideUp, "slideup"),
+            (XfadeTransition::SlideDown, "slidedown"),
+            (XfadeTransition::CircleOpen, "circleopen"),
+            (XfadeTransition::CircleClose, "circleclose"),
+            (XfadeTransition::FadeGrays, "fadegrays"),
+            (XfadeTransition::Pixelize, "pixelize"),
+        ];
+        for (variant, expected) in variants {
+            assert_eq!(
+                variant.as_str(),
+                expected,
+                "XfadeTransition::{variant:?} should produce \"{expected}\""
+            );
+        }
+    }
+
+    #[test]
+    fn filter_step_xfade_should_produce_correct_filter_name() {
+        let step = FilterStep::XFade {
+            transition: XfadeTransition::Dissolve,
+            duration: 1.0,
+            offset: 4.0,
+        };
+        assert_eq!(step.filter_name(), "xfade");
+    }
+
+    #[test]
+    fn filter_step_xfade_should_produce_correct_args() {
+        let step = FilterStep::XFade {
+            transition: XfadeTransition::Dissolve,
+            duration: 1.0,
+            offset: 4.0,
+        };
+        assert_eq!(step.args(), "transition=dissolve:duration=1:offset=4");
+    }
+
+    #[test]
+    fn filter_step_xfade_wipe_right_should_produce_correct_args() {
+        let step = FilterStep::XFade {
+            transition: XfadeTransition::WipeRight,
+            duration: 0.5,
+            offset: 9.5,
+        };
+        assert_eq!(step.args(), "transition=wiperight:duration=0.5:offset=9.5");
+    }
+
+    #[test]
+    fn builder_xfade_with_valid_params_should_succeed() {
+        let result = FilterGraph::builder()
+            .xfade(XfadeTransition::Dissolve, 1.0, 4.0)
+            .build();
+        assert!(
+            result.is_ok(),
+            "xfade(Dissolve, 1.0, 4.0) must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_xfade_with_zero_duration_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .xfade(XfadeTransition::Dissolve, 0.0, 4.0)
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for zero duration, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("duration"),
+                "reason should mention duration: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_xfade_with_negative_duration_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .xfade(XfadeTransition::Fade, -1.0, 0.0)
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for negative duration, got {result:?}"
+        );
     }
 }

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -37,5 +37,6 @@ pub mod graph;
 
 pub use error::FilterError;
 pub use graph::{
-    FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap, YadifMode,
+    FilterGraph, FilterGraphBuilder, HwAccel, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition,
+    YadifMode,
 };

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -9,7 +9,9 @@
 
 #![allow(clippy::unwrap_used)]
 
-use ff_filter::{FilterError, FilterGraph, HwAccel, Rgb, ScaleAlgorithm, ToneMap, YadifMode};
+use ff_filter::{
+    FilterError, FilterGraph, HwAccel, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
+};
 use ff_format::{AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame};
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
@@ -1078,5 +1080,49 @@ fn push_video_through_fade_out_white_should_return_frame_with_same_dimensions() 
         out.height(),
         64,
         "height should be unchanged after fade_out_white"
+    );
+}
+
+#[test]
+fn push_two_clips_through_xfade_dissolve_should_return_frame_with_same_dimensions() {
+    let mut graph = match FilterGraph::builder()
+        .xfade(XfadeTransition::Dissolve, 1.0, 4.0)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let clip_a = make_yuv420p_frame(64, 64);
+    let clip_b = make_yuv420p_frame(64, 64);
+    // Push clip A to slot 0 first; this initialises the graph.
+    match graph.push_video(0, &clip_a) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    // Push clip B to slot 1.
+    match graph.push_video(1, &clip_b) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after xfade push");
+    assert_eq!(
+        out.width(),
+        64,
+        "output width should match input after xfade"
+    );
+    assert_eq!(
+        out.height(),
+        64,
+        "output height should match input after xfade"
     );
 }


### PR DESCRIPTION
## Summary

Adds an `xfade` cross-dissolve transition step using FFmpeg's `xfade` filter. Introduces the `XfadeTransition` enum with 14 transition variants, a two-input `FilterGraphBuilder::xfade()` builder method, and the required two-input wiring in `filter_inner.rs` (following the same `Overlay` pattern). `XfadeTransition` is exported from both `ff-filter` and `avio`.

## Changes

- Added `XfadeTransition` enum (14 variants: `Dissolve`, `Fade`, wipes, slides, circle, `FadeGrays`, `Pixelize`) with `as_str()` method
- Added `FilterStep::XFade { transition, duration, offset }` with `filter_name()` → `"xfade"` and `args()` → `"transition={t}:duration={d}:offset={o}"`
- Added `FilterGraphBuilder::xfade(transition, duration, offset)` builder method
- Added `build()` validation: `duration <= 0.0` returns `FilterError::InvalidConfig`
- Updated `video_input_count()` in `filter_inner.rs` to return 2 for `XFade` steps
- Extended the two-input pad wiring loop to cover `XFade` (same as `Overlay`: `in1` → filter pad 1)
- Exported `XfadeTransition` from `ff-filter/src/lib.rs` and `avio/src/lib.rs`
- Added 9 unit tests covering all transition strings, filter name, args format, valid build, and invalid duration rejection
- Added 1 integration test pushing two 64×64 frames (slot 0 and slot 1) through a dissolve transition

## Related Issues

Closes #259

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes