### PR TITLE
feat(ff-decode): add UnsupportedResolution error and frame guard

### DIFF
--- a/crates/ff-decode/src/error.rs
+++ b/crates/ff-decode/src/error.rs
@@ -198,6 +198,15 @@ pub enum DecodeError {
     /// `is_live()` returns `true`.
     #[error("seek is not supported on live streams")]
     SeekNotSupported,
+
+    /// A decoded frame exceeds the supported resolution limit.
+    #[error("unsupported resolution {width}x{height}: exceeds 32768 in one or both axes")]
+    UnsupportedResolution {
+        /// Frame width.
+        width: u32,
+        /// Frame height.
+        height: u32,
+    },
 }
 
 impl DecodeError {
@@ -363,7 +372,8 @@ impl DecodeError {
             | Self::ConnectionFailed { .. }
             | Self::Io(_)
             | Self::Ffmpeg { .. }
-            | Self::SeekNotSupported => false,
+            | Self::SeekNotSupported
+            | Self::UnsupportedResolution { .. } => false,
         }
     }
 
@@ -415,7 +425,8 @@ impl DecodeError {
             | Self::NetworkTimeout { .. }
             | Self::StreamInterrupted { .. }
             | Self::Ffmpeg { .. }
-            | Self::SeekNotSupported => false,
+            | Self::SeekNotSupported
+            | Self::UnsupportedResolution { .. } => false,
         }
     }
 }
@@ -713,6 +724,36 @@ mod tests {
     #[test]
     fn seek_not_supported_should_be_neither_fatal_nor_recoverable() {
         let e = DecodeError::SeekNotSupported;
+        assert!(!e.is_fatal());
+        assert!(!e.is_recoverable());
+    }
+
+    #[test]
+    fn unsupported_resolution_display_should_contain_width_x_height() {
+        let e = DecodeError::UnsupportedResolution {
+            width: 40000,
+            height: 480,
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("40000x480"), "expected '40000x480' in '{msg}'");
+    }
+
+    #[test]
+    fn unsupported_resolution_display_should_contain_axes_hint() {
+        let e = DecodeError::UnsupportedResolution {
+            width: 640,
+            height: 40000,
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("32768"), "expected '32768' limit in '{msg}'");
+    }
+
+    #[test]
+    fn unsupported_resolution_should_be_neither_fatal_nor_recoverable() {
+        let e = DecodeError::UnsupportedResolution {
+            width: 40000,
+            height: 40000,
+        };
         assert!(!e.is_fatal());
         assert!(!e.is_recoverable());
     }

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -1050,6 +1050,19 @@ impl VideoDecoderInner {
                     // Check if this is a hardware frame and transfer to CPU memory if needed
                     self.transfer_hardware_frame_if_needed()?;
 
+                    // SAFETY: self.frame is valid and non-null after avcodec_receive_frame succeeded.
+                    let w = (*self.frame).width as u32;
+                    let h = (*self.frame).height as u32;
+                    if w > 32_768 || h > 32_768 {
+                        log::warn!(
+                            "frame rejected reason=unsupported_resolution width={w} height={h}"
+                        );
+                        return Err(DecodeError::UnsupportedResolution {
+                            width: w,
+                            height: h,
+                        });
+                    }
+
                     let video_frame = self.convert_frame_to_video_frame()?;
 
                     // Update position based on frame timestamp


### PR DESCRIPTION
## Summary

Adds `DecodeError::UnsupportedResolution` to reject decoded frames whose width or height exceeds 32768. The check runs in `VideoDecoderInner::decode_one_inner` immediately after hardware frame transfer, before any pixel format conversion, so oversized frames are caught as early as possible.

## Changes

- `crates/ff-decode/src/error.rs`: added `UnsupportedResolution { width: u32, height: u32 }` variant with display `"unsupported resolution {w}x{h}: exceeds 32768 in one or both axes"`; updated `is_recoverable()` and `is_fatal()` exhaustive match arms (both return `false`); added 3 unit tests covering display string and recoverability
- `crates/ff-decode/src/video/decoder_inner.rs`: after `transfer_hardware_frame_if_needed()` succeeds, reads frame dimensions and returns `Err(DecodeError::UnsupportedResolution)` with a `log::warn!` if either axis exceeds 32768
- `avio`: no change required — `DecodeError` is already re-exported wholesale under the `decode` feature

## Related Issues

Closes #285

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes