### PR TITLE
feat(ff-filter): add reverb_echo via aecho filter

### DIFF
--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -7,23 +7,6 @@ use crate::graph::FilterGraph;
 use crate::graph::filter_step::FilterStep;
 
 impl FilterGraph {
-    /// Add convolution reverb using an impulse response (IR) audio file.
-    ///
-    /// `ir_path` is a path to a `.wav` or `.flac` impulse response file.
-    /// `wet` and `dry` are mix levels clamped to [0.0, 1.0].
-    /// `pre_delay_ms` inserts silence before the reverb tail (clamped to 0–500 ms).
-    ///
-    /// Uses `FFmpeg`'s `amovie` (to load the IR) and `afir` (convolution) filters.
-    ///
-    /// Call this method after [`FilterGraph::builder()`] / [`build()`] but
-    /// **before** the first [`push_audio`] call.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FilterError::Ffmpeg`] if `ir_path` does not exist.
-    /// The `afir` filter availability is checked at graph build time; if not
-    /// available the graph build returns [`FilterError::BuildFailed`].
-    ///
     /// Add algorithmic echo/reverb with configurable delay taps.
     ///
     /// `in_gain` and `out_gain` are amplitude multipliers clamped to [0.0, 1.0].
@@ -64,8 +47,23 @@ impl FilterGraph {
         Ok(self)
     }
 
-    /// [`build()`]: crate::FilterGraphBuilder::build
-    /// [`push_audio`]: FilterGraph::push_audio
+    /// Add convolution reverb using an impulse response (IR) audio file.
+    ///
+    /// `ir_path` is a path to a `.wav` or `.flac` impulse response file.
+    /// `wet` and `dry` are mix levels clamped to [0.0, 1.0].
+    /// `pre_delay_ms` inserts silence before the reverb tail (clamped to 0–500 ms).
+    ///
+    /// Uses `FFmpeg`'s `amovie` (to load the IR) and `afir` (convolution) filters.
+    ///
+    /// Call this method after [`FilterGraph::builder()`] /
+    /// [`FilterGraphBuilder::build()`](crate::FilterGraphBuilder::build) but
+    /// **before** the first [`FilterGraph::push_audio()`] call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `ir_path` does not exist.
+    /// The `afir` filter availability is checked at graph build time; if not
+    /// available the graph build returns [`FilterError::BuildFailed`].
     pub fn reverb_ir(
         &mut self,
         ir_path: &Path,

--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -24,6 +24,46 @@ impl FilterGraph {
     /// The `afir` filter availability is checked at graph build time; if not
     /// available the graph build returns [`FilterError::BuildFailed`].
     ///
+    /// Add algorithmic echo/reverb with configurable delay taps.
+    ///
+    /// `in_gain` and `out_gain` are amplitude multipliers clamped to [0.0, 1.0].
+    /// `delays` is a list of delay times in milliseconds.
+    /// `decays` is the corresponding decay factor for each delay, clamped to [0.0, 1.0].
+    /// `delays` and `decays` must have equal length (1–8 taps).
+    ///
+    /// Uses `FFmpeg`'s `aecho` filter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if lengths differ or tap count is outside 1–8.
+    pub fn reverb_echo(
+        &mut self,
+        in_gain: f32,
+        out_gain: f32,
+        delays: &[f32],
+        decays: &[f32],
+    ) -> Result<&mut Self, FilterError> {
+        if delays.len() != decays.len() {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: "delays and decays must have equal length".into(),
+            });
+        }
+        if !(1..=8).contains(&delays.len()) {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("tap count must be 1–8, got {}", delays.len()),
+            });
+        }
+        self.inner.push_step(FilterStep::ReverbEcho {
+            in_gain: in_gain.clamp(0.0, 1.0),
+            out_gain: out_gain.clamp(0.0, 1.0),
+            delays: delays.to_vec(),
+            decays: decays.iter().map(|d| d.clamp(0.0, 1.0)).collect(),
+        });
+        Ok(self)
+    }
+
     /// [`build()`]: crate::FilterGraphBuilder::build
     /// [`push_audio`]: FilterGraph::push_audio
     pub fn reverb_ir(
@@ -55,6 +95,95 @@ mod tests {
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
     use std::path::Path;
+
+    #[test]
+    fn reverb_echo_mismatched_lengths_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.reverb_echo(0.8, 0.9, &[500.0], &[0.5, 0.3]);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "mismatched lengths must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn reverb_echo_zero_taps_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.reverb_echo(0.8, 0.9, &[], &[]);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "zero taps must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn reverb_echo_nine_taps_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let delays = vec![100.0; 9];
+        let decays = vec![0.5; 9];
+        let result = graph.reverb_echo(0.8, 0.9, &delays, &decays);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "nine taps must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn filter_step_reverb_echo_should_have_aecho_filter_name() {
+        let step = FilterStep::ReverbEcho {
+            in_gain: 0.8,
+            out_gain: 0.9,
+            delays: vec![500.0],
+            decays: vec![0.5],
+        };
+        assert_eq!(step.filter_name(), "aecho");
+    }
+
+    #[test]
+    fn reverb_echo_args_should_contain_gains_delays_decays() {
+        let step = FilterStep::ReverbEcho {
+            in_gain: 0.8,
+            out_gain: 0.9,
+            delays: vec![500.0],
+            decays: vec![0.5],
+        };
+        let args = step.args();
+        assert!(
+            args.contains("in_gain=0.8"),
+            "args must contain in_gain=0.8: {args}"
+        );
+        assert!(
+            args.contains("out_gain=0.9"),
+            "args must contain out_gain=0.9: {args}"
+        );
+        assert!(
+            args.contains("delays=500"),
+            "args must contain delays=500: {args}"
+        );
+        assert!(
+            args.contains("decays=0.5"),
+            "args must contain decays=0.5: {args}"
+        );
+    }
+
+    #[test]
+    fn reverb_echo_multi_tap_args_should_join_with_pipe() {
+        let step = FilterStep::ReverbEcho {
+            in_gain: 0.8,
+            out_gain: 0.9,
+            delays: vec![500.0, 300.0],
+            decays: vec![0.5, 0.3],
+        };
+        let args = step.args();
+        assert!(
+            args.contains("500|300") || args.contains("500.0|300"),
+            "multi-tap delays must be joined with '|': {args}"
+        );
+        assert!(
+            args.contains("0.5|0.3"),
+            "multi-tap decays must be joined with '|': {args}"
+        );
+    }
 
     #[test]
     fn reverb_ir_nonexistent_path_should_return_ffmpeg_error() {

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -688,6 +688,24 @@ pub enum FilterStep {
         pre_delay_ms: u32,
     },
 
+    /// Algorithmic multi-tap echo/reverb via `FFmpeg`'s `aecho` filter.
+    ///
+    /// `in_gain` and `out_gain` are amplitude multipliers clamped to [0.0, 1.0].
+    /// `delays` contains delay times in milliseconds (one per tap); `decays`
+    /// contains the corresponding decay factors in [0.0, 1.0].  Both vecs must
+    /// have equal length in the range 1–8; validated by
+    /// [`FilterGraph::reverb_echo`](crate::FilterGraph::reverb_echo).
+    ReverbEcho {
+        /// Input gain (amplitude multiplier). Clamped to [0.0, 1.0].
+        in_gain: f32,
+        /// Output gain (amplitude multiplier). Clamped to [0.0, 1.0].
+        out_gain: f32,
+        /// Delay times in milliseconds (one per tap).
+        delays: Vec<f32>,
+        /// Decay factors per tap. Clamped to [0.0, 1.0].
+        decays: Vec<f32>,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -844,6 +862,7 @@ impl FilterStep {
             // ReverbIr is a compound step (amovie[+adelay] → afir);
             // "afir" is used by validate_filter_steps as the primary check.
             Self::ReverbIr { .. } => "afir",
+            Self::ReverbEcho { .. } => "aecho",
         }
     }
 
@@ -1279,6 +1298,30 @@ impl FilterStep {
                     "split=2[base][hl];[hl]curves=all='{hi_lo}'[glow_src];\
                      [glow_src]gblur=sigma={r}[glow];\
                      [base][glow]blend=all_mode=addition:all_opacity={iv}"
+                )
+            }
+            Self::ReverbEcho {
+                in_gain,
+                out_gain,
+                delays,
+                decays,
+            } => {
+                let delay_str = delays
+                    .iter()
+                    .map(|d| d.to_string())
+                    .collect::<Vec<_>>()
+                    .join("|");
+                let decay_str = decays
+                    .iter()
+                    .map(|d| d.to_string())
+                    .collect::<Vec<_>>()
+                    .join("|");
+                format!(
+                    "in_gain={ig}:out_gain={og}:delays={ds}:decays={dec}",
+                    ig = in_gain,
+                    og = out_gain,
+                    ds = delay_str,
+                    dec = decay_str,
                 )
             }
             // args() is not consumed by add_and_link_step (which is bypassed for


### PR DESCRIPTION
## Summary

Adds `FilterGraph::reverb_echo()` which applies algorithmic multi-tap echo/reverb to an audio stream using FFmpeg's `aecho` filter. Unlike `reverb_ir`, this is a simple linear filter requiring no compound graph step — it goes through the standard `add_and_link_step` path in the audio build loop.

## Changes

- `graph/filter_step.rs`: added `FilterStep::ReverbEcho { in_gain, out_gain, delays, decays }` with `filter_name()` → `"aecho"` and `args()` formatting `in_gain=…:out_gain=…:delays=…|…:decays=…|…`
- `effects/audio_effects.rs`: added `FilterGraph::reverb_echo()` with validation (equal-length slices, 1–8 tap count) and clamping of gains/decays; 6 unit tests covering error paths, filter name, single-tap args, and multi-tap `|`-joining

## Related Issues

Closes #402

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes