### PR TITLE
feat(ff-pipeline): add Timeline, TimelineBuilder, and pipeline error variants

### DIFF
--- a/crates/ff-pipeline/src/error.rs
+++ b/crates/ff-pipeline/src/error.rs
@@ -77,6 +77,24 @@ pub enum PipelineError {
     /// decodable frame exists at that point.
     #[error("no frame available at the requested position")]
     FrameNotAvailable,
+
+    /// A `Timeline::render()` call failed for a structural reason not covered
+    /// by a nested variant (e.g. [`PipelineError::Encode`] or [`PipelineError::Filter`]).
+    #[error("timeline render failed: {reason}")]
+    TimelineRenderFailed {
+        /// Human-readable description of the failure.
+        reason: String,
+    },
+
+    /// A clip's source file could not be found on disk.
+    ///
+    /// Returned by [`TimelineBuilder::build()`](crate::TimelineBuilder::build) and
+    /// `Timeline::render()` when `Clip.source` does not exist.
+    #[error("clip source not found: path={path}")]
+    ClipNotFound {
+        /// Absolute or relative path that could not be found.
+        path: String,
+    },
 }
 
 #[cfg(test)]
@@ -199,5 +217,24 @@ mod tests {
         let inner = std::io::Error::new(std::io::ErrorKind::Other, "some error");
         let err: PipelineError = inner.into();
         assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn pipeline_error_timeline_render_failed_should_display_correctly() {
+        let err = PipelineError::TimelineRenderFailed {
+            reason: "not implemented".to_string(),
+        };
+        assert_eq!(err.to_string(), "timeline render failed: not implemented");
+    }
+
+    #[test]
+    fn pipeline_error_clip_not_found_should_include_path_in_message() {
+        let err = PipelineError::ClipNotFound {
+            path: "/tmp/missing.mp4".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "clip source not found: path=/tmp/missing.mp4"
+        );
     }
 }

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -58,6 +58,7 @@ pub mod error;
 pub mod pipeline;
 pub mod progress;
 pub mod thumbnail;
+pub mod timeline;
 pub mod video_pipeline;
 
 pub use audio_pipeline::AudioPipeline;
@@ -67,4 +68,5 @@ pub use error::PipelineError;
 pub use pipeline::{Pipeline, PipelineBuilder};
 pub use progress::{Progress, ProgressCallback};
 pub use thumbnail::ThumbnailPipeline;
+pub use timeline::{Timeline, TimelineBuilder};
 pub use video_pipeline::VideoPipeline;

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -1,0 +1,256 @@
+//! Timeline data type for multi-track composition.
+//!
+//! This module provides [`Timeline`] and [`TimelineBuilder`], which represent
+//! an ordered layout of [`Clip`] instances across video and audio tracks.
+//! `Timeline` holds no `FFmpeg` context; all rendering is done in
+//! [`Timeline::render()`].
+
+use std::path::Path;
+
+use ff_decode::VideoDecoder;
+
+use crate::clip::Clip;
+use crate::encoder_config::EncoderConfig;
+use crate::error::PipelineError;
+
+/// An ordered layout of [`Clip`] instances across video and audio tracks.
+///
+/// `Timeline` is a plain Rust value type — it holds no `FFmpeg` context.
+/// All rendering happens in [`Timeline::render()`].
+///
+/// # Construction
+///
+/// Use [`Timeline::builder()`] to obtain a [`TimelineBuilder`].
+///
+/// # Examples
+///
+/// ```
+/// use ff_pipeline::{Clip, Timeline};
+/// use std::time::Duration;
+///
+/// let clip = Clip::new("intro.mp4")
+///     .trim(Duration::from_secs(0), Duration::from_secs(5));
+///
+/// let result = Timeline::builder()
+///     .canvas(1920, 1080)
+///     .frame_rate(30.0)
+///     .video_track(vec![clip])
+///     .build();
+///
+/// assert!(result.is_ok());
+/// ```
+#[derive(Debug, Clone)]
+pub struct Timeline {
+    pub(crate) canvas_width: u32,
+    pub(crate) canvas_height: u32,
+    pub(crate) frame_rate: f64,
+    /// `video_tracks[track_idx][clip_idx]`; track 0 = bottom layer.
+    pub(crate) video_tracks: Vec<Vec<Clip>>,
+    pub(crate) audio_tracks: Vec<Vec<Clip>>,
+}
+
+impl Timeline {
+    /// Returns a new [`TimelineBuilder`].
+    pub fn builder() -> TimelineBuilder {
+        TimelineBuilder::new()
+    }
+
+    /// Returns the canvas width in pixels.
+    pub fn canvas_width(&self) -> u32 {
+        self.canvas_width
+    }
+
+    /// Returns the canvas height in pixels.
+    pub fn canvas_height(&self) -> u32 {
+        self.canvas_height
+    }
+
+    /// Returns the frame rate in frames per second.
+    pub fn frame_rate(&self) -> f64 {
+        self.frame_rate
+    }
+
+    /// Returns a slice of all video tracks.
+    pub fn video_tracks(&self) -> &[Vec<Clip>] {
+        &self.video_tracks
+    }
+
+    /// Returns a slice of all audio tracks.
+    pub fn audio_tracks(&self) -> &[Vec<Clip>] {
+        &self.audio_tracks
+    }
+
+    /// Renders the timeline to an output file.
+    ///
+    /// # Errors
+    ///
+    /// - [`PipelineError::ClipNotFound`] — a clip's source file is missing
+    /// - [`PipelineError::Encode`] — encoder failure
+    /// - [`PipelineError::Filter`] — filter graph construction failure
+    /// - [`PipelineError::TimelineRenderFailed`] — other structural failure
+    pub fn render(
+        self,
+        _output: impl AsRef<Path>,
+        _config: EncoderConfig,
+    ) -> Result<(), PipelineError> {
+        // TODO(#675): implement timeline rendering
+        Err(PipelineError::TimelineRenderFailed {
+            reason: "not yet implemented".to_string(),
+        })
+    }
+}
+
+/// Builder for [`Timeline`].
+///
+/// Obtain one via [`Timeline::builder()`].
+pub struct TimelineBuilder {
+    canvas_width: Option<u32>,
+    canvas_height: Option<u32>,
+    frame_rate: Option<f64>,
+    video_tracks: Vec<Vec<Clip>>,
+    audio_tracks: Vec<Vec<Clip>>,
+}
+
+impl Default for TimelineBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TimelineBuilder {
+    /// Creates a new builder with no tracks and no canvas/frame-rate set.
+    pub fn new() -> Self {
+        Self {
+            canvas_width: None,
+            canvas_height: None,
+            frame_rate: None,
+            video_tracks: Vec::new(),
+            audio_tracks: Vec::new(),
+        }
+    }
+
+    /// Sets the output canvas dimensions in pixels.
+    #[must_use]
+    pub fn canvas(self, width: u32, height: u32) -> Self {
+        Self {
+            canvas_width: Some(width),
+            canvas_height: Some(height),
+            ..self
+        }
+    }
+
+    /// Sets the output frame rate in frames per second.
+    #[must_use]
+    pub fn frame_rate(self, fps: f64) -> Self {
+        Self {
+            frame_rate: Some(fps),
+            ..self
+        }
+    }
+
+    /// Appends a video track. Track 0 (first call) is the bottom layer.
+    #[must_use]
+    pub fn video_track(self, clips: Vec<Clip>) -> Self {
+        let mut video_tracks = self.video_tracks;
+        video_tracks.push(clips);
+        Self {
+            video_tracks,
+            ..self
+        }
+    }
+
+    /// Appends an audio track.
+    #[must_use]
+    pub fn audio_track(self, clips: Vec<Clip>) -> Self {
+        let mut audio_tracks = self.audio_tracks;
+        audio_tracks.push(clips);
+        Self {
+            audio_tracks,
+            ..self
+        }
+    }
+
+    /// Builds the [`Timeline`].
+    ///
+    /// # Errors
+    ///
+    /// - [`PipelineError::NoInput`] — both track lists are empty
+    /// - [`PipelineError::ClipNotFound`] — canvas/fps auto-probe needed but
+    ///   the first video clip's source file does not exist
+    /// - [`PipelineError::Decode`] — the first video clip could not be opened
+    pub fn build(self) -> Result<Timeline, PipelineError> {
+        if self.video_tracks.is_empty() && self.audio_tracks.is_empty() {
+            return Err(PipelineError::NoInput);
+        }
+
+        let (canvas_width, canvas_height, frame_rate) = self.resolve_canvas_and_fps()?;
+
+        Ok(Timeline {
+            canvas_width,
+            canvas_height,
+            frame_rate,
+            video_tracks: self.video_tracks,
+            audio_tracks: self.audio_tracks,
+        })
+    }
+
+    /// Resolves canvas dimensions and frame rate.
+    ///
+    /// When all three values are explicitly set, returns them directly.
+    /// Otherwise probes the first video clip with `VideoDecoder`. For
+    /// audio-only timelines (no video tracks) falls back to 1920×1080 @ 30 fps.
+    fn resolve_canvas_and_fps(&self) -> Result<(u32, u32, f64), PipelineError> {
+        let need_probe = self.canvas_width.is_none()
+            || self.canvas_height.is_none()
+            || self.frame_rate.is_none();
+
+        if need_probe && let Some(first_clip) = self.video_tracks.first().and_then(|t| t.first()) {
+            if !first_clip.source.exists() {
+                return Err(PipelineError::ClipNotFound {
+                    path: first_clip.source.to_string_lossy().into_owned(),
+                });
+            }
+            let vdec = VideoDecoder::open(&first_clip.source).build()?;
+            let w = self.canvas_width.unwrap_or_else(|| vdec.width());
+            let h = self.canvas_height.unwrap_or_else(|| vdec.height());
+            let fps = self.frame_rate.unwrap_or_else(|| vdec.frame_rate());
+            return Ok((w, h, fps));
+        }
+
+        // All values explicit, or no video tracks (audio-only) — fall back for absent values.
+        Ok((
+            self.canvas_width.unwrap_or(1920),
+            self.canvas_height.unwrap_or(1080),
+            self.frame_rate.unwrap_or(30.0),
+        ))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeline_builder_should_err_when_no_tracks() {
+        let result = Timeline::builder().build();
+        assert!(matches!(result, Err(PipelineError::NoInput)));
+    }
+
+    #[test]
+    fn timeline_builder_should_succeed_with_video_track() {
+        let clip = Clip::new("video.mp4");
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![clip])
+            .build()
+            .unwrap();
+
+        assert_eq!(timeline.canvas_width, 1920);
+        assert_eq!(timeline.canvas_height, 1080);
+        assert!((timeline.frame_rate - 30.0).abs() < f64::EPSILON);
+        assert_eq!(timeline.video_tracks.len(), 1);
+        assert!(timeline.audio_tracks.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Timeline` and `TimelineBuilder` to `ff-pipeline`, representing an ordered layout of `Clip` instances across video and audio tracks. Also adds the `ClipNotFound` and `TimelineRenderFailed` error variants to `PipelineError` (issue #826), which are required by `TimelineBuilder::build()` and `Timeline::render()`. `Timeline::render()` is left as a stub pending issue #675.

## Changes

- `crates/ff-pipeline/src/error.rs`: add `TimelineRenderFailed { reason }` and `ClipNotFound { path }` variants with doc-comments and display tests
- `crates/ff-pipeline/src/timeline.rs` (new): `Timeline` struct with `#[derive(Debug, Clone)]`, five accessor methods, and `render()` stub (TODO #675); `TimelineBuilder` with consuming builder methods (`canvas`, `frame_rate`, `video_track`, `audio_track`, `build()`); `build()` auto-probes canvas/fps from the first video clip via `VideoDecoder` when not explicitly set, following the same pattern as `VideoPipeline`; two unit tests
- `crates/ff-pipeline/src/lib.rs`: expose `pub mod timeline` and `pub use timeline::{Timeline, TimelineBuilder}`

## Related Issues

Closes #674
Closes #826

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes