### PR TITLE
feat(ff-filter): add subtitles_ass filter step for ASS/SSA subtitle burn-in

### DIFF
--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -495,6 +495,24 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Burn ASS/SSA styled subtitles into the video (hard subtitles).
+    ///
+    /// Subtitles are read from the `.ass` or `.ssa` file at `ass_path` and
+    /// rendered with full styling using `FFmpeg`'s dedicated `ass` filter,
+    /// which preserves fonts, colours, and positioning better than the generic
+    /// `subtitles` filter.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if:
+    /// - the extension is not `.ass` or `.ssa`, or
+    /// - the file does not exist at build time.
+    #[must_use]
+    pub fn subtitles_ass(mut self, ass_path: &str) -> Self {
+        self.steps.push(FilterStep::SubtitlesAss {
+            path: ass_path.to_owned(),
+        });
+        self
+    }
+
     // ── Audio filters ─────────────────────────────────────────────────────────
 
     /// Adjust audio volume by `gain_db` decibels (negative = quieter).
@@ -623,6 +641,24 @@ impl FilterGraphBuilder {
                 if ext != "srt" {
                     return Err(FilterError::InvalidConfig {
                         reason: format!("unsupported subtitle format: .{ext}; expected .srt"),
+                    });
+                }
+                if !Path::new(path).exists() {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("subtitle file not found: {path}"),
+                    });
+                }
+            }
+            if let FilterStep::SubtitlesAss { path } = step {
+                let ext = Path::new(path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("");
+                if !matches!(ext, "ass" | "ssa") {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!(
+                            "unsupported subtitle format: .{ext}; expected .ass or .ssa"
+                        ),
                     });
                 }
                 if !Path::new(path).exists() {

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -1899,3 +1899,83 @@ fn builder_subtitles_srt_with_nonexistent_file_should_return_invalid_config() {
         );
     }
 }
+
+#[test]
+fn filter_step_subtitles_ass_should_produce_correct_filter_name() {
+    let step = FilterStep::SubtitlesAss {
+        path: "subs.ass".to_owned(),
+    };
+    assert_eq!(step.filter_name(), "ass");
+}
+
+#[test]
+fn filter_step_subtitles_ass_should_produce_correct_args() {
+    let step = FilterStep::SubtitlesAss {
+        path: "subs.ass".to_owned(),
+    };
+    assert_eq!(step.args(), "filename=subs.ass");
+}
+
+#[test]
+fn filter_step_subtitles_ssa_should_produce_correct_filter_name() {
+    let step = FilterStep::SubtitlesAss {
+        path: "subs.ssa".to_owned(),
+    };
+    assert_eq!(step.filter_name(), "ass");
+}
+
+#[test]
+fn builder_subtitles_ass_with_wrong_extension_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .subtitles_ass("subtitles.srt")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for wrong extension, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("unsupported subtitle format"),
+            "reason should mention unsupported format: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_subtitles_ass_with_no_extension_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .subtitles_ass("subtitles_no_ext")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for missing extension, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_subtitles_ass_with_nonexistent_file_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .subtitles_ass("/nonexistent/path/subs_ab12cd.ass")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for nonexistent .ass file, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("subtitle file not found"),
+            "reason should mention file not found: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_subtitles_ssa_with_nonexistent_file_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .subtitles_ass("/nonexistent/path/subs_ab12cd.ssa")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for nonexistent .ssa file, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -189,6 +189,11 @@ pub(crate) enum FilterStep {
         /// Absolute or relative path to the `.srt` file.
         path: String,
     },
+    /// Burn-in ASS/SSA styled subtitles using the `ass` filter.
+    SubtitlesAss {
+        /// Absolute or relative path to the `.ass` or `.ssa` file.
+        path: String,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -257,6 +262,7 @@ impl FilterStep {
             Self::XFade { .. } => "xfade",
             Self::DrawText { .. } => "drawtext",
             Self::SubtitlesSrt { .. } => "subtitles",
+            Self::SubtitlesAss { .. } => "ass",
         }
     }
 
@@ -420,7 +426,9 @@ impl FilterStep {
                 }
                 parts.join(":")
             }
-            Self::SubtitlesSrt { path } => format!("filename={path}"),
+            Self::SubtitlesSrt { path } | Self::SubtitlesAss { path } => {
+                format!("filename={path}")
+            }
             Self::FitToAspect { width, height, .. } => {
                 // Scale to fit within the target dimensions, preserving the source
                 // aspect ratio.  The accompanying pad filter (inserted by


### PR DESCRIPTION
## Summary

Adds `FilterGraphBuilder::subtitles_ass` to burn ASS/SSA styled subtitles directly into video frames (hard subtitles) using FFmpeg's dedicated `ass` filter. Unlike the generic `subtitles` filter, `ass` preserves custom fonts, colours, and positioning defined in the subtitle file. Both `.ass` and `.ssa` extensions are accepted.

## Changes

- `filter_step.rs` — new `SubtitlesAss { path: String }` variant; `filter_name()` → `"ass"`; `args()` reuses the `filename={path}` arm alongside `SubtitlesSrt`
- `builder.rs` — new `subtitles_ass(&str)` setter; build-time validation rejects extensions other than `.ass`/`.ssa` and non-existent files with `FilterError::InvalidConfig`
- `builder_tests.rs` — 7 new unit tests covering filter name for `.ass`, args format, filter name for `.ssa`, wrong extension, no extension, nonexistent `.ass`, nonexistent `.ssa`

## Related Issues

Closes #263

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes