### PR TITLE
feat(ff-filter): add join_with_dissolve for cross-dissolve clip transitions

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -651,3 +651,117 @@ pub(super) unsafe fn add_parametric_eq_chain(
     }
     Ok(ctx)
 }
+
+// ── JoinWithDissolve compound step ────────────────────────────────────────────
+
+/// Expand a `JoinWithDissolve` step into the following compound filter graph:
+///
+/// ```text
+/// clip_a_src → trim(end=clip_a_end+dissolve_dur) → setpts → xfade[0]
+/// clip_b_src → trim(start=max(0, clip_b_start−dissolve_dur)) → setpts → xfade[1]
+/// ```
+///
+/// Returns the `xfade` filter context, which becomes the new `prev_ctx`.
+///
+/// # Safety
+///
+/// `graph`, `clip_a_src`, and `clip_b_src` must be valid non-null pointers
+/// belonging to the same `AVFilterGraph`.
+pub(super) unsafe fn add_join_with_dissolve_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    clip_a_src: *mut ff_sys::AVFilterContext,
+    clip_b_src: *mut ff_sys::AVFilterContext,
+    clip_a_end: f64,
+    clip_b_start: f64,
+    dissolve_dur: f64,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    // 1. trim_a: keep clip A frames up to clip_a_end + dissolve_dur
+    let a_trim_end = clip_a_end + dissolve_dur;
+    let trim_a = add_raw_filter_step(
+        graph,
+        clip_a_src,
+        "trim",
+        &format!("end={a_trim_end}"),
+        index,
+        "jwd_trima",
+    )?;
+
+    // 2. setpts_a: reset clip A timestamps to zero after trim
+    let setpts_a = add_raw_filter_step(
+        graph,
+        trim_a,
+        "setpts",
+        "PTS-STARTPTS",
+        index,
+        "jwd_setptsa",
+    )?;
+
+    // 3. Create xfade filter; pads are wired manually below.
+    let xfade_filter = ff_sys::avfilter_get_by_name(c"xfade".as_ptr());
+    if xfade_filter.is_null() {
+        log::warn!("filter not found name=xfade (join_with_dissolve)");
+        return Err(FilterError::BuildFailed);
+    }
+    let xfade_name = std::ffi::CString::new(format!("jwd_xfade{index}"))
+        .map_err(|_| FilterError::BuildFailed)?;
+    let xfade_args_str = format!("transition=dissolve:duration={dissolve_dur}:offset={clip_a_end}");
+    let xfade_args =
+        std::ffi::CString::new(xfade_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut xfade_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    // SAFETY: all pointers are valid; xfade_filter, xfade_name, and xfade_args
+    // are non-null and null-terminated.
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut xfade_ctx,
+        xfade_filter,
+        xfade_name.as_ptr(),
+        xfade_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=xfade args={xfade_args_str} (join_with_dissolve)");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=xfade args={xfade_args_str} (join_with_dissolve)");
+
+    // Link setpts_a (clip A chain) → xfade[0]
+    // SAFETY: setpts_a and xfade_ctx belong to the same graph; pad indices valid.
+    let ret = ff_sys::avfilter_link(setpts_a, 0, xfade_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // 4. trim_b: keep clip B frames from max(0, clip_b_start - dissolve_dur)
+    let b_trim_start = (clip_b_start - dissolve_dur).max(0.0);
+    let trim_b = add_raw_filter_step(
+        graph,
+        clip_b_src,
+        "trim",
+        &format!("start={b_trim_start}"),
+        index,
+        "jwd_trimb",
+    )?;
+
+    // 5. setpts_b: reset clip B timestamps to zero after trim
+    let setpts_b = add_raw_filter_step(
+        graph,
+        trim_b,
+        "setpts",
+        "PTS-STARTPTS",
+        index,
+        "jwd_setptsb",
+    )?;
+
+    // Link setpts_b (clip B chain) → xfade[1]
+    // SAFETY: setpts_b and xfade_ctx belong to the same graph; pad index 1 is valid for xfade.
+    let ret = ff_sys::avfilter_link(setpts_b, 0, xfade_ctx, 1);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    log::debug!(
+        "filter join_with_dissolve expanded dissolve_dur={dissolve_dur} offset={clip_a_end}"
+    );
+    Ok(xfade_ctx)
+}

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -16,9 +16,9 @@ mod build;
 mod convert;
 
 use build::{
-    add_and_link_step, add_atempo_chain, add_fit_to_aspect_pad, add_overlay_image_step,
-    add_parametric_eq_chain, add_raw_filter_step, add_setpts_after_trim, audio_buffersrc_args,
-    create_hw_filter, hw_accel_to_device_type, video_buffersrc_args,
+    add_and_link_step, add_atempo_chain, add_fit_to_aspect_pad, add_join_with_dissolve_step,
+    add_overlay_image_step, add_parametric_eq_chain, add_raw_filter_step, add_setpts_after_trim,
+    audio_buffersrc_args, create_hw_filter, hw_accel_to_device_type, video_buffersrc_args,
 };
 use convert::{
     audio_pts_ticks, av_frame_to_audio_frame, av_frame_to_video_frame, copy_audio_planes_to_av,
@@ -420,6 +420,34 @@ impl FilterGraphInner {
                 continue;
             }
 
+            // JoinWithDissolve is a compound step that expands to:
+            //   prev → trim_a → setpts_a → xfade[0]
+            //   in1  → trim_b → setpts_b → xfade[1]
+            // It bypasses the standard add_and_link_step path entirely.
+            if let FilterStep::JoinWithDissolve {
+                clip_a_end,
+                clip_b_start,
+                dissolve_dur,
+            } = step
+            {
+                let Some(b_src) = src_ctxs.get(1).and_then(|o| *o) else {
+                    bail!(FilterError::BuildFailed)
+                };
+                prev_ctx = match add_join_with_dissolve_step(
+                    graph,
+                    prev_ctx,
+                    b_src.as_ptr(),
+                    *clip_a_end,
+                    *clip_b_start,
+                    *dissolve_dur,
+                    i,
+                ) {
+                    Ok(ctx) => ctx,
+                    Err(e) => bail!(e),
+                };
+                continue;
+            }
+
             prev_ctx = match add_and_link_step(graph, prev_ctx, step, i, "step") {
                 Ok(ctx) => ctx,
                 Err(e) => bail!(e),
@@ -616,11 +644,17 @@ impl FilterGraphInner {
 
     /// Returns the number of video input slots required by the configured steps.
     ///
-    /// Returns 2 when [`FilterStep::Overlay`] is present (needs a main stream
-    /// on slot 0 and a secondary stream on slot 1), 1 otherwise.
+    /// Returns 2 when [`FilterStep::Overlay`], [`FilterStep::XFade`], or
+    /// [`FilterStep::JoinWithDissolve`] is present (each needs a main stream on
+    /// slot 0 and a secondary stream on slot 1), 1 otherwise.
     fn video_input_count(&self) -> usize {
         for step in &self.steps {
-            if matches!(step, FilterStep::Overlay { .. } | FilterStep::XFade { .. }) {
+            if matches!(
+                step,
+                FilterStep::Overlay { .. }
+                    | FilterStep::XFade { .. }
+                    | FilterStep::JoinWithDissolve { .. }
+            ) {
                 return 2;
             }
             if let FilterStep::ConcatVideo { n } = step {
@@ -790,7 +824,12 @@ impl FilterGraphInner {
         let mut prev_ctx = first_src_ctx.as_ptr();
         for (i, step) in steps.iter().enumerate() {
             // Video-only steps; skip them in the audio graph.
-            if matches!(step, FilterStep::Reverse | FilterStep::ConcatVideo { .. }) {
+            if matches!(
+                step,
+                FilterStep::Reverse
+                    | FilterStep::ConcatVideo { .. }
+                    | FilterStep::JoinWithDissolve { .. }
+            ) {
                 continue;
             }
 

--- a/crates/ff-filter/src/graph/builder.rs
+++ b/crates/ff-filter/src/graph/builder.rs
@@ -517,6 +517,34 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Join two video streams with a cross-dissolve transition.
+    ///
+    /// Requires two video input slots: push clip A frames to slot 0 and clip B
+    /// frames to slot 1.  Internally expands to
+    /// `trim` + `setpts` → `xfade` ← `setpts` + `trim`.
+    ///
+    /// - `clip_a_end_sec`: timestamp (seconds) where clip A ends. Must be > 0.0.
+    /// - `clip_b_start_sec`: timestamp (seconds) where clip B content starts
+    ///   (before the overlap region).
+    /// - `dissolve_dur_sec`: cross-dissolve overlap length in seconds. Must be > 0.0.
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `dissolve_dur_sec ≤ 0.0` or `clip_a_end_sec ≤ 0.0`.
+    #[must_use]
+    pub fn join_with_dissolve(
+        mut self,
+        clip_a_end_sec: f64,
+        clip_b_start_sec: f64,
+        dissolve_dur_sec: f64,
+    ) -> Self {
+        self.steps.push(FilterStep::JoinWithDissolve {
+            clip_a_end: clip_a_end_sec,
+            clip_b_start: clip_b_start_sec,
+            dissolve_dur: dissolve_dur_sec,
+        });
+        self
+    }
+
     /// Change playback speed by `factor`.
     ///
     /// `factor > 1.0` = fast motion (e.g. `2.0` = double speed).
@@ -945,6 +973,25 @@ impl FilterGraphBuilder {
                 return Err(FilterError::InvalidConfig {
                     reason: format!("xfade duration {duration} must be > 0.0"),
                 });
+            }
+            if let FilterStep::JoinWithDissolve {
+                dissolve_dur,
+                clip_a_end,
+                ..
+            } = step
+            {
+                if *dissolve_dur <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!(
+                            "join_with_dissolve dissolve_dur={dissolve_dur} must be > 0.0"
+                        ),
+                    });
+                }
+                if *clip_a_end <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("join_with_dissolve clip_a_end={clip_a_end} must be > 0.0"),
+                    });
+                }
             }
             if let FilterStep::ANoiseGate {
                 attack_ms,

--- a/crates/ff-filter/src/graph/builder_tests.rs
+++ b/crates/ff-filter/src/graph/builder_tests.rs
@@ -3006,3 +3006,71 @@ fn builder_concat_audio_with_n0_should_return_invalid_config() {
         "expected InvalidConfig for n=0, got {result:?}"
     );
 }
+
+#[test]
+fn filter_step_join_with_dissolve_should_have_correct_filter_name() {
+    let step = FilterStep::JoinWithDissolve {
+        clip_a_end: 4.0,
+        clip_b_start: 1.0,
+        dissolve_dur: 1.0,
+    };
+    assert_eq!(step.filter_name(), "xfade");
+}
+
+#[test]
+fn filter_step_join_with_dissolve_should_produce_correct_args() {
+    let step = FilterStep::JoinWithDissolve {
+        clip_a_end: 4.0,
+        clip_b_start: 1.0,
+        dissolve_dur: 1.0,
+    };
+    assert_eq!(
+        step.args(),
+        "transition=dissolve:duration=1:offset=4",
+        "args must match xfade format for join_with_dissolve"
+    );
+}
+
+#[test]
+fn builder_join_with_dissolve_valid_should_build_successfully() {
+    let result = FilterGraph::builder()
+        .join_with_dissolve(4.0, 1.0, 1.0)
+        .build();
+    assert!(
+        result.is_ok(),
+        "join_with_dissolve(4.0, 1.0, 1.0) must build successfully, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_join_with_dissolve_with_zero_dissolve_dur_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .join_with_dissolve(4.0, 1.0, 0.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for dissolve_dur=0.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_join_with_dissolve_with_negative_dissolve_dur_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .join_with_dissolve(4.0, 1.0, -1.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for dissolve_dur=-1.0, got {result:?}"
+    );
+}
+
+#[test]
+fn builder_join_with_dissolve_with_zero_clip_a_end_should_return_invalid_config() {
+    let result = FilterGraph::builder()
+        .join_with_dissolve(0.0, 1.0, 1.0)
+        .build();
+    assert!(
+        matches!(result, Err(FilterError::InvalidConfig { .. })),
+        "expected InvalidConfig for clip_a_end=0.0, got {result:?}"
+    );
+}

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -339,6 +339,24 @@ pub(crate) enum FilterStep {
         /// Font color as an `FFmpeg` color string, e.g. `"white"` or `"0xFFFFFF"`.
         font_color: String,
     },
+    /// Join two video clips with a cross-dissolve transition.
+    ///
+    /// Compound step — expands in `filter_inner` to:
+    /// ```text
+    /// in0 → trim(end=clip_a_end+dissolve_dur) → setpts → xfade[0]
+    /// in1 → trim(start=max(0, clip_b_start−dissolve_dur)) → setpts → xfade[1]
+    /// ```
+    ///
+    /// Requires two video input slots: slot 0 = clip A, slot 1 = clip B.
+    /// `clip_a_end` and `dissolve_dur` must be > 0.0.
+    JoinWithDissolve {
+        /// Timestamp (seconds) where clip A ends. Must be > 0.0.
+        clip_a_end: f64,
+        /// Timestamp (seconds) where clip B content starts (before the overlap).
+        clip_b_start: f64,
+        /// Cross-dissolve overlap duration in seconds. Must be > 0.0.
+        dissolve_dur: f64,
+    },
     /// Composite a PNG image (watermark / logo) over video with optional opacity.
     ///
     /// This is a compound step: internally it creates a `movie` source,
@@ -441,6 +459,9 @@ impl FilterStep {
             // build time; "adelay" is returned here for validate_filter_steps only.
             Self::AudioDelay { .. } => "adelay",
             Self::ConcatVideo { .. } | Self::ConcatAudio { .. } => "concat",
+            // JoinWithDissolve is a compound step (trim+setpts → xfade ← setpts+trim);
+            // "xfade" is used by validate_filter_steps as the primary filter check.
+            Self::JoinWithDissolve { .. } => "xfade",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -724,6 +745,14 @@ impl FilterStep {
             }
             Self::ConcatVideo { n } => format!("n={n}:v=1:a=0"),
             Self::ConcatAudio { n } => format!("n={n}:v=0:a=1"),
+            // args() for JoinWithDissolve is not used by the build loop (which is
+            // bypassed in favour of add_join_with_dissolve_step); provided here for
+            // completeness using the xfade args.
+            Self::JoinWithDissolve {
+                clip_a_end,
+                dissolve_dur,
+                ..
+            } => format!("transition=dissolve:duration={dissolve_dur}:offset={clip_a_end}"),
         }
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1430,3 +1430,47 @@ fn push_audio_through_concat_audio_should_produce_output() {
     assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");
     assert_eq!(out.channels(), 2, "channel count should be unchanged");
 }
+
+#[test]
+fn push_two_clips_through_join_with_dissolve_should_produce_output() {
+    let mut graph = match FilterGraph::builder()
+        .join_with_dissolve(4.0, 1.0, 1.0)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let clip_a = make_yuv420p_frame(64, 64);
+    let clip_b = make_yuv420p_frame(64, 64);
+    // Push clip A to slot 0 first; this initialises the graph.
+    match graph.push_video(0, &clip_a) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    // Push clip B to slot 1.
+    match graph.push_video(1, &clip_b) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after join_with_dissolve push");
+    assert_eq!(
+        out.width(),
+        64,
+        "output width should match input after join_with_dissolve"
+    );
+    assert_eq!(
+        out.height(),
+        64,
+        "output height should match input after join_with_dissolve"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `join_with_dissolve` step to `FilterGraphBuilder` that joins two video clips with a smooth cross-dissolve transition without requiring callers to manually compose trim and xfade steps. The step is a compound expansion handled in `filter_inner`: each input stream is trimmed to the overlap region, timestamps are reset, and both are wired into an `xfade` filter.

## Changes

- `crates/ff-filter/src/graph/filter_step.rs` — new `JoinWithDissolve { clip_a_end, clip_b_start, dissolve_dur }` variant; `filter_name()` returns `"xfade"` (for build-time validation); `args()` returns the equivalent xfade args string
- `crates/ff-filter/src/graph/builder.rs` — `join_with_dissolve(clip_a_end_sec, clip_b_start_sec, dissolve_dur_sec)` builder method; `build()` validation for `dissolve_dur > 0.0` and `clip_a_end > 0.0`
- `crates/ff-filter/src/filter_inner/build.rs` — `add_join_with_dissolve_step()` helper that constructs the compound graph: `trim_a → setpts_a → xfade[0]` and `trim_b → setpts_b → xfade[1]`
- `crates/ff-filter/src/filter_inner/mod.rs` — `video_input_count()` returns 2 for `JoinWithDissolve`; compound step is dispatched with `continue` before the standard `add_and_link_step` path; `JoinWithDissolve` added to the video-only skip list in the audio build loop
- `crates/ff-filter/src/graph/builder_tests.rs` — 6 unit tests: filter_name, args format, valid build, zero/negative dissolve_dur, zero clip_a_end
- `crates/ff-filter/tests/push_pull_tests.rs` — integration test pushing two clips through a dissolve graph and asserting output dimensions

## Related Issues

Closes #282

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes