### PR TITLE
feat(ff-encode): add input validation for dimensions, bitrate, and fps

### DIFF
--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -101,6 +101,22 @@ pub enum EncodeError {
         hint: String,
     },
 
+    /// Video dimensions are outside the supported range (2–32768 per axis).
+    #[error("invalid video dimensions: {width}x{height} (must be 2–32768)")]
+    InvalidDimensions {
+        /// Requested width in pixels.
+        width: u32,
+        /// Requested height in pixels.
+        height: u32,
+    },
+
+    /// Bitrate exceeds the supported ceiling (800 Mbps).
+    #[error("invalid bitrate: {bitrate} bps exceeds maximum 800 Mbps")]
+    InvalidBitrate {
+        /// Requested bitrate in bits per second.
+        bitrate: u64,
+    },
+
     /// Encoding cancelled by user
     #[error("Encoding cancelled by user")]
     Cancelled,

--- a/crates/ff-encode/src/video/builder.rs
+++ b/crates/ff-encode/src/video/builder.rs
@@ -519,18 +519,34 @@ impl VideoEncoderBuilder {
         let requires_even_dims = !matches!(self.video_codec, VideoCodec::Png);
 
         if has_video {
+            // Dimension range check (2–32768 inclusive).
+            let w = self.video_width.unwrap_or(0);
+            let h = self.video_height.unwrap_or(0);
+            if (self.video_width.is_some() || self.video_height.is_some())
+                && (!(2..=32_768).contains(&w) || !(2..=32_768).contains(&h))
+            {
+                log::warn!(
+                    "video dimensions out of range width={w} height={h} \
+                     (valid range 2–32768 per axis)"
+                );
+                return Err(EncodeError::InvalidDimensions {
+                    width: w,
+                    height: h,
+                });
+            }
+
             if let Some(width) = self.video_width
-                && (width == 0 || (requires_even_dims && width % 2 != 0))
+                && (requires_even_dims && width % 2 != 0)
             {
                 return Err(EncodeError::InvalidConfig {
-                    reason: format!("Video width must be non-zero and even, got {width}"),
+                    reason: format!("Video width must be even, got {width}"),
                 });
             }
             if let Some(height) = self.video_height
-                && (height == 0 || (requires_even_dims && height % 2 != 0))
+                && (requires_even_dims && height % 2 != 0)
             {
                 return Err(EncodeError::InvalidConfig {
-                    reason: format!("Video height must be non-zero and even, got {height}"),
+                    reason: format!("Video height must be even, got {height}"),
                 });
             }
             if let Some(fps) = self.video_fps
@@ -538,6 +554,14 @@ impl VideoEncoderBuilder {
             {
                 return Err(EncodeError::InvalidConfig {
                     reason: format!("Video FPS must be positive, got {fps}"),
+                });
+            }
+            if let Some(fps) = self.video_fps
+                && fps > 1000.0
+            {
+                log::warn!("video fps exceeds maximum fps={fps} (maximum 1000)");
+                return Err(EncodeError::InvalidConfig {
+                    reason: format!("fps {fps} exceeds maximum 1000"),
                 });
             }
             if let Some(crate::BitrateMode::Crf(q)) = self.video_bitrate_mode
@@ -556,6 +580,19 @@ impl VideoEncoderBuilder {
                 return Err(EncodeError::InvalidConfig {
                     reason: format!("BitrateMode::Vbr max ({max}) must be >= target ({target})"),
                 });
+            }
+
+            // Bitrate ceiling: 800 Mbps (800_000_000 bps).
+            let effective_bitrate: Option<u64> = match self.video_bitrate_mode {
+                Some(crate::BitrateMode::Cbr(bps)) => Some(bps),
+                Some(crate::BitrateMode::Vbr { max, .. }) => Some(max),
+                _ => None,
+            };
+            if let Some(bps) = effective_bitrate
+                && bps > 800_000_000
+            {
+                log::warn!("video bitrate exceeds maximum bitrate={bps} maximum=800000000");
+                return Err(EncodeError::InvalidBitrate { bitrate: bps });
             }
         }
 

--- a/crates/ff-encode/tests/error_handling_tests.rs
+++ b/crates/ff-encode/tests/error_handling_tests.rs
@@ -11,7 +11,7 @@
 
 mod fixtures;
 
-use ff_encode::{EncodeError, VideoCodec, VideoEncoder};
+use ff_encode::{BitrateMode, EncodeError, VideoCodec, VideoEncoder};
 use fixtures::{create_black_frame, test_output_path};
 
 // ============================================================================
@@ -262,4 +262,153 @@ fn test_very_high_framerate() {
             println!("High framerate rejected: {}", e);
         }
     }
+}
+
+// ============================================================================
+// Dimension Validation Tests (issue #283)
+// ============================================================================
+
+#[test]
+fn width_zero_should_return_invalid_dimensions() {
+    let output_path = test_output_path("dim_w0.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(0, 480, 30.0)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidDimensions { .. })),
+        "expected InvalidDimensions for width=0"
+    );
+}
+
+#[test]
+fn width_one_should_return_invalid_dimensions() {
+    let output_path = test_output_path("dim_w1.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(1, 480, 30.0)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidDimensions { .. })),
+        "expected InvalidDimensions for width=1"
+    );
+}
+
+#[test]
+fn width_above_maximum_should_return_invalid_dimensions() {
+    let output_path = test_output_path("dim_w_max.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(32769, 480, 30.0)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidDimensions { .. })),
+        "expected InvalidDimensions for width=32769"
+    );
+}
+
+#[test]
+fn height_one_should_return_invalid_dimensions() {
+    let output_path = test_output_path("dim_h1.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 1, 30.0)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidDimensions { .. })),
+        "expected InvalidDimensions for height=1"
+    );
+}
+
+#[test]
+fn height_above_maximum_should_return_invalid_dimensions() {
+    let output_path = test_output_path("dim_h_max.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 32769, 30.0)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidDimensions { .. })),
+        "expected InvalidDimensions for height=32769"
+    );
+}
+
+#[test]
+fn minimum_valid_dimensions_should_build_without_dimension_error() {
+    let output_path = test_output_path("dim_min_valid.mp4");
+    let result = VideoEncoder::create(&output_path).video(2, 2, 30.0).build();
+    // Build may fail for other reasons (codec, file system), but not InvalidDimensions.
+    assert!(
+        !matches!(result, Err(EncodeError::InvalidDimensions { .. })),
+        "expected no InvalidDimensions for width=2 height=2"
+    );
+}
+
+// ============================================================================
+// Bitrate Validation Tests (issue #283)
+// ============================================================================
+
+#[test]
+fn cbr_bitrate_above_800mbps_should_return_invalid_bitrate() {
+    let output_path = test_output_path("bitrate_cbr_max.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .bitrate_mode(BitrateMode::Cbr(900_000_000))
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidBitrate { .. })),
+        "expected InvalidBitrate for cbr=900_000_000"
+    );
+}
+
+#[test]
+fn vbr_max_above_800mbps_should_return_invalid_bitrate() {
+    let output_path = test_output_path("bitrate_vbr_max.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .bitrate_mode(BitrateMode::Vbr {
+            target: 400_000_000,
+            max: 900_000_000,
+        })
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidBitrate { .. })),
+        "expected InvalidBitrate for vbr max=900_000_000"
+    );
+}
+
+#[test]
+fn cbr_bitrate_at_800mbps_boundary_should_not_return_invalid_bitrate() {
+    let output_path = test_output_path("bitrate_cbr_boundary.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .bitrate_mode(BitrateMode::Cbr(800_000_000))
+        .build();
+    assert!(
+        !matches!(result, Err(EncodeError::InvalidBitrate { .. })),
+        "expected no InvalidBitrate for cbr=800_000_000"
+    );
+}
+
+// ============================================================================
+// FPS Upper Bound Tests (issue #283)
+// ============================================================================
+
+#[test]
+fn fps_above_1000_should_return_invalid_config() {
+    let output_path = test_output_path("fps_max.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 1001.0)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidConfig { .. })),
+        "expected InvalidConfig for fps=1001.0"
+    );
+}
+
+#[test]
+fn fps_at_1000_boundary_should_not_return_fps_error() {
+    let output_path = test_output_path("fps_boundary.mp4");
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 1000.0)
+        .build();
+    // Build may fail for other reasons (codec, file system), but not the fps cap.
+    let is_fps_error = matches!(&result, Err(EncodeError::InvalidConfig { reason })
+        if reason.contains("fps") && reason.contains("maximum"));
+    assert!(!is_fps_error, "expected no fps cap error for fps=1000.0");
 }


### PR DESCRIPTION
## Summary

Adds explicit input validation to `VideoEncoderBuilder::build()` for three parameters that previously had no upper-bound checks: video dimensions (2–32768 px per axis), bitrate (≤ 800 Mbps), and frame rate (≤ 1000 fps). Each invalid value is logged at `warn` level before the error is returned. Two new `EncodeError` variants are introduced to give callers a typed signal for the most common constraint violations.

## Changes

- `crates/ff-encode/src/error.rs` — added `InvalidDimensions { width, height }` and `InvalidBitrate { bitrate }` variants
- `crates/ff-encode/src/video/builder.rs` — `validate()` now checks:
  - dimensions outside `2..=32_768` → `EncodeError::InvalidDimensions`
  - `BitrateMode::Cbr(bps)` or `BitrateMode::Vbr { max }` > 800 Mbps → `EncodeError::InvalidBitrate`
  - `fps > 1000.0` → `EncodeError::InvalidConfig`
  - each check emits `log::warn!` before returning
- `crates/ff-encode/tests/error_handling_tests.rs` — 11 new tests covering: `width=0`, `width=1`, `width=32769`, `height=1`, `height=32769`, minimum valid dimensions (2×2), `Cbr(900M)`, `Vbr { max=900M }`, `Cbr(800M)` boundary, `fps=1001.0`, `fps=1000.0` boundary

## Related Issues

Closes #283

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes