### PR TITLE
feat(ff-decode): skip AVERROR_INVALIDDATA packets for corrupt stream recovery

### DIFF
--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -309,6 +309,9 @@ pub(crate) struct VideoDecoderInner {
     network_opts: NetworkOptions,
     /// Number of successful reconnects so far (for logging).
     reconnect_count: u32,
+    /// Number of consecutive `AVERROR_INVALIDDATA` packets skipped without a successful frame.
+    /// Reset to 0 on each successfully decoded frame.
+    consecutive_invalid: u32,
 }
 
 impl VideoDecoderInner {
@@ -732,6 +735,7 @@ impl VideoDecoderInner {
                 url,
                 network_opts: stored_network_opts,
                 reconnect_count: 0,
+                consecutive_invalid: 0,
             },
             stream_info,
             container_info,
@@ -1046,7 +1050,9 @@ impl VideoDecoderInner {
                 let ret = ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame);
 
                 if ret == 0 {
-                    // Successfully received a frame
+                    // Successfully received a frame — reset corrupt-stream counter.
+                    self.consecutive_invalid = 0;
+
                     // Check if this is a hardware frame and transfer to CPU memory if needed
                     self.transfer_hardware_frame_if_needed()?;
 
@@ -1108,9 +1114,15 @@ impl VideoDecoderInner {
                     if (*self.packet).stream_index == self.stream_index {
                         // Send the packet to the decoder
                         let send_ret = ff_sys::avcodec_send_packet(self.codec_ctx, self.packet);
+                        // SAFETY: self.packet is valid and non-null; pts is a plain i64 field.
+                        let pkt_pts = (*self.packet).pts;
                         ff_sys::av_packet_unref(self.packet);
 
-                        if send_ret < 0 && send_ret != ff_sys::error_codes::EAGAIN {
+                        if send_ret == ff_sys::error_codes::AVERROR_INVALIDDATA {
+                            log::warn!("packet skipped reason=invalid_data pts={pkt_pts}");
+                            self.consecutive_invalid += 1;
+                            // Do not return error; fall through to read the next packet.
+                        } else if send_ret < 0 && send_ret != ff_sys::error_codes::EAGAIN {
                             return Err(DecodeError::Ffmpeg {
                                 code: send_ret,
                                 message: format!(

--- a/crates/ff-sys/src/error_codes.rs
+++ b/crates/ff-sys/src/error_codes.rs
@@ -85,6 +85,12 @@ pub const ENETUNREACH: i32 = -101;
 /// I/O error (`EIO`). Same value on all POSIX platforms.
 pub const EIO: i32 = -5;
 
+/// Invalid data found when processing input (`AVERROR_INVALIDDATA`).
+///
+/// This is `FFERRTAG(0xF8,'I','N','V')` — a tag-based code, not an errno,
+/// so it has the same value on all platforms.
+pub const AVERROR_INVALIDDATA: i32 = -1_447_971_320;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,5 +101,17 @@ mod tests {
         assert!(EOF < 0);
         assert!(ENOMEM < 0);
         assert!(EINVAL < 0);
+    }
+
+    #[test]
+    fn averror_invaliddata_should_be_negative_and_distinct_from_einval() {
+        assert!(AVERROR_INVALIDDATA < 0);
+        assert_ne!(AVERROR_INVALIDDATA, EINVAL);
+    }
+
+    #[test]
+    fn averror_invaliddata_should_have_expected_value() {
+        // FFERRTAG(0xF8,'I','N','V') = -(0xF8 | 'I'<<8 | 'N'<<16 | 'V'<<24)
+        assert_eq!(AVERROR_INVALIDDATA, -1_447_971_320);
     }
 }


### PR DESCRIPTION
## Summary

Makes the video decoder resilient to corrupted packets: instead of aborting when `avcodec_send_packet` returns `AVERROR_INVALIDDATA`, the decoder now logs a warning with the packet PTS, increments a `consecutive_invalid` counter, and continues to the next packet. The counter resets to zero on each successfully decoded frame, providing a baseline for the threshold-based abort in issue #288.

## Changes

- `crates/ff-sys/src/error_codes.rs`: added `AVERROR_INVALIDDATA = -1_447_971_320` constant (`FFERRTAG(0xF8,'I','N','V')`); added 2 unit tests verifying the value and that it is distinct from `EINVAL`
- `crates/ff-decode/src/video/decoder_inner.rs`:
  - Added `consecutive_invalid: u32` field to `VideoDecoderInner`, initialized to `0`
  - In `decode_one_inner`: intercept `AVERROR_INVALIDDATA` from `avcodec_send_packet` — emit `log::warn!("packet skipped reason=invalid_data pts={pts}")`, increment counter, and fall through instead of returning an error
  - Reset `consecutive_invalid = 0` on each successful `avcodec_receive_frame`

## Related Issues

Closes #287

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes