### PR TITLE
feat(ff-filter): add FilterGraph::lens_correction for radial distortion

### DIFF
--- a/crates/ff-filter/src/effects/video_effects.rs
+++ b/crates/ff-filter/src/effects/video_effects.rs
@@ -42,6 +42,34 @@ impl FilterGraph {
         Ok(self)
     }
 
+    /// Correct radial lens distortion using two polynomial coefficients.
+    ///
+    /// `k1` and `k2` are the first- and second-order radial distortion
+    /// coefficients. Negative values correct barrel distortion; positive values
+    /// correct pincushion distortion.
+    ///
+    /// Uses `FFmpeg`'s `lenscorrection` filter.
+    ///
+    /// Call this method after [`FilterGraph::builder()`] / [`build()`] but
+    /// **before** the first [`push_video`] call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if either coefficient is outside [−1.0, 1.0].
+    ///
+    /// [`build()`]: crate::FilterGraphBuilder::build
+    /// [`push_video`]: FilterGraph::push_video
+    pub fn lens_correction(&mut self, k1: f32, k2: f32) -> Result<&mut Self, FilterError> {
+        if !(-1.0..=1.0).contains(&k1) || !(-1.0..=1.0).contains(&k2) {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("k1/k2 must be in −1.0..=1.0, got k1={k1} k2={k2}"),
+            });
+        }
+        self.inner.push_step(FilterStep::LensCorrection { k1, k2 });
+        Ok(self)
+    }
+
     /// Add random per-frame film grain to luma and chroma channels.
     ///
     /// `luma_strength` and `chroma_strength` control grain intensity and are
@@ -146,6 +174,65 @@ mod tests {
             args.contains("A*0.5+B*0.5"),
             "180° shutter angle must produce equal blend (A*0.5+B*0.5): {args}"
         );
+    }
+
+    // ── lens_correction ───────────────────────────────────────────────────────
+
+    #[test]
+    fn lens_correction_with_valid_coefficients_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.lens_correction(-0.2, 0.0);
+        assert!(
+            result.is_ok(),
+            "lens_correction(-0.2, 0.0) must succeed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn lens_correction_identity_k1_zero_k2_zero_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.lens_correction(0.0, 0.0);
+        assert!(
+            result.is_ok(),
+            "lens_correction(0.0, 0.0) identity must succeed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn lens_correction_k1_out_of_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.lens_correction(1.5, 0.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "k1=1.5 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn lens_correction_k2_out_of_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.lens_correction(0.0, -1.5);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "k2=-1.5 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn filter_step_lens_correction_should_have_lenscorrection_filter_name() {
+        let step = FilterStep::LensCorrection { k1: -0.2, k2: 0.0 };
+        assert_eq!(step.filter_name(), "lenscorrection");
+    }
+
+    #[test]
+    fn lens_correction_args_should_contain_k1_and_k2() {
+        let step = FilterStep::LensCorrection { k1: -0.2, k2: 0.1 };
+        let args = step.args();
+        assert!(
+            args.contains("k1=-0.2"),
+            "args must contain k1=-0.2: {args}"
+        );
+        assert!(args.contains("k2=0.1"), "args must contain k2=0.1: {args}");
     }
 
     // ── film_grain ────────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -607,6 +607,19 @@ pub enum FilterStep {
         sub_frames: u8,
     },
 
+    /// Correct radial lens distortion using two polynomial coefficients via
+    /// `FFmpeg`'s `lenscorrection` filter.
+    ///
+    /// Negative values correct barrel distortion; positive values correct
+    /// pincushion distortion. Both `k1` and `k2` must be in [−1.0, 1.0];
+    /// validated by [`FilterGraph::lens_correction`](crate::FilterGraph::lens_correction).
+    LensCorrection {
+        /// First-order radial distortion coefficient. Range: [−1.0, 1.0].
+        k1: f32,
+        /// Second-order radial distortion coefficient. Range: [−1.0, 1.0].
+        k2: f32,
+    },
+
     /// Add synthetic per-frame random film grain to luma and chroma channels
     /// via `FFmpeg`'s `noise` filter.
     ///
@@ -765,6 +778,7 @@ impl FilterStep {
             Self::CropAnimated { .. } => "crop",
             Self::GBlurAnimated { .. } => "gblur",
             Self::MotionBlur { .. } => "tblend",
+            Self::LensCorrection { .. } => "lenscorrection",
             Self::FilmGrain { .. } => "noise",
         }
     }
@@ -1169,6 +1183,7 @@ impl FilterStep {
                 let blend = alpha;
                 format!("all_expr='A*{keep}+B*{blend}'")
             }
+            Self::LensCorrection { k1, k2 } => format!("k1={k1}:k2={k2}"),
             Self::FilmGrain {
                 luma_strength,
                 chroma_strength,


### PR DESCRIPTION
## Summary

Adds `FilterGraph::lens_correction(k1, k2)`, which corrects radial barrel or pincushion lens distortion using FFmpeg's `lenscorrection` filter. Negative coefficients correct barrel distortion; positive correct pincushion. Both coefficients are validated to be in [−1.0, 1.0].

## Changes

- `FilterStep::LensCorrection { k1, k2 }` — new variant; `filter_name()` → `"lenscorrection"`, `args()` produces `k1={k1}:k2={k2}`
- `FilterGraph::lens_correction(&mut self, k1, k2) -> Result<&mut Self, FilterError>` in `effects/video_effects.rs` — validates range, returns `FilterError::Ffmpeg { code: 0 }` on out-of-range input
- 6 unit tests: valid barrel/pincushion coefficients, identity (0, 0), k1 out-of-range, k2 out-of-range, filter name, args content

## Related Issues

Closes #397

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes