### PR TITLE
fix(avio): add BlendMode to filter feature re-exports

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -259,10 +259,10 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    AudioConcatenator, AudioTrack, ClipJoiner, DrawTextOptions, EqBand, FilterError, FilterGraph,
-    FilterGraphBuilder, FilterStep, HwAccel, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer,
-    MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm, ToneMap, VideoConcatenator,
-    VideoLayer, XfadeTransition, YadifMode,
+    AudioConcatenator, AudioTrack, BlendMode, ClipJoiner, DrawTextOptions, EqBand, FilterError,
+    FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, LoudnessMeter, LoudnessResult,
+    MultiTrackAudioMixer, MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm, ToneMap,
+    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`BlendMode` was exported from `ff_filter` but missing from the `avio` facade crate's `pub use ff_filter::{...}` block, making blend-mode compositing inaccessible to users who depend on `avio` rather than `ff_filter` directly.

## Changes

- `crates/avio/src/lib.rs`: add `BlendMode` to the `#[cfg(feature = "filter")]` re-export list, inserted alphabetically between `AudioTrack` and `ClipJoiner`

## Related Issues

Fixes #930

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes