### PR TITLE
feat(ff-preview): integrate HardwareAccel into PlayerRunner

### DIFF
--- a/crates/ff-decode/src/video/decoder_inner/hardware.rs
+++ b/crates/ff-decode/src/video/decoder_inner/hardware.rs
@@ -57,12 +57,18 @@ impl VideoDecoderInner {
                 // Try hardware accelerators in priority order
                 for &hw_type in Self::hw_accel_auto_priority() {
                     // SAFETY: Caller ensures codec_ctx is valid and not yet configured with hardware
-                    if let Ok((Some(ctx), active)) =
-                        unsafe { Self::try_init_hw_device(codec_ctx, hw_type) }
-                    {
-                        return Ok((Some(ctx), active));
+                    match unsafe { Self::try_init_hw_device(codec_ctx, hw_type) } {
+                        Ok((Some(ctx), active)) => {
+                            log::info!("hwaccel selected backend={}", active.name());
+                            return Ok((Some(ctx), active));
+                        }
+                        _ => {
+                            log::debug!(
+                                "hwaccel probe failed backend={} trying next",
+                                hw_type.name()
+                            );
+                        }
                     }
-                    // Ignore errors in Auto mode and try the next one
                 }
                 // All hardware accelerators failed, fall back to software
                 Ok((None, HardwareAccel::None))

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -41,6 +41,7 @@ pub mod timeline;
 pub use audio::{AudioMixer, AudioTrackHandle};
 pub use error::PreviewError;
 pub use event::PlayerEvent;
+pub use ff_decode::HardwareAccel;
 pub use playback::{
     DecodeBuffer, DecodeBufferBuilder, FrameResult, FrameSink, PlaybackClock, PlayerCommand,
     PlayerHandle, PlayerRunner, PreviewPlayer, RgbaFrame, RgbaSink, SeekEvent,

--- a/crates/ff-preview/src/playback/decode_buffer.rs
+++ b/crates/ff-preview/src/playback/decode_buffer.rs
@@ -11,7 +11,7 @@ use std::sync::mpsc::{Receiver, Sender, SyncSender, channel, sync_channel};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use ff_decode::{SeekMode, VideoDecoder};
+use ff_decode::{HardwareAccel, SeekMode, VideoDecoder};
 use ff_format::VideoFrame;
 
 use crate::error::PreviewError;
@@ -67,6 +67,7 @@ pub enum SeekEvent {
 pub struct DecodeBufferBuilder {
     pub(super) path: PathBuf,
     pub(super) capacity: usize,
+    pub(super) hw_accel: HardwareAccel,
 }
 
 impl DecodeBufferBuilder {
@@ -78,6 +79,21 @@ impl DecodeBufferBuilder {
     pub fn capacity(self, n: usize) -> Self {
         Self {
             capacity: n,
+            ..self
+        }
+    }
+
+    /// Set the hardware acceleration mode. Default: [`HardwareAccel::Auto`].
+    ///
+    /// [`HardwareAccel::Auto`] probes available backends in priority order
+    /// (NVDEC → QSV → `VideoToolbox` → VAAPI → AMF) and falls back to software
+    /// decoding without error if none are available.
+    ///
+    /// [`HardwareAccel::None`] forces CPU-only decoding.
+    #[must_use]
+    pub fn hardware_accel(self, accel: HardwareAccel) -> Self {
+        Self {
+            hw_accel: accel,
             ..self
         }
     }
@@ -95,7 +111,9 @@ impl DecodeBufferBuilder {
     pub fn build(self) -> Result<DecodeBuffer, PreviewError> {
         // Open decoder on the calling thread for early validation.
         // Propagates FileNotFound / NoVideoStream / Ffmpeg errors immediately.
-        let mut decoder = VideoDecoder::open(&self.path).build()?;
+        let mut decoder = VideoDecoder::open(&self.path)
+            .hardware_accel(self.hw_accel)
+            .build()?;
 
         let (tx, rx) = sync_channel(self.capacity);
         let buffered = Arc::new(AtomicUsize::new(0));
@@ -201,6 +219,7 @@ impl DecodeBuffer {
         DecodeBufferBuilder {
             path: path.to_path_buf(),
             capacity: DEFAULT_DECODE_BUFFER_CAPACITY,
+            hw_accel: HardwareAccel::Auto,
         }
     }
 

--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -265,6 +265,7 @@ pub struct PlayerRunner {
     rate: f64,
     duration_millis: u64,
     frame_cache: Option<FrameCache>,
+    hw_accel: HardwareAccel,
 }
 
 impl PlayerRunner {
@@ -273,11 +274,15 @@ impl PlayerRunner {
         self.sink = Some(sink);
     }
 
-    /// Configure hardware acceleration.
+    /// Configure hardware acceleration. Call before [`run`](Self::run).
     ///
-    /// Currently a no-op stub — hardware acceleration is applied when the
-    /// decode buffer is next rebuilt (e.g., after proxy activation).
-    pub fn set_hardware_accel(&mut self, _accel: HardwareAccel) {}
+    /// The setting takes effect at the start of `run()`. [`HardwareAccel::Auto`]
+    /// (the default) probes available backends and falls back to software.
+    /// [`HardwareAccel::None`] forces CPU-only decoding.
+    pub fn set_hardware_accel(&mut self, accel: HardwareAccel) -> &mut Self {
+        self.hw_accel = accel;
+        self
+    }
 
     /// Returns the path currently being decoded (original or active proxy).
     #[must_use]
@@ -364,6 +369,27 @@ impl PlayerRunner {
     pub fn run(mut self) -> Result<(), PreviewError> {
         let fps = self.fps.max(1.0);
         let frame_period = Duration::from_secs_f64(1.0 / fps);
+
+        // Rebuild the decode buffer when the caller has explicitly configured a
+        // hardware acceleration mode other than the default (Auto). The initial
+        // buffer is always built with Auto by PreviewPlayer::open(); rebuilding
+        // here ensures the user's explicit setting is respected.
+        if self.hw_accel != HardwareAccel::Auto && self.decode_buf.is_some() {
+            match DecodeBuffer::open(&self.active_path)
+                .hardware_accel(self.hw_accel)
+                .build()
+            {
+                Ok(buf) => {
+                    self.decode_buf = Some(buf);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "hwaccel decode buffer rebuild failed accel={} error={e}",
+                        self.hw_accel.name()
+                    );
+                }
+            }
+        }
 
         self.clock.reset(Duration::ZERO);
 
@@ -580,7 +606,9 @@ impl PlayerRunner {
     fn activate_proxy(&mut self, proxy_path: &Path) -> Result<(), PreviewError> {
         let info = ff_probe::open(proxy_path)?;
         let fps = info.frame_rate().unwrap_or(30.0).max(1.0);
-        let decode_buf = DecodeBuffer::open(proxy_path).build()?;
+        let decode_buf = DecodeBuffer::open(proxy_path)
+            .hardware_accel(self.hw_accel)
+            .build()?;
 
         if let Some(cancel) = &self.audio_cancel {
             cancel.store(true, Ordering::Release);
@@ -816,6 +844,7 @@ impl PreviewPlayer {
             rate: 1.0,
             duration_millis,
             frame_cache: None,
+            hw_accel: HardwareAccel::Auto,
         };
 
         let handle = PlayerHandle {
@@ -1558,6 +1587,94 @@ mod tests {
             position_updates.len() <= frames,
             "PositionUpdate count ({}) must not exceed frame count ({frames})",
             position_updates.len()
+        );
+    }
+
+    // ── HardwareAccel ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn hardware_accel_variants_should_be_accessible_on_player_runner() {
+        // Type-check / accessibility test — no asset required.
+        let _ = HardwareAccel::Auto;
+        let _ = HardwareAccel::None;
+        let _ = HardwareAccel::Nvdec;
+        let _ = HardwareAccel::Qsv;
+        let _ = HardwareAccel::Amf;
+        let _ = HardwareAccel::VideoToolbox;
+        let _ = HardwareAccel::Vaapi;
+    }
+
+    #[test]
+    fn set_hardware_accel_none_should_complete_without_error_on_audio_only_file() {
+        // Audio-only path has no video decode buffer; the hw_accel rebuild
+        // at run() start is skipped.  Verifies the setter is a no-op when
+        // no decode buffer exists, and run() still returns Ok.
+        let path = test_audio_path();
+        let (mut runner, handle) = match PreviewPlayer::open(&path) {
+            Ok(p) => p.split(),
+            Err(e) => {
+                println!("skipping: audio file not available: {e}");
+                return;
+            }
+        };
+
+        runner.set_hardware_accel(HardwareAccel::None);
+        assert_eq!(runner.hw_accel, HardwareAccel::None);
+
+        let handle_stop = handle.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(150));
+            handle_stop.stop();
+        });
+
+        let result = runner.run();
+        assert!(
+            result.is_ok(),
+            "run() with HardwareAccel::None must return Ok; got {result:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires assets/video/gameplay.mp4 and hardware decoder; run with -- --include-ignored"]
+    fn hardware_accel_auto_should_deliver_frames_on_video_file() {
+        let path = test_video_path();
+        let (mut runner, handle) = match PreviewPlayer::open(&path) {
+            Ok(p) => p.split(),
+            Err(e) => {
+                println!("skipping: video file not available: {e}");
+                return;
+            }
+        };
+
+        runner.set_hardware_accel(HardwareAccel::Auto);
+
+        struct CountSink {
+            count: usize,
+            max: usize,
+            handle: PlayerHandle,
+        }
+        impl FrameSink for CountSink {
+            fn push_frame(&mut self, _rgba: &[u8], _w: u32, _h: u32, _pts: Duration) {
+                self.count += 1;
+                if self.count >= self.max {
+                    self.handle.stop();
+                }
+            }
+        }
+        runner.set_sink(Box::new(CountSink {
+            count: 0,
+            max: 5,
+            handle: handle.clone(),
+        }));
+
+        let result = runner.run();
+        assert!(
+            result.is_ok(),
+            "run() with HardwareAccel::Auto must return Ok; got {result:?}"
+        );
+        assert!(
+            handle.current_pts() > Duration::ZERO,
+            "at least one frame must have been presented"
         );
     }
 }


### PR DESCRIPTION
## Summary

Exposes `HardwareAccel` (already implemented in `ff-decode`) as a pre-run configuration option on `PlayerRunner`. `HardwareAccel::Auto` (the default) probes available GPU backends in priority order and falls back to software without error. Re-exports `HardwareAccel` from `ff-preview` so callers do not need to depend on `ff-decode` directly.

## Changes

- `ff-decode/src/video/decoder_inner/hardware.rs`: added `log::debug!` per failed backend probe and `log::info!` when a backend is selected in `Auto` mode
- `ff-preview/src/playback/decode_buffer.rs`: added `hw_accel: HardwareAccel` field to `DecodeBufferBuilder`, `hardware_accel()` builder method, forwarded to `VideoDecoder::open().hardware_accel()`
- `ff-preview/src/playback/player.rs`: added `hw_accel` field to `PlayerRunner` (default `Auto`), implemented `set_hardware_accel()`, rebuild `decode_buf` at `run()` start when `hw_accel != Auto`, forwarded `hw_accel` in `activate_proxy()`; 3 new tests: variant accessibility, `None` on audio-only (always passes), `#[ignore]` video+hardware test
- `ff-preview/src/lib.rs`: re-exported `ff_decode::HardwareAccel`

## Related Issues

Closes #1026

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes