### PR TITLE
feat(ff-filter): add afade_in and afade_out audio fade steps

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -373,8 +373,12 @@ impl FilterGraphInner {
         // 4-5. Add each `FilterStep`, link the main chain (in0 → step[0] → …),
         // and wire extra input pads for multi-input filters.
         for (i, step) in steps.iter().enumerate() {
-            // AReverse is audio-only; skip it in the video graph.
-            if matches!(step, FilterStep::AReverse) {
+            // AReverse, AFadeIn, and AFadeOut are audio-only; skip them in the
+            // video graph.
+            if matches!(
+                step,
+                FilterStep::AReverse | FilterStep::AFadeIn { .. } | FilterStep::AFadeOut { .. }
+            ) {
                 continue;
             }
 

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -128,6 +128,34 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Audio fade-in from silence, starting at `start_sec` seconds and reaching
+    /// full volume after `duration_sec` seconds.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `duration_sec` is ≤ 0.0.
+    #[must_use]
+    pub fn afade_in(mut self, start_sec: f64, duration_sec: f64) -> Self {
+        self.steps.push(FilterStep::AFadeIn {
+            start: start_sec,
+            duration: duration_sec,
+        });
+        self
+    }
+
+    /// Audio fade-out to silence, starting at `start_sec` seconds and reaching
+    /// full silence after `duration_sec` seconds.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `duration_sec` is ≤ 0.0.
+    #[must_use]
+    pub fn afade_out(mut self, start_sec: f64, duration_sec: f64) -> Self {
+        self.steps.push(FilterStep::AFadeOut {
+            start: start_sec,
+            duration: duration_sec,
+        });
+        self
+    }
+
     /// Rotate the video clockwise by `angle_degrees`, filling exposed corners
     /// with `fill_color`.
     ///
@@ -782,6 +810,14 @@ impl FilterGraphBuilder {
             {
                 return Err(FilterError::InvalidConfig {
                     reason: format!("fade duration {duration} must be > 0.0"),
+                });
+            }
+            if let FilterStep::AFadeIn { duration, .. } | FilterStep::AFadeOut { duration, .. } =
+                step
+                && *duration <= 0.0
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: format!("afade duration {duration} must be > 0.0"),
                 });
             }
             if let FilterStep::XFade { duration, .. } = step

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2472,3 +2472,75 @@ fn builder_normalize_peak_with_positive_target_db_should_return_invalid_config()
         "expected InvalidConfig for target_db=1.0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_afade_in_should_have_correct_filter_name() {
+    let step = FilterStep::AFadeIn {
+        start: 0.0,
+        duration: 1.0,
+    };
+    assert_eq!(step.filter_name(), "afade");
+}
+
+#[test]
+fn filter_step_afade_out_should_have_correct_filter_name() {
+    let step = FilterStep::AFadeOut {
+        start: 4.0,
+        duration: 1.0,
+    };
+    assert_eq!(step.filter_name(), "afade");
+}
+
+#[test]
+fn filter_step_afade_in_should_produce_correct_args() {
+    let step = FilterStep::AFadeIn {
+        start: 0.0,
+        duration: 1.0,
+    };
+    assert_eq!(step.args(), "type=in:start_time=0:duration=1");
+}
+
+#[test]
+fn filter_step_afade_out_should_produce_correct_args() {
+    let step = FilterStep::AFadeOut {
+        start: 4.0,
+        duration: 1.0,
+    };
+    assert_eq!(step.args(), "type=out:start_time=4:duration=1");
+}
+
+#[test]
+fn builder_afade_in_with_valid_params_should_succeed() {
+    let result = FilterGraph::builder().afade_in(0.0, 1.0).build();
+    assert!(
+        result.is_ok(),
+        "afade_in(0.0, 1.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_afade_out_with_valid_params_should_succeed() {
+    let result = FilterGraph::builder().afade_out(4.0, 1.0).build();
+    assert!(
+        result.is_ok(),
+        "afade_out(4.0, 1.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_afade_in_with_zero_duration_should_return_invalid_config() {
+    let result = FilterGraph::builder().afade_in(0.0, 0.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for duration=0.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_afade_out_with_negative_duration_should_return_invalid_config() {
+    let result = FilterGraph::builder().afade_out(4.0, -1.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for duration=-1.0, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -31,6 +31,10 @@ pub(crate) enum FilterStep {
     FadeIn { start: f64, duration: f64 },
     /// Fade-out to black starting at `start` seconds, over `duration` seconds.
     FadeOut { start: f64, duration: f64 },
+    /// Audio fade-in from silence starting at `start` seconds, over `duration` seconds.
+    AFadeIn { start: f64, duration: f64 },
+    /// Audio fade-out to silence starting at `start` seconds, over `duration` seconds.
+    AFadeOut { start: f64, duration: f64 },
     /// Fade-in from white starting at `start` seconds, over `duration` seconds.
     FadeInWhite { start: f64, duration: f64 },
     /// Fade-out to white starting at `start` seconds, over `duration` seconds.
@@ -317,6 +321,7 @@ impl FilterStep {
             | Self::FadeOut { .. }
             | Self::FadeInWhite { .. }
             | Self::FadeOutWhite { .. } => "fade",
+            Self::AFadeIn { .. } | Self::AFadeOut { .. } => "afade",
             Self::Rotate { .. } => "rotate",
             Self::ToneMap(_) => "tonemap",
             Self::Volume(_) => "volume",
@@ -391,6 +396,12 @@ impl FilterStep {
             }
             Self::FadeOutWhite { start, duration } => {
                 format!("type=out:start_time={start}:duration={duration}:color=white")
+            }
+            Self::AFadeIn { start, duration } => {
+                format!("type=in:start_time={start}:duration={duration}")
+            }
+            Self::AFadeOut { start, duration } => {
+                format!("type=out:start_time={start}:duration={duration}")
             }
             Self::Rotate {
                 angle_degrees,


### PR DESCRIPTION
## Summary

Adds `afade_in(start_sec, duration_sec)` and `afade_out(start_sec, duration_sec)` to `FilterGraphBuilder` using FFmpeg's `afade` filter. Both variants are audio-only and are skipped in the video build loop alongside the existing `AReverse` guard.

## Changes

- `FilterStep::AFadeIn` and `FilterStep::AFadeOut` variants — both map to `filter_name() = "afade"` with `type=in/out:start_time=...:duration=...` args
- `FilterGraphBuilder::afade_in()` and `afade_out()` setters; `build()` rejects `duration <= 0.0` with `InvalidConfig`
- Video build loop skip guard extended to include `AFadeIn` and `AFadeOut`
- 8 unit tests covering filter names, args, valid builds, zero duration, and negative duration

## Related Issues

Closes #272

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes