### PR TITLE
feat(ff-preview): add multi-track AudioMixer for real-time preview

### DIFF
--- a/crates/ff-preview/src/audio/mod.rs
+++ b/crates/ff-preview/src/audio/mod.rs
@@ -57,6 +57,7 @@ impl AudioTrackHandle {
     /// Number of samples currently buffered.
     ///
     /// Used by background audio threads to implement back-pressure.
+    #[cfg(feature = "timeline")]
     pub(crate) fn buffered_samples(&self) -> usize {
         self.buf
             .lock()
@@ -67,6 +68,7 @@ impl AudioTrackHandle {
     /// Drain all buffered samples.
     ///
     /// Called on seek to discard audio that is no longer relevant.
+    #[cfg(feature = "timeline")]
     pub(crate) fn clear(&self) {
         self.buf
             .lock()
@@ -183,6 +185,7 @@ impl AudioMixer {
     /// Drain all track buffers.
     ///
     /// Called on seek to discard stale audio across all tracks.
+    #[cfg(feature = "timeline")]
     pub(crate) fn invalidate_all(&mut self) {
         for track in &self.tracks {
             track
@@ -334,6 +337,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "timeline")]
     #[test]
     fn audio_mixer_invalidate_all_should_clear_all_buffers() {
         let mut mixer = AudioMixer::new(48_000);
@@ -365,6 +369,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "timeline")]
     #[test]
     fn audio_track_handle_clear_should_drain_buffered_samples() {
         let mut mixer = AudioMixer::new(48_000);

--- a/crates/ff-preview/src/audio/mod.rs
+++ b/crates/ff-preview/src/audio/mod.rs
@@ -1,0 +1,381 @@
+//! Multi-track audio mixer for real-time preview.
+//!
+//! [`AudioMixer`] combines `N` mono tracks into a single interleaved stereo
+//! `f32` output at 48 kHz. Per-track volume and pan are controlled from any
+//! thread via the cloneable [`AudioTrackHandle`].
+
+use std::collections::VecDeque;
+use std::f32::consts;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+// ── AudioTrack (private) ──────────────────────────────────────────────────────
+
+struct AudioTrack {
+    buf: Arc<Mutex<VecDeque<f32>>>,
+    volume: Arc<AtomicU32>,
+    pan: Arc<AtomicU32>,
+}
+
+// ── AudioTrackHandle ──────────────────────────────────────────────────────────
+
+/// Cloneable handle for filling a track and adjusting its gain from any thread.
+///
+/// Obtained by calling [`AudioMixer::add_track`]. All methods are lock-free
+/// on the hot path (volume/pan reads) and only lock for buffer access.
+#[derive(Clone)]
+pub struct AudioTrackHandle {
+    buf: Arc<Mutex<VecDeque<f32>>>,
+    volume: Arc<AtomicU32>,
+    pan: Arc<AtomicU32>,
+}
+
+impl AudioTrackHandle {
+    /// Set per-track volume. Clamped to `[0.0, 1.0]`.
+    pub fn set_volume(&self, v: f32) {
+        self.volume
+            .store(v.clamp(0.0, 1.0).to_bits(), Ordering::Relaxed);
+    }
+
+    /// Set stereo pan. Clamped to `[-1.0` (full left) `.. +1.0` (full right)`]`.
+    pub fn set_pan(&self, p: f32) {
+        self.pan
+            .store(p.clamp(-1.0, 1.0).to_bits(), Ordering::Relaxed);
+    }
+
+    /// Push decoded mono PCM samples into the track buffer.
+    ///
+    /// Called by the background audio-decode thread. The samples should be
+    /// `f32` mono at 48 kHz (i.e., one value per time step).
+    pub fn push_samples(&self, samples: &[f32]) {
+        self.buf
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend(samples.iter().copied());
+    }
+
+    /// Number of samples currently buffered.
+    ///
+    /// Used by background audio threads to implement back-pressure.
+    pub(crate) fn buffered_samples(&self) -> usize {
+        self.buf
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
+    /// Drain all buffered samples.
+    ///
+    /// Called on seek to discard audio that is no longer relevant.
+    pub(crate) fn clear(&self) {
+        self.buf
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
+    }
+}
+
+// ── AudioMixer ────────────────────────────────────────────────────────────────
+
+/// Multi-track, constant-power-panned stereo mixer.
+///
+/// Combines `N` mono tracks into a single interleaved stereo `f32` output at
+/// 48 kHz.  Per-track volume and pan adjustments take effect on the next call
+/// to [`mix`](Self::mix).
+///
+/// # Pan law
+///
+/// For a pan position `p ∈ [-1.0, +1.0]`:
+/// ```text
+/// p_norm = (p + 1.0) * π / 4
+/// l_gain = volume * cos(p_norm)
+/// r_gain = volume * sin(p_norm)
+/// ```
+/// At `p = 0` (center): `l_gain == r_gain ≈ 0.707 × volume` (constant-power
+/// law — equal loudness in both ears).
+///
+/// # Example
+///
+/// ```ignore
+/// let mut mixer = AudioMixer::new(48_000);
+/// let track = mixer.add_track();
+///
+/// // Background audio-decode thread:
+/// track.push_samples(&mono_pcm_chunk);
+///
+/// // Audio-device output callback:
+/// let stereo = mixer.mix(output_buf.len());
+/// output_buf[..stereo.len()].copy_from_slice(&stereo);
+/// ```
+pub struct AudioMixer {
+    tracks: Vec<AudioTrack>,
+    /// Output sample rate in Hz.
+    pub sample_rate: u32,
+    /// Number of output channels — always 2 (stereo).
+    pub channels: u16,
+}
+
+impl AudioMixer {
+    /// Create a new mixer with no tracks.
+    #[must_use]
+    pub fn new(sample_rate: u32) -> Self {
+        Self {
+            tracks: Vec::new(),
+            sample_rate,
+            channels: 2,
+        }
+    }
+
+    /// Add a new mono track and return a cloneable handle.
+    ///
+    /// The track starts with `volume = 1.0` and `pan = 0.0` (center).
+    pub fn add_track(&mut self) -> AudioTrackHandle {
+        let buf = Arc::new(Mutex::new(VecDeque::new()));
+        let volume = Arc::new(AtomicU32::new(1.0_f32.to_bits()));
+        let pan = Arc::new(AtomicU32::new(0.0_f32.to_bits()));
+        let handle = AudioTrackHandle {
+            buf: Arc::clone(&buf),
+            volume: Arc::clone(&volume),
+            pan: Arc::clone(&pan),
+        };
+        self.tracks.push(AudioTrack { buf, volume, pan });
+        handle
+    }
+
+    /// Mix `n_samples` interleaved stereo `f32` values from all tracks.
+    ///
+    /// `n_samples` is the total number of `f32` elements to produce (L + R
+    /// interleaved). Tracks with insufficient buffered data are zero-padded.
+    /// The output is clipped to `[-1.0, 1.0]`.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn mix(&mut self, n_samples: usize) -> Vec<f32> {
+        let n_frames = n_samples / 2;
+        let mut out = vec![0.0_f32; n_frames * 2];
+
+        for track in &self.tracks {
+            let volume = f32::from_bits(track.volume.load(Ordering::Relaxed));
+            let pan = f32::from_bits(track.pan.load(Ordering::Relaxed));
+
+            // Constant-power pan law.
+            let p_norm = (pan + 1.0) * consts::FRAC_PI_4;
+            let l_gain = volume * p_norm.cos();
+            let r_gain = volume * p_norm.sin();
+
+            let mut guard = track
+                .buf
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for i in 0..n_frames {
+                let s = guard.pop_front().unwrap_or(0.0);
+                out[i * 2] += s * l_gain;
+                out[i * 2 + 1] += s * r_gain;
+            }
+        }
+
+        // Clip to [-1.0, 1.0].
+        for sample in &mut out {
+            *sample = sample.clamp(-1.0, 1.0);
+        }
+
+        out
+    }
+
+    /// Drain all track buffers.
+    ///
+    /// Called on seek to discard stale audio across all tracks.
+    pub(crate) fn invalidate_all(&mut self) {
+        for track in &self.tracks {
+            track
+                .buf
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clear();
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audio_mixer_mix_two_tracks_should_sum_and_clip_left_channel() {
+        // Two tracks, full-left pan (l_gain = volume = 1.0), amplitude 0.8.
+        // Without clipping: L = 0.8 + 0.8 = 1.6. After clip: 1.0.
+        let mut mixer = AudioMixer::new(48_000);
+        let t1 = mixer.add_track();
+        let t2 = mixer.add_track();
+        t1.set_pan(-1.0);
+        t2.set_pan(-1.0);
+        t1.push_samples(&[0.8, 0.8]);
+        t2.push_samples(&[0.8, 0.8]);
+
+        let out = mixer.mix(4); // 2 stereo frames
+        assert_eq!(out.len(), 4);
+        assert!(
+            (out[0] - 1.0).abs() < 1e-6,
+            "L must clip to 1.0; got {}",
+            out[0]
+        );
+        assert!(
+            out[1].abs() < 1e-6,
+            "R must be 0.0 for full-left pan; got {}",
+            out[1]
+        );
+    }
+
+    #[test]
+    fn audio_mixer_pan_full_left_should_produce_zero_right_channel() {
+        let mut mixer = AudioMixer::new(48_000);
+        let track = mixer.add_track();
+        track.set_pan(-1.0);
+        track.push_samples(&[0.5, 0.5, 0.5, 0.5]);
+
+        let out = mixer.mix(8); // 4 stereo frames
+        assert_eq!(out.len(), 8);
+        for i in (1..8usize).step_by(2) {
+            assert!(
+                out[i].abs() < 1e-6,
+                "R channel must be 0.0 for full-left pan; got {} at index {i}",
+                out[i]
+            );
+        }
+    }
+
+    #[test]
+    fn audio_mixer_pan_full_right_should_produce_zero_left_channel() {
+        let mut mixer = AudioMixer::new(48_000);
+        let track = mixer.add_track();
+        track.set_pan(1.0);
+        track.push_samples(&[0.5, 0.5, 0.5, 0.5]);
+
+        let out = mixer.mix(8);
+        for i in (0..8usize).step_by(2) {
+            assert!(
+                out[i].abs() < 1e-6,
+                "L channel must be 0.0 for full-right pan; got {} at index {i}",
+                out[i]
+            );
+        }
+    }
+
+    #[test]
+    fn audio_mixer_two_tracks_volume_sum_exceeding_one_should_be_clipped() {
+        // Two tracks, volume 0.7, full-left pan, amplitude 0.8.
+        // L = 0.8 * 0.7 + 0.8 * 0.7 = 1.12 > 1.0 → clipped to 1.0.
+        let mut mixer = AudioMixer::new(48_000);
+        let t1 = mixer.add_track();
+        let t2 = mixer.add_track();
+        t1.set_volume(0.7);
+        t2.set_volume(0.7);
+        t1.set_pan(-1.0);
+        t2.set_pan(-1.0);
+        t1.push_samples(&[0.8, 0.8]);
+        t2.push_samples(&[0.8, 0.8]);
+
+        let out = mixer.mix(4);
+        for &s in &out {
+            assert!(
+                s >= -1.0 && s <= 1.0,
+                "all output must be within [-1.0, 1.0]; got {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn audio_mixer_center_pan_should_apply_constant_power_law() {
+        // At pan = 0.0: p_norm = π/4, cos = sin = 1/√2 ≈ 0.7071.
+        let mut mixer = AudioMixer::new(48_000);
+        let track = mixer.add_track();
+        // pan = 0 (center) by default, volume = 1.0 by default.
+        track.push_samples(&[1.0]);
+
+        let out = mixer.mix(2); // 1 stereo frame
+        let expected = (std::f32::consts::FRAC_PI_4).cos(); // ≈ 0.7071
+        assert!(
+            (out[0] - expected).abs() < 1e-5,
+            "L at center should be cos(π/4) ≈ {expected:.5}; got {}",
+            out[0]
+        );
+        assert!(
+            (out[1] - expected).abs() < 1e-5,
+            "R at center should be sin(π/4) ≈ {expected:.5}; got {}",
+            out[1]
+        );
+    }
+
+    #[test]
+    fn audio_mixer_underrun_should_zero_pad_remaining_frames() {
+        let mut mixer = AudioMixer::new(48_000);
+        let track = mixer.add_track();
+        track.set_pan(-1.0); // full left for determinism
+        track.push_samples(&[0.5]); // only one sample, but we request 4 frames
+
+        let out = mixer.mix(8);
+        assert_eq!(out.len(), 8);
+
+        // Frames 1-3 must be zero (underrun).
+        for i in 2..8 {
+            assert_eq!(out[i], 0.0, "underrun frame must be silent; got {}", out[i]);
+        }
+    }
+
+    #[test]
+    fn audio_mixer_empty_tracks_should_produce_silence() {
+        let mut mixer = AudioMixer::new(48_000);
+        let _track = mixer.add_track();
+        let out = mixer.mix(8);
+        assert_eq!(out.len(), 8);
+        assert!(
+            out.iter().all(|&s| s == 0.0),
+            "empty track must produce silence"
+        );
+    }
+
+    #[test]
+    fn audio_mixer_invalidate_all_should_clear_all_buffers() {
+        let mut mixer = AudioMixer::new(48_000);
+        let t1 = mixer.add_track();
+        let t2 = mixer.add_track();
+        t1.push_samples(&[0.5, 0.5]);
+        t2.push_samples(&[0.5, 0.5]);
+
+        mixer.invalidate_all();
+
+        let out = mixer.mix(4);
+        assert!(
+            out.iter().all(|&s| s == 0.0),
+            "after invalidate_all, mix must be silent"
+        );
+    }
+
+    #[test]
+    fn audio_track_handle_set_volume_should_clamp_to_zero_one() {
+        let mut mixer = AudioMixer::new(48_000);
+        let track = mixer.add_track();
+        track.set_volume(2.0); // should clamp to 1.0
+        track.push_samples(&[1.0]);
+        let out = mixer.mix(2);
+        // With volume clamped to 1.0 and center pan, L = cos(π/4) ≈ 0.707.
+        assert!(
+            out[0] <= 1.0,
+            "volume clamped to 1.0 must not exceed gain 1.0"
+        );
+    }
+
+    #[test]
+    fn audio_track_handle_clear_should_drain_buffered_samples() {
+        let mut mixer = AudioMixer::new(48_000);
+        let track = mixer.add_track();
+        track.push_samples(&[0.5, 0.5, 0.5, 0.5]);
+        assert_eq!(track.buffered_samples(), 4);
+        track.clear();
+        assert_eq!(
+            track.buffered_samples(),
+            0,
+            "clear() must drain all samples"
+        );
+    }
+}

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -26,6 +26,7 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 
+pub mod audio;
 pub(crate) mod cache;
 pub mod error;
 pub mod event;
@@ -37,6 +38,7 @@ pub mod proxy;
 #[cfg(feature = "timeline")]
 pub mod timeline;
 
+pub use audio::{AudioMixer, AudioTrackHandle};
 pub use error::PreviewError;
 pub use event::PlayerEvent;
 pub use playback::{

--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -27,6 +27,7 @@ use ff_format::SampleFormat;
 use super::clock::MasterClock;
 use super::decode_buffer::{DecodeBuffer, FrameResult};
 use super::sink::FrameSink;
+use crate::audio::AudioMixer;
 use crate::cache::FrameCache;
 use crate::error::PreviewError;
 use crate::event::PlayerEvent;
@@ -82,6 +83,8 @@ pub struct PlayerHandle {
     /// Mirrors the runner's stopped state; updated immediately by `stop`.
     stopped: Arc<AtomicBool>,
     duration_millis: u64,
+    /// Multi-track mixer — present when the runner was created by `TimelinePlayer`.
+    audio_mixer: Option<Arc<Mutex<AudioMixer>>>,
 }
 
 impl PlayerHandle {
@@ -162,6 +165,15 @@ impl PlayerHandle {
         if n == 0 {
             return Vec::new();
         }
+        // Mixer path — used when the handle was created by TimelinePlayer.
+        // The timeline clock is System-based so samples_consumed is not advanced here.
+        if let Some(mixer) = &self.audio_mixer {
+            return mixer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .mix(n);
+        }
+        // Legacy ring-buffer path — used by PlayerRunner (single-track audio).
         let Some(buf) = &self.audio_buf else {
             return Vec::new();
         };
@@ -208,6 +220,7 @@ impl PlayerHandle {
         paused: Arc<AtomicBool>,
         stopped: Arc<AtomicBool>,
         duration_millis: u64,
+        audio_mixer: Option<Arc<Mutex<AudioMixer>>>,
     ) -> Self {
         Self {
             cmd_tx,
@@ -215,6 +228,7 @@ impl PlayerHandle {
             current_pts,
             audio_buf: None,
             samples_consumed: None,
+            audio_mixer,
             paused,
             stopped,
             duration_millis,
@@ -810,6 +824,7 @@ impl PreviewPlayer {
             current_pts,
             audio_buf: audio_buf_for_handle,
             samples_consumed,
+            audio_mixer: None,
             paused,
             stopped,
             duration_millis,

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -10,20 +10,29 @@
 //! | [`TimelineRunner`] | Owns the decode pipelines; move to a thread and call [`run`](TimelineRunner::run) |
 //! | [`PlayerHandle`] | Shared, cloneable control handle |
 //!
-//! ## Limitations
+//! ## Audio
 //!
-//! - Only `video_tracks[0]` is played; additional tracks are ignored.
-//! - Audio is not supported; [`PlayerHandle::pop_audio_samples`] always returns an empty `Vec`.
+//! When any clip on the primary video track carries an audio stream,
+//! [`TimelinePlayer::open`] creates an [`AudioMixer`] with one track per
+//! audio-bearing clip.  A background [`AudioDecoder`] thread is started for
+//! the active clip and pushes mono samples via [`AudioTrackHandle`].  On clip
+//! transition or seek the old thread is cancelled and a new one is started.
+//! [`PlayerHandle::pop_audio_samples`] calls [`AudioMixer::mix`] and returns
+//! interleaved stereo `f32` output.
 
 mod timeline_inner;
 
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use ff_decode::{AudioDecoder, SeekMode};
+use ff_format::SampleFormat;
 use ff_pipeline::timeline::Timeline;
 
+use crate::audio::{AudioMixer, AudioTrackHandle};
 use crate::error::PreviewError;
 use crate::event::PlayerEvent;
 use crate::playback::SwsRgbaConverter;
@@ -35,10 +44,14 @@ use crate::playback::sink::FrameSink;
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const CHANNEL_CAP: usize = 64;
+/// Back-pressure limit for the audio decode thread (mono samples).
+const AUDIO_MAX_BUF: usize = 96_000;
 
 // ── ClipState ─────────────────────────────────────────────────────────────────
 
 struct ClipState {
+    /// Source file path — needed to spawn audio threads on clip transition.
+    source: PathBuf,
     decode_buf: DecodeBuffer,
     /// Global timeline position where this clip starts.
     timeline_start: Duration,
@@ -51,6 +64,8 @@ struct ClipState {
     /// Duration of the crossfade from the previous clip into this one.
     /// `Duration::ZERO` = hard cut.
     transition_dur: Duration,
+    /// Audio track handle — `None` if the clip has no audio stream.
+    audio_track: Option<AudioTrackHandle>,
 }
 
 // ── TransitionState ───────────────────────────────────────────────────────────
@@ -69,8 +84,9 @@ struct TransitionState {
 /// Thin builder for a ([`TimelineRunner`], [`PlayerHandle`]) pair backed by a
 /// [`Timeline`].
 ///
-/// Playback is limited to the primary video track (`video_tracks[0]`). Audio
-/// is not currently supported.
+/// Playback is limited to the primary video track (`video_tracks[0]`). When
+/// any clip carries an audio stream, an [`AudioMixer`] is created and audio
+/// is mixed into the stereo output from [`PlayerHandle::pop_audio_samples`].
 ///
 /// # Example
 ///
@@ -97,9 +113,12 @@ pub struct TimelinePlayer;
 impl TimelinePlayer {
     /// Open `timeline` for real-time preview playback.
     ///
-    /// Probes every clip's source file to determine effective durations, opens
-    /// a [`DecodeBuffer`] for each clip on the primary video track, and seeks
-    /// each buffer to its configured `in_point`.
+    /// Probes every clip's source file to determine effective durations and
+    /// audio availability, opens a [`DecodeBuffer`] for each clip on the
+    /// primary video track, and seeks each buffer to its configured `in_point`.
+    ///
+    /// When any clip carries an audio stream an [`AudioMixer`] is created and
+    /// the first audio-bearing clip's decode thread is started immediately.
     ///
     /// # Errors
     ///
@@ -107,7 +126,18 @@ impl TimelinePlayer {
     /// - `timeline` has no video tracks or the primary track is empty,
     /// - a clip source file cannot be found or opened,
     /// - a clip cannot be probed for duration.
+    #[allow(clippy::too_many_lines)]
     pub fn open(timeline: &Timeline) -> Result<(TimelineRunner, PlayerHandle), PreviewError> {
+        struct ProbeResult {
+            source: PathBuf,
+            in_pt: Duration,
+            clip_dur: Duration,
+            timeline_offset: Duration,
+            out_point: Option<Duration>,
+            transition_dur: Duration,
+            has_audio: bool,
+        }
+
         let tracks = timeline.video_tracks();
         if tracks.is_empty() || tracks[0].is_empty() {
             return Err(PreviewError::Ffmpeg {
@@ -118,26 +148,21 @@ impl TimelinePlayer {
 
         let fps = timeline.frame_rate().max(1.0);
         let clip_list = &tracks[0];
-        let mut clip_states: Vec<ClipState> = Vec::with_capacity(clip_list.len());
+
+        // ── Phase 1: probe all clips ──────────────────────────────────────────
+
+        let mut probes: Vec<ProbeResult> = Vec::with_capacity(clip_list.len());
+        let mut has_any_audio = false;
 
         for clip in clip_list {
             let in_pt = clip.in_point.unwrap_or(Duration::ZERO);
+            let info = ff_probe::open(&clip.source)?;
 
-            // Clip duration = out_point - in_point, or probe the file if out_point is absent.
             let clip_dur = if let (Some(ip), Some(op)) = (clip.in_point, clip.out_point) {
                 op.saturating_sub(ip)
             } else {
-                let info = ff_probe::open(&clip.source)?;
                 info.duration().saturating_sub(in_pt)
             };
-
-            let timeline_start = clip.timeline_offset;
-            let timeline_end = timeline_start + clip_dur;
-
-            let mut decode_buf = DecodeBuffer::open(&clip.source).build()?;
-            if in_pt > Duration::ZERO {
-                decode_buf.seek(in_pt)?;
-            }
 
             let transition_dur = if clip.transition.is_some() {
                 clip.transition_duration
@@ -145,17 +170,68 @@ impl TimelinePlayer {
                 Duration::ZERO
             };
 
-            clip_states.push(ClipState {
-                decode_buf,
-                timeline_start,
-                timeline_end,
-                in_point: in_pt,
+            let has_audio = info.has_audio();
+            has_any_audio |= has_audio;
+
+            probes.push(ProbeResult {
+                source: clip.source.clone(),
+                in_pt,
+                clip_dur,
+                timeline_offset: clip.timeline_offset,
                 out_point: clip.out_point,
                 transition_dur,
+                has_audio,
             });
         }
 
-        // Compute total timeline duration from the last clip's end.
+        // ── Phase 2: build mixer and track handles (if audio present) ─────────
+
+        let (mixer_arc, audio_track_handles): (
+            Option<Arc<Mutex<AudioMixer>>>,
+            Vec<Option<AudioTrackHandle>>,
+        ) = if has_any_audio {
+            let mut mixer = AudioMixer::new(48_000);
+            let handles: Vec<Option<AudioTrackHandle>> = probes
+                .iter()
+                .map(|p| {
+                    if p.has_audio {
+                        Some(mixer.add_track())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            (Some(Arc::new(Mutex::new(mixer))), handles)
+        } else {
+            (None, probes.iter().map(|_| None).collect())
+        };
+
+        // ── Phase 3: build ClipState objects ──────────────────────────────────
+
+        let mut clip_states: Vec<ClipState> = Vec::with_capacity(probes.len());
+        for (i, p) in probes.iter().enumerate() {
+            let timeline_start = p.timeline_offset;
+            let timeline_end = timeline_start + p.clip_dur;
+
+            let mut decode_buf = DecodeBuffer::open(&p.source).build()?;
+            if p.in_pt > Duration::ZERO {
+                decode_buf.seek(p.in_pt)?;
+            }
+
+            clip_states.push(ClipState {
+                source: p.source.clone(),
+                decode_buf,
+                timeline_start,
+                timeline_end,
+                in_point: p.in_pt,
+                out_point: p.out_point,
+                transition_dur: p.transition_dur,
+                audio_track: audio_track_handles[i].clone(),
+            });
+        }
+
+        // ── Compute total duration ─────────────────────────────────────────────
+
         let total_dur = clip_states
             .iter()
             .map(|c| c.timeline_end)
@@ -163,11 +239,25 @@ impl TimelinePlayer {
             .unwrap_or(Duration::ZERO);
         let duration_millis = u64::try_from(total_dur.as_millis()).unwrap_or(u64::MAX);
 
+        // ── Build runner and handle ───────────────────────────────────────────
+
         let current_pts = Arc::new(AtomicU64::new(0));
         let paused = Arc::new(AtomicBool::new(false));
         let stopped = Arc::new(AtomicBool::new(false));
         let (cmd_tx, cmd_rx) = mpsc::sync_channel(CHANNEL_CAP);
         let (event_tx, event_rx) = mpsc::sync_channel::<PlayerEvent>(CHANNEL_CAP);
+
+        // Start audio for the first clip immediately.
+        let (initial_audio_cancel, initial_audio_thread) =
+            if let Some(handle) = clip_states.first().and_then(|c| c.audio_track.clone()) {
+                let source = clip_states[0].source.clone();
+                let in_pt = clip_states[0].in_point;
+                let cancel = Arc::new(AtomicBool::new(false));
+                let thread = spawn_audio_track_thread(source, in_pt, handle, Arc::clone(&cancel));
+                (Some(cancel), Some(thread))
+            } else {
+                (None, None)
+            };
 
         let runner = TimelineRunner {
             clips: clip_states,
@@ -190,6 +280,9 @@ impl TimelinePlayer {
             rgba_a: Vec::new(),
             rgba_b: Vec::new(),
             blend_buf: Vec::new(),
+            audio_mixer: mixer_arc.clone(),
+            active_audio_cancel: initial_audio_cancel,
+            active_audio_thread: initial_audio_thread,
         };
 
         let handle = PlayerHandle::for_timeline(
@@ -199,6 +292,7 @@ impl TimelinePlayer {
             paused,
             stopped,
             duration_millis,
+            mixer_arc,
         );
 
         Ok((runner, handle))
@@ -233,6 +327,12 @@ pub struct TimelineRunner {
     rgba_a: Vec<u8>,
     rgba_b: Vec<u8>,
     blend_buf: Vec<u8>,
+    /// Multi-track audio mixer — `None` when no clip has audio.
+    audio_mixer: Option<Arc<Mutex<AudioMixer>>>,
+    /// Cancel flag for the currently running audio decode thread.
+    active_audio_cancel: Option<Arc<AtomicBool>>,
+    /// Handle to the currently running audio decode thread.
+    active_audio_thread: Option<JoinHandle<()>>,
 }
 
 impl TimelineRunner {
@@ -287,7 +387,7 @@ impl TimelineRunner {
                             self.rate = r;
                         }
                     }
-                    PlayerCommand::SetAvOffset(_) => {} // audio not supported
+                    PlayerCommand::SetAvOffset(_) => {} // audio timing is system-clock driven
                 }
             }
 
@@ -327,12 +427,17 @@ impl TimelineRunner {
 
             match pop_result {
                 FrameResult::Eof => {
+                    let old_active = active;
                     if let Some(tp) = self.transition.take() {
                         self.active = tp.next_idx;
                     } else if active + 1 < self.clips.len() {
                         self.active += 1;
                     } else {
                         break;
+                    }
+                    if self.active != old_active {
+                        let in_pt = self.clips[self.active].in_point;
+                        self.restart_audio_at(self.active, in_pt);
                     }
                 }
 
@@ -372,12 +477,17 @@ impl TimelineRunner {
                     };
 
                     if past_out || past_end {
+                        let old_active = active;
                         if let Some(tp) = self.transition.take() {
                             self.active = tp.next_idx;
                         } else if active + 1 < self.clips.len() {
                             self.active += 1;
                         } else {
                             break;
+                        }
+                        if self.active != old_active {
+                            let in_pt = self.clips[self.active].in_point;
+                            self.restart_audio_at(self.active, in_pt);
                         }
                         continue;
                     }
@@ -403,8 +513,13 @@ impl TimelineRunner {
                                     duration: next.transition_dur,
                                 });
                             } else {
-                                // We jumped past the entire transition zone.
+                                // Jumped past the entire transition zone.
+                                let old_active = active;
                                 self.active = active + 1;
+                                if self.active != old_active {
+                                    let in_pt = self.clips[self.active].in_point;
+                                    self.restart_audio_at(self.active, in_pt);
+                                }
                                 continue;
                             }
                         }
@@ -475,8 +590,13 @@ impl TimelineRunner {
                         }
 
                         if timeline_pts >= trans_start + trans_dur {
+                            let old_active = self.active;
                             self.transition = None;
                             self.active = next_idx;
+                            if self.active != old_active {
+                                let in_pt = self.clips[self.active].in_point;
+                                self.restart_audio_at(self.active, in_pt);
+                            }
                         }
                     } else if a_ok && let Some(sink) = self.sink.as_mut() {
                         sink.push_frame(&self.rgba_a, w, h, timeline_pts);
@@ -515,8 +635,107 @@ impl TimelineRunner {
         self.active = clip_idx;
         self.transition = None;
 
+        // Discard stale audio and restart from the seek position.
+        if let Some(mixer_arc) = &self.audio_mixer {
+            mixer_arc
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .invalidate_all();
+        }
+        self.restart_audio_at(clip_idx, clip_local_pts);
+
         Ok(())
     }
+
+    /// Cancel the current audio decode thread (if any) and start a new one
+    /// for `clip_idx` beginning at `start_pts`.
+    fn restart_audio_at(&mut self, clip_idx: usize, start_pts: Duration) {
+        // Cancel and drop the previous thread.
+        if let Some(cancel) = &self.active_audio_cancel {
+            cancel.store(true, Ordering::Release);
+        }
+        drop(self.active_audio_thread.take());
+        self.active_audio_cancel = None;
+
+        let Some(handle) = self.clips.get(clip_idx).and_then(|c| c.audio_track.clone()) else {
+            return;
+        };
+        handle.clear(); // discard stale samples
+
+        let source = self.clips[clip_idx].source.clone();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let thread = spawn_audio_track_thread(source, start_pts, handle, Arc::clone(&cancel));
+        self.active_audio_cancel = Some(cancel);
+        self.active_audio_thread = Some(thread);
+    }
+}
+
+impl Drop for TimelineRunner {
+    fn drop(&mut self) {
+        if let Some(cancel) = &self.active_audio_cancel {
+            cancel.store(true, Ordering::Release);
+        }
+        if let Some(h) = self.active_audio_thread.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+// ── spawn_audio_track_thread ──────────────────────────────────────────────────
+
+fn spawn_audio_track_thread(
+    path: PathBuf,
+    start_pts: Duration,
+    track: AudioTrackHandle,
+    cancel: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        let mut decoder = match AudioDecoder::open(&path)
+            .output_format(SampleFormat::F32)
+            .output_sample_rate(48_000)
+            .output_channels(1) // mono — the mixer applies panning
+            .build()
+        {
+            Ok(d) => d,
+            Err(e) => {
+                log::warn!("timeline audio thread open failed error={e}");
+                return;
+            }
+        };
+
+        if start_pts > Duration::ZERO
+            && let Err(e) = decoder.seek(start_pts, SeekMode::Backward)
+        {
+            log::warn!("timeline audio seek failed pts={start_pts:?} error={e}");
+        }
+
+        loop {
+            if cancel.load(Ordering::Acquire) {
+                break;
+            }
+
+            // Back-pressure: pause decoding when the buffer is full.
+            if track.buffered_samples() >= AUDIO_MAX_BUF {
+                thread::sleep(Duration::from_millis(1));
+                continue;
+            }
+
+            match decoder.decode_one() {
+                Ok(Some(frame)) => {
+                    if let Some(samples) = frame.as_f32()
+                        && !samples.is_empty()
+                    {
+                        track.push_samples(samples);
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    log::warn!("timeline audio decode error error={e}");
+                    break;
+                }
+            }
+        }
+    })
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -545,13 +764,6 @@ mod tests {
 
     #[test]
     fn timeline_player_open_should_fail_when_no_video_tracks() {
-        // Build a Timeline with only an audio track (or just an empty video track).
-        // Timeline requires at least one track, so use video_track with a dummy clip
-        // but zero clips.
-        // Actually, Timeline::builder() errors on zero tracks.
-        // We test the guard inside TimelinePlayer::open() directly:
-        // We can't easily build a zero-track timeline (builder rejects it), so
-        // instead verify the error path via a type check.
         let _ = PreviewError::SeekOutOfRange {
             pts: Duration::from_secs(1),
         };


### PR DESCRIPTION
## Summary

Adds `AudioMixer` and `AudioTrackHandle` to `ff-preview` for mixing N mono audio tracks into interleaved stereo `f32` output at 48 kHz. Wires the mixer into `TimelinePlayer` so each audio-bearing clip gets its own decode thread and track handle; `PlayerHandle::pop_audio_samples` returns mixed stereo output.

## Changes

- `crates/ff-preview/src/audio/mod.rs` (new): `AudioMixer` with constant-power pan law, `AudioTrackHandle` (`Clone + Send`) backed by `Arc<Mutex<VecDeque<f32>>>` and two `Arc<AtomicU32>` fields for lock-free volume/pan; 11 unit tests covering mixing, clipping, panning, underrun, and seek invalidation
- `crates/ff-preview/src/lib.rs`: re-export `AudioMixer` and `AudioTrackHandle`
- `crates/ff-preview/src/playback/player.rs`: add `audio_mixer: Option<Arc<Mutex<AudioMixer>>>` field to `PlayerHandle`; `pop_audio_samples` calls `mixer.mix(n)` when a mixer is present; `for_timeline` accepts the mixer arc
- `crates/ff-preview/src/timeline/mod.rs`: two-phase `open()` probes all clips for audio, builds one mixer track per audio-bearing clip; `TimelineRunner` owns the active audio thread and cancel token; `restart_audio_at` cancels the old thread and starts a new `AudioDecoder` thread on clip transition or seek; `Drop` cancels and joins the audio thread

## Related Issues

Closes #1025

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes