### PR TITLE
feat(ff-filter): add ticker filter step for scrolling text overlay

### DIFF
--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -479,6 +479,37 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Scroll text from right to left as a news ticker.
+    ///
+    /// Uses `FFmpeg`'s `drawtext` filter with the expression `x = w - t * speed`
+    /// so the text enters from the right edge at playback start and advances
+    /// left by `speed_px_per_sec` pixels per second.
+    ///
+    /// `y` is an `FFmpeg` expression string for the vertical position,
+    /// e.g. `"h-50"` for 50 pixels above the bottom.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if:
+    /// - `text` is empty, or
+    /// - `speed_px_per_sec` is ≤ 0.0.
+    #[must_use]
+    pub fn ticker(
+        mut self,
+        text: &str,
+        y: &str,
+        speed_px_per_sec: f32,
+        font_size: u32,
+        font_color: &str,
+    ) -> Self {
+        self.steps.push(FilterStep::Ticker {
+            text: text.to_owned(),
+            y: y.to_owned(),
+            speed_px_per_sec,
+            font_size,
+            font_color: font_color.to_owned(),
+        });
+        self
+    }
+
     /// Burn SRT subtitles into the video (hard subtitles).
     ///
     /// Subtitles are read from the `.srt` file at `srt_path` and rendered
@@ -628,6 +659,23 @@ impl FilterGraphBuilder {
                             "drawtext opacity {} out of range [0.0, 1.0]",
                             opts.opacity
                         ),
+                    });
+                }
+            }
+            if let FilterStep::Ticker {
+                text,
+                speed_px_per_sec,
+                ..
+            } = step
+            {
+                if text.is_empty() {
+                    return Err(FilterError::InvalidConfig {
+                        reason: "ticker text must not be empty".to_string(),
+                    });
+                }
+                if *speed_px_per_sec <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("ticker speed_px_per_sec {speed_px_per_sec} must be > 0.0"),
                     });
                 }
             }

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2074,3 +2074,113 @@ fn builder_overlay_image_with_negative_opacity_should_return_invalid_config() {
         "expected InvalidConfig for opacity < 0.0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_ticker_should_produce_correct_filter_name() {
+    let step = FilterStep::Ticker {
+        text: "Breaking news".to_owned(),
+        y: "h-50".to_owned(),
+        speed_px_per_sec: 100.0,
+        font_size: 24,
+        font_color: "white".to_owned(),
+    };
+    assert_eq!(step.filter_name(), "drawtext");
+}
+
+#[test]
+fn filter_step_ticker_should_produce_correct_args() {
+    let step = FilterStep::Ticker {
+        text: "Breaking news".to_owned(),
+        y: "h-50".to_owned(),
+        speed_px_per_sec: 100.0,
+        font_size: 24,
+        font_color: "white".to_owned(),
+    };
+    let args = step.args();
+    assert!(
+        args.contains("text='Breaking news'"),
+        "args should contain escaped text: {args}"
+    );
+    assert!(
+        args.contains("x=w-t*100"),
+        "args should contain scrolling x expression: {args}"
+    );
+    assert!(args.contains("y=h-50"), "args should contain y: {args}");
+    assert!(
+        args.contains("fontsize=24"),
+        "args should contain fontsize: {args}"
+    );
+    assert!(
+        args.contains("fontcolor=white"),
+        "args should contain fontcolor: {args}"
+    );
+}
+
+#[test]
+fn filter_step_ticker_should_escape_special_characters_in_text() {
+    let step = FilterStep::Ticker {
+        text: "colon:backslash\\apostrophe'".to_owned(),
+        y: "10".to_owned(),
+        speed_px_per_sec: 50.0,
+        font_size: 20,
+        font_color: "red".to_owned(),
+    };
+    let args = step.args();
+    assert!(
+        args.contains("\\:"),
+        "colon should be escaped in args: {args}"
+    );
+    assert!(
+        args.contains("\\'"),
+        "apostrophe should be escaped in args: {args}"
+    );
+    assert!(
+        args.contains("\\\\"),
+        "backslash should be escaped in args: {args}"
+    );
+}
+
+#[test]
+fn builder_ticker_with_empty_text_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .ticker("", "h-50", 100.0, 24, "white")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for empty text, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("ticker text must not be empty"),
+            "reason should mention empty text: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_ticker_with_zero_speed_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .ticker("Breaking news", "h-50", 0.0, 24, "white")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for speed = 0.0, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("speed_px_per_sec"),
+            "reason should mention speed_px_per_sec: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_ticker_with_negative_speed_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .ticker("Breaking news", "h-50", -50.0, 24, "white")
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for negative speed, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -194,6 +194,23 @@ pub(crate) enum FilterStep {
         /// Absolute or relative path to the `.ass` or `.ssa` file.
         path: String,
     },
+    /// Scrolling text ticker (right-to-left) using the `drawtext` filter.
+    ///
+    /// The text starts off-screen to the right and scrolls left at
+    /// `speed_px_per_sec` pixels per second using the expression
+    /// `x = w - t * speed`.
+    Ticker {
+        /// Text to display. Special characters (`\`, `:`, `'`) are escaped.
+        text: String,
+        /// Y position as an `FFmpeg` expression, e.g. `"h-50"` or `"10"`.
+        y: String,
+        /// Horizontal scroll speed in pixels per second (must be > 0.0).
+        speed_px_per_sec: f32,
+        /// Font size in points.
+        font_size: u32,
+        /// Font color as an `FFmpeg` color string, e.g. `"white"` or `"0xFFFFFF"`.
+        font_color: String,
+    },
     /// Composite a PNG image (watermark / logo) over video with optional opacity.
     ///
     /// This is a compound step: internally it creates a `movie` source,
@@ -275,7 +292,7 @@ impl FilterStep {
             Self::Nlmeans { .. } => "nlmeans",
             Self::Yadif { .. } => "yadif",
             Self::XFade { .. } => "xfade",
-            Self::DrawText { .. } => "drawtext",
+            Self::DrawText { .. } | Self::Ticker { .. } => "drawtext",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -445,6 +462,25 @@ impl FilterStep {
                     parts.push(format!("boxborderw={}", opts.box_border_width));
                 }
                 parts.join(":")
+            }
+            Self::Ticker {
+                text,
+                y,
+                speed_px_per_sec,
+                font_size,
+                font_color,
+            } => {
+                // Use the same escaping as DrawText.
+                let escaped = text
+                    .replace('\\', "\\\\")
+                    .replace(':', "\\:")
+                    .replace('\'', "\\'");
+                // x = w - t * speed: at t=0 the text starts fully off the right
+                // edge (x = w) and scrolls left by `speed` pixels per second.
+                format!(
+                    "text='{escaped}':x=w-t*{speed_px_per_sec}:y={y}:\
+                     fontsize={font_size}:fontcolor={font_color}"
+                )
             }
             Self::SubtitlesSrt { path } | Self::SubtitlesAss { path } => {
                 format!("filename={path}")


### PR DESCRIPTION
## Summary

Adds `FilterGraphBuilder::ticker` to scroll text from right to left as a news ticker using FFmpeg's `drawtext` filter. The horizontal position is computed with the expression `x = w - t * speed_px_per_sec`, so the text enters from the right edge at playback start and advances left at the configured speed.

## Changes

- `filter_step.rs` — new `Ticker { text, y, speed_px_per_sec, font_size, font_color }` variant; `filter_name()` shares the `"drawtext"` arm with `DrawText`; `args()` produces the scrolling drawtext args with the same special-character escaping (`\`, `:`, `'`) as `DrawText`
- `builder.rs` — new `ticker(text, y, speed_px_per_sec, font_size, font_color)` setter; validates that `text` is not empty and `speed_px_per_sec` > 0.0
- `builder_tests.rs` — 6 new unit tests: filter name, args correctness, special-character escaping, empty text, zero speed, negative speed

## Related Issues

Closes #265

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes