### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.0] - 2026-04-10
+
+### Added
+
+#### ff-filter — blend modes
+- `BlendMode` enum with 14 photographic blend modes (Normal, Multiply, Screen, Overlay, SoftLight, HardLight, ColorDodge, ColorBurn, Darken, Lighten, Difference, Exclusion, Add, Subtract) and 4 HSL-space variants (accepted but unsupported by bundled FFmpeg) ([#327](https://github.com/itsakeyfut/avio/issues/327)–[#334](https://github.com/itsakeyfut/avio/issues/334))
+- `FilterGraphBuilder::blend()` — layer a top `FilterGraphBuilder` over the main stream with a specified `BlendMode` and opacity ([#327](https://github.com/itsakeyfut/avio/issues/327))
+- Porter-Duff Over compositing (`BlendMode::PorterDuffOver`) via `overlay=format=auto:shortest=1` ([#335](https://github.com/itsakeyfut/avio/issues/335))
+- Porter-Duff Under, In, Out operations ([#336](https://github.com/itsakeyfut/avio/issues/336))
+- Porter-Duff Atop and XOR operations ([#337](https://github.com/itsakeyfut/avio/issues/337))
+
+#### ff-filter — keying
+- `FilterGraphBuilder::chromakey()` — YCbCr chroma key with similarity and blend parameters ([#338](https://github.com/itsakeyfut/avio/issues/338))
+- `FilterGraphBuilder::colorkey()` — RGB-space color removal ([#339](https://github.com/itsakeyfut/avio/issues/339))
+- `FilterGraphBuilder::spill_suppress()` — reduce chroma spill on keyed subject edges ([#340](https://github.com/itsakeyfut/avio/issues/340))
+- `FilterGraphBuilder::lumakey()` — key out bright or dark regions by luminance ([#341](https://github.com/itsakeyfut/avio/issues/341))
+
+#### ff-filter — masking
+- `FilterGraphBuilder::alpha_matte()` — merge a grayscale matte stream as the alpha channel of the main video ([#342](https://github.com/itsakeyfut/avio/issues/342))
+- `FilterGraphBuilder::rect_mask()` — rectangular alpha mask via `geq` filter ([#343](https://github.com/itsakeyfut/avio/issues/343))
+- `FilterGraphBuilder::polygon_matte()` — polygon mask with up to 16 vertices in normalised coordinates, using a crossing-number point-in-polygon test ([#344](https://github.com/itsakeyfut/avio/issues/344))
+- `FilterGraphBuilder::feather_mask()` — Gaussian blur of the alpha channel edges for smooth compositing ([#345](https://github.com/itsakeyfut/avio/issues/345))
+
+#### avio (facade)
+- `BlendMode` re-exported under the `filter` feature flag ([#930](https://github.com/itsakeyfut/avio/issues/930))
+- New compositing examples: `chroma_key_green_screen`, `blend_modes_demo`, `luma_key_title_card`, `polygon_garbage_matte`, `mask_feathering`, `alpha_matte_external` ([#932](https://github.com/itsakeyfut/avio/issues/932)–[#937](https://github.com/itsakeyfut/avio/issues/937))
+
+### Fixed
+
+- `BlendMode::ColorDodge` mapped to wrong FFmpeg mode name (`colordodge` → `dodge`) ([#347](https://github.com/itsakeyfut/avio/issues/347))
+- `BlendMode::ColorBurn` mapped to wrong FFmpeg mode name (`colorburn` → `burn`) ([#347](https://github.com/itsakeyfut/avio/issues/347))
+
+### Tests
+
+- Golden-image regression test for all 18 photographic blend modes against committed reference PNGs within ±2 per-channel tolerance ([#347](https://github.com/itsakeyfut/avio/issues/347))
+- End-to-end compositing pipeline integration test: polygon garbage matte → chroma key → Porter-Duff Over blend ([#346](https://github.com/itsakeyfut/avio/issues/346))
+
+---
+
 ## [0.10.0] - 2026-04-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.10.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.10.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.10.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.10.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.10.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.10.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.10.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.10.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.10.0" }
-avio        = { path = "crates/avio",        version = "0.10.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.11.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.11.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.11.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.11.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.11.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.11.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.11.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.11.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.11.0" }
+avio        = { path = "crates/avio",        version = "0.11.0" }
 
 # Error handling
 thiserror = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ff-probe  = "0.10"
-ff-decode = "0.10"
-ff-encode = "0.10"
+ff-probe  = "0.11"
+ff-decode = "0.11"
+ff-encode = "0.11"
 
 # Or use the facade crate for everything
-avio = "0.10"
+avio = "0.11"
 ```
 
 ### Prerequisites

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -14,16 +14,16 @@ to only the capabilities you need via feature flags.
 ```toml
 [dependencies]
 # Default: probe + decode + encode
-avio = "0.10"
+avio = "0.11"
 
 # Add filtering
-avio = { version = "0.10", features = ["filter"] }
+avio = { version = "0.11", features = ["filter"] }
 
 # Full stack (implies filter + pipeline)
-avio = { version = "0.10", features = ["stream"] }
+avio = { version = "0.11", features = ["stream"] }
 
 # Async decode/encode (requires tokio runtime)
-avio = { version = "0.10", features = ["tokio"] }
+avio = { version = "0.11", features = ["tokio"] }
 ```
 
 ## Feature Flags

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -22,13 +22,13 @@
 //! ```toml
 //! # Default: probe + decode + encode
 //! [dependencies]
-//! avio = "0.10"
+//! avio = "0.11"
 //!
 //! # Add filtering
-//! avio = { version = "0.10", features = ["filter"] }
+//! avio = { version = "0.11", features = ["filter"] }
 //!
 //! # Full stack (implies filter + pipeline)
-//! avio = { version = "0.10", features = ["stream"] }
+//! avio = { version = "0.11", features = ["stream"] }
 //! ```
 //!
 //! # Quick Start

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -8,8 +8,8 @@ Decode video and audio frames without managing codec contexts, packet queues, or
 
 ```toml
 [dependencies]
-ff-decode = "0.10"
-ff-format = "0.10"
+ff-decode = "0.11"
+ff-format = "0.11"
 ```
 
 ## Video Decoding
@@ -191,7 +191,7 @@ let mut decoder = VideoDecoder::open("video.mp4")
 
 ```toml
 [dependencies]
-ff-decode = { version = "0.10", features = ["tokio"] }
+ff-decode = { version = "0.11", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoDecoder` and `AudioDecoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -8,12 +8,12 @@ Encode video and audio to any format with a builder chain. The encoder validates
 
 ```toml
 [dependencies]
-ff-encode = "0.10"
-ff-format = "0.10"
+ff-encode = "0.11"
+ff-format = "0.11"
 
 # Enable GPL-licensed encoders (libx264, libx265).
 # Requires GPL compliance or MPEG LA licensing in your project.
-# ff-encode = { version = "0.10", features = ["gpl"] }
+# ff-encode = { version = "0.11", features = ["gpl"] }
 ```
 
 By default, only LGPL-compatible encoders are enabled.
@@ -326,7 +326,7 @@ Enable the `gpl` feature to add libx264 and libx265. This changes the license te
 
 ```toml
 [dependencies]
-ff-encode = { version = "0.10", features = ["tokio"] }
+ff-encode = { version = "0.11", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoEncoder`, `AudioEncoder`, and `ImageEncoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-filter/README.md
+++ b/crates/ff-filter/README.md
@@ -8,7 +8,7 @@ Apply video and audio transformations without writing FFmpeg filter-graph string
 
 ```toml
 [dependencies]
-ff-filter = "0.10"
+ff-filter = "0.11"
 ```
 
 ## Building a Filter Chain

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -8,7 +8,7 @@ Wire decode, filter, and encode into a single configured pipeline. Instead of ma
 
 ```toml
 [dependencies]
-ff-pipeline = "0.10"
+ff-pipeline = "0.11"
 ```
 
 ## Building a Pipeline

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -8,7 +8,7 @@ Read media file metadata with one function call. No knowledge of container forma
 
 ```toml
 [dependencies]
-ff-probe = "0.10"
+ff-probe = "0.11"
 ```
 
 ## Quick Start

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -9,7 +9,7 @@ point it at an input file, and receive a standards-compliant package ready for C
 
 ```toml
 [dependencies]
-ff-stream = "0.10"
+ff-stream = "0.11"
 ```
 
 ## HLS Output


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.10.0 to 0.11.0 and documents all v0.11.0 changes in CHANGELOG.md. This release covers the full compositing, keying & blend modes milestone.

## Changes

- `Cargo.toml`: workspace version `0.10.0` → `0.11.0`; all intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.11.0]` entry covering blend modes, Porter-Duff ops, keying filters, masking filters, examples, and bug fixes
- README files and `avio/src/lib.rs`: version references updated to `0.11`

## Related Issues

Closes #469

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes