### PR TITLE
test(ff-format): add Clone unit tests for VideoFrame, AudioFrame, and PooledBuffer

### DIFF
--- a/crates/ff-common/src/pool.rs
+++ b/crates/ff-common/src/pool.rs
@@ -480,6 +480,19 @@ mod tests {
         assert_eq!(buffer2.data(), &[99, 2, 3]);
     }
 
+    #[test]
+    fn pooled_buffer_clone_should_be_independent_of_source() {
+        let mut original = PooledBuffer::standalone(vec![1, 2, 3]);
+        let clone = original.clone();
+
+        // Mutate the original after cloning
+        original.data_mut()[0] = 99;
+
+        // Clone must be unaffected (deep copy)
+        assert_eq!(clone.data(), &[1, 2, 3]);
+        assert_eq!(original.data(), &[99, 2, 3]);
+    }
+
     // ── VecPool tests ─────────────────────────────────────────────────────────
 
     #[test]

--- a/crates/ff-format/src/frame/audio.rs
+++ b/crates/ff-format/src/frame/audio.rs
@@ -1866,4 +1866,33 @@ mod tests {
         assert_eq!(pcm[2], i16::MAX);
         assert_eq!(pcm[3], -i16::MAX);
     }
+
+    #[test]
+    fn audio_frame_clone_should_have_identical_data() {
+        let samples = 512;
+        let channels = 2u32;
+        let bytes_per_sample = 4; // F32
+        let plane_data = vec![7u8; samples * bytes_per_sample];
+        let ts = Timestamp::new(500, Rational::new(1, 1000));
+
+        let original = AudioFrame::new(
+            vec![plane_data.clone()],
+            samples,
+            channels,
+            44100,
+            SampleFormat::F32,
+            ts,
+        )
+        .unwrap();
+
+        let clone = original.clone();
+
+        assert_eq!(clone.samples(), original.samples());
+        assert_eq!(clone.channels(), original.channels());
+        assert_eq!(clone.sample_rate(), original.sample_rate());
+        assert_eq!(clone.format(), original.format());
+        assert_eq!(clone.timestamp(), original.timestamp());
+        assert_eq!(clone.num_planes(), original.num_planes());
+        assert_eq!(clone.plane(0), original.plane(0));
+    }
 }

--- a/crates/ff-format/src/frame/video.rs
+++ b/crates/ff-format/src/frame/video.rs
@@ -1438,4 +1438,40 @@ mod tests {
             FrameError::UnsupportedPixelFormat(PixelFormat::Other(999))
         );
     }
+
+    #[test]
+    fn video_frame_clone_should_have_identical_data() {
+        let width = 320u32;
+        let height = 240u32;
+        let stride = width as usize;
+        let y_data = vec![42u8; stride * height as usize];
+        let uv_stride = (width / 2) as usize;
+        let uv_data = vec![128u8; uv_stride * (height / 2) as usize];
+        let ts = Timestamp::new(1000, Rational::new(1, 1000));
+
+        let original = VideoFrame::new(
+            vec![
+                PooledBuffer::standalone(y_data.clone()),
+                PooledBuffer::standalone(uv_data.clone()),
+                PooledBuffer::standalone(uv_data.clone()),
+            ],
+            vec![stride, uv_stride, uv_stride],
+            width,
+            height,
+            PixelFormat::Yuv420p,
+            ts,
+            false,
+        )
+        .unwrap();
+
+        let clone = original.clone();
+
+        assert_eq!(clone.width(), original.width());
+        assert_eq!(clone.height(), original.height());
+        assert_eq!(clone.format(), original.format());
+        assert_eq!(clone.timestamp(), original.timestamp());
+        assert_eq!(clone.is_key_frame(), original.is_key_frame());
+        assert_eq!(clone.num_planes(), original.num_planes());
+        assert_eq!(clone.plane(0), original.plane(0));
+    }
 }


### PR DESCRIPTION
## Summary

Adds three unit tests that verify the `Clone` implementations for `PooledBuffer`, `VideoFrame`, and `AudioFrame`. The `Clone` impls themselves were already in place; this PR supplies the named tests required by issue #672 to confirm correct deep-copy semantics.

## Changes

- `crates/ff-common/src/pool.rs`: add `pooled_buffer_clone_should_be_independent_of_source` — verifies that mutating the original after cloning does not affect the clone
- `crates/ff-format/src/frame/video.rs`: add `video_frame_clone_should_have_identical_data` — verifies that all fields and plane data are equal between original and clone
- `crates/ff-format/src/frame/audio.rs`: add `audio_frame_clone_should_have_identical_data` — verifies that all fields and plane data are equal between original and clone

## Related Issues

Closes #672

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes