### PR TITLE
feat(ff-filter): animated VideoLayer properties via AnimatedValue<T>

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -22,8 +22,8 @@
 use std::{path::PathBuf, process, time::Duration};
 
 use avio::{
-    AudioCodec, AudioTrack, ChannelLayout, MultiTrackAudioMixer, MultiTrackComposer, VideoCodec,
-    VideoEncoder, VideoLayer,
+    AnimatedValue, AudioCodec, AudioTrack, ChannelLayout, MultiTrackAudioMixer, MultiTrackComposer,
+    VideoCodec, VideoEncoder, VideoLayer,
 };
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
@@ -90,10 +90,12 @@ fn main() {
     let mut video_graph = match MultiTrackComposer::new(args.width, args.height)
         .add_layer(VideoLayer {
             source: args.base.clone(),
-            x: 0,
-            y: 0,
-            scale: 1.0,
-            opacity: 1.0,
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(1.0),
             z_order: 0,
             time_offset: Duration::ZERO,
             in_point: None,
@@ -101,10 +103,12 @@ fn main() {
         })
         .add_layer(VideoLayer {
             source: args.overlay.clone(),
-            x: overlay_x.cast_signed(),
-            y: 0,
-            scale: 0.5,
-            opacity: 0.85,
+            x: AnimatedValue::Static(f64::from(overlay_x)),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(0.5),
+            scale_y: AnimatedValue::Static(0.5),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(0.85),
             z_order: 1,
             time_offset: Duration::ZERO,
             in_point: None,

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -259,10 +259,11 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    AudioConcatenator, AudioTrack, BlendMode, ClipJoiner, DrawTextOptions, EqBand, FilterError,
-    FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, LoudnessMeter, LoudnessResult,
-    MultiTrackAudioMixer, MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm, ToneMap,
-    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    AnimatedValue, AnimationTrack, AudioConcatenator, AudioTrack, BlendMode, ClipJoiner,
+    DrawTextOptions, Easing, EqBand, FilterError, FilterGraph, FilterGraphBuilder, FilterStep,
+    HwAccel, Keyframe, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer,
+    MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm, ToneMap, VideoConcatenator,
+    VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/animation/mod.rs
+++ b/crates/ff-filter/src/animation/mod.rs
@@ -7,13 +7,16 @@
 //!    `EaseInOut`, `Bezier` (#352–#357)
 //! 3. [`Keyframe<T>`] — timestamp + value + per-segment easing (#349)
 //! 4. [`AnimationTrack<T>`] — sorted collection with `value_at(t)` (#350)
+//! 5. [`AnimatedValue<T>`] — `Static(T)` or `Track(AnimationTrack<T>)` (#358)
 
 mod easing;
 mod keyframe;
 mod lerp;
 mod track;
+mod value;
 
 pub use easing::Easing;
 pub use keyframe::Keyframe;
 pub use lerp::Lerp;
 pub use track::AnimationTrack;
+pub use value::AnimatedValue;

--- a/crates/ff-filter/src/animation/value.rs
+++ b/crates/ff-filter/src/animation/value.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use super::{AnimationTrack, Lerp};
+
+/// A value that is either constant or animated over time.
+///
+/// Use [`Static`](AnimatedValue::Static) for values that never change, and
+/// [`Track`](AnimatedValue::Track) for values driven by a keyframe
+/// [`AnimationTrack`].
+///
+/// Evaluated at build time via [`value_at(Duration::ZERO)`](Self::value_at) to
+/// set initial filter parameters.  Per-frame updates are wired up in issue
+/// #363.
+#[derive(Debug, Clone)]
+pub enum AnimatedValue<T: Lerp> {
+    /// A constant value, independent of time.
+    Static(T),
+    /// A time-varying value driven by a keyframe track.
+    Track(AnimationTrack<T>),
+}
+
+impl<T: Lerp> AnimatedValue<T> {
+    /// Evaluates the value at time `t`.
+    ///
+    /// - `Static(v)` — returns a clone of `v` regardless of `t`.
+    /// - `Track(track)` — delegates to [`AnimationTrack::value_at`].
+    pub fn value_at(&self, t: Duration) -> T {
+        match self {
+            AnimatedValue::Static(v) => v.clone(),
+            AnimatedValue::Track(track) => track.value_at(t),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::animation::{Easing, Keyframe};
+
+    #[test]
+    fn animated_value_static_should_return_constant_at_any_time() {
+        let v: AnimatedValue<f64> = AnimatedValue::Static(42.0);
+        assert!(
+            (v.value_at(Duration::ZERO) - 42.0).abs() < f64::EPSILON,
+            "expected 42.0 at t=0"
+        );
+        assert!(
+            (v.value_at(Duration::from_secs(9999)) - 42.0).abs() < f64::EPSILON,
+            "expected 42.0 at t=9999s"
+        );
+    }
+
+    #[test]
+    fn animated_value_track_should_delegate_to_track() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0_f64, Easing::Linear))
+            .push(Keyframe::new(
+                Duration::from_secs(1),
+                1.0_f64,
+                Easing::Linear,
+            ));
+        let v: AnimatedValue<f64> = AnimatedValue::Track(track);
+        let mid = v.value_at(Duration::from_millis(500));
+        assert!(
+            (mid - 0.5).abs() < 1e-9,
+            "expected 0.5 at midpoint, got {mid}"
+        );
+    }
+}

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -222,9 +222,11 @@ pub(super) unsafe fn build_video_composition(
         }
 
         // ── Optional scale ────────────────────────────────────────────────────
-        if (layer.scale - 1.0_f32).abs() > f32::EPSILON {
-            let sw = (canvas_width as f32 * layer.scale).round() as u32;
-            let sh = (canvas_height as f32 * layer.scale).round() as u32;
+        let sx = layer.scale_x.value_at(Duration::ZERO);
+        let sy = layer.scale_y.value_at(Duration::ZERO);
+        if (sx - 1.0).abs() > f64::EPSILON || (sy - 1.0).abs() > f64::EPSILON {
+            let sw = (f64::from(canvas_width) * sx).round() as u32;
+            let sh = (f64::from(canvas_height) * sy).round() as u32;
             let scale_filter = ff_sys::avfilter_get_by_name(c"scale".as_ptr());
             if scale_filter.is_null() {
                 bail!(graph, "filter not found: scale");
@@ -257,9 +259,46 @@ pub(super) unsafe fn build_video_composition(
             chain_end = sc_ctx;
         }
 
+        // ── Optional rotation ─────────────────────────────────────────────────
+        let rotation_deg = layer.rotation.value_at(Duration::ZERO);
+        if rotation_deg.abs() > f64::EPSILON {
+            let angle_rad = rotation_deg.to_radians();
+            let rotate_filter = ff_sys::avfilter_get_by_name(c"rotate".as_ptr());
+            if rotate_filter.is_null() {
+                bail!(graph, "filter not found: rotate");
+            }
+            let Ok(rot_name) = CString::new(format!("layer_{idx}_rotate")) else {
+                bail!(graph, "CString::new failed for rotate name");
+            };
+            let Ok(rot_args) = CString::new(format!("{angle_rad}")) else {
+                bail!(graph, "CString::new failed for rotate args");
+            };
+            let mut rot_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+            let ret = ff_sys::avfilter_graph_create_filter(
+                &raw mut rot_ctx,
+                rotate_filter,
+                rot_name.as_ptr(),
+                rot_args.as_ptr(),
+                std::ptr::null_mut(),
+                graph,
+            );
+            if ret < 0 {
+                bail!(
+                    graph,
+                    format!("failed to create rotate filter layer={idx} code={ret}")
+                );
+            }
+            let ret = ff_sys::avfilter_link(chain_end, 0, rot_ctx, 0);
+            if ret < 0 {
+                bail!(graph, format!("link failed: →rotate layer={idx}"));
+            }
+            chain_end = rot_ctx;
+            log::debug!("video composition layer={idx} rotate angle_deg={rotation_deg}");
+        }
+
         // ── Optional opacity ──────────────────────────────────────────────────
-        if layer.opacity < 1.0 {
-            let opacity = layer.opacity.clamp(0.0, 1.0);
+        let opacity = layer.opacity.value_at(Duration::ZERO).clamp(0.0, 1.0);
+        if opacity < 1.0 {
             let ccm_filter = ff_sys::avfilter_get_by_name(c"colorchannelmixer".as_ptr());
             if ccm_filter.is_null() {
                 bail!(graph, "filter not found: colorchannelmixer");
@@ -307,8 +346,9 @@ pub(super) unsafe fn build_video_composition(
         let Ok(ov_name) = CString::new(format!("overlay{idx}")) else {
             bail!(graph, "CString::new failed for overlay name");
         };
-        let Ok(ov_args) = CString::new(format!("{}:{}:eof_action={eof_action}", layer.x, layer.y))
-        else {
+        let lx = layer.x.value_at(Duration::ZERO).round() as i64;
+        let ly = layer.y.value_at(Duration::ZERO).round() as i64;
+        let Ok(ov_args) = CString::new(format!("{lx}:{ly}:eof_action={eof_action}")) else {
             bail!(graph, "CString::new failed for overlay args");
         };
         let mut overlay_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();

--- a/crates/ff-filter/src/graph/composition/multi_track_composer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_composer.rs
@@ -5,6 +5,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::animation::AnimatedValue;
 use crate::error::FilterError;
 use crate::graph::graph::FilterGraph;
 use crate::graph::types::Rgb;
@@ -15,18 +16,27 @@ use crate::graph::types::Rgb;
 ///
 /// Layers are composited in ascending [`z_order`](Self::z_order), with
 /// `0` rendered first (bottom of the stack).
+///
+/// The `x`, `y`, `scale_x`, `scale_y`, `rotation`, and `opacity` fields accept
+/// either a constant ([`AnimatedValue::Static`]) or a time-varying keyframe
+/// track ([`AnimatedValue::Track`]).  The initial filter graph is built from
+/// the value at `Duration::ZERO`; per-frame updates are added in issue #363.
 #[derive(Debug, Clone)]
 pub struct VideoLayer {
     /// Source media file path.
     pub source: PathBuf,
     /// X offset on the canvas in pixels (top-left origin).
-    pub x: i32,
+    pub x: AnimatedValue<f64>,
     /// Y offset on the canvas in pixels.
-    pub y: i32,
-    /// Uniform scale factor applied to the source frame (`1.0` = original size).
-    pub scale: f32,
+    pub y: AnimatedValue<f64>,
+    /// Horizontal scale factor applied to the source frame (`1.0` = original width).
+    pub scale_x: AnimatedValue<f64>,
+    /// Vertical scale factor applied to the source frame (`1.0` = original height).
+    pub scale_y: AnimatedValue<f64>,
+    /// Clockwise rotation in degrees (`0.0` = no rotation).
+    pub rotation: AnimatedValue<f64>,
     /// Opacity (`0.0` = fully transparent, `1.0` = fully opaque).
-    pub opacity: f32,
+    pub opacity: AnimatedValue<f64>,
     /// Compositing order (`0` = bottom layer; higher values render on top).
     pub z_order: u32,
     /// Start offset on the output timeline (`Duration::ZERO` = at the beginning).
@@ -49,14 +59,22 @@ pub struct VideoLayer {
 /// # Examples
 ///
 /// ```ignore
-/// use ff_filter::{MultiTrackComposer, VideoLayer};
+/// use ff_filter::{AnimatedValue, MultiTrackComposer, VideoLayer};
 /// use std::time::Duration;
 ///
 /// let mut graph = MultiTrackComposer::new(1920, 1080)
 ///     .add_layer(VideoLayer {
 ///         source: "clip.mp4".into(),
-///         x: 0, y: 0, scale: 1.0, opacity: 1.0, z_order: 0,
-///         time_offset: Duration::ZERO, in_point: None, out_point: None,
+///         x: AnimatedValue::Static(0.0),
+///         y: AnimatedValue::Static(0.0),
+///         scale_x: AnimatedValue::Static(1.0),
+///         scale_y: AnimatedValue::Static(1.0),
+///         rotation: AnimatedValue::Static(0.0),
+///         opacity: AnimatedValue::Static(1.0),
+///         z_order: 0,
+///         time_offset: Duration::ZERO,
+///         in_point: None,
+///         out_point: None,
 ///     })
 ///     .build()?;
 ///
@@ -155,10 +173,12 @@ mod tests {
         let result = MultiTrackComposer::new(0, 1080)
             .add_layer(VideoLayer {
                 source: "clip.mp4".into(),
-                x: 0,
-                y: 0,
-                scale: 1.0,
-                opacity: 1.0,
+                x: AnimatedValue::Static(0.0),
+                y: AnimatedValue::Static(0.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                opacity: AnimatedValue::Static(1.0),
                 z_order: 0,
                 time_offset: Duration::ZERO,
                 in_point: None,
@@ -174,10 +194,12 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 0)
             .add_layer(VideoLayer {
                 source: "clip.mp4".into(),
-                x: 0,
-                y: 0,
-                scale: 1.0,
-                opacity: 1.0,
+                x: AnimatedValue::Static(0.0),
+                y: AnimatedValue::Static(0.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                opacity: AnimatedValue::Static(1.0),
                 z_order: 0,
                 time_offset: Duration::ZERO,
                 in_point: None,
@@ -201,10 +223,12 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent_640x480.mp4".into(),
-                x: 100,
-                y: 100,
-                scale: 1.0,
-                opacity: 1.0,
+                x: AnimatedValue::Static(100.0),
+                y: AnimatedValue::Static(100.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                opacity: AnimatedValue::Static(1.0),
                 z_order: 0,
                 time_offset: Duration::ZERO,
                 in_point: None,
@@ -236,10 +260,12 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent.mp4".into(),
-                x: 0,
-                y: 0,
-                scale: 1.0,
-                opacity: 1.0,
+                x: AnimatedValue::Static(0.0),
+                y: AnimatedValue::Static(0.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                opacity: AnimatedValue::Static(1.0),
                 z_order: 0,
                 time_offset: Duration::from_secs(2),
                 in_point: None,
@@ -261,10 +287,12 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent.mp4".into(),
-                x: 0,
-                y: 0,
-                scale: 1.0,
-                opacity: 1.0,
+                x: AnimatedValue::Static(0.0),
+                y: AnimatedValue::Static(0.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                opacity: AnimatedValue::Static(1.0),
                 z_order: 0,
                 time_offset: Duration::ZERO,
                 in_point: None,

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -39,7 +39,7 @@ mod filter_inner;
 pub mod graph;
 
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
-pub use animation::{AnimationTrack, Easing, Keyframe, Lerp};
+pub use animation::{AnimatedValue, AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
 pub use error::FilterError;
 pub use graph::{

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 
 use ff_encode::{AudioCodec, AudioEncoder, VideoCodec, VideoEncoder};
 use ff_filter::{
-    AudioConcatenator, AudioTrack, MultiTrackAudioMixer, MultiTrackComposer, VideoConcatenator,
-    VideoLayer,
+    AnimatedValue, AudioConcatenator, AudioTrack, MultiTrackAudioMixer, MultiTrackComposer,
+    VideoConcatenator, VideoLayer,
 };
 use ff_format::{AudioFrame, ChannelLayout, SampleFormat};
 use fixtures::{FileGuard, make_source_file, test_output_path, yuv420p_frame};
@@ -77,10 +77,12 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
     let mut composer = match MultiTrackComposer::new(CANVAS_W, CANVAS_H)
         .add_layer(VideoLayer {
             source: src1_path.clone(),
-            x: 0,
-            y: 0,
-            scale: 1.0,
-            opacity: 1.0,
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(1.0),
             z_order: 0,
             time_offset: Duration::ZERO,
             in_point: None,
@@ -88,10 +90,12 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
         })
         .add_layer(VideoLayer {
             source: src2_path.clone(),
-            x: 160,
-            y: 0,
-            scale: 1.0,
-            opacity: 1.0,
+            x: AnimatedValue::Static(160.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(1.0),
             z_order: 1,
             time_offset: Duration::ZERO,
             in_point: None,
@@ -99,10 +103,12 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
         })
         .add_layer(VideoLayer {
             source: src3_path.clone(),
-            x: 0,
-            y: 134,
-            scale: 1.0,
-            opacity: 1.0,
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(134.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(1.0),
             z_order: 2,
             time_offset: Duration::ZERO,
             in_point: None,

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use ff_decode::VideoDecoder;
 use ff_encode::VideoEncoder;
-use ff_filter::{AudioTrack, MultiTrackAudioMixer, MultiTrackComposer, VideoLayer};
+use ff_filter::{AnimatedValue, AudioTrack, MultiTrackAudioMixer, MultiTrackComposer, VideoLayer};
 use ff_format::ChannelLayout;
 
 use crate::clip::Clip;
@@ -120,10 +120,12 @@ impl Timeline {
                 for clip in track {
                     composer = composer.add_layer(VideoLayer {
                         source: clip.source.clone(),
-                        x: 0,
-                        y: 0,
-                        scale: 1.0,
-                        opacity: 1.0,
+                        x: AnimatedValue::Static(0.0),
+                        y: AnimatedValue::Static(0.0),
+                        scale_x: AnimatedValue::Static(1.0),
+                        scale_y: AnimatedValue::Static(1.0),
+                        rotation: AnimatedValue::Static(0.0),
+                        opacity: AnimatedValue::Static(1.0),
                         z_order: u32::try_from(track_idx).unwrap_or(u32::MAX),
                         time_offset: clip.timeline_offset,
                         in_point: clip.in_point,


### PR DESCRIPTION
## Summary

Introduces `AnimatedValue<T: Lerp>` — an enum wrapping either a constant (`Static(T)`) or a keyframe track (`Track(AnimationTrack<T>)`) — and replaces all static numeric fields in `VideoLayer` with animated equivalents. This is a breaking API change that enables per-frame position, scale, rotation, and opacity animation in `MultiTrackComposer`.

## Changes

- `animation/value.rs`: new `AnimatedValue<T: Lerp>` with `value_at(t: Duration) -> T`; `Static` clones the constant, `Track` delegates to `AnimationTrack::value_at`
- `animation/mod.rs`: expose `mod value` and `pub use value::AnimatedValue`
- `lib.rs`: re-export `AnimatedValue`
- `multi_track_composer.rs`: **breaking** — `VideoLayer` fields changed:
  - `x: i32` → `x: AnimatedValue<f64>`
  - `y: i32` → `y: AnimatedValue<f64>`
  - `scale: f32` removed → `scale_x: AnimatedValue<f64>` + `scale_y: AnimatedValue<f64>`
  - `opacity: f32` → `opacity: AnimatedValue<f64>`
  - `rotation: AnimatedValue<f64>` added (degrees clockwise, default `Static(0.0)`)
- `composition_inner.rs`: evaluate all animated fields at `Duration::ZERO` when building the filter graph; add optional `rotate` filter step (named `layer_{i}_rotate`) when rotation is non-zero; update x/y overlay args via `.round() as i64`
- `composition_tests.rs`: update `VideoLayer` literals to use new field names
- `ff-pipeline/src/timeline.rs`: update `VideoLayer` literals in `Timeline::render()`
- Unit tests: `animated_value_static_should_return_constant_at_any_time`, `animated_value_track_should_delegate_to_track`

## Related Issues

Closes #358

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes