### PR TITLE
test(ff-filter): verify volume dB args and add named test

### DIFF
--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -39,6 +39,13 @@ fn filter_step_volume_should_produce_correct_args() {
 }
 
 #[test]
+fn volume_should_convert_db_to_ffmpeg_string() {
+    assert_eq!(FilterStep::Volume(-6.0).args(), "volume=-6dB");
+    assert_eq!(FilterStep::Volume(6.0).args(), "volume=6dB");
+    assert_eq!(FilterStep::Volume(0.0).args(), "volume=0dB");
+}
+
+#[test]
 fn tone_map_variants_should_have_correct_names() {
     assert_eq!(ToneMap::Hable.as_str(), "hable");
     assert_eq!(ToneMap::Reinhard.as_str(), "reinhard");


### PR DESCRIPTION
## Summary

The `volume` step was already implemented correctly — `args()` produces `volume={db}dB` as required. This PR adds the `volume_should_convert_db_to_ffmpeg_string` test explicitly named in the issue checklist, covering the `+6 dB`, `−6 dB`, and `0 dB` cases.

## Changes

- Added `volume_should_convert_db_to_ffmpeg_string` unit test in `builder_tests.rs` covering `6.0`, `-6.0`, and `0.0` dB values

## Related Issues

Closes #271

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes