### PR TITLE
feat(ff-filter): implement EaseIn cubic easing (t³)

### DIFF
--- a/crates/ff-filter/src/animation/easing.rs
+++ b/crates/ff-filter/src/animation/easing.rs
@@ -47,8 +47,8 @@ impl Easing {
                 }
             }
             Easing::Linear => t,
-            // Full cubic implementations added in #353–#357.
-            Easing::EaseIn => t,
+            // Cubic ease-in: slow start, fast end (y = t³).
+            Easing::EaseIn => t * t * t,
             Easing::EaseOut => t,
             Easing::EaseInOut => t,
             Easing::Bezier { .. } => t,
@@ -78,6 +78,14 @@ mod tests {
 
         let v = track.value_at(Duration::from_millis(500));
         assert!((v - 0.5).abs() < 0.001, "expected 0.5 at midpoint, got {v}");
+    }
+
+    #[test]
+    fn ease_in_should_be_below_linear_at_midpoint() {
+        // t³ at t=0.5 → 0.125, well below the linear 0.5.
+        let u = Easing::EaseIn.apply(0.5);
+        assert!(u < 0.5, "ease-in at t=0.5 should be below 0.5, got {u}");
+        assert!((u - 0.125).abs() < f64::EPSILON, "expected 0.125, got {u}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements `Easing::EaseIn` by replacing the linear stub with the cubic formula `t³`. Cubic ease-in starts slowly and accelerates into the transition, producing a value of `0.125` at the midpoint (`t = 0.5`) compared to the linear `0.5` — a perceptible slow start useful for elements entering the frame.

## Changes

- `animation/easing.rs`: replace `Easing::EaseIn => t` stub with `t * t * t`
- `animation/easing.rs`: unit test `ease_in_should_be_below_linear_at_midpoint` — asserts `apply(0.5) == 0.125 < 0.5`

## Related Issues

Closes #354

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes