### PR TITLE
feat(ff-preview): add RgbaFrame and RgbaSink reference FrameSink implementation

### DIFF
--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -35,7 +35,7 @@ pub mod proxy;
 pub use error::PreviewError;
 pub use playback::{
     DecodeBuffer, DecodeBufferBuilder, FrameResult, FrameSink, PlaybackClock, PreviewPlayer,
-    SeekEvent,
+    RgbaFrame, RgbaSink, SeekEvent,
 };
 
 #[cfg(feature = "proxy")]

--- a/crates/ff-preview/src/playback/mod.rs
+++ b/crates/ff-preview/src/playback/mod.rs
@@ -331,6 +331,88 @@ pub trait FrameSink: Send {
     fn flush(&mut self) {}
 }
 
+// ── RgbaFrame / RgbaSink ──────────────────────────────────────────────────────
+
+/// A decoded video frame as contiguous RGBA bytes.
+///
+/// Produced by [`RgbaSink`] and stored behind an [`Arc<Mutex>`] so it can be
+/// shared safely with a rendering thread.
+pub struct RgbaFrame {
+    /// Row-major RGBA pixel data.
+    ///
+    /// Total size: `width * height * 4` bytes. Each pixel is 4 bytes
+    /// (R, G, B, A) with alpha always 255.
+    pub data: Vec<u8>,
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Presentation timestamp of the frame.
+    pub pts: Duration,
+}
+
+/// Reference [`FrameSink`] implementation that stores the latest frame in a
+/// shared [`Arc<Mutex<Option<RgbaFrame>>>`].
+///
+/// Clone [`frame_handle`](Self::frame_handle) to share access with a rendering
+/// thread:
+///
+/// ```ignore
+/// let sink   = RgbaSink::new();
+/// let handle = sink.frame_handle();
+/// player.set_sink(Box::new(sink));
+///
+/// // In the render loop (any thread):
+/// if let Some(frame) = handle.lock().unwrap().as_ref() {
+///     upload_to_gpu(&frame.data, frame.width, frame.height);
+/// }
+/// ```
+///
+/// Only the **latest** frame is stored — not a queue. Renderers typically only
+/// need the current frame, not a backlog.
+pub struct RgbaSink {
+    /// Shared storage for the most recently received RGBA frame.
+    pub last_frame: Arc<Mutex<Option<RgbaFrame>>>,
+}
+
+impl RgbaSink {
+    /// Create a new `RgbaSink` with an empty frame store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            last_frame: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Clone the [`Arc`] for sharing with the rendering thread.
+    #[must_use]
+    pub fn frame_handle(&self) -> Arc<Mutex<Option<RgbaFrame>>> {
+        Arc::clone(&self.last_frame)
+    }
+}
+
+impl Default for RgbaSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FrameSink for RgbaSink {
+    fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
+        let mut guard = self
+            .last_frame
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(RgbaFrame {
+            data: rgba.to_vec(),
+            width,
+            height,
+            pts,
+        });
+    }
+    // flush() inherits the default no-op
+}
+
 /// Drives real-time playback of a single media file.
 ///
 /// `PreviewPlayer` decodes a video/audio file, synchronises video frame
@@ -2112,5 +2194,79 @@ mod tests {
         }
         let mut sink = NoFlushSink;
         sink.flush(); // must not panic
+    }
+
+    // ── RgbaSink tests ────────────────────────────────────────────────────────
+
+    #[test]
+    fn rgba_sink_should_store_latest_frame_on_push() {
+        let mut sink = RgbaSink::new();
+        let handle = sink.frame_handle();
+
+        // Before any push, the frame is None.
+        assert!(
+            handle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_none(),
+            "frame_handle must be None before any push"
+        );
+
+        let rgba: Vec<u8> = vec![255u8, 0, 0, 255, 0, 255, 0, 255]; // 2 × 1 RGBA
+        let pts = Duration::from_millis(100);
+        sink.push_frame(&rgba, 2, 1, pts);
+
+        let guard = handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let frame = guard.as_ref().expect("frame must be Some after push");
+
+        assert_eq!(frame.width, 2);
+        assert_eq!(frame.height, 1);
+        assert_eq!(frame.pts, pts);
+        assert_eq!(frame.data, rgba);
+    }
+
+    #[test]
+    fn rgba_sink_should_replace_frame_on_second_push() {
+        let mut sink = RgbaSink::new();
+        let handle = sink.frame_handle();
+
+        let first: Vec<u8> = vec![1, 2, 3, 255];
+        let second: Vec<u8> = vec![9, 8, 7, 255];
+        let pts1 = Duration::from_millis(0);
+        let pts2 = Duration::from_millis(33);
+
+        sink.push_frame(&first, 1, 1, pts1);
+        sink.push_frame(&second, 1, 1, pts2);
+
+        let guard = handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let frame = guard.as_ref().expect("frame must be Some after two pushes");
+        assert_eq!(
+            frame.data, second,
+            "latest push must overwrite previous frame"
+        );
+        assert_eq!(frame.pts, pts2);
+    }
+
+    #[test]
+    fn rgba_sink_default_should_equal_new() {
+        let a = RgbaSink::new();
+        let b = RgbaSink::default();
+        // Both must start with None.
+        assert!(
+            a.frame_handle()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_none()
+        );
+        assert!(
+            b.frame_handle()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds `RgbaFrame` and `RgbaSink` as the reference `FrameSink` implementation for `ff-preview`. `RgbaSink` stores the most recently received RGBA frame in an `Arc<Mutex<Option<RgbaFrame>>>` that can be cloned and shared with a rendering thread (egui, wgpu, SDL2, etc.) without any interaction with `PreviewPlayer`.

## Changes

- `playback/mod.rs`: add `RgbaFrame` struct (`data: Vec<u8>`, `width`, `height`, `pts`)
- `playback/mod.rs`: add `RgbaSink` with `new()`, `frame_handle()`, `impl Default`, and `impl FrameSink` (stores only the latest frame; mutex held only during the copy)
- `playback/mod.rs`: add three unit tests — `rgba_sink_should_store_latest_frame_on_push`, `rgba_sink_should_replace_frame_on_second_push`, `rgba_sink_default_should_equal_new`
- `lib.rs`: re-export `RgbaFrame` and `RgbaSink` from the crate root

## Related Issues

Closes #384

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes