### PR TITLE
fix(ff-decode): terminate into_stream after first error

### DIFF
--- a/crates/ff-decode/src/audio/async_decoder.rs
+++ b/crates/ff-decode/src/audio/async_decoder.rs
@@ -77,11 +77,12 @@ impl AsyncAudioDecoder {
     /// `decode_frame`). Errors are yielded as `Err` items; the stream
     /// terminates after the first error.
     pub fn into_stream(self) -> impl Stream<Item = Result<AudioFrame, DecodeError>> + Send {
-        stream::unfold(self, |mut decoder| async move {
+        stream::unfold(Some(self), |state| async move {
+            let mut decoder = state?; // None → stream already ended
             match decoder.decode_frame().await {
-                Ok(Some(frame)) => Some((Ok(frame), decoder)),
-                Ok(None) => None,
-                Err(e) => Some((Err(e), decoder)),
+                Ok(Some(frame)) => Some((Ok(frame), Some(decoder))),
+                Ok(None) => None,               // EOF → end stream
+                Err(e) => Some((Err(e), None)), // error → yield once, then end
             }
         })
     }
@@ -105,5 +106,35 @@ mod tests {
             matches!(result, Err(DecodeError::FileNotFound { .. })),
             "expected FileNotFound"
         );
+    }
+
+    /// Verifies the `Option<S>` unfold pattern used by `into_stream`: after the
+    /// error arm sets state to `None`, the stream yields no further items.
+    ///
+    /// Acceptance criterion for issue #1006.
+    #[tokio::test]
+    async fn into_stream_state_machine_should_terminate_after_error() {
+        use futures::StreamExt;
+
+        // Use the exact same stream::unfold(Option<S>, ...) pattern as
+        // into_stream() with a controlled error at position 2.
+        let items: Vec<Result<u32, u32>> = stream::unfold(Some(0u32), |state| async move {
+            let n = state?; // None → stream ends
+            match n {
+                0 | 1 => Some((Ok(n), Some(n + 1))),
+                _ => Some((Err(n), None)), // error → yield once, then end
+            }
+        })
+        .collect()
+        .await;
+
+        assert_eq!(
+            items.len(),
+            3,
+            "stream must stop after the error: expected 2 Ok + 1 Err, got {items:?}"
+        );
+        assert!(items[0].is_ok());
+        assert!(items[1].is_ok());
+        assert!(items[2].is_err());
     }
 }

--- a/crates/ff-decode/src/video/async_decoder.rs
+++ b/crates/ff-decode/src/video/async_decoder.rs
@@ -77,11 +77,12 @@ impl AsyncVideoDecoder {
     /// `decode_frame`). Errors are yielded as `Err` items; the stream
     /// terminates after the first error.
     pub fn into_stream(self) -> impl Stream<Item = Result<VideoFrame, DecodeError>> + Send {
-        stream::unfold(self, |mut decoder| async move {
+        stream::unfold(Some(self), |state| async move {
+            let mut decoder = state?; // None → stream already ended
             match decoder.decode_frame().await {
-                Ok(Some(frame)) => Some((Ok(frame), decoder)),
-                Ok(None) => None,
-                Err(e) => Some((Err(e), decoder)),
+                Ok(Some(frame)) => Some((Ok(frame), Some(decoder))),
+                Ok(None) => None,               // EOF → end stream
+                Err(e) => Some((Err(e), None)), // error → yield once, then end
             }
         })
     }
@@ -105,5 +106,35 @@ mod tests {
             matches!(result, Err(DecodeError::FileNotFound { .. })),
             "expected FileNotFound"
         );
+    }
+
+    /// Verifies the `Option<S>` unfold pattern used by `into_stream`: after the
+    /// error arm sets state to `None`, the stream yields no further items.
+    ///
+    /// Acceptance criterion for issue #1006.
+    #[tokio::test]
+    async fn into_stream_state_machine_should_terminate_after_error() {
+        use futures::StreamExt;
+
+        // Use the exact same stream::unfold(Option<S>, ...) pattern as
+        // into_stream() with a controlled error at position 2.
+        let items: Vec<Result<u32, u32>> = stream::unfold(Some(0u32), |state| async move {
+            let n = state?; // None → stream ends
+            match n {
+                0 | 1 => Some((Ok(n), Some(n + 1))),
+                _ => Some((Err(n), None)), // error → yield once, then end
+            }
+        })
+        .collect()
+        .await;
+
+        assert_eq!(
+            items.len(),
+            3,
+            "stream must stop after the error: expected 2 Ok + 1 Err, got {items:?}"
+        );
+        assert!(items[0].is_ok());
+        assert!(items[1].is_ok());
+        assert!(items[2].is_err());
     }
 }

--- a/crates/ff-decode/tests/async_audio_decoder_tests.rs
+++ b/crates/ff-decode/tests/async_audio_decoder_tests.rs
@@ -81,6 +81,29 @@ async fn into_stream_drop_mid_stream_should_not_leak() {
     // AudioDecoder cleanup happens via Drop when stream is dropped here
 }
 
+/// Acceptance criterion for issue #1006: the stream must terminate after EOF
+/// and not continue polling indefinitely.  This tests the `Ok(None)` path of
+/// the fixed `into_stream` (the error-termination path is covered by the unit
+/// test in `async_decoder.rs`).
+#[tokio::test]
+async fn into_stream_should_terminate_at_eof() {
+    use futures::StreamExt;
+    let decoder = match AsyncAudioDecoder::open(test_audio_path()).await {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    // collect() must complete — an infinite stream would hang the test.
+    let frames: Vec<_> = decoder.into_stream().collect().await;
+    assert!(!frames.is_empty(), "expected at least one frame before EOF");
+    assert!(
+        frames.iter().all(|r| r.is_ok()),
+        "no errors expected for a valid file"
+    );
+}
+
 #[tokio::test]
 async fn async_audio_decode_sample_count_matches_sync() {
     use futures::StreamExt;

--- a/crates/ff-decode/tests/async_video_decoder_tests.rs
+++ b/crates/ff-decode/tests/async_video_decoder_tests.rs
@@ -81,6 +81,29 @@ async fn into_stream_drop_mid_stream_should_not_leak() {
     // FFmpeg cleanup happens via VideoDecoder::drop when stream is dropped here
 }
 
+/// Acceptance criterion for issue #1006: the stream must terminate after EOF
+/// and not continue polling indefinitely.  This tests the `Ok(None)` path of
+/// the fixed `into_stream` (the error-termination path is covered by the unit
+/// test in `async_decoder.rs`).
+#[tokio::test]
+async fn into_stream_should_terminate_at_eof() {
+    use futures::StreamExt;
+    let decoder = match AsyncVideoDecoder::open(test_video_path()).await {
+        Ok(d) => d,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    // collect() must complete — an infinite stream would hang the test.
+    let frames: Vec<_> = decoder.into_stream().collect().await;
+    assert!(!frames.is_empty(), "expected at least one frame before EOF");
+    assert!(
+        frames.iter().all(|r| r.is_ok()),
+        "no errors expected for a valid file"
+    );
+}
+
 #[tokio::test]
 async fn async_video_decode_frame_count_matches_sync() {
     use futures::StreamExt;


### PR DESCRIPTION
## Summary

`AsyncVideoDecoder::into_stream()` and `AsyncAudioDecoder::into_stream()` used `Self` as the `stream::unfold` state, so returning `Some((Err(e), decoder))` on an error kept the stream alive. A persistent error would therefore produce an infinite sequence of the same error, hanging callers that iterate with `while let Some(...) = stream.next().await`. The fix changes the state type to `Option<Self>` so the error arm returns `None` as the next state, causing the stream to terminate after yielding the error exactly once.

## Changes

- **Root cause**: `stream::unfold(self, ...)` with `Err` arm returning `Some((Err(e), decoder))` — decoder passed back as state meant the stream continued polling.
- **Fix**: changed to `stream::unfold(Some(self), ...)` with `let mut decoder = state?` at the top; the error arm now returns `Some((Err(e), None))`, so the next poll hits `state?` with `None` and immediately terminates.
- Applied identically to `AsyncVideoDecoder::into_stream` and `AsyncAudioDecoder::into_stream`.
- **Unit tests** added in both source files: `into_stream_state_machine_should_terminate_after_error` — exercises the exact `Option<S>` unfold pattern with a controlled error to verify the stream produces `N Ok + 1 Err` and no more items.
- **Integration tests** added in `tests/async_video_decoder_tests.rs` and `tests/async_audio_decoder_tests.rs`: `into_stream_should_terminate_at_eof` — drains a real stream with `collect()`, which would hang on a non-terminating stream.

## Related Issues

Fixes #1006

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes