### PR TITLE
feat(ff-filter): add freeze_frame step via FFmpeg loop filter

### DIFF
--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -506,6 +506,23 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
+    ///
+    /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before
+    /// playback resumes. Frame numbers are approximated using a 25 fps assumption;
+    /// accuracy depends on the source stream's actual frame rate.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `pts_sec` is negative or `duration_sec` is ≤ 0.0.
+    #[must_use]
+    pub fn freeze_frame(mut self, pts_sec: f64, duration_sec: f64) -> Self {
+        self.steps.push(FilterStep::FreezeFrame {
+            pts: pts_sec,
+            duration: duration_sec,
+        });
+        self
+    }
+
     /// Overlay text onto the video using the `drawtext` filter.
     ///
     /// See [`DrawTextOptions`] for all configurable fields including position,
@@ -666,6 +683,18 @@ impl FilterGraphBuilder {
                 return Err(FilterError::InvalidConfig {
                     reason: format!("speed factor {factor} out of range [0.1, 100.0]"),
                 });
+            }
+            if let FilterStep::FreezeFrame { pts, duration } = step {
+                if *pts < 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("freeze_frame pts {pts} must be >= 0.0"),
+                    });
+                }
+                if *duration <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("freeze_frame duration {duration} must be > 0.0"),
+                    });
+                }
             }
             if let FilterStep::Crop { width, height, .. } = step
                 && (*width == 0 || *height == 0)

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2275,3 +2275,67 @@ fn builder_areverse_should_succeed() {
         "areverse must build successfully, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_freeze_frame_should_produce_correct_filter_name() {
+    let step = FilterStep::FreezeFrame {
+        pts: 2.0,
+        duration: 3.0,
+    };
+    assert_eq!(step.filter_name(), "loop");
+}
+
+#[test]
+fn filter_step_freeze_frame_should_produce_correct_args() {
+    let step = FilterStep::FreezeFrame {
+        pts: 2.0,
+        duration: 3.0,
+    };
+    // 2.0s * 25fps = frame 50; 3.0s * 25fps = 75 loop iterations
+    assert_eq!(step.args(), "loop=75:size=1:start=50");
+}
+
+#[test]
+fn filter_step_freeze_frame_at_zero_pts_should_produce_start_zero() {
+    let step = FilterStep::FreezeFrame {
+        pts: 0.0,
+        duration: 1.0,
+    };
+    assert_eq!(step.args(), "loop=25:size=1:start=0");
+}
+
+#[test]
+fn builder_freeze_frame_with_valid_params_should_succeed() {
+    let result = FilterGraph::builder().freeze_frame(2.0, 3.0).build();
+    assert!(
+        result.is_ok(),
+        "freeze_frame(2.0, 3.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_freeze_frame_with_negative_pts_should_return_invalid_config() {
+    let result = FilterGraph::builder().freeze_frame(-1.0, 3.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for negative pts, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_freeze_frame_with_zero_duration_should_return_invalid_config() {
+    let result = FilterGraph::builder().freeze_frame(2.0, 0.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for zero duration, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_freeze_frame_with_negative_duration_should_return_invalid_config() {
+    let result = FilterGraph::builder().freeze_frame(2.0, -1.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for negative duration, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -210,6 +210,17 @@ pub(crate) enum FilterStep {
         /// Speed multiplier. Must be in [0.1, 100.0].
         factor: f64,
     },
+    /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
+    ///
+    /// The frame nearest to `pts` seconds is held for `duration` seconds, then
+    /// playback resumes. Frame numbers are approximated using a 25 fps assumption;
+    /// accuracy depends on the source stream's actual frame rate.
+    FreezeFrame {
+        /// Timestamp of the frame to freeze, in seconds. Must be >= 0.0.
+        pts: f64,
+        /// Duration to hold the frozen frame, in seconds. Must be > 0.0.
+        duration: f64,
+    },
     /// Scrolling text ticker (right-to-left) using the `drawtext` filter.
     ///
     /// The text starts off-screen to the right and scrolls left at
@@ -314,6 +325,7 @@ impl FilterStep {
             // "setpts" is checked at build-time; the audio path uses "atempo"
             // which is verified at graph-construction time in filter_inner.
             Self::Speed { .. } => "setpts",
+            Self::FreezeFrame { .. } => "loop",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -506,6 +518,16 @@ impl FilterStep {
             // Video path: divide PTS by factor to change playback speed.
             // Audio path args are built by filter_inner (chained atempo).
             Self::Speed { factor } => format!("PTS/{factor}"),
+            Self::FreezeFrame { pts, duration } => {
+                // The `loop` filter needs a frame index and a loop count, not PTS or
+                // wall-clock duration.  We approximate both using 25 fps; accuracy
+                // depends on the source stream's actual frame rate.
+                #[allow(clippy::cast_possible_truncation)]
+                let start = (*pts * 25.0) as i64;
+                #[allow(clippy::cast_possible_truncation)]
+                let loop_count = (*duration * 25.0) as i64;
+                format!("loop={loop_count}:size=1:start={start}")
+            }
             Self::SubtitlesSrt { path } | Self::SubtitlesAss { path } => {
                 format!("filename={path}")
             }


### PR DESCRIPTION
## Summary

Adds a `FreezeFrame` filter step that holds a single video frame for a configurable duration using FFmpeg's `loop` filter. The frame nearest to `pts_sec` is frozen for `duration_sec` seconds before playback resumes. Frame numbers are approximated using a 25 fps assumption; accuracy scales with the source stream's actual frame rate.

## Changes

- `FilterStep::FreezeFrame { pts: f64, duration: f64 }` variant; `filter_name()` → `"loop"`; `args()` → `"loop={duration*25}:size=1:start={pts*25}"`
- `FilterGraphBuilder::freeze_frame(pts_sec, duration_sec)` setter with doc comment noting the 25 fps approximation
- Validation in `build()`: `pts >= 0.0` and `duration > 0.0`
- 7 new unit tests covering filter name, args values, valid build, and three invalid-config cases

## Related Issues

Closes #268

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes