### PR TITLE
feat(ff-filter): noise gate via agate filter (threshold, attack, release)

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -380,6 +380,7 @@ impl FilterGraphInner {
                     | FilterStep::AFadeIn { .. }
                     | FilterStep::AFadeOut { .. }
                     | FilterStep::ParametricEq { .. }
+                    | FilterStep::ANoiseGate { .. }
             ) {
                 continue;
             }

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -572,6 +572,24 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Apply a noise gate to suppress audio below a given threshold.
+    ///
+    /// Uses `FFmpeg`'s `agate` filter. Audio below `threshold_db` (dBFS) is
+    /// attenuated; audio above it passes through unmodified. The threshold is
+    /// converted from dBFS to the linear amplitude ratio expected by `agate`.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `attack_ms` or `release_ms` is ≤ 0.0.
+    #[must_use]
+    pub fn agate(mut self, threshold_db: f32, attack_ms: f32, release_ms: f32) -> Self {
+        self.steps.push(FilterStep::ANoiseGate {
+            threshold_db,
+            attack_ms,
+            release_ms,
+        });
+        self
+    }
+
     /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before
@@ -841,6 +859,23 @@ impl FilterGraphBuilder {
                 return Err(FilterError::InvalidConfig {
                     reason: format!("xfade duration {duration} must be > 0.0"),
                 });
+            }
+            if let FilterStep::ANoiseGate {
+                attack_ms,
+                release_ms,
+                ..
+            } = step
+            {
+                if *attack_ms <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("agate attack_ms {attack_ms} must be > 0.0"),
+                    });
+                }
+                if *release_ms <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("agate release_ms {release_ms} must be > 0.0"),
+                    });
+                }
             }
             if let FilterStep::DrawText { opts } = step {
                 if opts.text.is_empty() {

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2627,3 +2627,96 @@ fn builder_afade_out_with_negative_duration_should_return_invalid_config() {
         "expected InvalidConfig for duration=-1.0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_agate_should_have_correct_filter_name() {
+    let step = FilterStep::ANoiseGate {
+        threshold_db: -40.0,
+        attack_ms: 10.0,
+        release_ms: 100.0,
+    };
+    assert_eq!(step.filter_name(), "agate");
+}
+
+#[test]
+fn filter_step_agate_should_produce_correct_args_for_minus_40_db() {
+    let step = FilterStep::ANoiseGate {
+        threshold_db: -40.0,
+        attack_ms: 10.0,
+        release_ms: 100.0,
+    };
+    // 10^(-40/20) = 10^(-2) = 0.01
+    let args = step.args();
+    assert!(
+        args.starts_with("threshold=0.010000:"),
+        "expected args to start with threshold=0.010000:, got {args}"
+    );
+    assert!(
+        args.contains("attack=10:"),
+        "expected attack=10: in args, got {args}"
+    );
+    assert!(
+        args.contains("release=100"),
+        "expected release=100 in args, got {args}"
+    );
+}
+
+#[test]
+fn filter_step_agate_should_produce_correct_args_for_zero_db() {
+    let step = FilterStep::ANoiseGate {
+        threshold_db: 0.0,
+        attack_ms: 5.0,
+        release_ms: 50.0,
+    };
+    // 10^(0/20) = 1.0
+    let args = step.args();
+    assert!(
+        args.starts_with("threshold=1.000000:"),
+        "expected threshold=1.000000: in args, got {args}"
+    );
+}
+
+#[test]
+fn builder_agate_valid_should_build_successfully() {
+    let result = FilterGraph::builder().agate(-40.0, 10.0, 100.0).build();
+    assert!(
+        result.is_ok(),
+        "agate(-40.0, 10.0, 100.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_agate_with_zero_attack_should_return_invalid_config() {
+    let result = FilterGraph::builder().agate(-40.0, 0.0, 100.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for attack_ms=0.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_agate_with_negative_attack_should_return_invalid_config() {
+    let result = FilterGraph::builder().agate(-40.0, -1.0, 100.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for attack_ms=-1.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_agate_with_zero_release_should_return_invalid_config() {
+    let result = FilterGraph::builder().agate(-40.0, 10.0, 0.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for release_ms=0.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_agate_with_negative_release_should_return_invalid_config() {
+    let result = FilterGraph::builder().agate(-40.0, 10.0, -50.0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for release_ms=-50.0, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -243,6 +243,19 @@ pub(crate) enum FilterStep {
         /// Target peak level in dBFS (e.g. −1.0). Must be ≤ 0.0.
         target_db: f32,
     },
+    /// Noise gate via `FFmpeg`'s `agate` filter.
+    ///
+    /// Audio below `threshold_db` is attenuated; audio above passes through.
+    /// The threshold is converted from dBFS to the linear scale expected by
+    /// `agate`'s `threshold` parameter (`linear = 10^(dB/20)`).
+    ANoiseGate {
+        /// Gate open/close threshold in dBFS (e.g. −40.0).
+        threshold_db: f32,
+        /// Attack time in milliseconds — how quickly the gate opens. Must be > 0.0.
+        attack_ms: f32,
+        /// Release time in milliseconds — how quickly the gate closes. Must be > 0.0.
+        release_ms: f32,
+    },
     /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts` seconds is held for `duration` seconds, then
@@ -365,6 +378,7 @@ impl FilterStep {
             Self::FreezeFrame { .. } => "loop",
             Self::LoudnessNormalize { .. } => "ebur128",
             Self::NormalizePeak { .. } => "astats",
+            Self::ANoiseGate { .. } => "agate",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -612,6 +626,15 @@ impl FilterStep {
                     y.to_string()
                 };
                 format!("width={width}:height={height}:x={px}:y={py}:color={color}")
+            }
+            Self::ANoiseGate {
+                threshold_db,
+                attack_ms,
+                release_ms,
+            } => {
+                // `agate` expects threshold as a linear amplitude ratio (0.0–1.0).
+                let threshold_linear = 10f32.powf(threshold_db / 20.0);
+                format!("threshold={threshold_linear:.6}:attack={attack_ms}:release={release_ms}")
             }
         }
     }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1214,3 +1214,27 @@ fn push_video_through_drawtext_with_box_should_return_frame_with_same_dimensions
         "height should be unchanged after drawtext with box"
     );
 }
+
+#[test]
+fn push_audio_through_agate_should_return_frame_with_same_properties() {
+    let mut graph = match FilterGraph::builder().agate(-40.0, 10.0, 100.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    let out = result.expect("expected Some(frame) after agate push");
+    assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+    assert_eq!(out.channels(), 2, "channel count should be unchanged");
+    assert_eq!(out.samples(), 1024, "sample count should be unchanged");
+}


### PR DESCRIPTION
## Summary

Adds an `agate` noise gate step to `FilterGraphBuilder`. Audio below the threshold is attenuated; audio above passes through unmodified. The dBFS threshold is converted to the linear amplitude ratio expected by FFmpeg's `agate` filter.

## Changes

- Add `FilterStep::ANoiseGate { threshold_db, attack_ms, release_ms }` with `filter_name() → "agate"` and `args()` that converts dB to linear (`10^(dB/20)`)
- Add `FilterGraphBuilder::agate(threshold_db, attack_ms, release_ms)` builder method
- Validate `attack_ms > 0` and `release_ms > 0` in `build()`, returning `FilterError::InvalidConfig` on failure
- Add `ANoiseGate` to the video build loop skip guard (audio-only step)
- Add 7 unit tests covering filter name, args formatting, valid build, and invalid configs
- Add integration test verifying sample rate, channel count, and sample count are preserved

## Related Issues

Closes #274

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes