### PR TITLE
feat(ff-filter): add ClipJoiner for cross-dissolve transition

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -254,7 +254,7 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    AudioConcatenator, AudioTrack, DrawTextOptions, EqBand, FilterError, FilterGraph,
+    AudioConcatenator, AudioTrack, ClipJoiner, DrawTextOptions, EqBand, FilterError, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, MultiTrackAudioMixer, MultiTrackComposer, Rgb,
     ScaleAlgorithm, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };

--- a/crates/ff-filter/src/graph/composition.rs
+++ b/crates/ff-filter/src/graph/composition.rs
@@ -1493,6 +1493,289 @@ unsafe fn build_audio_concat(
     Ok(FilterGraph::from_prebuilt(inner))
 }
 
+// ── ClipJoiner ────────────────────────────────────────────────────────────────
+
+/// Joins two video clips with a cross-dissolve transition.
+///
+/// Each clip is loaded via a `movie=` source node.  The last
+/// `dissolve_duration` seconds of clip A overlap with the first
+/// `dissolve_duration` seconds of clip B, producing an output shorter than
+/// simple concatenation by `dissolve_duration`.
+///
+/// When `dissolve_duration` is [`Duration::ZERO`] the clips are concatenated
+/// without a transition (equivalent to
+/// [`VideoConcatenator::new(vec![clip_a, clip_b]).build()`]).
+///
+/// # Errors
+///
+/// Returns [`FilterError::CompositionFailed`] when:
+/// - The clip duration cannot be probed (e.g. file not found).
+/// - `dissolve_duration` exceeds the duration of either clip.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_filter::ClipJoiner;
+/// use std::time::Duration;
+///
+/// let mut graph = ClipJoiner::new("intro.mp4", "main.mp4", Duration::from_secs(1))
+///     .build()?;
+///
+/// while let Some(frame) = graph.pull_video()? {
+///     // encode or display `frame`
+/// }
+/// ```
+pub struct ClipJoiner {
+    clip_a: PathBuf,
+    clip_b: PathBuf,
+    dissolve_duration: Duration,
+}
+
+impl ClipJoiner {
+    /// Create a new `ClipJoiner`.
+    ///
+    /// `dissolve_duration` is the length of the cross-dissolve overlap.
+    /// Pass [`Duration::ZERO`] for plain concatenation (no transition).
+    pub fn new(
+        clip_a: impl AsRef<std::path::Path>,
+        clip_b: impl AsRef<std::path::Path>,
+        dissolve_duration: Duration,
+    ) -> Self {
+        Self {
+            clip_a: clip_a.as_ref().to_path_buf(),
+            clip_b: clip_b.as_ref().to_path_buf(),
+            dissolve_duration,
+        }
+    }
+
+    /// Builds a source-only [`FilterGraph`] that joins the two clips.
+    ///
+    /// # Errors
+    ///
+    /// - [`FilterError::CompositionFailed`] — clip duration probe failed, or
+    ///   `dissolve_duration` exceeds a clip's duration, or an `FFmpeg`
+    ///   graph-construction call failed.
+    pub fn build(self) -> Result<FilterGraph, FilterError> {
+        let dissolve_sec = self.dissolve_duration.as_secs_f64();
+        // SAFETY: avformat and avfilter invariants are maintained internally;
+        //         all pointers are null-checked; resources are freed on every
+        //         error path.
+        unsafe { build_dissolve_join(&self.clip_a, &self.clip_b, dissolve_sec) }
+    }
+}
+
+// ── Dissolve-join graph builder ────────────────────────────────────────────────
+
+/// Probe a clip's duration in seconds using `avformat_open_input` +
+/// `avformat_find_stream_info`.  Returns `CompositionFailed` if the file
+/// cannot be opened or has an unknown duration.
+unsafe fn probe_clip_duration_sec(path: &PathBuf) -> Result<f64, FilterError> {
+    let ctx = ff_sys::avformat::open_input(path.as_ref()).map_err(|code| {
+        FilterError::CompositionFailed {
+            reason: format!(
+                "failed to probe clip duration code={code} path={}",
+                path.display()
+            ),
+        }
+    })?;
+
+    if let Err(code) = ff_sys::avformat::find_stream_info(ctx) {
+        let mut p = ctx;
+        ff_sys::avformat::close_input(&raw mut p);
+        return Err(FilterError::CompositionFailed {
+            reason: format!("avformat_find_stream_info failed code={code}"),
+        });
+    }
+
+    let duration_val = (*ctx).duration;
+    let mut p = ctx;
+    ff_sys::avformat::close_input(&raw mut p);
+
+    if duration_val <= 0 {
+        return Err(FilterError::CompositionFailed {
+            reason: format!("clip has unknown duration path={}", path.display()),
+        });
+    }
+    // AV_TIME_BASE = 1_000_000 microseconds per second.
+    Ok(duration_val as f64 / 1_000_000.0)
+}
+
+unsafe fn build_dissolve_join(
+    clip_a: &PathBuf,
+    clip_b: &PathBuf,
+    dissolve_sec: f64,
+) -> Result<FilterGraph, FilterError> {
+    use std::ffi::CString;
+
+    macro_rules! bail {
+        ($graph:ident, $reason:expr) => {{
+            let mut g = $graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::CompositionFailed {
+                reason: format!("{}", $reason),
+            });
+        }};
+    }
+
+    // ── Dissolve-duration == 0: use concat (plain concatenation) ──────────────
+    if dissolve_sec == 0.0 {
+        return build_video_concat(&[clip_a.clone(), clip_b.clone()], None, None);
+    }
+
+    // ── Probe clip durations ──────────────────────────────────────────────────
+    let clip_a_dur = probe_clip_duration_sec(clip_a)?;
+    let clip_b_dur = probe_clip_duration_sec(clip_b)?;
+
+    if dissolve_sec > clip_a_dur {
+        return Err(FilterError::CompositionFailed {
+            reason: format!(
+                "dissolve_duration ({dissolve_sec:.3}s) exceeds clip_a duration ({clip_a_dur:.3}s)"
+            ),
+        });
+    }
+    if dissolve_sec > clip_b_dur {
+        return Err(FilterError::CompositionFailed {
+            reason: format!(
+                "dissolve_duration ({dissolve_sec:.3}s) exceeds clip_b duration ({clip_b_dur:.3}s)"
+            ),
+        });
+    }
+
+    // xfade offset = when the crossfade starts (measured from the beginning of
+    // the first stream).
+    let xfade_offset = clip_a_dur - dissolve_sec;
+
+    // ── Allocate graph ────────────────────────────────────────────────────────
+    let graph = ff_sys::avfilter_graph_alloc();
+    if graph.is_null() {
+        return Err(FilterError::CompositionFailed {
+            reason: "avfilter_graph_alloc failed".to_string(),
+        });
+    }
+
+    // ── movie[a] source ───────────────────────────────────────────────────────
+    let movie_filter = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
+    if movie_filter.is_null() {
+        bail!(graph, "filter not found: movie");
+    }
+    let path_a = clip_a.to_string_lossy();
+    let Ok(movie_a_name) = CString::new("jd_movie_a") else {
+        bail!(graph, "CString::new failed for movie_a name");
+    };
+    let Ok(movie_a_args) = CString::new(format!("filename={path_a}")) else {
+        bail!(graph, "CString::new failed for movie_a args");
+    };
+    let mut movie_a_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut movie_a_ctx,
+        movie_filter,
+        movie_a_name.as_ptr(),
+        movie_a_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create movie_a filter code={ret}"));
+    }
+    log::debug!("dissolve join clip_a movie source path={path_a}");
+
+    // ── movie[b] source ───────────────────────────────────────────────────────
+    let path_b = clip_b.to_string_lossy();
+    let Ok(movie_b_name) = CString::new("jd_movie_b") else {
+        bail!(graph, "CString::new failed for movie_b name");
+    };
+    let Ok(movie_b_args) = CString::new(format!("filename={path_b}")) else {
+        bail!(graph, "CString::new failed for movie_b args");
+    };
+    let mut movie_b_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut movie_b_ctx,
+        movie_filter,
+        movie_b_name.as_ptr(),
+        movie_b_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create movie_b filter code={ret}"));
+    }
+    log::debug!("dissolve join clip_b movie source path={path_b}");
+
+    // ── xfade ─────────────────────────────────────────────────────────────────
+    let xfade_filter = ff_sys::avfilter_get_by_name(c"xfade".as_ptr());
+    if xfade_filter.is_null() {
+        bail!(graph, "filter not found: xfade");
+    }
+    let xfade_args_str =
+        format!("transition=dissolve:duration={dissolve_sec}:offset={xfade_offset}");
+    let Ok(xfade_args) = CString::new(xfade_args_str.as_str()) else {
+        bail!(graph, "CString::new failed for xfade args");
+    };
+    let mut xfade_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut xfade_ctx,
+        xfade_filter,
+        c"jd_xfade".as_ptr(),
+        xfade_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("failed to create xfade filter args={xfade_args_str} code={ret}")
+        );
+    }
+    log::debug!("dissolve join xfade args={xfade_args_str}");
+
+    // movie_a → xfade[0]
+    let ret = ff_sys::avfilter_link(movie_a_ctx, 0, xfade_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: movie_a→xfade[0]");
+    }
+    // movie_b → xfade[1]
+    let ret = ff_sys::avfilter_link(movie_b_ctx, 0, xfade_ctx, 1);
+    if ret < 0 {
+        bail!(graph, "link failed: movie_b→xfade[1]");
+    }
+
+    // ── buffersink ────────────────────────────────────────────────────────────
+    let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
+    if sink_filter.is_null() {
+        bail!(graph, "filter not found: buffersink");
+    }
+    let mut sink_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sink_ctx,
+        sink_filter,
+        c"jd_vsink".as_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create buffersink code={ret}"));
+    }
+    let ret = ff_sys::avfilter_link(xfade_ctx, 0, sink_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: xfade→buffersink");
+    }
+
+    // ── Configure graph ───────────────────────────────────────────────────────
+    let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
+    if ret < 0 {
+        log::warn!("dissolve join avfilter_graph_config failed code={ret}");
+        bail!(graph, format!("avfilter_graph_config failed code={ret}"));
+    }
+
+    // SAFETY: ret >= 0 guarantees both pointers are non-null.
+    let graph_nn = NonNull::new_unchecked(graph);
+    let sink_nn = NonNull::new_unchecked(sink_ctx);
+    let inner = FilterGraphInner::with_prebuilt_video_graph(graph_nn, sink_nn);
+    log::info!("dissolve join graph built dissolve_sec={dissolve_sec} xfade_offset={xfade_offset}");
+    Ok(FilterGraph::from_prebuilt(inner))
+}
+
 // ── Unit tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1832,6 +2115,42 @@ mod tests {
         if let Err(FilterError::CompositionFailed { ref reason }) = result {
             if reason.contains("filter not found: movie")
                 || reason.contains("filter not found: concat")
+            {
+                println!(
+                    "Skipping: required lavfi filter unavailable in this FFmpeg build ({reason})"
+                );
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn join_with_dissolve_exceeding_clip_duration_should_err() {
+        // dissolve_duration (9999 s) exceeds any realistic clip.  With
+        // nonexistent files the probe itself returns CompositionFailed, which
+        // also satisfies the assertion.  With real files the duration check
+        // fires.
+        let result = ClipJoiner::new("a.mp4", "b.mp4", Duration::from_secs(9999)).build();
+        assert!(
+            matches!(result, Err(FilterError::CompositionFailed { .. })),
+            "expected CompositionFailed for dissolve_duration > clip duration, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn join_with_dissolve_should_reduce_total_duration() {
+        // With nonexistent files the probe step returns CompositionFailed.
+        // This test verifies: (a) no panic, (b) the error is CompositionFailed
+        // (not an unexpected variant), and (c) the `xfade` filter exists in the
+        // running FFmpeg build (if the error mentions "filter not found: xfade"
+        // we skip instead of failing, matching the pattern used by the concat
+        // tests).
+        let result =
+            ClipJoiner::new("clip_a.mp4", "clip_b.mp4", Duration::from_millis(500)).build();
+        assert!(result.is_err(), "expected error (probe or graph failure)");
+        if let Err(FilterError::CompositionFailed { ref reason }) = result {
+            if reason.contains("filter not found: xfade")
+                || reason.contains("filter not found: movie")
             {
                 println!(
                     "Skipping: required lavfi filter unavailable in this FFmpeg build ({reason})"

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -9,8 +9,8 @@ pub mod types;
 
 pub use builder::FilterGraphBuilder;
 pub use composition::{
-    AudioConcatenator, AudioTrack, MultiTrackAudioMixer, MultiTrackComposer, VideoConcatenator,
-    VideoLayer,
+    AudioConcatenator, AudioTrack, ClipJoiner, MultiTrackAudioMixer, MultiTrackComposer,
+    VideoConcatenator, VideoLayer,
 };
 pub use filter_step::FilterStep;
 pub use graph::FilterGraph;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -37,7 +37,7 @@ pub mod graph;
 
 pub use error::FilterError;
 pub use graph::{
-    AudioConcatenator, AudioTrack, DrawTextOptions, EqBand, FilterGraph, FilterGraphBuilder,
-    FilterStep, HwAccel, MultiTrackAudioMixer, MultiTrackComposer, Rgb, ScaleAlgorithm, ToneMap,
-    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    AudioConcatenator, AudioTrack, ClipJoiner, DrawTextOptions, EqBand, FilterGraph,
+    FilterGraphBuilder, FilterStep, HwAccel, MultiTrackAudioMixer, MultiTrackComposer, Rgb,
+    ScaleAlgorithm, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };


### PR DESCRIPTION
## Summary

Adds `ClipJoiner` to `ff-filter`, which joins two video clips with an `xfade=transition=dissolve` filter. The dissolve duration and xfade offset are computed automatically from the probed duration of the first clip. Passing `Duration::ZERO` skips `xfade` entirely and falls back to a plain `concat`.

## Changes

- `ClipJoiner` struct with consuming builder: `new(clip_a, clip_b, dissolve_duration)` + `build()`
- `probe_clip_duration_sec` unsafe helper: opens clip via `avformat_open_input`/`avformat_find_stream_info`, reads `AVFormatContext::duration` (µs), then closes the context
- `build_dissolve_join` unsafe fn: builds `movie[a] → xfade ← movie[b] → buffersink` graph with computed `offset = clip_a_dur − dissolve_sec`; delegates to `build_video_concat` when `dissolve_sec == 0.0`
- Re-exports added to `ff-filter/src/graph/mod.rs`, `ff-filter/src/lib.rs`, `avio/src/lib.rs`
- Unit tests: `join_with_dissolve_exceeding_clip_duration_should_err`, `join_with_dissolve_should_reduce_total_duration`

## Related Issues

Closes #304

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes