### PR TITLE
test(ff-preview): add v0.13.0 DoD integration tests for seek, RGBA, and proxy

### DIFF
--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -32,10 +32,15 @@ proxy   = ["dep:ff-encode", "dep:ff-filter", "dep:ff-pipeline"]
 
 [dev-dependencies]
 criterion = { workspace = true }
+ff-probe  = { workspace = true }
 
 [[bench]]
 name    = "preview_bench"
 harness = false
+
+[[test]]
+name              = "proxy_test"
+required-features = ["proxy"]
 
 [lints]
 workspace = true

--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -55,7 +55,7 @@ pub struct PreviewPlayer {
     /// Set to `true` while the presentation loop is paused.
     paused: AtomicBool,
     /// Set to `true` to signal [`run`](Self::run) to stop after the current frame.
-    stopped: AtomicBool,
+    stopped: Arc<AtomicBool>,
     /// Master clock for A/V sync: audio samples counter or `Instant` wall clock.
     clock: MasterClock,
     /// A/V offset correction in milliseconds (default: 0).
@@ -139,7 +139,7 @@ impl PreviewPlayer {
             fps,
             sink: None,
             paused: AtomicBool::new(false),
-            stopped: AtomicBool::new(false),
+            stopped: Arc::new(AtomicBool::new(false)),
             clock,
             av_offset_ms: AtomicI64::new(0),
             audio_buf,
@@ -178,6 +178,24 @@ impl PreviewPlayer {
     /// [`run`](Self::run) returns after the current frame completes.
     pub fn stop(&mut self) {
         self.stopped.store(true, Ordering::Release);
+    }
+
+    /// Returns a cloneable handle to the stop signal.
+    ///
+    /// Storing `true` into the returned [`Arc<AtomicBool>`] has the same effect
+    /// as calling [`stop`](Self::stop) and is safe to call from any context,
+    /// including from within a [`FrameSink::push_frame`] callback.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let stop = player.stop_handle();
+    /// player.set_sink(Box::new(MySink { stop, max_frames: 10 }));
+    /// player.play();
+    /// player.run()?;
+    /// ```
+    pub fn stop_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.stopped)
     }
 
     /// Pop the next decoded video frame.

--- a/crates/ff-preview/tests/proxy_test.rs
+++ b/crates/ff-preview/tests/proxy_test.rs
@@ -1,0 +1,185 @@
+//! Integration tests for proxy generation and transparent substitution.
+//!
+//! Requires the `proxy` feature:
+//! ```bash
+//! cargo test -p ff-preview --features proxy -- --include-ignored proxy_
+//! ```
+//!
+//! Reference asset: `assets/test/preview_bench_1080p.mp4` (1920×1080 30 fps
+//! H.264+AAC, 60 s synthetic video).
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ff_preview::{FrameSink, PreviewPlayer, ProxyGenerator, ProxyResolution};
+
+// ── Asset path ────────────────────────────────────────────────────────────────
+
+fn bench_video_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/test/preview_bench_1080p.mp4")
+}
+
+// ── DimSink ───────────────────────────────────────────────────────────────────
+
+/// Records `(width, height)` per delivered frame; stops the player after
+/// `max_frames` frames via the shared stop flag.
+struct DimSink {
+    dims: Arc<Mutex<Vec<(u32, u32)>>>,
+    max_frames: usize,
+    stop: Arc<AtomicBool>,
+}
+
+impl FrameSink for DimSink {
+    fn push_frame(&mut self, _rgba: &[u8], width: u32, height: u32, _pts: Duration) {
+        let mut guard = self
+            .dims
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.push((width, height));
+        if guard.len() >= self.max_frames {
+            self.stop.store(true, Ordering::Release);
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "requires assets/test/preview_bench_1080p.mp4 and --features proxy; \
+            run with: cargo test -p ff-preview --features proxy -- --include-ignored"]
+fn proxy_quarter_resolution_should_produce_480x270_output() {
+    let input = bench_video_path();
+    if !input.exists() {
+        println!("skipping: reference file not found at {}", input.display());
+        return;
+    }
+
+    let tmp = std::env::temp_dir();
+
+    let proxy_path = match ProxyGenerator::new(&input) {
+        Ok(g) => match g
+            .resolution(ProxyResolution::Quarter)
+            .output_dir(&tmp)
+            .generate()
+        {
+            Ok(p) => p,
+            Err(e) => {
+                println!("skipping: proxy generation failed: {e}");
+                return;
+            }
+        },
+        Err(e) => {
+            println!("skipping: {e}");
+            return;
+        }
+    };
+
+    // Probe the generated proxy to verify dimensions.
+    let info = match ff_probe::open(&proxy_path) {
+        Ok(i) => i,
+        Err(e) => {
+            let _ = std::fs::remove_file(&proxy_path);
+            panic!("failed to probe proxy output: {e}");
+        }
+    };
+
+    let (w, h) = info
+        .resolution()
+        .expect("proxy must contain a video stream");
+
+    let _ = std::fs::remove_file(&proxy_path);
+
+    assert_eq!(
+        w, 480,
+        "quarter-resolution proxy width must be 480 (1920 / 4); got {w}"
+    );
+    assert_eq!(
+        h, 270,
+        "quarter-resolution proxy height must be 270 (1080 / 4); got {h}"
+    );
+}
+
+#[test]
+#[ignore = "requires assets/test/preview_bench_1080p.mp4 and --features proxy; \
+            run with: cargo test -p ff-preview --features proxy -- --include-ignored"]
+fn proxy_substitution_should_deliver_frames_at_proxy_dimensions() {
+    let input = bench_video_path();
+    if !input.exists() {
+        println!("skipping: reference file not found at {}", input.display());
+        return;
+    }
+
+    let tmp = std::env::temp_dir();
+
+    // Generate a half-resolution proxy (960×540).
+    let proxy_path = match ProxyGenerator::new(&input) {
+        Ok(g) => match g
+            .resolution(ProxyResolution::Half)
+            .output_dir(&tmp)
+            .generate()
+        {
+            Ok(p) => p,
+            Err(e) => {
+                println!("skipping: proxy generation failed: {e}");
+                return;
+            }
+        },
+        Err(e) => {
+            println!("skipping: {e}");
+            return;
+        }
+    };
+
+    // Open the player for the original (1920×1080) file.
+    let mut player = match PreviewPlayer::open(&input) {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = std::fs::remove_file(&proxy_path);
+            println!("skipping: {e}");
+            return;
+        }
+    };
+
+    // Activate the proxy before playback begins.
+    let activated = player.use_proxy_if_available(&tmp);
+    assert!(
+        activated,
+        "use_proxy_if_available must return true when a half proxy exists in the temp dir"
+    );
+
+    // Run with a sink that records frame dimensions and stops after 20 frames.
+    let dims = Arc::new(Mutex::new(Vec::<(u32, u32)>::new()));
+    let stop = player.stop_handle();
+
+    player.set_sink(Box::new(DimSink {
+        dims: Arc::clone(&dims),
+        max_frames: 20,
+        stop,
+    }));
+    player.play();
+    let _ = player.run();
+
+    let _ = std::fs::remove_file(&proxy_path);
+
+    let dims = dims
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    assert!(
+        !dims.is_empty(),
+        "no frames were delivered during proxy playback"
+    );
+
+    for (i, &(w, h)) in dims.iter().enumerate() {
+        assert_eq!(
+            w, 960,
+            "frame {i}: expected proxy width 960 (half of 1920); got {w}"
+        );
+        assert_eq!(
+            h, 540,
+            "frame {i}: expected proxy height 540 (half of 1080); got {h}"
+        );
+    }
+}

--- a/crates/ff-preview/tests/rgba_sink_test.rs
+++ b/crates/ff-preview/tests/rgba_sink_test.rs
@@ -1,0 +1,106 @@
+//! Integration test: `RgbaSink` decodes ≥10 real video frames and delivers
+//! correctly-sized, non-blank RGBA buffers.
+//!
+//! Opens `assets/test/av_sync_test_60s.mp4` (video-only, 30 fps) via
+//! [`PreviewPlayer`], records the first 10 frames, then stops the player early
+//! via [`PreviewPlayer::stop_handle`]. Asserts buffer sizes and non-blank pixel
+//! content for all recorded frames.
+//!
+//! Run with:
+//! ```bash
+//! cargo test -p ff-preview -- --include-ignored rgba_sink
+//! ```
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ff_preview::{FrameSink, PreviewPlayer};
+
+// ── Asset path ────────────────────────────────────────────────────────────────
+
+fn test_file_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/test/av_sync_test_60s.mp4")
+}
+
+// ── EarlySink ─────────────────────────────────────────────────────────────────
+
+/// Records `(width, height, rgba_len, any_nonzero_pixel)` for each frame.
+/// Stops the player after `max_frames` frames by setting the shared stop flag.
+struct EarlySink {
+    records: Arc<Mutex<Vec<(u32, u32, usize, bool)>>>,
+    max_frames: usize,
+    stop: Arc<AtomicBool>,
+}
+
+impl FrameSink for EarlySink {
+    fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, _pts: Duration) {
+        let any_nonzero = rgba.iter().any(|&b| b != 0);
+        let mut guard = self
+            .records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.push((width, height, rgba.len(), any_nonzero));
+        if guard.len() >= self.max_frames {
+            self.stop.store(true, Ordering::Release);
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "requires assets/test/av_sync_test_60s.mp4; run with -- --include-ignored"]
+fn rgba_sink_should_deliver_10_frames_with_correct_size_and_no_blank_output() {
+    let path = test_file_path();
+    if !path.exists() {
+        println!("skipping: reference file not found at {}", path.display());
+        return;
+    }
+
+    let mut player = match PreviewPlayer::open(&path) {
+        Ok(p) => p,
+        Err(e) => {
+            println!("skipping: {e}");
+            return;
+        }
+    };
+
+    let records = Arc::new(Mutex::new(Vec::<(u32, u32, usize, bool)>::new()));
+    let stop = player.stop_handle();
+
+    player.set_sink(Box::new(EarlySink {
+        records: Arc::clone(&records),
+        max_frames: 10,
+        stop,
+    }));
+    player.play();
+    let _ = player.run();
+
+    let records = records
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    assert!(
+        records.len() >= 10,
+        "expected ≥10 frames; got {} — sink may not have been called",
+        records.len()
+    );
+
+    for (i, &(w, h, len, any_nonzero)) in records.iter().enumerate() {
+        let expected_len = (w * h * 4) as usize;
+        assert_eq!(
+            len, expected_len,
+            "frame {i}: RGBA buffer length must equal width × height × 4; \
+             got len={len} expected={expected_len} ({}×{})",
+            w, h
+        );
+        assert!(
+            any_nonzero,
+            "frame {i}: RGBA output is all-zero — indicates a blank or corrupt decode \
+             ({}×{} frame)",
+            w, h
+        );
+    }
+}

--- a/crates/ff-preview/tests/seek_exact_test.rs
+++ b/crates/ff-preview/tests/seek_exact_test.rs
@@ -1,0 +1,75 @@
+//! Integration test: frame-accurate seek to t=30s returns a frame within one
+//! frame period of the target PTS.
+//!
+//! Plays `assets/test/av_sync_test_60s.mp4` (60-second, 30 fps, video-only
+//! synthetic file), seeks to t=30.000s via [`DecodeBuffer::seek`], and asserts
+//! that the first frame delivered after the seek has a PTS within ±34 ms of
+//! the target (one 30 fps frame period plus 1 ms margin).
+//!
+//! Run with:
+//! ```bash
+//! cargo test -p ff-preview -- --include-ignored seek_to_30s
+//! ```
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ff_preview::{DecodeBuffer, FrameResult};
+
+// ── Asset path ────────────────────────────────────────────────────────────────
+
+fn test_file_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/test/av_sync_test_60s.mp4")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "requires assets/test/av_sync_test_60s.mp4; run with -- --include-ignored"]
+fn seek_to_30s_should_deliver_frame_within_one_frame_period() {
+    let path = test_file_path();
+    if !path.exists() {
+        println!("skipping: reference file not found at {}", path.display());
+        return;
+    }
+
+    let mut buf = match DecodeBuffer::open(&path).build() {
+        Ok(b) => b,
+        Err(e) => {
+            println!("skipping: {e}");
+            return;
+        }
+    };
+
+    let target = Duration::from_secs(30);
+    if let Err(e) = buf.seek(target) {
+        println!("skipping: seek not supported: {e}");
+        return;
+    }
+
+    // Drain any Seeking placeholders; wait for the first real Frame.
+    let frame = loop {
+        match buf.pop_frame() {
+            FrameResult::Frame(f) => break f,
+            FrameResult::Seeking(_) => std::thread::sleep(Duration::from_millis(5)),
+            FrameResult::Eof => {
+                panic!("EOF reached before any frame was delivered after seek to {target:?}");
+            }
+        }
+    };
+
+    // 30 fps → one frame period ≈ 33.3 ms; add 1 ms rounding margin.
+    let one_frame = Duration::from_millis(34);
+    let pts = frame.timestamp().as_duration();
+
+    assert!(
+        pts >= target.saturating_sub(one_frame),
+        "post-seek frame PTS must be ≥ (target − 1 frame); \
+         target={target:?} pts={pts:?}"
+    );
+    assert!(
+        pts <= target + one_frame,
+        "post-seek frame PTS must be ≤ (target + 1 frame); \
+         target={target:?} pts={pts:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds three integration tests that complete the v0.13.0 Definition of Done for `ff-preview`. Also adds `PreviewPlayer::stop_handle()` — a minimal public API that returns a cloneable `Arc<AtomicBool>` tied to the player's stop signal, enabling sinks to halt playback from within `push_frame` without deadlocking.

## Changes

- `src/playback/player.rs`: change `stopped: AtomicBool` → `stopped: Arc<AtomicBool>`; add `stop_handle() -> Arc<AtomicBool>`; existing `store`/`load` call sites are unchanged because `Arc<AtomicBool>` derefs to `AtomicBool`
- `Cargo.toml`: add `ff-probe` dev-dependency; add `[[test]] name = "proxy_test" required-features = ["proxy"]`
- `tests/seek_exact_test.rs`: opens `av_sync_test_60s.mp4`, seeks to t=30s via `DecodeBuffer::seek`, asserts first frame PTS is within ±34 ms of target
- `tests/rgba_sink_test.rs`: opens `av_sync_test_60s.mp4`, drives `PreviewPlayer` until 10 frames are received (stopped early via `stop_handle()`), asserts each RGBA buffer length equals `w×h×4` and contains at least one non-zero pixel
- `tests/proxy_test.rs`: (a) generates quarter-resolution proxy of `preview_bench_1080p.mp4`, probes output with `ff_probe` and asserts dimensions 480×270; (b) generates half-resolution proxy, calls `use_proxy_if_available`, runs player, asserts all delivered frames are 960×540

## Related Issues

Closes #996
Closes #997
Closes #998

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes