### PR TITLE
refactor(ff-stream): deduplicate builder boilerplate with macro_rules macros

### DIFF
--- a/crates/ff-stream/src/builder_macros.rs
+++ b/crates/ff-stream/src/builder_macros.rs
@@ -1,0 +1,211 @@
+//! Internal `macro_rules!` helpers that eliminate builder boilerplate shared
+//! across the frame-push stream output types.
+//!
+//! Loaded via `#[macro_use] mod builder_macros` in `lib.rs` so every stream
+//! output module can invoke the macros without a path prefix.
+
+// ============================================================================
+// impl_frame_push_stream_output!
+// ============================================================================
+
+/// Generates the [`StreamOutput`] implementation for a frame-push stream output
+/// type.
+///
+/// **Assumes** the struct has:
+/// - `inner: Option<T>` — where `T` exposes `push_video`, `push_audio`, and
+///   `flush_and_close` methods.
+/// - `finished: bool`
+///
+/// [`StreamOutput`]: crate::output::StreamOutput
+macro_rules! impl_frame_push_stream_output {
+    ($type:ident) => {
+        impl crate::output::StreamOutput for $type {
+            fn push_video(
+                &mut self,
+                frame: &ff_format::VideoFrame,
+            ) -> Result<(), crate::error::StreamError> {
+                if self.finished {
+                    return Err(crate::error::StreamError::InvalidConfig {
+                        reason: "push_video called after finish()".into(),
+                    });
+                }
+                let inner = self.inner.as_mut().ok_or_else(|| {
+                    crate::error::StreamError::InvalidConfig {
+                        reason: "push_video called before build()".into(),
+                    }
+                })?;
+                inner.push_video(frame)
+            }
+
+            fn push_audio(
+                &mut self,
+                frame: &ff_format::AudioFrame,
+            ) -> Result<(), crate::error::StreamError> {
+                if self.finished {
+                    return Err(crate::error::StreamError::InvalidConfig {
+                        reason: "push_audio called after finish()".into(),
+                    });
+                }
+                let inner = self.inner.as_mut().ok_or_else(|| {
+                    crate::error::StreamError::InvalidConfig {
+                        reason: "push_audio called before build()".into(),
+                    }
+                })?;
+                inner.push_audio(frame);
+                Ok(())
+            }
+
+            fn finish(mut self: Box<Self>) -> Result<(), crate::error::StreamError> {
+                if self.finished {
+                    return Ok(());
+                }
+                self.finished = true;
+                let inner =
+                    self.inner
+                        .take()
+                        .ok_or_else(|| crate::error::StreamError::InvalidConfig {
+                            reason: "finish() called before build()".into(),
+                        })?;
+                inner.flush_and_close();
+                Ok(())
+            }
+        }
+    };
+}
+
+// ============================================================================
+// impl_live_stream_setters!
+// ============================================================================
+
+/// Generates the common setter methods for a live stream output builder.
+///
+/// Two variants select the `audio()` setter body:
+/// - `required_audio` — `sample_rate`/`channels` fields are `u32` (RTMP, SRT).
+/// - `optional_audio` — `sample_rate`/`channels` fields are `Option<u32>`
+///   (`LiveHLS`, `LiveDASH`).
+///
+/// **Assumes** the struct has:
+/// - `video_width: Option<u32>`, `video_height: Option<u32>`, `fps: Option<f64>`
+/// - `video_codec: VideoCodec`, `audio_codec: AudioCodec`
+/// - `video_bitrate: u64`, `audio_bitrate: u64`
+/// - For `required_audio`: `sample_rate: u32`, `channels: u32`
+/// - For `optional_audio`: `sample_rate: Option<u32>`, `channels: Option<u32>`
+macro_rules! impl_live_stream_setters {
+    ($type:ident, required_audio) => {
+        impl $type {
+            /// Set the video encoding parameters (width, height, fps).
+            ///
+            /// This method **must** be called before [`build`](Self::build).
+            #[must_use]
+            pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
+                self.video_width = Some(width);
+                self.video_height = Some(height);
+                self.fps = Some(fps);
+                self
+            }
+
+            /// Set the audio sample rate and channel count.
+            ///
+            /// Defaults: 44 100 Hz, 2 channels (stereo).
+            #[must_use]
+            pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
+                self.sample_rate = sample_rate;
+                self.channels = channels;
+                self
+            }
+
+            /// Set the video codec.
+            ///
+            /// Default: [`VideoCodec::H264`].
+            #[must_use]
+            pub fn video_codec(mut self, codec: ff_format::VideoCodec) -> Self {
+                self.video_codec = codec;
+                self
+            }
+
+            /// Set the audio codec.
+            ///
+            /// Default: [`AudioCodec::Aac`].
+            #[must_use]
+            pub fn audio_codec(mut self, codec: ff_format::AudioCodec) -> Self {
+                self.audio_codec = codec;
+                self
+            }
+
+            /// Set the video encoder target bit rate in bits/s.
+            #[must_use]
+            pub fn video_bitrate(mut self, bitrate: u64) -> Self {
+                self.video_bitrate = bitrate;
+                self
+            }
+
+            /// Set the audio encoder target bit rate in bits/s.
+            ///
+            /// Default: 128 000 (128 kbit/s).
+            #[must_use]
+            pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
+                self.audio_bitrate = bitrate;
+                self
+            }
+        }
+    };
+
+    ($type:ident, optional_audio) => {
+        impl $type {
+            /// Set the video encoding parameters (width, height, fps).
+            ///
+            /// This method **must** be called before [`build`](Self::build).
+            #[must_use]
+            pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
+                self.video_width = Some(width);
+                self.video_height = Some(height);
+                self.fps = Some(fps);
+                self
+            }
+
+            /// Enable audio output with the given sample rate and channel count.
+            ///
+            /// If this method is not called, audio is disabled.
+            #[must_use]
+            pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
+                self.sample_rate = Some(sample_rate);
+                self.channels = Some(channels);
+                self
+            }
+
+            /// Set the video codec.
+            ///
+            /// Default: [`VideoCodec::H264`].
+            #[must_use]
+            pub fn video_codec(mut self, codec: ff_format::VideoCodec) -> Self {
+                self.video_codec = codec;
+                self
+            }
+
+            /// Set the audio codec.
+            ///
+            /// Default: [`AudioCodec::Aac`].
+            #[must_use]
+            pub fn audio_codec(mut self, codec: ff_format::AudioCodec) -> Self {
+                self.audio_codec = codec;
+                self
+            }
+
+            /// Set the video encoder target bit rate in bits/s.
+            #[must_use]
+            pub fn video_bitrate(mut self, bitrate: u64) -> Self {
+                self.video_bitrate = bitrate;
+                self
+            }
+
+            /// Set the audio encoder target bit rate in bits/s.
+            ///
+            /// Default: 128 000 (128 kbit/s).
+            #[must_use]
+            pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
+                self.audio_bitrate = bitrate;
+                self
+            }
+        }
+    };
+}

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -69,6 +69,9 @@
 
 #![warn(missing_docs)]
 
+#[macro_use]
+mod builder_macros;
+
 pub mod abr;
 pub(crate) mod codec_utils;
 pub mod dash;

--- a/crates/ff-stream/src/live_dash.rs
+++ b/crates/ff-stream/src/live_dash.rs
@@ -1,6 +1,6 @@
 //! Frame-push live DASH output.
 //!
-//! [`LiveDashOutput`] receives pre-decoded [`VideoFrame`] / [`AudioFrame`] values
+//! [`LiveDashOutput`] receives pre-decoded [`ff_format::VideoFrame`] / [`ff_format::AudioFrame`] values
 //! from the caller, encodes them with H.264/AAC, and muxes them into a DASH
 //! manifest (`manifest.mpd`) backed by `.m4s` segment files.
 //!
@@ -27,24 +27,19 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ff_format::{AudioCodec, AudioFrame, VideoCodec, VideoFrame};
+use ff_format::{AudioCodec, VideoCodec};
 
 use crate::error::StreamError;
 use crate::live_dash_inner::LiveDashInner;
-use crate::output::StreamOutput;
-
-// ============================================================================
-// LiveDashOutput — safe builder + StreamOutput impl
-// ============================================================================
 
 /// Live DASH output: receives frames and writes a `manifest.mpd` playlist.
 ///
 /// Build with [`LiveDashOutput::new`], chain setter methods, then call
 /// [`build`](Self::build) to open the `FFmpeg` contexts. After `build()`:
 ///
-/// - [`push_video`](Self::push_video) and [`push_audio`](Self::push_audio) encode and
+/// - `push_video` and `push_audio` encode and
 ///   mux frames in real time.
-/// - [`StreamOutput::finish`] flushes all encoders and writes the DASH trailer.
+/// - [`crate::StreamOutput::finish`] flushes all encoders and writes the DASH trailer.
 ///
 /// The output directory is created automatically by `build()` if it does not exist.
 pub struct LiveDashOutput {
@@ -94,69 +89,12 @@ impl LiveDashOutput {
         }
     }
 
-    /// Set the video encoding parameters.
-    ///
-    /// This method **must** be called before [`build`](Self::build).
-    #[must_use]
-    pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
-        self.video_width = Some(width);
-        self.video_height = Some(height);
-        self.fps = Some(fps);
-        self
-    }
-
-    /// Enable audio output with the given sample rate and channel count.
-    ///
-    /// If this method is not called, audio is disabled.
-    #[must_use]
-    pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
-        self.sample_rate = Some(sample_rate);
-        self.channels = Some(channels);
-        self
-    }
-
     /// Set the target DASH segment duration.
     ///
     /// Default: 4 seconds.
     #[must_use]
     pub fn segment_duration(mut self, duration: Duration) -> Self {
         self.segment_duration = duration;
-        self
-    }
-
-    /// Set the video codec.
-    ///
-    /// Default: [`VideoCodec::H264`].
-    #[must_use]
-    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
-        self.video_codec = codec;
-        self
-    }
-
-    /// Set the audio codec.
-    ///
-    /// Default: [`AudioCodec::Aac`].
-    #[must_use]
-    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
-        self.audio_codec = codec;
-        self
-    }
-
-    /// Set the video encoder target bit rate in bits/s.
-    ///
-    /// Default: 2 000 000 (2 Mbit/s).
-    #[must_use]
-    pub fn video_bitrate(mut self, bitrate: u64) -> Self {
-        self.video_bitrate = bitrate;
-        self
-    }
-
-    /// Set the audio encoder target bit rate in bits/s.
-    ///
-    /// Default: 128 000 (128 kbit/s).
-    #[must_use]
-    pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
-        self.audio_bitrate = bitrate;
         self
     }
 
@@ -224,61 +162,8 @@ impl LiveDashOutput {
     }
 }
 
-// ============================================================================
-// StreamOutput impl
-// ============================================================================
-
-impl StreamOutput for LiveDashOutput {
-    fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_video called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_video called before build()".into(),
-            })?;
-        inner.push_video(frame)
-    }
-
-    fn push_audio(&mut self, frame: &AudioFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_audio called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_audio called before build()".into(),
-            })?;
-        inner.push_audio(frame);
-        Ok(())
-    }
-
-    fn finish(mut self: Box<Self>) -> Result<(), StreamError> {
-        if self.finished {
-            return Ok(());
-        }
-        self.finished = true;
-        let inner = self
-            .inner
-            .take()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "finish() called before build()".into(),
-            })?;
-        inner.flush_and_close();
-        Ok(())
-    }
-}
-
-// ============================================================================
-// Unit tests
-// ============================================================================
+impl_live_stream_setters!(LiveDashOutput, optional_audio);
+impl_frame_push_stream_output!(LiveDashOutput);
 
 #[cfg(test)]
 mod tests {

--- a/crates/ff-stream/src/live_hls.rs
+++ b/crates/ff-stream/src/live_hls.rs
@@ -1,6 +1,6 @@
 //! Frame-push live HLS output.
 //!
-//! [`LiveHlsOutput`] receives pre-decoded [`VideoFrame`] / [`AudioFrame`] values
+//! [`LiveHlsOutput`] receives pre-decoded [`ff_format::VideoFrame`] / [`ff_format::AudioFrame`] values
 //! from the caller, encodes them with H.264/AAC, and muxes them into a sliding-
 //! window HLS playlist (`index.m3u8`) backed by `.ts` segment files.
 //!
@@ -28,25 +28,20 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ff_format::{AudioCodec, AudioFrame, VideoCodec, VideoFrame};
+use ff_format::{AudioCodec, VideoCodec};
 
 use crate::error::StreamError;
 use crate::hls::HlsSegmentFormat;
 use crate::live_hls_inner::LiveHlsInner;
-use crate::output::StreamOutput;
-
-// ============================================================================
-// LiveHlsOutput — safe builder + StreamOutput impl
-// ============================================================================
 
 /// Live HLS output: receives frames and writes a sliding-window `.m3u8` playlist.
 ///
 /// Build with [`LiveHlsOutput::new`], chain setter methods, then call
 /// [`build`](Self::build) to open the `FFmpeg` contexts. After `build()`:
 ///
-/// - [`push_video`](Self::push_video) and [`push_audio`](Self::push_audio) encode and
+/// - `push_video` and `push_audio` encode and
 ///   mux frames in real time.
-/// - [`StreamOutput::finish`] flushes all encoders and writes the HLS trailer.
+/// - [`crate::StreamOutput::finish`] flushes all encoders and writes the HLS trailer.
 ///
 /// The output directory is created automatically by `build()` if it does not exist.
 pub struct LiveHlsOutput {
@@ -100,27 +95,6 @@ impl LiveHlsOutput {
         }
     }
 
-    /// Set the video encoding parameters.
-    ///
-    /// This method **must** be called before [`build`](Self::build).
-    #[must_use]
-    pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
-        self.video_width = Some(width);
-        self.video_height = Some(height);
-        self.fps = Some(fps);
-        self
-    }
-
-    /// Enable audio output with the given sample rate and channel count.
-    ///
-    /// If this method is not called, audio is disabled.
-    #[must_use]
-    pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
-        self.sample_rate = Some(sample_rate);
-        self.channels = Some(channels);
-        self
-    }
-
     /// Set the target HLS segment duration.
     ///
     /// Default: 6 seconds.
@@ -136,42 +110,6 @@ impl LiveHlsOutput {
     #[must_use]
     pub fn playlist_size(mut self, size: u32) -> Self {
         self.playlist_size = size;
-        self
-    }
-
-    /// Set the video codec.
-    ///
-    /// Default: [`VideoCodec::H264`].
-    #[must_use]
-    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
-        self.video_codec = codec;
-        self
-    }
-
-    /// Set the audio codec.
-    ///
-    /// Default: [`AudioCodec::Aac`].
-    #[must_use]
-    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
-        self.audio_codec = codec;
-        self
-    }
-
-    /// Set the video encoder target bit rate in bits/s.
-    ///
-    /// Default: 2 000 000 (2 Mbit/s).
-    #[must_use]
-    pub fn video_bitrate(mut self, bitrate: u64) -> Self {
-        self.video_bitrate = bitrate;
-        self
-    }
-
-    /// Set the audio encoder target bit rate in bits/s.
-    ///
-    /// Default: 128 000 (128 kbit/s).
-    #[must_use]
-    pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
-        self.audio_bitrate = bitrate;
         self
     }
 
@@ -251,61 +189,8 @@ impl LiveHlsOutput {
     }
 }
 
-// ============================================================================
-// StreamOutput impl
-// ============================================================================
-
-impl StreamOutput for LiveHlsOutput {
-    fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_video called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_video called before build()".into(),
-            })?;
-        inner.push_video(frame)
-    }
-
-    fn push_audio(&mut self, frame: &AudioFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_audio called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_audio called before build()".into(),
-            })?;
-        inner.push_audio(frame);
-        Ok(())
-    }
-
-    fn finish(mut self: Box<Self>) -> Result<(), StreamError> {
-        if self.finished {
-            return Ok(());
-        }
-        self.finished = true;
-        let inner = self
-            .inner
-            .take()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "finish() called before build()".into(),
-            })?;
-        inner.flush_and_close();
-        Ok(())
-    }
-}
-
-// ============================================================================
-// Unit tests
-// ============================================================================
+impl_live_stream_setters!(LiveHlsOutput, optional_audio);
+impl_frame_push_stream_output!(LiveHlsOutput);
 
 #[cfg(test)]
 mod tests {

--- a/crates/ff-stream/src/rtmp.rs
+++ b/crates/ff-stream/src/rtmp.rs
@@ -1,6 +1,6 @@
 //! Frame-push RTMP output.
 //!
-//! [`RtmpOutput`] receives pre-decoded [`VideoFrame`] / [`AudioFrame`] values
+//! [`RtmpOutput`] receives pre-decoded [`ff_format::VideoFrame`] / [`ff_format::AudioFrame`] values
 //! from the caller, encodes them with H.264/AAC, and pushes the stream to an
 //! RTMP ingest endpoint using `FFmpeg`'s built-in RTMP support.
 //!
@@ -24,15 +24,10 @@
 //! Box::new(out).finish()?;
 //! ```
 
-use ff_format::{AudioCodec, AudioFrame, VideoCodec, VideoFrame};
+use ff_format::{AudioCodec, VideoCodec};
 
 use crate::error::StreamError;
-use crate::output::StreamOutput;
 use crate::rtmp_inner::RtmpInner;
-
-// ============================================================================
-// RtmpOutput — safe builder + StreamOutput impl
-// ============================================================================
 
 /// Live RTMP output: encodes frames and pushes them to an RTMP ingest endpoint.
 ///
@@ -40,9 +35,9 @@ use crate::rtmp_inner::RtmpInner;
 /// [`build`](Self::build) to open the `FFmpeg` context and establish the
 /// RTMP connection. After `build()`:
 ///
-/// - [`push_video`](Self::push_video) and [`push_audio`](Self::push_audio) encode and
+/// - `push_video` and `push_audio` encode and
 ///   transmit frames in real time.
-/// - [`StreamOutput::finish`] flushes all encoders, sends the FLV end-of-stream
+/// - [`crate::StreamOutput::finish`] flushes all encoders, sends the FLV end-of-stream
 ///   marker, and closes the RTMP connection.
 ///
 /// RTMP/FLV requires H.264 video and AAC audio; [`build`](Self::build) returns
@@ -91,67 +86,6 @@ impl RtmpOutput {
             inner: None,
             finished: false,
         }
-    }
-
-    /// Set the video encoding parameters.
-    ///
-    /// This method **must** be called before [`build`](Self::build).
-    #[must_use]
-    pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
-        self.video_width = Some(width);
-        self.video_height = Some(height);
-        self.fps = Some(fps);
-        self
-    }
-
-    /// Set the audio sample rate and channel count.
-    ///
-    /// Defaults: 44 100 Hz, 2 channels (stereo).
-    #[must_use]
-    pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
-        self.sample_rate = sample_rate;
-        self.channels = channels;
-        self
-    }
-
-    /// Set the video codec.
-    ///
-    /// Default: [`VideoCodec::H264`]. Only `H264` is accepted by
-    /// [`build`](Self::build); any other value returns
-    /// [`StreamError::UnsupportedCodec`].
-    #[must_use]
-    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
-        self.video_codec = codec;
-        self
-    }
-
-    /// Set the audio codec.
-    ///
-    /// Default: [`AudioCodec::Aac`]. Only `Aac` is accepted by
-    /// [`build`](Self::build); any other value returns
-    /// [`StreamError::UnsupportedCodec`].
-    #[must_use]
-    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
-        self.audio_codec = codec;
-        self
-    }
-
-    /// Set the video encoder target bit rate in bits/s.
-    ///
-    /// Default: 4 000 000 (4 Mbit/s).
-    #[must_use]
-    pub fn video_bitrate(mut self, bitrate: u64) -> Self {
-        self.video_bitrate = bitrate;
-        self
-    }
-
-    /// Set the audio encoder target bit rate in bits/s.
-    ///
-    /// Default: 128 000 (128 kbit/s).
-    #[must_use]
-    pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
-        self.audio_bitrate = bitrate;
-        self
     }
 
     /// Open the `FFmpeg` context and establish the RTMP connection.
@@ -217,61 +151,8 @@ impl RtmpOutput {
     }
 }
 
-// ============================================================================
-// StreamOutput impl
-// ============================================================================
-
-impl StreamOutput for RtmpOutput {
-    fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_video called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_video called before build()".into(),
-            })?;
-        inner.push_video(frame)
-    }
-
-    fn push_audio(&mut self, frame: &AudioFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_audio called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_audio called before build()".into(),
-            })?;
-        inner.push_audio(frame);
-        Ok(())
-    }
-
-    fn finish(mut self: Box<Self>) -> Result<(), StreamError> {
-        if self.finished {
-            return Ok(());
-        }
-        self.finished = true;
-        let inner = self
-            .inner
-            .take()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "finish() called before build()".into(),
-            })?;
-        inner.flush_and_close();
-        Ok(())
-    }
-}
-
-// ============================================================================
-// Unit tests
-// ============================================================================
+impl_live_stream_setters!(RtmpOutput, required_audio);
+impl_frame_push_stream_output!(RtmpOutput);
 
 #[cfg(test)]
 mod tests {

--- a/crates/ff-stream/src/srt_output.rs
+++ b/crates/ff-stream/src/srt_output.rs
@@ -1,6 +1,6 @@
 //! Frame-push SRT output.
 //!
-//! [`SrtOutput`] receives pre-decoded [`VideoFrame`] / [`AudioFrame`] values
+//! [`SrtOutput`] receives pre-decoded [`ff_format::VideoFrame`] / [`ff_format::AudioFrame`] values
 //! from the caller, encodes them with H.264/AAC, and pushes the MPEG-TS
 //! stream to an SRT destination using `FFmpeg`'s built-in SRT support.
 //!
@@ -26,15 +26,10 @@
 //! Box::new(out).finish()?;
 //! ```
 
-use ff_format::{AudioCodec, AudioFrame, VideoCodec, VideoFrame};
+use ff_format::{AudioCodec, VideoCodec};
 
 use crate::error::StreamError;
-use crate::output::StreamOutput;
 use crate::srt_output_inner::SrtInner;
-
-// ============================================================================
-// SrtOutput — safe builder + StreamOutput impl
-// ============================================================================
 
 /// Live SRT output: encodes frames as MPEG-TS and pushes them to an SRT
 /// destination.
@@ -43,9 +38,9 @@ use crate::srt_output_inner::SrtInner;
 /// [`build`](Self::build) to open the `FFmpeg` context and establish the SRT
 /// connection. After `build()`:
 ///
-/// - [`push_video`](Self::push_video) and [`push_audio`](Self::push_audio)
+/// - `push_video` and `push_audio`
 ///   encode and transmit frames in real time.
-/// - [`StreamOutput::finish`] flushes all encoders, writes the MPEG-TS
+/// - [`crate::StreamOutput::finish`] flushes all encoders, writes the MPEG-TS
 ///   end-of-stream, and closes the SRT connection.
 ///
 /// The SRT transport uses MPEG-TS as the container (H.264 video + AAC audio).
@@ -99,67 +94,6 @@ impl SrtOutput {
             inner: None,
             finished: false,
         }
-    }
-
-    /// Set the video encoding parameters.
-    ///
-    /// This method **must** be called before [`build`](Self::build).
-    #[must_use]
-    pub fn video(mut self, width: u32, height: u32, fps: f64) -> Self {
-        self.video_width = Some(width);
-        self.video_height = Some(height);
-        self.fps = Some(fps);
-        self
-    }
-
-    /// Set the audio sample rate and channel count.
-    ///
-    /// Defaults: 44 100 Hz, 2 channels (stereo).
-    #[must_use]
-    pub fn audio(mut self, sample_rate: u32, channels: u32) -> Self {
-        self.sample_rate = sample_rate;
-        self.channels = channels;
-        self
-    }
-
-    /// Set the video codec.
-    ///
-    /// Default: [`VideoCodec::H264`]. Only `H264` is accepted by
-    /// [`build`](Self::build); any other value returns
-    /// [`StreamError::UnsupportedCodec`].
-    #[must_use]
-    pub fn video_codec(mut self, codec: VideoCodec) -> Self {
-        self.video_codec = codec;
-        self
-    }
-
-    /// Set the audio codec.
-    ///
-    /// Default: [`AudioCodec::Aac`]. Only `Aac` is accepted by
-    /// [`build`](Self::build); any other value returns
-    /// [`StreamError::UnsupportedCodec`].
-    #[must_use]
-    pub fn audio_codec(mut self, codec: AudioCodec) -> Self {
-        self.audio_codec = codec;
-        self
-    }
-
-    /// Set the video encoder target bit rate in bits/s.
-    ///
-    /// Default: 4 000 000 (4 Mbit/s).
-    #[must_use]
-    pub fn video_bitrate(mut self, bitrate: u64) -> Self {
-        self.video_bitrate = bitrate;
-        self
-    }
-
-    /// Set the audio encoder target bit rate in bits/s.
-    ///
-    /// Default: 128 000 (128 kbit/s).
-    #[must_use]
-    pub fn audio_bitrate(mut self, bitrate: u64) -> Self {
-        self.audio_bitrate = bitrate;
-        self
     }
 
     /// Open the `FFmpeg` MPEG-TS context and establish the SRT connection.
@@ -235,61 +169,8 @@ impl SrtOutput {
     }
 }
 
-// ============================================================================
-// StreamOutput impl
-// ============================================================================
-
-impl StreamOutput for SrtOutput {
-    fn push_video(&mut self, frame: &VideoFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_video called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_video called before build()".into(),
-            })?;
-        inner.push_video(frame)
-    }
-
-    fn push_audio(&mut self, frame: &AudioFrame) -> Result<(), StreamError> {
-        if self.finished {
-            return Err(StreamError::InvalidConfig {
-                reason: "push_audio called after finish()".into(),
-            });
-        }
-        let inner = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "push_audio called before build()".into(),
-            })?;
-        inner.push_audio(frame);
-        Ok(())
-    }
-
-    fn finish(mut self: Box<Self>) -> Result<(), StreamError> {
-        if self.finished {
-            return Ok(());
-        }
-        self.finished = true;
-        let inner = self
-            .inner
-            .take()
-            .ok_or_else(|| StreamError::InvalidConfig {
-                reason: "finish() called before build()".into(),
-            })?;
-        inner.flush_and_close();
-        Ok(())
-    }
-}
-
-// ============================================================================
-// Unit tests
-// ============================================================================
+impl_live_stream_setters!(SrtOutput, required_audio);
+impl_frame_push_stream_output!(SrtOutput);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Six ff-stream output types (`RtmpOutput`, `SrtOutput`, `LiveHlsOutput`, `LiveDashOutput`, and the ABR ladder outputs) each contained near-identical setter methods (`video`, `audio`, `video_codec`, `audio_codec`, `video_bitrate`, `audio_bitrate`) and a full `StreamOutput` trait implementation. This PR extracts that repeated code into two `macro_rules!` macros, eliminating ~460 lines of duplication.

## Changes

- Add `crates/ff-stream/src/builder_macros.rs` with two macros:
  - `impl_live_stream_setters!(Type, required_audio | optional_audio)` — generates the 6 builder setter methods; the two variants handle structs where audio fields are `u32` (RTMP, SRT) vs `Option<u32>` (LiveHLS, LiveDASH)
  - `impl_frame_push_stream_output!(Type)` — generates the `StreamOutput` trait impl with `push_video`, `push_audio`, and `finish`
- Apply both macros to `rtmp.rs`, `srt_output.rs`, `live_hls.rs`, and `live_dash.rs`, removing the hand-written duplicates
- Add `#[macro_use] mod builder_macros` to `lib.rs` so the macros are available crate-wide

## Related Issues

Resolves #806

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes