### PR TITLE
feat(ff-filter): add AnimationTrack<T> with sorted keyframes and value_at

### DIFF
--- a/crates/ff-filter/src/animation/easing.rs
+++ b/crates/ff-filter/src/animation/easing.rs
@@ -28,3 +28,22 @@ pub enum Easing {
         p2: (f64, f64),
     },
 }
+
+impl Easing {
+    /// Applies the easing function to a normalised progress value `t ∈ [0, 1]`.
+    ///
+    /// Returns a remapped progress value `u ∈ [0, 1]` that is then used to
+    /// drive `T::lerp`.  Full per-variant implementations are added in issues
+    /// #352–#357; variants not yet implemented fall back to linear.
+    pub(crate) fn apply(&self, t: f64) -> f64 {
+        match self {
+            Easing::Hold => 0.0,
+            Easing::Linear => t,
+            // Full cubic implementations added in #352–#357.
+            Easing::EaseIn => t,
+            Easing::EaseOut => t,
+            Easing::EaseInOut => t,
+            Easing::Bezier { .. } => t,
+        }
+    }
+}

--- a/crates/ff-filter/src/animation/lerp.rs
+++ b/crates/ff-filter/src/animation/lerp.rs
@@ -2,9 +2,15 @@
 ///
 /// `t = 0.0` returns a clone of `a`; `t = 1.0` returns a clone of `b`.
 ///
-/// Implementations for `f64`, `(f64, f64)`, and `(f64, f64, f64)` are added
+/// Implementations for `(f64, f64)` and `(f64, f64, f64)` are added
 /// in issue #351.
 pub trait Lerp: Clone {
     /// Linearly interpolates between `a` and `b` by the factor `t`.
     fn lerp(a: &Self, b: &Self, t: f64) -> Self;
+}
+
+impl Lerp for f64 {
+    fn lerp(a: &Self, b: &Self, t: f64) -> Self {
+        a + (b - a) * t
+    }
 }

--- a/crates/ff-filter/src/animation/mod.rs
+++ b/crates/ff-filter/src/animation/mod.rs
@@ -6,12 +6,14 @@
 //! 2. [`Easing`] — six easing functions: `Hold`, `Linear`, `EaseIn`, `EaseOut`,
 //!    `EaseInOut`, `Bezier` (#352–#357)
 //! 3. [`Keyframe<T>`] — timestamp + value + per-segment easing (#349)
-//! 4. `AnimationTrack<T>` — sorted collection with `value_at(t)` (#350)
+//! 4. [`AnimationTrack<T>`] — sorted collection with `value_at(t)` (#350)
 
 mod easing;
 mod keyframe;
 mod lerp;
+mod track;
 
 pub use easing::Easing;
 pub use keyframe::Keyframe;
 pub use lerp::Lerp;
+pub use track::AnimationTrack;

--- a/crates/ff-filter/src/animation/track.rs
+++ b/crates/ff-filter/src/animation/track.rs
@@ -1,0 +1,151 @@
+use std::time::Duration;
+
+use super::{Keyframe, Lerp};
+
+/// A sorted collection of keyframes with interpolated `value_at(t)` lookup.
+///
+/// Keyframes are kept in ascending timestamp order at all times.  The easing
+/// used for each interval is taken from the **preceding** keyframe's `easing`
+/// field; the last keyframe's easing is never read.
+///
+/// # Panics
+///
+/// `value_at` panics if the track is empty.  Always push at least one keyframe
+/// before querying.
+#[derive(Debug, Clone)]
+pub struct AnimationTrack<T: Lerp> {
+    keyframes: Vec<Keyframe<T>>,
+}
+
+impl<T: Lerp> AnimationTrack<T> {
+    /// Creates an empty track.
+    pub fn new() -> Self {
+        Self {
+            keyframes: Vec::new(),
+        }
+    }
+
+    /// Inserts a keyframe, maintaining timestamp-sorted order.
+    ///
+    /// If a keyframe at the same timestamp already exists it is replaced.
+    #[must_use]
+    pub fn push(mut self, kf: Keyframe<T>) -> Self {
+        let pos = self
+            .keyframes
+            .partition_point(|k| k.timestamp < kf.timestamp);
+        if self
+            .keyframes
+            .get(pos)
+            .is_some_and(|k| k.timestamp == kf.timestamp)
+        {
+            self.keyframes[pos] = kf;
+        } else {
+            self.keyframes.insert(pos, kf);
+        }
+        self
+    }
+
+    /// Returns the interpolated value at time `t`.
+    ///
+    /// - Before the first keyframe: returns the first value (hold).
+    /// - After the last keyframe: returns the last value (hold).
+    /// - Between two keyframes: uses the preceding keyframe's `easing`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the track is empty.
+    pub fn value_at(&self, t: Duration) -> T {
+        let len = self.keyframes.len();
+        // pos = number of keyframes with timestamp < t
+        let pos = self.keyframes.partition_point(|k| k.timestamp <= t);
+
+        if pos == 0 {
+            // Before or exactly at the first keyframe.
+            return self.keyframes[0].value.clone();
+        }
+        if pos >= len {
+            // After or exactly at the last keyframe.
+            return self.keyframes[len - 1].value.clone();
+        }
+
+        let a = &self.keyframes[pos - 1];
+        let b = &self.keyframes[pos];
+
+        let span = b
+            .timestamp
+            .checked_sub(a.timestamp)
+            .map_or(0.0, |d| d.as_secs_f64());
+        let elapsed = t.checked_sub(a.timestamp).map_or(0.0, |d| d.as_secs_f64());
+        let norm_t = if span > 0.0 { elapsed / span } else { 1.0 };
+
+        let u = a.easing.apply(norm_t);
+        T::lerp(&a.value, &b.value, u)
+    }
+
+    /// Returns the number of keyframes in the track.
+    pub fn len(&self) -> usize {
+        self.keyframes.len()
+    }
+
+    /// Returns `true` if the track has no keyframes.
+    pub fn is_empty(&self) -> bool {
+        self.keyframes.is_empty()
+    }
+}
+
+impl<T: Lerp> Default for AnimationTrack<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::animation::Easing;
+
+    fn kf(ms: u64, v: f64) -> Keyframe<f64> {
+        Keyframe::new(Duration::from_millis(ms), v, Easing::Linear)
+    }
+
+    #[test]
+    fn animation_track_should_return_first_value_before_first_keyframe() {
+        let track = AnimationTrack::new()
+            .push(kf(500, 10.0))
+            .push(kf(1000, 20.0));
+
+        let v = track.value_at(Duration::from_millis(0));
+        assert!((v - 10.0).abs() < f64::EPSILON, "expected 10.0, got {v}");
+
+        let v2 = track.value_at(Duration::from_millis(499));
+        assert!((v2 - 10.0).abs() < f64::EPSILON, "expected 10.0, got {v2}");
+    }
+
+    #[test]
+    fn animation_track_should_return_last_value_after_last_keyframe() {
+        let track = AnimationTrack::new().push(kf(0, 0.0)).push(kf(1000, 50.0));
+
+        let v = track.value_at(Duration::from_millis(1000));
+        assert!((v - 50.0).abs() < f64::EPSILON, "expected 50.0, got {v}");
+
+        let v2 = track.value_at(Duration::from_millis(9999));
+        assert!((v2 - 50.0).abs() < f64::EPSILON, "expected 50.0, got {v2}");
+    }
+
+    #[test]
+    fn animation_track_should_interpolate_between_keyframes() {
+        // 0 ms → 0.0, 1000 ms → 1.0, linear easing.
+        let track = AnimationTrack::new().push(kf(0, 0.0)).push(kf(1000, 1.0));
+
+        let v = track.value_at(Duration::from_millis(500));
+        assert!((v - 0.5).abs() < 1e-9, "expected 0.5 at midpoint, got {v}");
+
+        let v2 = track.value_at(Duration::from_millis(250));
+        assert!(
+            (v2 - 0.25).abs() < 1e-9,
+            "expected 0.25 at quarter-point, got {v2}"
+        );
+    }
+}

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -39,7 +39,7 @@ mod filter_inner;
 pub mod graph;
 
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
-pub use animation::{Easing, Keyframe, Lerp};
+pub use animation::{AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
 pub use error::FilterError;
 pub use graph::{


### PR DESCRIPTION
## Summary

Implements `AnimationTrack<T: Lerp>`, a timestamp-sorted keyframe collection with `value_at(t)` interpolation. This is the core data structure of the v0.12.0 keyframe animation system, providing the lookup engine that drives time-varying filter parameters.

## Changes

- `animation/track.rs`: new `AnimationTrack<T: Lerp>` struct with `push()` (consuming builder, sorted insert via `partition_point`), `value_at(t)` (hold before first/after last, easing-driven interpolation between), `len()`, `is_empty()`, and `Default`
- `animation/easing.rs`: add `pub(crate) fn apply(&self, t: f64) -> f64` to `Easing`; `Hold` returns `0.0`, `Linear` returns `t`, remaining variants stub to `t` pending #352–#357
- `animation/lerp.rs`: add `impl Lerp for f64`
- `animation/mod.rs`: expose `AnimationTrack` and wire in `mod track`
- `lib.rs`: re-export `AnimationTrack`

## Related Issues

Closes #350

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes