### PR TITLE
feat(ff-filter): add concat_video step for multi-clip video concatenation via concat filter

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -385,6 +385,7 @@ impl FilterGraphInner {
                     | FilterStep::StereoToMono
                     | FilterStep::ChannelMap { .. }
                     | FilterStep::AudioDelay { .. }
+                    | FilterStep::ConcatVideo { .. }
             ) {
                 continue;
             }
@@ -457,6 +458,20 @@ impl FilterGraphInner {
                     bail!(FilterError::BuildFailed);
                 }
                 log::debug!("filter linked extra_input=in1 to two-input filter pad=1");
+            }
+
+            // ConcatVideo consumes n input pads; link src_ctxs[1..n-1] to pads 1..n-1.
+            if let FilterStep::ConcatVideo { n } = step {
+                for slot in 1..*n as usize {
+                    if let Some(Some(extra_src)) = src_ctxs.get(slot) {
+                        let ret =
+                            ff_sys::avfilter_link(extra_src.as_ptr(), 0, prev_ctx, slot as u32);
+                        if ret < 0 {
+                            bail!(FilterError::BuildFailed);
+                        }
+                        log::debug!("filter linked extra_input=in{slot} to concat pad={slot}");
+                    }
+                }
             }
         }
 
@@ -607,6 +622,9 @@ impl FilterGraphInner {
         for step in &self.steps {
             if matches!(step, FilterStep::Overlay { .. } | FilterStep::XFade { .. }) {
                 return 2;
+            }
+            if let FilterStep::ConcatVideo { n } = step {
+                return *n as usize;
             }
         }
         1

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -654,6 +654,17 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Concatenate `n_segments` sequential video inputs using `FFmpeg`'s `concat` filter.
+    ///
+    /// Requires `n_segments` video input slots (push to slots 0 through
+    /// `n_segments - 1` in order). [`build`](Self::build) returns
+    /// [`FilterError::InvalidConfig`] if `n_segments < 2`.
+    #[must_use]
+    pub fn concat_video(mut self, n_segments: u32) -> Self {
+        self.steps.push(FilterStep::ConcatVideo { n: n_segments });
+        self
+    }
+
     /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before
@@ -969,6 +980,13 @@ impl FilterGraphBuilder {
             {
                 return Err(FilterError::InvalidConfig {
                     reason: "channel_map mapping must not be empty".to_string(),
+                });
+            }
+            if let FilterStep::ConcatVideo { n } = step
+                && *n < 2
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: format!("concat_video n={n} must be >= 2"),
                 });
             }
             if let FilterStep::DrawText { opts } = step {

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2916,3 +2916,48 @@ fn builder_audio_delay_negative_should_build_successfully() {
         "audio_delay(-100.0) must build successfully, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_concat_video_should_have_correct_filter_name() {
+    let step = FilterStep::ConcatVideo { n: 2 };
+    assert_eq!(step.filter_name(), "concat");
+}
+
+#[test]
+fn filter_step_concat_video_should_produce_correct_args_for_n2() {
+    let step = FilterStep::ConcatVideo { n: 2 };
+    assert_eq!(step.args(), "n=2:v=1:a=0");
+}
+
+#[test]
+fn filter_step_concat_video_should_produce_correct_args_for_n3() {
+    let step = FilterStep::ConcatVideo { n: 3 };
+    assert_eq!(step.args(), "n=3:v=1:a=0");
+}
+
+#[test]
+fn builder_concat_video_valid_should_build_successfully() {
+    let result = FilterGraph::builder().concat_video(2).build();
+    assert!(
+        result.is_ok(),
+        "concat_video(2) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_concat_video_with_n1_should_return_invalid_config() {
+    let result = FilterGraph::builder().concat_video(1).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for n=1, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_concat_video_with_n0_should_return_invalid_config() {
+    let result = FilterGraph::builder().concat_video(0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for n=0, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -297,6 +297,13 @@ pub(crate) enum FilterStep {
         /// Delay in milliseconds. Positive = delay; negative = advance.
         ms: f64,
     },
+    /// Concatenate `n` sequential video input segments via `FFmpeg`'s `concat` filter.
+    ///
+    /// Requires `n` video input slots (0 through `n-1`). `n` must be ≥ 2.
+    ConcatVideo {
+        /// Number of video input segments to concatenate. Must be ≥ 2.
+        n: u32,
+    },
     /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts` seconds is held for `duration` seconds, then
@@ -426,6 +433,7 @@ impl FilterStep {
             // AudioDelay dispatches to adelay (positive) or atrim (negative) at
             // build time; "adelay" is returned here for validate_filter_steps only.
             Self::AudioDelay { .. } => "adelay",
+            Self::ConcatVideo { .. } => "concat",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -707,6 +715,7 @@ impl FilterStep {
                     format!("start={}", -ms / 1000.0)
                 }
             }
+            Self::ConcatVideo { n } => format!("n={n}:v=1:a=0"),
         }
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1370,3 +1370,33 @@ fn push_audio_through_audio_delay_negative_should_not_error() {
         assert_eq!(out.channels(), 2, "channel count should be unchanged");
     }
 }
+
+#[test]
+fn push_video_through_concat_video_should_produce_output() {
+    let mut graph = match FilterGraph::builder().concat_video(2).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 64);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after concat push to both slots");
+    assert_eq!(out.width(), 64, "width should be unchanged");
+    assert_eq!(out.height(), 64, "height should be unchanged");
+}


### PR DESCRIPTION
## Summary

Adds `concat_video(n)` to `FilterGraphBuilder` for joining multiple video clips in sequence using FFmpeg's `concat` filter. Validates that `n >= 2` at build time.

## Changes

- Add `ConcatVideo { n: u32 }` variant to `FilterStep` with filter name `concat` and args `n={n}:v=1:a=0`
- Add `concat_video(n)` builder method; validation rejects `n < 2` with `InvalidConfig`
- Update `video_input_count()` to return `n` buffersrc contexts for multi-input wiring
- Wire extra input pads in the video build loop (same pattern as `Overlay`/`XFade`)
- Add 6 unit tests in `builder_tests.rs` and 1 integration test in `push_pull_tests.rs`

## Related Issues

Closes #279

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes