### PR TITLE
feat(ff-encode): add AudioReplacement for stream-copy audio track replacement

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -232,12 +232,13 @@ pub use ff_decode::{
 // default_extension) on the shared VideoCodec type; import it to call them.
 #[cfg(feature = "encode")]
 pub use ff_encode::{
-    AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, Av1Options, Av1Usage, BitrateMode,
-    CRF_MAX, DnxhdOptions, DnxhdVariant, EncodeError, EncodeProgress, EncodeProgressCallback,
-    FlacOptions, H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile,
-    H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
-    OutputContainer, Preset, ProResOptions, ProResProfile, StreamCopyTrim, StreamCopyTrimmer,
-    SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, Vp9Options,
+    AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, AudioReplacement, Av1Options,
+    Av1Usage, BitrateMode, CRF_MAX, DnxhdOptions, DnxhdVariant, EncodeError, EncodeProgress,
+    EncodeProgressCallback, FlacOptions, H264Options, H264Preset, H264Profile, H264Tune,
+    H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality,
+    OpusApplication, OpusOptions, OutputContainer, Preset, ProResOptions, ProResProfile,
+    StreamCopyTrim, StreamCopyTrimmer, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions,
+    VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -197,6 +197,7 @@ mod async_encoder;
 mod audio;
 mod error;
 mod image;
+mod media_ops;
 mod shared;
 mod trim;
 mod video;
@@ -207,6 +208,7 @@ pub use audio::{
 };
 pub use error::EncodeError;
 pub use image::{ImageEncoder, ImageEncoderBuilder};
+pub use media_ops::AudioReplacement;
 pub use shared::{
     AudioCodec, BitrateMode, CRF_MAX, EncodeProgress, EncodeProgressCallback, HardwareEncoder,
     OutputContainer, Preset, VideoCodec, VideoCodecEncodeExt,

--- a/crates/ff-encode/src/media_ops/media_inner.rs
+++ b/crates/ff-encode/src/media_ops/media_inner.rs
@@ -1,0 +1,369 @@
+//! Unsafe FFmpeg calls for audio stream replacement (remux operations).
+
+#![allow(unsafe_code)]
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::path::Path;
+
+use crate::error::EncodeError;
+
+/// Replace the audio stream of `video_input` with the audio from `audio_input`,
+/// writing the combined result to `output`.
+///
+/// # Safety
+///
+/// All FFmpeg pointer invariants are maintained internally.  The public
+/// `AudioReplacement::run` wraps this function safely.
+pub(crate) fn run_audio_replacement(
+    video_input: &Path,
+    audio_input: &Path,
+    output: &Path,
+) -> Result<(), EncodeError> {
+    // SAFETY: All pointers are validated (null-checked) before use; resources
+    //         are freed on every exit path.
+    unsafe { run_audio_replacement_unsafe(video_input, audio_input, output) }
+}
+
+unsafe fn run_audio_replacement_unsafe(
+    video_input: &Path,
+    audio_input: &Path,
+    output: &Path,
+) -> Result<(), EncodeError> {
+    // ── Step 1: open video input ──────────────────────────────────────────────
+    // SAFETY: video_input is a caller-supplied path; open_input returns Err on failure.
+    let vid_ctx =
+        ff_sys::avformat::open_input(video_input).map_err(EncodeError::from_ffmpeg_error)?;
+
+    // ── Step 2: find stream info for video input ──────────────────────────────
+    // SAFETY: vid_ctx is non-null (open_input succeeded).
+    if let Err(e) = ff_sys::avformat::find_stream_info(vid_ctx) {
+        let mut p = vid_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::from_ffmpeg_error(e));
+    }
+
+    // ── Step 3: locate the first video stream ─────────────────────────────────
+    // SAFETY: nb_streams is the valid count; streams is a valid array of that length.
+    let nb_vid_streams = (*vid_ctx).nb_streams as usize;
+    let mut video_stream_idx: Option<usize> = None;
+    for i in 0..nb_vid_streams {
+        let stream = *(*vid_ctx).streams.add(i);
+        if (*(*stream).codecpar).codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO {
+            video_stream_idx = Some(i);
+            break;
+        }
+    }
+    let Some(video_stream_idx) = video_stream_idx else {
+        let mut p = vid_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::MediaOperationFailed {
+            reason: format!(
+                "no video stream found in video input path={}",
+                video_input.display()
+            ),
+        });
+    };
+
+    // ── Step 4: open audio input ──────────────────────────────────────────────
+    // SAFETY: audio_input is a caller-supplied path; open_input returns Err on failure.
+    let aud_ctx = match ff_sys::avformat::open_input(audio_input) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            let mut p = vid_ctx;
+            ff_sys::avformat::close_input(&mut p);
+            return Err(EncodeError::from_ffmpeg_error(e));
+        }
+    };
+
+    // ── Step 5: find stream info for audio input ──────────────────────────────
+    // SAFETY: aud_ctx is non-null (open_input succeeded).
+    if let Err(e) = ff_sys::avformat::find_stream_info(aud_ctx) {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        return Err(EncodeError::from_ffmpeg_error(e));
+    }
+
+    // ── Step 6: locate the first audio stream ─────────────────────────────────
+    // SAFETY: nb_streams is the valid count; streams is a valid array of that length.
+    let nb_aud_streams = (*aud_ctx).nb_streams as usize;
+    let mut audio_stream_idx: Option<usize> = None;
+    for i in 0..nb_aud_streams {
+        let stream = *(*aud_ctx).streams.add(i);
+        if (*(*stream).codecpar).codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO {
+            audio_stream_idx = Some(i);
+            break;
+        }
+    }
+    let Some(audio_stream_idx) = audio_stream_idx else {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        return Err(EncodeError::MediaOperationFailed {
+            reason: format!(
+                "no audio stream found in audio input path={}",
+                audio_input.display()
+            ),
+        });
+    };
+
+    // ── Step 7: allocate output context ──────────────────────────────────────
+    let Some(output_str) = output.to_str() else {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "output path is not valid UTF-8".to_string(),
+        });
+    };
+    let Ok(c_output) = std::ffi::CString::new(output_str) else {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "output path contains null bytes".to_string(),
+        });
+    };
+
+    let mut out_ctx: *mut ff_sys::AVFormatContext = std::ptr::null_mut();
+    // SAFETY: c_output is a valid null-terminated C string.
+    let ret = ff_sys::avformat_alloc_output_context2(
+        &mut out_ctx,
+        std::ptr::null_mut(),
+        std::ptr::null(),
+        c_output.as_ptr(),
+    );
+    if ret < 0 || out_ctx.is_null() {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        return Err(EncodeError::from_ffmpeg_error(ret));
+    }
+
+    // ── Step 8: copy video stream parameters to output ────────────────────────
+    // SAFETY: video_stream_idx < nb_vid_streams; streams is a valid array.
+    let vid_in_stream = *(*vid_ctx).streams.add(video_stream_idx);
+    // SAFETY: out_ctx is non-null (avformat_alloc_output_context2 succeeded).
+    let vid_out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
+    if vid_out_stream.is_null() {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat_free_context(out_ctx);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "avformat_new_stream failed for video".to_string(),
+        });
+    }
+    // SAFETY: both codecpar pointers are non-null (created by FFmpeg).
+    let ret =
+        ff_sys::avcodec_parameters_copy((*vid_out_stream).codecpar, (*vid_in_stream).codecpar);
+    if ret < 0 {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat_free_context(out_ctx);
+        return Err(EncodeError::from_ffmpeg_error(ret));
+    }
+    // Clear codec_tag so the muxer assigns the correct value for the container.
+    (*(*vid_out_stream).codecpar).codec_tag = 0;
+
+    // ── Step 9: copy audio stream parameters to output ────────────────────────
+    // SAFETY: audio_stream_idx < nb_aud_streams; streams is a valid array.
+    let aud_in_stream = *(*aud_ctx).streams.add(audio_stream_idx);
+    // SAFETY: out_ctx is non-null (avformat_alloc_output_context2 succeeded).
+    let aud_out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
+    if aud_out_stream.is_null() {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat_free_context(out_ctx);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "avformat_new_stream failed for audio".to_string(),
+        });
+    }
+    // SAFETY: both codecpar pointers are non-null (created by FFmpeg).
+    let ret =
+        ff_sys::avcodec_parameters_copy((*aud_out_stream).codecpar, (*aud_in_stream).codecpar);
+    if ret < 0 {
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat_free_context(out_ctx);
+        return Err(EncodeError::from_ffmpeg_error(ret));
+    }
+    // Clear codec_tag so the muxer assigns the correct value for the container.
+    (*(*aud_out_stream).codecpar).codec_tag = 0;
+
+    // ── Step 10: open output file ─────────────────────────────────────────────
+    // SAFETY: output is a valid path; WRITE opens the file for writing.
+    let pb = match ff_sys::avformat::open_output(output, ff_sys::avformat::avio_flags::WRITE) {
+        Ok(pb) => pb,
+        Err(e) => {
+            let mut pv = vid_ctx;
+            ff_sys::avformat::close_input(&mut pv);
+            let mut pa = aud_ctx;
+            ff_sys::avformat::close_input(&mut pa);
+            ff_sys::avformat_free_context(out_ctx);
+            return Err(EncodeError::from_ffmpeg_error(e));
+        }
+    };
+    // SAFETY: out_ctx is non-null; pb is a valid AVIOContext.
+    (*out_ctx).pb = pb;
+
+    // ── Step 11: write header ─────────────────────────────────────────────────
+    // SAFETY: out_ctx is fully configured with streams and pb set.
+    let ret = ff_sys::avformat_write_header(out_ctx, std::ptr::null_mut());
+    if ret < 0 {
+        // SAFETY: (*out_ctx).pb was set above and is non-null.
+        ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+        ff_sys::avformat_free_context(out_ctx);
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        return Err(EncodeError::from_ffmpeg_error(ret));
+    }
+
+    // Read time bases after avformat_write_header — the muxer may adjust them.
+    // SAFETY: stream pointers remain valid for the lifetime of their parent contexts.
+    let vid_in_tb = (*vid_in_stream).time_base;
+    let aud_in_tb = (*aud_in_stream).time_base;
+    let vid_out_tb = (*vid_out_stream).time_base;
+    let aud_out_tb = (*aud_out_stream).time_base;
+
+    log::debug!(
+        "audio replacement header written \
+         video_stream_idx={video_stream_idx} audio_stream_idx={audio_stream_idx}"
+    );
+
+    // ── Step 12: allocate packet ──────────────────────────────────────────────
+    // SAFETY: av_packet_alloc never returns null in practice (aborts on OOM).
+    let pkt = ff_sys::av_packet_alloc();
+    if pkt.is_null() {
+        ff_sys::av_write_trailer(out_ctx);
+        ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+        ff_sys::avformat_free_context(out_ctx);
+        let mut pv = vid_ctx;
+        ff_sys::avformat::close_input(&mut pv);
+        let mut pa = aud_ctx;
+        ff_sys::avformat::close_input(&mut pa);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "av_packet_alloc failed".to_string(),
+        });
+    }
+
+    // ── Step 13: interleaved packet copy loop ─────────────────────────────────
+    // Alternate between video and audio inputs; use av_interleaved_write_frame
+    // so the muxer buffers and flushes packets in the correct timestamp order.
+    let mut loop_err: Option<EncodeError> = None;
+    let mut vid_eof = false;
+    let mut aud_eof = false;
+
+    'copy: loop {
+        // Read one packet from the video input, forwarding only the target stream.
+        if !vid_eof {
+            // SAFETY: vid_ctx and pkt are valid non-null pointers.
+            match ff_sys::avformat::read_frame(vid_ctx, pkt) {
+                Err(e) if e == ff_sys::error_codes::EOF => {
+                    vid_eof = true;
+                }
+                Err(e) => {
+                    loop_err = Some(EncodeError::from_ffmpeg_error(e));
+                    break 'copy;
+                }
+                Ok(()) => {
+                    if (*pkt).stream_index as usize == video_stream_idx {
+                        // SAFETY: pkt, vid_in_tb, vid_out_tb are valid plain-data values.
+                        ff_sys::av_packet_rescale_ts(pkt, vid_in_tb, vid_out_tb);
+                        (*pkt).stream_index = 0;
+                        // SAFETY: out_ctx and pkt are valid.
+                        let ret = ff_sys::av_interleaved_write_frame(out_ctx, pkt);
+                        // av_interleaved_write_frame takes the packet's buf reference;
+                        // unref to clear any remaining fields.
+                        ff_sys::av_packet_unref(pkt);
+                        if ret < 0 {
+                            loop_err = Some(EncodeError::from_ffmpeg_error(ret));
+                            break 'copy;
+                        }
+                    } else {
+                        ff_sys::av_packet_unref(pkt);
+                    }
+                }
+            }
+        }
+
+        // Read one packet from the audio input, forwarding only the target stream.
+        if !aud_eof {
+            // SAFETY: aud_ctx and pkt are valid non-null pointers.
+            match ff_sys::avformat::read_frame(aud_ctx, pkt) {
+                Err(e) if e == ff_sys::error_codes::EOF => {
+                    aud_eof = true;
+                }
+                Err(e) => {
+                    loop_err = Some(EncodeError::from_ffmpeg_error(e));
+                    break 'copy;
+                }
+                Ok(()) => {
+                    if (*pkt).stream_index as usize == audio_stream_idx {
+                        // SAFETY: pkt, aud_in_tb, aud_out_tb are valid plain-data values.
+                        ff_sys::av_packet_rescale_ts(pkt, aud_in_tb, aud_out_tb);
+                        (*pkt).stream_index = 1;
+                        // SAFETY: out_ctx and pkt are valid.
+                        let ret = ff_sys::av_interleaved_write_frame(out_ctx, pkt);
+                        ff_sys::av_packet_unref(pkt);
+                        if ret < 0 {
+                            loop_err = Some(EncodeError::from_ffmpeg_error(ret));
+                            break 'copy;
+                        }
+                    } else {
+                        ff_sys::av_packet_unref(pkt);
+                    }
+                }
+            }
+        }
+
+        if vid_eof && aud_eof {
+            break 'copy;
+        }
+    }
+
+    // SAFETY: pkt was allocated by av_packet_alloc above and is still valid.
+    let mut pkt_ptr = pkt;
+    ff_sys::av_packet_free(&mut pkt_ptr);
+
+    // ── Step 14: write trailer ────────────────────────────────────────────────
+    // SAFETY: out_ctx is valid; write_header was called successfully.
+    ff_sys::av_write_trailer(out_ctx);
+
+    // ── Step 15: cleanup ──────────────────────────────────────────────────────
+    // SAFETY: (*out_ctx).pb is non-null (opened above; still set after write_header).
+    ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+    // SAFETY: out_ctx is non-null and was allocated by avformat_alloc_output_context2.
+    ff_sys::avformat_free_context(out_ctx);
+    // SAFETY: vid_ctx and aud_ctx are non-null (open_input succeeded).
+    let mut pv = vid_ctx;
+    ff_sys::avformat::close_input(&mut pv);
+    let mut pa = aud_ctx;
+    ff_sys::avformat::close_input(&mut pa);
+
+    log::info!("audio replaced output={}", output.display());
+
+    match loop_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}

--- a/crates/ff-encode/src/media_ops/mod.rs
+++ b/crates/ff-encode/src/media_ops/mod.rs
@@ -1,0 +1,81 @@
+//! Media stream operations — audio replacement via stream-copy remux.
+
+mod media_inner;
+
+use std::path::PathBuf;
+
+use crate::error::EncodeError;
+
+/// Replace a video file's audio track with audio from a separate source file.
+///
+/// The video bitstream is copied bit-for-bit (no decode/encode cycle).  The
+/// audio track from `audio_input` replaces any existing audio in
+/// `video_input`.
+///
+/// Returns [`EncodeError::MediaOperationFailed`] when no audio stream is found
+/// in `audio_input`, or no video stream is found in `video_input`.
+///
+/// # Example
+///
+/// ```ignore
+/// use ff_encode::AudioReplacement;
+///
+/// AudioReplacement::new("source.mp4", "new_audio.aac", "output.mp4").run()?;
+/// ```
+pub struct AudioReplacement {
+    video_input: PathBuf,
+    audio_input: PathBuf,
+    output: PathBuf,
+}
+
+impl AudioReplacement {
+    /// Create a new `AudioReplacement`.
+    ///
+    /// - `video_input` — source file whose video stream is kept.
+    /// - `audio_input` — source file whose first audio stream is used.
+    /// - `output`      — path for the combined output file.
+    pub fn new(
+        video_input: impl Into<PathBuf>,
+        audio_input: impl Into<PathBuf>,
+        output: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            video_input: video_input.into(),
+            audio_input: audio_input.into(),
+            output: output.into(),
+        }
+    }
+
+    /// Execute the audio replacement operation.
+    ///
+    /// # Errors
+    ///
+    /// - [`EncodeError::MediaOperationFailed`] if `video_input` has no video
+    ///   stream or `audio_input` has no audio stream.
+    /// - [`EncodeError::Ffmpeg`] if any FFmpeg API call fails.
+    pub fn run(self) -> Result<(), EncodeError> {
+        log::debug!(
+            "audio replacement start video_input={} audio_input={} output={}",
+            self.video_input.display(),
+            self.audio_input.display(),
+            self.output.display(),
+        );
+        media_inner::run_audio_replacement(&self.video_input, &self.audio_input, &self.output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audio_replacement_run_with_nonexistent_video_input_should_fail() {
+        let result =
+            AudioReplacement::new("nonexistent_video.mp4", "nonexistent_audio.mp3", "out.mp4")
+                .run();
+        assert!(
+            result.is_err(),
+            "expected error for nonexistent video input, got Ok(())"
+        );
+    }
+}

--- a/crates/ff-encode/tests/audio_replacement_tests.rs
+++ b/crates/ff-encode/tests/audio_replacement_tests.rs
@@ -1,0 +1,165 @@
+//! Integration tests for AudioReplacement.
+//!
+//! Tests verify:
+//! - Errors on nonexistent inputs
+//! - `MediaOperationFailed` when the audio input has no audio stream
+//! - Successful remux when valid video and audio sources are provided
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use ff_encode::{AudioReplacement, EncodeError};
+use fixtures::{FileGuard, assert_valid_output_file, create_black_frame, test_output_path};
+
+// ── Error-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn audio_replacement_should_fail_when_video_input_missing() {
+    let result =
+        AudioReplacement::new("nonexistent_video.mp4", "nonexistent_audio.mp3", "out.mp4").run();
+    assert!(
+        result.is_err(),
+        "expected error for nonexistent video input, got Ok(())"
+    );
+}
+
+/// A video-only mp4 (no audio stream) used as the `audio_input` must return
+/// `EncodeError::MediaOperationFailed`.
+#[test]
+fn audio_replacement_should_fail_when_audio_input_has_no_audio_stream() {
+    use ff_encode::{BitrateMode, Preset, VideoCodec, VideoEncoder};
+
+    let video_only_path = test_output_path("audio_replacement_video_only.mp4");
+    let output_path = test_output_path("audio_replacement_no_audio_stream.mp4");
+    let _guard_v = FileGuard::new(video_only_path.clone());
+    let _guard_o = FileGuard::new(output_path.clone());
+
+    // Build a video-only file (no audio stream).
+    let mut encoder = match VideoEncoder::create(&video_only_path)
+        .video(160, 120, 15.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(200_000))
+        .preset(Preset::Ultrafast)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: video encoder unavailable ({e})");
+            return;
+        }
+    };
+    for _ in 0..15 {
+        let frame = create_black_frame(160, 120);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: push_video failed ({e})");
+            return;
+        }
+    }
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: encoder.finish failed ({e})");
+        return;
+    }
+
+    // Use the video-only file as the audio input — must fail with MediaOperationFailed.
+    let result = AudioReplacement::new(&video_only_path, &video_only_path, &output_path).run();
+    assert!(
+        matches!(result, Err(EncodeError::MediaOperationFailed { .. })),
+        "expected MediaOperationFailed when audio input has no audio stream, got {result:?}"
+    );
+}
+
+// ── Functional tests ──────────────────────────────────────────────────────────
+
+/// Encode a video-only source and a separate audio-only source, then replace
+/// the audio.  The output file must exist and be non-empty.
+#[test]
+fn audio_replacement_should_produce_output_with_both_streams() {
+    use ff_encode::{AudioCodec, AudioEncoder, BitrateMode, Preset, VideoCodec, VideoEncoder};
+    use ff_format::{AudioFrame, SampleFormat};
+
+    let video_path = test_output_path("audio_replacement_video_src.mp4");
+    let audio_path = test_output_path("audio_replacement_audio_src.mp3");
+    let output_path = test_output_path("audio_replacement_out.mp4");
+    let _guard_v = FileGuard::new(video_path.clone());
+    let _guard_a = FileGuard::new(audio_path.clone());
+    let _guard_o = FileGuard::new(output_path.clone());
+
+    // ── Build video-only source (1 s at 15 fps, 160×120) ───────────────────
+    let mut venc = match VideoEncoder::create(&video_path)
+        .video(160, 120, 15.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(200_000))
+        .preset(Preset::Ultrafast)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: video encoder unavailable ({e})");
+            return;
+        }
+    };
+    for _ in 0..15 {
+        let frame = create_black_frame(160, 120);
+        if let Err(e) = venc.push_video(&frame) {
+            println!("Skipping: push_video failed ({e})");
+            return;
+        }
+    }
+    if let Err(e) = venc.finish() {
+        println!("Skipping: video encoder finish failed ({e})");
+        return;
+    }
+
+    // ── Build audio-only source (~1 s of silence at 44100 Hz mono) ─────────
+    let sample_rate = 44100_u32;
+    let channels = 1_u32;
+    let samples_per_frame = 1152_usize; // MP3 frame size
+
+    let mut aenc = match AudioEncoder::create(&audio_path)
+        .audio(sample_rate, channels)
+        .audio_codec(AudioCodec::Mp3)
+        .audio_bitrate(64_000)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: audio encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let total_samples = sample_rate as usize;
+    let mut pushed = 0_usize;
+    while pushed < total_samples {
+        let n = samples_per_frame.min(total_samples - pushed);
+        let frame = match AudioFrame::empty(n, channels, sample_rate, SampleFormat::F32) {
+            Ok(f) => f,
+            Err(e) => {
+                println!("Skipping: AudioFrame::empty failed ({e})");
+                return;
+            }
+        };
+        if let Err(e) = aenc.push(&frame) {
+            println!("Skipping: push_audio failed ({e})");
+            return;
+        }
+        pushed += n;
+    }
+    if let Err(e) = aenc.finish() {
+        println!("Skipping: audio encoder finish failed ({e})");
+        return;
+    }
+
+    // ── Replace audio ──────────────────────────────────────────────────────
+    let result = AudioReplacement::new(&video_path, &audio_path, &output_path).run();
+    match result {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: AudioReplacement::run failed ({e})");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}


### PR DESCRIPTION
## Summary

Adds `AudioReplacement` to `ff-encode` under a new `media_ops` module. The type replaces a video file's audio track with audio from a separate source file, copying the video bitstream bit-for-bit (no decode/encode cycle) via FFmpeg's remux APIs.

## Changes

- New `crates/ff-encode/src/media_ops/mod.rs`: public safe `AudioReplacement` struct with consuming `new()` + `run()` API
- New `crates/ff-encode/src/media_ops/media_inner.rs`: unsafe FFmpeg call sequence — open both inputs, locate video/audio streams by `AVMEDIA_TYPE_*`, allocate output context, copy stream parameters with `avcodec_parameters_copy`, interleaved packet copy loop with `av_packet_rescale_ts` + `av_interleaved_write_frame`, `av_write_trailer`
- Returns `EncodeError::MediaOperationFailed` when no video stream is found in the video input or no audio stream in the audio input
- Re-exported from `ff-encode/src/lib.rs` and `avio/src/lib.rs` (encode feature)
- New `crates/ff-encode/tests/audio_replacement_tests.rs` covering: nonexistent video input, video-only file used as audio input, and full encode→replace→output functional path

## Related Issues

Closes #305

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes