### PR TITLE
fix(fuzz): add [workspace] table to isolate fuzz crates from root workspace

### DIFF
--- a/crates/ff-decode/fuzz/Cargo.toml
+++ b/crates/ff-decode/fuzz/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 
+[workspace]
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/crates/ff-encode/fuzz/Cargo.toml
+++ b/crates/ff-encode/fuzz/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 
+[workspace]
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/crates/ff-probe/fuzz/Cargo.toml
+++ b/crates/ff-probe/fuzz/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 
+[workspace]
+
 [package.metadata]
 cargo-fuzz = true
 


### PR DESCRIPTION
## Summary

Fixes the fuzz CI failure introduced in #792. Cargo resolves workspace membership by walking up the directory tree, so the three fuzz packages under `crates/*/fuzz/` were being detected as belonging to the root workspace even though `members = ["crates/*"]` doesn't explicitly include them. Adding an empty `[workspace]` table to each fuzz `Cargo.toml` declares them as independent workspace roots and stops Cargo from erroring.

## Changes

- `crates/ff-decode/fuzz/Cargo.toml`: added `[workspace]`
- `crates/ff-probe/fuzz/Cargo.toml`: added `[workspace]`
- `crates/ff-encode/fuzz/Cargo.toml`: added `[workspace]`

## Related Issues

Fixes #289
Fixes #290
Fixes #291
Fixes #292

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes