### PR TITLE
feat(ff-filter): add QualityMetrics::psnr for PSNR video quality measurement

### DIFF
--- a/crates/ff-filter/src/analysis/analysis_inner.rs
+++ b/crates/ff-filter/src/analysis/analysis_inner.rs
@@ -5,6 +5,7 @@
 //! Current entry points:
 //! - [`measure_loudness_unsafe`] — EBU R128 loudness via `ebur128` filter
 //! - [`compute_ssim_unsafe`] — mean SSIM via `ssim` filter
+//! - [`compute_psnr_unsafe`] — mean PSNR via `psnr` filter
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
@@ -414,6 +415,221 @@ pub(super) unsafe fn compute_ssim_unsafe(
     log::debug!("ssim complete mean={mean_ssim:.6} frames={frame_count}");
 
     Ok(mean_ssim)
+}
+
+/// Computes the mean PSNR (Peak Signal-to-Noise Ratio, in dB) between
+/// `reference` and `distorted` using the filter graph:
+///
+/// `movie=reference [r]; movie=distorted [d]; [r][d] psnr=eof_action=endall → buffersink`
+///
+/// Drains all output frames, reading `lavfi.psnr.psnr.y` (luminance PSNR) from
+/// each frame's metadata.  Returns the arithmetic mean over all frames.
+///
+/// When both inputs are identical every frame has MSE=0 and therefore infinite
+/// PSNR; in that case this function returns `f32::INFINITY`.
+///
+/// Performs a pre-flight frame-count check identical to [`compute_ssim_unsafe`].
+///
+/// # Safety
+///
+/// All raw pointer operations follow the avfilter ownership rules:
+/// - `avfilter_graph_alloc()` returns an owned pointer freed via
+///   `avfilter_graph_free()` on every exit path (bail! or normal).
+/// - `avfilter_graph_create_filter()` adds contexts owned by the graph.
+/// - `avfilter_link()` connects pads owned by the graph.
+/// - `avfilter_graph_config()` finalises the graph.
+/// - `av_frame_alloc()` / `av_frame_free()` manage per-frame lifetimes.
+/// - Frame metadata is read via `av_dict_get`; the returned pointer is valid
+///   for the lifetime of the frame.
+pub(super) unsafe fn compute_psnr_unsafe(
+    reference: &Path,
+    distorted: &Path,
+) -> Result<f32, FilterError> {
+    // ── Pre-flight: reject inputs with different frame counts ──────────────
+    let ref_count = probe_video_frame_count(reference);
+    let dist_count = probe_video_frame_count(distorted);
+    if let (Some(r), Some(d)) = (ref_count, dist_count)
+        && (r - d).abs() > 1
+    {
+        return Err(FilterError::AnalysisFailed {
+            reason: format!("frame count mismatch: reference={r} distorted={d}"),
+        });
+    }
+
+    macro_rules! bail {
+        ($graph:ident, $reason:expr) => {{
+            let mut g = $graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::AnalysisFailed {
+                reason: format!("{}", $reason),
+            });
+        }};
+    }
+
+    let ref_str = reference.to_string_lossy();
+    let dist_str = distorted.to_string_lossy();
+
+    let ref_args =
+        CString::new(format!("filename={ref_str}")).map_err(|_| FilterError::AnalysisFailed {
+            reason: "reference path contains null byte".to_string(),
+        })?;
+    let dist_args =
+        CString::new(format!("filename={dist_str}")).map_err(|_| FilterError::AnalysisFailed {
+            reason: "distorted path contains null byte".to_string(),
+        })?;
+
+    let graph = ff_sys::avfilter_graph_alloc();
+    if graph.is_null() {
+        return Err(FilterError::AnalysisFailed {
+            reason: "avfilter_graph_alloc failed".to_string(),
+        });
+    }
+
+    // 1. movie source — reference video.
+    let movie_filt = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
+    if movie_filt.is_null() {
+        bail!(graph, "filter not found: movie");
+    }
+    let mut ref_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut ref_ctx,
+        movie_filt,
+        c"psnr_ref".as_ptr(),
+        ref_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("movie(reference) create_filter failed code={ret}")
+        );
+    }
+
+    // 2. movie source — distorted video.
+    let mut dist_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut dist_ctx,
+        movie_filt,
+        c"psnr_dist".as_ptr(),
+        dist_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("movie(distorted) create_filter failed code={ret}")
+        );
+    }
+
+    // 3. psnr=eof_action=endall — annotates output frames with lavfi.psnr.* metadata.
+    let psnr_filt = ff_sys::avfilter_get_by_name(c"psnr".as_ptr());
+    if psnr_filt.is_null() {
+        bail!(graph, "filter not found: psnr");
+    }
+    let mut psnr_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut psnr_ctx,
+        psnr_filt,
+        c"psnr_compute".as_ptr(),
+        c"eof_action=endall".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("psnr create_filter failed code={ret}"));
+    }
+
+    // 4. buffersink — drains psnr output frames so we can read their metadata.
+    let buffersink_filt = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
+    if buffersink_filt.is_null() {
+        bail!(graph, "filter not found: buffersink");
+    }
+    let mut sink_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sink_ctx,
+        buffersink_filt,
+        c"psnr_sink".as_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("buffersink create_filter failed code={ret}"));
+    }
+
+    // Link: ref_ctx[0] → psnr[0], dist_ctx[0] → psnr[1], psnr[0] → sink
+    let ret = ff_sys::avfilter_link(ref_ctx, 0, psnr_ctx, 0);
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("avfilter_link ref→psnr[0] failed code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(dist_ctx, 0, psnr_ctx, 1);
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("avfilter_link dist→psnr[1] failed code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(psnr_ctx, 0, sink_ctx, 0);
+    if ret < 0 {
+        bail!(graph, format!("avfilter_link psnr→sink failed code={ret}"));
+    }
+
+    // Configure the graph.
+    let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
+    if ret < 0 {
+        bail!(graph, format!("avfilter_graph_config failed code={ret}"));
+    }
+
+    // Drain all frames; collect per-frame lavfi.psnr.psnr.y values.
+    // Use NEG_INFINITY as a sentinel (actual PSNR is always ≥ 0 or +infinity).
+    let mut psnr_sum: f64 = 0.0;
+    let mut frame_count: u64 = 0;
+
+    loop {
+        let raw_frame = ff_sys::av_frame_alloc();
+        if raw_frame.is_null() {
+            break;
+        }
+        let ret = ff_sys::av_buffersink_get_frame(sink_ctx, raw_frame);
+        if ret < 0 {
+            let mut ptr = raw_frame;
+            ff_sys::av_frame_free(std::ptr::addr_of_mut!(ptr));
+            break;
+        }
+
+        // SAFETY: `(*raw_frame).metadata` is a valid `AVDictionary*` (may be null);
+        // `av_dict_get` handles null dictionaries by returning null.
+        let mut psnr_val = f32::NEG_INFINITY; // sentinel: "key not present"
+        read_f32_meta(raw_frame, c"lavfi.psnr.psnr.y".as_ptr(), &mut psnr_val);
+        if psnr_val > f32::NEG_INFINITY {
+            psnr_sum += f64::from(psnr_val);
+            frame_count += 1;
+        }
+
+        let mut ptr = raw_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(ptr));
+    }
+
+    let mut g = graph;
+    ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+
+    if frame_count == 0 {
+        return Err(FilterError::AnalysisFailed {
+            reason: "no frames were compared (empty or incompatible inputs)".to_string(),
+        });
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    let mean_psnr = (psnr_sum / frame_count as f64) as f32;
+
+    log::debug!("psnr complete mean={mean_psnr:.3} frames={frame_count}");
+
+    Ok(mean_psnr)
 }
 
 /// Returns the estimated frame count for the first video stream in `path`.

--- a/crates/ff-filter/src/analysis/mod.rs
+++ b/crates/ff-filter/src/analysis/mod.rs
@@ -143,6 +143,55 @@ impl QualityMetrics {
         // returning, either in the bail! macro or in the normal cleanup path.
         unsafe { analysis_inner::compute_ssim_unsafe(reference, distorted) }
     }
+
+    /// Computes the mean PSNR (Peak Signal-to-Noise Ratio, in dB) over all
+    /// frames between `reference` and `distorted`.
+    ///
+    /// Uses the luminance (Y-plane) PSNR as the representative value.
+    ///
+    /// - Identical inputs → `f32::INFINITY` (MSE = 0).
+    /// - Lightly compressed → typically > 40 dB.
+    /// - Heavy degradation → typically < 30 dB.
+    ///
+    /// Uses `FFmpeg`'s `psnr` filter internally.  Both inputs must have the
+    /// same frame count; if they differ the function returns an error.
+    ///
+    /// # Errors
+    ///
+    /// - [`FilterError::AnalysisFailed`] — either input file is not found, the
+    ///   inputs have different frame counts, or the internal filter graph fails.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_filter::QualityMetrics;
+    ///
+    /// // Compare a video against itself — should return infinity.
+    /// let psnr = QualityMetrics::psnr("reference.mp4", "reference.mp4")?;
+    /// assert!(psnr > 100.0 || psnr == f32::INFINITY);
+    /// ```
+    pub fn psnr(
+        reference: impl AsRef<Path>,
+        distorted: impl AsRef<Path>,
+    ) -> Result<f32, FilterError> {
+        let reference = reference.as_ref();
+        let distorted = distorted.as_ref();
+
+        if !reference.exists() {
+            return Err(FilterError::AnalysisFailed {
+                reason: format!("reference file not found: {}", reference.display()),
+            });
+        }
+        if !distorted.exists() {
+            return Err(FilterError::AnalysisFailed {
+                reason: format!("distorted file not found: {}", distorted.display()),
+            });
+        }
+        // SAFETY: compute_psnr_unsafe manages all raw pointer lifetimes according
+        // to the avfilter ownership rules: every allocated object is freed before
+        // returning, either in the bail! macro or in the normal cleanup path.
+        unsafe { analysis_inner::compute_psnr_unsafe(reference, distorted) }
+    }
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────────
@@ -176,6 +225,25 @@ mod tests {
         // Use a path that is guaranteed to exist: the Cargo.toml for this crate.
         let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
         let result = QualityMetrics::ssim(&manifest, "does_not_exist_dist_99999.mp4");
+        assert!(
+            matches!(result, Err(FilterError::AnalysisFailed { .. })),
+            "expected AnalysisFailed for missing distorted, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn quality_metrics_psnr_missing_reference_should_return_analysis_failed() {
+        let result = QualityMetrics::psnr("does_not_exist_ref.mp4", "does_not_exist_dist.mp4");
+        assert!(
+            matches!(result, Err(FilterError::AnalysisFailed { .. })),
+            "expected AnalysisFailed for missing reference, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn quality_metrics_psnr_missing_distorted_should_return_analysis_failed() {
+        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let result = QualityMetrics::psnr(&manifest, "does_not_exist_dist_99999.mp4");
         assert!(
             matches!(result, Err(FilterError::AnalysisFailed { .. })),
             "expected AnalysisFailed for missing distorted, got {result:?}"

--- a/crates/ff-filter/tests/quality_metrics_tests.rs
+++ b/crates/ff-filter/tests/quality_metrics_tests.rs
@@ -4,6 +4,8 @@
 //! - Missing reference returns `FilterError::AnalysisFailed`
 //! - Comparing a video to itself returns SSIM ≈ 1.0
 //! - The returned SSIM is in [0.0, 1.0]
+//! - Comparing a video to itself returns PSNR = infinity (or very large)
+//! - The returned PSNR is non-negative
 
 #![allow(clippy::unwrap_used)]
 
@@ -71,5 +73,65 @@ fn quality_metrics_ssim_result_should_be_between_zero_and_one() {
     assert!(
         (0.0..=1.0).contains(&ssim),
         "expected SSIM in [0.0, 1.0], got {ssim}"
+    );
+}
+
+// ── PSNR error-path tests ─────────────────────────────────────────────────────
+
+#[test]
+fn quality_metrics_psnr_missing_reference_should_return_analysis_failed() {
+    let result = QualityMetrics::psnr(
+        "does_not_exist_ref_99999.mp4",
+        "does_not_exist_dist_99999.mp4",
+    );
+    assert!(
+        matches!(result, Err(FilterError::AnalysisFailed { .. })),
+        "expected AnalysisFailed for missing reference, got {result:?}"
+    );
+}
+
+// ── PSNR functional tests ─────────────────────────────────────────────────────
+
+#[test]
+fn quality_metrics_psnr_identical_files_should_return_large_value() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video file not found at {}", path.display());
+        return;
+    }
+
+    let psnr = match QualityMetrics::psnr(&path, &path) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: QualityMetrics::psnr failed ({e})");
+            return;
+        }
+    };
+
+    assert!(
+        psnr > 100.0 || psnr == f32::INFINITY,
+        "expected PSNR > 100 dB or infinity when comparing a file to itself, got {psnr}"
+    );
+}
+
+#[test]
+fn quality_metrics_psnr_result_should_be_non_negative() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video file not found at {}", path.display());
+        return;
+    }
+
+    let psnr = match QualityMetrics::psnr(&path, &path) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: QualityMetrics::psnr failed ({e})");
+            return;
+        }
+    };
+
+    assert!(
+        psnr >= 0.0 || psnr == f32::INFINITY,
+        "expected PSNR ≥ 0.0 dB, got {psnr}"
     );
 }


### PR DESCRIPTION
## Summary

Adds `QualityMetrics::psnr` to `ff-filter::analysis`, which computes the mean PSNR (Peak Signal-to-Noise Ratio, in dB) between a reference and a distorted video using FFmpeg's `psnr` filter. Uses the luminance (Y-plane) PSNR as the representative value. Identical inputs return `f32::INFINITY` (MSE = 0); the same pre-flight frame-count validation from `ssim` is reused.

## Changes

- `analysis/analysis_inner.rs`: added `compute_psnr_unsafe()` — two-input `movie → psnr=eof_action=endall → buffersink` filter graph; reads `lavfi.psnr.psnr.y` per frame; uses `f32::NEG_INFINITY` as a sentinel to distinguish "key not present" from a real zero-dB value; returns `f32::INFINITY` for identical inputs
- `analysis/mod.rs`: added `QualityMetrics::psnr()` static method with existence checks and two unit tests for missing-file error paths
- `tests/quality_metrics_tests.rs`: added three PSNR integration tests — missing reference error path, identical-file PSNR > 100 dB or infinity, result non-negative

## Related Issues

Closes #314

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes