### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.0] - 2026-04-13
+
+### Added
+
+#### ff-preview — new crate
+- New `ff-preview` crate: real-time video preview and proxy workflow ([#369](https://github.com/itsakeyfut/avio/issues/369))
+- `PlaybackClock`: start / stop / pause / resume with nanosecond resolution ([#370](https://github.com/itsakeyfut/avio/issues/370))
+- Playback rate control (0.25×, 0.5×, 1×, 2×, arbitrary fractional) via `set_rate` ([#371](https://github.com/itsakeyfut/avio/issues/371))
+- `current_pts` and `set_position` for real-time position query and seek support ([#372](https://github.com/itsakeyfut/avio/issues/372))
+- `DecodeBuffer`: configurable frame decode-ahead ring buffer (default 8 frames) ([#373](https://github.com/itsakeyfut/avio/issues/373))
+- Background decode thread with bounded channel and back-pressure ([#374](https://github.com/itsakeyfut/avio/issues/374))
+- Frame-accurate seek: I-frame seek + forward decode to target PTS ([#375](https://github.com/itsakeyfut/avio/issues/375))
+- Coarse seek: nearest I-frame only (fast path for scrub-bar drag) ([#376](https://github.com/itsakeyfut/avio/issues/376))
+- `FrameResult` enum and non-blocking `seek_async`: returns `Seeking` placeholder while decoder catches up ([#377](https://github.com/itsakeyfut/avio/issues/377))
+- `SeekEvent` channel: seek completion notification for UI synchronization ([#378](https://github.com/itsakeyfut/avio/issues/378))
+- `PreviewPlayer` with A/V sync using audio master clock ([#379](https://github.com/itsakeyfut/avio/issues/379))
+- `MasterClock::System` fallback for video-only files ([#380](https://github.com/itsakeyfut/avio/issues/380))
+- `set_av_offset`: configurable ±ms A/V offset correction ([#381](https://github.com/itsakeyfut/avio/issues/381))
+- Audio PCM delivery aligned to presentation clock via background decode thread and ring buffer ([#382](https://github.com/itsakeyfut/avio/issues/382))
+- `FrameSink` trait (`Send`, called on dedicated thread) for custom frame consumers ([#383](https://github.com/itsakeyfut/avio/issues/383))
+- `RgbaFrame` and `RgbaSink`: reference `FrameSink` implementation using `sws_scale` to deliver contiguous RGBA `Vec<u8>` ([#384](https://github.com/itsakeyfut/avio/issues/384))
+- `ProxyGenerator`: generates down-scaled proxy files at 1/2, 1/4, or 1/8 resolution with configurable codec ([#385](https://github.com/itsakeyfut/avio/issues/385))
+- `use_proxy_if_available` and `active_source` for transparent proxy substitution during playback ([#386](https://github.com/itsakeyfut/avio/issues/386))
+- `ProxyJob` and `generate_async` for non-blocking background proxy generation ([#387](https://github.com/itsakeyfut/avio/issues/387))
+- `AsyncPreviewPlayer` behind `tokio` feature flag ([#388](https://github.com/itsakeyfut/avio/issues/388))
+- `stop_handle() -> Arc<AtomicBool>`: cloneable stop signal for use inside `FrameSink::push_frame`
+
+#### avio — facade additions
+- `RgbaSink` and `RgbaFrame` re-exported under the `preview` feature ([#999](https://github.com/itsakeyfut/avio/issues/999))
+- `AsyncPreviewPlayer` re-exported under `preview + tokio`; `ff-preview/tokio` wired into the `tokio` feature ([#1000](https://github.com/itsakeyfut/avio/issues/1000))
+- `preview-proxy` feature: re-exports `ProxyGenerator`, `ProxyJob`, and `ProxyResolution` ([#1001](https://github.com/itsakeyfut/avio/issues/1001))
+
+### Fixed
+
+- `SeekEvent` race condition: event sent before the frame is pushed to avoid `try_recv` miss on the receiver side ([#379](https://github.com/itsakeyfut/avio/issues/379))
+- Circular dev-dependency between `ff-decode` and `ff-encode`: replaced cross-crate asset generation with pre-committed test assets ([#970](https://github.com/itsakeyfut/avio/issues/970))
+- Broken intra-doc links in `sink.rs` after module split ([#992](https://github.com/itsakeyfut/avio/issues/992))
+
+### Tests
+
+- Integration test: frame-accurate seek to t=30s returns frame within ±1 frame period (±34 ms at 30 fps) ([#996](https://github.com/itsakeyfut/avio/issues/996))
+- Integration test: `RgbaSink` decodes ≥10 real frames to correctly-sized, non-blank RGBA buffers ([#997](https://github.com/itsakeyfut/avio/issues/997))
+- Integration test: proxy generation at 1/4 resolution produces 480×270 output; half-resolution substitution delivers 960×540 frames ([#998](https://github.com/itsakeyfut/avio/issues/998))
+- Integration test: A/V sync consecutive-frame jitter ≤67 ms over 60-second playback ([#390](https://github.com/itsakeyfut/avio/issues/390))
+- Criterion benchmark: 1080p/30 fps playback loop frames delivered on time ([#389](https://github.com/itsakeyfut/avio/issues/389))
+
+---
+
 ## [0.12.0] - 2026-04-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,17 +12,17 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.12.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.12.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.12.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.12.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.12.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.12.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.12.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.12.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.12.0" }
-ff-preview  = { path = "crates/ff-preview", version = "0.12.0" }
-avio        = { path = "crates/avio",        version = "0.12.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.13.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.13.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.13.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.13.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.13.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.13.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.13.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.13.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.13.0" }
+ff-preview  = { path = "crates/ff-preview", version = "0.13.0" }
+avio        = { path = "crates/avio",        version = "0.13.0" }
 
 # Error handling
 thiserror = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ff-probe  = "0.12"
-ff-decode = "0.12"
-ff-encode = "0.12"
+ff-probe  = "0.13"
+ff-decode = "0.13"
+ff-encode = "0.13"
 
 # Or use the facade crate for everything
-avio = "0.12"
+avio = "0.13"
 ```
 
 ### Prerequisites

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -14,16 +14,16 @@ to only the capabilities you need via feature flags.
 ```toml
 [dependencies]
 # Default: probe + decode + encode
-avio = "0.12"
+avio = "0.13"
 
 # Add filtering
-avio = { version = "0.12", features = ["filter"] }
+avio = { version = "0.13", features = ["filter"] }
 
 # Full stack (implies filter + pipeline)
-avio = { version = "0.12", features = ["stream"] }
+avio = { version = "0.13", features = ["stream"] }
 
 # Async decode/encode (requires tokio runtime)
-avio = { version = "0.12", features = ["tokio"] }
+avio = { version = "0.13", features = ["tokio"] }
 ```
 
 ## Feature Flags

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -22,13 +22,13 @@
 //! ```toml
 //! # Default: probe + decode + encode
 //! [dependencies]
-//! avio = "0.12"
+//! avio = "0.13"
 //!
 //! # Add filtering
-//! avio = { version = "0.12", features = ["filter"] }
+//! avio = { version = "0.13", features = ["filter"] }
 //!
 //! # Full stack (implies filter + pipeline)
-//! avio = { version = "0.12", features = ["stream"] }
+//! avio = { version = "0.13", features = ["stream"] }
 //! ```
 //!
 //! # Quick Start

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -8,8 +8,8 @@ Decode video and audio frames without managing codec contexts, packet queues, or
 
 ```toml
 [dependencies]
-ff-decode = "0.12"
-ff-format = "0.12"
+ff-decode = "0.13"
+ff-format = "0.13"
 ```
 
 ## Video Decoding
@@ -191,7 +191,7 @@ let mut decoder = VideoDecoder::open("video.mp4")
 
 ```toml
 [dependencies]
-ff-decode = { version = "0.12", features = ["tokio"] }
+ff-decode = { version = "0.13", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoDecoder` and `AudioDecoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -8,12 +8,12 @@ Encode video and audio to any format with a builder chain. The encoder validates
 
 ```toml
 [dependencies]
-ff-encode = "0.12"
-ff-format = "0.12"
+ff-encode = "0.13"
+ff-format = "0.13"
 
 # Enable GPL-licensed encoders (libx264, libx265).
 # Requires GPL compliance or MPEG LA licensing in your project.
-# ff-encode = { version = "0.12", features = ["gpl"] }
+# ff-encode = { version = "0.13", features = ["gpl"] }
 ```
 
 By default, only LGPL-compatible encoders are enabled.
@@ -326,7 +326,7 @@ Enable the `gpl` feature to add libx264 and libx265. This changes the license te
 
 ```toml
 [dependencies]
-ff-encode = { version = "0.12", features = ["tokio"] }
+ff-encode = { version = "0.13", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoEncoder`, `AudioEncoder`, and `ImageEncoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -8,7 +8,7 @@ Wire decode, filter, and encode into a single configured pipeline. Instead of ma
 
 ```toml
 [dependencies]
-ff-pipeline = "0.12"
+ff-pipeline = "0.13"
 ```
 
 ## Building a Pipeline

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -8,7 +8,7 @@ Read media file metadata with one function call. No knowledge of container forma
 
 ```toml
 [dependencies]
-ff-probe = "0.12"
+ff-probe = "0.13"
 ```
 
 ## Quick Start

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -9,7 +9,7 @@ point it at an input file, and receive a standards-compliant package ready for C
 
 ```toml
 [dependencies]
-ff-stream = "0.12"
+ff-stream = "0.13"
 ```
 
 ## HLS Output


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.12.0 to 0.13.0 and documents all v0.13.0 changes in CHANGELOG.md. This release ships the complete Real-time Preview & Proxy Workflow milestone, introducing the new `ff-preview` crate and extending the `avio` facade with preview, async, and proxy feature flags.

## Changes

- `Cargo.toml`: workspace version 0.12.0 → 0.13.0; all intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.13.0]` entry covering new `ff-preview` crate, avio facade additions, bug fixes, and integration tests
- `README.md`, `crates/*/README.md`, `crates/avio/src/lib.rs`: version references updated from 0.12 → 0.13

## Related Issues

Closes #368

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes