### PR TITLE
feat(ff-filter): add per-track audio effect chain to AudioTrack

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -254,8 +254,8 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    AudioTrack, DrawTextOptions, EqBand, FilterError, FilterGraph, FilterGraphBuilder, HwAccel,
-    MultiTrackAudioMixer, MultiTrackComposer, Rgb, ScaleAlgorithm, ToneMap, VideoLayer,
+    AudioTrack, DrawTextOptions, EqBand, FilterError, FilterGraph, FilterGraphBuilder, FilterStep,
+    HwAccel, MultiTrackAudioMixer, MultiTrackComposer, Rgb, ScaleAlgorithm, ToneMap, VideoLayer,
     XfadeTransition, YadifMode,
 };
 

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -95,7 +95,7 @@ pub(super) unsafe fn create_hw_filter(
 ///
 /// `graph` and `prev_ctx` must be valid pointers owned by the same
 /// `AVFilterGraph`.
-pub(super) unsafe fn add_and_link_step(
+pub(crate) unsafe fn add_and_link_step(
     graph: *mut ff_sys::AVFilterGraph,
     prev_ctx: *mut ff_sys::AVFilterContext,
     step: &FilterStep,

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -17,6 +17,8 @@ mod convert;
 mod normalize;
 mod push_pull;
 
+pub(crate) use build::add_and_link_step;
+
 use std::ptr::NonNull;
 
 use ff_format::AudioFrame;

--- a/crates/ff-filter/src/graph/composition.rs
+++ b/crates/ff-filter/src/graph/composition.rs
@@ -25,6 +25,7 @@ use ff_format::ChannelLayout;
 
 use crate::error::FilterError;
 use crate::filter_inner::FilterGraphInner;
+use crate::graph::filter_step::FilterStep;
 use crate::graph::graph::FilterGraph;
 use crate::graph::types::Rgb;
 
@@ -526,6 +527,14 @@ pub struct AudioTrack {
     pub pan: f32,
     /// Start offset on the output timeline (`Duration::ZERO` = at the beginning).
     pub time_offset: Duration,
+    /// Ordered per-track audio effect chain applied before mixing.
+    ///
+    /// Each [`FilterStep`] is inserted as a filter node immediately after
+    /// the track's pan/volume chain and before the `amix` node.
+    /// Use audio-relevant variants such as [`FilterStep::Volume`],
+    /// [`FilterStep::AFadeIn`], and [`FilterStep::ACompressor`].
+    /// An empty vec inserts no extra nodes (zero overhead).
+    pub effects: Vec<FilterStep>,
 }
 
 // ── MultiTrackAudioMixer ──────────────────────────────────────────────────────
@@ -548,6 +557,7 @@ pub struct AudioTrack {
 ///         volume_db: -3.0,
 ///         pan: 0.0,
 ///         time_offset: Duration::ZERO,
+///         effects: vec![],
 ///     })
 ///     .build()?;
 ///
@@ -724,6 +734,24 @@ unsafe fn build_audio_mix(
                 bail!(graph, format!("link failed: →volume track={idx}"));
             }
             chain_end = vol_ctx;
+        }
+
+        // ── Per-track effects chain ───────────────────────────────────────────
+        for (eff_idx, step) in track.effects.iter().enumerate() {
+            let combined_idx = idx * 1000 + eff_idx;
+            let result =
+                crate::filter_inner::add_and_link_step(graph, chain_end, step, combined_idx, "eff");
+            if let Ok(ctx) = result {
+                chain_end = ctx;
+            } else {
+                bail!(
+                    graph,
+                    format!(
+                        "failed to apply effect track={idx} effect={eff_idx} filter={}",
+                        step.filter_name()
+                    )
+                );
+            }
         }
 
         end_ctxs.push(chain_end);
@@ -918,6 +946,44 @@ mod tests {
         assert!(
             matches!(result, Err(FilterError::CompositionFailed { .. })),
             "expected CompositionFailed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn audio_track_with_empty_effects_should_build_successfully() {
+        // build() may fail because the source doesn't exist, but must NOT fail
+        // with a reason related to effects.
+        let result = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo)
+            .add_track(AudioTrack {
+                source: "nonexistent.mp3".into(),
+                volume_db: 0.0,
+                pan: 0.0,
+                time_offset: Duration::ZERO,
+                effects: vec![],
+            })
+            .build();
+        if let Err(FilterError::CompositionFailed { ref reason }) = result {
+            assert!(
+                !reason.contains("effect"),
+                "build must not fail due to empty effects, got: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn audio_track_with_volume_effect_should_include_volume_filter() {
+        // Structural test: verify the effects field accepts FilterStep::Volume.
+        let track = AudioTrack {
+            source: "track.mp3".into(),
+            volume_db: 0.0,
+            pan: 0.0,
+            time_offset: Duration::ZERO,
+            effects: vec![FilterStep::Volume(6.0)],
+        };
+        assert_eq!(track.effects.len(), 1);
+        assert!(
+            matches!(track.effects[0], FilterStep::Volume(_)),
+            "expected Volume variant"
         );
     }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -6,12 +6,12 @@ use super::types::{
 
 // ── FilterStep ────────────────────────────────────────────────────────────────
 
-/// A single step in a filter chain, constructed by the builder methods.
+/// A single step in a filter chain.
 ///
-/// This is an internal representation; users interact with it only via the
-/// [`FilterGraphBuilder`] API.
+/// Used by [`crate::FilterGraphBuilder`] to build pipeline filter graphs, and by
+/// [`crate::AudioTrack::effects`] to attach per-track effects in a multi-track mix.
 #[derive(Debug, Clone)]
-pub(crate) enum FilterStep {
+pub enum FilterStep {
     /// Trim: keep only frames in `[start, end)` seconds.
     Trim { start: f64, end: f64 },
     /// Scale to a new resolution using the given resampling algorithm.

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -9,10 +9,8 @@ pub mod types;
 
 pub use builder::FilterGraphBuilder;
 pub use composition::{AudioTrack, MultiTrackAudioMixer, MultiTrackComposer, VideoLayer};
+pub use filter_step::FilterStep;
 pub use graph::FilterGraph;
 pub use types::{
     DrawTextOptions, EqBand, HwAccel, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
-
-// Re-export FilterStep for use by filter_inner
-pub(crate) use filter_step::FilterStep;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -37,7 +37,7 @@ pub mod graph;
 
 pub use error::FilterError;
 pub use graph::{
-    AudioTrack, DrawTextOptions, EqBand, FilterGraph, FilterGraphBuilder, HwAccel,
+    AudioTrack, DrawTextOptions, EqBand, FilterGraph, FilterGraphBuilder, FilterStep, HwAccel,
     MultiTrackAudioMixer, MultiTrackComposer, Rgb, ScaleAlgorithm, ToneMap, VideoLayer,
     XfadeTransition, YadifMode,
 };

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -145,6 +145,7 @@ impl Timeline {
                         volume_db: 0.0,
                         pan: 0.0,
                         time_offset: clip.timeline_offset,
+                        effects: vec![],
                     });
                 }
             }


### PR DESCRIPTION
## Summary

Adds an `effects: Vec<FilterStep>` field to `AudioTrack` so that callers can attach an ordered chain of audio filters (EQ, compressor, fade, etc.) to each track individually, applied after the track's volume/pan adjustments and before the `amix` mixing node.

## Changes

- `FilterStep` promoted from `pub(crate)` to `pub` and re-exported from `ff_filter` and `avio`
- `add_and_link_step` promoted from `pub(super)` to `pub(crate)` and re-exported from `filter_inner`
- `AudioTrack`: new `pub effects: Vec<FilterStep>` field with doc comment
- `build_audio_mix`: iterates `track.effects` and applies each step as a filter node via `add_and_link_step`; on failure returns `CompositionFailed` with the filter name and indices
- `ff-pipeline/timeline.rs`: updated `AudioTrack` struct literal to include `effects: vec![]`
- Fixed pre-existing broken intra-doc link on `FilterStep` (newly surfaced when type became public)
- New unit tests: `audio_track_with_empty_effects_should_build_successfully`, `audio_track_with_volume_effect_should_include_volume_filter`

## Related Issues

Closes #679

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes