### PR TITLE
feat(ff-filter): add overlay_image step for PNG watermark compositing

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -233,6 +233,132 @@ pub(super) unsafe fn add_fit_to_aspect_pad(
     Ok(ctx)
 }
 
+// ── Overlay image compound step ───────────────────────────────────────────────
+
+/// Insert the compound `movie → lut → overlay` filter chain for an
+/// [`FilterStep::OverlayImage`] step.
+///
+/// Unlike standard steps (which go through [`add_and_link_step`]), this step
+/// creates three filter contexts internally:
+///
+/// 1. `movie` — loads the PNG from `path` as a self-contained video source
+///    (no buffersrc input slot is consumed).
+/// 2. `lut` — scales the alpha channel by `opacity` (`a = val * opacity`).
+/// 3. `overlay` — composites the main stream (pad 0) with the image (pad 1)
+///    at position `(x, y)`.
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+pub(super) unsafe fn add_overlay_image_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    path: &str,
+    x: &str,
+    y: &str,
+    opacity: f32,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    use std::ffi::CString;
+
+    // 1. movie filter — self-contained PNG source, no buffersrc slot needed.
+    let movie_filter = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
+    if movie_filter.is_null() {
+        log::warn!("filter not found name=movie (overlay_image)");
+        return Err(FilterError::BuildFailed);
+    }
+    let movie_name = CString::new(format!("movie{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let movie_args =
+        CString::new(format!("filename={path}")).map_err(|_| FilterError::BuildFailed)?;
+    let mut movie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut movie_ctx,
+        movie_filter,
+        movie_name.as_ptr(),
+        movie_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=movie args=filename={path}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=movie args=filename={path} index={index}");
+
+    // 2. lut filter — scale the alpha channel: a = val * opacity.
+    //    For 8-bit RGBA the `lut` filter operates per-channel; `val` is the
+    //    current pixel value (0–255) and the expression is evaluated per sample.
+    let lut_filter = ff_sys::avfilter_get_by_name(c"lut".as_ptr());
+    if lut_filter.is_null() {
+        log::warn!("filter not found name=lut (overlay_image)");
+        return Err(FilterError::BuildFailed);
+    }
+    let lut_name = CString::new(format!("lut{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let lut_args_str = format!("a=val*{opacity}");
+    let lut_args = CString::new(lut_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut lut_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut lut_ctx,
+        lut_filter,
+        lut_name.as_ptr(),
+        lut_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=lut args={lut_args_str}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=lut args={lut_args_str} index={index}");
+
+    // Link: movie → lut (alpha scaling).
+    let ret = ff_sys::avfilter_link(movie_ctx, 0, lut_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // 3. overlay filter — composite main stream (pad 0) with image (pad 1).
+    let overlay_filter = ff_sys::avfilter_get_by_name(c"overlay".as_ptr());
+    if overlay_filter.is_null() {
+        log::warn!("filter not found name=overlay (overlay_image)");
+        return Err(FilterError::BuildFailed);
+    }
+    let overlay_name =
+        CString::new(format!("step{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let overlay_args_str = format!("{x}:{y}");
+    let overlay_args =
+        CString::new(overlay_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut overlay_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut overlay_ctx,
+        overlay_filter,
+        overlay_name.as_ptr(),
+        overlay_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=overlay args={overlay_args_str}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=overlay args={overlay_args_str} index={index}");
+
+    // Link: prev_ctx → overlay pad 0 (main video stream).
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, overlay_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // Link: lut → overlay pad 1 (image stream).
+    let ret = ff_sys::avfilter_link(lut_ctx, 0, overlay_ctx, 1);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    Ok(overlay_ctx)
+}
+
 // ── buffersrc / buffersink arg-string helpers ──────────────────────────────────
 
 /// Build the `args` string passed to `avfilter_graph_create_filter` when

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -16,8 +16,8 @@ mod build;
 mod convert;
 
 use build::{
-    add_and_link_step, add_fit_to_aspect_pad, add_setpts_after_trim, audio_buffersrc_args,
-    create_hw_filter, hw_accel_to_device_type, video_buffersrc_args,
+    add_and_link_step, add_fit_to_aspect_pad, add_overlay_image_step, add_setpts_after_trim,
+    audio_buffersrc_args, create_hw_filter, hw_accel_to_device_type, video_buffersrc_args,
 };
 use convert::{
     audio_pts_ticks, av_frame_to_audio_frame, av_frame_to_video_frame, copy_audio_planes_to_av,
@@ -346,6 +346,24 @@ impl FilterGraphInner {
         // 4-5. Add each `FilterStep`, link the main chain (in0 → step[0] → …),
         // and wire extra input pads for multi-input filters.
         for (i, step) in steps.iter().enumerate() {
+            // OverlayImage is a compound step (movie → lut → overlay).  It
+            // creates its own internal source node via the `movie` filter and
+            // does not consume a buffersrc slot, so it must bypass the standard
+            // `add_and_link_step` path which assumes a single filter per step.
+            if let FilterStep::OverlayImage {
+                path,
+                x,
+                y,
+                opacity,
+            } = step
+            {
+                prev_ctx = match add_overlay_image_step(graph, prev_ctx, path, x, y, *opacity, i) {
+                    Ok(ctx) => ctx,
+                    Err(e) => bail!(e),
+                };
+                continue;
+            }
+
             prev_ctx = match add_and_link_step(graph, prev_ctx, step, i, "step") {
                 Ok(ctx) => ctx,
                 Err(e) => bail!(e),

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -513,6 +513,30 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Composite a PNG image (watermark / logo) over video.
+    ///
+    /// The image at `path` is loaded once at graph construction time via
+    /// `FFmpeg`'s `movie` source filter. Its alpha channel is scaled by
+    /// `opacity` using a `lut` filter, then composited onto the main stream
+    /// with the `overlay` filter at position `(x, y)`.
+    ///
+    /// `x` and `y` are `FFmpeg` expression strings, e.g. `"10"`, `"W-w-10"`.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if:
+    /// - the extension is not `.png`,
+    /// - the file does not exist at build time, or
+    /// - `opacity` is outside `[0.0, 1.0]`.
+    #[must_use]
+    pub fn overlay_image(mut self, path: &str, x: &str, y: &str, opacity: f32) -> Self {
+        self.steps.push(FilterStep::OverlayImage {
+            path: path.to_owned(),
+            x: x.to_owned(),
+            y: y.to_owned(),
+            opacity,
+        });
+        self
+    }
+
     // ── Audio filters ─────────────────────────────────────────────────────────
 
     /// Adjust audio volume by `gain_db` decibels (negative = quieter).
@@ -664,6 +688,27 @@ impl FilterGraphBuilder {
                 if !Path::new(path).exists() {
                     return Err(FilterError::InvalidConfig {
                         reason: format!("subtitle file not found: {path}"),
+                    });
+                }
+            }
+            if let FilterStep::OverlayImage { path, opacity, .. } = step {
+                let ext = Path::new(path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("");
+                if ext != "png" {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("unsupported image format: .{ext}; expected .png"),
+                    });
+                }
+                if !(0.0..=1.0).contains(opacity) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("overlay_image opacity {opacity} out of range [0.0, 1.0]"),
+                    });
+                }
+                if !Path::new(path).exists() {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("overlay image not found: {path}"),
                     });
                 }
             }

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -1979,3 +1979,98 @@ fn builder_subtitles_ssa_with_nonexistent_file_should_return_invalid_config() {
         "expected InvalidConfig for nonexistent .ssa file, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_overlay_image_should_produce_correct_filter_name() {
+    let step = FilterStep::OverlayImage {
+        path: "logo.png".to_owned(),
+        x: "10".to_owned(),
+        y: "10".to_owned(),
+        opacity: 1.0,
+    };
+    assert_eq!(step.filter_name(), "overlay");
+}
+
+#[test]
+fn filter_step_overlay_image_should_produce_correct_args() {
+    let step = FilterStep::OverlayImage {
+        path: "logo.png".to_owned(),
+        x: "W-w-10".to_owned(),
+        y: "H-h-10".to_owned(),
+        opacity: 0.7,
+    };
+    assert_eq!(step.args(), "W-w-10:H-h-10");
+}
+
+#[test]
+fn builder_overlay_image_with_wrong_extension_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .overlay_image("logo.jpg", "10", "10", 1.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for wrong extension, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("unsupported image format"),
+            "reason should mention unsupported format: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_overlay_image_with_no_extension_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .overlay_image("logo_no_ext", "10", "10", 1.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for missing extension, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_overlay_image_with_nonexistent_file_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .overlay_image("/nonexistent/path/logo_ab12cd.png", "10", "10", 1.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for nonexistent file, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("overlay image not found"),
+            "reason should mention file not found: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_overlay_image_with_opacity_above_1_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .overlay_image("/nonexistent/logo.png", "10", "10", 1.1)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for opacity > 1.0, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("opacity"),
+            "reason should mention opacity: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_overlay_image_with_negative_opacity_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .overlay_image("/nonexistent/logo.png", "10", "10", -0.1)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for opacity < 0.0, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -194,6 +194,21 @@ pub(crate) enum FilterStep {
         /// Absolute or relative path to the `.ass` or `.ssa` file.
         path: String,
     },
+    /// Composite a PNG image (watermark / logo) over video with optional opacity.
+    ///
+    /// This is a compound step: internally it creates a `movie` source,
+    /// a `lut` alpha-scaling filter, and an `overlay` compositing filter.
+    /// The image file is loaded once at graph construction time.
+    OverlayImage {
+        /// Absolute or relative path to the `.png` file.
+        path: String,
+        /// Horizontal position as an `FFmpeg` expression, e.g. `"10"` or `"W-w-10"`.
+        x: String,
+        /// Vertical position as an `FFmpeg` expression, e.g. `"10"` or `"H-h-10"`.
+        y: String,
+        /// Opacity 0.0 (fully transparent) to 1.0 (fully opaque).
+        opacity: f32,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -263,6 +278,11 @@ impl FilterStep {
             Self::DrawText { .. } => "drawtext",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
+            // OverlayImage is a compound step (movie → lut → overlay); "overlay"
+            // is used only by validate_filter_steps as a best-effort existence
+            // check.  The actual graph construction is handled by
+            // `filter_inner::build::add_overlay_image_step`.
+            Self::OverlayImage { .. } => "overlay",
         }
     }
 
@@ -429,6 +449,10 @@ impl FilterStep {
             Self::SubtitlesSrt { path } | Self::SubtitlesAss { path } => {
                 format!("filename={path}")
             }
+            // args() for OverlayImage returns the overlay positional args (x:y).
+            // These are not consumed by add_and_link_step (which is bypassed for
+            // this compound step); they exist here only for completeness.
+            Self::OverlayImage { x, y, .. } => format!("{x}:{y}"),
             Self::FitToAspect { width, height, .. } => {
                 // Scale to fit within the target dimensions, preserving the source
                 // aspect ratio.  The accompanying pad filter (inserted by


### PR DESCRIPTION
## Summary

Adds `FilterGraphBuilder::overlay_image` to composite a PNG image (watermark, logo) over video with controllable opacity. Because the image is self-contained, it uses FFmpeg's `movie` source filter rather than a second `buffersrc` slot, making it a compound step that is handled specially in the graph-building loop.

## Changes

- `filter_step.rs` — new `OverlayImage { path, x, y, opacity }` variant; `filter_name()` → `"overlay"` (used only for best-effort validation); `args()` → `"x:y"` (not used at runtime)
- `builder.rs` — new `overlay_image(path, x, y, opacity)` setter; validation order: extension (`.png`) → opacity (`[0.0, 1.0]`) → file exists
- `filter_inner/build.rs` — new `add_overlay_image_step` helper that creates `movie=filename={path}` → `lut=a=val*{opacity}` → `overlay={x}:{y}`, linking lut→overlay pad 1 and prev_ctx→overlay pad 0
- `filter_inner/mod.rs` — build loop detects `OverlayImage`, calls `add_overlay_image_step` and `continue`s, bypassing the standard `add_and_link_step` path
- `builder_tests.rs` — 7 new unit tests: filter name, args format, wrong extension, no extension, nonexistent file, opacity > 1.0, opacity < 0.0

## Related Issues

Closes #264

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes