### PR TITLE
feat(ff-filter): audio channel remapping via channelmap filter

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -383,6 +383,7 @@ impl FilterGraphInner {
                     | FilterStep::ANoiseGate { .. }
                     | FilterStep::ACompressor { .. }
                     | FilterStep::StereoToMono
+                    | FilterStep::ChannelMap { .. }
             ) {
                 continue;
             }

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -627,6 +627,21 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Remap audio channels using `FFmpeg`'s `channelmap` filter.
+    ///
+    /// `mapping` is a `|`-separated list of output channel names taken from
+    /// input channels, e.g. `"FR|FL"` swaps left and right.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `mapping` is empty.
+    #[must_use]
+    pub fn channel_map(mut self, mapping: &str) -> Self {
+        self.steps.push(FilterStep::ChannelMap {
+            mapping: mapping.to_string(),
+        });
+        self
+    }
+
     /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before
@@ -936,6 +951,13 @@ impl FilterGraphBuilder {
                         reason: format!("compressor release_ms {release_ms} must be > 0.0"),
                     });
                 }
+            }
+            if let FilterStep::ChannelMap { mapping } = step
+                && mapping.is_empty()
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: "channel_map mapping must not be empty".to_string(),
+                });
             }
             if let FilterStep::DrawText { opts } = step {
                 if opts.text.is_empty() {

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2822,3 +2822,37 @@ fn builder_stereo_to_mono_should_build_successfully() {
         "stereo_to_mono() must build successfully, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_channel_map_should_have_correct_filter_name() {
+    let step = FilterStep::ChannelMap {
+        mapping: "FR|FL".to_string(),
+    };
+    assert_eq!(step.filter_name(), "channelmap");
+}
+
+#[test]
+fn filter_step_channel_map_should_produce_correct_args() {
+    let step = FilterStep::ChannelMap {
+        mapping: "FR|FL".to_string(),
+    };
+    assert_eq!(step.args(), "map=FR|FL");
+}
+
+#[test]
+fn builder_channel_map_valid_should_build_successfully() {
+    let result = FilterGraph::builder().channel_map("FR|FL").build();
+    assert!(
+        result.is_ok(),
+        "channel_map(\"FR|FL\") must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_channel_map_with_empty_mapping_should_return_invalid_config() {
+    let result = FilterGraph::builder().channel_map("").build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for empty mapping, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -278,6 +278,15 @@ pub(crate) enum FilterStep {
     /// Both channels are mixed with equal weight:
     /// `mono|c0=0.5*c0+0.5*c1`.  The output has a single channel.
     StereoToMono,
+    /// Remap audio channels using `FFmpeg`'s `channelmap` filter.
+    ///
+    /// `mapping` is a `|`-separated list of output channel names taken
+    /// from input channels, e.g. `"FR|FL"` swaps left and right.
+    /// Must not be empty.
+    ChannelMap {
+        /// `FFmpeg` channelmap mapping expression (e.g. `"FR|FL"`).
+        mapping: String,
+    },
     /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts` seconds is held for `duration` seconds, then
@@ -403,6 +412,7 @@ impl FilterStep {
             Self::ANoiseGate { .. } => "agate",
             Self::ACompressor { .. } => "acompressor",
             Self::StereoToMono => "pan",
+            Self::ChannelMap { .. } => "channelmap",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -673,6 +683,7 @@ impl FilterStep {
                 )
             }
             Self::StereoToMono => "mono|c0=0.5*c0+0.5*c1".to_string(),
+            Self::ChannelMap { mapping } => format!("map={mapping}"),
         }
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1288,3 +1288,32 @@ fn push_stereo_audio_through_stereo_to_mono_should_return_mono_frame() {
     assert_eq!(out.channels(), 1, "output should be mono (1 channel)");
     assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
 }
+
+#[test]
+fn push_audio_through_channel_map_should_return_frame_with_same_properties() {
+    // "FL|FR" maps the two stereo channels to the same layout (identity remap).
+    let mut graph = match FilterGraph::builder().channel_map("FL|FR").build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    let out = result.expect("expected Some(frame) after channel_map push");
+    assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+    assert_eq!(
+        out.channels(),
+        2,
+        "channel count should be unchanged for identity remap"
+    );
+    assert_eq!(out.samples(), 1024, "sample count should be unchanged");
+}


### PR DESCRIPTION
## Summary

Adds a `channel_map` step to `FilterGraphBuilder` using FFmpeg's `channelmap` filter. An arbitrary mapping expression (e.g. `"FR|FL"` to swap left and right) selects which input channels feed each output channel.

## Changes

- Add `FilterStep::ChannelMap { mapping: String }` with `filter_name() → "channelmap"` and `args() → "map={mapping}"`
- Add `FilterGraphBuilder::channel_map(mapping: &str)` builder method
- Validate that `mapping` is not empty in `build()`, returning `FilterError::InvalidConfig` on failure
- Add `ChannelMap` to the video build loop skip guard (audio-only step)
- Add 4 unit tests covering filter name, args string, valid build, and empty mapping
- Add integration test using identity remap `"FL|FR"` verifying sample rate, channel count, and sample count are preserved

## Related Issues

Closes #277

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes