### PR TITLE
feat(ff-encode): add audio encoder validation for channel count and sample rate

### DIFF
--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -237,6 +237,20 @@ impl AudioEncoder {
             });
         }
 
+        // Validate channel count and sample rate before constructing inner.
+        if let Some(ch) = builder.audio_channels
+            && ch > 8
+        {
+            log::warn!("audio channel count out of range count={ch} maximum=8");
+            return Err(EncodeError::InvalidChannelCount { count: ch });
+        }
+        if let Some(sr) = builder.audio_sample_rate
+            && !(8_000..=384_000).contains(&sr)
+        {
+            log::warn!("audio sample rate out of range rate={sr} minimum=8000 maximum=384000");
+            return Err(EncodeError::InvalidSampleRate { rate: sr });
+        }
+
         let config = AudioEncoderConfig {
             path: builder.path.clone(),
             sample_rate: builder

--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -117,6 +117,20 @@ pub enum EncodeError {
         bitrate: u64,
     },
 
+    /// Audio channel count exceeds the supported maximum of 8.
+    #[error("channel count {count} exceeds maximum 8")]
+    InvalidChannelCount {
+        /// Requested channel count.
+        count: u32,
+    },
+
+    /// Audio sample rate is outside the supported range [8000, 384000] Hz.
+    #[error("sample rate {rate} Hz outside supported range [8000, 384000]")]
+    InvalidSampleRate {
+        /// Requested sample rate in Hz.
+        rate: u32,
+    },
+
     /// Encoding cancelled by user
     #[error("Encoding cancelled by user")]
     Cancelled,
@@ -220,6 +234,37 @@ mod tests {
         assert!(
             msg.contains("800,000,000"),
             "expected '800,000,000' in '{msg}'"
+        );
+    }
+
+    #[test]
+    fn invalid_channel_count_display_should_contain_count() {
+        let err = EncodeError::InvalidChannelCount { count: 9 };
+        let msg = err.to_string();
+        assert!(msg.contains('9'), "expected '9' in '{msg}'");
+    }
+
+    #[test]
+    fn invalid_channel_count_display_should_contain_maximum_hint() {
+        let err = EncodeError::InvalidChannelCount { count: 9 };
+        let msg = err.to_string();
+        assert!(msg.contains('8'), "expected '8' in '{msg}'");
+    }
+
+    #[test]
+    fn invalid_sample_rate_display_should_contain_rate() {
+        let err = EncodeError::InvalidSampleRate { rate: 7999 };
+        let msg = err.to_string();
+        assert!(msg.contains("7999"), "expected '7999' in '{msg}'");
+    }
+
+    #[test]
+    fn invalid_sample_rate_display_should_contain_range_hint() {
+        let err = EncodeError::InvalidSampleRate { rate: 7999 };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("[8000, 384000]"),
+            "expected '[8000, 384000]' in '{msg}'"
         );
     }
 }

--- a/crates/ff-encode/tests/error_handling_tests.rs
+++ b/crates/ff-encode/tests/error_handling_tests.rs
@@ -11,7 +11,7 @@
 
 mod fixtures;
 
-use ff_encode::{BitrateMode, EncodeError, VideoCodec, VideoEncoder};
+use ff_encode::{AudioCodec, AudioEncoder, BitrateMode, EncodeError, VideoCodec, VideoEncoder};
 use fixtures::{create_black_frame, test_output_path};
 
 // ============================================================================
@@ -411,4 +411,86 @@ fn fps_at_1000_boundary_should_not_return_fps_error() {
     let is_fps_error = matches!(&result, Err(EncodeError::InvalidConfig { reason })
         if reason.contains("fps") && reason.contains("maximum"));
     assert!(!is_fps_error, "expected no fps cap error for fps=1000.0");
+}
+
+// ============================================================================
+// Audio Validation Tests (issue #286)
+// ============================================================================
+
+#[test]
+fn channels_above_8_should_return_invalid_channel_count() {
+    let output_path = test_output_path("audio_ch9.m4a");
+    let result = AudioEncoder::create(&output_path)
+        .audio(48000, 9)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidChannelCount { .. })),
+        "expected InvalidChannelCount for channels=9"
+    );
+}
+
+#[test]
+fn channels_at_8_should_not_return_invalid_channel_count() {
+    let output_path = test_output_path("audio_ch8.m4a");
+    let result = AudioEncoder::create(&output_path)
+        .audio(48000, 8)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+    assert!(
+        !matches!(result, Err(EncodeError::InvalidChannelCount { .. })),
+        "expected no InvalidChannelCount for channels=8"
+    );
+}
+
+#[test]
+fn sample_rate_below_minimum_should_return_invalid_sample_rate() {
+    let output_path = test_output_path("audio_sr7999.m4a");
+    let result = AudioEncoder::create(&output_path)
+        .audio(7999, 2)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidSampleRate { .. })),
+        "expected InvalidSampleRate for sample_rate=7999"
+    );
+}
+
+#[test]
+fn sample_rate_above_maximum_should_return_invalid_sample_rate() {
+    let output_path = test_output_path("audio_sr384001.m4a");
+    let result = AudioEncoder::create(&output_path)
+        .audio(384_001, 2)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+    assert!(
+        matches!(result, Err(EncodeError::InvalidSampleRate { .. })),
+        "expected InvalidSampleRate for sample_rate=384001"
+    );
+}
+
+#[test]
+fn sample_rate_at_minimum_boundary_should_not_return_invalid_sample_rate() {
+    let output_path = test_output_path("audio_sr8000.m4a");
+    let result = AudioEncoder::create(&output_path)
+        .audio(8000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+    assert!(
+        !matches!(result, Err(EncodeError::InvalidSampleRate { .. })),
+        "expected no InvalidSampleRate for sample_rate=8000"
+    );
+}
+
+#[test]
+fn sample_rate_at_maximum_boundary_should_not_return_invalid_sample_rate() {
+    let output_path = test_output_path("audio_sr384000.m4a");
+    let result = AudioEncoder::create(&output_path)
+        .audio(384_000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .build();
+    assert!(
+        !matches!(result, Err(EncodeError::InvalidSampleRate { .. })),
+        "expected no InvalidSampleRate for sample_rate=384000"
+    );
 }


### PR DESCRIPTION
## Summary

Adds `EncodeError::InvalidChannelCount` and `EncodeError::InvalidSampleRate` variants, and validates both values in `AudioEncoder::from_builder` before any FFmpeg calls are made. Channel counts above 8 and sample rates outside [8000, 384000] Hz now return typed errors with a `log::warn!` before returning.

## Changes

- `crates/ff-encode/src/error.rs`: added `InvalidChannelCount { count: u32 }` with display `"channel count {count} exceeds maximum 8"` and `InvalidSampleRate { rate: u32 }` with display `"sample rate {rate} Hz outside supported range [8000, 384000]"`; added 4 unit tests for display strings
- `crates/ff-encode/src/audio/builder.rs`: added validation block in `AudioEncoder::from_builder` checking `channels > 8` and `sample_rate` outside `[8000, 384000]`, each preceded by `log::warn!`
- `crates/ff-encode/tests/error_handling_tests.rs`: added 6 integration tests covering channels=9, channels=8 boundary, sample_rate=7999, sample_rate=384001, and both boundary values 8000/384000
- `avio`: no change — `EncodeError` is already re-exported wholesale under the `encode` feature

## Related Issues

Closes #286

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes