### PR TITLE
feat(ff-filter): add reverse and areverse filter steps

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -347,6 +347,11 @@ impl FilterGraphInner {
         // 4-5. Add each `FilterStep`, link the main chain (in0 → step[0] → …),
         // and wire extra input pads for multi-input filters.
         for (i, step) in steps.iter().enumerate() {
+            // AReverse is audio-only; skip it in the video graph.
+            if matches!(step, FilterStep::AReverse) {
+                continue;
+            }
+
             // OverlayImage is a compound step (movie → lut → overlay).  It
             // creates its own internal source node via the `movie` filter and
             // does not consume a buffersrc slot, so it must bypass the standard
@@ -714,6 +719,11 @@ impl FilterGraphInner {
         // 3-5. Add each `FilterStep` (audio-relevant steps) and link.
         let mut prev_ctx = first_src_ctx.as_ptr();
         for (i, step) in steps.iter().enumerate() {
+            // Reverse is video-only; skip it in the audio graph.
+            if matches!(step, FilterStep::Reverse) {
+                continue;
+            }
+
             // Speed uses `setpts` for video but `atempo` for audio.  Bypass the
             // standard `add_and_link_step` path and insert the atempo chain here.
             if let FilterStep::Speed { factor } = step {

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -317,6 +317,26 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Reverse video playback using `FFmpeg`'s `reverse` filter.
+    ///
+    /// **Warning**: `reverse` buffers the entire clip in memory before producing
+    /// any output. Only use this on short clips to avoid excessive memory usage.
+    #[must_use]
+    pub fn reverse(mut self) -> Self {
+        self.steps.push(FilterStep::Reverse);
+        self
+    }
+
+    /// Reverse audio playback using `FFmpeg`'s `areverse` filter.
+    ///
+    /// **Warning**: `areverse` buffers the entire clip in memory before producing
+    /// any output. Only use this on short clips to avoid excessive memory usage.
+    #[must_use]
+    pub fn areverse(mut self) -> Self {
+        self.steps.push(FilterStep::AReverse);
+        self
+    }
+
     /// Pad the frame to `width × height` pixels, placing the source at `(x, y)`
     /// and filling the exposed borders with `color`.
     ///

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2243,3 +2243,35 @@ fn builder_speed_at_boundary_values_should_succeed() {
     let high = FilterGraph::builder().speed(100.0).build();
     assert!(high.is_ok(), "speed(100.0) should succeed, got {high:?}");
 }
+
+#[test]
+fn filter_step_reverse_should_produce_correct_filter_name_and_empty_args() {
+    let step = FilterStep::Reverse;
+    assert_eq!(step.filter_name(), "reverse");
+    assert_eq!(step.args(), "");
+}
+
+#[test]
+fn filter_step_areverse_should_produce_correct_filter_name_and_empty_args() {
+    let step = FilterStep::AReverse;
+    assert_eq!(step.filter_name(), "areverse");
+    assert_eq!(step.args(), "");
+}
+
+#[test]
+fn builder_reverse_should_succeed() {
+    let result = FilterGraph::builder().reverse().build();
+    assert!(
+        result.is_ok(),
+        "reverse must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_areverse_should_succeed() {
+    let result = FilterGraph::builder().areverse().build();
+    assert!(
+        result.is_ok(),
+        "areverse must build successfully, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -91,6 +91,10 @@ pub(crate) enum FilterStep {
     HFlip,
     /// Vertical flip (mirror top-bottom).
     VFlip,
+    /// Reverse video playback (buffers entire clip in memory — use only on short clips).
+    Reverse,
+    /// Reverse audio playback (buffers entire clip in memory — use only on short clips).
+    AReverse,
     /// Pad to a target resolution with a fill color (letterbox / pillarbox).
     Pad {
         /// Target canvas width in pixels.
@@ -293,6 +297,8 @@ impl FilterStep {
             Self::Vignette { .. } => "vignette",
             Self::HFlip => "hflip",
             Self::VFlip => "vflip",
+            Self::Reverse => "reverse",
+            Self::AReverse => "areverse",
             Self::Pad { .. } => "pad",
             // FitToAspect is implemented as scale + pad; "scale" is validated at
             // build time.  The pad filter is inserted by filter_inner at graph
@@ -429,7 +435,7 @@ impl FilterStep {
                     curve(lift.b, gamma.b, gain.b),
                 )
             }
-            Self::HFlip | Self::VFlip => String::new(),
+            Self::HFlip | Self::VFlip | Self::Reverse | Self::AReverse => String::new(),
             Self::GBlur { sigma } => format!("sigma={sigma}"),
             Self::Unsharp {
                 luma_strength,


### PR DESCRIPTION
## Summary

Adds `Reverse` and `AReverse` filter steps to `ff-filter` for reversing video and audio playback respectively. `reverse` is video-only and `areverse` is audio-only; each is skipped in the opposite graph's build loop so mixed pipelines work correctly.

## Changes

- `FilterStep::Reverse` and `FilterStep::AReverse` variants with doc comments warning about full-clip memory buffering
- `filter_name()` maps to `"reverse"` / `"areverse"`; `args()` returns empty string for both
- `FilterGraphBuilder::reverse()` and `::areverse()` setter methods with memory-warning doc comments
- Video build loop skips `AReverse` steps; audio build loop skips `Reverse` steps
- 4 new unit tests covering filter name, args, and builder success for both variants

## Related Issues

Closes #267

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes