### PR TITLE
feat(ff-filter): add duck() via sidechaincompress for audio ducking

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -262,9 +262,9 @@ pub use ff_filter::{
     AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
     BlendMode, ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile, Lerp,
-    LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, QualityMetrics, Rgb,
-    ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer,
-    XfadeTransition, YadifMode,
+    LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
+    QualityMetrics, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator,
+    VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -158,6 +158,60 @@ impl FilterGraph {
         Ok(self)
     }
 
+    /// Reduce background audio level when foreground signal exceeds a threshold
+    /// (audio ducking via sidechain compression).
+    ///
+    /// Push background audio to slot 0 and foreground (sidechain trigger) audio
+    /// to slot 1.  When the foreground signal rises above `threshold_db`, the
+    /// background is attenuated by `ratio`:1 over `attack_ms` milliseconds; it
+    /// recovers over `release_ms` milliseconds when the foreground drops below the
+    /// threshold.
+    ///
+    /// `threshold_db` is the trigger level in dBFS (e.g., −20.0).  It is
+    /// converted to a linear amplitude ratio before being passed to the filter.
+    /// `ratio` must be ≥ 1.0.  `attack_ms` and `release_ms` must be ≥ 0.0.
+    ///
+    /// Uses `FFmpeg`'s `sidechaincompress` filter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `ratio < 1.0` or either time value is
+    /// negative.
+    pub fn duck(
+        &mut self,
+        threshold_db: f32,
+        ratio: f32,
+        attack_ms: f32,
+        release_ms: f32,
+    ) -> Result<&mut Self, FilterError> {
+        if ratio < 1.0 {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("duck ratio must be >= 1.0, got {ratio}"),
+            });
+        }
+        if attack_ms < 0.0 {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("duck attack_ms must be >= 0.0, got {attack_ms}"),
+            });
+        }
+        if release_ms < 0.0 {
+            return Err(FilterError::Ffmpeg {
+                code: 0,
+                message: format!("duck release_ms must be >= 0.0, got {release_ms}"),
+            });
+        }
+        let threshold_linear = 10f32.powf(threshold_db / 20.0);
+        self.inner.push_step(FilterStep::Duck {
+            threshold_linear,
+            ratio,
+            attack_ms,
+            release_ms,
+        });
+        Ok(self)
+    }
+
     /// Add convolution reverb using an impulse response (IR) audio file.
     ///
     /// `ir_path` is a path to a `.wav` or `.flac` impulse response file.
@@ -520,6 +574,83 @@ mod tests {
         assert!(
             args.contains("adelay=100"),
             "args must contain adelay=100 when pre_delay_ms=100: {args}"
+        );
+    }
+
+    #[test]
+    fn duck_ratio_below_one_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.duck(-20.0, 0.5, 10.0, 200.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "ratio=0.5 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn duck_negative_attack_ms_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.duck(-20.0, 20.0, -1.0, 200.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "attack_ms=-1.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn duck_negative_release_ms_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.duck(-20.0, 20.0, 10.0, -1.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "release_ms=-1.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn duck_valid_params_should_push_duck_step() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(
+            graph.duck(-20.0, 20.0, 10.0, 200.0).is_ok(),
+            "valid duck params must succeed"
+        );
+    }
+
+    #[test]
+    fn filter_step_duck_should_have_sidechaincompress_filter_name() {
+        let step = FilterStep::Duck {
+            threshold_linear: 0.1,
+            ratio: 20.0,
+            attack_ms: 10.0,
+            release_ms: 200.0,
+        };
+        assert_eq!(step.filter_name(), "sidechaincompress");
+    }
+
+    #[test]
+    fn filter_step_duck_args_should_contain_threshold_ratio_attack_release() {
+        let step = FilterStep::Duck {
+            threshold_linear: 0.1,
+            ratio: 20.0,
+            attack_ms: 10.0,
+            release_ms: 200.0,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("threshold=0.1"),
+            "args must contain threshold=0.1: {args}"
+        );
+        assert!(
+            args.contains("ratio=20"),
+            "args must contain ratio=20: {args}"
+        );
+        assert!(
+            args.contains("attack=10"),
+            "args must contain attack=10: {args}"
+        );
+        assert!(
+            args.contains("release=200"),
+            "args must contain release=200: {args}"
         );
     }
 

--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -6,7 +6,56 @@ use crate::error::FilterError;
 use crate::graph::FilterGraph;
 use crate::graph::filter_step::FilterStep;
 
+/// Noise type used as the initial spectral model for `afftdn`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NoiseType {
+    /// White noise (flat spectrum).
+    White,
+    /// Pink noise (−3 dB/octave).
+    Pink,
+    /// Brown / red noise (−6 dB/octave).
+    Brown,
+}
+
+impl NoiseType {
+    fn afftdn_flag(self) -> &'static str {
+        match self {
+            NoiseType::White => "w",
+            NoiseType::Pink => "p",
+            NoiseType::Brown => "b",
+        }
+    }
+}
+
 impl FilterGraph {
+    /// Reduce noise using a statistical noise-type model.
+    ///
+    /// `nr_level` is the noise reduction amount in dB, clamped to [0.0, 97.0].
+    ///
+    /// Uses `FFmpeg`'s `afftdn` filter.
+    pub fn noise_reduce(&mut self, nt: NoiseType, nr_level: f32) -> &mut Self {
+        self.inner.push_step(FilterStep::NoiseReduce {
+            noise_type_flag: nt.afftdn_flag().to_string(),
+            nr_level: nr_level.clamp(0.0, 97.0),
+        });
+        self
+    }
+
+    /// Capture a noise profile from the first `profile_duration_secs` seconds,
+    /// then reduce noise in the full stream.
+    ///
+    /// `nr_level` is the reduction amount in dB, clamped to [0.0, 97.0].
+    /// `profile_duration_secs` is clamped to a minimum of 0.1 seconds.
+    ///
+    /// Uses `FFmpeg`'s `afftdn` filter with the `pl` profile-length option.
+    pub fn noise_reduce_profile(&mut self, profile_duration_secs: f32, nr_level: f32) -> &mut Self {
+        self.inner.push_step(FilterStep::NoiseReduceProfile {
+            profile_duration_secs: profile_duration_secs.max(0.1),
+            nr_level: nr_level.clamp(0.0, 97.0),
+        });
+        self
+    }
+
     /// Change audio speed and pitch simultaneously by `factor`.
     ///
     /// Equivalent to playing a tape at a different speed: `factor > 1.0` makes
@@ -152,9 +201,63 @@ impl FilterGraph {
 
 #[cfg(test)]
 mod tests {
+    use crate::effects::audio_effects::NoiseType;
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
     use std::path::Path;
+
+    #[test]
+    fn noise_reduce_should_push_noise_reduce_step() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        graph.noise_reduce(NoiseType::White, 50.0);
+        let step = FilterStep::NoiseReduce {
+            noise_type_flag: "w".to_string(),
+            nr_level: 50.0,
+        };
+        assert_eq!(step.filter_name(), "afftdn");
+        assert!(
+            step.args().contains("nt=w"),
+            "args must contain nt=w: {}",
+            step.args()
+        );
+        assert!(
+            step.args().contains("nr=50"),
+            "args must contain nr=50: {}",
+            step.args()
+        );
+    }
+
+    #[test]
+    fn noise_reduce_clamps_nr_level_above_97() {
+        let step = FilterStep::NoiseReduce {
+            noise_type_flag: "p".to_string(),
+            nr_level: 97.0,
+        };
+        assert!(
+            step.args().contains("nr=97"),
+            "nr_level=97.0 must appear in args: {}",
+            step.args()
+        );
+    }
+
+    #[test]
+    fn noise_reduce_profile_args_should_contain_pl_and_nr() {
+        let step = FilterStep::NoiseReduceProfile {
+            profile_duration_secs: 0.5,
+            nr_level: 30.0,
+        };
+        let args = step.args();
+        assert!(args.contains("pl=0.5"), "args must contain pl=0.5: {args}");
+        assert!(args.contains("nr=30"), "args must contain nr=30: {args}");
+        assert!(args.contains("nf=-25"), "args must contain nf=-25: {args}");
+    }
+
+    #[test]
+    fn noise_type_flags_should_match_afftdn_spec() {
+        assert_eq!(NoiseType::White.afftdn_flag(), "w");
+        assert_eq!(NoiseType::Pink.afftdn_flag(), "p");
+        assert_eq!(NoiseType::Brown.afftdn_flag(), "b");
+    }
 
     #[test]
     fn speed_change_zero_should_return_ffmpeg_error() {

--- a/crates/ff-filter/src/effects/mod.rs
+++ b/crates/ff-filter/src/effects/mod.rs
@@ -12,5 +12,6 @@ pub mod lens_profile;
 mod stabilizer;
 mod video_effects;
 
+pub use audio_effects::NoiseType;
 pub use lens_profile::LensProfile;
 pub use stabilizer::{AnalyzeOptions, Interpolation, StabilizeOptions, Stabilizer};

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2429,6 +2429,36 @@ impl FilterGraphInner {
                 continue;
             }
 
+            // Duck — two-input compound step: sidechaincompress.
+            // Slot 0 = background (main signal, gets ducked); slot 1 = foreground (sidechain).
+            if let FilterStep::Duck {
+                threshold_linear,
+                ratio,
+                attack_ms,
+                release_ms,
+            } = step
+            {
+                let side_ctx = src_ctxs
+                    .get(1)
+                    .and_then(|s| *s)
+                    .ok_or(FilterError::BuildFailed)?
+                    .as_ptr();
+                // SAFETY: graph, prev_ctx, and side_ctx are valid pointers in the same graph.
+                prev_ctx = add_sidechain_compress_step(
+                    graph,
+                    prev_ctx,
+                    side_ctx,
+                    &DuckArgs {
+                        threshold_linear: *threshold_linear,
+                        ratio: *ratio,
+                        attack_ms: *attack_ms,
+                        release_ms: *release_ms,
+                    },
+                    i,
+                )?;
+                continue;
+            }
+
             // AudioDelay dispatches to adelay (positive/zero) or atrim (negative).
             if let FilterStep::AudioDelay { ms } = step {
                 let (filter_name, args) = if *ms >= 0.0 {
@@ -2616,4 +2646,95 @@ pub(super) unsafe fn add_reverb_ir_step(
         "filter reverb_ir expanded ir_path={ir_path} wet={wet} dry={dry} pre_delay_ms={pre_delay_ms} index={index}"
     );
     Ok(afir_ctx)
+}
+
+// ── SidechainCompress compound step ──────────────────────────────────────────
+
+/// Parameters for `add_sidechain_compress_step`.
+pub(super) struct DuckArgs {
+    pub threshold_linear: f32,
+    pub ratio: f32,
+    pub attack_ms: f32,
+    pub release_ms: f32,
+}
+
+/// Wire the two-input `sidechaincompress` filter for audio ducking.
+///
+/// ```text
+/// main_ctx (background, slot 0) ──→ sidechaincompress[0]
+/// side_ctx (foreground, slot 1) ──→ sidechaincompress[1]
+///                                   sidechaincompress → out
+/// ```
+///
+/// # Safety
+///
+/// `graph`, `main_ctx`, and `side_ctx` must be valid pointers owned by the
+/// same `AVFilterGraph`.
+pub(super) unsafe fn add_sidechain_compress_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    main_ctx: *mut ff_sys::AVFilterContext,
+    side_ctx: *mut ff_sys::AVFilterContext,
+    args: &DuckArgs,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    use std::ffi::CString;
+
+    let DuckArgs {
+        threshold_linear,
+        ratio,
+        attack_ms,
+        release_ms,
+    } = args;
+
+    let filter = ff_sys::avfilter_get_by_name(c"sidechaincompress".as_ptr());
+    if filter.is_null() {
+        log::warn!("filter not found name=sidechaincompress (duck)");
+        return Err(FilterError::BuildFailed);
+    }
+
+    let name = CString::new(format!("duck{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let args_str = format!(
+        "threshold={threshold_linear}:ratio={ratio}:attack={attack_ms}:release={release_ms}"
+    );
+    let cargs = CString::new(args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+
+    let mut sc_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    // SAFETY: filter and graph are non-null; args are valid null-terminated C strings.
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sc_ctx,
+        filter,
+        name.as_ptr(),
+        cargs.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!(
+            "filter creation failed name=sidechaincompress args={args_str} code={ret} (duck)"
+        );
+        return Err(ffmpeg_err(ret));
+    }
+    log::debug!("filter added name=sidechaincompress args={args_str} index={index} (duck)");
+
+    // Link main signal → input pad 0 (the stream to be compressed).
+    // SAFETY: main_ctx and sc_ctx belong to the same graph; pad indices are valid.
+    let ret = ff_sys::avfilter_link(main_ctx, 0, sc_ctx, 0);
+    if ret < 0 {
+        log::warn!("avfilter_link failed main→sidechaincompress[0] code={ret}");
+        return Err(ffmpeg_err(ret));
+    }
+
+    // Link sidechain signal → input pad 1 (the trigger signal).
+    // SAFETY: side_ctx and sc_ctx belong to the same graph; pad indices are valid.
+    let ret = ff_sys::avfilter_link(side_ctx, 0, sc_ctx, 1);
+    if ret < 0 {
+        log::warn!("avfilter_link failed sidechain→sidechaincompress[1] code={ret}");
+        return Err(ffmpeg_err(ret));
+    }
+
+    log::debug!(
+        "filter duck expanded threshold_linear={threshold_linear} ratio={ratio} \
+         attack_ms={attack_ms} release_ms={release_ms} index={index}"
+    );
+    Ok(sc_ctx)
 }

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -274,6 +274,9 @@ impl FilterGraphInner {
             if let FilterStep::ConcatAudio { n } = step {
                 return *n as usize;
             }
+            if matches!(step, FilterStep::Duck { .. }) {
+                return 2;
+            }
         }
         1
     }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -778,6 +778,27 @@ pub enum FilterStep {
         nr_level: f32,
     },
 
+    /// Sidechain compression for audio ducking via `FFmpeg`'s `sidechaincompress` filter.
+    ///
+    /// Reduces the background audio level when the foreground (sidechain) signal
+    /// exceeds the threshold.  Push background audio to slot 0 and foreground
+    /// audio to slot 1.
+    ///
+    /// `threshold_linear` is the trigger level as a linear amplitude (pre-converted
+    /// from dBFS by [`FilterGraph::duck`](crate::FilterGraph::duck)).
+    /// `ratio`, `attack_ms`, and `release_ms` are validated by
+    /// [`FilterGraph::duck`](crate::FilterGraph::duck).
+    Duck {
+        /// Compression threshold as a linear amplitude ratio in (0.0, 1.0].
+        threshold_linear: f32,
+        /// Compression ratio (e.g. 20.0 for near hard-limiting). Must be >= 1.0.
+        ratio: f32,
+        /// Attack time in milliseconds. Must be >= 0.0.
+        attack_ms: f32,
+        /// Release time in milliseconds. Must be >= 0.0.
+        release_ms: f32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -943,6 +964,9 @@ impl FilterStep {
             // SpeedChange uses asetrate to shift speed and pitch together.
             Self::SpeedChange { .. } => "asetrate",
             Self::NoiseReduce { .. } | Self::NoiseReduceProfile { .. } => "afftdn",
+            // Duck is a two-input compound step; "sidechaincompress" is checked at
+            // build time by validate_filter_steps.
+            Self::Duck { .. } => "sidechaincompress",
         }
     }
 
@@ -1441,6 +1465,16 @@ impl FilterStep {
                 profile_duration_secs,
                 nr_level,
             } => format!("nr={nr_level}:nf=-25:nt=w:pl={profile_duration_secs}"),
+            // args() is not consumed by add_and_link_step (bypassed for this
+            // compound two-input step); provided for completeness.
+            Self::Duck {
+                threshold_linear,
+                ratio,
+                attack_ms,
+                release_ms,
+            } => format!(
+                "threshold={threshold_linear}:ratio={ratio}:attack={attack_ms}:release={release_ms}"
+            ),
         }
     }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -748,6 +748,36 @@ pub enum FilterStep {
         factor: f64,
     },
 
+    /// Spectral noise reduction using a statistical noise-type model.
+    ///
+    /// Uses `FFmpeg`'s `afftdn` filter.  `noise_type_flag` is the single-letter
+    /// `nt` parameter (`"w"` = white, `"p"` = pink, `"b"` = brown).
+    /// `nr_level` is the reduction amount in dB, clamped to [0.0, 97.0].
+    ///
+    /// Created by [`FilterGraph::noise_reduce`](crate::FilterGraph::noise_reduce).
+    NoiseReduce {
+        /// `afftdn` `nt` flag: `"w"`, `"p"`, or `"b"`.
+        noise_type_flag: String,
+        /// Noise reduction amount in dB. Clamped to [0.0, 97.0].
+        nr_level: f32,
+    },
+
+    /// Spectral noise reduction using a captured noise profile.
+    ///
+    /// Uses `FFmpeg`'s `afftdn` with the `pl` (profile length) option: the
+    /// filter learns the noise profile from the first `profile_duration_secs`
+    /// seconds, then subtracts it from the rest of the stream.
+    /// `nr_level` is the reduction amount in dB, clamped to [0.0, 97.0].
+    ///
+    /// Created by
+    /// [`FilterGraph::noise_reduce_profile`](crate::FilterGraph::noise_reduce_profile).
+    NoiseReduceProfile {
+        /// Duration in seconds from which to capture the noise profile. Minimum 0.1.
+        profile_duration_secs: f32,
+        /// Noise reduction amount in dB. Clamped to [0.0, 97.0].
+        nr_level: f32,
+    },
+
     /// Apply a polygon alpha mask using `FFmpeg`'s `geq` filter with a
     /// crossing-number point-in-polygon test.
     ///
@@ -912,6 +942,7 @@ impl FilterStep {
             Self::TimeStretch { .. } => "atempo",
             // SpeedChange uses asetrate to shift speed and pitch together.
             Self::SpeedChange { .. } => "asetrate",
+            Self::NoiseReduce { .. } | Self::NoiseReduceProfile { .. } => "afftdn",
         }
     }
 
@@ -1402,6 +1433,14 @@ impl FilterStep {
             // args() is not consumed by add_and_link_step (bypassed; sample rate
             // is resolved from buffersrc_args at build time); provided for completeness.
             Self::SpeedChange { factor } => format!("asetrate=sr*{factor:.6}"),
+            Self::NoiseReduce {
+                noise_type_flag,
+                nr_level,
+            } => format!("nt={noise_type_flag}:nr={nr_level}"),
+            Self::NoiseReduceProfile {
+                profile_duration_secs,
+                nr_level,
+            } => format!("nr={nr_level}:nf=-25:nt=w:pl={profile_duration_secs}"),
         }
     }
 }

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -42,7 +42,9 @@ pub mod graph;
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
 pub use animation::{AnimatedValue, AnimationEntry, AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
-pub use effects::{AnalyzeOptions, Interpolation, LensProfile, StabilizeOptions, Stabilizer};
+pub use effects::{
+    AnalyzeOptions, Interpolation, LensProfile, NoiseType, StabilizeOptions, Stabilizer,
+};
 pub use error::FilterError;
 pub use graph::{
     AudioConcatenator, AudioTrack, ClipJoiner, ClipTransition, DrawTextOptions, EqBand,


### PR DESCRIPTION
## Summary

Adds `FilterGraph::duck()` — sidechain compression that reduces background audio level when a foreground signal exceeds a threshold. The method uses FFmpeg's `sidechaincompress` filter, wiring slot 0 (background) as the main signal and slot 1 (foreground) as the sidechain trigger.

## Changes

- `audio_effects.rs`: Added `duck(threshold_db, ratio, attack_ms, release_ms)` method with validation (`ratio >= 1.0`, times `>= 0.0`); `threshold_db` is converted from dBFS to linear amplitude before being stored in the step; added 6 unit tests
- `filter_step.rs`: Added `FilterStep::Duck { threshold_linear, ratio, attack_ms, release_ms }` with `filter_name() → "sidechaincompress"` and formatted `args()`
- `push_pull.rs`: Updated `audio_input_count()` to return 2 when `Duck` is in the step list, so two `abuffer` sources are created (slot 0 = background, slot 1 = sidechain)
- `build.rs`: Added `Duck` dispatch in `build_audio_graph` using `src_ctxs[1]` as the sidechain input; added `add_sidechain_compress_step` helper with `DuckArgs` struct to stay within clippy's 7-argument limit

## Related Issues

Closes #407

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes