### PR TITLE
feat(ff-filter): implement EaseOut cubic easing (1-(1-t)³)

### DIFF
--- a/crates/ff-filter/src/animation/easing.rs
+++ b/crates/ff-filter/src/animation/easing.rs
@@ -49,7 +49,8 @@ impl Easing {
             Easing::Linear => t,
             // Cubic ease-in: slow start, fast end (y = t³).
             Easing::EaseIn => t * t * t,
-            Easing::EaseOut => t,
+            // Cubic ease-out: fast start, slow end (y = 1 − (1−t)³).
+            Easing::EaseOut => 1.0 - (1.0 - t).powi(3),
             Easing::EaseInOut => t,
             Easing::Bezier { .. } => t,
         }
@@ -78,6 +79,14 @@ mod tests {
 
         let v = track.value_at(Duration::from_millis(500));
         assert!((v - 0.5).abs() < 0.001, "expected 0.5 at midpoint, got {v}");
+    }
+
+    #[test]
+    fn ease_out_should_be_above_linear_at_midpoint() {
+        // 1 − (1−0.5)³ = 1 − 0.125 = 0.875, well above the linear 0.5.
+        let u = Easing::EaseOut.apply(0.5);
+        assert!(u > 0.5, "ease-out at t=0.5 should be above 0.5, got {u}");
+        assert!((u - 0.875).abs() < f64::EPSILON, "expected 0.875, got {u}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements `Easing::EaseOut` by replacing the linear stub with `1.0 - (1.0 - t).powi(3)`. Cubic ease-out is the mirror of ease-in: it starts fast and decelerates at the end, producing a value of `0.875` at the midpoint (`t = 0.5`) — well above the linear `0.5`. Commonly used for elements exiting the frame.

## Changes

- `animation/easing.rs`: replace `Easing::EaseOut => t` stub with `1.0 - (1.0 - t).powi(3)`
- `animation/easing.rs`: unit test `ease_out_should_be_above_linear_at_midpoint` — asserts `apply(0.5) == 0.875 > 0.5`

## Related Issues

Closes #355

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes