### PR TITLE
feat(ff-filter): avfilter_graph_send_command per-frame animation updates

### DIFF
--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -412,6 +412,59 @@ mod tests {
         }
     }
 
+    // ── apply_animations ──────────────────────────────────────────────────────
+
+    /// `apply_animations` must be a no-op when the graph has not yet been
+    /// initialised (i.e. `graph == None`).  It must not panic or access any
+    /// FFmpeg API.
+    #[test]
+    fn apply_animations_with_no_graph_should_be_a_no_op() {
+        use crate::animation::{AnimatedValue, AnimationEntry, AnimationTrack, Easing, Keyframe};
+        use std::time::Duration;
+
+        let inner = FilterGraphInner::new(
+            vec![FilterStep::Scale {
+                width: 1280,
+                height: 720,
+                algorithm: crate::graph::ScaleAlgorithm::Fast,
+            }],
+            None,
+        );
+
+        assert!(
+            inner.graph.is_none(),
+            "graph must be None before first push"
+        );
+
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0_f64, Easing::Linear))
+            .push(Keyframe::new(
+                Duration::from_secs(1),
+                1.0_f64,
+                Easing::Linear,
+            ));
+
+        let animations = vec![AnimationEntry {
+            node_name: "gblur_0".to_owned(),
+            param: "sigma",
+            track,
+        }];
+
+        // Must not panic even though graph == None.
+        inner.apply_animations(&animations, Duration::from_millis(500));
+    }
+
+    /// Calling `apply_animations` with an empty slice must be a no-op
+    /// regardless of graph state.
+    #[test]
+    fn apply_animations_with_empty_slice_should_be_a_no_op() {
+        use std::time::Duration;
+
+        let inner = FilterGraphInner::new(vec![], None);
+        // No FFmpeg calls expected; must not panic.
+        inner.apply_animations(&[], Duration::ZERO);
+    }
+
     // ── validate_filter_steps ─────────────────────────────────────────────────
 
     /// `validate_filter_steps` must return `Ok` for a known-good filter name.

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -10,6 +10,72 @@ use crate::error::FilterError;
 use std::ptr::NonNull;
 
 impl FilterGraphInner {
+    // ── Animation ─────────────────────────────────────────────────────────────
+
+    /// Evaluates every registered [`AnimationEntry`] at time `t` and sends the
+    /// updated value to the corresponding filter node via
+    /// `avfilter_graph_send_command`.
+    ///
+    /// **No-op** when the graph has not yet been initialised (i.e. before the
+    /// first `push_video` / `push_audio` call).  Individual `send_command`
+    /// failures are logged as `warn!` and do not abort the loop.
+    pub(crate) fn apply_animations(
+        &self,
+        animations: &[crate::animation::AnimationEntry],
+        t: std::time::Duration,
+    ) {
+        use std::ffi::CString;
+
+        let Some(graph_ptr) = self.graph.map(|nn| nn.as_ptr()) else {
+            return;
+        };
+
+        for entry in animations {
+            let value = entry.track.value_at(t);
+            let arg_str = format!("{value:.6}");
+
+            let Ok(target_cstr) = CString::new(entry.node_name.as_str()) else {
+                continue;
+            };
+            let Ok(cmd_cstr) = CString::new(entry.param) else {
+                continue;
+            };
+            let Ok(arg_cstr) = CString::new(arg_str.as_str()) else {
+                continue;
+            };
+
+            // `c_char` is `i8` on all supported targets.
+            let mut resp = [0_i8; 64];
+
+            // SAFETY: `graph_ptr` is non-null (derived from `NonNull` after a
+            // `Some` check above). `target_cstr`, `cmd_cstr`, and `arg_cstr`
+            // are valid null-terminated C strings held alive for the duration
+            // of this call. `resp` is a valid stack-allocated mutable buffer
+            // of 64 bytes. `FilterGraph` does not implement `Sync`, so this
+            // call is always single-threaded with no concurrent access to the
+            // same graph.
+            let ret = unsafe {
+                ff_sys::avfilter_graph_send_command(
+                    graph_ptr,
+                    target_cstr.as_ptr(),
+                    cmd_cstr.as_ptr(),
+                    arg_cstr.as_ptr(),
+                    resp.as_mut_ptr(),
+                    resp.len() as std::os::raw::c_int,
+                    0,
+                )
+            };
+
+            if ret < 0 {
+                log::warn!(
+                    "send_command failed target={} cmd={} value={value:.6} code={ret}",
+                    entry.node_name,
+                    entry.param,
+                );
+            }
+        }
+    }
+
     // ── Video ─────────────────────────────────────────────────────────────────
 
     /// Lazily initialise the video filter graph from the first pushed frame.

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -26,6 +26,22 @@ impl FilterGraphInner {
     ) {
         use std::ffi::CString;
 
+        // Declare `avfilter_graph_send_command` locally: bindgen includes it
+        // on some platforms (Windows/VCPKG) but omits it on others (Linux apt).
+        // Declaring it here avoids a platform-specific ff-sys gap while still
+        // linking against the same libavfilter that ff-sys already pulls in.
+        unsafe extern "C" {
+            fn avfilter_graph_send_command(
+                graph: *mut ff_sys::AVFilterGraph,
+                target: *const std::os::raw::c_char,
+                cmd: *const std::os::raw::c_char,
+                arg: *const std::os::raw::c_char,
+                res: *mut std::os::raw::c_char,
+                res_len: std::os::raw::c_int,
+                flags: std::os::raw::c_int,
+            ) -> std::os::raw::c_int;
+        }
+
         let Some(graph_ptr) = self.graph.map(|nn| nn.as_ptr()) else {
             return;
         };
@@ -55,7 +71,7 @@ impl FilterGraphInner {
             // call is always single-threaded with no concurrent access to the
             // same graph.
             let ret = unsafe {
-                ff_sys::avfilter_graph_send_command(
+                avfilter_graph_send_command(
                     graph_ptr,
                     target_cstr.as_ptr(),
                     cmd_cstr.as_ptr(),

--- a/crates/ff-filter/src/graph/graph.rs
+++ b/crates/ff-filter/src/graph/graph.rs
@@ -36,11 +36,11 @@ use super::builder::FilterGraphBuilder;
 pub struct FilterGraph {
     pub(crate) inner: FilterGraphInner,
     pub(crate) output_resolution: Option<(u32, u32)>,
-    /// Animation entries registered via `crop_animated` / `gblur_animated`.
+    /// Animation entries registered via animated builder methods (e.g.
+    /// `crop_animated`, `gblur_animated`, `eq_animated`).
     ///
-    /// Consumed by per-frame `avfilter_graph_send_command` in #363.
-    // TODO(#363): remove allow once consumed by the send_command loop.
-    #[allow(dead_code)]
+    /// Evaluated on every `push_video` / `push_audio` call and applied to
+    /// the live filter graph via `avfilter_graph_send_command`.
     pub(crate) pending_animations: Vec<AnimationEntry>,
 }
 
@@ -86,17 +86,6 @@ impl FilterGraph {
         }
     }
 
-    /// Returns the registered animation entries accumulated by
-    /// [`crop_animated`](FilterGraphBuilder::crop_animated) and
-    /// [`gblur_animated`](FilterGraphBuilder::gblur_animated).
-    ///
-    /// These are consumed by per-frame `avfilter_graph_send_command` in #363.
-    // TODO(#363): remove allow once consumed by the send_command loop.
-    #[allow(dead_code)]
-    pub(crate) fn pending_animations(&self) -> &[AnimationEntry] {
-        &self.pending_animations
-    }
-
     /// Returns the output resolution produced by this graph's `scale` filter step,
     /// if one was configured.
     ///
@@ -112,12 +101,20 @@ impl FilterGraph {
     /// On the first call the filter graph is initialised using this frame's
     /// format, resolution, and time base.
     ///
+    /// All registered animation entries are evaluated at the frame's PTS and
+    /// applied to the live graph via `avfilter_graph_send_command` before the
+    /// frame is pushed.
+    ///
     /// # Errors
     ///
     /// - [`FilterError::InvalidInput`] if `slot` is out of range.
     /// - [`FilterError::BuildFailed`] if the graph cannot be initialised.
     /// - [`FilterError::ProcessFailed`] if the `FFmpeg` push fails.
     pub fn push_video(&mut self, slot: usize, frame: &VideoFrame) -> Result<(), FilterError> {
+        if !self.pending_animations.is_empty() {
+            let t = frame.timestamp().as_duration();
+            self.inner.apply_animations(&self.pending_animations, t);
+        }
         self.inner.push_video(slot, frame)
     }
 
@@ -138,12 +135,20 @@ impl FilterGraph {
     /// On the first call the audio filter graph is initialised using this
     /// frame's format, sample rate, and channel count.
     ///
+    /// All registered animation entries are evaluated at the frame's PTS and
+    /// applied to the live graph via `avfilter_graph_send_command` before the
+    /// frame is pushed.
+    ///
     /// # Errors
     ///
     /// - [`FilterError::InvalidInput`] if `slot` is out of range.
     /// - [`FilterError::BuildFailed`] if the graph cannot be initialised.
     /// - [`FilterError::ProcessFailed`] if the `FFmpeg` push fails.
     pub fn push_audio(&mut self, slot: usize, frame: &AudioFrame) -> Result<(), FilterError> {
+        if !self.pending_animations.is_empty() {
+            let t = frame.timestamp().as_duration();
+            self.inner.apply_animations(&self.pending_animations, t);
+        }
         self.inner.push_audio(slot, frame)
     }
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -662,6 +662,18 @@ pub unsafe fn avfilter_graph_config(
 
 pub unsafe fn avfilter_graph_set_auto_convert(_graph: *mut AVFilterGraph, _flags: c_uint) {}
 
+pub unsafe fn avfilter_graph_send_command(
+    _graph: *mut AVFilterGraph,
+    _target: *const c_char,
+    _cmd: *const c_char,
+    _arg: *const c_char,
+    _res: *mut c_char,
+    _res_len: c_int,
+    _flags: c_int,
+) -> c_int {
+    0
+}
+
 pub unsafe fn av_buffersrc_add_frame_flags(
     _ctx: *mut AVFilterContext,
     _frame: *mut AVFrame,


### PR DESCRIPTION
## Summary

Wires up the animation infrastructure accumulated since #359–#362 to the live FFmpeg filter graph. On every `push_video` and `push_audio` call, all registered `AnimationEntry` items are evaluated at the frame's PTS and sent to the matching filter nodes via `avfilter_graph_send_command`. This makes time-varying filter parameters (sigma, brightness, volume, etc.) actually change at runtime rather than being fixed at graph-construction time.

## Changes

- `filter_inner/push_pull.rs`: new `FilterGraphInner::apply_animations(animations, t)` method — evaluates each `AnimationEntry` track at `t`, formats the value as `"{:.6}"`, and calls `avfilter_graph_send_command`; returns early if graph not yet initialised; warns on non-zero return (non-fatal); includes full `// SAFETY:` comment
- `graph/graph.rs`: `FilterGraph::push_video` and `push_audio` now extract `frame.timestamp().as_duration()` and call `inner.apply_animations(&self.pending_animations, t)` before delegating to the inner push; removed `#[allow(dead_code)]` and `TODO(#363)` annotations from `pending_animations`; removed the now-redundant `pending_animations()` accessor
- `filter_inner/mod.rs`: two new unit tests — `apply_animations_with_no_graph_should_be_a_no_op` and `apply_animations_with_empty_slice_should_be_a_no_op`

## Related Issues

Closes #363

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes