### PR TITLE
feat(ff-filter): add glow/bloom effect via split+curves+gblur+blend

### DIFF
--- a/crates/ff-filter/src/effects/video_effects.rs
+++ b/crates/ff-filter/src/effects/video_effects.rs
@@ -134,6 +134,30 @@ impl FilterGraph {
         Ok(self)
     }
 
+    /// Add a glow / bloom effect by blending blurred highlights back over the image.
+    ///
+    /// `threshold` controls which luminance level triggers glow (clamped to [0.0, 1.0]).
+    /// `radius` is the Gaussian blur sigma in pixels (clamped to [0.5, 50.0]).
+    /// `intensity` is the additive blend strength (clamped to [0.0, 2.0]).
+    ///
+    /// Values outside the valid ranges are silently clamped — no error is returned.
+    ///
+    /// Uses `FFmpeg`'s `split`, `curves`, `gblur`, and `blend` filters.
+    ///
+    /// Call this method after [`FilterGraph::builder()`] / [`build()`] but
+    /// **before** the first [`push_video`] call.
+    ///
+    /// [`build()`]: crate::FilterGraphBuilder::build
+    /// [`push_video`]: FilterGraph::push_video
+    pub fn glow(&mut self, threshold: f32, radius: f32, intensity: f32) -> &mut Self {
+        self.inner.push_step(FilterStep::Glow {
+            threshold,
+            radius,
+            intensity,
+        });
+        self
+    }
+
     /// Apply a predefined camera lens distortion correction profile.
     ///
     /// Looks up the radial coefficients (`k1`, `k2`) and `scale` from the
@@ -476,5 +500,99 @@ mod tests {
         let step = FilterStep::ChromaticAberration { rh: 0, bh: 0 };
         let args = step.args();
         assert_eq!(args, "rh=0:bh=0:edge=smear");
+    }
+
+    // ── glow ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn glow_with_valid_params_should_return_mutable_self() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.glow(0.8, 10.0, 0.8);
+        let _ = result;
+    }
+
+    #[test]
+    fn glow_identity_zero_intensity_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.glow(0.8, 10.0, 0.0);
+        let _ = result;
+    }
+
+    #[test]
+    fn filter_step_glow_should_have_split_filter_name() {
+        let step = FilterStep::Glow {
+            threshold: 0.8,
+            radius: 10.0,
+            intensity: 0.8,
+        };
+        assert_eq!(step.filter_name(), "split");
+    }
+
+    #[test]
+    fn glow_args_should_contain_threshold_radius_intensity() {
+        let step = FilterStep::Glow {
+            threshold: 0.8,
+            radius: 10.0,
+            intensity: 0.8,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("0.8/0"),
+            "args must contain threshold in curve: {args}"
+        );
+        assert!(
+            args.contains("sigma=10"),
+            "args must contain sigma=10: {args}"
+        );
+        assert!(
+            args.contains("all_opacity=0.8"),
+            "args must contain all_opacity=0.8: {args}"
+        );
+        assert!(
+            args.contains("all_mode=addition"),
+            "args must contain all_mode=addition: {args}"
+        );
+    }
+
+    #[test]
+    fn glow_threshold_above_one_should_be_clamped() {
+        let step = FilterStep::Glow {
+            threshold: 1.1,
+            radius: 5.0,
+            intensity: 1.0,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("1/0"),
+            "threshold=1.1 must clamp to 1.0 in curve (1/0): {args}"
+        );
+    }
+
+    #[test]
+    fn glow_radius_below_min_should_be_clamped_to_half() {
+        let step = FilterStep::Glow {
+            threshold: 0.5,
+            radius: 0.1,
+            intensity: 1.0,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("sigma=0.5"),
+            "radius=0.1 must clamp to 0.5: {args}"
+        );
+    }
+
+    #[test]
+    fn glow_intensity_above_two_should_be_clamped() {
+        let step = FilterStep::Glow {
+            threshold: 0.5,
+            radius: 5.0,
+            intensity: 5.0,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("all_opacity=2"),
+            "intensity=5.0 must clamp to 2.0: {args}"
+        );
     }
 }

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -1018,6 +1018,173 @@ pub(super) unsafe fn add_blend_expr_step(
 ///
 /// `graph` and `prev_ctx` must be valid pointers owned by the same
 /// `AVFilterGraph`.
+// ── Glow compound step ────────────────────────────────────────────────────────
+/// Insert the glow / bloom compound step.
+///
+/// ```text
+/// prev_ctx → split=2 → pad0 ──────────────────────────────→ blend[0]
+///                    → pad1 → curves(hi_lo) → gblur(r) ──→ blend[1]
+///                                                            blend(addition, opacity=iv) → out
+/// ```
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+pub(super) unsafe fn add_glow_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    threshold: f32,
+    radius: f32,
+    intensity: f32,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    use std::ffi::CString;
+
+    let t = threshold.clamp(0.0, 1.0);
+    let r = radius.clamp(0.5, 50.0);
+    let iv = intensity.clamp(0.0, 2.0);
+
+    // 1. split=2 — duplicate the stream into a base path and a highlights path.
+    let split_filter = ff_sys::avfilter_get_by_name(c"split".as_ptr());
+    if split_filter.is_null() {
+        log::warn!("filter not found name=split (glow)");
+        return Err(FilterError::BuildFailed);
+    }
+    let split_name =
+        CString::new(format!("glow_split{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let mut split_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    // SAFETY: split_filter and graph are non-null; "2" is valid args.
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut split_ctx,
+        split_filter,
+        split_name.as_ptr(),
+        c"2".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=split (glow) code={ret}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=split args=2 index={index} (glow)");
+
+    // Link: prev_ctx → split[0].
+    // SAFETY: prev_ctx and split_ctx belong to the same graph; pad indices valid.
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, split_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // 2. curves — extract highlights: below threshold → black; above → full.
+    let curves_filter = ff_sys::avfilter_get_by_name(c"curves".as_ptr());
+    if curves_filter.is_null() {
+        log::warn!("filter not found name=curves (glow)");
+        return Err(FilterError::BuildFailed);
+    }
+    let curves_name =
+        CString::new(format!("glow_curves{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let hi_lo = format!("0/0 {t}/0 1/1");
+    let curves_args_str = format!("all='{hi_lo}'");
+    let curves_args =
+        CString::new(curves_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut curves_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut curves_ctx,
+        curves_filter,
+        curves_name.as_ptr(),
+        curves_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=curves args={curves_args_str} (glow) code={ret}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=curves args={curves_args_str} index={index} (glow)");
+
+    // Link: split[1] → curves[0] (highlights path).
+    // SAFETY: split_ctx and curves_ctx belong to the same graph; pad 1 of split valid.
+    let ret = ff_sys::avfilter_link(split_ctx, 1, curves_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // 3. gblur — blur the extracted highlights.
+    let gblur_filter = ff_sys::avfilter_get_by_name(c"gblur".as_ptr());
+    if gblur_filter.is_null() {
+        log::warn!("filter not found name=gblur (glow)");
+        return Err(FilterError::BuildFailed);
+    }
+    let gblur_name =
+        CString::new(format!("glow_gblur{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let gblur_args_str = format!("sigma={r}");
+    let gblur_args = CString::new(gblur_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut gblur_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut gblur_ctx,
+        gblur_filter,
+        gblur_name.as_ptr(),
+        gblur_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=gblur args={gblur_args_str} (glow) code={ret}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=gblur args={gblur_args_str} index={index} (glow)");
+
+    // Link: curves → gblur.
+    let ret = ff_sys::avfilter_link(curves_ctx, 0, gblur_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // 4. blend — additively blend blurred highlights back over the base image.
+    let blend_filter = ff_sys::avfilter_get_by_name(c"blend".as_ptr());
+    if blend_filter.is_null() {
+        log::warn!("filter not found name=blend (glow)");
+        return Err(FilterError::BuildFailed);
+    }
+    let blend_name =
+        CString::new(format!("glow_blend{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let blend_args_str = format!("all_mode=addition:all_opacity={iv}");
+    let blend_args = CString::new(blend_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut blend_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut blend_ctx,
+        blend_filter,
+        blend_name.as_ptr(),
+        blend_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=blend args={blend_args_str} (glow) code={ret}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=blend args={blend_args_str} index={index} (glow)");
+
+    // Link: split[0] → blend[0] (base path — the bottom stream).
+    // SAFETY: split_ctx and blend_ctx belong to the same graph; pad indices valid.
+    let ret = ff_sys::avfilter_link(split_ctx, 0, blend_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // Link: gblur → blend[1] (blurred highlights — the top stream).
+    let ret = ff_sys::avfilter_link(gblur_ctx, 0, blend_ctx, 1);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    log::debug!(
+        "filter glow expanded threshold={threshold} radius={radius} intensity={intensity} index={index}"
+    );
+    Ok(blend_ctx)
+}
+
 pub(super) unsafe fn add_feather_mask_step(
     graph: *mut ff_sys::AVFilterGraph,
     prev_ctx: *mut ff_sys::AVFilterContext,
@@ -1682,6 +1849,22 @@ impl FilterGraphInner {
                     *dissolve_dur,
                     i,
                 ) {
+                    Ok(ctx) => ctx,
+                    Err(e) => bail!(e),
+                };
+                continue;
+            }
+
+            // Glow — compound step: split → [base | curves → gblur] → blend(addition).
+            // All filters operate on the single main stream; no extra buffersrc needed.
+            if let FilterStep::Glow {
+                threshold,
+                radius,
+                intensity,
+            } = step
+            {
+                prev_ctx = match add_glow_step(graph, prev_ctx, *threshold, *radius, *intensity, i)
+                {
                     Ok(ctx) => ctx,
                     Err(e) => bail!(e),
                 };

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -654,6 +654,20 @@ pub enum FilterStep {
         bh: i32,
     },
 
+    /// Glow / bloom effect: blends blurred highlights back over the image via
+    /// `split`, `curves`, `gblur`, and `blend` filters.
+    ///
+    /// This is a compound step — see
+    /// [`FilterGraph::glow`](crate::FilterGraph::glow) for parameter semantics.
+    Glow {
+        /// Luminance threshold that triggers the glow (clamped to [0.0, 1.0]).
+        threshold: f32,
+        /// Gaussian blur radius in pixels (clamped to [0.5, 50.0]).
+        radius: f32,
+        /// Additive blend strength (clamped to [0.0, 2.0]).
+        intensity: f32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -804,6 +818,9 @@ impl FilterStep {
             Self::FilmGrain { .. } => "noise",
             Self::ScaleMultiplier { .. } => "scale",
             Self::ChromaticAberration { .. } => "rgbashift",
+            // Glow is a compound step (split → curves → gblur → blend);
+            // "split" is used by validate_filter_steps as the primary check.
+            Self::Glow { .. } => "split",
         }
     }
 
@@ -1223,6 +1240,23 @@ impl FilterStep {
             }
             Self::ChromaticAberration { rh, bh } => {
                 format!("rh={rh}:bh={bh}:edge=smear")
+            }
+            // args() is not consumed by add_and_link_step (which is bypassed for
+            // this compound step); provided here for completeness.
+            Self::Glow {
+                threshold,
+                radius,
+                intensity,
+            } => {
+                let t = threshold.clamp(0.0, 1.0);
+                let r = radius.clamp(0.5, 50.0);
+                let iv = intensity.clamp(0.0, 2.0);
+                let hi_lo = format!("0/0 {t}/0 1/1");
+                format!(
+                    "split=2[base][hl];[hl]curves=all='{hi_lo}'[glow_src];\
+                     [glow_src]gblur=sigma={r}[glow];\
+                     [base][glow]blend=all_mode=addition:all_opacity={iv}"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds `FilterGraph::glow()` — a bloom/glow effect that extracts highlights above a luminance threshold, blurs them with a Gaussian kernel, and additively blends them back over the original image. All parameters are silently clamped so no error is returned.

## Changes

- `crates/ff-filter/src/graph/filter_step.rs`: add `FilterStep::Glow { threshold, radius, intensity }` compound step with `filter_name = "split"` for validation and a descriptive `args()` string
- `crates/ff-filter/src/filter_inner/build.rs`: add `add_glow_step()` — builds the DAG `split[1] → curves(highlight extraction) → gblur → blend(addition)[1]` with `split[0] → blend[0]`; dispatch added in `build_video_graph` loop
- `crates/ff-filter/src/effects/video_effects.rs`: add `FilterGraph::glow(threshold, radius, intensity) -> &mut Self` with silent clamping; add 7 unit tests covering basic usage, identity, filter name, args format, and clamping behavior

## Related Issues

Closes #400

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes