### PR TITLE
feat(ff-filter): add LensProfile enum and FilterGraph::lens_profile

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -261,10 +261,10 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 pub use ff_filter::{
     AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
     BlendMode, ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
-    FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, Lerp, LoudnessMeter,
-    LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, QualityMetrics, Rgb, ScaleAlgorithm,
-    StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition,
-    YadifMode,
+    FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile, Lerp,
+    LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, QualityMetrics, Rgb,
+    ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer,
+    XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/effects/lens_profile.rs
+++ b/crates/ff-filter/src/effects/lens_profile.rs
@@ -1,0 +1,90 @@
+//! Predefined lens distortion correction profiles for common cameras.
+
+/// Predefined lens distortion correction profiles for common cameras.
+///
+/// Each variant stores the radial coefficients (`k1`, `k2`) and a `scale`
+/// factor that zooms slightly to hide the warped border pixels left after
+/// correction.
+///
+/// Use with [`FilterGraph::lens_profile`](crate::FilterGraph::lens_profile).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LensProfile {
+    /// `GoPro` Hero 9 / 10 / 11 wide-angle mode (heavy barrel distortion).
+    GoproHero9Wide,
+    /// `GoPro` Hero 11 linear mode (mild distortion).
+    GoproHero11Linear,
+    /// Apple iPhone 14 Pro main camera (mild barrel).
+    Iphone14ProMain,
+    /// DJI Mini 3 Pro wide-angle lens.
+    DjiMini3ProWide,
+    /// User-supplied coefficients for any other camera.
+    Custom {
+        /// First-order radial coefficient (−1.0 to 1.0).
+        k1: f32,
+        /// Second-order radial coefficient (−1.0 to 1.0).
+        k2: f32,
+        /// Uniform scale applied after correction to hide warped border pixels.
+        /// 1.0 = no scale.
+        scale: f32,
+    },
+}
+
+impl LensProfile {
+    /// Return `(k1, k2, scale)` for this profile.
+    pub fn coefficients(&self) -> (f32, f32, f32) {
+        match self {
+            Self::GoproHero9Wide => (-0.21, 0.05, 1.05),
+            Self::GoproHero11Linear => (-0.04, 0.01, 1.01),
+            Self::Iphone14ProMain => (-0.03, 0.00, 1.01),
+            Self::DjiMini3ProWide => (-0.16, 0.03, 1.03),
+            Self::Custom { k1, k2, scale } => (*k1, *k2, *scale),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gopro_hero9_wide_should_have_expected_coefficients() {
+        let (k1, k2, scale) = LensProfile::GoproHero9Wide.coefficients();
+        assert!((k1 - (-0.21_f32)).abs() < f32::EPSILON);
+        assert!((k2 - 0.05_f32).abs() < f32::EPSILON);
+        assert!((scale - 1.05_f32).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn iphone14_pro_main_should_have_expected_coefficients() {
+        let (k1, k2, scale) = LensProfile::Iphone14ProMain.coefficients();
+        assert!((k1 - (-0.03_f32)).abs() < f32::EPSILON);
+        assert!((k2 - 0.00_f32).abs() < f32::EPSILON);
+        assert!((scale - 1.01_f32).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn custom_should_return_supplied_values() {
+        let (k1, k2, scale) = LensProfile::Custom {
+            k1: -0.1,
+            k2: 0.02,
+            scale: 1.02,
+        }
+        .coefficients();
+        assert!((k1 - (-0.1_f32)).abs() < f32::EPSILON);
+        assert!((k2 - 0.02_f32).abs() < f32::EPSILON);
+        assert!((scale - 1.02_f32).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn custom_identity_should_return_zero_k1_k2_and_unit_scale() {
+        let (k1, k2, scale) = LensProfile::Custom {
+            k1: 0.0,
+            k2: 0.0,
+            scale: 1.0,
+        }
+        .coefficients();
+        assert!((k1 - 0.0_f32).abs() < f32::EPSILON);
+        assert!((k2 - 0.0_f32).abs() < f32::EPSILON);
+        assert!((scale - 1.0_f32).abs() < f32::EPSILON);
+    }
+}

--- a/crates/ff-filter/src/effects/mod.rs
+++ b/crates/ff-filter/src/effects/mod.rs
@@ -4,9 +4,12 @@
 //!   `vidstabtransform` (whole-file).
 //! - [`FilterGraph::motion_blur`](crate::FilterGraph::motion_blur) — shutter-angle
 //!   motion blur via `tblend` (frame-level, extends [`crate::FilterGraph`]).
+//! - [`LensProfile`] — predefined lens distortion correction profiles for common cameras.
 
 pub(crate) mod effects_inner;
+pub mod lens_profile;
 mod stabilizer;
 mod video_effects;
 
+pub use lens_profile::LensProfile;
 pub use stabilizer::{AnalyzeOptions, Interpolation, StabilizeOptions, Stabilizer};

--- a/crates/ff-filter/src/effects/video_effects.rs
+++ b/crates/ff-filter/src/effects/video_effects.rs
@@ -1,5 +1,6 @@
 //! Frame-level video effects added to [`FilterGraph`] after construction.
 
+use crate::effects::lens_profile::LensProfile;
 use crate::error::FilterError;
 use crate::graph::FilterGraph;
 use crate::graph::filter_step::FilterStep;
@@ -91,10 +92,32 @@ impl FilterGraph {
         });
         self
     }
+
+    /// Apply a predefined camera lens distortion correction profile.
+    ///
+    /// Looks up the radial coefficients (`k1`, `k2`) and `scale` from the
+    /// profile and pushes a `lenscorrection` step followed by a `scale` step
+    /// that zooms slightly to hide the warped border pixels.
+    ///
+    /// Uses `FFmpeg`'s `lenscorrection` and `scale` filters.
+    ///
+    /// Call this method after [`FilterGraph::builder()`] / [`build()`] but
+    /// **before** the first [`push_video`] call.
+    ///
+    /// [`build()`]: crate::FilterGraphBuilder::build
+    /// [`push_video`]: FilterGraph::push_video
+    pub fn lens_profile(&mut self, profile: LensProfile) -> &mut Self {
+        let (k1, k2, scale) = profile.coefficients();
+        self.inner.push_step(FilterStep::LensCorrection { k1, k2 });
+        self.inner
+            .push_step(FilterStep::ScaleMultiplier { factor: scale });
+        self
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::effects::lens_profile::LensProfile;
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
 
@@ -305,5 +328,45 @@ mod tests {
         };
         let args = step.args();
         assert_eq!(args, "alls=0:c0s=0:c1s=0:allf=t");
+    }
+
+    // ── lens_profile ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn lens_profile_gopro_hero9_wide_should_push_two_steps() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.lens_profile(LensProfile::GoproHero9Wide);
+        let _ = result; // returns &mut Self
+    }
+
+    #[test]
+    fn lens_profile_custom_should_push_lens_correction_step() {
+        let step = FilterStep::LensCorrection { k1: -0.1, k2: 0.02 };
+        assert_eq!(step.filter_name(), "lenscorrection");
+        assert!(step.args().contains("k1=-0.1"));
+        assert!(step.args().contains("k2=0.02"));
+    }
+
+    #[test]
+    fn lens_profile_scale_multiplier_should_have_scale_filter_name() {
+        let step = FilterStep::ScaleMultiplier { factor: 1.05 };
+        assert_eq!(step.filter_name(), "scale");
+    }
+
+    #[test]
+    fn lens_profile_scale_multiplier_args_should_contain_factor() {
+        let step = FilterStep::ScaleMultiplier { factor: 1.05 };
+        let args = step.args();
+        assert!(
+            args.contains("iw*1.05") && args.contains("ih*1.05"),
+            "ScaleMultiplier args must reference iw*factor and ih*factor: {args}"
+        );
+    }
+
+    #[test]
+    fn lens_profile_identity_custom_should_use_unit_scale() {
+        let step = FilterStep::ScaleMultiplier { factor: 1.0 };
+        let args = step.args();
+        assert_eq!(args, "w=iw*1:h=ih*1");
     }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -632,6 +632,15 @@ pub enum FilterStep {
         chroma_strength: f32,
     },
 
+    /// Uniform scale by a fractional multiplier via `FFmpeg`'s `scale` filter.
+    ///
+    /// Both width and height are multiplied by `factor`. Used to hide warped
+    /// border pixels left after lens distortion correction.
+    ScaleMultiplier {
+        /// Scale factor applied to both dimensions (e.g. `1.05` = 5 % zoom-in).
+        factor: f32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -780,6 +789,7 @@ impl FilterStep {
             Self::MotionBlur { .. } => "tblend",
             Self::LensCorrection { .. } => "lenscorrection",
             Self::FilmGrain { .. } => "noise",
+            Self::ScaleMultiplier { .. } => "scale",
         }
     }
 
@@ -1193,6 +1203,9 @@ impl FilterStep {
                 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                 let cs = chroma_strength.clamp(0.0, 100.0) as u32;
                 format!("alls={ls}:c0s={cs}:c1s={cs}:allf=t")
+            }
+            Self::ScaleMultiplier { factor } => {
+                format!("w=iw*{factor}:h=ih*{factor}")
             }
         }
     }

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -42,7 +42,7 @@ pub mod graph;
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
 pub use animation::{AnimatedValue, AnimationEntry, AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
-pub use effects::{AnalyzeOptions, Interpolation, StabilizeOptions, Stabilizer};
+pub use effects::{AnalyzeOptions, Interpolation, LensProfile, StabilizeOptions, Stabilizer};
 pub use error::FilterError;
 pub use graph::{
     AudioConcatenator, AudioTrack, ClipJoiner, ClipTransition, DrawTextOptions, EqBand,


### PR DESCRIPTION
## Summary

Adds `LensProfile`, a predefined set of radial lens distortion correction profiles for common cameras (`GoproHero9Wide`, `GoproHero11Linear`, `Iphone14ProMain`, `DjiMini3ProWide`, and `Custom`). `FilterGraph::lens_profile` applies the profile by chaining a `lenscorrection` step with a `scale` step that zooms slightly to hide the warped border pixels.

## Changes

- `crates/ff-filter/src/effects/lens_profile.rs` (new): `LensProfile` enum with `coefficients()` method and 4 unit tests
- `crates/ff-filter/src/graph/filter_step.rs`: add `FilterStep::ScaleMultiplier { factor }` with `filter_name = "scale"` and `args = "w=iw*{factor}:h=ih*{factor}"`
- `crates/ff-filter/src/effects/video_effects.rs`: add `FilterGraph::lens_profile(&mut self, profile: LensProfile) -> &mut Self` plus 5 new unit tests
- `crates/ff-filter/src/effects/mod.rs`: expose `pub mod lens_profile` and `pub use lens_profile::LensProfile`
- `crates/ff-filter/src/lib.rs`: re-export `LensProfile`
- `crates/avio/src/lib.rs`: re-export `LensProfile` under the `filter` feature

## Related Issues

Closes #398

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes