### PR TITLE
feat(ff-preview): add crate scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ ff-encode   = { path = "crates/ff-encode",   version = "0.12.0" }
 ff-filter   = { path = "crates/ff-filter",   version = "0.12.0" }
 ff-pipeline = { path = "crates/ff-pipeline", version = "0.12.0" }
 ff-stream   = { path = "crates/ff-stream",   version = "0.12.0" }
+ff-preview  = { path = "crates/ff-preview", version = "0.12.0" }
 avio        = { path = "crates/avio",        version = "0.12.0" }
 
 # Error handling

--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -18,6 +18,7 @@ encode   = ["dep:ff-encode"]
 filter   = ["dep:ff-filter"]
 pipeline = ["dep:ff-pipeline", "filter"]
 stream   = ["dep:ff-stream", "pipeline"]
+preview  = ["dep:ff-preview"]
 tokio    = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio"]
 gpl      = ["ff-encode/gpl"]
 hwaccel  = ["ff-encode/hwaccel"]
@@ -36,6 +37,7 @@ ff-encode   = { workspace = true, optional = true }
 ff-filter   = { workspace = true, optional = true }
 ff-pipeline = { workspace = true, optional = true }
 ff-stream   = { workspace = true, optional = true }
+ff-preview  = { workspace = true, optional = true }
 
 [[example]]
 name = "probe_info"

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -289,6 +289,14 @@ pub use ff_stream::{
 #[cfg(all(feature = "stream", feature = "srt"))]
 pub use ff_stream::SrtOutput;
 
+// ── preview feature ───────────────────────────────────────────────────────────
+//
+// Single-file real-time playback with frame-accurate seek and A/V sync.
+// Enable the `preview` feature to access `PreviewPlayer`, `PlaybackClock`,
+// and (with the `proxy` sub-feature on `ff-preview`) `ProxyGenerator`.
+#[cfg(feature = "preview")]
+pub use ff_preview::{PlaybackClock, PreviewError, PreviewPlayer};
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "ff-preview"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Real-time video/audio preview and proxy workflow"
+license.workspace = true
+readme = "README.md"
+repository.workspace = true
+keywords = ["video", "audio", "ffmpeg", "preview", "playback"]
+categories = ["multimedia::video", "multimedia::audio"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+ff-decode   = { workspace = true }
+ff-format   = { workspace = true }
+ff-sys      = { workspace = true }
+thiserror   = { workspace = true }
+log         = { workspace = true }
+tokio       = { version = "1.50.0", features = ["rt", "sync"], optional = true }
+ff-encode   = { workspace = true, optional = true }
+ff-pipeline = { workspace = true, optional = true }
+
+[features]
+default = []
+tokio   = ["dep:tokio"]
+proxy   = ["dep:ff-encode", "dep:ff-pipeline"]
+
+[lints]
+workspace = true

--- a/crates/ff-preview/src/error.rs
+++ b/crates/ff-preview/src/error.rs
@@ -1,0 +1,53 @@
+//! Error types for ff-preview.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Errors that can occur during preview and proxy operations.
+#[derive(Debug, Error)]
+pub enum PreviewError {
+    /// The media file was not found at the specified path.
+    #[error("file not found: path={path}")]
+    FileNotFound {
+        /// Path that was not found.
+        path: PathBuf,
+    },
+
+    /// The media file has no video stream.
+    #[error("no video stream found: path={path}")]
+    NoVideoStream {
+        /// Path to the media file.
+        path: PathBuf,
+    },
+
+    /// A seek operation failed.
+    #[error("seek failed: target={target:?} reason={reason}")]
+    SeekFailed {
+        /// Target timestamp of the failed seek.
+        target: std::time::Duration,
+        /// Human-readable reason for the failure.
+        reason: String,
+    },
+
+    /// An underlying decode error occurred.
+    #[error("decode failed: {0}")]
+    Decode(#[from] ff_decode::DecodeError),
+
+    /// A raw `FFmpeg` error.
+    ///
+    /// `code` is the negative integer returned by the `FFmpeg` API, or `0` when no
+    /// numeric code is available. `message` is from `av_strerror` or an internal
+    /// description.
+    #[error("ffmpeg error: {message} (code={code})")]
+    Ffmpeg {
+        /// Raw `FFmpeg` error code (negative i32). `0` when no numeric code is available.
+        code: i32,
+        /// Human-readable message from `av_strerror` or an internal description.
+        message: String,
+    },
+
+    /// An I/O error during file operations.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -1,0 +1,39 @@
+//! # ff-preview
+//!
+//! Real-time video/audio preview and proxy workflow for the `avio` crate family.
+//!
+//! This crate provides single-file playback (`PreviewPlayer`) with frame-accurate
+//! seek, A/V sync, and an optional proxy generation workflow.
+//!
+//! ## Feature Flags
+//!
+//! | Feature | Description | Default |
+//! |---------|-------------|---------|
+//! | `tokio` | Async `AsyncPreviewPlayer` backed by `spawn_blocking` | no |
+//! | `proxy` | `ProxyGenerator` for lower-resolution proxy files | no |
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use ff_preview::{PreviewPlayer, RgbaSink};
+//!
+//! let mut player = PreviewPlayer::open("clip.mp4")?;
+//! player.set_sink(Box::new(RgbaSink::new()));
+//! player.play();
+//! player.run()?;
+//! ```
+
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+
+pub mod error;
+pub mod playback;
+
+#[cfg(feature = "proxy")]
+pub mod proxy;
+
+pub use error::PreviewError;
+pub use playback::{PlaybackClock, PreviewPlayer};
+
+#[cfg(feature = "proxy")]
+pub use proxy::ProxyGenerator;

--- a/crates/ff-preview/src/playback/mod.rs
+++ b/crates/ff-preview/src/playback/mod.rs
@@ -1,7 +1,7 @@
 //! Real-time playback types for ff-preview.
 //!
 //! This module exposes the primary public API for single-file video/audio
-//! playback. All `unsafe` `FFmpeg` calls are isolated in [`playback_inner`].
+//! playback. All `unsafe` `FFmpeg` calls are isolated in `playback_inner`.
 
 mod playback_inner;
 
@@ -9,7 +9,7 @@ mod playback_inner;
 ///
 /// `PreviewPlayer` decodes a video/audio file, synchronises video frame
 /// presentation to an audio master clock, and delivers RGBA frames to a
-/// registered [`FrameSink`].
+/// registered `FrameSink` (defined in issue #383).
 ///
 /// # Usage (stub — full implementation in later issues)
 ///

--- a/crates/ff-preview/src/playback/mod.rs
+++ b/crates/ff-preview/src/playback/mod.rs
@@ -1,0 +1,37 @@
+//! Real-time playback types for ff-preview.
+//!
+//! This module exposes the primary public API for single-file video/audio
+//! playback. All `unsafe` `FFmpeg` calls are isolated in [`playback_inner`].
+
+mod playback_inner;
+
+/// Drives real-time playback of a single media file.
+///
+/// `PreviewPlayer` decodes a video/audio file, synchronises video frame
+/// presentation to an audio master clock, and delivers RGBA frames to a
+/// registered [`FrameSink`].
+///
+/// # Usage (stub — full implementation in later issues)
+///
+/// ```ignore
+/// let mut player = PreviewPlayer::open("clip.mp4")?;
+/// player.set_sink(Box::new(RgbaSink::new()));
+/// player.play();
+/// player.run()?;
+/// ```
+pub struct PreviewPlayer;
+
+/// A monotonic clock that tracks elapsed playback time.
+///
+/// The clock supports start, stop, pause, resume, and rate scaling.
+/// It is used by `PreviewPlayer` internally; callers may also query it
+/// directly via `PreviewPlayer::clock()` (added in a later issue).
+///
+/// # Usage (stub — full implementation in #370)
+///
+/// ```ignore
+/// let mut clock = PlaybackClock::new();
+/// clock.start();
+/// let pts = clock.current_time();
+/// ```
+pub struct PlaybackClock;

--- a/crates/ff-preview/src/playback/playback_inner.rs
+++ b/crates/ff-preview/src/playback/playback_inner.rs
@@ -1,0 +1,10 @@
+//! Unsafe `FFmpeg` calls for the playback subsystem.
+//!
+//! This module is the only place in `ff-preview` where `unsafe` code is
+//! permitted. All `unsafe` blocks must carry a `// SAFETY:` comment explaining
+//! why the invariants hold.
+//!
+//! Future additions:
+//! - `sws_scale` conversion of `AVFrame` to contiguous RGBA bytes (for `FrameSink`)
+//! - `swr_convert` resampling to f32 / 48 kHz / stereo (for `pop_audio_samples`)
+//! - `avformat_seek_file` + `avcodec_flush_buffers` (for `DecodeBuffer::seek`)

--- a/crates/ff-preview/src/proxy/mod.rs
+++ b/crates/ff-preview/src/proxy/mod.rs
@@ -1,0 +1,24 @@
+//! Proxy file generation for ff-preview.
+//!
+//! This module is only compiled when the `proxy` feature is enabled.
+//! It provides `ProxyGenerator` for generating lower-resolution proxy files
+//! from original media, and `ProxyJob` for background generation.
+//!
+//! Full implementation tracked in issues #385–#387.
+
+/// Generates a lower-resolution proxy file from an original media file.
+///
+/// Proxy files allow smooth real-time playback of high-resolution footage by
+/// substituting a lower-quality copy during editing. The proxy API is
+/// transparent — `PreviewPlayer` serves identical RGBA frames regardless of
+/// whether it is reading the original or a proxy.
+///
+/// # Usage (stub — full implementation in #385)
+///
+/// ```ignore
+/// let path = ProxyGenerator::new("4k_clip.mp4")?
+///     .resolution(ProxyResolution::Half)
+///     .output_dir("/tmp/proxies")
+///     .generate()?;
+/// ```
+pub struct ProxyGenerator;


### PR DESCRIPTION
## Summary

Introduces the `ff-preview` crate scaffold at `crates/ff-preview/`. This crate will provide real-time single-file video/audio playback with frame-accurate seek, A/V sync, and an optional proxy workflow. This PR establishes the module structure, error type, and stub API surface that subsequent v0.13.0 issues will fill in.

## Changes

- **`crates/ff-preview/Cargo.toml`**: new package with `ff-decode`, `ff-format`, `ff-sys`, `thiserror`, `log` dependencies; optional `tokio`, `ff-encode`, `ff-pipeline`; feature flags `tokio` and `proxy`
- **`src/lib.rs`**: crate root with `#![warn(clippy::all/pedantic)]`, module declarations, and `pub use` re-exports
- **`src/error.rs`**: `PreviewError` enum — `FileNotFound`, `NoVideoStream`, `SeekFailed`, `Decode(#[from] DecodeError)`, `Ffmpeg { code, message }`, `Io(#[from] io::Error)`
- **`src/playback/mod.rs`**: stub `pub struct PreviewPlayer` and `pub struct PlaybackClock`
- **`src/playback/playback_inner.rs`**: stub module reserved for unsafe `FFmpeg` calls (sws_scale, swr_convert, avformat_seek_file)
- **`src/proxy/mod.rs`**: stub `pub struct ProxyGenerator` compiled only under the `proxy` feature
- **`Cargo.toml`** (root): added `ff-preview` to `[workspace.dependencies]`
- **`crates/avio/Cargo.toml`**: added `preview = ["dep:ff-preview"]` feature and optional `ff-preview` dependency
- **`crates/avio/src/lib.rs`**: added `#[cfg(feature = "preview")] pub use ff_preview::{...}` re-export section

## Related Issues

Closes #369

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes