### PR TITLE
feat(ff-decode): add KeyframeEnumerator for keyframe timestamp enumeration

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -220,8 +220,8 @@ pub use ff_probe::{ProbeError, open};
 pub use ff_common::VecPool;
 #[cfg(feature = "decode")]
 pub use ff_decode::{
-    AudioDecoder, DecodeError, FramePool, HardwareAccel, ImageDecoder, SceneDetector, SeekMode,
-    VideoDecoder, WaveformAnalyzer, WaveformSample,
+    AudioDecoder, DecodeError, FramePool, HardwareAccel, ImageDecoder, KeyframeEnumerator,
+    SceneDetector, SeekMode, VideoDecoder, WaveformAnalyzer, WaveformSample,
 };
 
 // ── encode feature ────────────────────────────────────────────────────────────

--- a/crates/ff-decode/src/analysis/analysis_inner.rs
+++ b/crates/ff-decode/src/analysis/analysis_inner.rs
@@ -192,3 +192,140 @@ pub(super) unsafe fn detect_scenes_unsafe(
 
     Ok(timestamps)
 }
+
+// ── KeyframeEnumerator inner ──────────────────────────────────────────────────
+
+/// Enumerates all keyframe PTS values for the given stream in `path`.
+///
+/// Processing flow:
+/// 1. `avformat_open_input` + `avformat_find_stream_info`
+/// 2. Locate the target stream (first video stream when `stream_index` is `None`)
+/// 3. `av_read_frame` loop — no decoder is opened
+/// 4. For packets on the target stream with `AV_PKT_FLAG_KEY` set, convert PTS
+///    to [`Duration`] using the stream's time base
+/// 5. `av_packet_unref` after each packet; `av_packet_free` + `avformat_close_input` on exit
+///
+/// # Safety
+///
+/// All raw pointer operations follow avformat ownership rules:
+/// - `avformat_open_input` returns an owned `AVFormatContext*` freed via
+///   `avformat_close_input` on every exit path.
+/// - `av_packet_alloc` returns an owned `AVPacket*` freed via `av_packet_free`.
+/// - `av_packet_unref` is called after every successful `av_read_frame`.
+/// - Stream pointer access is guarded by bounds checks on `nb_streams`.
+pub(super) unsafe fn enumerate_keyframes_unsafe(
+    path: &Path,
+    stream_index: Option<usize>,
+) -> Result<Vec<Duration>, DecodeError> {
+    // AV_PKT_FLAG_KEY = 1 (from FFmpeg's avcodec.h; not exported by ff_sys constants).
+    const AV_PKT_FLAG_KEY: i32 = 1;
+
+    // The `bail_ctx!` macro frees the format context before returning an error.
+    // It must not be used before `format_ctx` is initialised.
+    macro_rules! bail_ctx {
+        ($ctx:ident, $reason:expr) => {{
+            ff_sys::avformat::close_input(std::ptr::addr_of_mut!($ctx));
+            return Err(DecodeError::AnalysisFailed {
+                reason: format!("{}", $reason),
+            });
+        }};
+    }
+
+    // 1. Open input.
+    let mut format_ctx =
+        ff_sys::avformat::open_input(path).map_err(|code| DecodeError::AnalysisFailed {
+            reason: format!("avformat_open_input failed code={code}"),
+        })?;
+
+    // 2. Find stream info.
+    if let Err(code) = ff_sys::avformat::find_stream_info(format_ctx) {
+        bail_ctx!(
+            format_ctx,
+            format!("avformat_find_stream_info failed code={code}")
+        );
+    }
+
+    // 3. Locate the target stream.
+    let nb_streams = (*format_ctx).nb_streams as usize;
+    let target_stream: usize = if let Some(idx) = stream_index {
+        if idx >= nb_streams {
+            bail_ctx!(
+                format_ctx,
+                format!("stream_index {idx} out of range (file has {nb_streams} streams)")
+            );
+        }
+        idx
+    } else {
+        // Select the first video stream.
+        let mut found: Option<usize> = None;
+        for i in 0..nb_streams {
+            let stream = (*format_ctx).streams.add(i);
+            let codecpar = (*(*stream)).codecpar;
+            if (*codecpar).codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO {
+                found = Some(i);
+                break;
+            }
+        }
+        if let Some(i) = found {
+            i
+        } else {
+            bail_ctx!(format_ctx, "no video stream found in file")
+        }
+    };
+
+    // 4. Read the stream's time base for PTS → Duration conversion.
+    let stream = (*format_ctx).streams.add(target_stream);
+    let time_base = (*(*stream)).time_base;
+    let tb_num = f64::from(time_base.num);
+    let tb_den = f64::from(time_base.den);
+
+    // 5. Allocate a reusable packet.
+    let pkt = ff_sys::av_packet_alloc();
+    if pkt.is_null() {
+        bail_ctx!(format_ctx, "av_packet_alloc failed");
+    }
+
+    // 6. Read all packets; record the PTS of every keyframe on the target stream.
+    // Stream indices in AVPacket are i32; the cast is bounded by nb_streams which
+    // is u32, so values fit in i32 on all supported platforms.
+    #[allow(clippy::cast_possible_wrap)]
+    let target_i32 = target_stream as i32;
+    let mut timestamps: Vec<Duration> = Vec::new();
+
+    loop {
+        // `av_read_frame` returns a negative code on EOF or error.
+        let ret = ff_sys::av_read_frame(format_ctx, pkt);
+        if ret < 0 {
+            break;
+        }
+
+        if (*pkt).stream_index == target_i32 && (*pkt).flags & AV_PKT_FLAG_KEY != 0 {
+            // Prefer PTS; fall back to DTS for streams that only write DTS on packets.
+            let pts = if (*pkt).pts == ff_sys::AV_NOPTS_VALUE {
+                (*pkt).dts
+            } else {
+                (*pkt).pts
+            };
+            if pts != ff_sys::AV_NOPTS_VALUE && tb_den > 0.0 {
+                let secs = pts as f64 * tb_num / tb_den;
+                if secs >= 0.0 {
+                    timestamps.push(Duration::from_secs_f64(secs));
+                }
+            }
+        }
+
+        ff_sys::av_packet_unref(pkt);
+    }
+
+    // 7. Release resources.
+    let mut pkt_ptr = pkt;
+    ff_sys::av_packet_free(std::ptr::addr_of_mut!(pkt_ptr));
+    ff_sys::avformat::close_input(std::ptr::addr_of_mut!(format_ctx));
+
+    log::debug!(
+        "keyframe enumeration complete keyframes={} stream_index={target_stream}",
+        timestamps.len()
+    );
+
+    Ok(timestamps)
+}

--- a/crates/ff-decode/src/analysis/mod.rs
+++ b/crates/ff-decode/src/analysis/mod.rs
@@ -231,6 +231,74 @@ impl SceneDetector {
     }
 }
 
+// ── KeyframeEnumerator ────────────────────────────────────────────────────────
+
+/// Enumerates the timestamps of all keyframes in a video stream.
+///
+/// Reads only packet headers — **no decoding is performed** — making this
+/// significantly faster than frame-by-frame decoding.  By default the first
+/// video stream is selected; call [`stream_index`](Self::stream_index) to
+/// target a specific stream.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::KeyframeEnumerator;
+///
+/// let keyframes = KeyframeEnumerator::new("video.mp4").run()?;
+/// for ts in &keyframes {
+///     println!("Keyframe at {:?}", ts);
+/// }
+/// ```
+pub struct KeyframeEnumerator {
+    input: PathBuf,
+    stream_index: Option<usize>,
+}
+
+impl KeyframeEnumerator {
+    /// Creates a new enumerator for the given video file.
+    ///
+    /// The first video stream is used by default.  Call
+    /// [`stream_index`](Self::stream_index) to select a different stream.
+    pub fn new(input: impl AsRef<Path>) -> Self {
+        Self {
+            input: input.as_ref().to_path_buf(),
+            stream_index: None,
+        }
+    }
+
+    /// Selects a specific stream by zero-based index.
+    ///
+    /// When not set (the default), the first video stream in the file is used.
+    #[must_use]
+    pub fn stream_index(self, idx: usize) -> Self {
+        Self {
+            stream_index: Some(idx),
+            ..self
+        }
+    }
+
+    /// Enumerates keyframe timestamps and returns them in presentation order.
+    ///
+    /// # Errors
+    ///
+    /// - [`DecodeError::AnalysisFailed`] — input file not found, no video
+    ///   stream exists, the requested stream index is out of range, or an
+    ///   internal `FFmpeg` error occurs.
+    pub fn run(self) -> Result<Vec<Duration>, DecodeError> {
+        if !self.input.exists() {
+            return Err(DecodeError::AnalysisFailed {
+                reason: format!("file not found: {}", self.input.display()),
+            });
+        }
+        // SAFETY: enumerate_keyframes_unsafe manages all raw pointer lifetimes:
+        // - avformat_open_input / avformat_close_input own the format context.
+        // - av_packet_alloc / av_packet_free own the packet.
+        // - av_packet_unref is called after every av_read_frame success.
+        unsafe { analysis_inner::enumerate_keyframes_unsafe(&self.input, self.stream_index) }
+    }
+}
+
 // ── Private helpers ───────────────────────────────────────────────────────────
 
 /// Builds a [`WaveformSample`] from the raw `f32` PCM values accumulated for
@@ -301,6 +369,15 @@ mod tests {
         assert!(
             matches!(result, Err(DecodeError::AnalysisFailed { .. })),
             "expected AnalysisFailed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn keyframe_enumerator_missing_file_should_return_analysis_failed() {
+        let result = KeyframeEnumerator::new("does_not_exist_99999.mp4").run();
+        assert!(
+            matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+            "expected AnalysisFailed for missing file, got {result:?}"
         );
     }
 

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -113,7 +113,7 @@ pub mod video;
 pub(crate) use shared::network;
 
 // Re-exports for convenience
-pub use analysis::{SceneDetector, WaveformAnalyzer, WaveformSample};
+pub use analysis::{KeyframeEnumerator, SceneDetector, WaveformAnalyzer, WaveformSample};
 pub use audio::{AudioDecoder, AudioDecoderBuilder};
 pub use error::DecodeError;
 pub use ff_common::{FramePool, PooledBuffer};

--- a/crates/ff-decode/tests/keyframe_enumerator_tests.rs
+++ b/crates/ff-decode/tests/keyframe_enumerator_tests.rs
@@ -1,0 +1,163 @@
+//! Integration tests for KeyframeEnumerator.
+//!
+//! Tests verify:
+//! - Missing input file returns `DecodeError::AnalysisFailed`
+//! - Out-of-range stream_index returns `DecodeError::AnalysisFailed`
+//! - A real video file returns a non-empty `Vec<Duration>`
+//! - Returned timestamps are monotonically non-decreasing
+
+#![allow(clippy::unwrap_used)]
+
+use ff_decode::{DecodeError, KeyframeEnumerator};
+
+fn test_video_path() -> std::path::PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    std::path::PathBuf::from(format!("{manifest_dir}/../../assets/video/gameplay.mp4"))
+}
+
+// ── Error-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn keyframe_enumerator_missing_file_should_return_analysis_failed() {
+    let result = KeyframeEnumerator::new("does_not_exist_99999.mp4").run();
+    assert!(
+        matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+        "expected AnalysisFailed for missing file, got {result:?}"
+    );
+}
+
+#[test]
+fn keyframe_enumerator_invalid_stream_index_should_return_analysis_failed() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video file not found at {}", path.display());
+        return;
+    }
+
+    let result = KeyframeEnumerator::new(&path).stream_index(9999).run();
+    assert!(
+        matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+        "expected AnalysisFailed for stream_index=9999, got {result:?}"
+    );
+}
+
+// ── Functional tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn keyframe_enumerator_should_return_non_empty_vec() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video file not found at {}", path.display());
+        return;
+    }
+
+    let keyframes = match KeyframeEnumerator::new(&path).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: KeyframeEnumerator::run failed ({e})");
+            return;
+        }
+    };
+
+    assert!(
+        !keyframes.is_empty(),
+        "expected at least one keyframe in a real video file"
+    );
+}
+
+#[test]
+fn keyframe_enumerator_timestamps_should_be_monotonically_non_decreasing() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video file not found at {}", path.display());
+        return;
+    }
+
+    let keyframes = match KeyframeEnumerator::new(&path).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: KeyframeEnumerator::run failed ({e})");
+            return;
+        }
+    };
+
+    for window in keyframes.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "timestamps not monotonic: {:?} > {:?}",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+#[test]
+fn keyframe_enumerator_explicit_stream_zero_should_match_default() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video file not found at {}", path.display());
+        return;
+    }
+
+    let default_result = match KeyframeEnumerator::new(&path).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: default run failed ({e})");
+            return;
+        }
+    };
+
+    let explicit_result = match KeyframeEnumerator::new(&path).stream_index(0).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: stream_index(0) run failed ({e})");
+            return;
+        }
+    };
+
+    // Both should return the same keyframe count (stream 0 is always the first
+    // video stream for a typical video file).
+    assert_eq!(
+        default_result.len(),
+        explicit_result.len(),
+        "default and stream_index(0) should yield the same keyframe count"
+    );
+}
+
+#[test]
+fn keyframe_enumerator_all_timestamps_within_video_duration() {
+    use ff_decode::VideoDecoder;
+    use std::time::Duration;
+
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video file not found at {}", path.display());
+        return;
+    }
+
+    let duration = match VideoDecoder::open(&path).build() {
+        Ok(dec) => dec.duration(),
+        Err(e) => {
+            println!("Skipping: VideoDecoder failed ({e})");
+            return;
+        }
+    };
+
+    let keyframes = match KeyframeEnumerator::new(&path).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: KeyframeEnumerator::run failed ({e})");
+            return;
+        }
+    };
+
+    let margin = Duration::from_secs(1);
+    for ts in &keyframes {
+        assert!(
+            *ts <= duration + margin,
+            "keyframe timestamp {:?} exceeds video duration {:?}",
+            ts,
+            duration
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `KeyframeEnumerator` to `ff-decode`, which enumerates the PTS timestamps of all keyframes in a video stream by reading packet headers only — no decoding is performed. This makes it significantly faster than frame-by-frame decoding. Supports selecting a specific stream by index or defaulting to the first video stream.

## Changes

- `crates/ff-decode/src/analysis/mod.rs` — `KeyframeEnumerator` builder type with `new()`, `stream_index()`, and `run()` methods; unit test for missing-file error
- `crates/ff-decode/src/analysis/analysis_inner.rs` — `enumerate_keyframes_unsafe()`: `avformat_open_input` + `avformat_find_stream_info` + `av_read_frame` loop; records PTS of packets with `AV_PKT_FLAG_KEY` set; falls back to DTS when PTS is `AV_NOPTS_VALUE`
- `crates/ff-decode/src/lib.rs` — re-exports `KeyframeEnumerator`
- `crates/avio/src/lib.rs` — re-exports `KeyframeEnumerator` under the `decode` feature flag
- `crates/ff-decode/tests/keyframe_enumerator_tests.rs` — 6 integration tests covering missing file, out-of-range stream index, non-empty result, monotonic timestamps, stream-index(0) vs default, and all timestamps within video duration

## Related Issues

Closes #311

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes