### PR TITLE
test(ff-encode): add integration test for custom ExportPreset

### DIFF
--- a/crates/ff-encode/tests/preset_tests.rs
+++ b/crates/ff-encode/tests/preset_tests.rs
@@ -1,4 +1,4 @@
-//! Integration tests for predefined `ExportPreset` values.
+//! Integration tests for `ExportPreset` — both predefined and custom.
 //!
 //! Each test builds a short clip (≤ 1 s of synthetic frames) with one preset,
 //! then opens the output with `ff_probe::open()` to confirm the file is valid
@@ -13,8 +13,8 @@ mod fixtures;
 
 use std::path::Path;
 
-use ff_encode::{ExportPreset, VideoEncoder};
-use ff_format::{AudioFrame, SampleFormat};
+use ff_encode::{AudioEncoderConfig, BitrateMode, ExportPreset, VideoEncoder, VideoEncoderConfig};
+use ff_format::{AudioCodec, AudioFrame, SampleFormat, VideoCodec};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -194,4 +194,37 @@ fn export_preset_web_h264_should_produce_ffprobe_valid_output() {
     let output = fixtures::test_output_path("preset_web_h264.webm");
     let _guard = fixtures::FileGuard::new(output.clone());
     run_preset_test(&ExportPreset::web_h264(), &output, true);
+}
+
+// ── Custom preset test ────────────────────────────────────────────────────────
+
+#[test]
+fn custom_export_preset_should_produce_ffprobe_valid_output() {
+    // Construct ExportPreset directly as a struct literal — no predefined
+    // factory method.  This exercises the public struct fields that #324 added
+    // and confirms that user-defined presets apply correctly to the encoder.
+    let preset = ExportPreset {
+        name: "custom_test".to_string(),
+        video: Some(VideoEncoderConfig {
+            codec: VideoCodec::H264,
+            width: None,
+            height: None,
+            fps: Some(30.0),
+            bitrate_mode: BitrateMode::Crf(28),
+            pixel_format: None,
+            codec_options: None,
+        }),
+        audio: AudioEncoderConfig {
+            codec: AudioCodec::Aac,
+            sample_rate: 44_100,
+            channels: 2,
+            bitrate: 128_000,
+        },
+    };
+
+    let output = fixtures::test_output_path("custom_preset_test.mp4");
+    let _guard = fixtures::FileGuard::new(output.clone());
+
+    // expect_video = true: preset has a video config, so both streams are expected.
+    run_preset_test(&preset, &output, true);
 }


### PR DESCRIPTION
## Summary

Adds an integration test that constructs an `ExportPreset` directly as a struct literal and verifies the encoded output is valid. The existing `preset_tests.rs` exercised all nine predefined presets but never tested user-defined presets built by filling in `VideoEncoderConfig` and `AudioEncoderConfig` by hand, leaving the public struct fields (added by #324) untested end-to-end.

## Changes

- `crates/ff-encode/tests/preset_tests.rs`:
  - Extended imports: added `AudioEncoderConfig`, `BitrateMode`, `VideoEncoderConfig` from `ff_encode`; added `AudioCodec`, `VideoCodec` from `ff_format`
  - Updated module doc comment to mention custom preset coverage
  - Added `custom_export_preset_should_produce_ffprobe_valid_output`:
    - Constructs `ExportPreset { name, video: Some(VideoEncoderConfig { codec: H264, bitrate_mode: Crf(28), fps: Some(30.0), .. }), audio: AudioEncoderConfig { codec: Aac, sample_rate: 44_100, channels: 2, bitrate: 128_000 } }` directly as a struct literal — no predefined factory method
    - Passes the preset to the existing `run_preset_test` helper (resolution overridden to 160×90, 15 video frames + 1 s silent audio)
    - Asserts the output contains a video stream and an audio stream via `ff_probe`
    - Skips gracefully if H.264 or AAC is unavailable

## Related Issues

Closes #873

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes