### PR TITLE
feat(ff-encode): add StreamCopyTrim with Duration API and MediaOperationFailed

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -236,8 +236,8 @@ pub use ff_encode::{
     CRF_MAX, DnxhdOptions, DnxhdVariant, EncodeError, EncodeProgress, EncodeProgressCallback,
     FlacOptions, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
     H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
-    OutputContainer, Preset, ProResOptions, ProResProfile, StreamCopyTrimmer, SvtAv1Options,
-    VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    OutputContainer, Preset, ProResOptions, ProResProfile, StreamCopyTrim, StreamCopyTrimmer,
+    SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -138,6 +138,17 @@ pub enum EncodeError {
     /// Async encoder worker thread panicked or disconnected unexpectedly
     #[error("Async encoder worker panicked or disconnected")]
     WorkerPanicked,
+
+    /// A media operation (trim, extract, replace, …) failed.
+    ///
+    /// Returned by [`StreamCopyTrim`](crate::StreamCopyTrim) and other
+    /// `media_ops` types when a structural precondition is violated or an
+    /// FFmpeg mux/remux call fails.
+    #[error("media operation failed: {reason}")]
+    MediaOperationFailed {
+        /// Human-readable description of the failure.
+        reason: String,
+    },
 }
 
 impl EncodeError {

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -211,7 +211,7 @@ pub use shared::{
     AudioCodec, BitrateMode, CRF_MAX, EncodeProgress, EncodeProgressCallback, HardwareEncoder,
     OutputContainer, Preset, VideoCodec, VideoCodecEncodeExt,
 };
-pub use trim::StreamCopyTrimmer;
+pub use trim::{StreamCopyTrim, StreamCopyTrimmer};
 pub use video::{
     Av1Options, Av1Usage, DnxhdOptions, DnxhdVariant, H264Options, H264Preset, H264Profile,
     H264Tune, H265Options, H265Profile, H265Tier, ProResOptions, ProResProfile, SvtAv1Options,

--- a/crates/ff-encode/src/trim/mod.rs
+++ b/crates/ff-encode/src/trim/mod.rs
@@ -3,4 +3,4 @@
 mod trim_inner;
 mod trimmer;
 
-pub use trimmer::StreamCopyTrimmer;
+pub use trimmer::{StreamCopyTrim, StreamCopyTrimmer};

--- a/crates/ff-encode/src/trim/trim_inner.rs
+++ b/crates/ff-encode/src/trim/trim_inner.rs
@@ -17,7 +17,7 @@ const AV_TIME_BASE: i64 = 1_000_000;
 ///
 /// All FFmpeg pointer invariants are maintained internally.  The function is
 /// safe to call from safe Rust — the public `StreamCopyTrimmer::run` wraps it.
-pub(super) fn run_trim(
+pub(crate) fn run_trim(
     input: &Path,
     output: &Path,
     start_sec: f64,

--- a/crates/ff-encode/src/trim/trimmer.rs
+++ b/crates/ff-encode/src/trim/trimmer.rs
@@ -1,6 +1,7 @@
 //! Stream-copy trimming — cut a media file to a time range without re-encoding.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::error::EncodeError;
 
@@ -75,6 +76,81 @@ impl StreamCopyTrimmer {
     }
 }
 
+// ── StreamCopyTrim ────────────────────────────────────────────────────────────
+
+/// Trim a media file to a time range using stream copy (no re-encode).
+///
+/// Equivalent to [`StreamCopyTrimmer`] but accepts [`Duration`] for `start` and
+/// `end` instead of raw seconds, and returns
+/// [`EncodeError::MediaOperationFailed`] when the time range is invalid.
+///
+/// # Example
+///
+/// ```ignore
+/// use ff_encode::StreamCopyTrim;
+/// use std::time::Duration;
+///
+/// StreamCopyTrim::new(
+///     "input.mp4",
+///     Duration::from_secs(2),
+///     Duration::from_secs(7),
+///     "output.mp4",
+/// )
+/// .run()?;
+/// ```
+pub struct StreamCopyTrim {
+    input: PathBuf,
+    start: Duration,
+    end: Duration,
+    output: PathBuf,
+}
+
+impl StreamCopyTrim {
+    /// Create a new `StreamCopyTrim`.
+    ///
+    /// `start` and `end` are absolute timestamps measured from the start of
+    /// the source file.  [`run`](Self::run) returns
+    /// [`EncodeError::MediaOperationFailed`] if `start >= end`.
+    pub fn new(
+        input: impl Into<PathBuf>,
+        start: Duration,
+        end: Duration,
+        output: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            input: input.into(),
+            start,
+            end,
+            output: output.into(),
+        }
+    }
+
+    /// Execute the trim operation.
+    ///
+    /// # Errors
+    ///
+    /// - [`EncodeError::MediaOperationFailed`] if `start >= end`.
+    /// - [`EncodeError::Ffmpeg`] if any FFmpeg API call fails.
+    pub fn run(self) -> Result<(), EncodeError> {
+        if self.start >= self.end {
+            return Err(EncodeError::MediaOperationFailed {
+                reason: format!(
+                    "start ({:?}) must be less than end ({:?})",
+                    self.start, self.end
+                ),
+            });
+        }
+        let start_sec = self.start.as_secs_f64();
+        let end_sec = self.end.as_secs_f64();
+        log::debug!(
+            "stream copy trim start input={} output={} start_sec={start_sec} end_sec={end_sec}",
+            self.input.display(),
+            self.output.display(),
+        );
+        trim_inner::run_trim(&self.input, &self.output, start_sec, end_sec)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,6 +170,36 @@ mod tests {
         assert!(
             matches!(result, Err(EncodeError::InvalidConfig { .. })),
             "expected InvalidConfig for start == end, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn stream_copy_trim_should_reject_start_greater_than_end() {
+        let result = StreamCopyTrim::new(
+            "input.mp4",
+            Duration::from_secs(7),
+            Duration::from_secs(2),
+            "output.mp4",
+        )
+        .run();
+        assert!(
+            matches!(result, Err(EncodeError::MediaOperationFailed { .. })),
+            "expected MediaOperationFailed for start > end, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn stream_copy_trim_should_reject_equal_start_and_end() {
+        let result = StreamCopyTrim::new(
+            "input.mp4",
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            "output.mp4",
+        )
+        .run();
+        assert!(
+            matches!(result, Err(EncodeError::MediaOperationFailed { .. })),
+            "expected MediaOperationFailed for start == end, got {result:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds `StreamCopyTrim` to `ff-encode` as a `Duration`-based API for stream-copy clip trimming, complementing the existing `StreamCopyTrimmer` (which uses `f64` seconds). Also adds `EncodeError::MediaOperationFailed` required by the v0.10.0 media-ops API surface. The underlying FFmpeg call sequence is reused from `trim_inner::run_trim` — no logic is duplicated.

## Changes

- `EncodeError::MediaOperationFailed { reason }` added to `error.rs` (required by #825 and multiple v0.10.0 media-ops types)
- `StreamCopyTrim` struct in `trim/trimmer.rs`: accepts `Duration` for `start`/`end`, delegates to the existing `trim_inner::run_trim`, returns `MediaOperationFailed` for `start >= end`
- `trim_inner::run_trim` promoted from `pub(super)` to `pub(crate)` to allow reuse
- Re-exported from `ff-encode` and `avio`
- Two unit tests: `stream_copy_trim_should_reject_start_greater_than_end` and `stream_copy_trim_should_reject_equal_start_and_end`

## Related Issues

Closes #303

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes