### PR TITLE
feat(ff-filter): add pitch_shift via asetrate+atempo

### DIFF
--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -7,6 +7,25 @@ use crate::graph::FilterGraph;
 use crate::graph::filter_step::FilterStep;
 
 impl FilterGraph {
+    /// Shift audio pitch by `semitones` without changing playback speed.
+    ///
+    /// Range: −12.0 to +12.0 semitones. Uses `asetrate` to change the
+    /// decoded sample rate followed by `atempo` to restore original duration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `semitones` is outside −12.0..=12.0.
+    pub fn pitch_shift(&mut self, semitones: f32) -> Result<&mut Self, FilterError> {
+        if !(-12.0..=12.0).contains(&semitones) {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("semitones must be in -12..=12, got {semitones}"),
+            });
+        }
+        self.inner.push_step(FilterStep::PitchShift { semitones });
+        Ok(self)
+    }
+
     /// Add algorithmic echo/reverb with configurable delay taps.
     ///
     /// `in_gain` and `out_gain` are amplitude multipliers clamped to [0.0, 1.0].
@@ -93,6 +112,48 @@ mod tests {
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
     use std::path::Path;
+
+    #[test]
+    fn pitch_shift_above_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.pitch_shift(13.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "semitones=13.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn pitch_shift_below_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.pitch_shift(-13.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "semitones=-13.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn pitch_shift_boundary_values_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(
+            graph.pitch_shift(12.0).is_ok(),
+            "semitones=12.0 must succeed"
+        );
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(
+            graph.pitch_shift(-12.0).is_ok(),
+            "semitones=-12.0 must succeed"
+        );
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.pitch_shift(0.0).is_ok(), "semitones=0.0 must succeed");
+    }
+
+    #[test]
+    fn filter_step_pitch_shift_should_have_asetrate_filter_name() {
+        let step = FilterStep::PitchShift { semitones: 7.0 };
+        assert_eq!(step.filter_name(), "asetrate");
+    }
 
     #[test]
     fn reverb_echo_mismatched_lengths_should_return_ffmpeg_error() {

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -1451,6 +1451,24 @@ pub(super) fn audio_buffersrc_args(
     )
 }
 
+/// Parse the `sample_rate` field from a `buffersrc_args` string.
+///
+/// The expected format is `sample_rate=R:sample_fmt=FMT:channels=C:...`.
+/// Returns `44100` as a safe fallback if the field is absent or unparseable.
+pub(super) fn parse_sample_rate_from_buffersrc(buffersrc_args: &str) -> u32 {
+    buffersrc_args
+        .split(':')
+        .find_map(|kv| {
+            let (k, v) = kv.split_once('=')?;
+            if k == "sample_rate" {
+                v.parse().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(44100)
+}
+
 // ── Parametric EQ (multi-band chain) ─────────────────────────────────────────
 
 /// Insert a chain of filter nodes for a [`FilterStep::ParametricEq`] step.
@@ -2352,6 +2370,36 @@ impl FilterGraphInner {
             {
                 prev_ctx =
                     add_reverb_ir_step(graph, prev_ctx, ir_path, *wet, *dry, *pre_delay_ms, i)?;
+                continue;
+            }
+
+            // PitchShift — compound step: asetrate → atempo.
+            // asetrate changes the declared sample rate (shifting pitch); atempo
+            // restores the original duration.  The actual sample rate is resolved
+            // from buffersrc_args so the integer value is substituted literally.
+            if let FilterStep::PitchShift { semitones } = step {
+                let rate = 2f64.powf(f64::from(*semitones) / 12.0);
+                let sr = parse_sample_rate_from_buffersrc(buffersrc_args);
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let new_sr = (f64::from(sr) * rate).round() as u64;
+                let atempo = 1.0 / rate;
+                // SAFETY: graph and prev_ctx are valid pointers in the same graph.
+                prev_ctx = add_raw_filter_step(
+                    graph,
+                    prev_ctx,
+                    "asetrate",
+                    &format!("r={new_sr}"),
+                    i,
+                    "pitch_asetrate",
+                )?;
+                prev_ctx = add_raw_filter_step(
+                    graph,
+                    prev_ctx,
+                    "atempo",
+                    &format!("{atempo:.6}"),
+                    i,
+                    "pitch_atempo",
+                )?;
                 continue;
             }
 

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -706,6 +706,23 @@ pub enum FilterStep {
         decays: Vec<f32>,
     },
 
+    /// Pitch shift without tempo change.
+    ///
+    /// Shifts audio pitch by `semitones` semitones without altering playback
+    /// duration.  Implemented as `asetrate` (changes the declared sample rate
+    /// to shift pitch) followed by `atempo` (restores the original duration).
+    ///
+    /// Range: [−12.0, 12.0]; validated by
+    /// [`FilterGraph::pitch_shift`](crate::FilterGraph::pitch_shift).
+    ///
+    /// This is a compound step — `filter_name()` returns `"asetrate"` for
+    /// `validate_filter_steps`; the actual graph construction is handled by
+    /// `filter_inner::build::build_audio_graph`.
+    PitchShift {
+        /// Pitch shift in semitones. Range: [−12.0, 12.0].
+        semitones: f32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -863,6 +880,9 @@ impl FilterStep {
             // "afir" is used by validate_filter_steps as the primary check.
             Self::ReverbIr { .. } => "afir",
             Self::ReverbEcho { .. } => "aecho",
+            // PitchShift is a compound step (asetrate → atempo);
+            // "asetrate" is used by validate_filter_steps as the primary check.
+            Self::PitchShift { .. } => "asetrate",
         }
     }
 
@@ -1339,6 +1359,13 @@ impl FilterStep {
                     String::new()
                 };
                 format!("amovie={ir_path}{delay_part}[ir];[0:a][ir]afir=dry={dry}:wet={wet}")
+            }
+            // args() is not consumed by add_and_link_step (which is bypassed for
+            // this compound step); provided here for completeness.
+            Self::PitchShift { semitones } => {
+                let rate = 2f64.powf(f64::from(*semitones) / 12.0);
+                let atempo = 1.0 / rate;
+                format!("asetrate=sr*{rate:.6},atempo={atempo:.6}")
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds `FilterGraph::pitch_shift()` which shifts audio pitch by −12 to +12 semitones without changing playback duration. The implementation uses `asetrate` to change the declared sample rate (shifting pitch) followed by `atempo` to restore the original duration. The actual sample rate is resolved from the `buffersrc_args` string at graph build time so the integer value is substituted literally into `asetrate`.

## Changes

- `graph/filter_step.rs`: added `FilterStep::PitchShift { semitones: f32 }` with `filter_name()` → `"asetrate"` and descriptive `args()` for completeness
- `filter_inner/build.rs`: added `parse_sample_rate_from_buffersrc()` helper to extract sample rate from `buffersrc_args`; added `PitchShift` dispatch in `build_audio_graph` — computes `new_sr = sr * 2^(semitones/12)` and `atempo = 1/rate`, then calls `add_raw_filter_step` twice
- `effects/audio_effects.rs`: added `FilterGraph::pitch_shift()` with ±12 semitone range validation; 4 unit tests covering out-of-range errors, boundary acceptance, and filter name

## Related Issues

Closes #403

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes