### PR TITLE
feat(ff-filter): add playback speed change step via setpts + atempo

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -233,6 +233,148 @@ pub(super) unsafe fn add_fit_to_aspect_pad(
     Ok(ctx)
 }
 
+// ── Speed (atempo chain) ──────────────────────────────────────────────────────
+
+/// Decompose a speed `factor` into a chain of `atempo` values, each in [0.5, 2.0].
+///
+/// The `atempo` filter only accepts values in [0.5, 2.0] per instance.
+/// Chaining multiple instances multiplies the effective speed factor:
+///
+/// - `factor = 4.0`  → `[2.0, 2.0]`       (2.0 × 2.0 = 4.0)
+/// - `factor = 0.25` → `[0.5, 0.5]`       (0.5 × 0.5 = 0.25)
+/// - `factor = 8.0`  → `[2.0, 2.0, 2.0]`  (2.0³ = 8.0)
+/// - `factor = 1.5`  → `[1.5]`            (within range directly)
+pub(super) fn decompose_atempo(factor: f64) -> Vec<f64> {
+    let mut remaining = factor;
+    let mut chain = Vec::new();
+    while remaining > 2.0 {
+        chain.push(2.0);
+        remaining /= 2.0;
+    }
+    while remaining < 0.5 {
+        chain.push(0.5);
+        remaining /= 0.5;
+    }
+    chain.push(remaining);
+    chain
+}
+
+/// Insert a chain of `atempo` filters for the audio path of a `Speed` step.
+///
+/// Creates as many `atempo` instances as needed (see [`decompose_atempo`]) and
+/// links them in series after `prev_ctx`.
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+pub(super) unsafe fn add_atempo_chain(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    factor: f64,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let atempo_filter = ff_sys::avfilter_get_by_name(c"atempo".as_ptr());
+    if atempo_filter.is_null() {
+        log::warn!("filter not found name=atempo (speed)");
+        return Err(FilterError::BuildFailed);
+    }
+
+    let chain = decompose_atempo(factor);
+    let mut ctx = prev_ctx;
+    for (j, &val) in chain.iter().enumerate() {
+        let name = std::ffi::CString::new(format!("atempo{index}_{j}"))
+            .map_err(|_| FilterError::BuildFailed)?;
+        let args_str = format!("{val}");
+        let args =
+            std::ffi::CString::new(args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+        let mut atempo_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+        let ret = ff_sys::avfilter_graph_create_filter(
+            &raw mut atempo_ctx,
+            atempo_filter,
+            name.as_ptr(),
+            args.as_ptr(),
+            std::ptr::null_mut(),
+            graph,
+        );
+        if ret < 0 {
+            log::warn!("filter creation failed name=atempo args={val}");
+            return Err(FilterError::BuildFailed);
+        }
+        log::debug!("filter added name=atempo args={val} index={index}_{j}");
+
+        let ret = ff_sys::avfilter_link(ctx, 0, atempo_ctx, 0);
+        if ret < 0 {
+            return Err(FilterError::BuildFailed);
+        }
+        ctx = atempo_ctx;
+    }
+    Ok(ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decompose_atempo;
+
+    #[test]
+    fn decompose_atempo_should_return_single_value_for_factor_within_range() {
+        assert_eq!(decompose_atempo(1.5), vec![1.5]);
+    }
+
+    #[test]
+    fn decompose_atempo_should_return_single_value_for_factor_1() {
+        assert_eq!(decompose_atempo(1.0), vec![1.0]);
+    }
+
+    #[test]
+    fn decompose_atempo_should_chain_two_instances_for_factor_4() {
+        assert_eq!(decompose_atempo(4.0), vec![2.0, 2.0]);
+    }
+
+    #[test]
+    fn decompose_atempo_should_chain_three_instances_for_factor_8() {
+        assert_eq!(decompose_atempo(8.0), vec![2.0, 2.0, 2.0]);
+    }
+
+    #[test]
+    fn decompose_atempo_should_chain_two_instances_for_factor_0_25() {
+        let chain = decompose_atempo(0.25);
+        let product: f64 = chain.iter().product();
+        assert!(
+            (product - 0.25).abs() < 1e-9,
+            "product should be ~0.25, got {product}, chain={chain:?}"
+        );
+        for &v in &chain {
+            assert!(
+                (0.5..=2.0).contains(&v),
+                "each value must be in [0.5, 2.0], got {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn decompose_atempo_should_produce_values_all_within_valid_range() {
+        for factor in [0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 4.0, 8.0, 16.0, 100.0] {
+            let chain = decompose_atempo(factor);
+            assert!(
+                !chain.is_empty(),
+                "chain must not be empty for factor={factor}"
+            );
+            let product: f64 = chain.iter().product();
+            assert!(
+                (product - factor).abs() < 1e-6,
+                "product {product} must equal factor {factor}, chain={chain:?}"
+            );
+            for &v in &chain {
+                assert!(
+                    (0.5..=2.0).contains(&v),
+                    "each value must be in [0.5, 2.0], got {v} for factor={factor}"
+                );
+            }
+        }
+    }
+}
+
 // ── Overlay image compound step ───────────────────────────────────────────────
 
 /// Insert the compound `movie → lut → overlay` filter chain for an

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -16,8 +16,9 @@ mod build;
 mod convert;
 
 use build::{
-    add_and_link_step, add_fit_to_aspect_pad, add_overlay_image_step, add_setpts_after_trim,
-    audio_buffersrc_args, create_hw_filter, hw_accel_to_device_type, video_buffersrc_args,
+    add_and_link_step, add_atempo_chain, add_fit_to_aspect_pad, add_overlay_image_step,
+    add_setpts_after_trim, audio_buffersrc_args, create_hw_filter, hw_accel_to_device_type,
+    video_buffersrc_args,
 };
 use convert::{
     audio_pts_ticks, av_frame_to_audio_frame, av_frame_to_video_frame, copy_audio_planes_to_av,
@@ -713,6 +714,12 @@ impl FilterGraphInner {
         // 3-5. Add each `FilterStep` (audio-relevant steps) and link.
         let mut prev_ctx = first_src_ctx.as_ptr();
         for (i, step) in steps.iter().enumerate() {
+            // Speed uses `setpts` for video but `atempo` for audio.  Bypass the
+            // standard `add_and_link_step` path and insert the atempo chain here.
+            if let FilterStep::Speed { factor } = step {
+                prev_ctx = add_atempo_chain(graph, prev_ctx, *factor, i)?;
+                continue;
+            }
             prev_ctx = add_and_link_step(graph, prev_ctx, step, i, "astep")?;
         }
 

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -469,6 +469,23 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Change playback speed by `factor`.
+    ///
+    /// `factor > 1.0` = fast motion (e.g. `2.0` = double speed).
+    /// `factor < 1.0` = slow motion (e.g. `0.5` = half speed).
+    ///
+    /// **Video**: uses `setpts=PTS/{factor}`.
+    /// **Audio**: uses chained `atempo` filters (each in [0.5, 2.0]) so the
+    /// full range 0.1–100.0 is covered without quality degradation.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `factor` is outside [0.1, 100.0].
+    #[must_use]
+    pub fn speed(mut self, factor: f64) -> Self {
+        self.steps.push(FilterStep::Speed { factor });
+        self
+    }
+
     /// Overlay text onto the video using the `drawtext` filter.
     ///
     /// See [`DrawTextOptions`] for all configurable fields including position,
@@ -623,6 +640,13 @@ impl FilterGraphBuilder {
         // (e.g. a watermark larger than the video). Catch it early with a
         // descriptive error rather than silently producing invisible output.
         for step in &self.steps {
+            if let FilterStep::Speed { factor } = step
+                && !(0.1..=100.0).contains(factor)
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: format!("speed factor {factor} out of range [0.1, 100.0]"),
+                });
+            }
             if let FilterStep::Crop { width, height, .. } = step
                 && (*width == 0 || *height == 0)
             {

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2184,3 +2184,62 @@ fn builder_ticker_with_negative_speed_should_return_invalid_config() {
         "expected InvalidConfig for negative speed, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_speed_should_produce_correct_filter_name() {
+    let step = FilterStep::Speed { factor: 2.0 };
+    assert_eq!(step.filter_name(), "setpts");
+}
+
+#[test]
+fn filter_step_speed_should_produce_correct_args_for_double_speed() {
+    let step = FilterStep::Speed { factor: 2.0 };
+    assert_eq!(step.args(), "PTS/2");
+}
+
+#[test]
+fn filter_step_speed_should_produce_correct_args_for_half_speed() {
+    let step = FilterStep::Speed { factor: 0.5 };
+    assert_eq!(step.args(), "PTS/0.5");
+}
+
+#[test]
+fn builder_speed_with_factor_below_minimum_should_return_invalid_config() {
+    let result = FilterGraph::builder().speed(0.09).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for factor below 0.1, got {result:?}"
+    );
+    if let Err(FilterError::InvalidConfig { reason }) = result {
+        assert!(
+            reason.contains("speed factor"),
+            "reason should mention speed factor: {reason}"
+        );
+    }
+}
+
+#[test]
+fn builder_speed_with_factor_above_maximum_should_return_invalid_config() {
+    let result = FilterGraph::builder().speed(100.1).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for factor above 100.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_speed_with_zero_factor_should_return_invalid_config() {
+    let result = FilterGraph::builder().speed(0.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for factor 0.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_speed_at_boundary_values_should_succeed() {
+    let low = FilterGraph::builder().speed(0.1).build();
+    assert!(low.is_ok(), "speed(0.1) should succeed, got {low:?}");
+    let high = FilterGraph::builder().speed(100.0).build();
+    assert!(high.is_ok(), "speed(100.0) should succeed, got {high:?}");
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -194,6 +194,18 @@ pub(crate) enum FilterStep {
         /// Absolute or relative path to the `.ass` or `.ssa` file.
         path: String,
     },
+    /// Playback speed change using `setpts` (video) and chained `atempo` (audio).
+    ///
+    /// `factor > 1.0` = fast motion; `factor < 1.0` = slow motion.
+    /// Valid range: 0.1–100.0.
+    ///
+    /// Video path: `setpts=PTS/{factor}`.
+    /// Audio path: the `atempo` filter only accepts [0.5, 2.0] per instance;
+    /// `filter_inner` chains multiple instances to cover the full range.
+    Speed {
+        /// Speed multiplier. Must be in [0.1, 100.0].
+        factor: f64,
+    },
     /// Scrolling text ticker (right-to-left) using the `drawtext` filter.
     ///
     /// The text starts off-screen to the right and scrolls left at
@@ -293,6 +305,9 @@ impl FilterStep {
             Self::Yadif { .. } => "yadif",
             Self::XFade { .. } => "xfade",
             Self::DrawText { .. } | Self::Ticker { .. } => "drawtext",
+            // "setpts" is checked at build-time; the audio path uses "atempo"
+            // which is verified at graph-construction time in filter_inner.
+            Self::Speed { .. } => "setpts",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -482,6 +497,9 @@ impl FilterStep {
                      fontsize={font_size}:fontcolor={font_color}"
                 )
             }
+            // Video path: divide PTS by factor to change playback speed.
+            // Audio path args are built by filter_inner (chained atempo).
+            Self::Speed { factor } => format!("PTS/{factor}"),
             Self::SubtitlesSrt { path } | Self::SubtitlesAss { path } => {
                 format!("filename={path}")
             }


### PR DESCRIPTION
## Summary

Adds a `Speed` filter step to `ff-filter` that changes playback speed over the range 0.1x–100x. Video speed is changed with `setpts=PTS/factor`; audio speed is changed by chaining `atempo` filters (each clamped to [0.5, 2.0]) to cover the full range.

## Changes

- `FilterStep::Speed { factor: f64 }` variant in `filter_step.rs` with `filter_name() = "setpts"` and `args() = "PTS/{factor}"`
- `FilterGraphBuilder::speed(factor)` setter with validation: factor must be in [0.1, 100.0]
- `decompose_atempo(factor)` helper in `filter_inner/build.rs` decomposes an arbitrary speed factor into a chain of `atempo` values each within [0.5, 2.0]
- `add_atempo_chain` creates and links the chained `atempo` filters for the audio graph
- Audio build loop detects `Speed` steps and routes them to `add_atempo_chain`; video build loop uses the standard `setpts` path
- 13 new unit tests covering filter name/args, boundary validation, and `decompose_atempo` correctness

## Related Issues

Closes #266

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes