### PR TITLE
feat(ff-preview): add PositionUpdate and Error variants to PlayerEvent

### DIFF
--- a/crates/ff-preview/src/event.rs
+++ b/crates/ff-preview/src/event.rs
@@ -16,4 +16,15 @@ pub enum PlayerEvent {
 
     /// The media file has been fully decoded; `run()` is about to return.
     Eof,
+
+    /// Current playback position; emitted once per decoded and presented video frame.
+    ///
+    /// Not emitted during seeking (while [`FrameResult::Seeking`](crate::playback::FrameResult)
+    /// is being returned) — only for fully decoded frames.
+    PositionUpdate(Duration),
+
+    /// A non-fatal decode error encountered by the background decode thread.
+    ///
+    /// Playback continues until EOF; [`PlayerEvent::Eof`] follows shortly after.
+    Error(String),
 }

--- a/crates/ff-preview/src/playback/decode_buffer.rs
+++ b/crates/ff-preview/src/playback/decode_buffer.rs
@@ -104,12 +104,20 @@ impl DecodeBufferBuilder {
         let buffered_thread = Arc::clone(&buffered);
         let cancel_thread = Arc::clone(&cancel);
 
+        let (seek_tx, seek_rx) = channel::<SeekEvent>();
+        let (error_tx, error_rx) = channel::<String>();
+
+        let error_tx_thread = error_tx.clone();
         let handle = thread::spawn(move || -> VideoDecoder {
-            decode_loop(&mut decoder, &tx, &buffered_thread, &cancel_thread);
+            decode_loop(
+                &mut decoder,
+                &tx,
+                &buffered_thread,
+                &cancel_thread,
+                &error_tx_thread,
+            );
             decoder
         });
-
-        let (seek_tx, seek_rx) = channel::<SeekEvent>();
 
         Ok(DecodeBuffer {
             rx: Some(rx),
@@ -121,6 +129,8 @@ impl DecodeBufferBuilder {
             last_good_frame: None,
             seek_tx,
             seek_rx,
+            error_tx,
+            error_rx,
         })
     }
 }
@@ -175,6 +185,10 @@ pub struct DecodeBuffer {
     seek_tx: Sender<SeekEvent>,
     /// Receiver for seek completion events; exposed via `seek_events()`.
     seek_rx: Receiver<SeekEvent>,
+    /// Sender side of the decode error channel; cloned into each decode thread.
+    error_tx: Sender<String>,
+    /// Receiver for non-fatal decode error messages; exposed via `error_events()`.
+    error_rx: Receiver<String>,
 }
 
 impl DecodeBuffer {
@@ -238,6 +252,17 @@ impl DecodeBuffer {
         &self.seek_rx
     }
 
+    /// Returns the receiver for non-fatal decode error messages.
+    ///
+    /// Poll with `try_recv()` in the presentation loop. Each message
+    /// corresponds to one failed `decode_one()` call in the background thread.
+    /// The background thread exits after sending the error, so
+    /// [`pop_frame`](Self::pop_frame) will return `Eof` shortly after.
+    #[must_use]
+    pub fn error_events(&self) -> &Receiver<String> {
+        &self.error_rx
+    }
+
     /// Frame-accurate seek to `target_pts`.
     ///
     /// Stops the background decode thread, seeks the underlying decoder to the
@@ -256,6 +281,7 @@ impl DecodeBuffer {
         let (mut decoder, tx) = self.stop_and_seek(target_pts)?;
         let buffered_thread = Arc::clone(&self.buffered);
         let cancel_thread = Arc::clone(&self.cancel);
+        let error_tx_thread = self.error_tx.clone();
 
         self.handle = Some(thread::spawn(move || -> VideoDecoder {
             // Forward-decode discard: drop frames whose PTS is before target_pts.
@@ -283,13 +309,20 @@ impl DecodeBuffer {
                     Ok(None) => return decoder, // EOF before target
                     Err(e) => {
                         log::warn!("decode error during seek discard error={e}");
+                        let _ = error_tx_thread.send(e.to_string());
                         return decoder;
                     }
                 }
             }
 
             // Normal decode loop after the discard phase.
-            decode_loop(&mut decoder, &tx, &buffered_thread, &cancel_thread);
+            decode_loop(
+                &mut decoder,
+                &tx,
+                &buffered_thread,
+                &cancel_thread,
+                &error_tx_thread,
+            );
             decoder
         }));
 
@@ -315,10 +348,17 @@ impl DecodeBuffer {
         let (mut decoder, tx) = self.stop_and_seek(target_pts)?;
         let buffered_thread = Arc::clone(&self.buffered);
         let cancel_thread = Arc::clone(&self.cancel);
+        let error_tx_thread = self.error_tx.clone();
 
         // No discard loop — start the normal decode loop directly from the I-frame.
         self.handle = Some(thread::spawn(move || -> VideoDecoder {
-            decode_loop(&mut decoder, &tx, &buffered_thread, &cancel_thread);
+            decode_loop(
+                &mut decoder,
+                &tx,
+                &buffered_thread,
+                &cancel_thread,
+                &error_tx_thread,
+            );
             decoder
         }));
 
@@ -365,6 +405,7 @@ impl DecodeBuffer {
         let cancel = Arc::clone(&self.cancel);
         let seeking = Arc::clone(&self.seeking);
         let seek_event_tx = self.seek_tx.clone();
+        let error_tx_async = self.error_tx.clone();
 
         let worker = thread::spawn(move || -> VideoDecoder {
             // Recover the decoder from the old thread. In normal operation the
@@ -427,12 +468,13 @@ impl DecodeBuffer {
                     Ok(None) => return decoder, // EOF before target
                     Err(e) => {
                         log::warn!("seek_async discard error error={e}");
+                        let _ = error_tx_async.send(e.to_string());
                         return decoder;
                     }
                 }
             }
 
-            decode_loop(&mut decoder, &new_tx, &buffered, &cancel);
+            decode_loop(&mut decoder, &new_tx, &buffered, &cancel, &error_tx_async);
             decoder
         });
 
@@ -515,6 +557,7 @@ pub(super) fn decode_loop(
     tx: &SyncSender<VideoFrame>,
     buffered: &AtomicUsize,
     cancel: &AtomicBool,
+    error_tx: &Sender<String>,
 ) {
     loop {
         if cancel.load(Ordering::Acquire) {
@@ -532,6 +575,7 @@ pub(super) fn decode_loop(
             Ok(None) => break, // EOF
             Err(e) => {
                 log::warn!("decode error in background thread error={e}");
+                let _ = error_tx.send(e.to_string());
                 break;
             }
         }

--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -297,7 +297,9 @@ impl PlayerRunner {
     /// channel. Consecutive [`PlayerCommand::Seek`] commands are coalesced —
     /// only the last one executes.
     ///
-    /// Emits [`PlayerEvent::SeekCompleted`] after each successful seek and
+    /// Emits [`PlayerEvent::SeekCompleted`] after each successful seek,
+    /// [`PlayerEvent::PositionUpdate`] after each presented video frame,
+    /// [`PlayerEvent::Error`] on non-fatal decode errors, and
     /// [`PlayerEvent::Eof`] before returning.
     ///
     /// # Errors
@@ -346,6 +348,13 @@ impl PlayerRunner {
                 self.clock.reset(pts);
                 self.restart_audio_from(pts);
                 let _ = self.event_tx.try_send(PlayerEvent::SeekCompleted(pts));
+            }
+
+            // Surface non-fatal decode errors from the background thread.
+            if let Some(buf) = self.decode_buf.as_ref() {
+                while let Ok(msg) = buf.error_events().try_recv() {
+                    let _ = self.event_tx.try_send(PlayerEvent::Error(msg));
+                }
             }
 
             if self.stopped.load(Ordering::Acquire) {
@@ -426,6 +435,8 @@ impl PlayerRunner {
                     }
 
                     self.present_frame(&frame);
+                    let pts = frame.timestamp().as_duration();
+                    let _ = self.event_tx.try_send(PlayerEvent::PositionUpdate(pts));
                 }
             }
         }
@@ -1354,9 +1365,107 @@ mod tests {
             Some(PlayerEvent::Eof) => {
                 panic!("received Eof before SeekCompleted — file may be too short");
             }
-            None => {
+            Some(PlayerEvent::PositionUpdate(_) | PlayerEvent::Error(_)) | None => {
                 panic!("no PlayerEvent::SeekCompleted received within 2 seconds");
             }
         }
+    }
+
+    // ── PlayerEvent: PositionUpdate + Error ───────────────────────────────────
+
+    #[test]
+    fn position_update_and_error_event_variants_should_be_accessible() {
+        let _ = PlayerEvent::PositionUpdate(Duration::ZERO);
+        let _ = PlayerEvent::Error("test error".to_string());
+    }
+
+    #[test]
+    fn eof_event_should_be_delivered_after_run_completes() {
+        let path = test_audio_path();
+        let (runner, handle) = match PreviewPlayer::open(&path) {
+            Ok(p) => p.split(),
+            Err(e) => {
+                println!("skipping: {e}");
+                return;
+            }
+        };
+
+        // Stop after 150 ms so the test does not wait for the full audio duration.
+        let handle_stop = handle.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(150));
+            handle_stop.stop();
+        });
+
+        let _ = runner.run();
+        let events: Vec<_> = std::iter::from_fn(|| handle.poll_event()).collect();
+        assert!(
+            events.iter().any(|e| matches!(e, PlayerEvent::Eof)),
+            "Eof event must be delivered after run() returns; collected {} events",
+            events.len()
+        );
+    }
+
+    #[test]
+    #[ignore = "requires assets/video/gameplay.mp4; run with -- --include-ignored"]
+    fn position_update_should_be_emitted_for_each_video_frame() {
+        let path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/video/gameplay.mp4");
+        if !path.exists() {
+            println!("skipping: video asset not found");
+            return;
+        }
+
+        use std::sync::{Arc, Mutex};
+        struct CountSink {
+            count: Arc<Mutex<usize>>,
+            max: usize,
+            handle: PlayerHandle,
+        }
+        impl FrameSink for CountSink {
+            fn push_frame(&mut self, _rgba: &[u8], _w: u32, _h: u32, _pts: Duration) {
+                let mut g = self
+                    .count
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                *g += 1;
+                if *g >= self.max {
+                    self.handle.stop();
+                }
+            }
+        }
+
+        let (mut runner, handle) = match PreviewPlayer::open(&path) {
+            Ok(p) => p.split(),
+            Err(e) => {
+                println!("skipping: {e}");
+                return;
+            }
+        };
+
+        let count = Arc::new(Mutex::new(0usize));
+        runner.set_sink(Box::new(CountSink {
+            count: Arc::clone(&count),
+            max: 20,
+            handle: handle.clone(),
+        }));
+        let _ = runner.run();
+
+        let frames = *count
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let position_updates: Vec<_> = std::iter::from_fn(|| handle.poll_event())
+            .filter(|e| matches!(e, PlayerEvent::PositionUpdate(_)))
+            .collect();
+
+        assert!(
+            !position_updates.is_empty(),
+            "at least one PositionUpdate event must be emitted; frames delivered={frames}"
+        );
+        assert!(
+            position_updates.len() <= frames,
+            "PositionUpdate count ({}) must not exceed frame count ({frames})",
+            position_updates.len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Extends `PlayerEvent` with `PositionUpdate(Duration)` and `Error(String)` variants so callers can observe per-frame playback position and non-fatal decode errors without polling shared atomics. This completes the bidirectional communication channel between `PlayerRunner` and `PlayerHandle` introduced in #1021.

## Changes

- **`src/event.rs`**: Added `PositionUpdate(Duration)` (emitted after each presented video frame) and `Error(String)` (emitted on non-fatal background decode errors)
- **`src/playback/decode_buffer.rs`**: Added `error_tx`/`error_rx` channel (same pattern as `seek_rx`); updated `decode_loop` to send the error message before exiting; threaded `error_tx.clone()` into all decode threads (`build()`, `seek()`, `seek_coarse()`, `seek_async()`); added `error_events() -> &Receiver<String>` accessor
- **`src/playback/player.rs`**: Emits `PositionUpdate(pts)` after each `FrameResult::Frame` presentation; polls `error_events()` at the top of each loop iteration and emits `Error(msg)`; updated `run()` doc to list all four events; fixed non-exhaustive match in existing seek test for new variants
- **Tests added**: `position_update_and_error_event_variants_should_be_accessible` (compile-time type check), `eof_event_should_be_delivered_after_run_completes` (verifies Eof is always emitted when `run()` exits), `position_update_should_be_emitted_for_each_video_frame` (ignored, requires video asset)

## Related Issues

Closes #1022

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes