### PR TITLE
feat(ff-filter): add Keyframe<T> type with per-segment easing

### DIFF
--- a/crates/ff-filter/src/animation/easing.rs
+++ b/crates/ff-filter/src/animation/easing.rs
@@ -1,0 +1,30 @@
+/// Easing function applied to a keyframe interval.
+///
+/// Controls the shape of interpolation from one [`super::Keyframe`] to the
+/// next.  Each keyframe carries the easing used for the transition *from that
+/// keyframe to the subsequent one*; the last keyframe's easing is unused.
+///
+/// Individual easing functions are implemented across issues #352–#357.
+#[derive(Debug, Clone)]
+pub enum Easing {
+    /// Hold: the value snaps to the next keyframe without interpolation.
+    Hold,
+    /// Linear: constant-rate interpolation (`y = t`).
+    Linear,
+    /// Cubic ease-in: slow start, fast end (`y = t³`).
+    EaseIn,
+    /// Cubic ease-out: fast start, slow end (`y = 1 − (1−t)³`).
+    EaseOut,
+    /// Cubic ease-in-out: slow at both ends, fast middle (`y = 3t² − 2t³`).
+    EaseInOut,
+    /// CSS-compatible cubic Bézier with two user-defined control points.
+    ///
+    /// P0 = (0, 0) and P3 = (1, 1) are fixed; `p1` and `p2` define the curve
+    /// shape.  Equivalent to the CSS `cubic-bezier()` function.
+    Bezier {
+        /// First control point `(x, y)`, x clamped to `[0, 1]`.
+        p1: (f64, f64),
+        /// Second control point `(x, y)`, x clamped to `[0, 1]`.
+        p2: (f64, f64),
+    },
+}

--- a/crates/ff-filter/src/animation/keyframe.rs
+++ b/crates/ff-filter/src/animation/keyframe.rs
@@ -1,0 +1,124 @@
+use std::cmp::Ordering;
+use std::time::Duration;
+
+use super::{Easing, Lerp};
+
+/// A single keyframe in an animation track.
+///
+/// The `easing` field controls the interpolation from **this** keyframe to the
+/// next one.  The last keyframe's `easing` is never used (there is no
+/// subsequent keyframe to interpolate toward).
+///
+/// # Ordering
+///
+/// Keyframes are ordered and compared by `timestamp` only.  Two keyframes at
+/// the same timestamp are considered equal regardless of their values or easing
+/// — this keeps binary-search by timestamp correct inside
+/// `AnimationTrack` (added in issue #350).
+#[derive(Debug, Clone)]
+pub struct Keyframe<T: Lerp> {
+    /// Position of this keyframe on the timeline.
+    pub timestamp: Duration,
+    /// Value held at (and interpolated from) this keyframe.
+    pub value: T,
+    /// Easing applied for the transition from this keyframe to the next.
+    pub easing: Easing,
+}
+
+impl<T: Lerp> Keyframe<T> {
+    /// Creates a new keyframe.
+    pub fn new(timestamp: Duration, value: T, easing: Easing) -> Self {
+        Self {
+            timestamp,
+            value,
+            easing,
+        }
+    }
+}
+
+// ── Ordering by timestamp only ────────────────────────────────────────────────
+
+impl<T: Lerp> PartialEq for Keyframe<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp
+    }
+}
+
+impl<T: Lerp> Eq for Keyframe<T> {}
+
+impl<T: Lerp> PartialOrd for Keyframe<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Lerp> Ord for Keyframe<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.timestamp.cmp(&other.timestamp)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Minimal Lerp impl used only within these tests.
+    // The real impl for f64 is added in issue #351.
+    #[derive(Clone, Debug)]
+    struct TestVal(f64);
+
+    impl Lerp for TestVal {
+        fn lerp(a: &Self, b: &Self, t: f64) -> Self {
+            TestVal(a.0 + (b.0 - a.0) * t)
+        }
+    }
+
+    fn kf(ms: u64, v: f64) -> Keyframe<TestVal> {
+        Keyframe::new(Duration::from_millis(ms), TestVal(v), Easing::Linear)
+    }
+
+    #[test]
+    fn keyframe_new_should_store_all_fields() {
+        let ts = Duration::from_millis(500);
+        let kf = Keyframe::new(ts, TestVal(1.0), Easing::EaseInOut);
+        assert_eq!(kf.timestamp, ts);
+        assert!((kf.value.0 - 1.0).abs() < f64::EPSILON);
+        assert!(matches!(kf.easing, Easing::EaseInOut));
+    }
+
+    #[test]
+    fn keyframe_should_order_by_timestamp() {
+        let a = kf(100, 0.0);
+        let b = kf(200, 0.5);
+        let c = kf(300, 1.0);
+
+        assert!(a < b);
+        assert!(b < c);
+        assert!(a < c);
+
+        let mut frames = vec![c, a, b];
+        frames.sort();
+        assert_eq!(frames[0].timestamp, Duration::from_millis(100));
+        assert_eq!(frames[1].timestamp, Duration::from_millis(200));
+        assert_eq!(frames[2].timestamp, Duration::from_millis(300));
+    }
+
+    #[test]
+    fn keyframe_should_compare_equal_by_timestamp_only() {
+        let a = Keyframe::new(Duration::from_millis(100), TestVal(0.0), Easing::Linear);
+        let b = Keyframe::new(Duration::from_millis(100), TestVal(99.0), Easing::Hold);
+        // Same timestamp → equal regardless of value or easing.
+        assert_eq!(a, b);
+        assert_eq!(a.cmp(&b), Ordering::Equal);
+    }
+
+    #[test]
+    fn keyframe_should_be_less_than_later_keyframe() {
+        let early = kf(0, 0.0);
+        let late = kf(1000, 1.0);
+        assert!(early < late);
+        assert!(late > early);
+    }
+}

--- a/crates/ff-filter/src/animation/lerp.rs
+++ b/crates/ff-filter/src/animation/lerp.rs
@@ -1,0 +1,10 @@
+/// A value that supports linear component-wise interpolation.
+///
+/// `t = 0.0` returns a clone of `a`; `t = 1.0` returns a clone of `b`.
+///
+/// Implementations for `f64`, `(f64, f64)`, and `(f64, f64, f64)` are added
+/// in issue #351.
+pub trait Lerp: Clone {
+    /// Linearly interpolates between `a` and `b` by the factor `t`.
+    fn lerp(a: &Self, b: &Self, t: f64) -> Self;
+}

--- a/crates/ff-filter/src/animation/mod.rs
+++ b/crates/ff-filter/src/animation/mod.rs
@@ -1,0 +1,17 @@
+//! Keyframe animation system for time-varying filter parameters.
+//!
+//! The animation system is built in layers:
+//!
+//! 1. [`Lerp`] — trait for component-wise linear interpolation (#351)
+//! 2. [`Easing`] — six easing functions: `Hold`, `Linear`, `EaseIn`, `EaseOut`,
+//!    `EaseInOut`, `Bezier` (#352–#357)
+//! 3. [`Keyframe<T>`] — timestamp + value + per-segment easing (#349)
+//! 4. `AnimationTrack<T>` — sorted collection with `value_at(t)` (#350)
+
+mod easing;
+mod keyframe;
+mod lerp;
+
+pub use easing::Easing;
+pub use keyframe::Keyframe;
+pub use lerp::Lerp;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -32,12 +32,14 @@
 //! - `filter_inner` — `pub(crate)` unsafe `FFmpeg` calls (not part of the public API)
 
 pub mod analysis;
+pub mod animation;
 pub mod blend;
 pub mod error;
 mod filter_inner;
 pub mod graph;
 
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
+pub use animation::{Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
 pub use error::FilterError;
 pub use graph::{


### PR DESCRIPTION
## Summary

Introduces the `Keyframe<T>` type as the foundational building block of the v0.12.0 keyframe animation system. Each keyframe stores a timestamp, a value, and the easing function used for the transition from that keyframe to the next (per-segment easing model). The PR also creates the `animation` module scaffold with stub definitions of the `Lerp` trait and `Easing` enum, which subsequent issues (#350–#357) will fill in.

## Changes

- `crates/ff-filter/src/animation/lerp.rs` — `pub trait Lerp: Clone` with required `fn lerp(a, b, t)` method
- `crates/ff-filter/src/animation/easing.rs` — `Easing` enum with all six variant names (`Hold`, `Linear`, `EaseIn`, `EaseOut`, `EaseInOut`, `Bezier { p1, p2 }`)
- `crates/ff-filter/src/animation/keyframe.rs` — `Keyframe<T: Lerp>` struct with `new()` constructor; manual `Ord`, `PartialOrd`, `Eq`, `PartialEq` implementations that compare by `timestamp` only; four unit tests
- `crates/ff-filter/src/animation/mod.rs` — module declarations and public re-exports
- `crates/ff-filter/src/lib.rs` — registers `pub mod animation` and re-exports `Easing`, `Keyframe`, `Lerp`

## Related Issues

Closes #349

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes