### PR TITLE
fix(fuzz): add rust-toolchain.toml to fuzz dirs to enforce nightly

### DIFF
--- a/crates/ff-decode/fuzz/rust-toolchain.toml
+++ b/crates/ff-decode/fuzz/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/crates/ff-encode/fuzz/rust-toolchain.toml
+++ b/crates/ff-encode/fuzz/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/crates/ff-probe/fuzz/rust-toolchain.toml
+++ b/crates/ff-probe/fuzz/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
## Summary

The fuzz CI was failing because the workspace-level `rust-toolchain.toml` pins the toolchain to `1.93.0` (stable). When `cargo fuzz run` was executed from each crate's directory, Rust's toolchain resolution walked up and found the workspace file, forcing stable — but `cargo fuzz` requires nightly for `-Zsanitizer=address` and other unstable flags.

Adding a `rust-toolchain.toml` with `channel = "nightly"` to each fuzz subdirectory takes precedence over the parent, so `cargo fuzz` always uses nightly regardless of how the workflow installs the toolchain.

## Changes

- `crates/ff-decode/fuzz/rust-toolchain.toml` — pin to nightly
- `crates/ff-probe/fuzz/rust-toolchain.toml` — pin to nightly
- `crates/ff-encode/fuzz/rust-toolchain.toml` — pin to nightly

## Related Issues

Fixes #793

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes