### PR TITLE
feat(avio): add multi-track composition and Timeline rendering examples

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -456,6 +456,16 @@ name = "export_preset"
 path = "examples/encode/export_preset.rs"
 required-features = ["decode", "encode"]
 
+[[example]]
+name = "multi_track_compose"
+path = "examples/filter/multi_track_compose.rs"
+required-features = ["filter", "pipeline", "encode"]
+
+[[example]]
+name = "timeline_render"
+path = "examples/transcode/timeline_render.rs"
+required-features = ["filter", "pipeline", "encode"]
+
 [dev-dependencies]
 futures = { workspace = true }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -1,0 +1,232 @@
+//! Overlay two video layers onto a canvas and mix two audio tracks.
+//!
+//! Demonstrates [`MultiTrackComposer`] for video layer composition and
+//! [`MultiTrackAudioMixer`] for audio track mixing. Both produce source-only
+//! [`FilterGraph`] instances whose frames are pulled in a loop and fed directly
+//! into a [`VideoEncoder`].
+//!
+//! The overlay layer is placed at the top-right corner at half scale.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example multi_track_compose --features filter,pipeline -- \
+//!   --base    base.mp4       \
+//!   --overlay overlay.mp4   \
+//!   --output  composed.mp4  \
+//!   [--audio-a audio_a.mp4] \
+//!   [--audio-b audio_b.mp4] \
+//!   [--width 1280] [--height 720] [--fps 30]
+//! ```
+
+use std::{path::PathBuf, process, time::Duration};
+
+use avio::{
+    AudioCodec, AudioTrack, ChannelLayout, MultiTrackAudioMixer, MultiTrackComposer, VideoCodec,
+    VideoEncoder, VideoLayer,
+};
+
+// ── Argument parsing ──────────────────────────────────────────────────────────
+
+struct Args {
+    base: PathBuf,
+    overlay: PathBuf,
+    output: PathBuf,
+    audio_a: Option<PathBuf>,
+    audio_b: Option<PathBuf>,
+    width: u32,
+    height: u32,
+    fps: f64,
+}
+
+fn parse_args() -> Args {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let get = |flag: &str| -> Option<String> {
+        args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
+    };
+
+    let base = if let Some(p) = get("--base") {
+        PathBuf::from(p)
+    } else {
+        eprintln!("error: --base <path> is required");
+        process::exit(1);
+    };
+    let overlay = if let Some(p) = get("--overlay") {
+        PathBuf::from(p)
+    } else {
+        eprintln!("error: --overlay <path> is required");
+        process::exit(1);
+    };
+    let output = if let Some(p) = get("--output") {
+        PathBuf::from(p)
+    } else {
+        eprintln!("error: --output <path> is required");
+        process::exit(1);
+    };
+
+    Args {
+        base,
+        overlay,
+        output,
+        audio_a: get("--audio-a").map(PathBuf::from),
+        audio_b: get("--audio-b").map(PathBuf::from),
+        width: get("--width").and_then(|v| v.parse().ok()).unwrap_or(1280),
+        height: get("--height").and_then(|v| v.parse().ok()).unwrap_or(720),
+        fps: get("--fps").and_then(|v| v.parse().ok()).unwrap_or(30.0),
+    }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let args = parse_args();
+
+    // ── 1. Build video composition graph ─────────────────────────────────────
+
+    // The overlay occupies the top-right quadrant at half the canvas width.
+    let overlay_x = args.width / 2;
+
+    let mut video_graph = match MultiTrackComposer::new(args.width, args.height)
+        .add_layer(VideoLayer {
+            source: args.base.clone(),
+            x: 0,
+            y: 0,
+            scale: 1.0,
+            opacity: 1.0,
+            z_order: 0,
+            time_offset: Duration::ZERO,
+            in_point: None,
+            out_point: None,
+        })
+        .add_layer(VideoLayer {
+            source: args.overlay.clone(),
+            x: overlay_x.cast_signed(),
+            y: 0,
+            scale: 0.5,
+            opacity: 0.85,
+            z_order: 1,
+            time_offset: Duration::ZERO,
+            in_point: None,
+            out_point: None,
+        })
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("error: failed to build video composition graph: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── 2. Build audio mix graph (optional) ───────────────────────────────────
+
+    let has_audio = args.audio_a.is_some() && args.audio_b.is_some();
+    let mut audio_graph = if let (Some(audio_a), Some(audio_b)) = (&args.audio_a, &args.audio_b) {
+        match MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo)
+            .add_track(AudioTrack {
+                source: audio_a.clone(),
+                volume_db: 0.0,
+                pan: -0.2, // slight left pan
+                time_offset: Duration::ZERO,
+                effects: vec![],
+                sample_rate: 48_000,
+                channel_layout: ChannelLayout::Stereo,
+            })
+            .add_track(AudioTrack {
+                source: audio_b.clone(),
+                volume_db: 0.0,
+                pan: 0.2, // slight right pan
+                time_offset: Duration::ZERO,
+                effects: vec![],
+                sample_rate: 48_000,
+                channel_layout: ChannelLayout::Stereo,
+            })
+            .build()
+        {
+            Ok(g) => Some(g),
+            Err(e) => {
+                eprintln!("error: failed to build audio mix graph: {e}");
+                process::exit(1);
+            }
+        }
+    } else {
+        None
+    };
+
+    // ── 3. Create encoder ─────────────────────────────────────────────────────
+
+    let mut enc_builder = VideoEncoder::create(&args.output)
+        .video(args.width, args.height, args.fps)
+        .video_codec(VideoCodec::H264);
+
+    if has_audio {
+        enc_builder = enc_builder
+            .audio(48_000, 2)
+            .audio_codec(AudioCodec::Aac)
+            .audio_bitrate(192_000);
+    }
+
+    let mut encoder = match enc_builder.build() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("error: failed to create encoder: {e}");
+            process::exit(1);
+        }
+    };
+
+    // ── 4. Drain video graph → encoder ────────────────────────────────────────
+
+    loop {
+        match video_graph.pull_video() {
+            Ok(Some(frame)) => {
+                if let Err(e) = encoder.push_video(&frame) {
+                    eprintln!("error: push_video failed: {e}");
+                    process::exit(1);
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("error: pull_video failed: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    // ── 5. Drain audio graph → encoder ────────────────────────────────────────
+
+    if let Some(ref mut agraph) = audio_graph {
+        loop {
+            match agraph.pull_audio() {
+                Ok(Some(frame)) => {
+                    if let Err(e) = encoder.push_audio(&frame) {
+                        eprintln!("error: push_audio failed: {e}");
+                        process::exit(1);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("error: pull_audio failed: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    // ── 6. Finish ─────────────────────────────────────────────────────────────
+
+    if let Err(e) = encoder.finish() {
+        eprintln!("error: encoder.finish() failed: {e}");
+        process::exit(1);
+    }
+
+    println!(
+        "composed: {} → {}  ({}x{} @ {:.0}fps{})",
+        args.base.display(),
+        args.output.display(),
+        args.width,
+        args.height,
+        args.fps,
+        if has_audio { " + audio mix" } else { "" },
+    );
+}

--- a/crates/avio/examples/transcode/timeline_render.rs
+++ b/crates/avio/examples/transcode/timeline_render.rs
@@ -1,0 +1,106 @@
+//! Arrange two clips on a video track and render them with `Timeline::render()`.
+//!
+//! Demonstrates the [`Timeline`] and [`Clip`] APIs. Two clips are placed on a
+//! single video track: the first starts at the beginning of the timeline, the
+//! second is offset by five seconds. `Timeline::render()` builds the filter
+//! graph and encodes the composition to the output file in one call.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example timeline_render --features filter,pipeline -- \
+//!   --clip-a  intro.mp4   \
+//!   --clip-b  main.mp4    \
+//!   --output  rendered.mp4
+//! ```
+
+use std::{path::PathBuf, process, time::Duration};
+
+use avio::{Clip, EncoderConfig, Timeline};
+
+// ── Argument parsing ──────────────────────────────────────────────────────────
+
+struct Args {
+    clip_a: PathBuf,
+    clip_b: PathBuf,
+    output: PathBuf,
+}
+
+fn parse_args() -> Args {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let get = |flag: &str| -> Option<String> {
+        args.windows(2).find(|w| w[0] == flag).map(|w| w[1].clone())
+    };
+
+    let clip_a = if let Some(p) = get("--clip-a") {
+        PathBuf::from(p)
+    } else {
+        eprintln!("error: --clip-a <path> is required");
+        process::exit(1);
+    };
+    let clip_b = if let Some(p) = get("--clip-b") {
+        PathBuf::from(p)
+    } else {
+        eprintln!("error: --clip-b <path> is required");
+        process::exit(1);
+    };
+    let output = if let Some(p) = get("--output") {
+        PathBuf::from(p)
+    } else {
+        eprintln!("error: --output <path> is required");
+        process::exit(1);
+    };
+
+    Args {
+        clip_a,
+        clip_b,
+        output,
+    }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let args = parse_args();
+
+    // ── 1. Build clips ────────────────────────────────────────────────────────
+
+    // clip_a starts at the beginning of the timeline.
+    let clip_a = Clip::new(&args.clip_a);
+
+    // clip_b is offset by 5 seconds on the timeline.
+    let clip_b = Clip::new(&args.clip_b).offset(Duration::from_secs(5));
+
+    // ── 2. Build timeline ─────────────────────────────────────────────────────
+
+    let timeline = match Timeline::builder()
+        .canvas(1280, 720)
+        .frame_rate(30.0)
+        .video_track(vec![clip_a, clip_b])
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: failed to build timeline: {e}");
+            process::exit(1);
+        }
+    };
+
+    println!(
+        "rendering {} video track(s) → {}",
+        timeline.video_tracks().len(),
+        args.output.display(),
+    );
+
+    // ── 3. Render ─────────────────────────────────────────────────────────────
+
+    let config = EncoderConfig::builder().build();
+
+    if let Err(e) = timeline.render(&args.output, config) {
+        eprintln!("error: timeline render failed: {e}");
+        process::exit(1);
+    }
+
+    println!("done: {}", args.output.display());
+}


### PR DESCRIPTION
## Summary

Adds two runnable examples demonstrating the multi-track composition and Timeline APIs introduced in v0.10.0. These are the first examples covering `MultiTrackComposer`, `MultiTrackAudioMixer`, and `Timeline::render()`.

## Changes

- Add `examples/filter/multi_track_compose.rs` — composites two video layers onto a canvas using `MultiTrackComposer` and mixes two audio tracks with `MultiTrackAudioMixer`; frames are drained from source-only filter graphs and fed into a `VideoEncoder`
- Add `examples/transcode/timeline_render.rs` — arranges two `Clip` instances on a video track (second clip offset by 5 s) and calls `Timeline::render()` to produce the output file
- Register both examples in `crates/avio/Cargo.toml` with `required-features = ["filter", "pipeline", "encode"]`

## Related Issues

Closes #876

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes