### PR TITLE
feat(ff-filter): add concat_audio step for multi-clip audio concatenation via concat filter

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -385,7 +385,7 @@ impl FilterGraphInner {
                     | FilterStep::StereoToMono
                     | FilterStep::ChannelMap { .. }
                     | FilterStep::AudioDelay { .. }
-                    | FilterStep::ConcatVideo { .. }
+                    | FilterStep::ConcatAudio { .. }
             ) {
                 continue;
             }
@@ -636,6 +636,9 @@ impl FilterGraphInner {
             if let FilterStep::Amix(n) = step {
                 return *n;
             }
+            if let FilterStep::ConcatAudio { n } = step {
+                return *n as usize;
+            }
         }
         1
     }
@@ -786,8 +789,8 @@ impl FilterGraphInner {
         // 3-5. Add each `FilterStep` (audio-relevant steps) and link.
         let mut prev_ctx = first_src_ctx.as_ptr();
         for (i, step) in steps.iter().enumerate() {
-            // Reverse is video-only; skip it in the audio graph.
-            if matches!(step, FilterStep::Reverse) {
+            // Video-only steps; skip them in the audio graph.
+            if matches!(step, FilterStep::Reverse | FilterStep::ConcatVideo { .. }) {
                 continue;
             }
 
@@ -831,6 +834,20 @@ impl FilterGraphInner {
             }
 
             prev_ctx = add_and_link_step(graph, prev_ctx, step, i, "astep")?;
+
+            // ConcatAudio consumes n input pads; link src_ctxs[1..n-1] to pads 1..n-1.
+            if let FilterStep::ConcatAudio { n } = step {
+                for slot in 1..*n as usize {
+                    if let Some(Some(extra_src)) = src_ctxs.get(slot) {
+                        let ret =
+                            ff_sys::avfilter_link(extra_src.as_ptr(), 0, prev_ctx, slot as u32);
+                        if ret < 0 {
+                            return Err(FilterError::BuildFailed);
+                        }
+                        log::debug!("filter linked extra_input=in{slot} to concat pad={slot}");
+                    }
+                }
+            }
         }
 
         // Link last filter to sink.

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -665,6 +665,17 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Concatenate `n_segments` sequential audio inputs using `FFmpeg`'s `concat` filter.
+    ///
+    /// Requires `n_segments` audio input slots (push to slots 0 through
+    /// `n_segments - 1` in order). [`build`](Self::build) returns
+    /// [`FilterError::InvalidConfig`] if `n_segments < 2`.
+    #[must_use]
+    pub fn concat_audio(mut self, n_segments: u32) -> Self {
+        self.steps.push(FilterStep::ConcatAudio { n: n_segments });
+        self
+    }
+
     /// Freeze the frame at `pts_sec` for `duration_sec` seconds using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts_sec` is held for `duration_sec` seconds before
@@ -987,6 +998,13 @@ impl FilterGraphBuilder {
             {
                 return Err(FilterError::InvalidConfig {
                     reason: format!("concat_video n={n} must be >= 2"),
+                });
+            }
+            if let FilterStep::ConcatAudio { n } = step
+                && *n < 2
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: format!("concat_audio n={n} must be >= 2"),
                 });
             }
             if let FilterStep::DrawText { opts } = step {

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -2961,3 +2961,48 @@ fn builder_concat_video_with_n0_should_return_invalid_config() {
         "expected InvalidConfig for n=0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_concat_audio_should_have_correct_filter_name() {
+    let step = FilterStep::ConcatAudio { n: 2 };
+    assert_eq!(step.filter_name(), "concat");
+}
+
+#[test]
+fn filter_step_concat_audio_should_produce_correct_args_for_n2() {
+    let step = FilterStep::ConcatAudio { n: 2 };
+    assert_eq!(step.args(), "n=2:v=0:a=1");
+}
+
+#[test]
+fn filter_step_concat_audio_should_produce_correct_args_for_n3() {
+    let step = FilterStep::ConcatAudio { n: 3 };
+    assert_eq!(step.args(), "n=3:v=0:a=1");
+}
+
+#[test]
+fn builder_concat_audio_valid_should_build_successfully() {
+    let result = FilterGraph::builder().concat_audio(2).build();
+    assert!(
+        result.is_ok(),
+        "concat_audio(2) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_concat_audio_with_n1_should_return_invalid_config() {
+    let result = FilterGraph::builder().concat_audio(1).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for n=1, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_concat_audio_with_n0_should_return_invalid_config() {
+    let result = FilterGraph::builder().concat_audio(0).build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for n=0, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -304,6 +304,13 @@ pub(crate) enum FilterStep {
         /// Number of video input segments to concatenate. Must be ≥ 2.
         n: u32,
     },
+    /// Concatenate `n` sequential audio input segments via `FFmpeg`'s `concat` filter.
+    ///
+    /// Requires `n` audio input slots (0 through `n-1`). `n` must be ≥ 2.
+    ConcatAudio {
+        /// Number of audio input segments to concatenate. Must be ≥ 2.
+        n: u32,
+    },
     /// Freeze a single frame for a configurable duration using `FFmpeg`'s `loop` filter.
     ///
     /// The frame nearest to `pts` seconds is held for `duration` seconds, then
@@ -433,7 +440,7 @@ impl FilterStep {
             // AudioDelay dispatches to adelay (positive) or atrim (negative) at
             // build time; "adelay" is returned here for validate_filter_steps only.
             Self::AudioDelay { .. } => "adelay",
-            Self::ConcatVideo { .. } => "concat",
+            Self::ConcatVideo { .. } | Self::ConcatAudio { .. } => "concat",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -716,6 +723,7 @@ impl FilterStep {
                 }
             }
             Self::ConcatVideo { n } => format!("n={n}:v=1:a=0"),
+            Self::ConcatAudio { n } => format!("n={n}:v=0:a=1"),
         }
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1400,3 +1400,33 @@ fn push_video_through_concat_video_should_produce_output() {
     assert_eq!(out.width(), 64, "width should be unchanged");
     assert_eq!(out.height(), 64, "height should be unchanged");
 }
+
+#[test]
+fn push_audio_through_concat_audio_should_produce_output() {
+    let mut graph = match FilterGraph::builder().concat_audio(2).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_audio_frame();
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_audio(1, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_audio().expect("pull_audio must not fail");
+    let out = result.expect("expected Some(frame) after concat push to both slots");
+    assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
+    assert_eq!(out.channels(), 2, "channel count should be unchanged");
+}


### PR DESCRIPTION
## Summary

Adds `concat_audio(n)` to `FilterGraphBuilder` for joining multiple audio clips in sequence using FFmpeg's `concat` filter. Validates that `n >= 2` at build time. Also fixes a bug introduced in #279 where `ConcatVideo` was incorrectly placed in the audio-only skip list of the video build loop, preventing the concat filter from being added to the video graph.

## Changes

- Add `ConcatAudio { n: u32 }` variant to `FilterStep` with filter name `concat` and args `n={n}:v=0:a=1`
- Add `concat_audio(n)` builder method; validation rejects `n < 2` with `InvalidConfig`
- Update `audio_input_count()` to return `n` buffersrc contexts for `ConcatAudio`
- Add extra-pad wiring in the audio build loop (links `in1..n-1` to concat pads `1..n-1`)
- Fix `ConcatVideo` bug: remove it from the video build loop's audio-only skip list (it was incorrectly skipped, so no `concat` filter was ever added to the video graph); add it to the audio build loop's video-only skip instead
- Add 6 unit tests in `builder_tests.rs` and 1 integration test in `push_pull_tests.rs`

## Related Issues

Closes #280

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes