### PR TITLE
feat(ff-filter): add noise_reduce and noise_reduce_profile via afftdn

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -262,9 +262,9 @@ pub use ff_filter::{
     AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
     BlendMode, ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile, Lerp,
-    LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, QualityMetrics, Rgb,
-    ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer,
-    XfadeTransition, YadifMode,
+    LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
+    QualityMetrics, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator,
+    VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -6,7 +6,56 @@ use crate::error::FilterError;
 use crate::graph::FilterGraph;
 use crate::graph::filter_step::FilterStep;
 
+/// Noise type used as the initial spectral model for `afftdn`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NoiseType {
+    /// White noise (flat spectrum).
+    White,
+    /// Pink noise (−3 dB/octave).
+    Pink,
+    /// Brown / red noise (−6 dB/octave).
+    Brown,
+}
+
+impl NoiseType {
+    fn afftdn_flag(self) -> &'static str {
+        match self {
+            NoiseType::White => "w",
+            NoiseType::Pink => "p",
+            NoiseType::Brown => "b",
+        }
+    }
+}
+
 impl FilterGraph {
+    /// Reduce noise using a statistical noise-type model.
+    ///
+    /// `nr_level` is the noise reduction amount in dB, clamped to [0.0, 97.0].
+    ///
+    /// Uses `FFmpeg`'s `afftdn` filter.
+    pub fn noise_reduce(&mut self, nt: NoiseType, nr_level: f32) -> &mut Self {
+        self.inner.push_step(FilterStep::NoiseReduce {
+            noise_type_flag: nt.afftdn_flag().to_string(),
+            nr_level: nr_level.clamp(0.0, 97.0),
+        });
+        self
+    }
+
+    /// Capture a noise profile from the first `profile_duration_secs` seconds,
+    /// then reduce noise in the full stream.
+    ///
+    /// `nr_level` is the reduction amount in dB, clamped to [0.0, 97.0].
+    /// `profile_duration_secs` is clamped to a minimum of 0.1 seconds.
+    ///
+    /// Uses `FFmpeg`'s `afftdn` filter with the `pl` profile-length option.
+    pub fn noise_reduce_profile(&mut self, profile_duration_secs: f32, nr_level: f32) -> &mut Self {
+        self.inner.push_step(FilterStep::NoiseReduceProfile {
+            profile_duration_secs: profile_duration_secs.max(0.1),
+            nr_level: nr_level.clamp(0.0, 97.0),
+        });
+        self
+    }
+
     /// Change audio speed and pitch simultaneously by `factor`.
     ///
     /// Equivalent to playing a tape at a different speed: `factor > 1.0` makes
@@ -152,9 +201,63 @@ impl FilterGraph {
 
 #[cfg(test)]
 mod tests {
+    use crate::effects::audio_effects::NoiseType;
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
     use std::path::Path;
+
+    #[test]
+    fn noise_reduce_should_push_noise_reduce_step() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        graph.noise_reduce(NoiseType::White, 50.0);
+        let step = FilterStep::NoiseReduce {
+            noise_type_flag: "w".to_string(),
+            nr_level: 50.0,
+        };
+        assert_eq!(step.filter_name(), "afftdn");
+        assert!(
+            step.args().contains("nt=w"),
+            "args must contain nt=w: {}",
+            step.args()
+        );
+        assert!(
+            step.args().contains("nr=50"),
+            "args must contain nr=50: {}",
+            step.args()
+        );
+    }
+
+    #[test]
+    fn noise_reduce_clamps_nr_level_above_97() {
+        let step = FilterStep::NoiseReduce {
+            noise_type_flag: "p".to_string(),
+            nr_level: 97.0,
+        };
+        assert!(
+            step.args().contains("nr=97"),
+            "nr_level=97.0 must appear in args: {}",
+            step.args()
+        );
+    }
+
+    #[test]
+    fn noise_reduce_profile_args_should_contain_pl_and_nr() {
+        let step = FilterStep::NoiseReduceProfile {
+            profile_duration_secs: 0.5,
+            nr_level: 30.0,
+        };
+        let args = step.args();
+        assert!(args.contains("pl=0.5"), "args must contain pl=0.5: {args}");
+        assert!(args.contains("nr=30"), "args must contain nr=30: {args}");
+        assert!(args.contains("nf=-25"), "args must contain nf=-25: {args}");
+    }
+
+    #[test]
+    fn noise_type_flags_should_match_afftdn_spec() {
+        assert_eq!(NoiseType::White.afftdn_flag(), "w");
+        assert_eq!(NoiseType::Pink.afftdn_flag(), "p");
+        assert_eq!(NoiseType::Brown.afftdn_flag(), "b");
+    }
 
     #[test]
     fn speed_change_zero_should_return_ffmpeg_error() {

--- a/crates/ff-filter/src/effects/mod.rs
+++ b/crates/ff-filter/src/effects/mod.rs
@@ -12,5 +12,6 @@ pub mod lens_profile;
 mod stabilizer;
 mod video_effects;
 
+pub use audio_effects::NoiseType;
 pub use lens_profile::LensProfile;
 pub use stabilizer::{AnalyzeOptions, Interpolation, StabilizeOptions, Stabilizer};

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -748,6 +748,36 @@ pub enum FilterStep {
         factor: f64,
     },
 
+    /// Spectral noise reduction using a statistical noise-type model.
+    ///
+    /// Uses `FFmpeg`'s `afftdn` filter.  `noise_type_flag` is the single-letter
+    /// `nt` parameter (`"w"` = white, `"p"` = pink, `"b"` = brown).
+    /// `nr_level` is the reduction amount in dB, clamped to [0.0, 97.0].
+    ///
+    /// Created by [`FilterGraph::noise_reduce`](crate::FilterGraph::noise_reduce).
+    NoiseReduce {
+        /// `afftdn` `nt` flag: `"w"`, `"p"`, or `"b"`.
+        noise_type_flag: String,
+        /// Noise reduction amount in dB. Clamped to [0.0, 97.0].
+        nr_level: f32,
+    },
+
+    /// Spectral noise reduction using a captured noise profile.
+    ///
+    /// Uses `FFmpeg`'s `afftdn` with the `pl` (profile length) option: the
+    /// filter learns the noise profile from the first `profile_duration_secs`
+    /// seconds, then subtracts it from the rest of the stream.
+    /// `nr_level` is the reduction amount in dB, clamped to [0.0, 97.0].
+    ///
+    /// Created by
+    /// [`FilterGraph::noise_reduce_profile`](crate::FilterGraph::noise_reduce_profile).
+    NoiseReduceProfile {
+        /// Duration in seconds from which to capture the noise profile. Minimum 0.1.
+        profile_duration_secs: f32,
+        /// Noise reduction amount in dB. Clamped to [0.0, 97.0].
+        nr_level: f32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -912,6 +942,7 @@ impl FilterStep {
             Self::TimeStretch { .. } => "atempo",
             // SpeedChange uses asetrate to shift speed and pitch together.
             Self::SpeedChange { .. } => "asetrate",
+            Self::NoiseReduce { .. } | Self::NoiseReduceProfile { .. } => "afftdn",
         }
     }
 
@@ -1402,6 +1433,14 @@ impl FilterStep {
             // args() is not consumed by add_and_link_step (bypassed; sample rate
             // is resolved from buffersrc_args at build time); provided for completeness.
             Self::SpeedChange { factor } => format!("asetrate=sr*{factor:.6}"),
+            Self::NoiseReduce {
+                noise_type_flag,
+                nr_level,
+            } => format!("nt={noise_type_flag}:nr={nr_level}"),
+            Self::NoiseReduceProfile {
+                profile_duration_secs,
+                nr_level,
+            } => format!("nr={nr_level}:nf=-25:nt=w:pl={profile_duration_secs}"),
         }
     }
 }

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -42,7 +42,9 @@ pub mod graph;
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
 pub use animation::{AnimatedValue, AnimationEntry, AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
-pub use effects::{AnalyzeOptions, Interpolation, LensProfile, StabilizeOptions, Stabilizer};
+pub use effects::{
+    AnalyzeOptions, Interpolation, LensProfile, NoiseType, StabilizeOptions, Stabilizer,
+};
 pub use error::FilterError;
 pub use graph::{
     AudioConcatenator, AudioTrack, ClipJoiner, ClipTransition, DrawTextOptions, EqBand,


### PR DESCRIPTION
## Summary

Adds spectral noise reduction to `FilterGraph` via FFmpeg's `afftdn` filter. Two methods are provided: `noise_reduce` for applying noise reduction with a known noise type, and `noise_reduce_profile` for profile-based capture that automatically learns the noise floor from the first N seconds of audio.

## Changes

- `audio_effects.rs`: Added `NoiseType` enum (`White`, `Pink`, `Brown`) with `afftdn_flag()` mapping; added `noise_reduce(noise_type, nr_level)` and `noise_reduce_profile(profile_duration_secs, nr_level)` methods with silent clamping; added 4 unit tests
- `filter_step.rs`: Added `FilterStep::NoiseReduce { noise_type_flag, nr_level }` and `FilterStep::NoiseReduceProfile { profile_duration_secs, nr_level }` with `filter_name() → "afftdn"` and formatted `args()`
- `effects/mod.rs`: Re-exported `NoiseType` publicly
- `ff-filter/src/lib.rs`: Added `NoiseType` to top-level pub use
- `avio/src/lib.rs`: Added `NoiseType` to filter feature re-exports

## Related Issues

Closes #406

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes