### PR TITLE
feat(ff-filter): stereo to mono downmix via pan filter

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -382,6 +382,7 @@ impl FilterGraphInner {
                     | FilterStep::ParametricEq { .. }
                     | FilterStep::ANoiseGate { .. }
                     | FilterStep::ACompressor { .. }
+                    | FilterStep::StereoToMono
             ) {
                 continue;
             }

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -617,6 +617,16 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Downmix stereo audio to mono by equally mixing both channels.
+    ///
+    /// Uses `FFmpeg`'s `pan` filter with the expression
+    /// `mono|c0=0.5*c0+0.5*c1`.  The output has a single channel.
+    #[must_use]
+    pub fn stereo_to_mono(mut self) -> Self {
+        self.steps.push(FilterStep::StereoToMono);
+        self
+    }
+
     /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2803,3 +2803,22 @@ fn builder_compressor_with_zero_release_should_return_invalid_config() {
         "expected InvalidConfig for release_ms=0.0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_stereo_to_mono_should_have_correct_filter_name() {
+    assert_eq!(FilterStep::StereoToMono.filter_name(), "pan");
+}
+
+#[test]
+fn filter_step_stereo_to_mono_should_produce_correct_args() {
+    assert_eq!(FilterStep::StereoToMono.args(), "mono|c0=0.5*c0+0.5*c1");
+}
+
+#[test]
+fn builder_stereo_to_mono_should_build_successfully() {
+    let result = FilterGraph::builder().stereo_to_mono().build();
+    assert!(
+        result.is_ok(),
+        "stereo_to_mono() must build successfully, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -273,6 +273,11 @@ pub(crate) enum FilterStep {
         /// Make-up gain in dB applied after compression (e.g. 6.0).
         makeup_db: f32,
     },
+    /// Downmix stereo to mono via `FFmpeg`'s `pan` filter.
+    ///
+    /// Both channels are mixed with equal weight:
+    /// `mono|c0=0.5*c0+0.5*c1`.  The output has a single channel.
+    StereoToMono,
     /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts` seconds is held for `duration` seconds, then
@@ -397,6 +402,7 @@ impl FilterStep {
             Self::NormalizePeak { .. } => "astats",
             Self::ANoiseGate { .. } => "agate",
             Self::ACompressor { .. } => "acompressor",
+            Self::StereoToMono => "pan",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -666,6 +672,7 @@ impl FilterStep {
                      release={release_ms}:makeup={makeup_db}dB"
                 )
             }
+            Self::StereoToMono => "mono|c0=0.5*c0+0.5*c1".to_string(),
         }
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1265,3 +1265,26 @@ fn push_audio_through_compressor_should_return_frame_with_same_properties() {
     assert_eq!(out.channels(), 2, "channel count should be unchanged");
     assert_eq!(out.samples(), 1024, "sample count should be unchanged");
 }
+
+#[test]
+fn push_stereo_audio_through_stereo_to_mono_should_return_mono_frame() {
+    let mut graph = match FilterGraph::builder().stereo_to_mono().build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    let out = result.expect("expected Some(frame) after stereo_to_mono push");
+    assert_eq!(out.channels(), 1, "output should be mono (1 channel)");
+    assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+}


### PR DESCRIPTION
## Summary

Adds a `stereo_to_mono` step to `FilterGraphBuilder` using FFmpeg's `pan` filter. Both stereo channels are mixed with equal weight (`mono|c0=0.5*c0+0.5*c1`), producing a single-channel output.

## Changes

- Add `FilterStep::StereoToMono` with `filter_name() → "pan"` and `args() → "mono|c0=0.5*c0+0.5*c1"`
- Add `FilterGraphBuilder::stereo_to_mono()` builder method (no validation needed)
- Add `StereoToMono` to the video build loop skip guard (audio-only step)
- Add 3 unit tests covering filter name, args string, and valid build
- Add integration test verifying the output channel count drops from 2 to 1

## Related Issues

Closes #276

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes