### PR TITLE
chore: add cargo-fuzz targets for ff-decode, ff-probe, ff-encode with CI workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,47 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'   # weekly on Monday at 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  fuzz:
+    name: Fuzz targets
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Install FFmpeg development libraries
+        run: sudo apt-get update && sudo apt-get install -y libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libswresample-dev libclang-dev pkg-config
+
+      - name: Fuzz ff-decode open_video
+        run: cargo fuzz run open_video -- -max_total_time=60
+        working-directory: crates/ff-decode
+
+      - name: Fuzz ff-probe probe_open
+        run: cargo fuzz run probe_open -- -max_total_time=60
+        working-directory: crates/ff-probe
+
+      - name: Fuzz ff-encode encode_video
+        run: cargo fuzz run encode_video -- -max_total_time=60
+        working-directory: crates/ff-encode
+
+      - name: Upload crash inputs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashes
+          path: |
+            crates/ff-decode/fuzz/artifacts/
+            crates/ff-probe/fuzz/artifacts/
+            crates/ff-encode/fuzz/artifacts/

--- a/crates/ff-decode/fuzz/Cargo.toml
+++ b/crates/ff-decode/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ff-decode-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[[bin]]
+name = "open_video"
+path = "fuzz_targets/open_video.rs"
+test = false
+doc = false
+
+[dependencies]
+libfuzzer-sys = "0.4.12"
+ff-decode = { path = ".." }
+tempfile = "3.27.0"

--- a/crates/ff-decode/fuzz/fuzz_targets/open_video.rs
+++ b/crates/ff-decode/fuzz/fuzz_targets/open_video.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(mut tmp) = tempfile::NamedTempFile::new() else {
+        return;
+    };
+    use std::io::Write as _;
+    let _ = tmp.write_all(data);
+    let _ = tmp.flush();
+    // Must not panic or abort — only return Err.
+    let _ = ff_decode::VideoDecoder::open(tmp.path()).build();
+});

--- a/crates/ff-encode/fuzz/Cargo.toml
+++ b/crates/ff-encode/fuzz/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ff-encode-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[[bin]]
+name = "encode_video"
+path = "fuzz_targets/encode_video.rs"
+test = false
+doc = false
+
+[dependencies]
+libfuzzer-sys = "0.4.12"
+ff-encode = { path = ".." }
+ff-format = { path = "../../ff-format" }
+tempfile = "3.27.0"

--- a/crates/ff-encode/fuzz/fuzz_targets/encode_video.rs
+++ b/crates/ff-encode/fuzz/fuzz_targets/encode_video.rs
@@ -1,0 +1,45 @@
+#![no_main]
+
+use ff_format::{PixelFormat, PooledBuffer, Timestamp, VideoFrame};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Fixed encoder parameters to avoid config-level panics.
+    let Ok(tmp) = tempfile::NamedTempFile::new() else {
+        return;
+    };
+    let mut enc = match ff_encode::VideoEncoder::create(tmp.path())
+        .video(64, 64, 30.0)
+        .video_codec(ff_format::VideoCodec::Mpeg4)
+        .build()
+    {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    // Fill a YUV420P frame with fuzzer-supplied bytes.
+    let y_size = 64 * 64;
+    let uv_size = 32 * 32;
+    let total = y_size + uv_size * 2;
+    if data.len() < total {
+        return;
+    }
+
+    let y = PooledBuffer::standalone(data[..y_size].to_vec());
+    let u = PooledBuffer::standalone(data[y_size..y_size + uv_size].to_vec());
+    let v = PooledBuffer::standalone(data[y_size + uv_size..total].to_vec());
+    let Ok(frame) = VideoFrame::new(
+        vec![y, u, v],
+        vec![64, 32, 32],
+        64,
+        64,
+        PixelFormat::Yuv420p,
+        Timestamp::default(),
+        true,
+    ) else {
+        return;
+    };
+
+    let _ = enc.push_video(&frame);
+    let _ = enc.finish();
+});

--- a/crates/ff-probe/fuzz/Cargo.toml
+++ b/crates/ff-probe/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ff-probe-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[[bin]]
+name = "probe_open"
+path = "fuzz_targets/probe_open.rs"
+test = false
+doc = false
+
+[dependencies]
+libfuzzer-sys = "0.4.12"
+ff-probe = { path = ".." }
+tempfile = "3.27.0"

--- a/crates/ff-probe/fuzz/fuzz_targets/probe_open.rs
+++ b/crates/ff-probe/fuzz/fuzz_targets/probe_open.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(mut tmp) = tempfile::NamedTempFile::new() else {
+        return;
+    };
+    use std::io::Write as _;
+    let _ = tmp.write_all(data);
+    let _ = tmp.flush();
+    // Must not panic or abort.
+    let _ = ff_probe::open(tmp.path());
+});


### PR DESCRIPTION
## Summary

Adds cargo-fuzz targets for the three main crates and a dedicated `fuzz.yml` CI workflow that runs each target for 60 seconds on push to `main` and on a weekly schedule. Each fuzz target writes arbitrary bytes to a temporary file and feeds it to the relevant public entry point, verifying that only `Err(_)` is returned — no panics, aborts, or undefined behaviour.

## Changes

- `crates/ff-decode/fuzz/Cargo.toml` + `fuzz_targets/open_video.rs`: fuzz `VideoDecoder::open(path).build()` with arbitrary bytes
- `crates/ff-probe/fuzz/Cargo.toml` + `fuzz_targets/probe_open.rs`: fuzz `ff_probe::open(path)` with arbitrary bytes
- `crates/ff-encode/fuzz/Cargo.toml` + `fuzz_targets/encode_video.rs`: fuzz `VideoEncoder` with arbitrary YUV420P pixel data in a 64×64 Mpeg4 encoder; skips gracefully if encoder unavailable
- `.github/workflows/fuzz.yml`: new workflow triggered on push to `main`, weekly (`0 3 * * 1`), and `workflow_dispatch`; installs system FFmpeg dev libs and nightly Rust; runs all three targets with `-max_total_time=60`; uploads crash artifacts on failure
- Note: the `encode_video` target uses the actual public API (`VideoEncoder::create()/.video()/.video_codec()/.push_video()`) which differs from the pseudocode in the issue

## Related Issues

Closes #289
Closes #290
Closes #291
Closes #292

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes