### PR TITLE
refactor(ff-decode, ff-encode): extract generic async wrapper helpers

### DIFF
--- a/crates/ff-decode/src/async_decoder.rs
+++ b/crates/ff-decode/src/async_decoder.rs
@@ -1,0 +1,53 @@
+//! Generic async decoder helper backed by `tokio::task::spawn_blocking`.
+
+use std::sync::{Arc, Mutex};
+
+use crate::error::DecodeError;
+
+/// Generic async wrapper for a synchronous decoder `T`.
+///
+/// Holds the decoder behind `Arc<Mutex<T>>` and offloads every blocking call
+/// to a `spawn_blocking` thread so the Tokio executor is never blocked.
+///
+/// This is a crate-internal helper used by [`AsyncVideoDecoder`] and
+/// [`AsyncAudioDecoder`]; it is not part of the public API.
+///
+/// [`AsyncVideoDecoder`]: crate::video::AsyncVideoDecoder
+/// [`AsyncAudioDecoder`]: crate::audio::AsyncAudioDecoder
+pub(crate) struct AsyncDecoder<T> {
+    pub(crate) inner: Arc<Mutex<T>>,
+}
+
+impl<T: Send + 'static> AsyncDecoder<T> {
+    /// Wraps an already-opened synchronous decoder.
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    /// Runs a blocking closure on the inner decoder in a `spawn_blocking` thread.
+    ///
+    /// Acquires the mutex, calls `f` with a mutable reference to `T`, and
+    /// returns the result.  Both mutex poisoning and `spawn_blocking` panics are
+    /// surfaced as [`DecodeError::Ffmpeg`] variants with `code = 0`.
+    pub(crate) async fn with<F, R>(&self, f: F) -> Result<R, DecodeError>
+    where
+        F: FnOnce(&mut T) -> Result<R, DecodeError> + Send + 'static,
+        R: Send + 'static,
+    {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let mut guard = inner.lock().map_err(|_| DecodeError::Ffmpeg {
+                code: 0,
+                message: "mutex poisoned".to_string(),
+            })?;
+            f(&mut *guard)
+        })
+        .await
+        .map_err(|e| DecodeError::Ffmpeg {
+            code: 0,
+            message: format!("spawn_blocking panicked: {e}"),
+        })?
+    }
+}

--- a/crates/ff-decode/src/audio/async_decoder.rs
+++ b/crates/ff-decode/src/audio/async_decoder.rs
@@ -1,11 +1,11 @@
 //! Async audio decoder backed by `tokio::task::spawn_blocking`.
 
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 
 use ff_format::AudioFrame;
 use futures::stream::{self, Stream};
 
+use crate::async_decoder::AsyncDecoder;
 use crate::audio::builder::AudioDecoder;
 use crate::error::DecodeError;
 
@@ -27,7 +27,7 @@ use crate::error::DecodeError;
 /// }
 /// ```
 pub struct AsyncAudioDecoder {
-    inner: Arc<Mutex<AudioDecoder>>,
+    inner: AsyncDecoder<AudioDecoder>,
 }
 
 impl AsyncAudioDecoder {
@@ -49,7 +49,7 @@ impl AsyncAudioDecoder {
                 message: format!("spawn_blocking panicked: {e}"),
             })??;
         Ok(Self {
-            inner: Arc::new(Mutex::new(decoder)),
+            inner: AsyncDecoder::new(decoder),
         })
     }
 
@@ -64,21 +64,7 @@ impl AsyncAudioDecoder {
     ///
     /// Returns [`DecodeError`] on codec or I/O errors.
     pub async fn decode_frame(&mut self) -> Result<Option<AudioFrame>, DecodeError> {
-        let inner = Arc::clone(&self.inner);
-        tokio::task::spawn_blocking(move || {
-            inner
-                .lock()
-                .map_err(|_| DecodeError::Ffmpeg {
-                    code: 0,
-                    message: "mutex poisoned".to_string(),
-                })?
-                .decode_one()
-        })
-        .await
-        .map_err(|e| DecodeError::Ffmpeg {
-            code: 0,
-            message: format!("spawn_blocking panicked: {e}"),
-        })?
+        self.inner.with(AudioDecoder::decode_one).await
     }
 
     /// Converts this decoder into a [`Stream`] of audio frames.

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -100,6 +100,8 @@
 #![warn(clippy::pedantic)]
 
 // Module declarations
+#[cfg(feature = "tokio")]
+pub(crate) mod async_decoder;
 pub mod audio;
 pub mod error;
 mod hardware;

--- a/crates/ff-decode/src/video/async_decoder.rs
+++ b/crates/ff-decode/src/video/async_decoder.rs
@@ -1,11 +1,11 @@
 //! Async video decoder backed by `tokio::task::spawn_blocking`.
 
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 
 use ff_format::VideoFrame;
 use futures::stream::{self, Stream};
 
+use crate::async_decoder::AsyncDecoder;
 use crate::error::DecodeError;
 use crate::video::builder::VideoDecoder;
 
@@ -27,7 +27,7 @@ use crate::video::builder::VideoDecoder;
 /// }
 /// ```
 pub struct AsyncVideoDecoder {
-    inner: Arc<Mutex<VideoDecoder>>,
+    inner: AsyncDecoder<VideoDecoder>,
 }
 
 impl AsyncVideoDecoder {
@@ -49,7 +49,7 @@ impl AsyncVideoDecoder {
                 message: format!("spawn_blocking panicked: {e}"),
             })??;
         Ok(Self {
-            inner: Arc::new(Mutex::new(decoder)),
+            inner: AsyncDecoder::new(decoder),
         })
     }
 
@@ -64,21 +64,7 @@ impl AsyncVideoDecoder {
     ///
     /// Returns [`DecodeError`] on codec or I/O errors.
     pub async fn decode_frame(&mut self) -> Result<Option<VideoFrame>, DecodeError> {
-        let inner = Arc::clone(&self.inner);
-        tokio::task::spawn_blocking(move || {
-            inner
-                .lock()
-                .map_err(|_| DecodeError::Ffmpeg {
-                    code: 0,
-                    message: "mutex poisoned".to_string(),
-                })?
-                .decode_one()
-        })
-        .await
-        .map_err(|e| DecodeError::Ffmpeg {
-            code: 0,
-            message: format!("spawn_blocking panicked: {e}"),
-        })?
+        self.inner.with(VideoDecoder::decode_one).await
     }
 
     /// Converts this decoder into a [`Stream`] of video frames.

--- a/crates/ff-encode/src/async_encoder.rs
+++ b/crates/ff-encode/src/async_encoder.rs
@@ -1,0 +1,122 @@
+//! Generic async encoder helper backed by a bounded `tokio::sync::mpsc` channel.
+
+use tokio::sync::mpsc;
+
+use crate::EncodeError;
+
+/// Abstraction over a synchronous encoder that accepts frames of type `F`.
+///
+/// Implement this trait on a synchronous encoder to make it usable with
+/// [`AsyncEncoder`].  Both [`VideoEncoder`] and [`AudioEncoder`] implement it.
+///
+/// [`VideoEncoder`]: crate::video::VideoEncoder
+/// [`AudioEncoder`]: crate::audio::AudioEncoder
+pub(crate) trait SyncEncoder<F> {
+    /// Push one frame into the encoder.
+    fn push_frame(&mut self, frame: &F) -> Result<(), EncodeError>;
+
+    /// Flush all buffered frames and write the container trailer.
+    fn drain_and_finish(self) -> Result<(), EncodeError>;
+}
+
+/// Messages sent from the async front-end to the worker thread.
+enum WorkerMsg<F> {
+    Frame(F),
+    Finish,
+}
+
+/// Generic async wrapper for a synchronous encoder `E` that encodes frames of
+/// type `F`.
+///
+/// Frames are queued into a bounded channel (capacity 8) and encoded by a
+/// dedicated worker thread.  When the channel is full, [`push`] suspends the
+/// caller, providing natural back-pressure.
+///
+/// This is a crate-internal helper used by [`AsyncVideoEncoder`] and
+/// [`AsyncAudioEncoder`]; it is not part of the public API.
+///
+/// [`push`]: AsyncEncoder::push
+/// [`AsyncVideoEncoder`]: crate::video::AsyncVideoEncoder
+/// [`AsyncAudioEncoder`]: crate::audio::AsyncAudioEncoder
+pub(crate) struct AsyncEncoder<F> {
+    sender: mpsc::Sender<WorkerMsg<F>>,
+    join_handle: Option<std::thread::JoinHandle<Result<(), EncodeError>>>,
+}
+
+impl<F: Send + 'static> AsyncEncoder<F> {
+    /// Wraps an already-opened synchronous encoder and starts the worker thread.
+    pub(crate) fn new<E>(encoder: E) -> Self
+    where
+        E: SyncEncoder<F> + Send + 'static,
+    {
+        let (tx, rx) = mpsc::channel::<WorkerMsg<F>>(8);
+
+        let handle = std::thread::spawn(move || -> Result<(), EncodeError> {
+            let mut enc = encoder;
+            let mut rx = rx;
+            #[allow(clippy::while_let_loop)]
+            loop {
+                match rx.blocking_recv() {
+                    Some(WorkerMsg::Frame(frame)) => enc.push_frame(&frame)?,
+                    Some(WorkerMsg::Finish) | None => break,
+                }
+            }
+            enc.drain_and_finish()
+        });
+
+        Self {
+            sender: tx,
+            join_handle: Some(handle),
+        }
+    }
+
+    /// Queues a frame for encoding.
+    ///
+    /// If the internal channel (capacity 8) is full, this method suspends
+    /// the caller until the worker drains a slot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError::WorkerPanicked`] if the worker thread has
+    /// exited unexpectedly.
+    pub(crate) async fn push(&mut self, frame: F) -> Result<(), EncodeError> {
+        self.sender
+            .send(WorkerMsg::Frame(frame))
+            .await
+            .map_err(|_| EncodeError::WorkerPanicked)
+    }
+
+    /// Signals end-of-stream, flushes remaining frames, and writes the file trailer.
+    ///
+    /// Sends the `Finish` sentinel to the worker, drops the sender to close
+    /// the channel, then waits for the worker thread on a `spawn_blocking`
+    /// thread so the async executor is not blocked.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError`] if encoding fails during flush or if the
+    /// worker thread panicked.
+    pub(crate) async fn finish(self) -> Result<(), EncodeError> {
+        let Self {
+            sender,
+            join_handle,
+        } = self;
+        // Send the Finish sentinel so the worker exits its loop cleanly, then
+        // drop the sender to close the channel.
+        sender
+            .send(WorkerMsg::Finish)
+            .await
+            .map_err(|_| EncodeError::WorkerPanicked)?;
+        drop(sender);
+        if let Some(handle) = join_handle {
+            // Join on a spawn_blocking thread so the async executor is not blocked.
+            tokio::task::spawn_blocking(move || {
+                handle.join().map_err(|_| EncodeError::WorkerPanicked)?
+            })
+            .await
+            .map_err(|_| EncodeError::WorkerPanicked)?
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/crates/ff-encode/src/audio/async_encoder.rs
+++ b/crates/ff-encode/src/audio/async_encoder.rs
@@ -1,15 +1,19 @@
 //! Async audio encoder backed by a bounded `tokio::sync::mpsc` channel.
 
 use ff_format::AudioFrame;
-use tokio::sync::mpsc;
 
 use super::builder::{AudioEncoder, AudioEncoderBuilder};
 use crate::EncodeError;
+use crate::async_encoder::{AsyncEncoder, SyncEncoder};
 
-/// Messages sent from the async front-end to the worker thread.
-enum WorkerMsg {
-    Frame(AudioFrame),
-    Finish,
+impl SyncEncoder<AudioFrame> for AudioEncoder {
+    fn push_frame(&mut self, frame: &AudioFrame) -> Result<(), EncodeError> {
+        self.push(frame)
+    }
+
+    fn drain_and_finish(self) -> Result<(), EncodeError> {
+        self.finish()
+    }
 }
 
 /// Async wrapper around [`AudioEncoder`].
@@ -44,8 +48,7 @@ enum WorkerMsg {
 ///
 /// [`push`]: AsyncAudioEncoder::push
 pub struct AsyncAudioEncoder {
-    sender: mpsc::Sender<WorkerMsg>,
-    join_handle: Option<std::thread::JoinHandle<Result<(), EncodeError>>>,
+    inner: AsyncEncoder<AudioFrame>,
 }
 
 impl std::fmt::Debug for AsyncAudioEncoder {
@@ -67,25 +70,8 @@ impl AsyncAudioEncoder {
     /// the output file cannot be created.
     pub fn from_builder(builder: AudioEncoderBuilder) -> Result<Self, EncodeError> {
         let encoder = builder.build()?;
-        let (tx, rx) = mpsc::channel::<WorkerMsg>(8);
-
-        let handle = std::thread::spawn(move || -> Result<(), EncodeError> {
-            let mut encoder: AudioEncoder = encoder;
-            let mut rx = rx;
-            #[allow(clippy::while_let_loop)]
-            loop {
-                match rx.blocking_recv() {
-                    Some(WorkerMsg::Frame(frame)) => encoder.push(&frame)?,
-                    Some(WorkerMsg::Finish) | None => break,
-                }
-            }
-            // Flush remaining frames and write the container trailer.
-            encoder.finish()
-        });
-
         Ok(Self {
-            sender: tx,
-            join_handle: Some(handle),
+            inner: AsyncEncoder::new(encoder),
         })
     }
 
@@ -99,10 +85,7 @@ impl AsyncAudioEncoder {
     /// Returns [`EncodeError::WorkerPanicked`] if the worker thread has
     /// exited unexpectedly.
     pub async fn push(&mut self, frame: AudioFrame) -> Result<(), EncodeError> {
-        self.sender
-            .send(WorkerMsg::Frame(frame))
-            .await
-            .map_err(|_| EncodeError::WorkerPanicked)
+        self.inner.push(frame).await
     }
 
     /// Signals end-of-stream, flushes remaining frames, and writes the file trailer.
@@ -116,27 +99,7 @@ impl AsyncAudioEncoder {
     /// Returns [`EncodeError`] if encoding fails during flush or if the
     /// worker thread panicked.
     pub async fn finish(self) -> Result<(), EncodeError> {
-        let Self {
-            sender,
-            join_handle,
-        } = self;
-        // Send the Finish sentinel so the worker exits its loop cleanly, then
-        // drop the sender to close the channel.
-        sender
-            .send(WorkerMsg::Finish)
-            .await
-            .map_err(|_| EncodeError::WorkerPanicked)?;
-        drop(sender);
-        if let Some(handle) = join_handle {
-            // Join on a spawn_blocking thread so the async executor is not blocked.
-            tokio::task::spawn_blocking(move || {
-                handle.join().map_err(|_| EncodeError::WorkerPanicked)?
-            })
-            .await
-            .map_err(|_| EncodeError::WorkerPanicked)?
-        } else {
-            Ok(())
-        }
+        self.inner.finish().await
     }
 }
 

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -192,6 +192,8 @@
 //! println!("LGPL compliant: {}", encoder.is_lgpl_compliant());
 //! ```
 
+#[cfg(feature = "tokio")]
+mod async_encoder;
 mod audio;
 mod bitrate;
 mod codec;

--- a/crates/ff-encode/src/video/async_encoder.rs
+++ b/crates/ff-encode/src/video/async_encoder.rs
@@ -1,15 +1,19 @@
 //! Async video encoder backed by a bounded `tokio::sync::mpsc` channel.
 
 use ff_format::VideoFrame;
-use tokio::sync::mpsc;
 
 use super::builder::{VideoEncoder, VideoEncoderBuilder};
 use crate::EncodeError;
+use crate::async_encoder::{AsyncEncoder, SyncEncoder};
 
-/// Messages sent from the async front-end to the worker thread.
-enum WorkerMsg {
-    Frame(VideoFrame),
-    Finish,
+impl SyncEncoder<VideoFrame> for VideoEncoder {
+    fn push_frame(&mut self, frame: &VideoFrame) -> Result<(), EncodeError> {
+        self.push_video(frame)
+    }
+
+    fn drain_and_finish(self) -> Result<(), EncodeError> {
+        self.finish()
+    }
 }
 
 /// Async wrapper around [`VideoEncoder`].
@@ -44,8 +48,7 @@ enum WorkerMsg {
 ///
 /// [`push`]: AsyncVideoEncoder::push
 pub struct AsyncVideoEncoder {
-    sender: mpsc::Sender<WorkerMsg>,
-    join_handle: Option<std::thread::JoinHandle<Result<(), EncodeError>>>,
+    inner: AsyncEncoder<VideoFrame>,
 }
 
 impl std::fmt::Debug for AsyncVideoEncoder {
@@ -67,25 +70,8 @@ impl AsyncVideoEncoder {
     /// the output file cannot be created.
     pub fn from_builder(builder: VideoEncoderBuilder) -> Result<Self, EncodeError> {
         let encoder = builder.build()?;
-        let (tx, rx) = mpsc::channel::<WorkerMsg>(8);
-
-        let handle = std::thread::spawn(move || -> Result<(), EncodeError> {
-            let mut encoder: VideoEncoder = encoder;
-            let mut rx = rx;
-            #[allow(clippy::while_let_loop)]
-            loop {
-                match rx.blocking_recv() {
-                    Some(WorkerMsg::Frame(frame)) => encoder.push_video(&frame)?,
-                    Some(WorkerMsg::Finish) | None => break,
-                }
-            }
-            // Flush remaining frames and write the container trailer.
-            encoder.finish()
-        });
-
         Ok(Self {
-            sender: tx,
-            join_handle: Some(handle),
+            inner: AsyncEncoder::new(encoder),
         })
     }
 
@@ -99,10 +85,7 @@ impl AsyncVideoEncoder {
     /// Returns [`EncodeError::WorkerPanicked`] if the worker thread has
     /// exited unexpectedly.
     pub async fn push(&mut self, frame: VideoFrame) -> Result<(), EncodeError> {
-        self.sender
-            .send(WorkerMsg::Frame(frame))
-            .await
-            .map_err(|_| EncodeError::WorkerPanicked)
+        self.inner.push(frame).await
     }
 
     /// Signals end-of-stream, flushes remaining frames, and writes the file trailer.
@@ -116,27 +99,7 @@ impl AsyncVideoEncoder {
     /// Returns [`EncodeError`] if encoding fails during flush or if the
     /// worker thread panicked.
     pub async fn finish(self) -> Result<(), EncodeError> {
-        let Self {
-            sender,
-            join_handle,
-        } = self;
-        // Send the Finish sentinel so the worker exits its loop cleanly, then
-        // drop the sender to close the channel.
-        sender
-            .send(WorkerMsg::Finish)
-            .await
-            .map_err(|_| EncodeError::WorkerPanicked)?;
-        drop(sender);
-        if let Some(handle) = join_handle {
-            // Join on a spawn_blocking thread so the async executor is not blocked.
-            tokio::task::spawn_blocking(move || {
-                handle.join().map_err(|_| EncodeError::WorkerPanicked)?
-            })
-            .await
-            .map_err(|_| EncodeError::WorkerPanicked)?
-        } else {
-            Ok(())
-        }
+        self.inner.finish().await
     }
 }
 


### PR DESCRIPTION
## Summary

Extracts a generic `AsyncDecoder<T>` helper in `ff-decode` and a generic `AsyncEncoder<F>` + `SyncEncoder<F>` trait in `ff-encode` to eliminate the near-identical copy-paste logic that existed across the four async wrapper files. The public API of all four types (`AsyncVideoDecoder`, `AsyncAudioDecoder`, `AsyncVideoEncoder`, `AsyncAudioEncoder`) is unchanged.

## Changes

- `crates/ff-decode/src/async_decoder.rs` (new): `AsyncDecoder<T>` — generic `Arc<Mutex<T>>` + `spawn_blocking` wrapper with a single `with()` method
- `crates/ff-decode/src/video/async_decoder.rs`: replaced `Arc<Mutex<VideoDecoder>>` field + inline spawn logic with `AsyncDecoder<VideoDecoder>`; `decode_frame` delegates to `self.inner.with(VideoDecoder::decode_one)`
- `crates/ff-decode/src/audio/async_decoder.rs`: same refactor for `AsyncAudioDecoder`
- `crates/ff-encode/src/async_encoder.rs` (new): `SyncEncoder<F>` trait + `AsyncEncoder<F>` — generic `mpsc::channel` + worker thread with `push` / `finish`
- `crates/ff-encode/src/video/async_encoder.rs`: `impl SyncEncoder<VideoFrame> for VideoEncoder`; `AsyncVideoEncoder` now wraps `AsyncEncoder<VideoFrame>`
- `crates/ff-encode/src/audio/async_encoder.rs`: same refactor for `AsyncAudioEncoder`
- Both new modules are gated behind `#[cfg(feature = "tokio")]`

## Related Issues

Resolves #803

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes