### PR TITLE
feat(ff-decode): add AsyncVideoDecoderBuilder and AsyncAudioDecoderBuilder

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -252,7 +252,10 @@ pub use ff_encode::{
 // is a thin Send + async shell around its synchronous counterpart, backed by
 // spawn_blocking and a bounded tokio::sync::mpsc channel (encoders, cap=8).
 #[cfg(feature = "tokio")]
-pub use ff_decode::{AsyncAudioDecoder, AsyncImageDecoder, AsyncVideoDecoder};
+pub use ff_decode::{
+    AsyncAudioDecoder, AsyncAudioDecoderBuilder, AsyncImageDecoder, AsyncVideoDecoder,
+    AsyncVideoDecoderBuilder,
+};
 #[cfg(feature = "tokio")]
 pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 

--- a/crates/ff-decode/src/audio/async_decoder.rs
+++ b/crates/ff-decode/src/audio/async_decoder.rs
@@ -2,12 +2,92 @@
 
 use std::path::{Path, PathBuf};
 
-use ff_format::AudioFrame;
+use ff_format::{AudioFrame, SampleFormat};
 use futures::stream::{self, Stream};
 
 use crate::async_decoder::AsyncDecoder;
-use crate::audio::builder::AudioDecoder;
+use crate::audio::builder::{AudioDecoder, AudioDecoderBuilder};
 use crate::error::DecodeError;
+
+/// Async builder for [`AsyncAudioDecoder`] that mirrors the options available
+/// on the synchronous [`AudioDecoderBuilder`].
+///
+/// Obtain one with [`AsyncAudioDecoder::builder`]. Call [`build`](Self::build)
+/// to open the file asynchronously on a `spawn_blocking` thread.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::AsyncAudioDecoder;
+/// use ff_format::SampleFormat;
+///
+/// let decoder = AsyncAudioDecoder::builder("audio.mp3")
+///     .output_format(SampleFormat::F32)
+///     .output_sample_rate(48_000)
+///     .build()
+///     .await?;
+/// ```
+pub struct AsyncAudioDecoderBuilder {
+    inner: AudioDecoderBuilder,
+}
+
+impl AsyncAudioDecoderBuilder {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            inner: AudioDecoderBuilder::new(path),
+        }
+    }
+
+    /// Sets the output sample format for decoded frames.
+    ///
+    /// Equivalent to [`AudioDecoderBuilder::output_format`].
+    #[must_use]
+    pub fn output_format(mut self, format: SampleFormat) -> Self {
+        self.inner = self.inner.output_format(format);
+        self
+    }
+
+    /// Sets the output sample rate in Hz.
+    ///
+    /// Equivalent to [`AudioDecoderBuilder::output_sample_rate`].
+    #[must_use]
+    pub fn output_sample_rate(mut self, sample_rate: u32) -> Self {
+        self.inner = self.inner.output_sample_rate(sample_rate);
+        self
+    }
+
+    /// Sets the output channel count.
+    ///
+    /// Equivalent to [`AudioDecoderBuilder::output_channels`].
+    #[must_use]
+    pub fn output_channels(mut self, channels: u32) -> Self {
+        self.inner = self.inner.output_channels(channels);
+        self
+    }
+
+    /// Opens the file and builds the async decoder.
+    ///
+    /// File I/O and codec initialisation run on a `spawn_blocking` thread so
+    /// the async executor is not blocked. All errors from
+    /// [`AudioDecoderBuilder::build`] are propagated transparently.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if the file is missing, contains no audio
+    /// stream, or uses an unsupported codec.
+    pub async fn build(self) -> Result<AsyncAudioDecoder, DecodeError> {
+        let builder = self.inner;
+        let decoder = tokio::task::spawn_blocking(move || builder.build())
+            .await
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("spawn_blocking panicked: {e}"),
+            })??;
+        Ok(AsyncAudioDecoder {
+            inner: AsyncDecoder::new(decoder),
+        })
+    }
+}
 
 /// Async wrapper around [`AudioDecoder`].
 ///
@@ -31,6 +111,28 @@ pub struct AsyncAudioDecoder {
 }
 
 impl AsyncAudioDecoder {
+    /// Returns a builder for configuring the async audio decoder.
+    ///
+    /// Use this when you need to control the output sample format, sample rate,
+    /// or channel count. For zero-configuration decoding, prefer
+    /// [`AsyncAudioDecoder::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_decode::AsyncAudioDecoder;
+    /// use ff_format::SampleFormat;
+    ///
+    /// let decoder = AsyncAudioDecoder::builder("audio.mp3")
+    ///     .output_format(SampleFormat::F32)
+    ///     .output_sample_rate(48_000)
+    ///     .build()
+    ///     .await?;
+    /// ```
+    pub fn builder(path: impl AsRef<Path>) -> AsyncAudioDecoderBuilder {
+        AsyncAudioDecoderBuilder::new(path.as_ref().to_path_buf())
+    }
+
     /// Opens the audio file asynchronously.
     ///
     /// File I/O and codec initialisation are performed on a `spawn_blocking`
@@ -105,6 +207,30 @@ mod tests {
         assert!(
             matches!(result, Err(DecodeError::FileNotFound { .. })),
             "expected FileNotFound"
+        );
+    }
+
+    #[tokio::test]
+    async fn async_audio_decoder_builder_output_format_should_propagate_to_sync_builder() {
+        let result = AsyncAudioDecoder::builder("/nonexistent/path/audio.mp3")
+            .output_format(SampleFormat::F32)
+            .build()
+            .await;
+        assert!(
+            matches!(result, Err(DecodeError::FileNotFound { .. })),
+            "builder with output_format must propagate FileNotFound"
+        );
+    }
+
+    #[tokio::test]
+    async fn async_audio_decoder_builder_output_sample_rate_should_propagate_to_sync_builder() {
+        let result = AsyncAudioDecoder::builder("/nonexistent/path/audio.mp3")
+            .output_sample_rate(48_000)
+            .build()
+            .await;
+        assert!(
+            matches!(result, Err(DecodeError::FileNotFound { .. })),
+            "builder with output_sample_rate must propagate FileNotFound"
         );
     }
 

--- a/crates/ff-decode/src/audio/mod.rs
+++ b/crates/ff-decode/src/audio/mod.rs
@@ -10,5 +10,5 @@ pub mod decoder_inner;
 pub(crate) mod resample_inner;
 
 #[cfg(feature = "tokio")]
-pub use async_decoder::AsyncAudioDecoder;
+pub use async_decoder::{AsyncAudioDecoder, AsyncAudioDecoderBuilder};
 pub use builder::{AudioDecoder, AudioDecoderBuilder};

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -130,11 +130,11 @@ pub use shared::{HardwareAccel, SeekMode};
 pub use video::{VideoDecoder, VideoDecoderBuilder};
 
 #[cfg(feature = "tokio")]
-pub use audio::AsyncAudioDecoder;
+pub use audio::{AsyncAudioDecoder, AsyncAudioDecoderBuilder};
 #[cfg(feature = "tokio")]
 pub use image::AsyncImageDecoder;
 #[cfg(feature = "tokio")]
-pub use video::AsyncVideoDecoder;
+pub use video::{AsyncVideoDecoder, AsyncVideoDecoderBuilder};
 
 /// Prelude module for convenient imports.
 ///

--- a/crates/ff-decode/src/video/async_decoder.rs
+++ b/crates/ff-decode/src/video/async_decoder.rs
@@ -2,12 +2,100 @@
 
 use std::path::{Path, PathBuf};
 
-use ff_format::VideoFrame;
+use ff_format::{PixelFormat, VideoFrame};
 use futures::stream::{self, Stream};
 
 use crate::async_decoder::AsyncDecoder;
 use crate::error::DecodeError;
-use crate::video::builder::VideoDecoder;
+use crate::video::builder::{VideoDecoder, VideoDecoderBuilder};
+
+/// Async builder for [`AsyncVideoDecoder`] that mirrors the options available
+/// on the synchronous [`VideoDecoderBuilder`].
+///
+/// Obtain one with [`AsyncVideoDecoder::builder`]. Call [`build`](Self::build)
+/// to open the file asynchronously on a `spawn_blocking` thread.
+///
+/// # Examples
+///
+/// ```ignore
+/// use ff_decode::AsyncVideoDecoder;
+/// use ff_format::PixelFormat;
+///
+/// let decoder = AsyncVideoDecoder::builder("video.mp4")
+///     .output_format(PixelFormat::Rgb24)
+///     .build()
+///     .await?;
+/// ```
+pub struct AsyncVideoDecoderBuilder {
+    inner: VideoDecoderBuilder,
+}
+
+impl AsyncVideoDecoderBuilder {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            inner: VideoDecoderBuilder::new(path),
+        }
+    }
+
+    /// Sets the output pixel format for decoded frames.
+    ///
+    /// Equivalent to [`VideoDecoderBuilder::output_format`].
+    #[must_use]
+    pub fn output_format(mut self, format: PixelFormat) -> Self {
+        self.inner = self.inner.output_format(format);
+        self
+    }
+
+    /// Scales decoded frames to exact dimensions.
+    ///
+    /// Equivalent to [`VideoDecoderBuilder::output_size`].
+    #[must_use]
+    pub fn output_size(mut self, width: u32, height: u32) -> Self {
+        self.inner = self.inner.output_size(width, height);
+        self
+    }
+
+    /// Scales decoded frames to the given width, preserving the aspect ratio.
+    ///
+    /// Equivalent to [`VideoDecoderBuilder::output_width`].
+    #[must_use]
+    pub fn output_width(mut self, width: u32) -> Self {
+        self.inner = self.inner.output_width(width);
+        self
+    }
+
+    /// Scales decoded frames to the given height, preserving the aspect ratio.
+    ///
+    /// Equivalent to [`VideoDecoderBuilder::output_height`].
+    #[must_use]
+    pub fn output_height(mut self, height: u32) -> Self {
+        self.inner = self.inner.output_height(height);
+        self
+    }
+
+    /// Opens the file and builds the async decoder.
+    ///
+    /// File I/O and codec initialisation run on a `spawn_blocking` thread so
+    /// the async executor is not blocked. All errors from
+    /// [`VideoDecoderBuilder::build`] are propagated transparently.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError`] if the file is missing, contains no video
+    /// stream, uses an unsupported codec, or has invalid output dimensions.
+    pub async fn build(self) -> Result<AsyncVideoDecoder, DecodeError> {
+        let builder = self.inner;
+        let decoder = tokio::task::spawn_blocking(move || builder.build())
+            .await
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("spawn_blocking panicked: {e}"),
+            })??;
+        Ok(AsyncVideoDecoder {
+            inner: AsyncDecoder::new(decoder),
+        })
+    }
+}
 
 /// Async wrapper around [`VideoDecoder`].
 ///
@@ -31,6 +119,27 @@ pub struct AsyncVideoDecoder {
 }
 
 impl AsyncVideoDecoder {
+    /// Returns a builder for configuring the async video decoder.
+    ///
+    /// Use this when you need to control the output pixel format or frame
+    /// scaling. For zero-configuration decoding, prefer [`AsyncVideoDecoder::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ff_decode::AsyncVideoDecoder;
+    /// use ff_format::PixelFormat;
+    ///
+    /// let decoder = AsyncVideoDecoder::builder("video.mp4")
+    ///     .output_format(PixelFormat::Rgb24)
+    ///     .output_size(640, 360)
+    ///     .build()
+    ///     .await?;
+    /// ```
+    pub fn builder(path: impl AsRef<Path>) -> AsyncVideoDecoderBuilder {
+        AsyncVideoDecoderBuilder::new(path.as_ref().to_path_buf())
+    }
+
     /// Opens the video file asynchronously.
     ///
     /// File I/O and codec initialisation are performed on a `spawn_blocking`
@@ -105,6 +214,30 @@ mod tests {
         assert!(
             matches!(result, Err(DecodeError::FileNotFound { .. })),
             "expected FileNotFound"
+        );
+    }
+
+    #[tokio::test]
+    async fn async_video_decoder_builder_output_format_should_propagate_to_sync_builder() {
+        let result = AsyncVideoDecoder::builder("/nonexistent/path/video.mp4")
+            .output_format(PixelFormat::Rgb24)
+            .build()
+            .await;
+        assert!(
+            matches!(result, Err(DecodeError::FileNotFound { .. })),
+            "builder with output_format must propagate FileNotFound"
+        );
+    }
+
+    #[tokio::test]
+    async fn async_video_decoder_builder_zero_size_should_return_invalid_dimensions() {
+        let result = AsyncVideoDecoder::builder("/nonexistent/path/video.mp4")
+            .output_size(0, 480)
+            .build()
+            .await;
+        assert!(
+            matches!(result, Err(DecodeError::InvalidOutputDimensions { .. })),
+            "output_size(0, 480) must return InvalidOutputDimensions"
         );
     }
 

--- a/crates/ff-decode/src/video/mod.rs
+++ b/crates/ff-decode/src/video/mod.rs
@@ -9,5 +9,5 @@ pub mod builder;
 pub mod decoder_inner;
 
 #[cfg(feature = "tokio")]
-pub use async_decoder::AsyncVideoDecoder;
+pub use async_decoder::{AsyncVideoDecoder, AsyncVideoDecoderBuilder};
 pub use builder::{VideoDecoder, VideoDecoderBuilder};


### PR DESCRIPTION
## Summary

`AsyncVideoDecoder::open()` and `AsyncAudioDecoder::open()` previously called the sync builder with no configuration, forcing callers who need format conversion or scaling to hand-roll their own `spawn_blocking` wrapper. This PR adds `AsyncVideoDecoderBuilder` and `AsyncAudioDecoderBuilder` — thin wrappers around the existing sync builders — accessible via new `AsyncVideoDecoder::builder(path)` and `AsyncAudioDecoder::builder(path)` entry points. The zero-configuration `open()` shorthand is preserved unchanged.

## Changes

- `crates/ff-decode/src/video/async_decoder.rs`: add `AsyncVideoDecoderBuilder` with `output_format`, `output_size`, `output_width`, `output_height`, and async `build()`; add `AsyncVideoDecoder::builder(path)` entry point
- `crates/ff-decode/src/audio/async_decoder.rs`: add `AsyncAudioDecoderBuilder` with `output_format`, `output_sample_rate`, `output_channels`, and async `build()`; add `AsyncAudioDecoder::builder(path)` entry point
- `crates/ff-decode/src/video/mod.rs`, `crates/ff-decode/src/audio/mod.rs`: re-export new builder types
- `crates/ff-decode/src/lib.rs`: re-export `AsyncVideoDecoderBuilder` and `AsyncAudioDecoderBuilder` under `#[cfg(feature = "tokio")]`
- `crates/avio/src/lib.rs`: re-export both new builder types from the facade crate
- Unit tests: `async_video_decoder_builder_output_format_should_propagate_to_sync_builder`, `async_video_decoder_builder_zero_size_should_return_invalid_dimensions`, `async_audio_decoder_builder_output_format_should_propagate_to_sync_builder`, `async_audio_decoder_builder_output_sample_rate_should_propagate_to_sync_builder`

## Related Issues

Closes #1005

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes