### PR TITLE
fix(ff-filter): constrain video buffersink to yuv420p to prevent gbrp negotiation

### DIFF
--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -578,6 +578,29 @@ pub(super) unsafe fn build_video_composition(
         }
     }
 
+    // ── format=yuv420p: constrain output pixel format before sink ────────────
+    let vfmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if vfmt_filter.is_null() {
+        bail!(graph, "filter not found: format");
+    }
+    let mut vfmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut vfmt_ctx,
+        vfmt_filter,
+        c"vformat".as_ptr(),
+        c"pix_fmts=yuv420p".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create format filter code={ret}"));
+    }
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, vfmt_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: last→format");
+    }
+    log::debug!("video composition format filter inserted output=yuv420p");
+
     // ── Video buffersink ──────────────────────────────────────────────────────
     let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
     if sink_filter.is_null() {
@@ -595,9 +618,9 @@ pub(super) unsafe fn build_video_composition(
     if ret < 0 {
         bail!(graph, format!("failed to create buffersink code={ret}"));
     }
-    let ret = ff_sys::avfilter_link(prev_ctx, 0, sink_ctx, 0);
+    let ret = ff_sys::avfilter_link(vfmt_ctx, 0, sink_ctx, 0);
     if ret < 0 {
-        bail!(graph, "link failed: last→buffersink");
+        bail!(graph, "link failed: format→buffersink");
     }
 
     // ── Configure graph ───────────────────────────────────────────────────────
@@ -1109,6 +1132,29 @@ pub(super) unsafe fn build_video_concat(
         concat_ctx
     };
 
+    // ── format=yuv420p: constrain output pixel format before sink ────────────
+    let vfmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if vfmt_filter.is_null() {
+        bail!(graph, "filter not found: format");
+    }
+    let mut vfmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut vfmt_ctx,
+        vfmt_filter,
+        c"vformat".as_ptr(),
+        c"pix_fmts=yuv420p".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create format filter code={ret}"));
+    }
+    let ret = ff_sys::avfilter_link(pre_sink_ctx, 0, vfmt_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: last→format");
+    }
+    log::debug!("video concat format filter inserted output=yuv420p");
+
     // ── buffersink ────────────────────────────────────────────────────────────
     let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
     if sink_filter.is_null() {
@@ -1126,9 +1172,9 @@ pub(super) unsafe fn build_video_concat(
     if ret < 0 {
         bail!(graph, format!("failed to create buffersink code={ret}"));
     }
-    let ret = ff_sys::avfilter_link(pre_sink_ctx, 0, sink_ctx, 0);
+    let ret = ff_sys::avfilter_link(vfmt_ctx, 0, sink_ctx, 0);
     if ret < 0 {
-        bail!(graph, "link failed: last→buffersink");
+        bail!(graph, "link failed: format→buffersink");
     }
 
     // ── Configure graph ───────────────────────────────────────────────────────
@@ -1534,6 +1580,29 @@ pub(super) unsafe fn build_dissolve_join(
         bail!(graph, "link failed: movie_b→xfade[1]");
     }
 
+    // ── format=yuv420p: constrain output pixel format before sink ────────────
+    let vfmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if vfmt_filter.is_null() {
+        bail!(graph, "filter not found: format");
+    }
+    let mut vfmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut vfmt_ctx,
+        vfmt_filter,
+        c"jd_vformat".as_ptr(),
+        c"pix_fmts=yuv420p".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create format filter code={ret}"));
+    }
+    let ret = ff_sys::avfilter_link(xfade_ctx, 0, vfmt_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: xfade→format");
+    }
+    log::debug!("dissolve join format filter inserted output=yuv420p");
+
     // ── buffersink ────────────────────────────────────────────────────────────
     let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
     if sink_filter.is_null() {
@@ -1551,9 +1620,9 @@ pub(super) unsafe fn build_dissolve_join(
     if ret < 0 {
         bail!(graph, format!("failed to create buffersink code={ret}"));
     }
-    let ret = ff_sys::avfilter_link(xfade_ctx, 0, sink_ctx, 0);
+    let ret = ff_sys::avfilter_link(vfmt_ctx, 0, sink_ctx, 0);
     if ret < 0 {
-        bail!(graph, "link failed: xfade→buffersink");
+        bail!(graph, "link failed: format→buffersink");
     }
 
     // ── Configure graph ───────────────────────────────────────────────────────

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -794,3 +794,69 @@ fn volume_automation_should_increase_audio_amplitude_over_time() {
          — volume automation did not take effect (total chunks={n})"
     );
 }
+
+/// Verifies that frames pulled from `MultiTrackComposer` always have `yuv420p` format,
+/// regardless of FFmpeg's internal format negotiation.
+///
+/// Acceptance criterion for issue #1017: newer FFmpeg builds may negotiate `gbrp` when
+/// no explicit format constraint is set on the buffersink, causing green-tinted output.
+/// The fix inserts a `format=yuv420p` filter before each video buffersink.
+#[test]
+fn multi_track_composition_should_produce_yuv420p_frames() {
+    use ff_format::PixelFormat;
+
+    const W: u32 = 64;
+    const H: u32 = 64;
+    const FPS_LOCAL: f64 = 30.0;
+    const FRAMES: usize = 5;
+
+    let src_path = test_output_path("yuv420p_check_src.mp4");
+    let _g = FileGuard::new(src_path.clone());
+
+    if make_source_file(&src_path, W, H, FPS_LOCAL, FRAMES, 128, 128, 128).is_none() {
+        return;
+    }
+
+    let mut composer = match MultiTrackComposer::new(W, H)
+        .add_layer(VideoLayer {
+            source: src_path.clone(),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(1.0),
+            z_order: 0,
+            time_offset: Duration::ZERO,
+            in_point: None,
+            out_point: None,
+            in_transition: None,
+        })
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: MultiTrackComposer::build failed: {e}");
+            return;
+        }
+    };
+
+    let frame = match composer.pull_video() {
+        Ok(Some(f)) => f,
+        Ok(None) => {
+            println!("Skipping: composer produced no frames");
+            return;
+        }
+        Err(e) => {
+            println!("Skipping: pull_video failed: {e}");
+            return;
+        }
+    };
+
+    assert_eq!(
+        frame.format(),
+        PixelFormat::Yuv420p,
+        "composition graph must deliver yuv420p frames; got {:?}",
+        frame.format()
+    );
+}


### PR DESCRIPTION
## Summary

On newer FFmpeg builds the `color` filter defaults to `gbrp`, so filter graphs with an unconstrained `buffersink` negotiate `gbrp` instead of `yuv420p`. The downstream `VideoEncoder` interprets the bytes as `yuv420p` (G plane treated as luma), producing severely green-tinted output. This PR inserts an explicit `format=yuv420p` filter immediately before each of the three video buffersinks in `composition_inner.rs`.

## Changes

- **Root cause**: `build_video_composition`, `build_video_concat`, and `build_dissolve_join` all created their video `buffersink` with a `NULL` options pointer, leaving FFmpeg free to negotiate any pixel format.
- **Fix**: inserted a `format=yuv420p` AVFilter node before the `buffersink` at all three sites, using filter names `vformat`, `vformat`, and `jd_vformat` respectively to match existing naming conventions.
- **Test**: added `multi_track_composition_should_produce_yuv420p_frames` to `composition_tests.rs`; builds a single-layer `MultiTrackComposer`, pulls one frame, and asserts `frame.format() == PixelFormat::Yuv420p`.

## Related Issues

Fixes #1017

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes