### PR TITLE
feat(ff-filter): add optional serde feature for animation types

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -22,6 +22,7 @@ tokio    = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio"]
 gpl      = ["ff-encode/gpl"]
 hwaccel  = ["ff-encode/hwaccel"]
 srt      = ["ff-decode/srt", "ff-stream/srt"]
+serde    = ["ff-filter/serde"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/ff-filter/Cargo.toml
+++ b/crates/ff-filter/Cargo.toml
@@ -10,20 +10,25 @@ repository.workspace = true
 keywords = ["video", "audio", "ffmpeg", "filter", "effect"]
 categories = ["multimedia::video", "multimedia::audio"]
 
+[features]
+serde = ["dep:serde"]
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ff-common = { workspace = true }
-ff-format = { workspace = true }
-ff-sys = { workspace = true }
-log = { workspace = true }
-thiserror = { workspace = true }
+ff-common  = { workspace = true }
+ff-format  = { workspace = true }
+ff-sys     = { workspace = true }
+log        = { workspace = true }
+thiserror  = { workspace = true }
+serde      = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
-ff-encode = { workspace = true }
-ff-probe  = { workspace = true }
-image     = { workspace = true, features = ["png"] }
+ff-encode  = { workspace = true }
+ff-probe   = { workspace = true }
+image      = { workspace = true, features = ["png"] }
+serde_json = "1.0.149"
 
 [lints]
 workspace = true

--- a/crates/ff-filter/src/animation/easing.rs
+++ b/crates/ff-filter/src/animation/easing.rs
@@ -6,6 +6,7 @@
 ///
 /// Individual easing functions are implemented across issues #352–#357.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Easing {
     /// Hold: the value snaps to the next keyframe without interpolation.
     Hold,

--- a/crates/ff-filter/src/animation/keyframe.rs
+++ b/crates/ff-filter/src/animation/keyframe.rs
@@ -16,6 +16,14 @@ use super::{Easing, Lerp};
 /// — this keeps binary-search by timestamp correct inside
 /// `AnimationTrack` (added in issue #350).
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T: serde::Serialize",
+        deserialize = "T: serde::Deserialize<'de>",
+    ))
+)]
 pub struct Keyframe<T: Lerp> {
     /// Position of this keyframe on the timeline.
     pub timestamp: Duration,

--- a/crates/ff-filter/src/animation/track.rs
+++ b/crates/ff-filter/src/animation/track.rs
@@ -13,6 +13,14 @@ use super::{Easing, Keyframe, Lerp};
 /// `value_at` panics if the track is empty.  Always push at least one keyframe
 /// before querying.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T: serde::Serialize",
+        deserialize = "T: serde::Deserialize<'de>",
+    ))
+)]
 pub struct AnimationTrack<T: Lerp> {
     keyframes: Vec<Keyframe<T>>,
 }

--- a/crates/ff-filter/src/animation/value.rs
+++ b/crates/ff-filter/src/animation/value.rs
@@ -12,6 +12,14 @@ use super::{AnimationTrack, Lerp};
 /// set initial filter parameters.  Per-frame updates are wired up in issue
 /// #363.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "T: serde::Serialize",
+        deserialize = "T: serde::Deserialize<'de>",
+    ))
+)]
 pub enum AnimatedValue<T: Lerp> {
     /// A constant value, independent of time.
     Static(T),

--- a/crates/ff-filter/tests/serde_tests.rs
+++ b/crates/ff-filter/tests/serde_tests.rs
@@ -1,0 +1,99 @@
+//! Serialization round-trip tests for animation types.
+//!
+//! Only compiled / run when the `serde` feature is enabled:
+//!   `cargo test -p ff-filter --features serde`
+
+#[cfg(feature = "serde")]
+mod serde_tests {
+    use std::time::Duration;
+
+    use ff_filter::AnimatedValue;
+    use ff_filter::animation::{AnimationTrack, Easing, Keyframe};
+
+    #[test]
+    fn animation_track_should_round_trip_through_json() {
+        let original: AnimationTrack<f64> = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0_f64, Easing::Linear))
+            .push(Keyframe::new(
+                Duration::from_secs(2),
+                1.0_f64,
+                Easing::EaseInOut,
+            ));
+
+        let json = serde_json::to_string(&original).expect("serialize failed");
+        let restored: AnimationTrack<f64> =
+            serde_json::from_str(&json).expect("deserialize failed");
+
+        assert_eq!(original.len(), restored.len());
+
+        let orig_kfs = original.keyframes();
+        let rest_kfs = restored.keyframes();
+
+        assert_eq!(orig_kfs[0].timestamp, rest_kfs[0].timestamp);
+        assert!(
+            (orig_kfs[0].value - rest_kfs[0].value).abs() < f64::EPSILON,
+            "first keyframe value mismatch"
+        );
+
+        assert_eq!(orig_kfs[1].timestamp, rest_kfs[1].timestamp);
+        assert!(
+            (orig_kfs[1].value - rest_kfs[1].value).abs() < f64::EPSILON,
+            "second keyframe value mismatch"
+        );
+    }
+
+    #[test]
+    fn animated_value_static_should_round_trip_through_json() {
+        let original: AnimatedValue<f64> = AnimatedValue::Static(3.14);
+
+        let json = serde_json::to_string(&original).expect("serialize failed");
+        let restored: AnimatedValue<f64> = serde_json::from_str(&json).expect("deserialize failed");
+
+        let AnimatedValue::Static(v) = restored else {
+            panic!("expected Static variant after round-trip");
+        };
+        assert!((v - 3.14).abs() < f64::EPSILON, "value mismatch: {v}");
+    }
+
+    #[test]
+    fn animated_value_track_should_round_trip_through_json() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0_f64, Easing::Hold))
+            .push(Keyframe::new(
+                Duration::from_millis(500),
+                0.5_f64,
+                Easing::Linear,
+            ));
+        let original: AnimatedValue<f64> = AnimatedValue::Track(track);
+
+        let json = serde_json::to_string(&original).expect("serialize failed");
+        let restored: AnimatedValue<f64> = serde_json::from_str(&json).expect("deserialize failed");
+
+        let AnimatedValue::Track(t) = restored else {
+            panic!("expected Track variant after round-trip");
+        };
+        assert_eq!(t.len(), 2, "keyframe count mismatch after round-trip");
+    }
+
+    #[test]
+    fn easing_variants_should_round_trip_through_json() {
+        let variants = [
+            Easing::Hold,
+            Easing::Linear,
+            Easing::EaseIn,
+            Easing::EaseOut,
+            Easing::EaseInOut,
+            Easing::Bezier {
+                p1: (0.25, 0.1),
+                p2: (0.25, 1.0),
+            },
+        ];
+
+        for easing in &variants {
+            let json = serde_json::to_string(easing)
+                .unwrap_or_else(|e| panic!("serialize failed for {easing:?}: {e}"));
+            let _: Easing = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("deserialize failed for {easing:?}: {e}"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional `serde` feature to `ff-filter` that gates `Serialize`/`Deserialize` derivations on all four animation types (`Easing`, `Keyframe<T>`, `AnimationTrack<T>`, `AnimatedValue<T>`). This allows animation data to be serialized to JSON, TOML, or any serde-compatible format for project file storage, without forcing a serde dependency on consumers that don't need it. The same feature is surfaced in the `avio` facade.

## Changes

- `crates/ff-filter/Cargo.toml`: added `[features] serde = ["dep:serde"]`, optional `serde = { version = "1", features = ["derive"] }` dependency, and `serde_json = "1"` dev-dependency
- `Easing`: added `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]`
- `Keyframe<T>`, `AnimationTrack<T>`, `AnimatedValue<T>`: same derive plus explicit `#[serde(bound(serialize = "T: serde::Serialize", deserialize = "T: serde::Deserialize<'de>"))]` to avoid requiring `T: Lerp + Serialize` in derived impls
- `crates/avio/Cargo.toml`: added `serde = ["ff-filter/serde"]` feature
- `crates/ff-filter/tests/serde_tests.rs`: new integration test file (gated by `#[cfg(feature = "serde")]`) with 4 round-trip tests covering `AnimationTrack<f64>`, `AnimatedValue::Static`, `AnimatedValue::Track`, and all 6 `Easing` variants

## Related Issues

Closes #365

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes