### PR TITLE
refactor(ff-filter): move FilterGraph impl into graph/graph.rs

### DIFF
--- a/crates/ff-filter/src/graph/graph.rs
+++ b/crates/ff-filter/src/graph/graph.rs
@@ -1,0 +1,114 @@
+//! [`FilterGraph`] struct definition and push/pull implementations.
+
+use ff_format::{AudioFrame, VideoFrame};
+
+use crate::error::FilterError;
+use crate::filter_inner::FilterGraphInner;
+
+use super::builder::FilterGraphBuilder;
+
+// ── FilterGraph ───────────────────────────────────────────────────────────────
+
+/// An `FFmpeg` libavfilter filter graph.
+///
+/// Constructed via [`FilterGraph::builder()`].  The underlying `AVFilterGraph` is
+/// initialised lazily on the first push call, deriving format information from
+/// the first frame.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_filter::FilterGraph;
+///
+/// let mut graph = FilterGraph::builder()
+///     .scale(1280, 720)
+///     .build()?;
+///
+/// // Push decoded frames in …
+/// graph.push_video(0, &video_frame)?;
+///
+/// // … and pull filtered frames out.
+/// while let Some(frame) = graph.pull_video()? {
+///     // use frame
+/// }
+/// ```
+pub struct FilterGraph {
+    pub(crate) inner: FilterGraphInner,
+    pub(crate) output_resolution: Option<(u32, u32)>,
+}
+
+impl std::fmt::Debug for FilterGraph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FilterGraph").finish_non_exhaustive()
+    }
+}
+
+impl FilterGraph {
+    /// Create a new builder.
+    #[must_use]
+    pub fn builder() -> FilterGraphBuilder {
+        FilterGraphBuilder::new()
+    }
+
+    /// Returns the output resolution produced by this graph's `scale` filter step,
+    /// if one was configured.
+    ///
+    /// When multiple `scale` steps are chained, the **last** one's dimensions are
+    /// returned. Returns `None` when no `scale` step was added.
+    #[must_use]
+    pub fn output_resolution(&self) -> Option<(u32, u32)> {
+        self.output_resolution
+    }
+
+    /// Push a video frame into input slot `slot`.
+    ///
+    /// On the first call the filter graph is initialised using this frame's
+    /// format, resolution, and time base.
+    ///
+    /// # Errors
+    ///
+    /// - [`FilterError::InvalidInput`] if `slot` is out of range.
+    /// - [`FilterError::BuildFailed`] if the graph cannot be initialised.
+    /// - [`FilterError::ProcessFailed`] if the `FFmpeg` push fails.
+    pub fn push_video(&mut self, slot: usize, frame: &VideoFrame) -> Result<(), FilterError> {
+        self.inner.push_video(slot, frame)
+    }
+
+    /// Pull the next filtered video frame, if one is available.
+    ///
+    /// Returns `None` when the internal `FFmpeg` buffer is empty (EAGAIN) or
+    /// at end-of-stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::ProcessFailed`] on an unexpected `FFmpeg` error.
+    pub fn pull_video(&mut self) -> Result<Option<VideoFrame>, FilterError> {
+        self.inner.pull_video()
+    }
+
+    /// Push an audio frame into input slot `slot`.
+    ///
+    /// On the first call the audio filter graph is initialised using this
+    /// frame's format, sample rate, and channel count.
+    ///
+    /// # Errors
+    ///
+    /// - [`FilterError::InvalidInput`] if `slot` is out of range.
+    /// - [`FilterError::BuildFailed`] if the graph cannot be initialised.
+    /// - [`FilterError::ProcessFailed`] if the `FFmpeg` push fails.
+    pub fn push_audio(&mut self, slot: usize, frame: &AudioFrame) -> Result<(), FilterError> {
+        self.inner.push_audio(slot, frame)
+    }
+
+    /// Pull the next filtered audio frame, if one is available.
+    ///
+    /// Returns `None` when the internal `FFmpeg` buffer is empty (EAGAIN) or
+    /// at end-of-stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::ProcessFailed`] on an unexpected `FFmpeg` error.
+    pub fn pull_audio(&mut self) -> Result<Option<AudioFrame>, FilterError> {
+        self.inner.pull_audio()
+    }
+}

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -2,123 +2,15 @@
 
 pub mod builder;
 pub(crate) mod filter_step;
+#[allow(clippy::module_inception)]
+mod graph;
 pub mod types;
 
 pub use builder::FilterGraphBuilder;
+pub use graph::FilterGraph;
 pub use types::{
     DrawTextOptions, EqBand, HwAccel, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
 
-use ff_format::{AudioFrame, VideoFrame};
-
-use crate::error::FilterError;
-use crate::filter_inner::FilterGraphInner;
-
 // Re-export FilterStep for use by filter_inner
 pub(crate) use filter_step::FilterStep;
-
-// ── FilterGraph ───────────────────────────────────────────────────────────────
-
-/// An `FFmpeg` libavfilter filter graph.
-///
-/// Constructed via [`FilterGraph::builder()`].  The underlying `AVFilterGraph` is
-/// initialised lazily on the first push call, deriving format information from
-/// the first frame.
-///
-/// # Examples
-///
-/// ```ignore
-/// use ff_filter::FilterGraph;
-///
-/// let mut graph = FilterGraph::builder()
-///     .scale(1280, 720)
-///     .build()?;
-///
-/// // Push decoded frames in …
-/// graph.push_video(0, &video_frame)?;
-///
-/// // … and pull filtered frames out.
-/// while let Some(frame) = graph.pull_video()? {
-///     // use frame
-/// }
-/// ```
-pub struct FilterGraph {
-    pub(crate) inner: FilterGraphInner,
-    pub(crate) output_resolution: Option<(u32, u32)>,
-}
-
-impl std::fmt::Debug for FilterGraph {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FilterGraph").finish_non_exhaustive()
-    }
-}
-
-impl FilterGraph {
-    /// Create a new builder.
-    #[must_use]
-    pub fn builder() -> FilterGraphBuilder {
-        FilterGraphBuilder::new()
-    }
-
-    /// Returns the output resolution produced by this graph's `scale` filter step,
-    /// if one was configured.
-    ///
-    /// When multiple `scale` steps are chained, the **last** one's dimensions are
-    /// returned. Returns `None` when no `scale` step was added.
-    #[must_use]
-    pub fn output_resolution(&self) -> Option<(u32, u32)> {
-        self.output_resolution
-    }
-
-    /// Push a video frame into input slot `slot`.
-    ///
-    /// On the first call the filter graph is initialised using this frame's
-    /// format, resolution, and time base.
-    ///
-    /// # Errors
-    ///
-    /// - [`FilterError::InvalidInput`] if `slot` is out of range.
-    /// - [`FilterError::BuildFailed`] if the graph cannot be initialised.
-    /// - [`FilterError::ProcessFailed`] if the `FFmpeg` push fails.
-    pub fn push_video(&mut self, slot: usize, frame: &VideoFrame) -> Result<(), FilterError> {
-        self.inner.push_video(slot, frame)
-    }
-
-    /// Pull the next filtered video frame, if one is available.
-    ///
-    /// Returns `None` when the internal `FFmpeg` buffer is empty (EAGAIN) or
-    /// at end-of-stream.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FilterError::ProcessFailed`] on an unexpected `FFmpeg` error.
-    pub fn pull_video(&mut self) -> Result<Option<VideoFrame>, FilterError> {
-        self.inner.pull_video()
-    }
-
-    /// Push an audio frame into input slot `slot`.
-    ///
-    /// On the first call the audio filter graph is initialised using this
-    /// frame's format, sample rate, and channel count.
-    ///
-    /// # Errors
-    ///
-    /// - [`FilterError::InvalidInput`] if `slot` is out of range.
-    /// - [`FilterError::BuildFailed`] if the graph cannot be initialised.
-    /// - [`FilterError::ProcessFailed`] if the `FFmpeg` push fails.
-    pub fn push_audio(&mut self, slot: usize, frame: &AudioFrame) -> Result<(), FilterError> {
-        self.inner.push_audio(slot, frame)
-    }
-
-    /// Pull the next filtered audio frame, if one is available.
-    ///
-    /// Returns `None` when the internal `FFmpeg` buffer is empty (EAGAIN) or
-    /// at end-of-stream.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FilterError::ProcessFailed`] on an unexpected `FFmpeg` error.
-    pub fn pull_audio(&mut self) -> Result<Option<AudioFrame>, FilterError> {
-        self.inner.pull_audio()
-    }
-}


### PR DESCRIPTION
## Summary

Moves the `FilterGraph` struct definition and all its `impl` blocks from `graph/mod.rs` into a new `graph/graph.rs` file, aligning with the module pattern in CLAUDE.md which requires `mod.rs` to contain re-exports only.

## Changes

- **`graph/graph.rs`** (new) — `FilterGraph` struct, `impl Debug`, `impl FilterGraph` with `builder()`, `output_resolution()`, `push_video()`, `pull_video()`, `push_audio()`, `pull_audio()`
- **`graph/mod.rs`** (shrunk from 124 → 15 lines) — module declarations and `pub use` re-exports only; adds `#[allow(clippy::module_inception)]` to suppress the `graph::graph` naming lint

## Related Issues

Resolves #801

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes