### PR TITLE
feat(ff-filter): add subtitles_srt filter step for hard subtitle burn-in

### DIFF
--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -479,6 +479,22 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Burn SRT subtitles into the video (hard subtitles).
+    ///
+    /// Subtitles are read from the `.srt` file at `srt_path` and rendered
+    /// at the timecodes defined in the file using `FFmpeg`'s `subtitles` filter.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if:
+    /// - the extension is not `.srt`, or
+    /// - the file does not exist at build time.
+    #[must_use]
+    pub fn subtitles_srt(mut self, srt_path: &str) -> Self {
+        self.steps.push(FilterStep::SubtitlesSrt {
+            path: srt_path.to_owned(),
+        });
+        self
+    }
+
     // ── Audio filters ─────────────────────────────────────────────────────────
 
     /// Adjust audio volume by `gain_db` decibels (negative = quieter).
@@ -596,6 +612,22 @@ impl FilterGraphBuilder {
                 if !Path::new(path).exists() {
                     return Err(FilterError::InvalidConfig {
                         reason: format!("LUT file not found: {path}"),
+                    });
+                }
+            }
+            if let FilterStep::SubtitlesSrt { path } = step {
+                let ext = Path::new(path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("");
+                if ext != "srt" {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("unsupported subtitle format: .{ext}; expected .srt"),
+                    });
+                }
+                if !Path::new(path).exists() {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("subtitle file not found: {path}"),
                     });
                 }
             }

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -1838,3 +1838,64 @@ fn builder_drawtext_with_negative_opacity_should_return_invalid_config() {
         "expected InvalidConfig for opacity < 0.0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_subtitles_srt_should_produce_correct_filter_name() {
+    let step = FilterStep::SubtitlesSrt {
+        path: "subs.srt".to_owned(),
+    };
+    assert_eq!(step.filter_name(), "subtitles");
+}
+
+#[test]
+fn filter_step_subtitles_srt_should_produce_correct_args() {
+    let step = FilterStep::SubtitlesSrt {
+        path: "subs.srt".to_owned(),
+    };
+    assert_eq!(step.args(), "filename=subs.srt");
+}
+
+#[test]
+fn builder_subtitles_srt_with_wrong_extension_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .subtitles_srt("subtitles.vtt")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for wrong extension, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("unsupported subtitle format"),
+            "reason should mention unsupported format: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_subtitles_srt_with_no_extension_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .subtitles_srt("subtitles_no_ext")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for missing extension, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_subtitles_srt_with_nonexistent_file_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .subtitles_srt("/nonexistent/path/subs_ab12cd.srt")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for nonexistent file, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("subtitle file not found"),
+            "reason should mention file not found: {reason}"
+        );
+    }
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -184,6 +184,11 @@ pub(crate) enum FilterStep {
         /// Full set of drawtext parameters.
         opts: DrawTextOptions,
     },
+    /// Burn-in SRT subtitles (hard subtitles) using the `subtitles` filter.
+    SubtitlesSrt {
+        /// Absolute or relative path to the `.srt` file.
+        path: String,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -251,6 +256,7 @@ impl FilterStep {
             Self::Yadif { .. } => "yadif",
             Self::XFade { .. } => "xfade",
             Self::DrawText { .. } => "drawtext",
+            Self::SubtitlesSrt { .. } => "subtitles",
         }
     }
 
@@ -414,6 +420,7 @@ impl FilterStep {
                 }
                 parts.join(":")
             }
+            Self::SubtitlesSrt { path } => format!("filename={path}"),
             Self::FitToAspect { width, height, .. } => {
                 // Scale to fit within the target dimensions, preserving the source
                 // aspect ratio.  The accompanying pad filter (inserted by


### PR DESCRIPTION
## Summary

Adds `FilterGraphBuilder::subtitles_srt` to burn SRT subtitles directly into video frames (hard subtitles) using FFmpeg's `subtitles` filter. The path is validated at `build()` time — wrong extension and missing file both produce `FilterError::InvalidConfig` with a descriptive message.

## Changes

- `filter_step.rs` — new `SubtitlesSrt { path: String }` variant; `filter_name()` → `"subtitles"`; `args()` → `"filename={path}"`
- `builder.rs` — new `subtitles_srt(&str)` setter; build-time validation rejects non-`.srt` extensions and non-existent files
- `builder_tests.rs` — 5 new unit tests covering filter name, args format, wrong extension, no extension, and nonexistent file

## Related Issues

Closes #262

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes