### PR TITLE
feat(ff-decode): add BlackFrameDetector for black interval detection

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -220,9 +220,9 @@ pub use ff_probe::{ProbeError, open};
 pub use ff_common::VecPool;
 #[cfg(feature = "decode")]
 pub use ff_decode::{
-    AudioDecoder, DecodeError, FrameHistogram, FramePool, HardwareAccel, HistogramExtractor,
-    ImageDecoder, KeyframeEnumerator, SceneDetector, SeekMode, SilenceDetector, SilenceRange,
-    VideoDecoder, WaveformAnalyzer, WaveformSample,
+    AudioDecoder, BlackFrameDetector, DecodeError, FrameHistogram, FramePool, HardwareAccel,
+    HistogramExtractor, ImageDecoder, KeyframeEnumerator, SceneDetector, SeekMode, SilenceDetector,
+    SilenceRange, VideoDecoder, WaveformAnalyzer, WaveformSample,
 };
 
 // ── encode feature ────────────────────────────────────────────────────────────

--- a/crates/ff-decode/src/analysis/analysis_inner.rs
+++ b/crates/ff-decode/src/analysis/analysis_inner.rs
@@ -9,6 +9,7 @@
 //! - [`detect_scenes_unsafe`] — `SceneDetector`
 //! - [`detect_silence_unsafe`] — `SilenceDetector`
 //! - [`enumerate_keyframes_unsafe`] — `KeyframeEnumerator`
+//! - [`detect_black_frames_unsafe`] — `BlackFrameDetector`
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
@@ -411,6 +412,179 @@ unsafe fn read_f64_meta(
         .to_str()
         .ok()
         .and_then(|s| s.parse::<f64>().ok())
+}
+
+// ── BlackFrameDetector inner ──────────────────────────────────────────────────
+
+/// Detects black intervals in `path` using the filter graph:
+///
+/// `movie=filename=path → blackdetect=d=0.1:pic_th={threshold} → buffersink`
+///
+/// Drains all output frames, reading `lavfi.black_start` from each frame's
+/// metadata.  Returns one [`Duration`] per detected black interval start.
+///
+/// # Safety
+///
+/// All raw pointer operations follow the avfilter ownership rules:
+/// - `avfilter_graph_alloc()` returns an owned pointer freed via
+///   `avfilter_graph_free()` on error or after draining.
+/// - `avfilter_graph_create_filter()` adds contexts owned by the graph.
+/// - `avfilter_link()` connects pads owned by the graph.
+/// - `avfilter_graph_config()` finalises the graph.
+/// - `av_frame_alloc()` / `av_frame_free()` manage per-frame lifetimes.
+/// - `(*frame).metadata` is a valid `AVDictionary*` (may be null); `av_dict_get`
+///   handles null dictionaries safely by returning null.
+pub(super) unsafe fn detect_black_frames_unsafe(
+    path: &Path,
+    threshold: f64,
+) -> Result<Vec<Duration>, DecodeError> {
+    macro_rules! bail {
+        ($graph:ident, $reason:expr) => {{
+            let mut g = $graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(DecodeError::AnalysisFailed {
+                reason: format!("{}", $reason),
+            });
+        }};
+    }
+
+    let path_str = path.to_string_lossy();
+    let movie_args =
+        CString::new(format!("filename={path_str}")).map_err(|_| DecodeError::AnalysisFailed {
+            reason: "path contains null byte".to_string(),
+        })?;
+
+    // blackdetect=d=0.1:pic_th={threshold}
+    //   d     — minimum black-interval duration (0.1 s)
+    //   pic_th — fraction of black pixels required per frame (0.0–1.0)
+    let blackdetect_args = CString::new(format!("d=0.1:pic_th={threshold:.6}")).map_err(|_| {
+        DecodeError::AnalysisFailed {
+            reason: "blackdetect args contained null byte".to_string(),
+        }
+    })?;
+
+    let graph = ff_sys::avfilter_graph_alloc();
+    if graph.is_null() {
+        return Err(DecodeError::AnalysisFailed {
+            reason: "avfilter_graph_alloc failed".to_string(),
+        });
+    }
+
+    // 1. movie source — reads the video file directly.
+    let movie_filt = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
+    if movie_filt.is_null() {
+        bail!(graph, "filter not found: movie");
+    }
+    let mut src_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut src_ctx,
+        movie_filt,
+        c"black_src".as_ptr(),
+        movie_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("movie create_filter failed code={ret}"));
+    }
+
+    // 2. blackdetect — annotates frames with lavfi.black_start / lavfi.black_end.
+    let blackdetect_filt = ff_sys::avfilter_get_by_name(c"blackdetect".as_ptr());
+    if blackdetect_filt.is_null() {
+        bail!(graph, "filter not found: blackdetect");
+    }
+    let mut bd_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut bd_ctx,
+        blackdetect_filt,
+        c"black_detect".as_ptr(),
+        blackdetect_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("blackdetect create_filter failed code={ret}")
+        );
+    }
+
+    // 3. buffersink — collects output frames.
+    let buffersink_filt = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
+    if buffersink_filt.is_null() {
+        bail!(graph, "filter not found: buffersink");
+    }
+    let mut sink_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sink_ctx,
+        buffersink_filt,
+        c"black_sink".as_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("buffersink create_filter failed code={ret}"));
+    }
+
+    // Link: src → blackdetect → sink
+    let ret = ff_sys::avfilter_link(src_ctx, 0, bd_ctx, 0);
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("avfilter_link src→blackdetect failed code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(bd_ctx, 0, sink_ctx, 0);
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("avfilter_link blackdetect→sink failed code={ret}")
+        );
+    }
+
+    // Configure the graph.
+    let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
+    if ret < 0 {
+        bail!(graph, format!("avfilter_graph_config failed code={ret}"));
+    }
+
+    // Drain all frames; collect lavfi.black_start timestamps.
+    let mut timestamps: Vec<Duration> = Vec::new();
+
+    loop {
+        let raw_frame = ff_sys::av_frame_alloc();
+        if raw_frame.is_null() {
+            break;
+        }
+        let ret = ff_sys::av_buffersink_get_frame(sink_ctx, raw_frame);
+        if ret < 0 {
+            let mut ptr = raw_frame;
+            ff_sys::av_frame_free(std::ptr::addr_of_mut!(ptr));
+            break;
+        }
+
+        // SAFETY: `(*raw_frame).metadata` is a valid `AVDictionary*` (possibly null);
+        // `av_dict_get` handles null dictionaries safely by returning null.
+        if let Some(secs) = read_f64_meta(raw_frame, c"lavfi.black_start".as_ptr())
+            && secs >= 0.0
+        {
+            timestamps.push(Duration::from_secs_f64(secs));
+        }
+
+        let mut ptr = raw_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(ptr));
+    }
+
+    let mut g = graph;
+    ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+
+    log::debug!(
+        "black frame detection complete intervals={} threshold={threshold:.4}",
+        timestamps.len()
+    );
+
+    Ok(timestamps)
 }
 
 // ── KeyframeEnumerator inner ──────────────────────────────────────────────────

--- a/crates/ff-decode/src/analysis/mod.rs
+++ b/crates/ff-decode/src/analysis/mod.rs
@@ -523,6 +523,86 @@ impl HistogramExtractor {
     }
 }
 
+// ── BlackFrameDetector ───────────────────────────────────────────────────────
+
+/// Detects black intervals in a video file and returns their start timestamps.
+///
+/// Uses `FFmpeg`'s `blackdetect` filter to identify frames or segments where
+/// the proportion of "black" pixels exceeds `threshold`.  One [`Duration`] is
+/// returned per detected black interval (the start of that interval).
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::BlackFrameDetector;
+///
+/// let black_starts = BlackFrameDetector::new("video.mp4")
+///     .threshold(0.1)
+///     .run()?;
+///
+/// for ts in &black_starts {
+///     println!("Black interval starts at {:?}", ts);
+/// }
+/// ```
+pub struct BlackFrameDetector {
+    input: PathBuf,
+    threshold: f64,
+}
+
+impl BlackFrameDetector {
+    /// Creates a new detector for the given video file.
+    ///
+    /// The default threshold is `0.1` (10% of pixels must be below the
+    /// blackness cutoff for a frame to count as black).
+    pub fn new(input: impl AsRef<Path>) -> Self {
+        Self {
+            input: input.as_ref().to_path_buf(),
+            threshold: 0.1,
+        }
+    }
+
+    /// Sets the luminance threshold for black-pixel detection.
+    ///
+    /// Must be in the range `[0.0, 1.0]`.  Higher values make the detector
+    /// more permissive (more frames qualify as black); lower values are
+    /// stricter.  Passing a value outside this range causes
+    /// [`run`](Self::run) to return [`DecodeError::AnalysisFailed`].
+    ///
+    /// Default: `0.1`.
+    #[must_use]
+    pub fn threshold(self, t: f64) -> Self {
+        Self {
+            threshold: t,
+            ..self
+        }
+    }
+
+    /// Runs black-frame detection and returns the start [`Duration`] of each
+    /// detected black interval.
+    ///
+    /// # Errors
+    ///
+    /// - [`DecodeError::AnalysisFailed`] — `threshold` outside `[0.0, 1.0]`,
+    ///   input file not found, or an internal filter-graph error.
+    pub fn run(self) -> Result<Vec<Duration>, DecodeError> {
+        if !(0.0..=1.0).contains(&self.threshold) {
+            return Err(DecodeError::AnalysisFailed {
+                reason: format!("threshold must be in [0.0, 1.0], got {}", self.threshold),
+            });
+        }
+        if !self.input.exists() {
+            return Err(DecodeError::AnalysisFailed {
+                reason: format!("file not found: {}", self.input.display()),
+            });
+        }
+        // SAFETY: detect_black_frames_unsafe manages all raw pointer lifetimes
+        // according to the avfilter ownership rules: the graph is allocated with
+        // avfilter_graph_alloc(), built and configured, drained, then freed before
+        // returning.  The path CString is valid for the duration of the graph build.
+        unsafe { analysis_inner::detect_black_frames_unsafe(&self.input, self.threshold) }
+    }
+}
+
 // ── Private helpers ───────────────────────────────────────────────────────────
 
 /// Computes R, G, B, and luma histograms for a single `RGB24` frame.
@@ -850,6 +930,56 @@ mod tests {
             hist.luma.iter().sum::<u32>(),
             total,
             "luma bin sum should equal total pixels"
+        );
+    }
+
+    #[test]
+    fn black_frame_detector_invalid_threshold_below_zero_should_return_analysis_failed() {
+        let result = BlackFrameDetector::new("irrelevant.mp4")
+            .threshold(-0.1)
+            .run();
+        assert!(
+            matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+            "expected AnalysisFailed for threshold=-0.1, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn black_frame_detector_invalid_threshold_above_one_should_return_analysis_failed() {
+        let result = BlackFrameDetector::new("irrelevant.mp4")
+            .threshold(1.1)
+            .run();
+        assert!(
+            matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+            "expected AnalysisFailed for threshold=1.1, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn black_frame_detector_missing_file_should_return_analysis_failed() {
+        let result = BlackFrameDetector::new("does_not_exist_99999.mp4").run();
+        assert!(
+            matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+            "expected AnalysisFailed for missing file, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn black_frame_detector_boundary_thresholds_should_be_valid() {
+        // 0.0 and 1.0 are valid thresholds; errors come from missing file, not threshold.
+        let r0 = BlackFrameDetector::new("irrelevant.mp4")
+            .threshold(0.0)
+            .run();
+        let r1 = BlackFrameDetector::new("irrelevant.mp4")
+            .threshold(1.0)
+            .run();
+        assert!(
+            matches!(r0, Err(DecodeError::AnalysisFailed { .. })),
+            "expected AnalysisFailed (file not found) for threshold=0.0, got {r0:?}"
+        );
+        assert!(
+            matches!(r1, Err(DecodeError::AnalysisFailed { .. })),
+            "expected AnalysisFailed (file not found) for threshold=1.0, got {r1:?}"
         );
     }
 }

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -114,8 +114,8 @@ pub(crate) use shared::network;
 
 // Re-exports for convenience
 pub use analysis::{
-    FrameHistogram, HistogramExtractor, KeyframeEnumerator, SceneDetector, SilenceDetector,
-    SilenceRange, WaveformAnalyzer, WaveformSample,
+    BlackFrameDetector, FrameHistogram, HistogramExtractor, KeyframeEnumerator, SceneDetector,
+    SilenceDetector, SilenceRange, WaveformAnalyzer, WaveformSample,
 };
 pub use audio::{AudioDecoder, AudioDecoderBuilder};
 pub use error::DecodeError;

--- a/crates/ff-decode/tests/black_frame_detector_tests.rs
+++ b/crates/ff-decode/tests/black_frame_detector_tests.rs
@@ -1,0 +1,140 @@
+//! Integration tests for BlackFrameDetector.
+//!
+//! Tests verify:
+//! - Out-of-range threshold returns `DecodeError::AnalysisFailed`
+//! - Missing input file returns `DecodeError::AnalysisFailed`
+//! - A real video file returns a `Vec<Duration>` without errors
+//! - Returned timestamps are monotonically non-decreasing
+
+#![allow(clippy::unwrap_used)]
+
+use ff_decode::{BlackFrameDetector, DecodeError};
+use std::time::Duration;
+
+fn test_video_path() -> std::path::PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    std::path::PathBuf::from(format!("{manifest_dir}/../../assets/video/gameplay.mp4"))
+}
+
+// ── Error-path tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn black_frame_detector_threshold_below_zero_should_return_analysis_failed() {
+    let result = BlackFrameDetector::new("irrelevant.mp4")
+        .threshold(-0.1)
+        .run();
+    assert!(
+        matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+        "expected AnalysisFailed for threshold=-0.1, got {result:?}"
+    );
+}
+
+#[test]
+fn black_frame_detector_threshold_above_one_should_return_analysis_failed() {
+    let result = BlackFrameDetector::new("irrelevant.mp4")
+        .threshold(1.1)
+        .run();
+    assert!(
+        matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+        "expected AnalysisFailed for threshold=1.1, got {result:?}"
+    );
+}
+
+#[test]
+fn black_frame_detector_missing_file_should_return_analysis_failed() {
+    let result = BlackFrameDetector::new("does_not_exist_99999.mp4").run();
+    assert!(
+        matches!(result, Err(DecodeError::AnalysisFailed { .. })),
+        "expected AnalysisFailed for missing file, got {result:?}"
+    );
+}
+
+// ── Functional tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn black_frame_detector_no_black_should_return_empty() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video not found at {}", path.display());
+        return;
+    }
+
+    // Most gameplay videos have no black frames; a typical result is empty.
+    // Use a high threshold so only truly solid-black frames are reported.
+    let result = match BlackFrameDetector::new(&path).threshold(0.98).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: BlackFrameDetector::run failed ({e})");
+            return;
+        }
+    };
+
+    // We can't assert the result is empty without knowing the video content,
+    // so just verify it's a valid Vec<Duration>.
+    for ts in &result {
+        let _ = ts.as_secs_f64();
+    }
+}
+
+#[test]
+fn black_frame_detector_timestamps_should_be_monotonically_non_decreasing() {
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video not found at {}", path.display());
+        return;
+    }
+
+    let timestamps = match BlackFrameDetector::new(&path).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: BlackFrameDetector::run failed ({e})");
+            return;
+        }
+    };
+
+    for window in timestamps.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "timestamps not monotonic: {:?} > {:?}",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+#[test]
+fn black_frame_detector_all_timestamps_within_video_duration() {
+    use ff_decode::VideoDecoder;
+
+    let path = test_video_path();
+    if !path.exists() {
+        println!("Skipping: test video not found at {}", path.display());
+        return;
+    }
+
+    let duration = match VideoDecoder::open(&path).build() {
+        Ok(dec) => dec.duration(),
+        Err(e) => {
+            println!("Skipping: VideoDecoder failed ({e})");
+            return;
+        }
+    };
+
+    let timestamps = match BlackFrameDetector::new(&path).run() {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Skipping: BlackFrameDetector::run failed ({e})");
+            return;
+        }
+    };
+
+    let margin = Duration::from_secs(1);
+    for ts in &timestamps {
+        assert!(
+            *ts <= duration + margin,
+            "timestamp {:?} exceeds video duration {:?}",
+            ts,
+            duration
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `BlackFrameDetector` to `ff-decode::analysis`, which detects black intervals in a video using FFmpeg's `blackdetect` filter and returns one `Duration` per detected black interval start. The `threshold` parameter (default `0.1`) controls the fraction of black pixels required per frame; values outside `[0.0, 1.0]` return an error.

## Changes

- `analysis_inner.rs`: added `detect_black_frames_unsafe()` — `movie → blackdetect=d=0.1:pic_th={threshold} → buffersink` filter graph; reads `lavfi.black_start` per frame and collects start timestamps into `Vec<Duration>`
- `analysis/mod.rs`: added `BlackFrameDetector` consuming builder (`new()`, `threshold()`, `run()`) with threshold and file existence validation; 4 unit tests covering invalid threshold (below/above range), missing file, and boundary values
- `ff-decode/src/lib.rs`: re-exported `BlackFrameDetector`
- `avio/src/lib.rs`: added `BlackFrameDetector` to the `decode` feature re-export block
- `tests/black_frame_detector_tests.rs`: 3 fast error-path integration tests + 3 functional tests against `gameplay.mp4` (timestamps monotonic, within video duration, no crash on typical video)

## Related Issues

Closes #316

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes