### PR TITLE
test(ff-pipeline): add integration test for Timeline::render()

### DIFF
--- a/crates/ff-pipeline/tests/fixtures/mod.rs
+++ b/crates/ff-pipeline/tests/fixtures/mod.rs
@@ -4,6 +4,9 @@
 
 use std::path::PathBuf;
 
+use ff_encode::{AudioCodec, VideoCodec, VideoEncoder};
+use ff_format::{AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame};
+
 /// Returns the path to the shared test assets directory.
 pub fn assets_dir() -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
@@ -67,4 +70,93 @@ impl Drop for FileGuard {
             }
         }
     }
+}
+
+// ── Synthetic frame factories ──────────────────────────────────────────────────
+
+/// YUV420P frame filled with a solid colour specified as (Y, U, V).
+pub fn yuv420p_frame(width: u32, height: u32, y: u8, u: u8, v: u8) -> VideoFrame {
+    let y_plane = PooledBuffer::standalone(vec![y; (width * height) as usize]);
+    let u_plane = PooledBuffer::standalone(vec![u; ((width / 2) * (height / 2)) as usize]);
+    let v_plane = PooledBuffer::standalone(vec![v; ((width / 2) * (height / 2)) as usize]);
+    VideoFrame::new(
+        vec![y_plane, u_plane, v_plane],
+        vec![width as usize, (width / 2) as usize, (width / 2) as usize],
+        width,
+        height,
+        PixelFormat::Yuv420p,
+        Timestamp::default(),
+        true,
+    )
+    .expect("failed to create test frame")
+}
+
+/// Stereo F32 audio frame filled with silence.
+pub fn silent_audio_frame(samples: usize, sample_rate: u32) -> AudioFrame {
+    AudioFrame::empty(samples, 2, sample_rate, SampleFormat::F32)
+        .expect("failed to create silent audio frame")
+}
+
+// ── Source file generator ─────────────────────────────────────────────────────
+
+/// Encodes `frame_count` synthetic frames to `path` as an MP4 with MPEG-4 video
+/// and AAC audio.  Returns `None` (and prints a skip message) if the encoder
+/// cannot be built — callers should treat this as "skip the test".
+///
+/// * `width` / `height` — video dimensions (must be even)
+/// * `fps` — frame rate
+/// * `frame_count` — number of video frames to write
+/// * `y`, `u`, `v` — solid fill colour for every frame
+pub fn make_source_file(
+    path: &PathBuf,
+    width: u32,
+    height: u32,
+    fps: f64,
+    frame_count: usize,
+    y: u8,
+    u: u8,
+    v: u8,
+) -> Option<()> {
+    let sample_rate = 48_000u32;
+    let audio_frame_samples = 1024usize;
+    let total_audio_samples = (sample_rate as f64 * frame_count as f64 / fps) as usize;
+    let audio_frames = total_audio_samples.div_ceil(audio_frame_samples);
+
+    let mut encoder = match VideoEncoder::create(path)
+        .video(width, height, fps)
+        .video_codec(VideoCodec::Mpeg4)
+        .audio(sample_rate, 2)
+        .audio_codec(AudioCodec::Aac)
+        .audio_bitrate(128_000)
+        .build()
+    {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: cannot build source encoder: {e}");
+            return None;
+        }
+    };
+
+    for _ in 0..frame_count {
+        let frame = yuv420p_frame(width, height, y, u, v);
+        if let Err(e) = encoder.push_video(&frame) {
+            println!("Skipping: push_video failed: {e}");
+            return None;
+        }
+    }
+
+    for _ in 0..audio_frames {
+        let frame = silent_audio_frame(audio_frame_samples, sample_rate);
+        if let Err(e) = encoder.push_audio(&frame) {
+            println!("Skipping: push_audio failed: {e}");
+            return None;
+        }
+    }
+
+    if let Err(e) = encoder.finish() {
+        println!("Skipping: encoder finish failed: {e}");
+        return None;
+    }
+
+    Some(())
 }

--- a/crates/ff-pipeline/tests/timeline_tests.rs
+++ b/crates/ff-pipeline/tests/timeline_tests.rs
@@ -1,0 +1,131 @@
+//! Integration tests for `Timeline::render()`.
+//!
+//! Creates synthetic source clips, builds a `Timeline`, calls `render()`,
+//! and validates the output with `ff_probe`.
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use std::time::Duration;
+
+use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
+use ff_pipeline::{Clip, EncoderConfig, PipelineError, Timeline};
+use fixtures::{FileGuard, make_source_file, test_output_path};
+
+// Small canvas for fast CI runs.
+const W: u32 = 160;
+const H: u32 = 90;
+const FPS: f64 = 30.0;
+// 30 frames ≈ 1 second of source content per clip.
+const FRAME_COUNT: usize = 30;
+
+fn render_config() -> EncoderConfig {
+    EncoderConfig::builder()
+        .video_codec(VideoCodec::Mpeg4)
+        .audio_codec(AudioCodec::Aac)
+        .bitrate_mode(BitrateMode::Cbr(500_000))
+        .build()
+}
+
+#[test]
+fn timeline_render_should_produce_ffprobe_valid_output() {
+    // ── Step 1: generate a synthetic source file ───────────────────────────────
+    //
+    // One 1-second solid-colour clip (red-ish in YUV) that is reused as both
+    // clip 1 (starts at t=0) and clip 2 (starts at t=1 s).  Using the same
+    // source for both clips keeps the test self-contained without requiring two
+    // encode passes.
+
+    let src_path = test_output_path("timeline_src.mp4");
+    let out_path = test_output_path("timeline_out.mp4");
+
+    let _g_src = FileGuard::new(src_path.clone());
+    let _g_out = FileGuard::new(out_path.clone());
+
+    // Y=76, U=84, V=255 ≈ red in YUV420P
+    if make_source_file(&src_path, W, H, FPS, FRAME_COUNT, 76, 84, 255).is_none() {
+        return;
+    }
+
+    // ── Step 2: build a Timeline with two clips in sequence ────────────────────
+    //
+    // Both video and audio tracks contain:
+    //   clip 1 — timeline_offset = 0 s  (plays from 0 → 1 s)
+    //   clip 2 — timeline_offset = 1 s  (plays from 1 → 2 s)
+    //
+    // `Clip::new` defaults: in_point = None, out_point = None (full file).
+
+    let clip1 = Clip::new(&src_path);
+    let clip2 = Clip::new(&src_path).offset(Duration::from_secs(1));
+
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![clip1.clone(), clip2.clone()])
+        .audio_track(vec![clip1, clip2])
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    // ── Step 3: render ─────────────────────────────────────────────────────────
+
+    match timeline.render(&out_path, render_config()) {
+        Ok(()) => {}
+        Err(PipelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+            return;
+        }
+        Err(PipelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+        Err(PipelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+            return;
+        }
+        Err(e) => panic!("unexpected error from Timeline::render: {e}"),
+    }
+
+    // ── Step 4: validate with ff_probe ─────────────────────────────────────────
+
+    let info = match ff_probe::open(&out_path) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping: ff_probe::open failed: {e}");
+            return;
+        }
+    };
+
+    assert!(
+        info.has_video(),
+        "rendered output must contain a video stream"
+    );
+    assert!(
+        info.has_audio(),
+        "rendered output must contain an audio stream"
+    );
+
+    let duration = info.duration();
+    assert!(
+        duration > Duration::ZERO,
+        "rendered output must have non-zero duration, got {duration:?}"
+    );
+
+    let video = info.video_stream(0).expect("video stream must be present");
+    assert_eq!(
+        video.width(),
+        W,
+        "output video width must match canvas width"
+    );
+    assert_eq!(
+        video.height(),
+        H,
+        "output video height must match canvas height"
+    );
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end integration test for `Timeline::render()`. Until now the only `Timeline` tests were builder-level unit tests in `src/timeline.rs` that verified field assignment without ever calling `render()` through FFmpeg. This PR closes that gap by exercising the full render path and validating the output file with `ff_probe`.

## Changes

- `crates/ff-pipeline/tests/fixtures/mod.rs`: added `yuv420p_frame`, `silent_audio_frame`, and `make_source_file` helpers (same pattern used by ff-filter fixtures) so timeline tests can generate synthetic source clips without external assets
- `crates/ff-pipeline/tests/timeline_tests.rs`: new integration test file
  - `timeline_render_should_produce_ffprobe_valid_output` — generates a 1-second solid-colour MP4, builds a `Timeline` with two clips (at `t=0 s` and `t=1 s`) on both video and audio tracks, calls `Timeline::render()`, then asserts the output has a video stream, audio stream, non-zero duration, and the correct canvas dimensions (160×90)
  - Skips gracefully when any required codec or filter is unavailable

## Related Issues

Closes #870

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes