### PR TITLE
feat(ff-decode): add StreamCorrupted error after 32 consecutive invalid packets

### DIFF
--- a/crates/ff-decode/src/error.rs
+++ b/crates/ff-decode/src/error.rs
@@ -207,6 +207,15 @@ pub enum DecodeError {
         /// Frame height.
         height: u32,
     },
+
+    /// Too many consecutive corrupt packets — the stream is unrecoverable.
+    #[error(
+        "stream corrupted: {consecutive_invalid_packets} consecutive invalid packets without recovery"
+    )]
+    StreamCorrupted {
+        /// Number of consecutive invalid packets that triggered the error.
+        consecutive_invalid_packets: u32,
+    },
 }
 
 impl DecodeError {
@@ -373,7 +382,8 @@ impl DecodeError {
             | Self::Io(_)
             | Self::Ffmpeg { .. }
             | Self::SeekNotSupported
-            | Self::UnsupportedResolution { .. } => false,
+            | Self::UnsupportedResolution { .. }
+            | Self::StreamCorrupted { .. } => false,
         }
     }
 
@@ -419,7 +429,8 @@ impl DecodeError {
             | Self::HwAccelUnavailable { .. }
             | Self::InvalidOutputDimensions { .. }
             | Self::ConnectionFailed { .. }
-            | Self::Io(_) => true,
+            | Self::Io(_)
+            | Self::StreamCorrupted { .. } => true,
             Self::DecodingFailed { .. }
             | Self::SeekFailed { .. }
             | Self::NetworkTimeout { .. }
@@ -755,6 +766,36 @@ mod tests {
             height: 40000,
         };
         assert!(!e.is_fatal());
+        assert!(!e.is_recoverable());
+    }
+
+    #[test]
+    fn stream_corrupted_display_should_contain_packet_count() {
+        let e = DecodeError::StreamCorrupted {
+            consecutive_invalid_packets: 32,
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("32"), "expected '32' in '{msg}'");
+    }
+
+    #[test]
+    fn stream_corrupted_display_should_mention_consecutive() {
+        let e = DecodeError::StreamCorrupted {
+            consecutive_invalid_packets: 32,
+        };
+        let msg = e.to_string();
+        assert!(
+            msg.contains("consecutive"),
+            "expected 'consecutive' in '{msg}'"
+        );
+    }
+
+    #[test]
+    fn stream_corrupted_should_be_fatal_and_not_recoverable() {
+        let e = DecodeError::StreamCorrupted {
+            consecutive_invalid_packets: 32,
+        };
+        assert!(e.is_fatal());
         assert!(!e.is_recoverable());
     }
 }

--- a/crates/ff-decode/src/video/decoder_inner.rs
+++ b/crates/ff-decode/src/video/decoder_inner.rs
@@ -1121,6 +1121,15 @@ impl VideoDecoderInner {
                         if send_ret == ff_sys::error_codes::AVERROR_INVALIDDATA {
                             log::warn!("packet skipped reason=invalid_data pts={pkt_pts}");
                             self.consecutive_invalid += 1;
+                            if self.consecutive_invalid >= 32 {
+                                log::warn!(
+                                    "stream corrupted consecutive_invalid_packets={}",
+                                    self.consecutive_invalid
+                                );
+                                return Err(DecodeError::StreamCorrupted {
+                                    consecutive_invalid_packets: self.consecutive_invalid,
+                                });
+                            }
                             // Do not return error; fall through to read the next packet.
                         } else if send_ret < 0 && send_ret != ff_sys::error_codes::EAGAIN {
                             return Err(DecodeError::Ffmpeg {


### PR DESCRIPTION
## Summary

Adds `DecodeError::StreamCorrupted` which is returned when the `consecutive_invalid` counter introduced in #287 reaches 32. At that point the stream is considered unrecoverable, a `log::warn!` is emitted with the count, and the decoder returns an error instead of continuing to skip packets indefinitely.

## Changes

- `crates/ff-decode/src/error.rs`: added `StreamCorrupted { consecutive_invalid_packets: u32 }` variant with display `"stream corrupted: {n} consecutive invalid packets without recovery"`; classified as fatal (`is_fatal = true`) and not recoverable; added 3 unit tests covering display output and fatality/recoverability
- `crates/ff-decode/src/video/decoder_inner.rs`: after `consecutive_invalid += 1`, checks `>= 32` and returns `Err(DecodeError::StreamCorrupted { .. })` with a preceding `log::warn!`
- `avio`: no change — `DecodeError` is already re-exported wholesale under the `decode` feature

## Related Issues

Closes #288

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes