### PR TITLE
feat(ff-encode): add MediaOperationFailed variant to EncodeError

### DIFF
--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -291,4 +291,24 @@ mod tests {
             "expected '[8000, 384000]' in '{msg}'"
         );
     }
+
+    #[test]
+    fn encode_error_media_operation_failed_should_display_correctly() {
+        let err = EncodeError::MediaOperationFailed {
+            reason: "input file has no audio stream".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("media operation failed"),
+            "expected 'media operation failed' in '{msg}'"
+        );
+        assert!(
+            msg.contains("input file has no audio stream"),
+            "expected reason in '{msg}'"
+        );
+        assert!(
+            matches!(err, EncodeError::MediaOperationFailed { .. }),
+            "pattern match with struct syntax must work"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`EncodeError::MediaOperationFailed` was already present in `ff-encode/src/error.rs` from prior work, but the required unit test `encode_error_media_operation_failed_should_display_correctly` was missing. This PR adds that test to satisfy all issue requirements and close the gap.

## Changes

- `ff-encode/src/error.rs`: added unit test `encode_error_media_operation_failed_should_display_correctly` that verifies the display string contains `"media operation failed"` and the `reason` field, and confirms `matches!(e, EncodeError::MediaOperationFailed { .. })` compiles and matches correctly

## Related Issues

Closes #825

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes