### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.1] - 2026-04-16
+
+### Added
+
+#### ff-pipeline
+- `Clip::transition` field and xfade filter wiring in `Timeline::render` ([#1015](https://github.com/itsakeyfut/avio/issues/1015))
+- `Timeline::render_with_progress()` with per-frame progress callback and cancellation support ([#1016](https://github.com/itsakeyfut/avio/issues/1016))
+
+#### ff-preview
+- Audio-only file support in `PreviewPlayer::open()` and `run()` ([#1009](https://github.com/itsakeyfut/avio/issues/1009))
+- `set_rate()` and `rate_handle()` for runtime playback speed control ([#1014](https://github.com/itsakeyfut/avio/issues/1014))
+- `av_offset_handle()`: cloneable `Arc<AtomicI64>` handle for A/V offset from outside the player ([#1013](https://github.com/itsakeyfut/avio/issues/1013))
+- `current_pts()` and `duration()` for real-time position and file length queries ([#1012](https://github.com/itsakeyfut/avio/issues/1012))
+- `seek_coarse()` exposed at both `PreviewPlayer` and `AsyncPreviewPlayer` level ([#1011](https://github.com/itsakeyfut/avio/issues/1011))
+- `pause_handle()`: cloneable `Arc<AtomicBool>` handle for external pause control ([#1008](https://github.com/itsakeyfut/avio/issues/1008))
+
+### Changed
+
+#### ff-preview
+- `pause()` and `play()` now take `&self` instead of `&mut self` ([#1008](https://github.com/itsakeyfut/avio/issues/1008))
+- `pop_audio_samples()` receiver changed from `&mut self` to `&self` ([#1007](https://github.com/itsakeyfut/avio/issues/1007))
+
+### Fixed
+
+#### ff-decode
+- `into_stream` now terminates after the first error; subsequent polls return `None` ([#1006](https://github.com/itsakeyfut/avio/issues/1006))
+
+#### ff-encode
+- `PixelFormat::Other(v)` now passes through `pixel_format_to_av` without silently falling back to `yuv420p` ([#1018](https://github.com/itsakeyfut/avio/issues/1018))
+
+#### ff-filter
+- Insert explicit `format=yuv420p` filter before video buffersinks to prevent `gbrp` format negotiation on newer FFmpeg builds ([#1017](https://github.com/itsakeyfut/avio/issues/1017))
+
+---
+
 ## [0.13.0] - 2026-04-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,17 +12,17 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.13.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.13.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.13.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.13.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.13.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.13.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.13.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.13.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.13.0" }
-ff-preview  = { path = "crates/ff-preview", version = "0.13.0" }
-avio        = { path = "crates/avio",        version = "0.13.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.13.1" }
+ff-common   = { path = "crates/ff-common",   version = "0.13.1" }
+ff-format   = { path = "crates/ff-format",   version = "0.13.1" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.13.1" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.13.1" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.13.1" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.13.1" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.13.1" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.13.1" }
+ff-preview  = { path = "crates/ff-preview", version = "0.13.1" }
+avio        = { path = "crates/avio",        version = "0.13.1" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.13.0 to 0.13.1 and documents all post-release changes in CHANGELOG.md.

## Changes

- `Cargo.toml`: workspace version `0.13.0` → `0.13.1`; all intra-workspace dependency version pins updated
- `CHANGELOG.md`: add `[0.13.1]` entry covering 12 merged PRs (ff-decode, ff-encode, ff-filter, ff-pipeline, ff-preview)

## Related Issues

Fixes #1006
Fixes #1007
Fixes #1008
Fixes #1009
Fixes #1011
Fixes #1012
Fixes #1013
Fixes #1014
Fixes #1015
Fixes #1016
Fixes #1017
Fixes #1018

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes