### PR TITLE
feat(ff-filter): add time_stretch via atempo chain

### DIFF
--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -26,6 +26,28 @@ impl FilterGraph {
         Ok(self)
     }
 
+    /// Stretch or compress audio duration by `factor` without pitch change.
+    ///
+    /// `factor < 1.0` = slower (longer duration); `factor > 1.0` = faster
+    /// (shorter duration). Range: 0.1–10.0.
+    ///
+    /// Uses `FFmpeg`'s `atempo` filter (WSOLA algorithm). Values outside
+    /// [0.5, 2.0] are realised by chaining multiple `atempo` instances.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `factor` is outside 0.1–10.0.
+    pub fn time_stretch(&mut self, factor: f32) -> Result<&mut Self, FilterError> {
+        if !(0.1..=10.0).contains(&factor) {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("time_stretch factor must be 0.1–10.0, got {factor}"),
+            });
+        }
+        self.inner.push_step(FilterStep::TimeStretch { factor });
+        Ok(self)
+    }
+
     /// Add algorithmic echo/reverb with configurable delay taps.
     ///
     /// `in_gain` and `out_gain` are amplitude multipliers clamped to [0.0, 1.0].
@@ -112,6 +134,40 @@ mod tests {
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
     use std::path::Path;
+
+    #[test]
+    fn time_stretch_zero_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.time_stretch(0.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "factor=0.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn time_stretch_above_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.time_stretch(11.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "factor=11.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn time_stretch_boundary_values_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.time_stretch(0.1).is_ok(), "factor=0.1 must succeed");
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.time_stretch(10.0).is_ok(), "factor=10.0 must succeed");
+    }
+
+    #[test]
+    fn filter_step_time_stretch_should_have_atempo_filter_name() {
+        let step = FilterStep::TimeStretch { factor: 1.5 };
+        assert_eq!(step.filter_name(), "atempo");
+    }
 
     #[test]
     fn pitch_shift_above_range_should_return_ffmpeg_error() {

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2373,6 +2373,13 @@ impl FilterGraphInner {
                 continue;
             }
 
+            // TimeStretch — uses the same atempo chain as the audio path of Speed,
+            // but without any video setpts change.
+            if let FilterStep::TimeStretch { factor } = step {
+                prev_ctx = add_atempo_chain(graph, prev_ctx, f64::from(*factor), i)?;
+                continue;
+            }
+
             // PitchShift — compound step: asetrate → atempo.
             // asetrate changes the declared sample rate (shifting pitch); atempo
             // restores the original duration.  The actual sample rate is resolved

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -723,6 +723,18 @@ pub enum FilterStep {
         semitones: f32,
     },
 
+    /// Time-stretch audio without changing pitch via `FFmpeg`'s `atempo` filter.
+    ///
+    /// `factor < 1.0` = slower (longer duration); `factor > 1.0` = faster
+    /// (shorter duration).  Range: [0.1, 10.0].  Values outside [0.5, 2.0]
+    /// are realised by chaining multiple `atempo` instances (each in [0.5, 2.0]).
+    ///
+    /// Validated by [`FilterGraph::time_stretch`](crate::FilterGraph::time_stretch).
+    TimeStretch {
+        /// Speed / duration factor. 0.5 = 2× longer; 2.0 = 2× shorter. Range: [0.1, 10.0].
+        factor: f32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -883,6 +895,8 @@ impl FilterStep {
             // PitchShift is a compound step (asetrate → atempo);
             // "asetrate" is used by validate_filter_steps as the primary check.
             Self::PitchShift { .. } => "asetrate",
+            // TimeStretch uses one or more chained atempo filters.
+            Self::TimeStretch { .. } => "atempo",
         }
     }
 
@@ -1367,6 +1381,9 @@ impl FilterStep {
                 let atempo = 1.0 / rate;
                 format!("asetrate=sr*{rate:.6},atempo={atempo:.6}")
             }
+            // args() is not consumed by add_and_link_step (bypassed in favour of
+            // add_atempo_chain); provided here for single-instance completeness.
+            Self::TimeStretch { factor } => format!("{factor:.6}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `FilterGraph::time_stretch()` which changes audio duration without altering pitch (WSOLA via `atempo`). Values outside `[0.5, 2.0]` are automatically handled by chaining multiple `atempo` instances using the existing `decompose_atempo` helper, reusing the same path as the audio side of `Speed`.

## Changes

- `graph/filter_step.rs`: added `FilterStep::TimeStretch { factor: f32 }` with `filter_name()` → `"atempo"` and single-instance `args()` for completeness
- `filter_inner/build.rs`: added `TimeStretch` dispatch in `build_audio_graph` — delegates to `add_atempo_chain(factor)`, which uses `decompose_atempo` to chain as many `atempo` instances as needed
- `effects/audio_effects.rs`: added `FilterGraph::time_stretch()` with 0.1–10.0 range validation; 4 unit tests covering zero error, above-range error, boundary success, and filter name

## Related Issues

Closes #404

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes