### PR TITLE
fix(ff-pipeline): add render_with_progress() to Timeline

### DIFF
--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ff_decode::VideoDecoder;
 use ff_encode::VideoEncoder;
@@ -20,6 +20,7 @@ use crate::clip::Clip;
 use crate::encoder_config::EncoderConfig;
 use crate::error::PipelineError;
 use crate::pipeline::hwaccel_to_hardware_encoder;
+use crate::progress::Progress;
 
 /// An ordered layout of [`Clip`] instances across video and audio tracks.
 ///
@@ -102,10 +103,8 @@ impl Timeline {
 
     /// Renders the timeline to an output file.
     ///
-    /// Animation tracks registered via [`TimelineBuilder::video_animation`] and
-    /// [`TimelineBuilder::audio_animation`] are forwarded to the corresponding
-    /// [`VideoLayer`] / [`AudioTrack`] fields before the filter graphs are built.
-    /// Unrecognised animation keys are ignored and logged as `warn!`.
+    /// Convenience wrapper around [`render_with_progress`](Self::render_with_progress)
+    /// that discards progress notifications.
     ///
     /// # Errors
     ///
@@ -118,7 +117,65 @@ impl Timeline {
         output: impl AsRef<Path>,
         config: EncoderConfig,
     ) -> Result<(), PipelineError> {
+        self.render_with_progress(output, config, |_| true)
+    }
+
+    /// Renders the timeline to an output file, invoking `on_progress` after
+    /// each encoded video frame.
+    ///
+    /// Animation tracks registered via [`TimelineBuilder::video_animation`] and
+    /// [`TimelineBuilder::audio_animation`] are forwarded to the corresponding
+    /// [`VideoLayer`] / [`AudioTrack`] fields before the filter graphs are built.
+    /// Unrecognised animation keys are ignored and logged as `warn!`.
+    ///
+    /// `on_progress` receives a [`Progress`] reference after every video frame.
+    /// Returning `false` cancels the render and returns
+    /// [`PipelineError::Cancelled`]. Audio-only timelines do not invoke the
+    /// callback (there are no video frames to report).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let timeline = Timeline::builder()
+    ///     .canvas(1920, 1080)
+    ///     .frame_rate(30.0)
+    ///     .video_track(vec![Clip::new("input.mp4")])
+    ///     .build()?;
+    ///
+    /// timeline.render_with_progress("output.mp4", EncoderConfig::default(), |p| {
+    ///     println!("frame {} / {:?}", p.frames_processed, p.total_frames);
+    ///     true // return false to cancel
+    /// })?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`PipelineError::ClipNotFound`] — a clip's source file is missing
+    /// - [`PipelineError::Cancelled`] — `on_progress` returned `false`
+    /// - [`PipelineError::Encode`] — encoder failure
+    /// - [`PipelineError::Filter`] — filter graph construction failure
+    /// - [`PipelineError::TimelineRenderFailed`] — other structural failure
+    pub fn render_with_progress(
+        self,
+        output: impl AsRef<Path>,
+        config: EncoderConfig,
+        on_progress: impl Fn(&Progress) -> bool + Send,
+    ) -> Result<(), PipelineError> {
         let output = output.as_ref();
+
+        // Compute total expected video frame count from clips with known durations.
+        // `None` when any clip runs to end-of-file (out_point not set).
+        // Sum clip durations; short-circuits to None if any clip has no out_point.
+        // frame_rate and total_dur are always non-negative; max(0.0) + round()
+        // guarantees the value fits in u64 for any realistic frame count.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let total_frames: Option<u64> = self
+            .video_tracks
+            .iter()
+            .flat_map(|track| track.iter())
+            .map(Clip::duration)
+            .try_fold(Duration::ZERO, |acc, dur| dur.map(|d| acc + d))
+            .map(|total_dur| (total_dur.as_secs_f64() * self.frame_rate).round().max(0.0) as u64);
 
         let Timeline {
             canvas_width,
@@ -243,9 +300,12 @@ impl Timeline {
         }
         let mut encoder = enc_builder.build().map_err(PipelineError::Encode)?;
 
+        let start = Instant::now();
+
         // 6. Drain video graph → encoder.
         //    tick() must be called before each pull so that animation entries
         //    registered on the graph update the filter parameters for that frame.
+        //    on_progress is invoked after each push; returning false cancels.
         if let Some(mut vgraph) = video_graph {
             let mut video_idx: u32 = 0;
             loop {
@@ -257,6 +317,14 @@ impl Timeline {
                     Some(frame) => {
                         encoder.push_video(&frame).map_err(PipelineError::Encode)?;
                         video_idx = video_idx.saturating_add(1);
+                        let progress = Progress {
+                            frames_processed: u64::from(video_idx),
+                            total_frames,
+                            elapsed: start.elapsed(),
+                        };
+                        if !on_progress(&progress) {
+                            return Err(PipelineError::Cancelled);
+                        }
                     }
                     None => break,
                 }

--- a/crates/ff-pipeline/tests/timeline_tests.rs
+++ b/crates/ff-pipeline/tests/timeline_tests.rs
@@ -131,6 +131,127 @@ fn timeline_render_should_produce_ffprobe_valid_output() {
     );
 }
 
+/// Verifies that `render_with_progress` returns `PipelineError::Cancelled` when
+/// the callback immediately returns `false`.
+///
+/// This is the acceptance-criterion test for issue #1016:
+/// "A unit test verifies that a cancelling callback returns `Cancelled` after
+/// the first frame."
+#[test]
+fn render_with_progress_should_cancel_when_callback_returns_false() {
+    let src_path = test_output_path("rwp_cancel_src.mp4");
+    let out_path = test_output_path("rwp_cancel_out.mp4");
+    let _g_src = FileGuard::new(src_path.clone());
+    let _g_out = FileGuard::new(out_path.clone());
+
+    // Y=100, U=100, V=100 ≈ grey
+    if make_source_file(&src_path, W, H, FPS, FRAME_COUNT, 100, 100, 100).is_none() {
+        return;
+    }
+
+    let clip = Clip::new(&src_path).trim(Duration::ZERO, Duration::from_secs(1));
+
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![clip])
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    // A callback that always returns false should cancel on the first frame.
+    let result = timeline.render_with_progress(&out_path, render_config(), |_| false);
+
+    match result {
+        Err(PipelineError::Cancelled) => { /* expected */ }
+        Err(PipelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+        }
+        Err(PipelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+        }
+        Err(PipelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+        }
+        Err(e) => panic!("expected Cancelled, got {e}"),
+        Ok(()) => panic!("render_with_progress must not succeed when callback returns false"),
+    }
+}
+
+/// Verifies that `render_with_progress` invokes the callback at least once
+/// and reports monotonically increasing `frames_processed`.
+#[test]
+fn render_with_progress_should_invoke_callback_with_incrementing_frame_count() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    let src_path = test_output_path("rwp_count_src.mp4");
+    let out_path = test_output_path("rwp_count_out.mp4");
+    let _g_src = FileGuard::new(src_path.clone());
+    let _g_out = FileGuard::new(out_path.clone());
+
+    if make_source_file(&src_path, W, H, FPS, FRAME_COUNT, 100, 100, 100).is_none() {
+        return;
+    }
+
+    let clip = Clip::new(&src_path).trim(Duration::ZERO, Duration::from_secs(1));
+
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![clip])
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    let call_count = AtomicU64::new(0);
+    let last_frames = AtomicU64::new(0);
+
+    let result = timeline.render_with_progress(&out_path, render_config(), |p| {
+        let prev = last_frames.load(Ordering::Relaxed);
+        assert!(
+            p.frames_processed > prev,
+            "frames_processed must increase monotonically: prev={prev} got={}",
+            p.frames_processed
+        );
+        last_frames.store(p.frames_processed, Ordering::Relaxed);
+        call_count.fetch_add(1, Ordering::Relaxed);
+        true
+    });
+
+    match result {
+        Ok(()) => {}
+        Err(PipelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+            return;
+        }
+        Err(PipelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+        Err(PipelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+            return;
+        }
+        Err(e) => panic!("unexpected error from render_with_progress: {e}"),
+    }
+
+    let count = call_count.load(Ordering::Relaxed);
+    assert!(
+        count > 0,
+        "on_progress must be invoked at least once, got {count} calls"
+    );
+}
+
 /// Verifies that a `Timeline` with an audio volume fade track encodes without
 /// error.  The volume track fades from −60 dB to 0 dB over the clip's
 /// duration; the test confirms the output is a valid file with both streams.


### PR DESCRIPTION
## Summary

`Timeline::render()` had no way for callers to receive per-frame progress updates or cancel a long-running export. This PR adds `render_with_progress()` which accepts a `Fn(&Progress) -> bool + Send` callback — the same pattern used by `PipelineBuilder::on_progress`. `render()` is kept as a no-op wrapper that passes `|_| true`.

## Changes

- `crates/ff-pipeline/src/timeline.rs`: refactored `render()` to delegate to new `render_with_progress()`; the new method computes `total_frames` from clip durations (using `try_fold` to short-circuit to `None` when any clip has no explicit `out_point`), tracks elapsed time via `Instant`, and calls `on_progress` after each pushed video frame — returning `PipelineError::Cancelled` immediately if the callback returns `false`
- `crates/ff-pipeline/tests/timeline_tests.rs`: added `render_with_progress_should_cancel_when_callback_returns_false` (verifies `Cancelled` is returned when callback always returns `false`) and `render_with_progress_should_invoke_callback_with_incrementing_frame_count` (verifies callback is invoked at least once with monotonically increasing `frames_processed`)

## Related Issues

Fixes #1016

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes