### PR TITLE
feat(ff-filter): add Stabilizer::transform for vidstabtransform pass 2

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -259,11 +259,12 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 // ── filter feature ────────────────────────────────────────────────────────────
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack, BlendMode,
-    ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph, FilterGraphBuilder,
-    FilterStep, HwAccel, Keyframe, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer,
-    MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm, ToneMap, VideoConcatenator,
-    VideoLayer, XfadeTransition, YadifMode,
+    AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
+    BlendMode, ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
+    FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, Lerp, LoudnessMeter,
+    LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm,
+    StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition,
+    YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/effects/effects_inner.rs
+++ b/crates/ff-filter/src/effects/effects_inner.rs
@@ -4,6 +4,7 @@
 //!
 //! Current `unsafe` entry points:
 //! - [`analyze_vidstab_unsafe`] — motion analysis via `vidstabdetect` filter
+//! - [`transform_vidstab_unsafe`] — correction via `vidstabtransform` filter + encode
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
@@ -12,7 +13,7 @@ use std::ffi::CString;
 use std::path::Path;
 
 use crate::FilterError;
-use crate::effects::stabilizer::AnalyzeOptions;
+use crate::effects::stabilizer::{AnalyzeOptions, Interpolation, StabilizeOptions};
 
 /// Runs `vidstabdetect` motion analysis on `input`, writing the transform data
 /// to `output_trf`.
@@ -209,6 +210,496 @@ pub(super) unsafe fn analyze_vidstab_unsafe(
     log::info!(
         "stabilization analysis complete trf={}",
         output_trf.display()
+    );
+
+    Ok(())
+}
+
+// ── Pass 2 — transform ────────────────────────────────────────────────────────
+
+/// Drain all available encoded packets from `enc_ctx` into `out_ctx`, rescaling
+/// timestamps from `enc_tb` to the output stream's time base.
+///
+/// # Safety
+///
+/// - `enc_ctx` must be a valid, open `AVCodecContext` after at least one
+///   `avcodec_send_frame` call.
+/// - `pkt` must be a valid, allocated `AVPacket`.
+/// - `out_ctx` must be a valid `AVFormatContext` whose header has been written.
+unsafe fn drain_encoded_packets(
+    enc_ctx: *mut ff_sys::AVCodecContext,
+    pkt: *mut ff_sys::AVPacket,
+    out_ctx: *mut ff_sys::AVFormatContext,
+    stream_tb: ff_sys::AVRational,
+) {
+    while ff_sys::avcodec::receive_packet(enc_ctx, pkt).is_ok() {
+        // Read enc_tb at drain time — some encoders mutate time_base lazily.
+        let enc_tb = (*enc_ctx).time_base;
+        ff_sys::av_packet_rescale_ts(pkt, enc_tb, stream_tb);
+        (*pkt).stream_index = 0;
+        let ret = ff_sys::av_interleaved_write_frame(out_ctx, pkt);
+        ff_sys::av_packet_unref(pkt);
+        if ret < 0 {
+            log::warn!(
+                "av_interleaved_write_frame failed error={}",
+                ff_sys::av_error_string(ret)
+            );
+            break;
+        }
+    }
+}
+
+/// Runs `vidstabtransform` motion correction on `input` using the `.trf` file
+/// produced by [`analyze_vidstab_unsafe`], writing the result to `output`.
+///
+/// Filter graph: `movie={input} → vidstabtransform=... → format=yuv420p → buffersink`
+///
+/// Decoded frames are re-encoded with the best available H.264 encoder and
+/// multiplexed into `output` (format inferred from the file extension).
+///
+/// # Safety
+///
+/// All raw pointer operations follow the avfilter / avcodec / avformat ownership
+/// rules. Every allocated resource is freed on all exit paths:
+/// - `avfilter_graph_alloc()` / `avfilter_graph_free()` for the filter graph.
+/// - `avcodec_alloc_context3()` / `avcodec_free_context()` for the encoder.
+/// - `avformat_alloc_output_context2()` / `avformat_free_context()` for the muxer.
+/// - `avio_open()` / `avio_closep()` (via wrappers) for the output file I/O.
+/// - `av_frame_alloc()` / `av_frame_free()` and `av_packet_alloc()` /
+///   `av_packet_free()` for frame and packet lifetimes.
+pub(super) unsafe fn transform_vidstab_unsafe(
+    input: &Path,
+    trf_path: &Path,
+    output: &Path,
+    opts: &StabilizeOptions,
+) -> Result<(), FilterError> {
+    macro_rules! bail {
+        ($graph:ident, $code:expr, $msg:expr) => {{
+            let mut g = $graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::Ffmpeg {
+                code: $code,
+                message: format!("{}", $msg),
+            });
+        }};
+    }
+
+    // ── Pre-flight: check that vidstabtransform is available ──────────────────
+    let vstab_filt = ff_sys::avfilter_get_by_name(c"vidstabtransform".as_ptr());
+    if vstab_filt.is_null() {
+        return Err(FilterError::Ffmpeg {
+            code: 0,
+            message: "vidstabtransform filter not available in this FFmpeg build".to_string(),
+        });
+    }
+
+    // ── Build CString arguments before allocating the graph ───────────────────
+    let input_str = input.to_string_lossy();
+    let trf_str = trf_path.to_string_lossy();
+
+    let movie_args =
+        CString::new(format!("filename={input_str}")).map_err(|_| FilterError::Ffmpeg {
+            code: 0,
+            message: "input path contains null byte".to_string(),
+        })?;
+
+    let c_output =
+        CString::new(output.to_string_lossy().as_ref()).map_err(|_| FilterError::Ffmpeg {
+            code: 0,
+            message: "output path contains null byte".to_string(),
+        })?;
+
+    let crop_str = if opts.crop_black { "black" } else { "keep" };
+    let interpol_str = match opts.interpol {
+        Interpolation::Bilinear => "bilinear",
+        Interpolation::Bicubic => "bicubic",
+    };
+    let smoothing = opts.smoothing;
+    let zoom = opts.zoom;
+    let optzoom = opts.optzoom.clamp(0, 2);
+
+    let vstab_args = CString::new(format!(
+        "input={trf_str}:smoothing={smoothing}:crop={crop_str}:zoom={zoom}:optzoom={optzoom}:interpol={interpol_str}"
+    ))
+    .map_err(|_| FilterError::Ffmpeg {
+        code: 0,
+        message: "trf path contains null byte".to_string(),
+    })?;
+
+    // ── Allocate the filter graph ─────────────────────────────────────────────
+    let graph = ff_sys::avfilter_graph_alloc();
+    if graph.is_null() {
+        return Err(FilterError::Ffmpeg {
+            code: 0,
+            message: "avfilter_graph_alloc failed".to_string(),
+        });
+    }
+
+    // ── 1. movie source ───────────────────────────────────────────────────────
+    let movie_filt = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
+    if movie_filt.is_null() {
+        bail!(graph, 0, "filter not found: movie");
+    }
+    let mut src_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut src_ctx,
+        movie_filt,
+        c"vstab_t_src".as_ptr(),
+        movie_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, ret, format!("movie create_filter failed code={ret}"));
+    }
+
+    // ── 2. vidstabtransform ───────────────────────────────────────────────────
+    log::debug!(
+        "filter added name=vidstabtransform args={}",
+        vstab_args.to_string_lossy()
+    );
+    let mut vstab_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut vstab_ctx,
+        vstab_filt,
+        c"vstab_t_filter".as_ptr(),
+        vstab_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            ret,
+            format!("vidstabtransform create_filter failed code={ret}")
+        );
+    }
+
+    // ── 3. format — normalize to yuv420p for encoder compatibility ────────────
+    let format_filt = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if format_filt.is_null() {
+        bail!(graph, 0, "filter not found: format");
+    }
+    let mut fmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut fmt_ctx,
+        format_filt,
+        c"vstab_t_fmt".as_ptr(),
+        c"pix_fmts=yuv420p".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            ret,
+            format!("format create_filter failed code={ret}")
+        );
+    }
+
+    // ── 4. buffersink ─────────────────────────────────────────────────────────
+    let buffersink_filt = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
+    if buffersink_filt.is_null() {
+        bail!(graph, 0, "filter not found: buffersink");
+    }
+    let mut sink_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sink_ctx,
+        buffersink_filt,
+        c"vstab_t_sink".as_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            ret,
+            format!("buffersink create_filter failed code={ret}")
+        );
+    }
+
+    // ── Link: movie → vidstabtransform → format → buffersink ─────────────────
+    let ret = ff_sys::avfilter_link(src_ctx, 0, vstab_ctx, 0);
+    if ret < 0 {
+        bail!(
+            graph,
+            ret,
+            format!("avfilter_link movie→vidstabtransform failed code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(vstab_ctx, 0, fmt_ctx, 0);
+    if ret < 0 {
+        bail!(
+            graph,
+            ret,
+            format!("avfilter_link vidstabtransform→format failed code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(fmt_ctx, 0, sink_ctx, 0);
+    if ret < 0 {
+        bail!(
+            graph,
+            ret,
+            format!("avfilter_link format→buffersink failed code={ret}")
+        );
+    }
+
+    // ── Configure the graph — opens input file and validates the trf path ─────
+    let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
+    if ret < 0 {
+        bail!(
+            graph,
+            ret,
+            format!(
+                "avfilter_graph_config failed code={ret} message={}",
+                ff_sys::av_error_string(ret)
+            )
+        );
+    }
+
+    // After graph config the output time base is stable.
+    let filter_tb = ff_sys::av_buffersink_get_time_base(sink_ctx);
+
+    // ── From here manual cleanup is required (encoder + muxer are allocated) ──
+
+    // Pull the first frame to discover frame dimensions.
+    let first_frame = ff_sys::av_frame_alloc();
+    if first_frame.is_null() {
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code: 0,
+            message: "av_frame_alloc failed".to_string(),
+        });
+    }
+    let ret = ff_sys::av_buffersink_get_frame(sink_ctx, first_frame);
+    if ret < 0 {
+        let mut fp = first_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code: ret,
+            message: format!(
+                "first frame pull failed code={ret} message={}",
+                ff_sys::av_error_string(ret)
+            ),
+        });
+    }
+    let frame_width = (*first_frame).width;
+    let frame_height = (*first_frame).height;
+
+    // ── Find the best available H.264 encoder ─────────────────────────────────
+    let enc_codec = {
+        let candidates: &[&std::ffi::CStr] = &[
+            c"h264_nvenc",
+            c"h264_qsv",
+            c"h264_amf",
+            c"h264_videotoolbox",
+            c"libx264",
+            c"mpeg4",
+        ];
+        let mut found: Option<*const ff_sys::AVCodec> = None;
+        for name in candidates {
+            if let Some(c) = ff_sys::avcodec::find_encoder_by_name(name.as_ptr()) {
+                log::info!(
+                    "stabilization transform selected encoder encoder={}",
+                    name.to_string_lossy()
+                );
+                found = Some(c);
+                break;
+            }
+        }
+        if let Some(c) = found {
+            c
+        } else {
+            let mut fp = first_frame;
+            ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+            let mut g = graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: "no H.264 encoder available (tried h264_nvenc, libx264, mpeg4, etc.)"
+                    .to_string(),
+            });
+        }
+    };
+
+    // ── Allocate and configure the encoder context ────────────────────────────
+    let mut enc_ctx = match ff_sys::avcodec::alloc_context3(enc_codec) {
+        Ok(ctx) => ctx,
+        Err(code) => {
+            let mut fp = first_frame;
+            ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+            let mut g = graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::Ffmpeg {
+                code,
+                message: "avcodec_alloc_context3 failed".to_string(),
+            });
+        }
+    };
+
+    (*enc_ctx).width = frame_width;
+    (*enc_ctx).height = frame_height;
+    (*enc_ctx).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
+    (*enc_ctx).time_base = filter_tb;
+
+    if let Err(code) = ff_sys::avcodec::open2(enc_ctx, enc_codec, std::ptr::null_mut()) {
+        let mut fp = first_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+        ff_sys::avcodec::free_context(&raw mut enc_ctx);
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code,
+            message: format!("avcodec_open2 failed code={code}"),
+        });
+    }
+
+    // ── Allocate the output format context ────────────────────────────────────
+    let mut out_ctx: *mut ff_sys::AVFormatContext = std::ptr::null_mut();
+    let ret = ff_sys::avformat_alloc_output_context2(
+        &raw mut out_ctx,
+        std::ptr::null_mut(),
+        std::ptr::null(),
+        c_output.as_ptr(),
+    );
+    if ret < 0 || out_ctx.is_null() {
+        let mut fp = first_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+        ff_sys::avcodec::free_context(&raw mut enc_ctx);
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code: ret,
+            message: format!("avformat_alloc_output_context2 failed code={ret}"),
+        });
+    }
+
+    // ── Add video stream and copy codec parameters ────────────────────────────
+    let out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
+    if out_stream.is_null() {
+        let mut fp = first_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+        ff_sys::avcodec::free_context(&raw mut enc_ctx);
+        ff_sys::avformat_free_context(out_ctx);
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code: 0,
+            message: "avformat_new_stream failed".to_string(),
+        });
+    }
+
+    if let Err(code) = ff_sys::avcodec::parameters_from_context((*out_stream).codecpar, enc_ctx) {
+        let mut fp = first_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+        ff_sys::avcodec::free_context(&raw mut enc_ctx);
+        ff_sys::avformat_free_context(out_ctx);
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code,
+            message: format!("avcodec_parameters_from_context failed code={code}"),
+        });
+    }
+
+    // ── Open the output file ──────────────────────────────────────────────────
+    let pb = match ff_sys::avformat::open_output(output, ff_sys::avformat::avio_flags::WRITE) {
+        Ok(pb) => pb,
+        Err(code) => {
+            let mut fp = first_frame;
+            ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+            ff_sys::avcodec::free_context(&raw mut enc_ctx);
+            ff_sys::avformat_free_context(out_ctx);
+            let mut g = graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::Ffmpeg {
+                code,
+                message: format!("avio_open failed code={code}"),
+            });
+        }
+    };
+    (*out_ctx).pb = pb;
+
+    // ── Write container header ────────────────────────────────────────────────
+    let ret = ff_sys::avformat_write_header(out_ctx, std::ptr::null_mut());
+    if ret < 0 {
+        let mut fp = first_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+        ff_sys::avcodec::free_context(&raw mut enc_ctx);
+        ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+        ff_sys::avformat_free_context(out_ctx);
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code: ret,
+            message: format!("avformat_write_header failed code={ret}"),
+        });
+    }
+
+    // Read stream time base AFTER write_header — the muxer may adjust it.
+    let stream_tb = (*out_stream).time_base;
+
+    // ── Allocate encode packet ────────────────────────────────────────────────
+    let mut pkt = ff_sys::av_packet_alloc();
+    if pkt.is_null() {
+        let mut fp = first_frame;
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+        ff_sys::avcodec::free_context(&raw mut enc_ctx);
+        ff_sys::av_write_trailer(out_ctx);
+        ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+        ff_sys::avformat_free_context(out_ctx);
+        let mut g = graph;
+        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(FilterError::Ffmpeg {
+            code: 0,
+            message: "av_packet_alloc failed".to_string(),
+        });
+    }
+
+    // ── Encode first frame ────────────────────────────────────────────────────
+    let _ = ff_sys::avcodec::send_frame(enc_ctx, first_frame);
+    drain_encoded_packets(enc_ctx, pkt, out_ctx, stream_tb);
+    let mut fp = first_frame;
+    ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+
+    // ── Encode remaining frames from the filter graph ─────────────────────────
+    loop {
+        let frame = ff_sys::av_frame_alloc();
+        if frame.is_null() {
+            break;
+        }
+        let ret = ff_sys::av_buffersink_get_frame(sink_ctx, frame);
+        let mut fp = frame;
+        if ret < 0 {
+            ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+            break;
+        }
+        let _ = ff_sys::avcodec::send_frame(enc_ctx, frame);
+        drain_encoded_packets(enc_ctx, pkt, out_ctx, stream_tb);
+        ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
+    }
+
+    // ── Flush the encoder ─────────────────────────────────────────────────────
+    let _ = ff_sys::avcodec::send_frame(enc_ctx, std::ptr::null());
+    drain_encoded_packets(enc_ctx, pkt, out_ctx, stream_tb);
+
+    // ── Finalize output ───────────────────────────────────────────────────────
+    ff_sys::av_packet_free(&raw mut pkt);
+    ff_sys::avcodec::free_context(&raw mut enc_ctx);
+    ff_sys::av_write_trailer(out_ctx);
+    ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
+    ff_sys::avformat_free_context(out_ctx);
+
+    let mut g = graph;
+    ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+
+    log::info!(
+        "stabilization transform complete output={}",
+        output.display()
     );
 
     Ok(())

--- a/crates/ff-filter/src/effects/mod.rs
+++ b/crates/ff-filter/src/effects/mod.rs
@@ -7,4 +7,4 @@
 pub(crate) mod effects_inner;
 mod stabilizer;
 
-pub use stabilizer::{AnalyzeOptions, Stabilizer};
+pub use stabilizer::{AnalyzeOptions, Interpolation, StabilizeOptions, Stabilizer};

--- a/crates/ff-filter/src/effects/stabilizer.rs
+++ b/crates/ff-filter/src/effects/stabilizer.rs
@@ -27,19 +27,56 @@ impl Default for AnalyzeOptions {
     }
 }
 
+/// Interpolation algorithm used by [`Stabilizer::transform`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interpolation {
+    /// Bilinear interpolation (faster, default).
+    Bilinear,
+    /// Bicubic interpolation (higher quality, slower).
+    Bicubic,
+}
+
+/// Options for the second stabilization pass (transform application).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StabilizeOptions {
+    /// Temporal smoothing radius in frames 0–500 (default: 10).
+    pub smoothing: u16,
+    /// Fill stabilization borders with black instead of previous-frame content
+    /// (default: true).
+    pub crop_black: bool,
+    /// Zoom factor: 0.0 = no zoom, positive = fixed zoom-in (default: 0.0).
+    pub zoom: f32,
+    /// Optimal zoom: 0 = disabled, 1 = auto-static, 2 = adaptive (default: 0).
+    pub optzoom: u8,
+    /// Pixel interpolation algorithm (default: [`Interpolation::Bilinear`]).
+    pub interpol: Interpolation,
+}
+
+impl Default for StabilizeOptions {
+    fn default() -> Self {
+        Self {
+            smoothing: 10,
+            crop_black: true,
+            zoom: 0.0,
+            optzoom: 0,
+            interpol: Interpolation::Bilinear,
+        }
+    }
+}
+
 /// Two-pass video stabilization using `FFmpeg`'s `vidstabdetect` /
 /// `vidstabtransform` filters.
 ///
 /// **Pass 1**: [`Stabilizer::analyze`] — motion analysis, produces a `.trf` file.
-/// **Pass 2**: `Stabilizer::transform` (issue #393) — correction, consumes the `.trf` file.
+/// **Pass 2**: [`Stabilizer::transform`] — correction, consumes the `.trf` file.
 pub struct Stabilizer;
 
 impl Stabilizer {
     /// Analyze motion in `input` and write the transform file to `output_trf`.
     ///
     /// Runs a self-contained `FFmpeg` filter graph:
-    /// `movie → vidstabdetect → nullsink`.
-    /// The resulting `.trf` file is consumed by `Stabilizer::transform` in pass 2.
+    /// `movie → vidstabdetect → buffersink`.
+    /// The resulting `.trf` file is consumed by [`Stabilizer::transform`] in pass 2.
     ///
     /// # Errors
     ///
@@ -55,9 +92,35 @@ impl Stabilizer {
         // SAFETY: analyze_vidstab_unsafe manages all raw pointer lifetimes
         // under the avfilter ownership rules: graph allocated with
         // avfilter_graph_alloc(), built and configured, drained via
-        // avfilter_graph_request_oldest(), then freed before returning.
+        // av_buffersink_get_frame(), then freed before returning.
         // All CString values are kept alive for the duration of the graph build.
         unsafe { super::effects_inner::analyze_vidstab_unsafe(input, output_trf, opts) }
+    }
+
+    /// Apply motion transforms from the `.trf` file produced by [`Stabilizer::analyze`].
+    ///
+    /// Reads `input`, applies `vidstabtransform`, and writes the stabilized video
+    /// to `output` (re-encoded with the best available H.264 encoder).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if:
+    /// - `vidstabtransform` is not available in the linked `FFmpeg` build.
+    /// - `trf_path` does not exist or is unreadable.
+    /// - The input file is unreadable or does not exist.
+    /// - The output file cannot be created or encoded.
+    pub fn transform(
+        input: &Path,
+        trf_path: &Path,
+        output: &Path,
+        opts: &StabilizeOptions,
+    ) -> Result<(), FilterError> {
+        // SAFETY: transform_vidstab_unsafe manages all raw pointer lifetimes:
+        // - avfilter graph is allocated, built, drained, then freed.
+        // - AVCodecContext is allocated, opened, flushed, then freed.
+        // - AVFormatContext is allocated, written to, trailer flushed, then freed.
+        // All CString values are kept alive for the duration of each operation.
+        unsafe { super::effects_inner::transform_vidstab_unsafe(input, trf_path, output, opts) }
     }
 }
 
@@ -71,5 +134,15 @@ mod tests {
         assert_eq!(opts.shakiness, 5);
         assert_eq!(opts.accuracy, 15);
         assert_eq!(opts.stepsize, 6);
+    }
+
+    #[test]
+    fn stabilize_options_default_should_have_expected_values() {
+        let opts = StabilizeOptions::default();
+        assert_eq!(opts.smoothing, 10);
+        assert!(opts.crop_black);
+        assert!((opts.zoom - 0.0_f32).abs() < f32::EPSILON);
+        assert_eq!(opts.optzoom, 0);
+        assert_eq!(opts.interpol, Interpolation::Bilinear);
     }
 }

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -42,7 +42,7 @@ pub mod graph;
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
 pub use animation::{AnimatedValue, AnimationEntry, AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
-pub use effects::{AnalyzeOptions, Stabilizer};
+pub use effects::{AnalyzeOptions, Interpolation, StabilizeOptions, Stabilizer};
 pub use error::FilterError;
 pub use graph::{
     AudioConcatenator, AudioTrack, ClipJoiner, ClipTransition, DrawTextOptions, EqBand,

--- a/crates/ff-filter/tests/stabilizer_tests.rs
+++ b/crates/ff-filter/tests/stabilizer_tests.rs
@@ -1,10 +1,10 @@
-//! Integration tests for `Stabilizer::analyze` (vidstabdetect pass 1).
+//! Integration tests for `Stabilizer::analyze` (pass 1) and `Stabilizer::transform` (pass 2).
 
 mod fixtures;
 
 use std::path::PathBuf;
 
-use ff_filter::{AnalyzeOptions, FilterError, Stabilizer};
+use ff_filter::{AnalyzeOptions, FilterError, Interpolation, StabilizeOptions, Stabilizer};
 use fixtures::{FileGuard, make_source_file, test_output_path};
 
 /// Verifies that `Stabilizer::analyze` produces a non-empty `.trf` file when
@@ -79,4 +79,129 @@ fn analyze_nonexistent_input_should_return_ffmpeg_error() {
         Err(e) => panic!("expected FilterError::Ffmpeg, got {e:?}"),
         Ok(()) => panic!("expected error for non-existent input, got Ok(())"),
     }
+}
+
+// ── Pass 2 — transform tests ──────────────────────────────────────────────────
+
+/// Verifies that `Stabilizer::transform` produces a non-empty output file when
+/// run through both passes against a valid synthetic video clip.
+///
+/// Acceptance criterion for issue #393.
+#[test]
+fn transform_should_produce_valid_output_file() {
+    const W: u32 = 64;
+    const H: u32 = 64;
+    const FPS: f64 = 30.0;
+    const FRAMES: usize = 15;
+
+    let src_path = test_output_path("vstab_t_src.mp4");
+    let trf_path = test_output_path("vstab_t_out.trf");
+    let out_path = test_output_path("vstab_t_output.mp4");
+
+    let _src_guard = FileGuard::new(src_path.clone());
+    let _trf_guard = FileGuard::new(trf_path.clone());
+    let _out_guard = FileGuard::new(out_path.clone());
+
+    if make_source_file(&src_path, W, H, FPS, FRAMES, 128, 128, 128).is_none() {
+        println!("Skipping: source encoder unavailable");
+        return;
+    }
+
+    // Pass 1: analyze
+    match Stabilizer::analyze(&src_path, &trf_path, &AnalyzeOptions::default()) {
+        Err(FilterError::Ffmpeg { ref message, .. })
+            if message.contains("not available in this FFmpeg build") =>
+        {
+            println!("Skipping: vidstabdetect not available: {message}");
+            return;
+        }
+        Err(e) => panic!("analyze failed unexpectedly: {e}"),
+        Ok(()) => {}
+    }
+
+    // Pass 2: transform
+    let result = Stabilizer::transform(
+        &src_path,
+        &trf_path,
+        &out_path,
+        &StabilizeOptions::default(),
+    );
+
+    match result {
+        Err(FilterError::Ffmpeg { ref message, .. })
+            if message.contains("not available in this FFmpeg build") =>
+        {
+            println!("Skipping: vidstabtransform not available: {message}");
+            return;
+        }
+        Err(FilterError::Ffmpeg { ref message, .. })
+            if message.contains("no H.264 encoder available") =>
+        {
+            println!("Skipping: no H.264 encoder available: {message}");
+            return;
+        }
+        Err(e) => panic!("transform failed unexpectedly: {e}"),
+        Ok(()) => {}
+    }
+
+    assert!(
+        out_path.exists(),
+        "output file should exist after transform: {out_path:?}"
+    );
+    let size = std::fs::metadata(&out_path)
+        .expect("metadata read failed")
+        .len();
+    assert!(
+        size > 0,
+        "output file should be non-empty (got {size} bytes)"
+    );
+}
+
+/// Verifies that `Stabilizer::transform` returns `Err(FilterError::Ffmpeg { .. })`
+/// when the `.trf` file does not exist.
+///
+/// Acceptance criterion for issue #393.
+#[test]
+fn transform_nonexistent_trf_should_return_ffmpeg_error() {
+    let src_path = test_output_path("vstab_t_err_src.mp4");
+    let out_path = test_output_path("vstab_t_err_out.mp4");
+
+    let _src_guard = FileGuard::new(src_path.clone());
+    let _out_guard = FileGuard::new(out_path.clone());
+
+    if make_source_file(&src_path, 64, 64, 30.0, 5, 128, 128, 128).is_none() {
+        println!("Skipping: source encoder unavailable");
+        return;
+    }
+
+    let result = Stabilizer::transform(
+        &src_path,
+        &PathBuf::from("no_such_trf_99999.trf"),
+        &out_path,
+        &StabilizeOptions::default(),
+    );
+
+    match result {
+        Err(FilterError::Ffmpeg { ref message, .. })
+            if message.contains("not available in this FFmpeg build") =>
+        {
+            println!("Skipping: vidstabtransform not available: {message}");
+        }
+        Err(FilterError::Ffmpeg { .. }) => {
+            // Expected: FFmpeg reported an error (trf file not found).
+        }
+        Err(e) => panic!("expected FilterError::Ffmpeg, got {e:?}"),
+        Ok(()) => panic!("expected error for non-existent trf, got Ok(())"),
+    }
+}
+
+/// Verifies that `StabilizeOptions::default()` has the documented field values.
+#[test]
+fn stabilize_options_default_should_have_expected_values() {
+    let opts = StabilizeOptions::default();
+    assert_eq!(opts.smoothing, 10);
+    assert!(opts.crop_black);
+    assert!((opts.zoom - 0.0_f32).abs() < f32::EPSILON);
+    assert_eq!(opts.optzoom, 0);
+    assert_eq!(opts.interpol, Interpolation::Bilinear);
 }


### PR DESCRIPTION
## Summary

Implements `Stabilizer::transform` — pass 2 of two-pass video stabilization. Reads the `.trf` motion-transform file produced by `Stabilizer::analyze`, applies `vidstabtransform` via a self-contained lavfi graph (`movie → vidstabtransform → format=yuv420p → buffersink`), then re-encodes the stabilized frames with the best available H.264 encoder and writes the result to the specified output file.

## Changes

- `effects/stabilizer.rs`: add `Interpolation` enum, `StabilizeOptions` struct with `Default`, and `Stabilizer::transform()` method
- `effects/effects_inner.rs`: add `transform_vidstab_unsafe()` with full lavfi graph + encode pipeline, plus `drain_encoded_packets()` helper; all resources freed on every exit path
- `effects/mod.rs`, `src/lib.rs`, `avio/src/lib.rs`: re-export `Interpolation`, `StabilizeOptions`, `Stabilizer` (also adds previously missing `AnalyzeOptions`/`Stabilizer` re-exports to `avio`)
- `tests/stabilizer_tests.rs`: add `transform_should_produce_valid_output_file`, `transform_nonexistent_trf_should_return_ffmpeg_error`, and `stabilize_options_default_should_have_expected_values` tests; both filter-unavailable and encoder-unavailable paths skip gracefully

## Related Issues

Closes #393

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes