### PR TITLE
feat(ff-filter): dynamic range compressor via acompressor filter

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -381,6 +381,7 @@ impl FilterGraphInner {
                     | FilterStep::AFadeOut { .. }
                     | FilterStep::ParametricEq { .. }
                     | FilterStep::ANoiseGate { .. }
+                    | FilterStep::ACompressor { .. }
             ) {
                 continue;
             }

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -590,6 +590,33 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Apply a dynamic range compressor to the audio.
+    ///
+    /// Uses `FFmpeg`'s `acompressor` filter. Audio peaks above `threshold_db`
+    /// (dBFS) are reduced by `ratio`:1.  `makeup_db` applies additional gain
+    /// after compression to restore perceived loudness.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `ratio < 1.0`, `attack_ms ≤ 0.0`, or `release_ms ≤ 0.0`.
+    #[must_use]
+    pub fn compressor(
+        mut self,
+        threshold_db: f32,
+        ratio: f32,
+        attack_ms: f32,
+        release_ms: f32,
+        makeup_db: f32,
+    ) -> Self {
+        self.steps.push(FilterStep::ACompressor {
+            threshold_db,
+            ratio,
+            attack_ms,
+            release_ms,
+            makeup_db,
+        });
+        self
+    }
+
     /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before
@@ -874,6 +901,29 @@ impl FilterGraphBuilder {
                 if *release_ms <= 0.0 {
                     return Err(FilterError::InvalidConfig {
                         reason: format!("agate release_ms {release_ms} must be > 0.0"),
+                    });
+                }
+            }
+            if let FilterStep::ACompressor {
+                ratio,
+                attack_ms,
+                release_ms,
+                ..
+            } = step
+            {
+                if *ratio < 1.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("compressor ratio {ratio} must be >= 1.0"),
+                    });
+                }
+                if *attack_ms <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("compressor attack_ms {attack_ms} must be > 0.0"),
+                    });
+                }
+                if *release_ms <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("compressor release_ms {release_ms} must be > 0.0"),
                     });
                 }
             }

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2720,3 +2720,86 @@ fn builder_agate_with_negative_release_should_return_invalid_config() {
         "expected InvalidConfig for release_ms=-50.0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_compressor_should_have_correct_filter_name() {
+    let step = FilterStep::ACompressor {
+        threshold_db: -20.0,
+        ratio: 4.0,
+        attack_ms: 10.0,
+        release_ms: 100.0,
+        makeup_db: 6.0,
+    };
+    assert_eq!(step.filter_name(), "acompressor");
+}
+
+#[test]
+fn filter_step_compressor_should_produce_correct_args() {
+    let step = FilterStep::ACompressor {
+        threshold_db: -20.0,
+        ratio: 4.0,
+        attack_ms: 10.0,
+        release_ms: 100.0,
+        makeup_db: 6.0,
+    };
+    assert_eq!(
+        step.args(),
+        "threshold=-20dB:ratio=4:attack=10:release=100:makeup=6dB"
+    );
+}
+
+#[test]
+fn builder_compressor_valid_should_build_successfully() {
+    let result = FilterGraph::builder()
+        .compressor(-20.0, 4.0, 10.0, 100.0, 6.0)
+        .build();
+    assert!(
+        result.is_ok(),
+        "compressor(-20.0, 4.0, 10.0, 100.0, 6.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_compressor_with_unity_ratio_should_build_successfully() {
+    // ratio=1.0 is the minimum valid value (no compression)
+    let result = FilterGraph::builder()
+        .compressor(-20.0, 1.0, 10.0, 100.0, 0.0)
+        .build();
+    assert!(
+        result.is_ok(),
+        "compressor with ratio=1.0 must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_compressor_with_ratio_below_one_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .compressor(-20.0, 0.5, 10.0, 100.0, 0.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for ratio=0.5, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_compressor_with_zero_attack_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .compressor(-20.0, 4.0, 0.0, 100.0, 0.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for attack_ms=0.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_compressor_with_zero_release_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .compressor(-20.0, 4.0, 10.0, 0.0, 0.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for release_ms=0.0, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -256,6 +256,23 @@ pub(crate) enum FilterStep {
         /// Release time in milliseconds — how quickly the gate closes. Must be > 0.0.
         release_ms: f32,
     },
+    /// Dynamic range compressor via `FFmpeg`'s `acompressor` filter.
+    ///
+    /// Reduces the dynamic range of the audio signal: peaks above
+    /// `threshold_db` are attenuated by `ratio`:1.  `makeup_db` applies
+    /// additional gain after compression to restore perceived loudness.
+    ACompressor {
+        /// Compression threshold in dBFS (e.g. −20.0).
+        threshold_db: f32,
+        /// Compression ratio (e.g. 4.0 = 4:1). Must be ≥ 1.0.
+        ratio: f32,
+        /// Attack time in milliseconds. Must be > 0.0.
+        attack_ms: f32,
+        /// Release time in milliseconds. Must be > 0.0.
+        release_ms: f32,
+        /// Make-up gain in dB applied after compression (e.g. 6.0).
+        makeup_db: f32,
+    },
     /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts` seconds is held for `duration` seconds, then
@@ -379,6 +396,7 @@ impl FilterStep {
             Self::LoudnessNormalize { .. } => "ebur128",
             Self::NormalizePeak { .. } => "astats",
             Self::ANoiseGate { .. } => "agate",
+            Self::ACompressor { .. } => "acompressor",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -635,6 +653,18 @@ impl FilterStep {
                 // `agate` expects threshold as a linear amplitude ratio (0.0–1.0).
                 let threshold_linear = 10f32.powf(threshold_db / 20.0);
                 format!("threshold={threshold_linear:.6}:attack={attack_ms}:release={release_ms}")
+            }
+            Self::ACompressor {
+                threshold_db,
+                ratio,
+                attack_ms,
+                release_ms,
+                makeup_db,
+            } => {
+                format!(
+                    "threshold={threshold_db}dB:ratio={ratio}:attack={attack_ms}:\
+                     release={release_ms}:makeup={makeup_db}dB"
+                )
             }
         }
     }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1238,3 +1238,30 @@ fn push_audio_through_agate_should_return_frame_with_same_properties() {
     assert_eq!(out.channels(), 2, "channel count should be unchanged");
     assert_eq!(out.samples(), 1024, "sample count should be unchanged");
 }
+
+#[test]
+fn push_audio_through_compressor_should_return_frame_with_same_properties() {
+    let mut graph = match FilterGraph::builder()
+        .compressor(-20.0, 4.0, 10.0, 100.0, 6.0)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    let out = result.expect("expected Some(frame) after compressor push");
+    assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+    assert_eq!(out.channels(), 2, "channel count should be unchanged");
+    assert_eq!(out.samples(), 1024, "sample count should be unchanged");
+}


### PR DESCRIPTION
## Summary

Adds a `compressor` step to `FilterGraphBuilder` using FFmpeg's `acompressor` filter. Audio peaks above the threshold are reduced by the given ratio, and an optional make-up gain is applied after compression to restore perceived loudness.

## Changes

- Add `FilterStep::ACompressor { threshold_db, ratio, attack_ms, release_ms, makeup_db }` with `filter_name() → "acompressor"` and dB-suffix args format
- Add `FilterGraphBuilder::compressor(threshold_db, ratio, attack_ms, release_ms, makeup_db)` builder method
- Validate `ratio >= 1.0`, `attack_ms > 0`, and `release_ms > 0` in `build()`, returning `FilterError::InvalidConfig` on failure
- Add `ACompressor` to the video build loop skip guard (audio-only step)
- Add 7 unit tests covering filter name, args formatting, valid build, unity ratio, and invalid configs
- Add integration test verifying sample rate, channel count, and sample count are preserved

## Related Issues

Closes #275

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes