### PR TITLE
feat(ff-filter): animated crop rectangle and blur radius

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -259,9 +259,9 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    AnimatedValue, AnimationTrack, AudioConcatenator, AudioTrack, BlendMode, ClipJoiner,
-    DrawTextOptions, Easing, EqBand, FilterError, FilterGraph, FilterGraphBuilder, FilterStep,
-    HwAccel, Keyframe, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer,
+    AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack, BlendMode,
+    ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph, FilterGraphBuilder,
+    FilterStep, HwAccel, Keyframe, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer,
     MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm, ToneMap, VideoConcatenator,
     VideoLayer, XfadeTransition, YadifMode,
 };

--- a/crates/ff-filter/src/animation/mod.rs
+++ b/crates/ff-filter/src/animation/mod.rs
@@ -8,6 +8,7 @@
 //! 3. [`Keyframe<T>`] — timestamp + value + per-segment easing (#349)
 //! 4. [`AnimationTrack<T>`] — sorted collection with `value_at(t)` (#350)
 //! 5. [`AnimatedValue<T>`] — `Static(T)` or `Track(AnimationTrack<T>)` (#358)
+//! 6. [`AnimationEntry`] — registered animation track for a specific filter parameter (#359)
 
 mod easing;
 mod keyframe;
@@ -20,3 +21,20 @@ pub use keyframe::Keyframe;
 pub use lerp::Lerp;
 pub use track::AnimationTrack;
 pub use value::AnimatedValue;
+
+/// A registered animation track for a specific filter parameter.
+///
+/// Accumulated in [`crate::FilterGraphBuilder`] and transferred to
+/// [`crate::FilterGraph`] on [`build()`](crate::FilterGraphBuilder::build).
+/// Per-frame `avfilter_graph_send_command` updates are applied during playback
+/// in issue #363.
+#[derive(Debug, Clone)]
+pub struct AnimationEntry {
+    /// `FFmpeg` filter node name, e.g. `"crop_0"` or `"gblur_0"`.
+    pub node_name: String,
+    /// `FFmpeg` `send_command` parameter name, e.g. `"w"`, `"h"`, `"x"`, `"y"`,
+    /// or `"sigma"`.
+    pub param: &'static str,
+    /// The animation track providing the value over time.
+    pub track: AnimationTrack<f64>,
+}

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -4,11 +4,13 @@ use super::{
     AUDIO_TIME_BASE_NUM, BuildResult, FilterCtxVec, VIDEO_TIME_BASE_DEN, VIDEO_TIME_BASE_NUM,
     VideoGraphResult, ffmpeg_err,
 };
+use std::ptr::NonNull;
+use std::time::Duration;
+
 use crate::blend::BlendMode;
 use crate::error::FilterError;
 use crate::graph::filter_step::FilterStep;
 use crate::graph::types::{EqBand, HwAccel};
-use std::ptr::NonNull;
 
 // ── Hardware acceleration helpers ─────────────────────────────────────────────
 
@@ -1863,7 +1865,28 @@ impl FilterGraphInner {
                 continue;
             }
 
-            prev_ctx = match add_and_link_step(graph, prev_ctx, step, i, "step") {
+            // Animated filter steps use type-specific node names ("crop_N",
+            // "gblur_N") so that avfilter_graph_send_command targets the correct
+            // context in #363.  The per-type index is the count of preceding steps
+            // of the same animated type.
+            let (step_prefix, step_index): (&str, usize) = match step {
+                FilterStep::CropAnimated { .. } => {
+                    let n = steps[..i]
+                        .iter()
+                        .filter(|s| matches!(s, FilterStep::CropAnimated { .. }))
+                        .count();
+                    ("crop_", n)
+                }
+                FilterStep::GBlurAnimated { .. } => {
+                    let n = steps[..i]
+                        .iter()
+                        .filter(|s| matches!(s, FilterStep::GBlurAnimated { .. }))
+                        .count();
+                    ("gblur_", n)
+                }
+                _ => ("step", i),
+            };
+            prev_ctx = match add_and_link_step(graph, prev_ctx, step, step_index, step_prefix) {
                 Ok(ctx) => ctx,
                 Err(e) => bail!(e),
             };
@@ -1957,17 +1980,34 @@ impl FilterGraphInner {
             log::warn!("avfilter_graph_config failed code={ret}");
             // If there is a crop step the most likely cause is the rectangle
             // extending beyond the source frame dimensions.
-            if let Some(FilterStep::Crop {
-                x,
-                y,
-                width,
-                height,
-            }) = steps.iter().find(|s| matches!(s, FilterStep::Crop { .. }))
-            {
+            let crop_info = steps.iter().find_map(|s| match s {
+                FilterStep::Crop {
+                    x,
+                    y,
+                    width,
+                    height,
+                } => Some((
+                    f64::from(*x),
+                    f64::from(*y),
+                    f64::from(*width),
+                    f64::from(*height),
+                )),
+                FilterStep::CropAnimated {
+                    x,
+                    y,
+                    width,
+                    height,
+                } => Some((
+                    x.value_at(Duration::ZERO),
+                    y.value_at(Duration::ZERO),
+                    width.value_at(Duration::ZERO),
+                    height.value_at(Duration::ZERO),
+                )),
+                _ => None,
+            });
+            if let Some((x, y, w, h)) = crop_info {
                 bail!(FilterError::InvalidConfig {
-                    reason: format!(
-                        "crop rect {x},{y}+{width}x{height} exceeds source frame dimensions"
-                    ),
+                    reason: format!("crop rect {x},{y}+{w}x{h} exceeds source frame dimensions"),
                 });
             }
             bail!(ffmpeg_err(ret));

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -1,12 +1,14 @@
 //! [`FilterGraphBuilder`] — consuming builder for filter graphs.
 
 use std::path::Path;
+use std::time::Duration;
 
 pub(super) use super::FilterGraph;
 pub(super) use super::filter_step::FilterStep;
 pub(super) use super::types::{
     DrawTextOptions, EqBand, HwAccel, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
+pub(super) use crate::animation::{AnimatedValue, AnimationEntry};
 pub(super) use crate::blend::BlendMode;
 pub(super) use crate::error::FilterError;
 use crate::filter_inner::FilterGraphInner;
@@ -35,6 +37,8 @@ mod video;
 pub struct FilterGraphBuilder {
     pub(super) steps: Vec<FilterStep>,
     pub(super) hw: Option<HwAccel>,
+    /// Registered animation entries, transferred to [`FilterGraph`] on [`build()`](Self::build).
+    pub(super) animations: Vec<AnimationEntry>,
 }
 
 impl FilterGraphBuilder {
@@ -147,6 +151,23 @@ impl FilterGraphBuilder {
                 return Err(FilterError::InvalidConfig {
                     reason: "crop width and height must be > 0".to_string(),
                 });
+            }
+            if let FilterStep::CropAnimated { width, height, .. } = step {
+                let w0 = width.value_at(Duration::ZERO);
+                let h0 = height.value_at(Duration::ZERO);
+                if w0 <= 0.0 || h0 <= 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: "crop width and height must be > 0".to_string(),
+                    });
+                }
+            }
+            if let FilterStep::GBlurAnimated { sigma } = step {
+                let s0 = sigma.value_at(Duration::ZERO);
+                if s0 < 0.0 {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("gblur sigma {s0} must be >= 0.0"),
+                    });
+                }
             }
             if let FilterStep::FadeIn { duration, .. }
             | FilterStep::FadeOut { duration, .. }
@@ -640,6 +661,7 @@ impl FilterGraphBuilder {
         Ok(FilterGraph {
             inner: FilterGraphInner::new(self.steps, self.hw),
             output_resolution,
+            pending_animations: self.animations,
         })
     }
 }

--- a/crates/ff-filter/src/graph/builder/video/effects.rs
+++ b/crates/ff-filter/src/graph/builder/video/effects.rs
@@ -10,13 +10,46 @@ impl FilterGraphBuilder {
     /// Values near `0.0` are nearly a no-op; values up to `10.0` produce
     /// progressively stronger blur.
     ///
+    /// Shorthand for [`gblur_animated`](Self::gblur_animated) with a static value.
+    ///
     /// # Validation
     ///
     /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
     /// `sigma` is negative.
     #[must_use]
-    pub fn gblur(mut self, sigma: f32) -> Self {
-        self.steps.push(FilterStep::GBlur { sigma });
+    pub fn gblur(self, sigma: f32) -> Self {
+        self.gblur_animated(AnimatedValue::Static(f64::from(sigma)))
+    }
+
+    /// Apply a Gaussian blur with an optionally animated `sigma` (blur radius).
+    ///
+    /// When an [`AnimatedValue::Track`] is supplied, the animation is registered
+    /// for per-frame `avfilter_graph_send_command` updates (#363).
+    /// The initial filter graph is built from the value at [`Duration::ZERO`].
+    ///
+    /// Filter node names are assigned deterministically: the first call produces
+    /// `"gblur_0"`, the second `"gblur_1"`, and so on.
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `sigma` evaluates to a negative value at `Duration::ZERO`.
+    #[must_use]
+    pub fn gblur_animated(mut self, sigma: AnimatedValue<f64>) -> Self {
+        let n = self
+            .steps
+            .iter()
+            .filter(|s| matches!(s, FilterStep::GBlurAnimated { .. }))
+            .count();
+        let node_name = format!("gblur_{n}");
+        if let AnimatedValue::Track(track) = &sigma {
+            self.animations.push(AnimationEntry {
+                node_name,
+                param: "sigma",
+                track: track.clone(),
+            });
+        }
+        self.steps.push(FilterStep::GBlurAnimated { sigma });
         self
     }
 
@@ -453,5 +486,93 @@ mod tests {
                 "yadif({mode:?}) must build successfully, got {result:?}"
             );
         }
+    }
+
+    #[test]
+    fn gblur_animated_static_value_should_produce_correct_args() {
+        let step = FilterStep::GBlurAnimated {
+            sigma: AnimatedValue::Static(5.0_f64),
+        };
+        assert_eq!(step.filter_name(), "gblur");
+        assert_eq!(step.args(), "sigma=5");
+    }
+
+    #[test]
+    fn gblur_animated_with_negative_sigma_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .gblur_animated(AnimatedValue::Static(-1.0_f64))
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for sigma < 0.0, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("sigma"),
+                "reason should mention sigma: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn gblur_animated_with_valid_sigma_should_succeed() {
+        let result = FilterGraph::builder()
+            .gblur_animated(AnimatedValue::Static(3.0_f64))
+            .build();
+        assert!(
+            result.is_ok(),
+            "gblur_animated(3.0) must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn gblur_animated_with_track_should_register_animation_entry() {
+        use crate::animation::{Easing, Keyframe};
+        use std::time::Duration;
+
+        let track = crate::animation::AnimationTrack::new()
+            .push(Keyframe {
+                timestamp: Duration::ZERO,
+                value: 0.0_f64,
+                easing: Easing::Linear,
+            })
+            .push(Keyframe {
+                timestamp: Duration::from_secs(1),
+                value: 8.0_f64,
+                easing: Easing::Linear,
+            });
+
+        let graph = FilterGraph::builder()
+            .gblur_animated(AnimatedValue::Track(track))
+            .build()
+            .unwrap();
+
+        assert_eq!(graph.pending_animations.len(), 1);
+        assert_eq!(graph.pending_animations[0].node_name, "gblur_0");
+        assert_eq!(graph.pending_animations[0].param, "sigma");
+    }
+
+    #[test]
+    fn gblur_animated_second_call_should_use_gblur_1_node_name() {
+        use crate::animation::{Easing, Keyframe};
+        use std::time::Duration;
+
+        let track = crate::animation::AnimationTrack::new().push(Keyframe {
+            timestamp: Duration::ZERO,
+            value: 5.0_f64,
+            easing: Easing::Linear,
+        });
+
+        let graph = FilterGraph::builder()
+            .gblur_animated(AnimatedValue::Static(2.0_f64))
+            .gblur_animated(AnimatedValue::Track(track))
+            .build()
+            .unwrap();
+
+        assert_eq!(graph.pending_animations.len(), 1);
+        assert_eq!(
+            graph.pending_animations[0].node_name, "gblur_1",
+            "second gblur_animated call must produce node name gblur_1"
+        );
     }
 }

--- a/crates/ff-filter/src/graph/builder/video/geometry.rs
+++ b/crates/ff-filter/src/graph/builder/video/geometry.rs
@@ -21,9 +21,69 @@ impl FilterGraphBuilder {
     }
 
     /// Crop a rectangle starting at `(x, y)` with the given dimensions.
+    ///
+    /// Shorthand for [`crop_animated`](Self::crop_animated) with static values.
     #[must_use]
-    pub fn crop(mut self, x: u32, y: u32, width: u32, height: u32) -> Self {
-        self.steps.push(FilterStep::Crop {
+    pub fn crop(self, x: u32, y: u32, width: u32, height: u32) -> Self {
+        self.crop_animated(
+            AnimatedValue::Static(f64::from(x)),
+            AnimatedValue::Static(f64::from(y)),
+            AnimatedValue::Static(f64::from(width)),
+            AnimatedValue::Static(f64::from(height)),
+        )
+    }
+
+    /// Crop with optionally animated boundaries (pixels).
+    ///
+    /// When an [`AnimatedValue::Track`] is supplied, the corresponding animation
+    /// is registered for per-frame `avfilter_graph_send_command` updates (#363).
+    /// The initial filter graph is built from the value at [`Duration::ZERO`].
+    ///
+    /// Filter node names are assigned deterministically: the first call produces
+    /// `"crop_0"`, the second `"crop_1"`, and so on.
+    #[must_use]
+    pub fn crop_animated(
+        mut self,
+        x: AnimatedValue<f64>,
+        y: AnimatedValue<f64>,
+        width: AnimatedValue<f64>,
+        height: AnimatedValue<f64>,
+    ) -> Self {
+        let n = self
+            .steps
+            .iter()
+            .filter(|s| matches!(s, FilterStep::CropAnimated { .. }))
+            .count();
+        let node_name = format!("crop_{n}");
+        if let AnimatedValue::Track(track) = &x {
+            self.animations.push(AnimationEntry {
+                node_name: node_name.clone(),
+                param: "x",
+                track: track.clone(),
+            });
+        }
+        if let AnimatedValue::Track(track) = &y {
+            self.animations.push(AnimationEntry {
+                node_name: node_name.clone(),
+                param: "y",
+                track: track.clone(),
+            });
+        }
+        if let AnimatedValue::Track(track) = &width {
+            self.animations.push(AnimationEntry {
+                node_name: node_name.clone(),
+                param: "w",
+                track: track.clone(),
+            });
+        }
+        if let AnimatedValue::Track(track) = &height {
+            self.animations.push(AnimationEntry {
+                node_name: node_name.clone(),
+                param: "h",
+                track: track.clone(),
+            });
+        }
+        self.steps.push(FilterStep::CropAnimated {
             x,
             y,
             width,
@@ -535,6 +595,187 @@ mod tests {
         assert!(
             matches!(result, Err(FilterError::InvalidConfig { .. })),
             "expected InvalidConfig for opacity < 0.0, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn crop_animated_static_values_should_produce_same_args_as_crop() {
+        let step_animated = FilterStep::CropAnimated {
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            width: AnimatedValue::Static(640.0),
+            height: AnimatedValue::Static(360.0),
+        };
+        assert_eq!(step_animated.filter_name(), "crop");
+        assert_eq!(step_animated.args(), "x=0:y=0:w=640:h=360");
+    }
+
+    #[test]
+    fn crop_animated_with_zero_width_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .crop_animated(
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(100.0),
+            )
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for width=0, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("crop width and height must be > 0"),
+                "reason should mention crop dimensions: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn crop_animated_with_zero_height_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .crop_animated(
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(100.0),
+                AnimatedValue::Static(0.0),
+            )
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for height=0, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn crop_animated_with_valid_dimensions_should_succeed() {
+        let result = FilterGraph::builder()
+            .crop_animated(
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(64.0),
+                AnimatedValue::Static(64.0),
+            )
+            .build();
+        assert!(
+            result.is_ok(),
+            "crop_animated with valid dimensions must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn crop_animated_with_track_should_register_animation_entry() {
+        use crate::animation::{Easing, Keyframe};
+        use std::time::Duration;
+
+        let track = crate::animation::AnimationTrack::new()
+            .push(Keyframe {
+                timestamp: Duration::ZERO,
+                value: 0.0_f64,
+                easing: Easing::Linear,
+            })
+            .push(Keyframe {
+                timestamp: Duration::from_secs(1),
+                value: 100.0_f64,
+                easing: Easing::Linear,
+            });
+
+        let graph = FilterGraph::builder()
+            .crop_animated(
+                AnimatedValue::Track(track),
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(64.0),
+                AnimatedValue::Static(64.0),
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            graph.pending_animations.len(),
+            1,
+            "one Track param should produce one AnimationEntry"
+        );
+        assert_eq!(graph.pending_animations[0].node_name, "crop_0");
+        assert_eq!(graph.pending_animations[0].param, "x");
+    }
+
+    #[test]
+    fn crop_animated_all_track_params_should_register_four_entries() {
+        use crate::animation::{Easing, Keyframe};
+        use std::time::Duration;
+
+        let make_track = |start: f64, end: f64| {
+            crate::animation::AnimationTrack::new()
+                .push(Keyframe {
+                    timestamp: Duration::ZERO,
+                    value: start,
+                    easing: Easing::Linear,
+                })
+                .push(Keyframe {
+                    timestamp: Duration::from_secs(1),
+                    value: end,
+                    easing: Easing::Linear,
+                })
+        };
+
+        let graph = FilterGraph::builder()
+            .crop_animated(
+                AnimatedValue::Track(make_track(0.0, 0.0)),
+                AnimatedValue::Track(make_track(0.0, 0.0)),
+                AnimatedValue::Track(make_track(640.0, 320.0)), // starts at 640 (valid)
+                AnimatedValue::Track(make_track(360.0, 180.0)), // starts at 360 (valid)
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            graph.pending_animations.len(),
+            4,
+            "four Track params should register four AnimationEntry items"
+        );
+        let params: Vec<&str> = graph.pending_animations.iter().map(|e| e.param).collect();
+        assert_eq!(params, ["x", "y", "w", "h"]);
+        assert!(
+            graph
+                .pending_animations
+                .iter()
+                .all(|e| e.node_name == "crop_0"),
+            "all entries must point to crop_0"
+        );
+    }
+
+    #[test]
+    fn crop_animated_second_call_should_use_crop_1_node_name() {
+        use crate::animation::{Easing, Keyframe};
+        use std::time::Duration;
+
+        let track = crate::animation::AnimationTrack::new().push(Keyframe {
+            timestamp: Duration::ZERO,
+            value: 50.0_f64,
+            easing: Easing::Linear,
+        });
+
+        let graph = FilterGraph::builder()
+            .crop_animated(
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(64.0),
+                AnimatedValue::Static(64.0),
+            )
+            .crop_animated(
+                AnimatedValue::Track(track),
+                AnimatedValue::Static(0.0),
+                AnimatedValue::Static(64.0),
+                AnimatedValue::Static(64.0),
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(graph.pending_animations.len(), 1);
+        assert_eq!(
+            graph.pending_animations[0].node_name, "crop_1",
+            "second crop_animated call must produce node name crop_1"
         );
     }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -1,9 +1,12 @@
 //! Internal filter step representation.
 
+use std::time::Duration;
+
 use super::builder::FilterGraphBuilder;
 use super::types::{
     DrawTextOptions, EqBand, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
+use crate::animation::AnimatedValue;
 use crate::blend::BlendMode;
 
 // ── FilterStep ────────────────────────────────────────────────────────────────
@@ -141,6 +144,28 @@ pub enum FilterStep {
     GBlur {
         /// Blur radius (standard deviation). Must be ≥ 0.0.
         sigma: f32,
+    },
+    /// Crop with optionally animated boundaries (pixels, `f64` for sub-pixel precision).
+    ///
+    /// Arguments are evaluated at [`Duration::ZERO`] for the initial graph build.
+    /// Per-frame updates are applied via `avfilter_graph_send_command` in #363.
+    CropAnimated {
+        /// X offset of the top-left corner, in pixels.
+        x: AnimatedValue<f64>,
+        /// Y offset of the top-left corner, in pixels.
+        y: AnimatedValue<f64>,
+        /// Width of the cropped region. Must evaluate to > 0 at `Duration::ZERO`.
+        width: AnimatedValue<f64>,
+        /// Height of the cropped region. Must evaluate to > 0 at `Duration::ZERO`.
+        height: AnimatedValue<f64>,
+    },
+    /// Gaussian blur with an optionally animated sigma (blur radius).
+    ///
+    /// Arguments are evaluated at [`Duration::ZERO`] for the initial graph build.
+    /// Per-frame updates are applied via `avfilter_graph_send_command` in #363.
+    GBlurAnimated {
+        /// Blur radius (standard deviation). Must evaluate to ≥ 0.0 at `Duration::ZERO`.
+        sigma: AnimatedValue<f64>,
     },
     /// Sharpen or blur via unsharp mask (luma + chroma strength).
     ///
@@ -681,6 +706,8 @@ impl FilterStep {
             Self::FeatherMask { .. } => "alphaextract",
             // PolygonMatte uses geq with a crossing-number point-in-polygon expression.
             Self::PolygonMatte { .. } => "geq",
+            Self::CropAnimated { .. } => "crop",
+            Self::GBlurAnimated { .. } => "gblur",
         }
     }
 
@@ -1041,6 +1068,22 @@ impl FilterStep {
                 dissolve_dur,
                 ..
             } => format!("transition=dissolve:duration={dissolve_dur}:offset={clip_a_end}"),
+            Self::CropAnimated {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                let x0 = x.value_at(Duration::ZERO);
+                let y0 = y.value_at(Duration::ZERO);
+                let w0 = width.value_at(Duration::ZERO);
+                let h0 = height.value_at(Duration::ZERO);
+                format!("x={x0}:y={y0}:w={w0}:h={h0}")
+            }
+            Self::GBlurAnimated { sigma } => {
+                let s0 = sigma.value_at(Duration::ZERO);
+                format!("sigma={s0}")
+            }
         }
     }
 }

--- a/crates/ff-filter/src/graph/graph.rs
+++ b/crates/ff-filter/src/graph/graph.rs
@@ -2,6 +2,7 @@
 
 use ff_format::{AudioFrame, VideoFrame};
 
+use crate::animation::AnimationEntry;
 use crate::error::FilterError;
 use crate::filter_inner::FilterGraphInner;
 
@@ -35,6 +36,12 @@ use super::builder::FilterGraphBuilder;
 pub struct FilterGraph {
     pub(crate) inner: FilterGraphInner,
     pub(crate) output_resolution: Option<(u32, u32)>,
+    /// Animation entries registered via `crop_animated` / `gblur_animated`.
+    ///
+    /// Consumed by per-frame `avfilter_graph_send_command` in #363.
+    // TODO(#363): remove allow once consumed by the send_command loop.
+    #[allow(dead_code)]
+    pub(crate) pending_animations: Vec<AnimationEntry>,
 }
 
 impl std::fmt::Debug for FilterGraph {
@@ -59,7 +66,19 @@ impl FilterGraph {
         Self {
             inner,
             output_resolution: None,
+            pending_animations: Vec::new(),
         }
+    }
+
+    /// Returns the registered animation entries accumulated by
+    /// [`crop_animated`](FilterGraphBuilder::crop_animated) and
+    /// [`gblur_animated`](FilterGraphBuilder::gblur_animated).
+    ///
+    /// These are consumed by per-frame `avfilter_graph_send_command` in #363.
+    // TODO(#363): remove allow once consumed by the send_command loop.
+    #[allow(dead_code)]
+    pub(crate) fn pending_animations(&self) -> &[AnimationEntry] {
+        &self.pending_animations
     }
 
     /// Returns the output resolution produced by this graph's `scale` filter step,

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -39,7 +39,7 @@ mod filter_inner;
 pub mod graph;
 
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
-pub use animation::{AnimatedValue, AnimationTrack, Easing, Keyframe, Lerp};
+pub use animation::{AnimatedValue, AnimationEntry, AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
 pub use error::FilterError;
 pub use graph::{


### PR DESCRIPTION
## Summary

Extends `FilterGraphBuilder` with `crop_animated()` and `gblur_animated()` methods that accept `AnimatedValue<f64>` parameters, enabling time-varying crop regions and blur radii. The existing `crop()` and `gblur()` methods are preserved as shorthands that delegate to the new animated variants using `AnimatedValue::Static`. Animation tracks are accumulated as `AnimationEntry` items on the `FilterGraph` for consumption by per-frame `avfilter_graph_send_command` in issue #363.

## Changes

- `animation/mod.rs`: add `AnimationEntry` struct (`node_name`, `param`, `track`) for future `send_command` targeting
- `graph/filter_step.rs`: add `CropAnimated` and `GBlurAnimated` variants; initial args evaluated at `Duration::ZERO`
- `graph/builder/video/geometry.rs`: add `crop_animated()` with deterministic node naming (`crop_0`, `crop_1`, …); `crop()` delegates to it; 7 unit tests
- `graph/builder/video/effects.rs`: add `gblur_animated()` with node naming (`gblur_0`, …); `gblur()` delegates to it; 5 unit tests
- `graph/builder/mod.rs`: add `animations` field; transfer to `FilterGraph.pending_animations` on `build()`; validate initial w/h > 0 and sigma ≥ 0
- `filter_inner/build.rs`: extend crop error diagnostics to cover `CropAnimated`; assign deterministic node names in the build loop
- `graph/graph.rs`: add `pending_animations` field with `#[allow(dead_code)]` / TODO(#363)
- `lib.rs` (ff-filter): re-export `AnimationEntry`
- `avio/src/lib.rs`: re-export `AnimationEntry` under `filter` feature

## Related Issues

Closes #359

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes