### PR TITLE
feat(ff-encode): add AudioExtractor for stream-copy audio track extraction

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -232,13 +232,13 @@ pub use ff_decode::{
 // default_extension) on the shared VideoCodec type; import it to call them.
 #[cfg(feature = "encode")]
 pub use ff_encode::{
-    AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, AudioReplacement, Av1Options,
-    Av1Usage, BitrateMode, CRF_MAX, DnxhdOptions, DnxhdVariant, EncodeError, EncodeProgress,
-    EncodeProgressCallback, FlacOptions, H264Options, H264Preset, H264Profile, H264Tune,
-    H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Mp3Options, Mp3Quality,
-    OpusApplication, OpusOptions, OutputContainer, Preset, ProResOptions, ProResProfile,
-    StreamCopyTrim, StreamCopyTrimmer, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions,
-    VideoEncoder, Vp9Options,
+    AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, AudioExtractor, AudioReplacement,
+    Av1Options, Av1Usage, BitrateMode, CRF_MAX, DnxhdOptions, DnxhdVariant, EncodeError,
+    EncodeProgress, EncodeProgressCallback, FlacOptions, H264Options, H264Preset, H264Profile,
+    H264Tune, H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder, Mp3Options,
+    Mp3Quality, OpusApplication, OpusOptions, OutputContainer, Preset, ProResOptions,
+    ProResProfile, StreamCopyTrim, StreamCopyTrimmer, SvtAv1Options, VideoCodecEncodeExt,
+    VideoCodecOptions, VideoEncoder, Vp9Options,
 };
 
 // ── tokio feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -208,7 +208,7 @@ pub use audio::{
 };
 pub use error::EncodeError;
 pub use image::{ImageEncoder, ImageEncoderBuilder};
-pub use media_ops::AudioReplacement;
+pub use media_ops::{AudioExtractor, AudioReplacement};
 pub use shared::{
     AudioCodec, BitrateMode, CRF_MAX, EncodeProgress, EncodeProgressCallback, HardwareEncoder,
     OutputContainer, Preset, VideoCodec, VideoCodecEncodeExt,

--- a/crates/ff-encode/src/media_ops/media_inner.rs
+++ b/crates/ff-encode/src/media_ops/media_inner.rs
@@ -1,4 +1,4 @@
-//! Unsafe FFmpeg calls for audio stream replacement (remux operations).
+//! Unsafe FFmpeg calls for audio stream operations (replacement, extraction).
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
@@ -361,6 +361,267 @@ unsafe fn run_audio_replacement_unsafe(
     ff_sys::avformat::close_input(&mut pa);
 
     log::info!("audio replaced output={}", output.display());
+
+    match loop_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+// ── Audio extraction ──────────────────────────────────────────────────────────
+
+/// Demux the audio track at `stream_index` (or the first audio stream when
+/// `stream_index` is `None`) from `input` and write it to `output`.
+///
+/// The audio bitstream is stream-copied (no decode/encode cycle).
+///
+/// # Safety
+///
+/// All FFmpeg pointer invariants are maintained internally.  The public
+/// `AudioExtractor::run` wraps this function safely.
+pub(crate) fn run_audio_extraction(
+    input: &Path,
+    output: &Path,
+    stream_index: Option<usize>,
+) -> Result<(), EncodeError> {
+    // SAFETY: All pointers are validated (null-checked) before use; resources
+    //         are freed on every exit path.
+    unsafe { run_audio_extraction_unsafe(input, output, stream_index) }
+}
+
+unsafe fn run_audio_extraction_unsafe(
+    input: &Path,
+    output: &Path,
+    requested_idx: Option<usize>,
+) -> Result<(), EncodeError> {
+    // ── Step 1: open input ────────────────────────────────────────────────────
+    // SAFETY: input is a caller-supplied path; open_input returns Err on failure.
+    let in_ctx = ff_sys::avformat::open_input(input).map_err(EncodeError::from_ffmpeg_error)?;
+
+    // ── Step 2: find stream info ──────────────────────────────────────────────
+    // SAFETY: in_ctx is non-null (open_input succeeded).
+    if let Err(e) = ff_sys::avformat::find_stream_info(in_ctx) {
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::from_ffmpeg_error(e));
+    }
+
+    // ── Step 3: locate the audio stream ──────────────────────────────────────
+    // SAFETY: nb_streams is the valid count; streams is a valid array of that length.
+    let nb_streams = (*in_ctx).nb_streams as usize;
+    let audio_stream_idx = if let Some(idx) = requested_idx {
+        // Validate that the requested index is actually an audio stream.
+        if idx >= nb_streams {
+            let mut p = in_ctx;
+            ff_sys::avformat::close_input(&mut p);
+            return Err(EncodeError::MediaOperationFailed {
+                reason: format!("stream index {idx} out of range (input has {nb_streams} streams)"),
+            });
+        }
+        let stream = *(*in_ctx).streams.add(idx);
+        if (*(*stream).codecpar).codec_type != ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO {
+            let mut p = in_ctx;
+            ff_sys::avformat::close_input(&mut p);
+            return Err(EncodeError::MediaOperationFailed {
+                reason: format!("stream index {idx} is not an audio stream"),
+            });
+        }
+        idx
+    } else {
+        // Find the first audio stream.
+        let mut found: Option<usize> = None;
+        for i in 0..nb_streams {
+            let stream = *(*in_ctx).streams.add(i);
+            if (*(*stream).codecpar).codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO {
+                found = Some(i);
+                break;
+            }
+        }
+        match found {
+            Some(idx) => idx,
+            None => {
+                let mut p = in_ctx;
+                ff_sys::avformat::close_input(&mut p);
+                return Err(EncodeError::MediaOperationFailed {
+                    reason: format!("no audio stream found in input path={}", input.display()),
+                });
+            }
+        }
+    };
+
+    // ── Step 4: allocate output context ──────────────────────────────────────
+    let Some(output_str) = output.to_str() else {
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "output path is not valid UTF-8".to_string(),
+        });
+    };
+    let Ok(c_output) = std::ffi::CString::new(output_str) else {
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "output path contains null bytes".to_string(),
+        });
+    };
+
+    let mut out_ctx: *mut ff_sys::AVFormatContext = std::ptr::null_mut();
+    // SAFETY: c_output is a valid null-terminated C string; format is auto-detected from ext.
+    let ret = ff_sys::avformat_alloc_output_context2(
+        &mut out_ctx,
+        std::ptr::null_mut(),
+        std::ptr::null(),
+        c_output.as_ptr(),
+    );
+    if ret < 0 || out_ctx.is_null() {
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::from_ffmpeg_error(ret));
+    }
+
+    // ── Step 5: copy audio stream parameters to output ────────────────────────
+    // SAFETY: audio_stream_idx < nb_streams; streams is a valid array.
+    let in_stream = *(*in_ctx).streams.add(audio_stream_idx);
+    // SAFETY: out_ctx is non-null (avformat_alloc_output_context2 succeeded).
+    let out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
+    if out_stream.is_null() {
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat_free_context(out_ctx);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "avformat_new_stream failed".to_string(),
+        });
+    }
+    // SAFETY: both codecpar pointers are non-null (created by FFmpeg).
+    let ret = ff_sys::avcodec_parameters_copy((*out_stream).codecpar, (*in_stream).codecpar);
+    if ret < 0 {
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat_free_context(out_ctx);
+        return Err(EncodeError::from_ffmpeg_error(ret));
+    }
+    // Clear codec_tag so the muxer assigns the correct value for the container.
+    (*(*out_stream).codecpar).codec_tag = 0;
+
+    // ── Step 6: open output file ──────────────────────────────────────────────
+    // SAFETY: output is a valid path; WRITE opens the file for writing.
+    let pb = match ff_sys::avformat::open_output(output, ff_sys::avformat::avio_flags::WRITE) {
+        Ok(pb) => pb,
+        Err(e) => {
+            let mut p = in_ctx;
+            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat_free_context(out_ctx);
+            return Err(EncodeError::from_ffmpeg_error(e));
+        }
+    };
+    // SAFETY: out_ctx is non-null; pb is a valid AVIOContext.
+    (*out_ctx).pb = pb;
+
+    // ── Step 7: write header ──────────────────────────────────────────────────
+    // A non-zero return here usually means the codec is incompatible with the
+    // chosen output container.  Wrap it as MediaOperationFailed with a clear
+    // message so callers know what went wrong.
+    // SAFETY: out_ctx is fully configured with the stream and pb set.
+    let ret = ff_sys::avformat_write_header(out_ctx, std::ptr::null_mut());
+    if ret < 0 {
+        // SAFETY: (*out_ctx).pb was set above and is non-null.
+        ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+        ff_sys::avformat_free_context(out_ctx);
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::MediaOperationFailed {
+            reason: format!(
+                "codec incompatible with output container: {}",
+                ff_sys::av_error_string(ret)
+            ),
+        });
+    }
+
+    // Read time bases after avformat_write_header — the muxer may adjust them.
+    // SAFETY: stream pointers remain valid for the lifetime of their parent contexts.
+    let in_tb = (*in_stream).time_base;
+    let out_tb = (*out_stream).time_base;
+
+    log::debug!(
+        "audio extraction header written audio_stream_idx={audio_stream_idx} \
+         output={}",
+        output.display()
+    );
+
+    // ── Step 8: allocate packet ───────────────────────────────────────────────
+    // SAFETY: av_packet_alloc never returns null in practice (aborts on OOM).
+    let pkt = ff_sys::av_packet_alloc();
+    if pkt.is_null() {
+        ff_sys::av_write_trailer(out_ctx);
+        ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+        ff_sys::avformat_free_context(out_ctx);
+        let mut p = in_ctx;
+        ff_sys::avformat::close_input(&mut p);
+        return Err(EncodeError::Ffmpeg {
+            code: 0,
+            message: "av_packet_alloc failed".to_string(),
+        });
+    }
+
+    // ── Step 9: packet copy loop (audio stream only) ──────────────────────────
+    let mut loop_err: Option<EncodeError> = None;
+
+    'read: loop {
+        // SAFETY: in_ctx and pkt are valid non-null pointers.
+        match ff_sys::avformat::read_frame(in_ctx, pkt) {
+            Err(e) if e == ff_sys::error_codes::EOF => break 'read,
+            Err(e) => {
+                loop_err = Some(EncodeError::from_ffmpeg_error(e));
+                break 'read;
+            }
+            Ok(()) => {}
+        }
+
+        if (*pkt).stream_index as usize != audio_stream_idx {
+            // Skip non-audio packets.
+            ff_sys::av_packet_unref(pkt);
+            continue 'read;
+        }
+
+        // Rescale timestamps to the output stream's time base and remap index.
+        // SAFETY: pkt, in_tb, out_tb are valid plain-data values.
+        ff_sys::av_packet_rescale_ts(pkt, in_tb, out_tb);
+        (*pkt).stream_index = 0;
+
+        // SAFETY: out_ctx and pkt are valid.
+        let ret = ff_sys::av_interleaved_write_frame(out_ctx, pkt);
+        // av_interleaved_write_frame takes the packet's buf reference; unref to clear.
+        ff_sys::av_packet_unref(pkt);
+        if ret < 0 {
+            loop_err = Some(EncodeError::from_ffmpeg_error(ret));
+            break 'read;
+        }
+    }
+
+    // SAFETY: pkt was allocated by av_packet_alloc above and is still valid.
+    let mut pkt_ptr = pkt;
+    ff_sys::av_packet_free(&mut pkt_ptr);
+
+    // ── Step 10: write trailer ────────────────────────────────────────────────
+    // SAFETY: out_ctx is valid; write_header was called successfully.
+    ff_sys::av_write_trailer(out_ctx);
+
+    // ── Step 11: cleanup ──────────────────────────────────────────────────────
+    // SAFETY: (*out_ctx).pb is non-null (opened above; still set after write_header).
+    ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+    // SAFETY: out_ctx is non-null and was allocated by avformat_alloc_output_context2.
+    ff_sys::avformat_free_context(out_ctx);
+    // SAFETY: in_ctx is non-null (open_input succeeded).
+    let mut p = in_ctx;
+    ff_sys::avformat::close_input(&mut p);
+
+    log::info!(
+        "audio extracted output={} stream_index={audio_stream_idx}",
+        output.display()
+    );
 
     match loop_err {
         Some(e) => Err(e),

--- a/crates/ff-encode/src/media_ops/mod.rs
+++ b/crates/ff-encode/src/media_ops/mod.rs
@@ -1,4 +1,4 @@
-//! Media stream operations — audio replacement via stream-copy remux.
+//! Media stream operations — audio replacement and extraction via stream-copy remux.
 
 mod media_inner;
 
@@ -64,6 +64,71 @@ impl AudioReplacement {
     }
 }
 
+// ── AudioExtractor ────────────────────────────────────────────────────────────
+
+/// Demux an audio track from a media file and write it to a standalone audio file.
+///
+/// The audio bitstream is stream-copied (no decode/encode cycle).  By default
+/// the first audio stream is selected; call [`stream_index`](Self::stream_index)
+/// to pick a specific one.
+///
+/// Returns [`EncodeError::MediaOperationFailed`] when:
+/// - no audio stream is found (or `stream_index` points to a non-audio stream), or
+/// - the audio codec is incompatible with the output container.
+///
+/// # Example
+///
+/// ```ignore
+/// use ff_encode::AudioExtractor;
+///
+/// AudioExtractor::new("source.mp4", "audio.mp3").run()?;
+/// ```
+pub struct AudioExtractor {
+    input: PathBuf,
+    output: PathBuf,
+    stream_index: Option<usize>,
+}
+
+impl AudioExtractor {
+    /// Create a new `AudioExtractor`.
+    ///
+    /// - `input`  — source media file.
+    /// - `output` — destination audio file (format auto-detected from extension).
+    pub fn new(input: impl Into<PathBuf>, output: impl Into<PathBuf>) -> Self {
+        Self {
+            input: input.into(),
+            output: output.into(),
+            stream_index: None,
+        }
+    }
+
+    /// Select a specific audio stream by index (0-based over all streams in
+    /// the container).  Defaults to the first audio stream when not set.
+    #[must_use]
+    pub fn stream_index(mut self, idx: usize) -> Self {
+        self.stream_index = Some(idx);
+        self
+    }
+
+    /// Execute the audio extraction operation.
+    ///
+    /// # Errors
+    ///
+    /// - [`EncodeError::MediaOperationFailed`] if no audio stream is found,
+    ///   the requested stream index is invalid or not audio, or the codec is
+    ///   incompatible with the output container.
+    /// - [`EncodeError::Ffmpeg`] if any FFmpeg API call fails.
+    pub fn run(self) -> Result<(), EncodeError> {
+        log::debug!(
+            "audio extraction start input={} output={} stream_index={:?}",
+            self.input.display(),
+            self.output.display(),
+            self.stream_index,
+        );
+        media_inner::run_audio_extraction(&self.input, &self.output, self.stream_index)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,6 +141,15 @@ mod tests {
         assert!(
             result.is_err(),
             "expected error for nonexistent video input, got Ok(())"
+        );
+    }
+
+    #[test]
+    fn audio_extractor_run_with_nonexistent_input_should_fail() {
+        let result = AudioExtractor::new("nonexistent_input.mp4", "out.mp3").run();
+        assert!(
+            result.is_err(),
+            "expected error for nonexistent input, got Ok(())"
         );
     }
 }

--- a/crates/ff-encode/tests/audio_extractor_tests.rs
+++ b/crates/ff-encode/tests/audio_extractor_tests.rs
@@ -1,0 +1,261 @@
+//! Integration tests for AudioExtractor.
+//!
+//! Tests verify:
+//! - Errors on nonexistent inputs
+//! - `MediaOperationFailed` when the input has no audio stream
+//! - Successful extraction when a video+audio source is provided
+//! - `stream_index()` selects the first audio stream explicitly
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use ff_encode::{AudioExtractor, EncodeError};
+use fixtures::{FileGuard, assert_valid_output_file, create_black_frame, test_output_path};
+
+// ── Error-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn audio_extractor_should_fail_when_input_missing() {
+    let result = AudioExtractor::new("nonexistent_input.mp4", "out.mp3").run();
+    assert!(
+        result.is_err(),
+        "expected error for nonexistent input, got Ok(())"
+    );
+}
+
+/// A video-only mp4 (no audio stream) must return `MediaOperationFailed`.
+#[test]
+fn audio_extractor_should_fail_when_input_has_no_audio_stream() {
+    use ff_encode::{BitrateMode, Preset, VideoCodec, VideoEncoder};
+
+    let video_only_path = test_output_path("extractor_video_only.mp4");
+    let output_path = test_output_path("extractor_no_audio_out.mp3");
+    let _guard_v = FileGuard::new(video_only_path.clone());
+    let _guard_o = FileGuard::new(output_path.clone());
+
+    // Build a video-only file (no audio stream).
+    let mut encoder = match VideoEncoder::create(&video_only_path)
+        .video(160, 120, 15.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(200_000))
+        .preset(Preset::Ultrafast)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: video encoder unavailable ({e})");
+            return;
+        }
+    };
+    for _ in 0..15 {
+        let frame = create_black_frame(160, 120);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: push_video failed ({e})");
+            return;
+        }
+    }
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: encoder.finish failed ({e})");
+        return;
+    }
+
+    let result = AudioExtractor::new(&video_only_path, &output_path).run();
+    assert!(
+        matches!(result, Err(EncodeError::MediaOperationFailed { .. })),
+        "expected MediaOperationFailed for input with no audio stream, got {result:?}"
+    );
+}
+
+/// An out-of-bounds `stream_index` must return `MediaOperationFailed`.
+#[test]
+fn audio_extractor_should_fail_when_stream_index_out_of_range() {
+    use ff_encode::{BitrateMode, Preset, VideoCodec, VideoEncoder};
+
+    let video_only_path = test_output_path("extractor_stream_idx_oob.mp4");
+    let output_path = test_output_path("extractor_stream_idx_oob_out.mp3");
+    let _guard_v = FileGuard::new(video_only_path.clone());
+    let _guard_o = FileGuard::new(output_path.clone());
+
+    let mut encoder = match VideoEncoder::create(&video_only_path)
+        .video(160, 120, 15.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(200_000))
+        .preset(Preset::Ultrafast)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: video encoder unavailable ({e})");
+            return;
+        }
+    };
+    for _ in 0..15 {
+        let frame = create_black_frame(160, 120);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: push_video failed ({e})");
+            return;
+        }
+    }
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: encoder.finish failed ({e})");
+        return;
+    }
+
+    // Stream index 99 doesn't exist in a 1-stream file.
+    let result = AudioExtractor::new(&video_only_path, &output_path)
+        .stream_index(99)
+        .run();
+    assert!(
+        matches!(result, Err(EncodeError::MediaOperationFailed { .. })),
+        "expected MediaOperationFailed for out-of-range stream_index, got {result:?}"
+    );
+}
+
+// ── Functional tests ──────────────────────────────────────────────────────────
+
+/// Encode a video+audio source, then extract the audio track.
+/// The output file must exist and be non-empty.
+#[test]
+fn audio_extractor_should_produce_audio_file() {
+    use ff_encode::{AudioCodec, BitrateMode, Preset, VideoCodec, VideoEncoder};
+    use ff_format::{AudioFrame, SampleFormat};
+
+    let source_path = test_output_path("extractor_source.mp4");
+    let output_path = test_output_path("extractor_output.mp3");
+    let _guard_s = FileGuard::new(source_path.clone());
+    let _guard_o = FileGuard::new(output_path.clone());
+
+    // Build a video+audio source (1 s at 15 fps, MP4/MPEG4+AAC).
+    let mut encoder = match VideoEncoder::create(&source_path)
+        .video(160, 120, 15.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(200_000))
+        .preset(Preset::Ultrafast)
+        .audio(44100, 1)
+        .audio_codec(AudioCodec::Mp3)
+        .audio_bitrate(64_000)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let sample_rate = 44100_u32;
+    let samples_per_video_frame = (sample_rate as f64 / 15.0) as usize;
+
+    for _ in 0..15 {
+        let frame = create_black_frame(160, 120);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: push_video failed ({e})");
+            return;
+        }
+        let audio =
+            match AudioFrame::empty(samples_per_video_frame, 1, sample_rate, SampleFormat::F32) {
+                Ok(f) => f,
+                Err(e) => {
+                    println!("Skipping: AudioFrame::empty failed ({e})");
+                    return;
+                }
+            };
+        if let Err(e) = encoder.push_audio(&audio) {
+            println!("Skipping: push_audio failed ({e})");
+            return;
+        }
+    }
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: encoder.finish failed ({e})");
+        return;
+    }
+
+    // Extract audio.
+    let result = AudioExtractor::new(&source_path, &output_path).run();
+    match result {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: AudioExtractor::run failed ({e})");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}
+
+/// Same as above but selects stream index 1 (the audio stream in a
+/// video=stream0 + audio=stream1 mp4).
+#[test]
+fn audio_extractor_stream_index_should_extract_selected_stream() {
+    use ff_encode::{AudioCodec, BitrateMode, Preset, VideoCodec, VideoEncoder};
+    use ff_format::{AudioFrame, SampleFormat};
+
+    let source_path = test_output_path("extractor_idx_source.mp4");
+    let output_path = test_output_path("extractor_idx_output.mp3");
+    let _guard_s = FileGuard::new(source_path.clone());
+    let _guard_o = FileGuard::new(output_path.clone());
+
+    let mut encoder = match VideoEncoder::create(&source_path)
+        .video(160, 120, 15.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(200_000))
+        .preset(Preset::Ultrafast)
+        .audio(44100, 1)
+        .audio_codec(AudioCodec::Mp3)
+        .audio_bitrate(64_000)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: encoder unavailable ({e})");
+            return;
+        }
+    };
+
+    let sample_rate = 44100_u32;
+    let samples_per_video_frame = (sample_rate as f64 / 15.0) as usize;
+
+    for _ in 0..15 {
+        let frame = create_black_frame(160, 120);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: push_video failed ({e})");
+            return;
+        }
+        let audio =
+            match AudioFrame::empty(samples_per_video_frame, 1, sample_rate, SampleFormat::F32) {
+                Ok(f) => f,
+                Err(e) => {
+                    println!("Skipping: AudioFrame::empty failed ({e})");
+                    return;
+                }
+            };
+        if let Err(e) = encoder.push_audio(&audio) {
+            println!("Skipping: push_audio failed ({e})");
+            return;
+        }
+    }
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: encoder.finish failed ({e})");
+        return;
+    }
+
+    // In a typical MPEG-4 file: stream 0 = video, stream 1 = audio.
+    let result = AudioExtractor::new(&source_path, &output_path)
+        .stream_index(1)
+        .run();
+    match result {
+        Ok(()) => {}
+        Err(EncodeError::MediaOperationFailed { reason }) if reason.contains("not an audio") => {
+            // stream 1 is video (container reordered) — acceptable, skip
+            println!("Skipping: stream 1 is not audio in this container ({reason})");
+            return;
+        }
+        Err(e) => {
+            println!("Skipping: AudioExtractor::run failed ({e})");
+            return;
+        }
+    }
+
+    assert_valid_output_file(&output_path);
+}


### PR DESCRIPTION
## Summary

Adds `AudioExtractor` to `ff-encode::media_ops` for demuxing an audio track from a media file and writing it to a standalone audio file. The audio bitstream is stream-copied (no decode/encode cycle). Selecting a specific stream by index is supported via the `stream_index()` builder method.

## Changes

- `crates/ff-encode/src/media_ops/media_inner.rs`: added `run_audio_extraction` / `run_audio_extraction_unsafe` following the design doc call sequence — open input, locate audio stream (explicit index or first `AVMEDIA_TYPE_AUDIO`), alloc output context, copy stream params, `avformat_write_header` (failure → `MediaOperationFailed` with container incompatibility message), packet copy loop (audio-only), `av_write_trailer`, cleanup
- `crates/ff-encode/src/media_ops/mod.rs`: added `AudioExtractor` struct with `new()`, `stream_index()`, `run()`, and a unit test
- `crates/ff-encode/src/lib.rs`: added `AudioExtractor` to public re-exports
- `crates/avio/src/lib.rs`: added `AudioExtractor` to the `encode` feature re-exports
- `crates/ff-encode/tests/audio_extractor_tests.rs`: 6 integration tests covering missing input, video-only input (no audio stream), out-of-range stream index, successful extraction, and explicit stream index selection

## Related Issues

Closes #306

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes