### PR TITLE
feat(avio): add analysis examples for media analysis APIs

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -371,6 +371,56 @@ name = "clip_trim"
 path = "examples/filter/clip_trim.rs"
 required-features = ["encode"]
 
+[[example]]
+name = "scene_detection"
+path = "examples/analysis/scene_detection.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "waveform"
+path = "examples/analysis/waveform.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "silence_detection"
+path = "examples/analysis/silence_detection.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "keyframes"
+path = "examples/analysis/keyframes.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "histogram"
+path = "examples/analysis/histogram.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "black_frames"
+path = "examples/analysis/black_frames.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "frame_extraction"
+path = "examples/analysis/frame_extraction.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "thumbnail_selector"
+path = "examples/analysis/thumbnail_selector.rs"
+required-features = ["decode"]
+
+[[example]]
+name = "loudness"
+path = "examples/analysis/loudness.rs"
+required-features = ["decode", "filter"]
+
+[[example]]
+name = "quality_metrics"
+path = "examples/analysis/quality_metrics.rs"
+required-features = ["decode", "filter"]
+
 [dev-dependencies]
 futures = { workspace = true }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/avio/examples/analysis/black_frames.rs
+++ b/crates/avio/examples/analysis/black_frames.rs
@@ -1,0 +1,75 @@
+//! Detect black intervals in a video file and print their start timestamps.
+//!
+//! Uses [`BlackFrameDetector`] to identify segments where the proportion of
+//! near-black pixels exceeds a configurable threshold.  Black intervals are
+//! commonly used to detect chapter breaks, fade-to-black transitions, and
+//! advertising boundaries.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example black_frames --features decode -- --input video.mp4
+//! cargo run --example black_frames --features decode -- --input video.mp4 --threshold 0.2
+//! ```
+
+use std::process;
+use std::time::Duration;
+
+use avio::BlackFrameDetector;
+
+fn fmt_duration(d: Duration) -> String {
+    let h = d.as_secs() / 3600;
+    let m = (d.as_secs() % 3600) / 60;
+    let s = d.as_secs() % 60;
+    let ms = d.subsec_millis();
+    format!("{h:02}:{m:02}:{s:02}.{ms:03}")
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut threshold = 0.1_f64;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--threshold" | "-t" => {
+                let raw = args.next().unwrap_or_default();
+                threshold = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid threshold: {raw}");
+                    process::exit(1);
+                });
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: black_frames --input <video> [--threshold <0.0–1.0>]");
+        process::exit(1);
+    });
+
+    println!("Detecting black frames in: {input}");
+    println!("Threshold: {threshold:.2}");
+    println!();
+
+    let black_starts = BlackFrameDetector::new(&input)
+        .threshold(threshold)
+        .run()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+
+    if black_starts.is_empty() {
+        println!("No black intervals detected.");
+    } else {
+        println!("Detected {} black interval(s):", black_starts.len());
+        for (i, ts) in black_starts.iter().enumerate() {
+            println!("  [{i:3}] {}", fmt_duration(*ts));
+        }
+    }
+}

--- a/crates/avio/examples/analysis/frame_extraction.rs
+++ b/crates/avio/examples/analysis/frame_extraction.rs
@@ -1,0 +1,76 @@
+//! Extract one frame per time interval from a video file.
+//!
+//! Uses [`FrameExtractor`] to sample frames at regular intervals across the
+//! full video duration.  Prints the timestamp, dimensions, and pixel format
+//! of each extracted frame.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example frame_extraction --features decode -- --input video.mp4
+//! cargo run --example frame_extraction --features decode -- --input video.mp4 --interval-secs 5
+//! ```
+
+use std::process;
+use std::time::Duration;
+
+use avio::FrameExtractor;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut interval_secs = 1u64;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--interval-secs" | "-s" => {
+                let raw = args.next().unwrap_or_default();
+                interval_secs = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid interval-secs: {raw}");
+                    process::exit(1);
+                });
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: frame_extraction --input <video> [--interval-secs <s>]");
+        process::exit(1);
+    });
+
+    println!("Extracting frames from: {input}");
+    println!("Interval: {interval_secs}s");
+    println!();
+
+    let frames = FrameExtractor::new(&input)
+        .interval(Duration::from_secs(interval_secs))
+        .run()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+
+    println!("Extracted {} frame(s):", frames.len());
+    println!(
+        "{:<6}  {:<12}  {:<10}  {:<10}  Pixel Format",
+        "Index", "Timestamp (s)", "Width", "Height"
+    );
+    println!("{}", "-".repeat(60));
+
+    for (i, frame) in frames.iter().enumerate() {
+        let ts_secs = frame.timestamp().as_secs_f64();
+        println!(
+            "{:<6}  {:<12.3}  {:<10}  {:<10}  {:?}",
+            i,
+            ts_secs,
+            frame.width(),
+            frame.height(),
+            frame.format(),
+        );
+    }
+}

--- a/crates/avio/examples/analysis/histogram.rs
+++ b/crates/avio/examples/analysis/histogram.rs
@@ -1,0 +1,112 @@
+//! Extract per-channel color histograms from a video file.
+//!
+//! Uses [`HistogramExtractor`] to compute R, G, B, and luma histograms at
+//! configurable frame intervals.  Prints a summary of each sampled frame's
+//! dominant color bin and mean luma.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example histogram --features decode -- --input video.mp4
+//! cargo run --example histogram --features decode -- --input video.mp4 --interval 30
+//! ```
+
+use std::process;
+
+use avio::{FrameHistogram, HistogramExtractor};
+
+/// Returns the bin index with the highest count (dominant intensity level).
+fn dominant_bin(channel: &[u32; 256]) -> usize {
+    channel
+        .iter()
+        .enumerate()
+        .max_by_key(|&(_, count)| count)
+        .map_or(0, |(i, _)| i)
+}
+
+/// Computes mean value from a histogram (weighted average of bin indices).
+fn mean_from_histogram(channel: &[u32; 256]) -> f64 {
+    let total: u64 = channel.iter().map(|&c| u64::from(c)).sum();
+    if total == 0 {
+        return 0.0;
+    }
+    let weighted_sum: u64 = channel
+        .iter()
+        .enumerate()
+        .map(|(i, &c)| i as u64 * u64::from(c))
+        .sum();
+    #[allow(clippy::cast_precision_loss)]
+    let result = weighted_sum as f64 / total as f64;
+    result
+}
+
+fn print_histogram_summary(i: usize, h: &FrameHistogram) {
+    let secs = h.timestamp.as_secs_f64();
+    let mean_r = mean_from_histogram(&h.r);
+    let mean_g = mean_from_histogram(&h.g);
+    let mean_b = mean_from_histogram(&h.b);
+    let mean_luma = mean_from_histogram(&h.luma);
+    println!(
+        "  [{i:4}] t={secs:7.3}s  R={mean_r:5.1}  G={mean_g:5.1}  B={mean_b:5.1}  luma={mean_luma:5.1}  \
+         dominant_r={:3}  dominant_g={:3}  dominant_b={:3}",
+        dominant_bin(&h.r),
+        dominant_bin(&h.g),
+        dominant_bin(&h.b),
+    );
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut interval_frames = 30u32;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--interval" | "-n" => {
+                let raw = args.next().unwrap_or_default();
+                interval_frames = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid interval: {raw}");
+                    process::exit(1);
+                });
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: histogram --input <video> [--interval <frames>]");
+        process::exit(1);
+    });
+
+    println!("Extracting color histograms from: {input}");
+    println!("Sampling every {interval_frames} frame(s)");
+    println!();
+
+    let histograms: Vec<FrameHistogram> = HistogramExtractor::new(&input)
+        .interval_frames(interval_frames)
+        .run()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+
+    println!("Extracted {} histogram(s).", histograms.len());
+    println!();
+    println!(
+        "  {:^6}  {:^8}  {:^6}  {:^6}  {:^6}  {:^6}  {:^11}  {:^11}  {:^11}",
+        "Index", "Time (s)", "Mean R", "Mean G", "Mean B", "Luma", "Dom. R", "Dom. G", "Dom. B"
+    );
+    println!("{}", "-".repeat(95));
+
+    let display_count = histograms.len().min(30);
+    for (i, h) in histograms.iter().take(display_count).enumerate() {
+        print_histogram_summary(i, h);
+    }
+    if histograms.len() > display_count {
+        println!("  … ({} more histograms)", histograms.len() - display_count);
+    }
+}

--- a/crates/avio/examples/analysis/keyframes.rs
+++ b/crates/avio/examples/analysis/keyframes.rs
@@ -1,0 +1,88 @@
+//! Enumerate keyframe timestamps in a video file.
+//!
+//! Uses [`KeyframeEnumerator`] to list the presentation timestamps of all
+//! keyframes (I-frames) in a video stream.  Only packet headers are read —
+//! no decoding is performed — so this is fast even for large files.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example keyframes --features decode -- --input video.mp4
+//! cargo run --example keyframes --features decode -- --input video.mp4 --stream 0
+//! ```
+
+use std::process;
+
+use avio::KeyframeEnumerator;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut stream_index = None::<usize>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--stream" | "-s" => {
+                let raw = args.next().unwrap_or_default();
+                stream_index = Some(raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid stream index: {raw}");
+                    process::exit(1);
+                }));
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: keyframes --input <video> [--stream <index>]");
+        process::exit(1);
+    });
+
+    println!("Enumerating keyframes in: {input}");
+    if let Some(idx) = stream_index {
+        println!("Stream index: {idx}");
+    } else {
+        println!("Stream: first video stream (default)");
+    }
+    println!();
+
+    let mut enumerator = KeyframeEnumerator::new(&input);
+    if let Some(idx) = stream_index {
+        enumerator = enumerator.stream_index(idx);
+    }
+
+    let keyframes = enumerator.run().unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
+
+    println!("Found {} keyframe(s):", keyframes.len());
+
+    // Print first 30 keyframes to avoid flooding the terminal.
+    let display_count = keyframes.len().min(30);
+    for (i, ts) in keyframes.iter().take(display_count).enumerate() {
+        let h = ts.as_secs() / 3600;
+        let m = (ts.as_secs() % 3600) / 60;
+        let s = ts.as_secs() % 60;
+        let ms = ts.subsec_millis();
+        println!("  [{i:4}] {h:02}:{m:02}:{s:02}.{ms:03}");
+    }
+    if keyframes.len() > display_count {
+        println!("  … ({} more keyframes)", keyframes.len() - display_count);
+    }
+
+    if !keyframes.is_empty() {
+        let avg_interval_ms = keyframes
+            .windows(2)
+            .map(|w| w[1].saturating_sub(w[0]).as_millis())
+            .sum::<u128>()
+            .checked_div((keyframes.len() - 1) as u128)
+            .unwrap_or(0);
+        println!();
+        println!("Average keyframe interval: {avg_interval_ms} ms");
+    }
+}

--- a/crates/avio/examples/analysis/loudness.rs
+++ b/crates/avio/examples/analysis/loudness.rs
@@ -1,0 +1,90 @@
+//! Measure EBU R128 integrated loudness, loudness range, and true peak.
+//!
+//! Uses [`LoudnessMeter`] to run the `ebur128` filter over an entire audio or
+//! video file and report the perceptual loudness metrics used in broadcast
+//! normalization workflows.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example loudness --features decode,filter -- --input audio.mp3
+//! cargo run --example loudness --features decode,filter -- --input video.mp4
+//! ```
+
+use std::process;
+
+use avio::LoudnessMeter;
+
+fn fmt_db(db: f32) -> String {
+    if db == f32::NEG_INFINITY {
+        "-inf".to_string()
+    } else {
+        format!("{db:+.1}")
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: loudness --input <audio-or-video>");
+        process::exit(1);
+    });
+
+    println!("Measuring loudness: {input}");
+    println!();
+
+    let result = LoudnessMeter::new(&input).measure().unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    });
+
+    println!("EBU R128 Loudness Results");
+    println!("{}", "-".repeat(32));
+    println!(
+        "  Integrated loudness: {} LUFS",
+        fmt_db(result.integrated_lufs)
+    );
+    println!("  Loudness range (LRA): {:.1} LU", result.lra);
+    println!(
+        "  True peak:            {} dBTP",
+        fmt_db(result.true_peak_dbtp)
+    );
+    println!();
+
+    // Indicate compliance with common broadcast targets.
+    let integrated = result.integrated_lufs;
+    if integrated != f32::NEG_INFINITY {
+        println!("Compliance:");
+        let youtube_ok = (-14.5..=-13.5).contains(&integrated);
+        let spotify_ok = (-14.5..=-13.5).contains(&integrated);
+        let broadcast_ok = (-24.0..=-22.0).contains(&integrated);
+        println!(
+            "  YouTube / Spotify target (-14 LUFS): {}",
+            if youtube_ok || spotify_ok {
+                "✓ within ±0.5 LU"
+            } else {
+                "outside target"
+            }
+        );
+        println!(
+            "  EBU R128 broadcast target (-23 LUFS): {}",
+            if broadcast_ok {
+                "✓ within ±1 LU"
+            } else {
+                "outside target"
+            }
+        );
+    }
+}

--- a/crates/avio/examples/analysis/quality_metrics.rs
+++ b/crates/avio/examples/analysis/quality_metrics.rs
@@ -1,0 +1,94 @@
+//! Compute SSIM and PSNR quality metrics between two video files.
+//!
+//! Uses [`QualityMetrics`] to compare a reference video against a distorted
+//! version (e.g., after compression or transcoding).  Both metrics are computed
+//! frame-by-frame using `FFmpeg`'s `ssim` and `psnr` filter graphs.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example quality_metrics --features decode,filter -- \
+//!     --reference original.mp4 --distorted compressed.mp4
+//!
+//! # Compare a video against itself — should give SSIM ≈ 1.0 and PSNR = ∞
+//! cargo run --example quality_metrics --features decode,filter -- \
+//!     --reference video.mp4 --distorted video.mp4
+//! ```
+
+use std::process;
+
+use avio::QualityMetrics;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut reference = None::<String>;
+    let mut distorted = None::<String>;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--reference" | "-r" => reference = Some(args.next().unwrap_or_default()),
+            "--distorted" | "-d" => distorted = Some(args.next().unwrap_or_default()),
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let reference = reference.unwrap_or_else(|| {
+        eprintln!("Usage: quality_metrics --reference <video> --distorted <video>");
+        process::exit(1);
+    });
+
+    let distorted = distorted.unwrap_or_else(|| {
+        eprintln!("Usage: quality_metrics --reference <video> --distorted <video>");
+        process::exit(1);
+    });
+
+    println!("Reference:  {reference}");
+    println!("Distorted:  {distorted}");
+    println!();
+
+    // SSIM
+    print!("Computing SSIM… ");
+    let ssim = QualityMetrics::ssim(&reference, &distorted).unwrap_or_else(|e| {
+        eprintln!("\nSSIM error: {e}");
+        process::exit(1);
+    });
+
+    // PSNR
+    print!("Computing PSNR… ");
+    let psnr = QualityMetrics::psnr(&reference, &distorted).unwrap_or_else(|e| {
+        eprintln!("\nPSNR error: {e}");
+        process::exit(1);
+    });
+
+    println!();
+    println!("Video Quality Metrics");
+    println!("{}", "-".repeat(32));
+
+    // SSIM: 1.0 = identical, 0.0 = no similarity
+    println!("  SSIM: {ssim:.6}");
+    let ssim_quality = match ssim {
+        s if s >= 0.99 => "excellent (near-lossless)",
+        s if s >= 0.95 => "good",
+        s if s >= 0.90 => "acceptable",
+        _ => "poor",
+    };
+    println!("        Quality: {ssim_quality}");
+    println!();
+
+    // PSNR: higher is better; infinity means identical inputs
+    if psnr == f32::INFINITY {
+        println!("  PSNR: ∞ dB  (inputs are identical)");
+    } else {
+        println!("  PSNR: {psnr:.2} dB");
+        let psnr_quality = match psnr {
+            p if p >= 50.0 => "excellent",
+            p if p >= 40.0 => "good",
+            p if p >= 30.0 => "acceptable",
+            _ => "poor",
+        };
+        println!("        Quality: {psnr_quality}");
+    }
+}

--- a/crates/avio/examples/analysis/scene_detection.rs
+++ b/crates/avio/examples/analysis/scene_detection.rs
@@ -1,0 +1,70 @@
+//! Detect scene changes in a video file and print their timestamps.
+//!
+//! Uses [`SceneDetector`] to identify hard cuts and transitions. The detection
+//! threshold controls sensitivity: lower values report more cuts (including
+//! subtle ones); higher values report only hard cuts.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example scene_detection --features decode -- --input video.mp4
+//! cargo run --example scene_detection --features decode -- --input video.mp4 --threshold 0.3
+//! ```
+
+use std::process;
+
+use avio::SceneDetector;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut threshold = 0.4_f64;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--threshold" | "-t" => {
+                let raw = args.next().unwrap_or_default();
+                threshold = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid threshold: {raw}");
+                    process::exit(1);
+                });
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: scene_detection --input <video> [--threshold <0.0–1.0>]");
+        process::exit(1);
+    });
+
+    println!("Detecting scene changes in: {input}");
+    println!("Threshold: {threshold:.2}");
+    println!();
+
+    let cuts = SceneDetector::new(&input)
+        .threshold(threshold)
+        .run()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+
+    if cuts.is_empty() {
+        println!("No scene changes detected.");
+    } else {
+        println!("Detected {} scene change(s):", cuts.len());
+        for (i, ts) in cuts.iter().enumerate() {
+            let secs = ts.as_secs_f64();
+            let h = ts.as_secs() / 3600;
+            let m = (ts.as_secs() % 3600) / 60;
+            let s = ts.as_secs() % 60;
+            let ms = ts.subsec_millis();
+            println!("  [{i:3}] {h:02}:{m:02}:{s:02}.{ms:03}  ({secs:.3}s)");
+        }
+    }
+}

--- a/crates/avio/examples/analysis/silence_detection.rs
+++ b/crates/avio/examples/analysis/silence_detection.rs
@@ -1,0 +1,92 @@
+//! Detect silent intervals in an audio file and print their time ranges.
+//!
+//! Uses [`SilenceDetector`] to find audio segments where the amplitude stays
+//! below a configurable threshold for at least a minimum duration.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example silence_detection --features decode -- --input audio.mp3
+//! cargo run --example silence_detection --features decode -- \
+//!     --input audio.mp3 --threshold-db -50 --min-duration-ms 300
+//! ```
+
+use std::process;
+use std::time::Duration;
+
+use avio::{SilenceDetector, SilenceRange};
+
+fn fmt_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    format!("{secs:.3}s")
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut threshold_db = -40.0_f32;
+    let mut min_duration_ms = 500u64;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--threshold-db" => {
+                let raw = args.next().unwrap_or_default();
+                threshold_db = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid threshold-db: {raw}");
+                    process::exit(1);
+                });
+            }
+            "--min-duration-ms" => {
+                let raw = args.next().unwrap_or_default();
+                min_duration_ms = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid min-duration-ms: {raw}");
+                    process::exit(1);
+                });
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!(
+            "Usage: silence_detection --input <audio> \
+             [--threshold-db <dB>] [--min-duration-ms <ms>]"
+        );
+        process::exit(1);
+    });
+
+    println!("Detecting silence in: {input}");
+    println!("Threshold: {threshold_db:.1} dBFS");
+    println!("Minimum duration: {min_duration_ms} ms");
+    println!();
+
+    let ranges: Vec<SilenceRange> = SilenceDetector::new(&input)
+        .threshold_db(threshold_db)
+        .min_duration(Duration::from_millis(min_duration_ms))
+        .run()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+
+    if ranges.is_empty() {
+        println!("No silence detected.");
+    } else {
+        println!("Detected {} silent interval(s):", ranges.len());
+        println!("{:<14}  {:<14}  {:<12}", "Start", "End", "Duration");
+        println!("{}", "-".repeat(44));
+        for r in &ranges {
+            let duration = r.end.saturating_sub(r.start);
+            println!(
+                "{:<14}  {:<14}  {:<12}",
+                fmt_duration(r.start),
+                fmt_duration(r.end),
+                fmt_duration(duration)
+            );
+        }
+    }
+}

--- a/crates/avio/examples/analysis/thumbnail_selector.rs
+++ b/crates/avio/examples/analysis/thumbnail_selector.rs
@@ -1,0 +1,73 @@
+//! Automatically select the best thumbnail frame from a video file.
+//!
+//! Uses [`ThumbnailSelector`] to pick the single most representative frame by
+//! scoring candidates for brightness and sharpness.  Near-black, near-white,
+//! and blurry frames are skipped; the sharpest acceptable frame is returned.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example thumbnail_selector --features decode -- --input video.mp4
+//! cargo run --example thumbnail_selector --features decode -- \
+//!     --input video.mp4 --interval-secs 10
+//! ```
+
+use std::process;
+use std::time::Duration;
+
+use avio::ThumbnailSelector;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut interval_secs = 5u64;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--interval-secs" | "-s" => {
+                let raw = args.next().unwrap_or_default();
+                interval_secs = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid interval-secs: {raw}");
+                    process::exit(1);
+                });
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: thumbnail_selector --input <video> [--interval-secs <s>]");
+        process::exit(1);
+    });
+
+    println!("Selecting best thumbnail from: {input}");
+    println!("Candidate interval: {interval_secs}s");
+    println!();
+
+    let frame = ThumbnailSelector::new(&input)
+        .candidate_interval(Duration::from_secs(interval_secs))
+        .run()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+
+    let ts = frame.timestamp().as_duration();
+    let ts_secs = frame.timestamp().as_secs_f64();
+    let h = ts.as_secs() / 3600;
+    let m = (ts.as_secs() % 3600) / 60;
+    let s = ts.as_secs() % 60;
+    let ms = ts.subsec_millis();
+
+    println!("Best thumbnail frame:");
+    println!("  Timestamp:    {h:02}:{m:02}:{s:02}.{ms:03}  ({ts_secs:.3}s)");
+    println!("  Dimensions:   {}×{}", frame.width(), frame.height());
+    println!("  Pixel format: {:?}", frame.format());
+    println!();
+    println!("To save this frame, pipe its raw bytes to an image encoder or use");
+    println!("the `encode` feature with ImageEncoder.");
+}

--- a/crates/avio/examples/analysis/waveform.rs
+++ b/crates/avio/examples/analysis/waveform.rs
@@ -1,0 +1,87 @@
+//! Compute peak and RMS amplitude per time interval for an audio file.
+//!
+//! Uses [`WaveformAnalyzer`] to produce waveform data suitable for rendering
+//! audio waveform displays.  Each sample covers one configurable time interval
+//! and reports peak and RMS amplitudes in dBFS.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example waveform --features decode -- --input audio.mp3
+//! cargo run --example waveform --features decode -- --input audio.mp3 --interval-ms 50
+//! ```
+
+use std::process;
+use std::time::Duration;
+
+use avio::{WaveformAnalyzer, WaveformSample};
+
+fn fmt_db(db: f32) -> String {
+    if db == f32::NEG_INFINITY {
+        "-inf".to_string()
+    } else {
+        format!("{db:+.1}")
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut input = None::<String>;
+    let mut interval_ms = 100u64;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--input" | "-i" => input = Some(args.next().unwrap_or_default()),
+            "--interval-ms" => {
+                let raw = args.next().unwrap_or_default();
+                interval_ms = raw.parse().unwrap_or_else(|_| {
+                    eprintln!("Invalid interval-ms: {raw}");
+                    process::exit(1);
+                });
+            }
+            other => {
+                eprintln!("Unknown flag: {other}");
+                process::exit(1);
+            }
+        }
+    }
+
+    let input = input.unwrap_or_else(|| {
+        eprintln!("Usage: waveform --input <audio> [--interval-ms <ms>]");
+        process::exit(1);
+    });
+
+    println!("Analyzing waveform: {input}");
+    println!("Interval: {interval_ms} ms");
+    println!();
+
+    let samples: Vec<WaveformSample> = WaveformAnalyzer::new(&input)
+        .interval(Duration::from_millis(interval_ms))
+        .run()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        });
+
+    println!("{} interval(s) analyzed.", samples.len());
+    println!();
+
+    // Print first 20 samples to avoid flooding the terminal.
+    let display_count = samples.len().min(20);
+    println!(
+        "{:<12}  {:>10}  {:>10}",
+        "Time (s)", "Peak dBFS", "RMS dBFS"
+    );
+    println!("{}", "-".repeat(38));
+    for s in samples.iter().take(display_count) {
+        let secs = s.timestamp.as_secs_f64();
+        println!(
+            "{secs:<12.3}  {:>10}  {:>10}",
+            fmt_db(s.peak_db),
+            fmt_db(s.rms_db)
+        );
+    }
+    if samples.len() > display_count {
+        println!("  … ({} more intervals)", samples.len() - display_count);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 10 runnable example programs under `crates/avio/examples/analysis/` covering all v0.10.0 media analysis APIs. Each example accepts command-line arguments, prints results to stdout in a human-readable format, and imports types exclusively from `avio`.

## Changes

- `analysis/scene_detection.rs` — `SceneDetector` with configurable threshold; prints cut timestamps
- `analysis/waveform.rs` — `WaveformAnalyzer` with configurable interval; prints peak/RMS dBFS per interval
- `analysis/silence_detection.rs` — `SilenceDetector` with configurable threshold and min duration; prints silence ranges
- `analysis/keyframes.rs` — `KeyframeEnumerator` with optional stream index; prints keyframe timestamps and average interval
- `analysis/histogram.rs` — `HistogramExtractor` with configurable frame interval; prints per-channel mean and dominant bin
- `analysis/black_frames.rs` — `BlackFrameDetector` with configurable threshold; prints black interval start timestamps
- `analysis/frame_extraction.rs` — `FrameExtractor` with configurable time interval; prints frame metadata (timestamp, dimensions, format)
- `analysis/thumbnail_selector.rs` — `ThumbnailSelector` with configurable candidate interval; prints selected frame metadata
- `analysis/loudness.rs` — `LoudnessMeter`; prints EBU R128 integrated loudness, LRA, true peak, and broadcast compliance
- `analysis/quality_metrics.rs` — `QualityMetrics`; computes SSIM and PSNR between two video files
- `crates/avio/Cargo.toml` — 10 new `[[example]]` entries under `required-features = ["decode"]` or `["decode", "filter"]`

## Related Issues

Closes #874

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes