### PR TITLE
feat(ff-filter): audio delay/advance for A/V sync correction

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -142,6 +142,57 @@ pub(super) unsafe fn add_and_link_step(
     Ok(step_ctx)
 }
 
+/// Create and link a filter by explicit name and args strings, without a
+/// `FilterStep`.  Used when the filter name cannot be determined statically
+/// (e.g., `AudioDelay` dispatches to `adelay` or `atrim` depending on sign).
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+pub(super) unsafe fn add_raw_filter_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    filter_name: &str,
+    args: &str,
+    index: usize,
+    prefix: &str,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let filter_cname = std::ffi::CString::new(filter_name).map_err(|_| FilterError::BuildFailed)?;
+    // SAFETY: `avfilter_get_by_name` reads a valid null-terminated C string.
+    let filter = ff_sys::avfilter_get_by_name(filter_cname.as_ptr());
+    if filter.is_null() {
+        log::warn!("filter not found name={filter_name}");
+        return Err(FilterError::BuildFailed);
+    }
+
+    let step_name =
+        std::ffi::CString::new(format!("{prefix}{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let step_args = std::ffi::CString::new(args).map_err(|_| FilterError::BuildFailed)?;
+
+    let mut step_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut step_ctx,
+        filter,
+        step_name.as_ptr(),
+        step_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name={filter_name} args={args}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name={filter_name} args={args}");
+
+    // SAFETY: `prev_ctx` and `step_ctx` belong to the same graph; pad indices are valid.
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, step_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+    Ok(step_ctx)
+}
+
 /// Insert a `setpts=PTS-STARTPTS` filter immediately after a `trim` step so
 /// that the output stream's timestamps start at zero.
 ///

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -17,8 +17,8 @@ mod convert;
 
 use build::{
     add_and_link_step, add_atempo_chain, add_fit_to_aspect_pad, add_overlay_image_step,
-    add_parametric_eq_chain, add_setpts_after_trim, audio_buffersrc_args, create_hw_filter,
-    hw_accel_to_device_type, video_buffersrc_args,
+    add_parametric_eq_chain, add_raw_filter_step, add_setpts_after_trim, audio_buffersrc_args,
+    create_hw_filter, hw_accel_to_device_type, video_buffersrc_args,
 };
 use convert::{
     audio_pts_ticks, av_frame_to_audio_frame, av_frame_to_video_frame, copy_audio_planes_to_av,
@@ -384,6 +384,7 @@ impl FilterGraphInner {
                     | FilterStep::ACompressor { .. }
                     | FilterStep::StereoToMono
                     | FilterStep::ChannelMap { .. }
+                    | FilterStep::AudioDelay { .. }
             ) {
                 continue;
             }
@@ -796,6 +797,18 @@ impl FilterGraphInner {
             // single-node `add_and_link_step` path.
             if let FilterStep::ParametricEq { bands } = step {
                 prev_ctx = add_parametric_eq_chain(graph, prev_ctx, bands, i)?;
+                continue;
+            }
+
+            // AudioDelay dispatches to adelay (positive/zero) or atrim (negative).
+            if let FilterStep::AudioDelay { ms } = step {
+                let (filter_name, args) = if *ms >= 0.0 {
+                    ("adelay".to_string(), format!("delays={ms}:all=1"))
+                } else {
+                    ("atrim".to_string(), format!("start={}", -ms / 1000.0))
+                };
+                // SAFETY: graph and prev_ctx are valid pointers in the same graph.
+                prev_ctx = add_raw_filter_step(graph, prev_ctx, &filter_name, &args, i, "adelay")?;
                 continue;
             }
 

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -642,6 +642,18 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Shift audio for A/V sync correction.
+    ///
+    /// Positive `ms`: uses `FFmpeg`'s `adelay` filter to delay the audio
+    /// (audio plays later). Negative `ms`: uses `FFmpeg`'s `atrim` filter to
+    /// advance the audio by trimming the start (audio plays earlier).
+    /// Zero `ms` is a no-op.
+    #[must_use]
+    pub fn audio_delay(mut self, ms: f64) -> Self {
+        self.steps.push(FilterStep::AudioDelay { ms });
+        self
+    }
+
     /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2856,3 +2856,63 @@ fn builder_channel_map_with_empty_mapping_should_return_invalid_config() {
         "expected InvalidConfig for empty mapping, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_audio_delay_positive_should_have_correct_filter_name() {
+    let step = FilterStep::AudioDelay { ms: 100.0 };
+    assert_eq!(step.filter_name(), "adelay");
+}
+
+#[test]
+fn filter_step_audio_delay_negative_should_have_correct_filter_name() {
+    // filter_name() always returns "adelay" (used for validation only);
+    // the build loop dispatches to "atrim" at runtime.
+    let step = FilterStep::AudioDelay { ms: -100.0 };
+    assert_eq!(step.filter_name(), "adelay");
+}
+
+#[test]
+fn filter_step_audio_delay_positive_should_produce_adelay_args() {
+    let step = FilterStep::AudioDelay { ms: 100.0 };
+    assert_eq!(step.args(), "delays=100:all=1");
+}
+
+#[test]
+fn filter_step_audio_delay_zero_should_produce_adelay_args() {
+    let step = FilterStep::AudioDelay { ms: 0.0 };
+    assert_eq!(step.args(), "delays=0:all=1");
+}
+
+#[test]
+fn filter_step_audio_delay_negative_should_produce_atrim_args() {
+    let step = FilterStep::AudioDelay { ms: -100.0 };
+    // -(-100) / 1000 = 0.1 seconds
+    assert_eq!(step.args(), "start=0.1");
+}
+
+#[test]
+fn builder_audio_delay_positive_should_build_successfully() {
+    let result = FilterGraph::builder().audio_delay(100.0).build();
+    assert!(
+        result.is_ok(),
+        "audio_delay(100.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_audio_delay_zero_should_build_successfully() {
+    let result = FilterGraph::builder().audio_delay(0.0).build();
+    assert!(
+        result.is_ok(),
+        "audio_delay(0.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_audio_delay_negative_should_build_successfully() {
+    let result = FilterGraph::builder().audio_delay(-100.0).build();
+    assert!(
+        result.is_ok(),
+        "audio_delay(-100.0) must build successfully, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -287,6 +287,16 @@ pub(crate) enum FilterStep {
         /// `FFmpeg` channelmap mapping expression (e.g. `"FR|FL"`).
         mapping: String,
     },
+    /// A/V sync correction via audio delay or advance.
+    ///
+    /// Positive `ms`: uses `FFmpeg`'s `adelay` filter to shift audio later.
+    /// Negative `ms`: uses `FFmpeg`'s `atrim` filter to trim the audio start,
+    /// effectively advancing audio by `|ms|` milliseconds.
+    /// Zero `ms`: uses `adelay` with zero delay (no-op).
+    AudioDelay {
+        /// Delay in milliseconds. Positive = delay; negative = advance.
+        ms: f64,
+    },
     /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts` seconds is held for `duration` seconds, then
@@ -413,6 +423,9 @@ impl FilterStep {
             Self::ACompressor { .. } => "acompressor",
             Self::StereoToMono => "pan",
             Self::ChannelMap { .. } => "channelmap",
+            // AudioDelay dispatches to adelay (positive) or atrim (negative) at
+            // build time; "adelay" is returned here for validate_filter_steps only.
+            Self::AudioDelay { .. } => "adelay",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -684,6 +697,16 @@ impl FilterStep {
             }
             Self::StereoToMono => "mono|c0=0.5*c0+0.5*c1".to_string(),
             Self::ChannelMap { mapping } => format!("map={mapping}"),
+            // args() is not used directly for AudioDelay — the audio build loop
+            // dispatches to add_raw_filter_step with the correct filter name and
+            // args based on the sign of ms.  These are provided for completeness.
+            Self::AudioDelay { ms } => {
+                if *ms >= 0.0 {
+                    format!("delays={ms}:all=1")
+                } else {
+                    format!("start={}", -ms / 1000.0)
+                }
+            }
         }
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1317,3 +1317,56 @@ fn push_audio_through_channel_map_should_return_frame_with_same_properties() {
     );
     assert_eq!(out.samples(), 1024, "sample count should be unchanged");
 }
+
+#[test]
+fn push_audio_through_audio_delay_positive_should_return_frame_with_same_properties() {
+    let mut graph = match FilterGraph::builder().audio_delay(100.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    // adelay pads with silence first; result may be None if the delay
+    // exceeds one frame's worth of samples.  No error is the key assertion.
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    if let Some(out) = result {
+        assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+        assert_eq!(out.channels(), 2, "channel count should be unchanged");
+    }
+}
+
+#[test]
+fn push_audio_through_audio_delay_negative_should_not_error() {
+    // Use a 5 ms advance. The test frame is 1024/48000 ≈ 21 ms, so atrim
+    // trims only a portion of it and may still return a frame.
+    // Regardless of whether a frame is returned, no error is the key assertion.
+    let mut graph = match FilterGraph::builder().audio_delay(-5.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    if let Some(out) = result {
+        assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+        assert_eq!(out.channels(), 2, "channel count should be unchanged");
+    }
+}


### PR DESCRIPTION
## Summary

Adds an `audio_delay` step to `FilterGraphBuilder` for A/V sync correction. Positive values delay audio using FFmpeg's `adelay` filter; negative values advance audio by trimming the start via `atrim`. The correct filter is selected at graph construction time based on the sign of `ms`.

## Changes

- Add `FilterStep::AudioDelay { ms: f64 }` with `filter_name() → "adelay"` (for validation) and sign-aware `args()`
- Add `add_raw_filter_step` helper in `build.rs` that creates and links a filter by explicit name/args strings, enabling runtime filter dispatch
- Add `FilterGraphBuilder::audio_delay(ms: f64)` builder method (all values including 0.0 are valid)
- Add `AudioDelay` to the video build loop skip guard (audio-only step)
- Add special handling in the audio build loop: dispatches to `adelay` (positive/zero) or `atrim` (negative) via `add_raw_filter_step`
- Add 8 unit tests covering filter name, args for each sign, and valid builds
- Add 2 integration tests verifying positive delay (no error) and negative advance (sample rate/channel count preserved)

## Related Issues

Closes #278

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes