### PR TITLE
fix(ff-encode): pass PixelFormat::Other(v) through to AVPixelFormat without fallback

### DIFF
--- a/crates/ff-encode/src/video/encoder_inner/color.rs
+++ b/crates/ff-encode/src/video/encoder_inner/color.rs
@@ -25,6 +25,7 @@ pub(super) fn pixel_format_to_av(format: ff_format::PixelFormat) -> AVPixelForma
         PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
         PixelFormat::Yuva444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE,
         PixelFormat::P010le => ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE,
+        PixelFormat::Other(v) => v as AVPixelFormat,
         _ => {
             log::warn!(
                 "pixel_format has no AV mapping, falling back to Yuv420p \
@@ -69,10 +70,7 @@ pub(super) fn from_av_pixel_format(fmt: AVPixelFormat) -> ff_format::PixelFormat
     } else if fmt == ff_sys::AVPixelFormat_AV_PIX_FMT_P010LE {
         PixelFormat::P010le
     } else {
-        log::warn!(
-            "pixel_format unsupported, falling back to Yuv420p requested={fmt} fallback=Yuv420p"
-        );
-        PixelFormat::Yuv420p
+        PixelFormat::Other(fmt as u32)
     }
 }
 
@@ -115,6 +113,49 @@ pub(super) fn color_primaries_to_av(cp: ff_format::ColorPrimaries) -> ff_sys::AV
         ColorPrimaries::Bt2020 => ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020,
         ColorPrimaries::Unknown => ff_sys::AVColorPrimaries_AVCOL_PRI_UNSPECIFIED,
         _ => ff_sys::AVColorPrimaries_AVCOL_PRI_UNSPECIFIED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_format::PixelFormat;
+
+    /// `PixelFormat::Other(v)` must pass through to the raw `AVPixelFormat` integer unchanged,
+    /// not fall back to `AV_PIX_FMT_YUV420P`.
+    #[test]
+    fn pixel_format_other_should_passthrough_av_value() {
+        // AVPixelFormat value 29 = AV_PIX_FMT_GBRP on most FFmpeg builds.
+        let result = pixel_format_to_av(PixelFormat::Other(29));
+        assert_eq!(
+            result, 29,
+            "Other(29) must map to AVPixelFormat 29, got {result}"
+        );
+    }
+
+    /// An unrecognised `AVPixelFormat` integer must be wrapped in `PixelFormat::Other`,
+    /// not silently coerced to `Yuv420p`.
+    #[test]
+    fn from_av_pixel_format_unknown_should_return_other() {
+        let result = from_av_pixel_format(99);
+        assert_eq!(
+            result,
+            PixelFormat::Other(99),
+            "AVPixelFormat 99 must yield Other(99), got {result:?}"
+        );
+    }
+
+    /// Round-trip: `from_av_pixel_format(pixel_format_to_av(Other(v))) == Other(v)`.
+    /// Acceptance criterion from issue #1018.
+    #[test]
+    fn pixel_format_other_round_trip_should_be_identity() {
+        let original = PixelFormat::Other(29);
+        let av_fmt = pixel_format_to_av(original);
+        let round_tripped = from_av_pixel_format(av_fmt);
+        assert_eq!(
+            round_tripped, original,
+            "Other(29) round-trip must be identity; got {round_tripped:?}"
+        );
     }
 }
 

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -745,10 +745,10 @@ mod tests {
             ff_sys::AVPixelFormat_AV_PIX_FMT_NV12
         );
 
-        // Test fallback for Other format
+        // Other(v) passes through the raw integer unchanged.
         assert_eq!(
             color::pixel_format_to_av(ff_format::PixelFormat::Other(999)),
-            ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P
+            999 as AVPixelFormat
         );
 
         // 10-bit formats
@@ -791,10 +791,12 @@ mod tests {
     }
 
     #[test]
-    fn from_av_pixel_format_unknown_should_fall_back_to_yuv420p() {
+    fn from_av_pixel_format_none_should_return_other() {
+        // AV_PIX_FMT_NONE (-1) is an unrecognised value; must round-trip as Other.
+        let fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_NONE;
         assert_eq!(
-            color::from_av_pixel_format(ff_sys::AVPixelFormat_AV_PIX_FMT_NONE),
-            ff_format::PixelFormat::Yuv420p
+            color::from_av_pixel_format(fmt),
+            ff_format::PixelFormat::Other(fmt as u32)
         );
     }
 


### PR DESCRIPTION
## Summary

`pixel_format_to_av` had no arm for `PixelFormat::Other(v)`, causing any unrecognised pixel format (e.g. `gbrp` from the filter graph) to silently fall back to `AV_PIX_FMT_YUV420P`. The encoder then skipped swscale conversion and wrote raw `gbrp` bytes into the output as if they were `yuv420p`, producing green-tinted corrupted video with no error. Symmetrically, `from_av_pixel_format` mapped unrecognised `AVPixelFormat` integers to `PixelFormat::Yuv420p` instead of preserving them.

## Changes

- **Root cause**: `pixel_format_to_av` wildcard arm discarded `PixelFormat::Other(v)` and returned `AV_PIX_FMT_YUV420P`; `from_av_pixel_format` final `else` branch logged a warning and returned `PixelFormat::Yuv420p` for any unknown format integer.
- **Fix in `color.rs`**: added `PixelFormat::Other(v) => v as AVPixelFormat` before the wildcard in `pixel_format_to_av`; replaced the final `else` block in `from_av_pixel_format` with `PixelFormat::Other(fmt as u32)`, removing the spurious fallback and warning.
- **New unit tests** in `color::tests`: `pixel_format_other_should_passthrough_av_value`, `from_av_pixel_format_unknown_should_return_other`, `pixel_format_other_round_trip_should_be_identity` (acceptance criterion from issue).
- **Updated existing tests** in `encoder_inner/mod.rs`: `test_pixel_format_to_av` (Other assertion) and `from_av_pixel_format_unknown_should_fall_back_to_yuv420p` → renamed `from_av_pixel_format_none_should_return_other` with corrected assertion.

## Related Issues

Fixes #1018

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes