### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.0] - 2026-04-12
+
+### Added
+
+#### ff-filter — keyframe animation types
+- `Keyframe<T>` — timestamp + value + per-segment easing, ordered by timestamp ([#349](https://github.com/itsakeyfut/avio/issues/349))
+- `AnimationTrack<T>` — sorted keyframe storage with `value_at(Duration)` interpolation ([#350](https://github.com/itsakeyfut/avio/issues/350))
+- `Lerp` trait implementations for `(f64, f64)` and `(f64, f64, f64)` tuple types ([#351](https://github.com/itsakeyfut/avio/issues/351))
+- `AnimationTrack::<f64>::fade()` — two-keyframe convenience constructor for volume fades, opacity ramps, and position sweeps ([#362](https://github.com/itsakeyfut/avio/issues/362))
+- `AnimatedValue<T>` — enum wrapping either a static `f64` or a live `AnimationTrack<f64>` ([#358](https://github.com/itsakeyfut/avio/issues/358))
+
+#### ff-filter — easing modes
+- `Easing::Hold` — step (snap-at-boundary) interpolation ([#352](https://github.com/itsakeyfut/avio/issues/352))
+- `Easing::Linear` — linear interpolation ([#353](https://github.com/itsakeyfut/avio/issues/353))
+- `Easing::EaseIn` — cubic ease-in (t³) ([#354](https://github.com/itsakeyfut/avio/issues/354))
+- `Easing::EaseOut` — cubic ease-out (1−(1−t)³) ([#355](https://github.com/itsakeyfut/avio/issues/355))
+- `Easing::EaseInOut` — cubic ease-in-out (smoothstep 3t²−2t³) ([#356](https://github.com/itsakeyfut/avio/issues/356))
+- `Easing::Bezier { p1, p2 }` — CSS cubic-bezier via Newton-Raphson root finding ([#357](https://github.com/itsakeyfut/avio/issues/357))
+
+#### ff-filter — animated filter parameters
+- `VideoLayer` fields `x`, `y`, `scale_x`, `scale_y`, `rotation`, `opacity` replaced with `AnimatedValue<f64>` ([#358](https://github.com/itsakeyfut/avio/issues/358))
+- `FilterGraphBuilder::crop_animated()` and `gblur_animated()` — animated crop rectangle and blur radius ([#359](https://github.com/itsakeyfut/avio/issues/359))
+- `FilterGraphBuilder::eq_animated()` and `colorbalance_animated()` — animated brightness, contrast, saturation, and lift/gamma/gain ([#360](https://github.com/itsakeyfut/avio/issues/360))
+- `AudioTrack` fields `volume` and `pan` replaced with `AnimatedValue<f64>` ([#361](https://github.com/itsakeyfut/avio/issues/361))
+- `FilterGraph::tick(t: Duration)` — applies all registered `AnimationEntry` values at time `t` via `avfilter_graph_send_command`; call before each `pull_video` / `pull_audio` on source-only graphs ([#363](https://github.com/itsakeyfut/avio/issues/363))
+- `AnimationEntry::suffix` field — appends a unit string (e.g. `"dB"`) to the formatted value sent to FFmpeg, required for filters whose options accept expression strings ([#363](https://github.com/itsakeyfut/avio/issues/363))
+
+#### ff-pipeline — Timeline animation
+- `TimelineBuilder::video_animation()` and `audio_animation()` — attach `AnimationTrack<f64>` keyed by `"video_{idx}_{prop}"` / `"audio_{idx}_{prop}"` ([#364](https://github.com/itsakeyfut/avio/issues/364))
+- `Timeline::render()` now calls `tick(pts)` before every `pull_video` and `pull_audio`, activating all registered animation tracks during render ([#968](https://github.com/itsakeyfut/avio/issues/968))
+
+#### ff-filter — serde
+- Optional `serde` feature flag: `Serialize` / `Deserialize` for `Keyframe<T>`, `AnimationTrack<T>`, `AnimatedValue<T>`, and all six `Easing` variants ([#365](https://github.com/itsakeyfut/avio/issues/365))
+
+### Fixed
+
+- `Timeline::render()` never called `FilterGraph::tick()` — all animation tracks passed via `video_animation` / `audio_animation` were silently ignored; every frame rendered with t=0 parameter values ([#968](https://github.com/itsakeyfut/avio/issues/968))
+- Animated `volume` filter sent plain float values (e.g. `"-60.000000"`) instead of dB-suffixed expressions (e.g. `"-60.000000dB"`), causing incorrect gain interpretation ([#363](https://github.com/itsakeyfut/avio/issues/363))
+- Animated overlay opacity required `format=yuva420p` conversion and `overlay format=auto` to correctly read the alpha plane ([#358](https://github.com/itsakeyfut/avio/issues/358))
+- `avfilter_graph_send_command` declared via local `extern` block for cross-platform compatibility (Windows MSVC linkage) ([#363](https://github.com/itsakeyfut/avio/issues/363))
+
+### Tests
+
+- Frame-accurate unit tests for all six `Easing` modes including Bezier Newton-Raphson convergence ([#366](https://github.com/itsakeyfut/avio/issues/366))
+- Integration test: Bezier-eased x-position animation verified against a standalone reference curve within ±2 px per frame ([#367](https://github.com/itsakeyfut/avio/issues/367))
+- Integration test: animated opacity fade darkens composite output over 30 frames ([#966](https://github.com/itsakeyfut/avio/pull/966))
+- Integration test: volume automation increases audio RMS amplitude from near-silence to full level ([#966](https://github.com/itsakeyfut/avio/pull/966))
+- Integration test: `Timeline` with a volume fade track encodes without error ([#967](https://github.com/itsakeyfut/avio/pull/967))
+
+---
+
 ## [0.11.0] - 2026-04-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,16 +12,16 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.11.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.11.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.11.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.11.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.11.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.11.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.11.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.11.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.11.0" }
-avio        = { path = "crates/avio",        version = "0.11.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.12.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.12.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.12.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.12.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.12.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.12.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.12.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.12.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.12.0" }
+avio        = { path = "crates/avio",        version = "0.12.0" }
 
 # Error handling
 thiserror = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ff-probe  = "0.11"
-ff-decode = "0.11"
-ff-encode = "0.11"
+ff-probe  = "0.12"
+ff-decode = "0.12"
+ff-encode = "0.12"
 
 # Or use the facade crate for everything
-avio = "0.11"
+avio = "0.12"
 ```
 
 ### Prerequisites

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -14,16 +14,16 @@ to only the capabilities you need via feature flags.
 ```toml
 [dependencies]
 # Default: probe + decode + encode
-avio = "0.11"
+avio = "0.12"
 
 # Add filtering
-avio = { version = "0.11", features = ["filter"] }
+avio = { version = "0.12", features = ["filter"] }
 
 # Full stack (implies filter + pipeline)
-avio = { version = "0.11", features = ["stream"] }
+avio = { version = "0.12", features = ["stream"] }
 
 # Async decode/encode (requires tokio runtime)
-avio = { version = "0.11", features = ["tokio"] }
+avio = { version = "0.12", features = ["tokio"] }
 ```
 
 ## Feature Flags

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -22,13 +22,13 @@
 //! ```toml
 //! # Default: probe + decode + encode
 //! [dependencies]
-//! avio = "0.11"
+//! avio = "0.12"
 //!
 //! # Add filtering
-//! avio = { version = "0.11", features = ["filter"] }
+//! avio = { version = "0.12", features = ["filter"] }
 //!
 //! # Full stack (implies filter + pipeline)
-//! avio = { version = "0.11", features = ["stream"] }
+//! avio = { version = "0.12", features = ["stream"] }
 //! ```
 //!
 //! # Quick Start

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -8,8 +8,8 @@ Decode video and audio frames without managing codec contexts, packet queues, or
 
 ```toml
 [dependencies]
-ff-decode = "0.11"
-ff-format = "0.11"
+ff-decode = "0.12"
+ff-format = "0.12"
 ```
 
 ## Video Decoding
@@ -191,7 +191,7 @@ let mut decoder = VideoDecoder::open("video.mp4")
 
 ```toml
 [dependencies]
-ff-decode = { version = "0.11", features = ["tokio"] }
+ff-decode = { version = "0.12", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoDecoder` and `AudioDecoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -8,12 +8,12 @@ Encode video and audio to any format with a builder chain. The encoder validates
 
 ```toml
 [dependencies]
-ff-encode = "0.11"
-ff-format = "0.11"
+ff-encode = "0.12"
+ff-format = "0.12"
 
 # Enable GPL-licensed encoders (libx264, libx265).
 # Requires GPL compliance or MPEG LA licensing in your project.
-# ff-encode = { version = "0.11", features = ["gpl"] }
+# ff-encode = { version = "0.12", features = ["gpl"] }
 ```
 
 By default, only LGPL-compatible encoders are enabled.
@@ -326,7 +326,7 @@ Enable the `gpl` feature to add libx264 and libx265. This changes the license te
 
 ```toml
 [dependencies]
-ff-encode = { version = "0.11", features = ["tokio"] }
+ff-encode = { version = "0.12", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoEncoder`, `AudioEncoder`, and `ImageEncoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-filter/README.md
+++ b/crates/ff-filter/README.md
@@ -8,7 +8,7 @@ Apply video and audio transformations without writing FFmpeg filter-graph string
 
 ```toml
 [dependencies]
-ff-filter = "0.11"
+ff-filter = "0.12"
 ```
 
 ## Building a Filter Chain

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -8,7 +8,7 @@ Wire decode, filter, and encode into a single configured pipeline. Instead of ma
 
 ```toml
 [dependencies]
-ff-pipeline = "0.11"
+ff-pipeline = "0.12"
 ```
 
 ## Building a Pipeline

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -8,7 +8,7 @@ Read media file metadata with one function call. No knowledge of container forma
 
 ```toml
 [dependencies]
-ff-probe = "0.11"
+ff-probe = "0.12"
 ```
 
 ## Quick Start

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -9,7 +9,7 @@ point it at an input file, and receive a standards-compliant package ready for C
 
 ```toml
 [dependencies]
-ff-stream = "0.11"
+ff-stream = "0.12"
 ```
 
 ## HLS Output


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.11.0 to 0.12.0 and documents all v0.12.0 Keyframe Animation changes in CHANGELOG.md.

## Changes

- `Cargo.toml`: workspace version `0.11.0` → `0.12.0`; all intra-workspace dependency pins updated to `0.12.0`
- `CHANGELOG.md`: add `[0.12.0]` entry covering animation types, 6 easing modes, animated filter parameters, Timeline animation, serde feature, bug fixes, and integration tests

## Related Issues

Closes #348

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes