### PR TITLE
feat(ff-filter): add reverb_ir via amovie+afir convolution reverb

### DIFF
--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -1,0 +1,136 @@
+//! Frame-level audio effects added to [`FilterGraph`] after construction.
+
+use std::path::Path;
+
+use crate::error::FilterError;
+use crate::graph::FilterGraph;
+use crate::graph::filter_step::FilterStep;
+
+impl FilterGraph {
+    /// Add convolution reverb using an impulse response (IR) audio file.
+    ///
+    /// `ir_path` is a path to a `.wav` or `.flac` impulse response file.
+    /// `wet` and `dry` are mix levels clamped to [0.0, 1.0].
+    /// `pre_delay_ms` inserts silence before the reverb tail (clamped to 0–500 ms).
+    ///
+    /// Uses `FFmpeg`'s `amovie` (to load the IR) and `afir` (convolution) filters.
+    ///
+    /// Call this method after [`FilterGraph::builder()`] / [`build()`] but
+    /// **before** the first [`push_audio`] call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `ir_path` does not exist.
+    /// The `afir` filter availability is checked at graph build time; if not
+    /// available the graph build returns [`FilterError::BuildFailed`].
+    ///
+    /// [`build()`]: crate::FilterGraphBuilder::build
+    /// [`push_audio`]: FilterGraph::push_audio
+    pub fn reverb_ir(
+        &mut self,
+        ir_path: &Path,
+        wet: f32,
+        dry: f32,
+        pre_delay_ms: u32,
+    ) -> Result<&mut Self, FilterError> {
+        if !ir_path.exists() {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("ir_path does not exist: {}", ir_path.display()),
+            });
+        }
+        let ir_str = ir_path.display().to_string();
+        self.inner.push_step(FilterStep::ReverbIr {
+            ir_path: ir_str,
+            wet: wet.clamp(0.0, 1.0),
+            dry: dry.clamp(0.0, 1.0),
+            pre_delay_ms: pre_delay_ms.min(500),
+        });
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::graph::filter_step::FilterStep;
+    use crate::{FilterError, FilterGraph};
+    use std::path::Path;
+
+    #[test]
+    fn reverb_ir_nonexistent_path_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.reverb_ir(Path::new("no_such_file.wav"), 0.8, 0.2, 0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "non-existent ir_path must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn filter_step_reverb_ir_should_have_afir_filter_name() {
+        let step = FilterStep::ReverbIr {
+            ir_path: "hall.wav".to_string(),
+            wet: 0.8,
+            dry: 0.2,
+            pre_delay_ms: 0,
+        };
+        assert_eq!(step.filter_name(), "afir");
+    }
+
+    #[test]
+    fn reverb_ir_args_should_contain_wet_dry_and_ir_path() {
+        let step = FilterStep::ReverbIr {
+            ir_path: "hall.wav".to_string(),
+            wet: 0.8,
+            dry: 0.2,
+            pre_delay_ms: 0,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("hall.wav"),
+            "args must contain ir_path: {args}"
+        );
+        assert!(
+            args.contains("wet=0.8"),
+            "args must contain wet=0.8: {args}"
+        );
+        assert!(
+            args.contains("dry=0.2"),
+            "args must contain dry=0.2: {args}"
+        );
+        assert!(
+            !args.contains("adelay"),
+            "no pre-delay when pre_delay_ms=0: {args}"
+        );
+    }
+
+    #[test]
+    fn reverb_ir_args_with_pre_delay_should_contain_adelay() {
+        let step = FilterStep::ReverbIr {
+            ir_path: "hall.wav".to_string(),
+            wet: 0.8,
+            dry: 0.2,
+            pre_delay_ms: 100,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("adelay=100"),
+            "args must contain adelay=100 when pre_delay_ms=100: {args}"
+        );
+    }
+
+    #[test]
+    fn reverb_ir_pre_delay_above_500_should_be_clamped() {
+        let step = FilterStep::ReverbIr {
+            ir_path: "hall.wav".to_string(),
+            wet: 0.8,
+            dry: 0.2,
+            pre_delay_ms: 999,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("adelay=500"),
+            "pre_delay_ms=999 must clamp to 500: {args}"
+        );
+    }
+}

--- a/crates/ff-filter/src/effects/mod.rs
+++ b/crates/ff-filter/src/effects/mod.rs
@@ -6,6 +6,7 @@
 //!   motion blur via `tblend` (frame-level, extends [`crate::FilterGraph`]).
 //! - [`LensProfile`] — predefined lens distortion correction profiles for common cameras.
 
+mod audio_effects;
 pub(crate) mod effects_inner;
 pub mod lens_profile;
 mod stabilizer;

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2341,6 +2341,20 @@ impl FilterGraphInner {
                 continue;
             }
 
+            // ReverbIr — compound step: amovie[+adelay] → afir.
+            // amovie is a self-contained audio source; no buffersrc slot is consumed.
+            if let FilterStep::ReverbIr {
+                ir_path,
+                wet,
+                dry,
+                pre_delay_ms,
+            } = step
+            {
+                prev_ctx =
+                    add_reverb_ir_step(graph, prev_ctx, ir_path, *wet, *dry, *pre_delay_ms, i)?;
+                continue;
+            }
+
             // AudioDelay dispatches to adelay (positive/zero) or atrim (negative).
             if let FilterStep::AudioDelay { ms } = step {
                 let (filter_name, args) = if *ms >= 0.0 {
@@ -2387,4 +2401,145 @@ impl FilterGraphInner {
         let sink_nn = NonNull::new_unchecked(sink_ctx);
         Ok((src_ctxs, sink_nn))
     }
+}
+
+// ── ReverbIr compound step ────────────────────────────────────────────────────
+/// Insert the convolution reverb compound step.
+///
+/// ```text
+/// prev_ctx ──────────────────────────────────────────→ afir[0]
+/// amovie(ir_path) [→ adelay(pre_delay_ms)] ─────────→ afir[1]
+///                                           afir(dry, wet) → out
+/// ```
+///
+/// `amovie` is a self-contained audio source — no buffersrc input slot is consumed.
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+pub(super) unsafe fn add_reverb_ir_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    ir_path: &str,
+    wet: f32,
+    dry: f32,
+    pre_delay_ms: u32,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    use std::ffi::CString;
+
+    let wet = wet.clamp(0.0, 1.0);
+    let dry = dry.clamp(0.0, 1.0);
+    let delay = pre_delay_ms.min(500);
+
+    // 1. amovie=filename={ir_path} — self-contained IR source.
+    let amovie_filter = ff_sys::avfilter_get_by_name(c"amovie".as_ptr());
+    if amovie_filter.is_null() {
+        log::warn!("filter not found name=amovie (reverb_ir)");
+        return Err(FilterError::BuildFailed);
+    }
+    let amovie_name =
+        CString::new(format!("reverb_amovie{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let amovie_args_str = format!("filename={ir_path}");
+    let amovie_args =
+        CString::new(amovie_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut amovie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    // SAFETY: amovie_filter and graph are non-null; args are valid null-terminated C strings.
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut amovie_ctx,
+        amovie_filter,
+        amovie_name.as_ptr(),
+        amovie_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!(
+            "filter creation failed name=amovie args={amovie_args_str} (reverb_ir) code={ret}"
+        );
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=amovie args={amovie_args_str} index={index} (reverb_ir)");
+
+    // 2. [optional] adelay={delay}:all=1 — pre-delay on the IR path.
+    let ir_out_ctx = if delay > 0 {
+        let adelay_filter = ff_sys::avfilter_get_by_name(c"adelay".as_ptr());
+        if adelay_filter.is_null() {
+            log::warn!("filter not found name=adelay (reverb_ir)");
+            return Err(FilterError::BuildFailed);
+        }
+        let adelay_name =
+            CString::new(format!("reverb_adelay{index}")).map_err(|_| FilterError::BuildFailed)?;
+        let adelay_args_str = format!("delays={delay}:all=1");
+        let adelay_args =
+            CString::new(adelay_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+        let mut adelay_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+        let ret = ff_sys::avfilter_graph_create_filter(
+            &raw mut adelay_ctx,
+            adelay_filter,
+            adelay_name.as_ptr(),
+            adelay_args.as_ptr(),
+            std::ptr::null_mut(),
+            graph,
+        );
+        if ret < 0 {
+            log::warn!(
+                "filter creation failed name=adelay args={adelay_args_str} (reverb_ir) code={ret}"
+            );
+            return Err(FilterError::BuildFailed);
+        }
+        log::debug!("filter added name=adelay args={adelay_args_str} index={index} (reverb_ir)");
+        // SAFETY: amovie_ctx and adelay_ctx belong to the same graph; pad indices valid.
+        let ret = ff_sys::avfilter_link(amovie_ctx, 0, adelay_ctx, 0);
+        if ret < 0 {
+            return Err(FilterError::BuildFailed);
+        }
+        adelay_ctx
+    } else {
+        amovie_ctx
+    };
+
+    // 3. afir=dry={dry}:wet={wet} — convolution reverb.
+    let afir_filter = ff_sys::avfilter_get_by_name(c"afir".as_ptr());
+    if afir_filter.is_null() {
+        log::warn!("filter not found name=afir (reverb_ir)");
+        return Err(FilterError::BuildFailed);
+    }
+    let afir_name =
+        CString::new(format!("reverb_afir{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let afir_args_str = format!("dry={dry}:wet={wet}");
+    let afir_args = CString::new(afir_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+    let mut afir_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut afir_ctx,
+        afir_filter,
+        afir_name.as_ptr(),
+        afir_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=afir args={afir_args_str} (reverb_ir) code={ret}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=afir args={afir_args_str} index={index} (reverb_ir)");
+
+    // Link: prev_ctx → afir[0] (dry audio input).
+    // SAFETY: prev_ctx and afir_ctx belong to the same graph; pad indices valid.
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, afir_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    // Link: ir_out_ctx → afir[1] (impulse response input).
+    let ret = ff_sys::avfilter_link(ir_out_ctx, 0, afir_ctx, 1);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    log::debug!(
+        "filter reverb_ir expanded ir_path={ir_path} wet={wet} dry={dry} pre_delay_ms={pre_delay_ms} index={index}"
+    );
+    Ok(afir_ctx)
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -668,6 +668,26 @@ pub enum FilterStep {
         intensity: f32,
     },
 
+    /// Convolution reverb using an impulse response (IR) audio file.
+    ///
+    /// The IR is loaded via `FFmpeg`'s `amovie` filter, optionally delayed by
+    /// `pre_delay_ms` via `adelay`, then convolved with the main audio stream
+    /// via `FFmpeg`'s `afir` filter.
+    ///
+    /// This is a compound step — see
+    /// [`FilterGraph::reverb_ir`](crate::FilterGraph::reverb_ir) for parameter
+    /// semantics.
+    ReverbIr {
+        /// Absolute or relative path to the `.wav` or `.flac` IR file.
+        ir_path: String,
+        /// Wet (reverb) mix level in [0.0, 1.0].
+        wet: f32,
+        /// Dry (original) mix level in [0.0, 1.0].
+        dry: f32,
+        /// Pre-delay before the reverb tail in milliseconds (clamped to 0–500).
+        pre_delay_ms: u32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -821,6 +841,9 @@ impl FilterStep {
             // Glow is a compound step (split → curves → gblur → blend);
             // "split" is used by validate_filter_steps as the primary check.
             Self::Glow { .. } => "split",
+            // ReverbIr is a compound step (amovie[+adelay] → afir);
+            // "afir" is used by validate_filter_steps as the primary check.
+            Self::ReverbIr { .. } => "afir",
         }
     }
 
@@ -1257,6 +1280,22 @@ impl FilterStep {
                      [glow_src]gblur=sigma={r}[glow];\
                      [base][glow]blend=all_mode=addition:all_opacity={iv}"
                 )
+            }
+            // args() is not consumed by add_and_link_step (which is bypassed for
+            // this compound step); provided here for completeness.
+            Self::ReverbIr {
+                ir_path,
+                wet,
+                dry,
+                pre_delay_ms,
+            } => {
+                let delay = pre_delay_ms.min(&500);
+                let delay_part = if *delay > 0 {
+                    format!(",adelay={delay}:all=1")
+                } else {
+                    String::new()
+                };
+                format!("amovie={ir_path}{delay_part}[ir];[0:a][ir]afir=dry={dry}:wet={wet}")
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds `FilterGraph::reverb_ir()` which applies convolution reverb to an audio stream using an impulse response (IR) file. The method uses FFmpeg's `amovie` filter to load the IR and `afir` for convolution, with optional `adelay` pre-delay before the reverb tail.

## Changes

- `effects/audio_effects.rs` (new): `FilterGraph::reverb_ir(&mut self, ir_path, wet, dry, pre_delay_ms)` — validates path exists, clamps parameters, pushes `FilterStep::ReverbIr`
- `effects/mod.rs`: added `mod audio_effects;`
- `graph/filter_step.rs`: added `FilterStep::ReverbIr { ir_path, wet, dry, pre_delay_ms }` with `filter_name()` → `"afir"` and `args()` producing the compound filter string
- `filter_inner/build.rs`: added `add_reverb_ir_step()` building the `amovie[→adelay]→afir` compound graph; dispatched in `build_audio_graph` loop

## Related Issues

Closes #401

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes