### PR TITLE
feat(ff-filter): add speed_change via asetrate

### DIFF
--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -7,6 +7,27 @@ use crate::graph::FilterGraph;
 use crate::graph::filter_step::FilterStep;
 
 impl FilterGraph {
+    /// Change audio speed and pitch simultaneously by `factor`.
+    ///
+    /// Equivalent to playing a tape at a different speed: `factor > 1.0` makes
+    /// audio faster and higher-pitched; `factor < 1.0` makes it slower and lower.
+    ///
+    /// Uses `FFmpeg`'s `asetrate` filter. Range: 0.1–10.0.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `factor` is outside 0.1–10.0.
+    pub fn speed_change(&mut self, factor: f64) -> Result<&mut Self, FilterError> {
+        if !(0.1..=10.0).contains(&factor) {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("speed_change factor must be 0.1–10.0, got {factor}"),
+            });
+        }
+        self.inner.push_step(FilterStep::SpeedChange { factor });
+        Ok(self)
+    }
+
     /// Shift audio pitch by `semitones` without changing playback speed.
     ///
     /// Range: −12.0 to +12.0 semitones. Uses `asetrate` to change the
@@ -134,6 +155,42 @@ mod tests {
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
     use std::path::Path;
+
+    #[test]
+    fn speed_change_zero_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.speed_change(0.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "factor=0.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn speed_change_above_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.speed_change(11.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "factor=11.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn speed_change_boundary_values_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.speed_change(0.1).is_ok(), "factor=0.1 must succeed");
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.speed_change(10.0).is_ok(), "factor=10.0 must succeed");
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.speed_change(1.0).is_ok(), "factor=1.0 must succeed");
+    }
+
+    #[test]
+    fn filter_step_speed_change_should_have_asetrate_filter_name() {
+        let step = FilterStep::SpeedChange { factor: 2.0 };
+        assert_eq!(step.filter_name(), "asetrate");
+    }
 
     #[test]
     fn time_stretch_zero_should_return_ffmpeg_error() {

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2380,6 +2380,25 @@ impl FilterGraphInner {
                 continue;
             }
 
+            // SpeedChange — asetrate only (speed and pitch change together).
+            // The sample rate is resolved from buffersrc_args so the integer
+            // value is substituted literally into the filter args.
+            if let FilterStep::SpeedChange { factor } = step {
+                let sr = parse_sample_rate_from_buffersrc(buffersrc_args);
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let new_sr = (f64::from(sr) * factor).round() as u64;
+                // SAFETY: graph and prev_ctx are valid pointers in the same graph.
+                prev_ctx = add_raw_filter_step(
+                    graph,
+                    prev_ctx,
+                    "asetrate",
+                    &format!("r={new_sr}"),
+                    i,
+                    "speed_asetrate",
+                )?;
+                continue;
+            }
+
             // PitchShift — compound step: asetrate → atempo.
             // asetrate changes the declared sample rate (shifting pitch); atempo
             // restores the original duration.  The actual sample rate is resolved

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -735,6 +735,19 @@ pub enum FilterStep {
         factor: f32,
     },
 
+    /// Simultaneously change audio speed and pitch by the same factor.
+    ///
+    /// Equivalent to playing a tape at a different speed: `factor > 1.0` makes
+    /// audio faster and higher; `factor < 1.0` makes it slower and lower.
+    ///
+    /// Uses `FFmpeg`'s `asetrate` to multiply the declared sample rate by
+    /// `factor` without resampling.  Range: [0.1, 10.0]; validated by
+    /// [`FilterGraph::speed_change`](crate::FilterGraph::speed_change).
+    SpeedChange {
+        /// Speed/pitch multiplier. Range: [0.1, 10.0].
+        factor: f64,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -897,6 +910,8 @@ impl FilterStep {
             Self::PitchShift { .. } => "asetrate",
             // TimeStretch uses one or more chained atempo filters.
             Self::TimeStretch { .. } => "atempo",
+            // SpeedChange uses asetrate to shift speed and pitch together.
+            Self::SpeedChange { .. } => "asetrate",
         }
     }
 
@@ -1384,6 +1399,9 @@ impl FilterStep {
             // args() is not consumed by add_and_link_step (bypassed in favour of
             // add_atempo_chain); provided here for single-instance completeness.
             Self::TimeStretch { factor } => format!("{factor:.6}"),
+            // args() is not consumed by add_and_link_step (bypassed; sample rate
+            // is resolved from buffersrc_args at build time); provided for completeness.
+            Self::SpeedChange { factor } => format!("asetrate=sr*{factor:.6}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `FilterGraph::speed_change()` which simultaneously changes audio speed and pitch by the same factor (phonograph-style). Unlike `pitch_shift` (which corrects tempo after shifting pitch) or `time_stretch` (which preserves pitch), `speed_change` applies only `asetrate` so both speed and pitch shift together. The actual sample rate is resolved from `buffersrc_args` at build time and substituted as a literal integer.

## Changes

- `graph/filter_step.rs`: added `FilterStep::SpeedChange { factor: f64 }` with `filter_name()` → `"asetrate"` and descriptive `args()`
- `filter_inner/build.rs`: added `SpeedChange` dispatch in `build_audio_graph` — parses sample rate from `buffersrc_args`, computes `new_sr = sr * factor`, calls `add_raw_filter_step` with a single `asetrate` filter
- `effects/audio_effects.rs`: added `FilterGraph::speed_change()` with 0.1–10.0 range validation; 4 unit tests covering zero error, above-range error, boundary success, and filter name

## Related Issues

Closes #405

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes