### PR TITLE
feat(ff-render): add GPU compositing pipeline crate (wgpu-based)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ ff-encode   = { path = "crates/ff-encode",   version = "0.13.1" }
 ff-filter   = { path = "crates/ff-filter",   version = "0.13.1" }
 ff-pipeline = { path = "crates/ff-pipeline", version = "0.13.1" }
 ff-stream   = { path = "crates/ff-stream",   version = "0.13.1" }
-ff-preview  = { path = "crates/ff-preview", version = "0.13.1" }
-avio        = { path = "crates/avio",        version = "0.13.1" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.13.1" }
+ff-render   = { path = "crates/ff-render",   version = "0.13.1" }
+avio        = { path = "crates/avio",         version = "0.13.1" }
 
 # Error handling
 thiserror = "2.0.17"

--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -20,6 +20,8 @@ pipeline = ["dep:ff-pipeline", "filter"]
 stream   = ["dep:ff-stream", "pipeline"]
 preview       = ["dep:ff-preview"]
 preview-proxy = ["preview", "ff-preview/proxy"]
+render        = ["dep:ff-render", "preview"]
+render-gpu    = ["render", "ff-render/wgpu"]
 tokio         = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio", "ff-preview/tokio"]
 gpl      = ["ff-encode/gpl"]
 hwaccel  = ["ff-encode/hwaccel"]
@@ -39,6 +41,7 @@ ff-filter   = { workspace = true, optional = true }
 ff-pipeline = { workspace = true, optional = true }
 ff-stream   = { workspace = true, optional = true }
 ff-preview  = { workspace = true, optional = true }
+ff-render   = { workspace = true, optional = true }
 
 [[example]]
 name = "probe_info"

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -24,7 +24,7 @@ log        = { workspace = true }
 thiserror  = { workspace = true }
 
 [dependencies.wgpu]
-version  = "22"
+version  = "29.0.1"
 optional = true
 
 [lints]

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "ff-render"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "GPU compositing pipeline for real-time preview (wgpu-based)"
+license.workspace = true
+readme = "README.md"
+repository.workspace = true
+keywords = ["video", "gpu", "wgpu", "compositing", "rendering"]
+categories = ["multimedia::video"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = []
+wgpu    = ["dep:wgpu"]
+
+[dependencies]
+ff-preview = { workspace = true }
+ff-format  = { workspace = true }
+log        = { workspace = true }
+thiserror  = { workspace = true }
+
+[dependencies.wgpu]
+version  = "22"
+optional = true
+
+[lints]
+workspace = true

--- a/crates/ff-render/src/context.rs
+++ b/crates/ff-render/src/context.rs
@@ -39,7 +39,10 @@ impl RenderContext {
     pub async fn init_with_backend(backends: wgpu::Backends) -> Result<Self, RenderError> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends,
-            ..Default::default()
+            flags: wgpu::InstanceFlags::default(),
+            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+            backend_options: wgpu::BackendOptions::default(),
+            display: None,
         });
 
         let adapter = instance
@@ -49,8 +52,8 @@ impl RenderContext {
                 compatible_surface: None,
             })
             .await
-            .ok_or_else(|| RenderError::DeviceCreation {
-                message: "no suitable GPU adapter found".to_string(),
+            .map_err(|e| RenderError::DeviceCreation {
+                message: e.to_string(),
             })?;
 
         log::info!(
@@ -60,13 +63,10 @@ impl RenderContext {
         );
 
         let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: Some("ff-render"),
-                    ..Default::default()
-                },
-                None,
-            )
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("ff-render"),
+                ..Default::default()
+            })
             .await
             .map_err(|e| RenderError::DeviceCreation {
                 message: e.to_string(),

--- a/crates/ff-render/src/context.rs
+++ b/crates/ff-render/src/context.rs
@@ -1,0 +1,77 @@
+use crate::error::RenderError;
+
+/// Owns the wgpu device and queue used by the render pipeline.
+///
+/// Share via `Arc<RenderContext>` when multiple components (graph, sink, etc.)
+/// need access to the same GPU device.
+pub struct RenderContext {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+}
+
+impl RenderContext {
+    /// Wrap an existing wgpu device (e.g. shared with the window renderer).
+    #[must_use]
+    pub fn new(device: wgpu::Device, queue: wgpu::Queue) -> Self {
+        Self { device, queue }
+    }
+
+    /// Initialise wgpu using the default (best available) backend.
+    ///
+    /// Backend priority: Metal → Vulkan → DX12 → WebGPU → OpenGL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RenderError::DeviceCreation`] if no suitable adapter is found or
+    /// the device request fails.
+    pub async fn init() -> Result<Self, RenderError> {
+        Self::init_with_backend(wgpu::Backends::all()).await
+    }
+
+    /// Initialise wgpu with an explicit backend set.
+    ///
+    /// Useful in CI where only `wgpu::Backends::GL` may be available.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RenderError::DeviceCreation`] if no suitable adapter is found or
+    /// the device request fails.
+    pub async fn init_with_backend(backends: wgpu::Backends) -> Result<Self, RenderError> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends,
+            ..Default::default()
+        });
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .ok_or_else(|| RenderError::DeviceCreation {
+                message: "no suitable GPU adapter found".to_string(),
+            })?;
+
+        log::info!(
+            "render adapter selected backend={:?} name={}",
+            adapter.get_info().backend,
+            adapter.get_info().name
+        );
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("ff-render"),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .map_err(|e| RenderError::DeviceCreation {
+                message: e.to_string(),
+            })?;
+
+        Ok(Self { device, queue })
+    }
+}

--- a/crates/ff-render/src/error.rs
+++ b/crates/ff-render/src/error.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error("GPU device creation failed: {message}")]
+    DeviceCreation { message: String },
+
+    #[error("shader compile failed: {message}")]
+    ShaderCompile { message: String },
+
+    #[error("texture creation failed: width={width} height={height} reason={reason}")]
+    TextureCreation {
+        width: u32,
+        height: u32,
+        reason: String,
+    },
+
+    #[error("composite failed: {message}")]
+    Composite { message: String },
+
+    #[error("lut load failed: path={path} reason={reason}")]
+    LutLoad { path: String, reason: String },
+
+    #[error("unsupported pixel format: {format}")]
+    UnsupportedFormat { format: String },
+
+    #[error("gpu operation timed out: {operation}")]
+    GpuTimeout { operation: String },
+
+    #[error("ffmpeg error: {message} (code={code})")]
+    Ffmpeg { code: i32, message: String },
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/ff-render/src/graph/graph_inner.rs
+++ b/crates/ff-render/src/graph/graph_inner.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+
+use crate::context::RenderContext;
+use crate::error::RenderError;
+use crate::nodes::RenderNode;
+
+/// Execute all `nodes` on the `rgba` input and return the processed RGBA bytes.
+///
+/// Allocates one pair of GPU textures per node — no texture pooling in Phase 1.
+#[allow(clippy::too_many_lines)]
+pub(super) fn run_gpu(
+    nodes: &[Box<dyn RenderNode>],
+    ctx: &Arc<RenderContext>,
+    rgba: &[u8],
+    w: u32,
+    h: u32,
+) -> Result<Vec<u8>, RenderError> {
+    if nodes.is_empty() {
+        return Ok(rgba.to_vec());
+    }
+
+    // Upload the input frame to the initial GPU texture.
+    let input_tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("ff-render input"),
+        size: wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+
+    ctx.queue.write_texture(
+        wgpu::ImageCopyTexture {
+            texture: &input_tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        rgba,
+        wgpu::ImageDataLayout {
+            offset: 0,
+            bytes_per_row: Some(w * 4),
+            rows_per_image: None,
+        },
+        wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        },
+    );
+
+    // Run each node: output of one node is the input of the next.
+    let mut current_tex = input_tex;
+
+    for node in nodes {
+        let output_tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("ff-render node output"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+
+        node.process(&[&current_tex], &[&output_tex], ctx);
+        current_tex = output_tex;
+    }
+
+    // Copy the final texture to a CPU-readable staging buffer.
+    let bytes_per_row_padded = align_up(w * 4, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    let buffer_size = u64::from(bytes_per_row_padded) * u64::from(h);
+
+    let staging_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("ff-render staging"),
+        size: buffer_size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("ff-render readback"),
+        });
+    encoder.copy_texture_to_buffer(
+        wgpu::ImageCopyTexture {
+            texture: &current_tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::ImageCopyBuffer {
+            buffer: &staging_buf,
+            layout: wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(bytes_per_row_padded),
+                rows_per_image: None,
+            },
+        },
+        wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        },
+    );
+    ctx.queue.submit(std::iter::once(encoder.finish()));
+
+    // Map the staging buffer synchronously.
+    let staging_slice = staging_buf.slice(..);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    staging_slice.map_async(wgpu::MapMode::Read, move |result| {
+        sender.send(result).ok();
+    });
+    ctx.device.poll(wgpu::Maintain::Wait);
+
+    receiver
+        .recv()
+        .map_err(|_| RenderError::Composite {
+            message: "staging buffer channel closed unexpectedly".to_string(),
+        })?
+        .map_err(|e| RenderError::Composite {
+            message: format!("staging buffer map failed: {e}"),
+        })?;
+
+    // Strip row padding from the staged data.
+    let raw = staging_slice.get_mapped_range();
+    let mut out = Vec::with_capacity((w * h * 4) as usize);
+    for y in 0..h as usize {
+        let row_start = y * bytes_per_row_padded as usize;
+        let row_end = row_start + (w * 4) as usize;
+        out.extend_from_slice(&raw[row_start..row_end]);
+    }
+    drop(raw);
+    staging_buf.unmap();
+
+    Ok(out)
+}
+
+fn align_up(value: u32, alignment: u32) -> u32 {
+    (value + alignment - 1) & !(alignment - 1)
+}

--- a/crates/ff-render/src/graph/graph_inner.rs
+++ b/crates/ff-render/src/graph/graph_inner.rs
@@ -36,14 +36,14 @@ pub(super) fn run_gpu(
     });
 
     ctx.queue.write_texture(
-        wgpu::ImageCopyTexture {
+        wgpu::TexelCopyTextureInfo {
             texture: &input_tex,
             mip_level: 0,
             origin: wgpu::Origin3d::ZERO,
             aspect: wgpu::TextureAspect::All,
         },
         rgba,
-        wgpu::ImageDataLayout {
+        wgpu::TexelCopyBufferLayout {
             offset: 0,
             bytes_per_row: Some(w * 4),
             rows_per_image: None,
@@ -97,15 +97,15 @@ pub(super) fn run_gpu(
             label: Some("ff-render readback"),
         });
     encoder.copy_texture_to_buffer(
-        wgpu::ImageCopyTexture {
+        wgpu::TexelCopyTextureInfo {
             texture: &current_tex,
             mip_level: 0,
             origin: wgpu::Origin3d::ZERO,
             aspect: wgpu::TextureAspect::All,
         },
-        wgpu::ImageCopyBuffer {
+        wgpu::TexelCopyBufferInfo {
             buffer: &staging_buf,
-            layout: wgpu::ImageDataLayout {
+            layout: wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(bytes_per_row_padded),
                 rows_per_image: None,
@@ -125,7 +125,7 @@ pub(super) fn run_gpu(
     staging_slice.map_async(wgpu::MapMode::Read, move |result| {
         sender.send(result).ok();
     });
-    ctx.device.poll(wgpu::Maintain::Wait);
+    ctx.device.poll(wgpu::PollType::wait_indefinitely()).ok();
 
     receiver
         .recv()

--- a/crates/ff-render/src/graph/mod.rs
+++ b/crates/ff-render/src/graph/mod.rs
@@ -1,0 +1,198 @@
+#[cfg(feature = "wgpu")]
+mod graph_inner;
+
+use crate::nodes::RenderNodeCpu;
+
+#[cfg(feature = "wgpu")]
+use crate::error::RenderError;
+
+#[cfg(feature = "wgpu")]
+use crate::context::RenderContext;
+#[cfg(feature = "wgpu")]
+use crate::nodes::RenderNode;
+#[cfg(feature = "wgpu")]
+use std::sync::Arc;
+
+// ── RenderGraph ───────────────────────────────────────────────────────────────
+
+/// Linear chain of render nodes executed in insertion order.
+///
+/// The CPU fallback path ([`process_cpu`](Self::process_cpu)) is always
+/// available and does not require the `wgpu` feature.  When the `wgpu` feature
+/// is enabled, [`process_gpu`](Self::process_gpu) runs every node on the GPU.
+///
+/// # Construction
+///
+/// ```ignore
+/// // GPU+CPU graph (wgpu feature):
+/// let ctx = Arc::new(RenderContext::init().await?);
+/// let graph = RenderGraph::new(Arc::clone(&ctx))
+///     .push(ColorGradeNode { brightness: 0.1, ..Default::default() });
+///
+/// // CPU-only graph (no wgpu feature needed):
+/// let graph = RenderGraph::new_cpu()
+///     .push_cpu(ColorGradeNode { brightness: 0.1, ..Default::default() });
+/// ```
+pub struct RenderGraph {
+    /// Nodes for the CPU fallback path only (added via `push_cpu`).
+    cpu_nodes: Vec<Box<dyn RenderNodeCpu>>,
+    #[cfg(feature = "wgpu")]
+    gpu_nodes: Vec<Box<dyn RenderNode>>,
+    /// `None` when constructed via `new_cpu` — `process_gpu` will return an error.
+    #[cfg(feature = "wgpu")]
+    ctx: Option<Arc<RenderContext>>,
+}
+
+impl RenderGraph {
+    /// Create a GPU+CPU graph.
+    ///
+    /// Nodes added via [`push`](Self::push) run on the GPU and expose a CPU
+    /// fallback via [`RenderNodeCpu`].  Nodes added via
+    /// [`push_cpu`](Self::push_cpu) run on the CPU path only.
+    #[cfg(feature = "wgpu")]
+    #[must_use]
+    pub fn new(ctx: Arc<RenderContext>) -> Self {
+        Self {
+            cpu_nodes: Vec::new(),
+            gpu_nodes: Vec::new(),
+            ctx: Some(ctx),
+        }
+    }
+
+    /// Create a CPU-only graph (no GPU context required).
+    ///
+    /// [`process_gpu`](Self::process_gpu) returns [`RenderError::Composite`]
+    /// when called on a CPU-only graph. Use [`process_cpu`](Self::process_cpu)
+    /// instead.
+    #[must_use]
+    pub fn new_cpu() -> Self {
+        Self {
+            cpu_nodes: Vec::new(),
+            #[cfg(feature = "wgpu")]
+            gpu_nodes: Vec::new(),
+            #[cfg(feature = "wgpu")]
+            ctx: None,
+        }
+    }
+
+    /// Append a GPU+CPU node to the chain.
+    ///
+    /// The node must implement both [`RenderNode`] (GPU, `wgpu` feature only)
+    /// and [`RenderNodeCpu`] (CPU, always available) — the `RenderNode`
+    /// supertrait bound guarantees this.
+    #[cfg(feature = "wgpu")]
+    #[must_use]
+    pub fn push(mut self, node: impl RenderNode + 'static) -> Self {
+        self.gpu_nodes.push(Box::new(node));
+        self
+    }
+
+    /// Append a CPU-only node to the chain.
+    ///
+    /// CPU-only nodes participate in [`process_cpu`](Self::process_cpu) but
+    /// not in [`process_gpu`](Self::process_gpu).
+    ///
+    /// When the `wgpu` feature is not enabled, this is the only `push` method.
+    #[cfg(not(feature = "wgpu"))]
+    #[must_use]
+    pub fn push(mut self, node: impl RenderNodeCpu + 'static) -> Self {
+        self.cpu_nodes.push(Box::new(node));
+        self
+    }
+
+    /// Append a CPU-only node (available regardless of the `wgpu` feature).
+    #[must_use]
+    pub fn push_cpu(mut self, node: impl RenderNodeCpu + 'static) -> Self {
+        self.cpu_nodes.push(Box::new(node));
+        self
+    }
+
+    // ── Processing ────────────────────────────────────────────────────────────
+
+    /// Run the GPU pipeline: upload `rgba` → execute all GPU nodes → download result.
+    ///
+    /// Requires the `wgpu` feature and a GPU context (created via [`new`](Self::new)).
+    /// Returns [`RenderError::Composite`] if called on a CPU-only graph.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on GPU device failure or staging-buffer readback failure.
+    #[cfg(feature = "wgpu")]
+    pub fn process_gpu(&self, rgba: &[u8], w: u32, h: u32) -> Result<Vec<u8>, RenderError> {
+        let ctx = self.ctx.as_ref().ok_or_else(|| RenderError::Composite {
+            message: "process_gpu called on a CPU-only RenderGraph (no RenderContext)".to_string(),
+        })?;
+        graph_inner::run_gpu(&self.gpu_nodes, ctx, rgba, w, h)
+    }
+
+    /// Run the CPU fallback pipeline: apply each node's `process_cpu` in order.
+    ///
+    /// Both CPU-only nodes (`push_cpu`) and GPU nodes (`push`, wgpu feature)
+    /// participate — GPU nodes expose a CPU path via the `RenderNodeCpu`
+    /// supertrait.
+    #[must_use]
+    pub fn process_cpu(&self, rgba: &[u8], w: u32, h: u32) -> Vec<u8> {
+        let mut out = rgba.to_vec();
+
+        for node in &self.cpu_nodes {
+            node.process_cpu(&mut out, w, h);
+        }
+
+        #[cfg(feature = "wgpu")]
+        for node in &self.gpu_nodes {
+            node.process_cpu(&mut out, w, h);
+        }
+
+        out
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nodes::ColorGradeNode;
+
+    #[test]
+    fn render_graph_empty_cpu_should_return_input_unchanged() {
+        let graph = RenderGraph::new_cpu();
+        let rgba = vec![100u8, 150, 200, 255];
+        let result = graph.process_cpu(&rgba, 1, 1);
+        assert_eq!(result, rgba, "empty graph must return input unchanged");
+    }
+
+    #[test]
+    fn render_graph_push_cpu_color_grade_should_brighten() {
+        let graph = RenderGraph::new_cpu().push_cpu(ColorGradeNode::new(0.5, 1.0, 1.0, 0.0, 0.0));
+        let rgba = vec![128u8, 128, 128, 255];
+        let result = graph.process_cpu(&rgba, 1, 1);
+        assert!(
+            result[0] > 128,
+            "brightness +0.5 must increase R; got {}",
+            result[0]
+        );
+    }
+
+    #[test]
+    fn render_graph_multiple_cpu_nodes_should_chain() {
+        // Two brightness boosts: +0.1 then +0.1 → total ≈ +0.2.
+        let graph = RenderGraph::new_cpu()
+            .push_cpu(ColorGradeNode::new(0.1, 1.0, 1.0, 0.0, 0.0))
+            .push_cpu(ColorGradeNode::new(0.1, 1.0, 1.0, 0.0, 0.0));
+        let single = RenderGraph::new_cpu().push_cpu(ColorGradeNode::new(0.2, 1.0, 1.0, 0.0, 0.0));
+
+        let rgba = vec![100u8, 100, 100, 255];
+        let chained = graph.process_cpu(&rgba, 1, 1);
+        let single_result = single.process_cpu(&rgba, 1, 1);
+
+        // Both should produce similar (but not necessarily identical) results.
+        let diff = (chained[0] as i32 - single_result[0] as i32).abs();
+        assert!(
+            diff <= 2,
+            "chained vs single brightness boost must be close; got chained={} single={}",
+            chained[0],
+            single_result[0]
+        );
+    }
+}

--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! GPU compositing pipeline for real-time video preview, built on [wgpu].
 //!
-//! `ff-render` sits above [`ff-preview`] in the crate stack and implements
+//! `ff-render` sits above `ff-preview` in the crate stack and implements
 //! [`ff_preview::FrameSink`] so it integrates directly with
 //! [`ff_preview::PlayerRunner`].
 //!

--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -1,0 +1,81 @@
+//! # ff-render
+//!
+//! GPU compositing pipeline for real-time video preview, built on [wgpu].
+//!
+//! `ff-render` sits above [`ff-preview`] in the crate stack and implements
+//! [`ff_preview::FrameSink`] so it integrates directly with
+//! [`ff_preview::PlayerRunner`].
+//!
+//! ## Feature flags
+//!
+//! | Feature | Description | Default |
+//! |---------|-------------|---------|
+//! | `wgpu`  | GPU processing via wgpu (Metal / Vulkan / DX12 / WebGPU) | no |
+//!
+//! Without `wgpu` only the CPU fallback path is available via
+//! [`RenderGraph::process_cpu`].
+//!
+//! ## Usage — wiring to `PlayerRunner`
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//!
+//! use ff_preview::{PreviewPlayer, RgbaSink};
+//! use ff_render::context::RenderContext;
+//! use ff_render::graph::RenderGraph;
+//! use ff_render::nodes::ColorGradeNode;
+//! use ff_render::sink::GpuFrameSink;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // 1. Initialise the GPU device (headless — no window required).
+//! let ctx = Arc::new(RenderContext::init().await?);
+//!
+//! // 2. Build a render graph: apply a gentle brightness boost.
+//! let graph = RenderGraph::new(Arc::clone(&ctx)).push(ColorGradeNode {
+//!     brightness: 0.1,
+//!     ..Default::default()
+//! });
+//!
+//! // 3. Open the player, attach the GPU sink, and run on a dedicated thread.
+//! let downstream = RgbaSink::new();
+//! let handle = downstream.frame_handle();
+//! let (mut runner, _player_handle) = PreviewPlayer::open("clip.mp4")?.split();
+//! runner.set_sink(Box::new(GpuFrameSink::new(graph, Box::new(downstream))));
+//!
+//! std::thread::spawn(move || runner.run());
+//!
+//! // 4. Retrieve the latest processed frame from any thread.
+//! if let Some(frame) = handle.lock().unwrap().as_ref() {
+//!     println!("frame: {}×{} pts={:?}", frame.width, frame.height, frame.pts);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+
+pub mod error;
+pub mod graph;
+pub mod nodes;
+pub mod sink;
+
+#[cfg(feature = "wgpu")]
+pub mod context;
+
+// ── Top-level re-exports ─────────────────────────────────────────────────────
+
+pub use error::RenderError;
+pub use graph::RenderGraph;
+pub use nodes::{
+    ColorGradeNode, CrossfadeNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode,
+};
+pub use sink::GpuFrameSink;
+
+#[cfg(feature = "wgpu")]
+pub use context::RenderContext;
+#[cfg(feature = "wgpu")]
+pub use nodes::RenderNode;
+#[cfg(feature = "wgpu")]
+pub use sink::TextureHandle;

--- a/crates/ff-render/src/nodes/color_grade.rs
+++ b/crates/ff-render/src/nodes/color_grade.rs
@@ -150,8 +150,8 @@ impl ColorGradeNode {
 
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("ColorGrade layout"),
-                bind_group_layouts: &[&bgl],
-                push_constant_ranges: &[],
+                bind_group_layouts: &[Some(&bgl)],
+                immediate_size: 0,
             });
 
             let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -159,13 +159,13 @@ impl ColorGradeNode {
                 layout: Some(&pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &shader,
-                    entry_point: "vs_main",
+                    entry_point: Some("vs_main"),
                     buffers: &[],
                     compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
-                    entry_point: "fs_main",
+                    entry_point: Some("fs_main"),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: wgpu::TextureFormat::Rgba8Unorm,
                         blend: None,
@@ -176,7 +176,7 @@ impl ColorGradeNode {
                 primitive: wgpu::PrimitiveState::default(),
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -272,6 +272,7 @@ impl super::RenderNode for ColorGradeNode {
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &output_view,
                     resolve_target: None,
+                    depth_slice: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                         store: wgpu::StoreOp::Store,
@@ -280,6 +281,7 @@ impl super::RenderNode for ColorGradeNode {
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
+                multiview_mask: None,
             });
             pass.set_pipeline(&pd.render_pipeline);
             pass.set_bind_group(0, &bind_group, &[]);

--- a/crates/ff-render/src/nodes/color_grade.rs
+++ b/crates/ff-render/src/nodes/color_grade.rs
@@ -1,0 +1,413 @@
+use super::RenderNodeCpu;
+
+// ── Pipeline cache ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+struct ColorGradePipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    uniform_buf: wgpu::Buffer,
+}
+
+// ── ColorGradeNode ────────────────────────────────────────────────────────────
+
+/// Basic colour grading: brightness, contrast, saturation, temperature, tint.
+///
+/// # Processing order
+///
+/// brightness → contrast → temperature/tint → saturation
+pub struct ColorGradeNode {
+    /// Additive brightness offset (−1.0 – +1.0; 0.0 = no change).
+    pub brightness: f32,
+    /// Contrast multiplier around 0.5 (0.0 – 4.0; 1.0 = no change).
+    pub contrast: f32,
+    /// Saturation multiplier (0.0 = greyscale; 1.0 = no change; 2.0 = double).
+    pub saturation: f32,
+    /// Colour temperature offset (−1.0 = cool/blue; +1.0 = warm/orange).
+    pub temperature: f32,
+    /// Tint offset (−1.0 = magenta; +1.0 = green).
+    pub tint: f32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<ColorGradePipeline>,
+}
+
+impl ColorGradeNode {
+    /// Identity node (no colour change).
+    #[must_use]
+    pub fn new(
+        brightness: f32,
+        contrast: f32,
+        saturation: f32,
+        temperature: f32,
+        tint: f32,
+    ) -> Self {
+        Self {
+            brightness,
+            contrast,
+            saturation,
+            temperature,
+            tint,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl Default for ColorGradeNode {
+    fn default() -> Self {
+        Self::new(0.0, 1.0, 1.0, 0.0, 0.0)
+    }
+}
+
+// ── CPU path ──────────────────────────────────────────────────────────────────
+
+impl RenderNodeCpu for ColorGradeNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        for pixel in rgba.chunks_exact_mut(4) {
+            let r = f32::from(pixel[0]) / 255.0;
+            let g = f32::from(pixel[1]) / 255.0;
+            let b = f32::from(pixel[2]) / 255.0;
+
+            // Brightness
+            let r = r + self.brightness;
+            let g = g + self.brightness;
+            let b = b + self.brightness;
+
+            // Contrast
+            let r = (r - 0.5) * self.contrast + 0.5;
+            let g = (g - 0.5) * self.contrast + 0.5;
+            let b = (b - 0.5) * self.contrast + 0.5;
+
+            // Temperature
+            let r = r + self.temperature * 0.1;
+            let b = b - self.temperature * 0.1;
+
+            // Tint
+            let g = g + self.tint * 0.1;
+
+            // Saturation (BT.709 luma coefficients)
+            let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+            let r = luma + (r - luma) * self.saturation;
+            let g = luma + (g - luma) * self.saturation;
+            let b = luma + (b - luma) * self.saturation;
+
+            pixel[0] = (r.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            pixel[1] = (g.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            pixel[2] = (b.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            // alpha unchanged
+        }
+    }
+}
+
+// ── GPU path ──────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+impl ColorGradeNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &ColorGradePipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("ColorGrade shader"),
+                source: wgpu::ShaderSource::Wgsl(
+                    include_str!("../shaders/color_grade.wgsl").into(),
+                ),
+            });
+
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("ColorGrade BGL"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("ColorGrade layout"),
+                bind_group_layouts: &[&bgl],
+                push_constant_ranges: &[],
+            });
+
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("ColorGrade pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+            let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                label: Some("ColorGrade sampler"),
+                address_mode_u: wgpu::AddressMode::ClampToEdge,
+                address_mode_v: wgpu::AddressMode::ClampToEdge,
+                mag_filter: wgpu::FilterMode::Linear,
+                min_filter: wgpu::FilterMode::Linear,
+                ..Default::default()
+            });
+
+            // 8 × f32 = 32 bytes — matches ColorGradeUniforms in the shader.
+            let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("ColorGrade uniforms"),
+                size: 32,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            ColorGradePipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                sampler,
+                uniform_buf,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for ColorGradeNode {
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("ColorGradeNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("ColorGradeNode::process called with no outputs");
+            return;
+        };
+
+        let pd = self.get_or_create_pipeline(ctx);
+
+        // Update uniforms for this frame.
+        let uniform_bytes = pack_f32(&[
+            self.brightness,
+            self.contrast,
+            self.saturation,
+            self.temperature,
+            self.tint,
+            0.0,
+            0.0,
+            0.0,
+        ]);
+        ctx.queue.write_buffer(&pd.uniform_buf, 0, &uniform_bytes);
+
+        let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("ColorGrade BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&pd.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: pd.uniform_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("ColorGrade pass"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("ColorGrade pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &output_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&pd.render_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..6, 0..1);
+        }
+        ctx.queue.submit(std::iter::once(encoder.finish()));
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_grade_node_default_should_be_identity() {
+        let node = ColorGradeNode::default();
+        let original = vec![100u8, 150, 200, 255];
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        // Identity: brightness=0, contrast=1, saturation=1, temperature=0, tint=0.
+        // Allow ±1 rounding error from f32 round-trip.
+        for i in 0..3 {
+            let diff = (rgba[i] as i32 - original[i] as i32).abs();
+            assert!(
+                diff <= 1,
+                "identity must preserve pixel at channel {i}: expected ~{} got {}",
+                original[i],
+                rgba[i]
+            );
+        }
+        assert_eq!(rgba[3], 255, "alpha must not change");
+    }
+
+    #[test]
+    fn color_grade_node_brightness_positive_should_increase_mid_grey() {
+        let node = ColorGradeNode {
+            brightness: 0.5,
+            ..Default::default()
+        };
+        let mut rgba = vec![128u8, 128, 128, 255]; // mid-grey
+        node.process_cpu(&mut rgba, 1, 1);
+        assert!(
+            rgba[0] > 128,
+            "brightness +0.5 must increase R; got {}",
+            rgba[0]
+        );
+        assert!(
+            rgba[1] > 128,
+            "brightness +0.5 must increase G; got {}",
+            rgba[1]
+        );
+        assert!(
+            rgba[2] > 128,
+            "brightness +0.5 must increase B; got {}",
+            rgba[2]
+        );
+        assert_eq!(rgba[3], 255, "alpha must not change");
+    }
+
+    #[test]
+    fn color_grade_node_brightness_negative_should_decrease_mid_grey() {
+        let node = ColorGradeNode {
+            brightness: -0.5,
+            ..Default::default()
+        };
+        let mut rgba = vec![128u8, 128, 128, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        assert!(
+            rgba[0] < 128,
+            "brightness −0.5 must decrease R; got {}",
+            rgba[0]
+        );
+    }
+
+    #[test]
+    fn color_grade_node_saturation_zero_should_produce_greyscale() {
+        let node = ColorGradeNode {
+            saturation: 0.0,
+            ..Default::default()
+        };
+        let mut rgba = vec![200u8, 100, 50, 255]; // colourful pixel
+        node.process_cpu(&mut rgba, 1, 1);
+        // All channels must be equal (greyscale) — allow ±1 rounding.
+        let diff_rg = (rgba[0] as i32 - rgba[1] as i32).abs();
+        let diff_rb = (rgba[0] as i32 - rgba[2] as i32).abs();
+        assert!(
+            diff_rg <= 1,
+            "saturation=0 must equalise R and G; got R={} G={}",
+            rgba[0],
+            rgba[1]
+        );
+        assert!(
+            diff_rb <= 1,
+            "saturation=0 must equalise R and B; got R={} B={}",
+            rgba[0],
+            rgba[2]
+        );
+    }
+
+    #[test]
+    fn color_grade_node_clamp_should_not_exceed_255() {
+        let node = ColorGradeNode {
+            brightness: 2.0,
+            ..Default::default()
+        };
+        let mut rgba = vec![200u8, 200, 200, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba[0], 255, "clamped R must be 255");
+        assert_eq!(rgba[1], 255, "clamped G must be 255");
+        assert_eq!(rgba[2], 255, "clamped B must be 255");
+    }
+
+    #[test]
+    fn color_grade_node_variants_should_construct_via_default() {
+        let _ = ColorGradeNode {
+            brightness: 0.1,
+            contrast: 1.2,
+            saturation: 0.9,
+            ..Default::default()
+        };
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+fn pack_f32(values: &[f32]) -> Vec<u8> {
+    values.iter().flat_map(|f| f.to_le_bytes()).collect()
+}

--- a/crates/ff-render/src/nodes/crossfade.rs
+++ b/crates/ff-render/src/nodes/crossfade.rs
@@ -1,0 +1,363 @@
+use super::RenderNodeCpu;
+
+// ── Pipeline cache ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+struct CrossfadePipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    uniform_buf: wgpu::Buffer,
+}
+
+// ── CrossfadeNode ─────────────────────────────────────────────────────────────
+
+/// Linear crossfade between two RGBA frames.
+///
+/// - `factor = 0.0` → output equals the input frame (`inputs[0]` / `process_cpu` argument).
+/// - `factor = 1.0` → output equals `to_rgba`.
+/// - `factor = 0.5` → arithmetic mean of both frames.
+///
+/// The "to" frame is stored in the node at construction time.
+pub struct CrossfadeNode {
+    /// Blend factor: 0.0 (from) → 1.0 (to).
+    pub factor: f32,
+    /// The "to" frame as RGBA bytes. Length must equal `to_width × to_height × 4`.
+    pub to_rgba: Vec<u8>,
+    /// Width of `to_rgba`.
+    pub to_width: u32,
+    /// Height of `to_rgba`.
+    pub to_height: u32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<CrossfadePipeline>,
+}
+
+impl CrossfadeNode {
+    /// Construct a crossfade node.
+    ///
+    /// `to_rgba` is the "to" frame (second input). It must be
+    /// `to_width × to_height × 4` bytes of RGBA data.
+    #[must_use]
+    pub fn new(factor: f32, to_rgba: Vec<u8>, to_width: u32, to_height: u32) -> Self {
+        Self {
+            factor,
+            to_rgba,
+            to_width,
+            to_height,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+// ── CPU path ──────────────────────────────────────────────────────────────────
+
+impl RenderNodeCpu for CrossfadeNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        if self.to_rgba.len() != rgba.len() {
+            log::warn!(
+                "CrossfadeNode::process_cpu skipped: size mismatch from={} to={}",
+                rgba.len(),
+                self.to_rgba.len()
+            );
+            return;
+        }
+        for (src, dst) in rgba.iter_mut().zip(self.to_rgba.iter()) {
+            let blended = (1.0 - self.factor) * f32::from(*src) + self.factor * f32::from(*dst);
+            *src = (blended + 0.5) as u8;
+        }
+    }
+}
+
+// ── GPU path ──────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+impl CrossfadeNode {
+    #[allow(clippy::too_many_lines)]
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &CrossfadePipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Crossfade shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/crossfade.wgsl").into()),
+            });
+
+            // binding 0: tex_from, 1: tex_to, 2: sampler, 3: uniforms
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Crossfade BGL"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Crossfade layout"),
+                bind_group_layouts: &[&bgl],
+                push_constant_ranges: &[],
+            });
+
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Crossfade pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+            let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                label: Some("Crossfade sampler"),
+                address_mode_u: wgpu::AddressMode::ClampToEdge,
+                address_mode_v: wgpu::AddressMode::ClampToEdge,
+                mag_filter: wgpu::FilterMode::Linear,
+                min_filter: wgpu::FilterMode::Linear,
+                ..Default::default()
+            });
+
+            // 4 × f32 = 16 bytes — matches CrossfadeUniforms in the shader.
+            let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("Crossfade uniforms"),
+                size: 16,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            CrossfadePipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                sampler,
+                uniform_buf,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for CrossfadeNode {
+    fn input_count(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(tex_from) = inputs.first() else {
+            log::warn!("CrossfadeNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("CrossfadeNode::process called with no outputs");
+            return;
+        };
+
+        let pd = self.get_or_create_pipeline(ctx);
+
+        // Write factor uniform.
+        let uniform_bytes: Vec<u8> = [self.factor, 0.0_f32, 0.0_f32, 0.0_f32]
+            .iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+        ctx.queue.write_buffer(&pd.uniform_buf, 0, &uniform_bytes);
+
+        // Upload the "to" frame to a temporary GPU texture.
+        let to_tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Crossfade to_tex"),
+            size: wgpu::Extent3d {
+                width: self.to_width,
+                height: self.to_height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        ctx.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &to_tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &self.to_rgba,
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(self.to_width * 4),
+                rows_per_image: None,
+            },
+            wgpu::Extent3d {
+                width: self.to_width,
+                height: self.to_height,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        let from_view = tex_from.create_view(&wgpu::TextureViewDescriptor::default());
+        let to_view = to_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let out_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Crossfade BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&from_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&to_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&pd.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: pd.uniform_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Crossfade pass"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Crossfade pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &out_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&pd.render_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..6, 0..1);
+        }
+        ctx.queue.submit(std::iter::once(encoder.finish()));
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crossfade_node_factor_zero_should_return_from_frame() {
+        let to = vec![200u8, 200, 200, 255];
+        let node = CrossfadeNode::new(0.0, to, 1, 1);
+        let mut rgba = vec![50u8, 60, 70, 255];
+        let original = rgba.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba[0], original[0], "factor=0 must keep from-frame R");
+    }
+
+    #[test]
+    fn crossfade_node_factor_one_should_return_to_frame() {
+        let to = vec![200u8, 200, 200, 255];
+        let node = CrossfadeNode::new(1.0, to.clone(), 1, 1);
+        let mut rgba = vec![50u8, 50, 50, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        // Allow ±1 for float rounding.
+        assert!(
+            (rgba[0] as i32 - 200).abs() <= 1,
+            "factor=1 must return to-frame R; got {}",
+            rgba[0]
+        );
+    }
+
+    #[test]
+    fn crossfade_node_factor_half_should_produce_arithmetic_mean() {
+        // from = 0, to = 200 → expected mean = 100
+        let to = vec![200u8, 200, 200, 255];
+        let node = CrossfadeNode::new(0.5, to, 1, 1);
+        let mut rgba = vec![0u8, 0, 0, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        let diff = (rgba[0] as i32 - 100).abs();
+        assert!(
+            diff <= 1,
+            "factor=0.5 must produce arithmetic mean ~100; got {}",
+            rgba[0]
+        );
+    }
+
+    #[test]
+    fn crossfade_node_size_mismatch_should_leave_rgba_unchanged() {
+        let to = vec![200u8; 8]; // 2 pixels
+        let node = CrossfadeNode::new(0.5, to, 2, 1);
+        let original = vec![50u8, 50, 50, 255]; // 1 pixel
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1); // size mismatch — must be a no-op
+        assert_eq!(rgba, original, "size mismatch must leave rgba unchanged");
+    }
+}

--- a/crates/ff-render/src/nodes/crossfade.rs
+++ b/crates/ff-render/src/nodes/crossfade.rs
@@ -129,8 +129,8 @@ impl CrossfadeNode {
 
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Crossfade layout"),
-                bind_group_layouts: &[&bgl],
-                push_constant_ranges: &[],
+                bind_group_layouts: &[Some(&bgl)],
+                immediate_size: 0,
             });
 
             let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -138,13 +138,13 @@ impl CrossfadeNode {
                 layout: Some(&pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &shader,
-                    entry_point: "vs_main",
+                    entry_point: Some("vs_main"),
                     buffers: &[],
                     compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
-                    entry_point: "fs_main",
+                    entry_point: Some("fs_main"),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: wgpu::TextureFormat::Rgba8Unorm,
                         blend: None,
@@ -155,7 +155,7 @@ impl CrossfadeNode {
                 primitive: wgpu::PrimitiveState::default(),
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -232,14 +232,14 @@ impl super::RenderNode for CrossfadeNode {
             view_formats: &[],
         });
         ctx.queue.write_texture(
-            wgpu::ImageCopyTexture {
+            wgpu::TexelCopyTextureInfo {
                 texture: &to_tex,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
             &self.to_rgba,
-            wgpu::ImageDataLayout {
+            wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(self.to_width * 4),
                 rows_per_image: None,
@@ -289,6 +289,7 @@ impl super::RenderNode for CrossfadeNode {
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &out_view,
                     resolve_target: None,
+                    depth_slice: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                         store: wgpu::StoreOp::Store,
@@ -297,6 +298,7 @@ impl super::RenderNode for CrossfadeNode {
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
+                multiview_mask: None,
             });
             pass.set_pipeline(&pd.render_pipeline);
             pass.set_bind_group(0, &bind_group, &[]);

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -1,0 +1,61 @@
+pub mod color_grade;
+pub mod crossfade;
+pub mod overlay;
+pub mod scale;
+
+pub use color_grade::ColorGradeNode;
+pub use crossfade::CrossfadeNode;
+pub use overlay::OverlayNode;
+pub use scale::{ScaleAlgorithm, ScaleNode};
+
+// ── RenderNodeCpu ─────────────────────────────────────────────────────────────
+
+/// CPU fallback processing for a render node.
+///
+/// Implemented by all built-in nodes. Nodes that do not change frame
+/// dimensions modify `rgba` in-place. Multi-input nodes (e.g. [`CrossfadeNode`])
+/// store their secondary inputs as fields and access them during `process_cpu`.
+pub trait RenderNodeCpu: Send {
+    /// Process `rgba` in-place.
+    ///
+    /// `rgba` is a row-major RGBA buffer of size `w × h × 4` bytes.
+    /// Nodes that cannot implement a CPU path leave `rgba` unchanged.
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32);
+}
+
+// ── RenderNode ────────────────────────────────────────────────────────────────
+
+/// GPU render node. Extends [`RenderNodeCpu`] so both paths are available.
+///
+/// Each node is responsible for creating and caching its own wgpu pipeline
+/// on first use. The pipeline is stored in a [`std::sync::OnceLock`] field
+/// so it is created exactly once per node instance.
+///
+/// `process` may submit one or more `wgpu::CommandEncoder` buffers. The
+/// [`RenderGraph`](crate::graph::RenderGraph) guarantees that the queue
+/// processes them in submission order.
+#[cfg(feature = "wgpu")]
+pub trait RenderNode: RenderNodeCpu {
+    /// Number of input textures required by this node (default: 1).
+    fn input_count(&self) -> usize {
+        1
+    }
+
+    /// Number of render passes (default: 1). Multi-pass nodes (e.g. gaussian
+    /// blur) return 2 or more.
+    fn pass_count(&self) -> usize {
+        1
+    }
+
+    /// Run the GPU render pass.
+    ///
+    /// `inputs[i]` are the source textures (`len == input_count()`).
+    /// `outputs[i]` are pre-allocated `Rgba8Unorm` target textures
+    /// (`len == pass_count()`). Write the final result into `outputs[pass_count()-1]`.
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    );
+}

--- a/crates/ff-render/src/nodes/overlay.rs
+++ b/crates/ff-render/src/nodes/overlay.rs
@@ -124,8 +124,8 @@ impl OverlayNode {
 
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Overlay layout"),
-                bind_group_layouts: &[&bgl],
-                push_constant_ranges: &[],
+                bind_group_layouts: &[Some(&bgl)],
+                immediate_size: 0,
             });
 
             let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -133,13 +133,13 @@ impl OverlayNode {
                 layout: Some(&pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &shader,
-                    entry_point: "vs_main",
+                    entry_point: Some("vs_main"),
                     buffers: &[],
                     compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
-                    entry_point: "fs_main",
+                    entry_point: Some("fs_main"),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: wgpu::TextureFormat::Rgba8Unorm,
                         blend: None,
@@ -150,7 +150,7 @@ impl OverlayNode {
                 primitive: wgpu::PrimitiveState::default(),
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -211,14 +211,14 @@ impl super::RenderNode for OverlayNode {
             view_formats: &[],
         });
         ctx.queue.write_texture(
-            wgpu::ImageCopyTexture {
+            wgpu::TexelCopyTextureInfo {
                 texture: &ov_tex,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
             &self.overlay_rgba,
-            wgpu::ImageDataLayout {
+            wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(self.overlay_width * 4),
                 rows_per_image: None,
@@ -264,6 +264,7 @@ impl super::RenderNode for OverlayNode {
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &out_view,
                     resolve_target: None,
+                    depth_slice: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                         store: wgpu::StoreOp::Store,
@@ -272,6 +273,7 @@ impl super::RenderNode for OverlayNode {
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
+                multiview_mask: None,
             });
             pass.set_pipeline(&pd.render_pipeline);
             pass.set_bind_group(0, &bind_group, &[]);

--- a/crates/ff-render/src/nodes/overlay.rs
+++ b/crates/ff-render/src/nodes/overlay.rs
@@ -1,0 +1,334 @@
+use super::RenderNodeCpu;
+
+// ── Pipeline cache ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+struct OverlayPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+}
+
+// ── OverlayNode ───────────────────────────────────────────────────────────────
+
+/// Porter-Duff "src over dst" alpha compositing.
+///
+/// The input frame (`inputs[0]` / `process_cpu` argument) is the base layer.
+/// `overlay_rgba` is composited on top using its alpha channel.
+///
+/// The CPU path performs the same `src_over` formula as the shader:
+/// ```text
+/// out_rgb = overlay.rgb * overlay.a + base.rgb * (1 − overlay.a)
+/// out_a   = overlay.a + base.a * (1 − overlay.a)
+/// ```
+pub struct OverlayNode {
+    /// The overlay frame (top layer) as RGBA bytes.
+    pub overlay_rgba: Vec<u8>,
+    /// Width of `overlay_rgba`.
+    pub overlay_width: u32,
+    /// Height of `overlay_rgba`.
+    pub overlay_height: u32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<OverlayPipeline>,
+}
+
+impl OverlayNode {
+    #[must_use]
+    pub fn new(overlay_rgba: Vec<u8>, overlay_width: u32, overlay_height: u32) -> Self {
+        Self {
+            overlay_rgba,
+            overlay_width,
+            overlay_height,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+// ── CPU path ──────────────────────────────────────────────────────────────────
+
+impl RenderNodeCpu for OverlayNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        if self.overlay_rgba.len() != rgba.len() {
+            log::warn!(
+                "OverlayNode::process_cpu skipped: size mismatch base={} overlay={}",
+                rgba.len(),
+                self.overlay_rgba.len()
+            );
+            return;
+        }
+        for (base, ov) in rgba
+            .chunks_exact_mut(4)
+            .zip(self.overlay_rgba.chunks_exact(4))
+        {
+            let ov_a = f32::from(ov[3]) / 255.0;
+            let base_a = f32::from(base[3]) / 255.0;
+            let out_a = ov_a + base_a * (1.0 - ov_a);
+            for ch in 0..3 {
+                let ov_c = f32::from(ov[ch]) / 255.0;
+                let base_c = f32::from(base[ch]) / 255.0;
+                let out_c = ov_c * ov_a + base_c * (1.0 - ov_a);
+                base[ch] = (out_c.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            }
+            base[3] = (out_a.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+        }
+    }
+}
+
+// ── GPU path ──────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+impl OverlayNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &OverlayPipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Overlay shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/overlay.wgsl").into()),
+            });
+
+            // binding 0: base, 1: overlay, 2: sampler
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Overlay BGL"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Overlay layout"),
+                bind_group_layouts: &[&bgl],
+                push_constant_ranges: &[],
+            });
+
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Overlay pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+            let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                label: Some("Overlay sampler"),
+                address_mode_u: wgpu::AddressMode::ClampToEdge,
+                address_mode_v: wgpu::AddressMode::ClampToEdge,
+                mag_filter: wgpu::FilterMode::Linear,
+                min_filter: wgpu::FilterMode::Linear,
+                ..Default::default()
+            });
+
+            OverlayPipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                sampler,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for OverlayNode {
+    fn input_count(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(tex_base) = inputs.first() else {
+            log::warn!("OverlayNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("OverlayNode::process called with no outputs");
+            return;
+        };
+
+        let pd = self.get_or_create_pipeline(ctx);
+
+        // Upload the overlay frame to a temporary GPU texture.
+        let ov_tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Overlay ov_tex"),
+            size: wgpu::Extent3d {
+                width: self.overlay_width,
+                height: self.overlay_height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        ctx.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &ov_tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &self.overlay_rgba,
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(self.overlay_width * 4),
+                rows_per_image: None,
+            },
+            wgpu::Extent3d {
+                width: self.overlay_width,
+                height: self.overlay_height,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        let base_view = tex_base.create_view(&wgpu::TextureViewDescriptor::default());
+        let ov_view = ov_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let out_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Overlay BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&base_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&ov_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&pd.sampler),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Overlay pass"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Overlay pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &out_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&pd.render_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..6, 0..1);
+        }
+        ctx.queue.submit(std::iter::once(encoder.finish()));
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlay_node_fully_opaque_overlay_should_replace_base() {
+        let base = vec![50u8, 50, 50, 255];
+        let overlay = vec![200u8, 100, 50, 255]; // alpha=255 → fully opaque
+        let node = OverlayNode::new(overlay.clone(), 1, 1);
+        let mut rgba = base;
+        node.process_cpu(&mut rgba, 1, 1);
+        // With overlay.alpha=255, output must equal overlay.
+        assert!(
+            (rgba[0] as i32 - 200).abs() <= 1,
+            "R must match overlay; got {}",
+            rgba[0]
+        );
+        assert!(
+            (rgba[1] as i32 - 100).abs() <= 1,
+            "G must match overlay; got {}",
+            rgba[1]
+        );
+    }
+
+    #[test]
+    fn overlay_node_fully_transparent_overlay_should_preserve_base() {
+        let base = vec![50u8, 80, 120, 255];
+        let overlay = vec![200u8, 100, 50, 0]; // alpha=0 → invisible
+        let node = OverlayNode::new(overlay, 1, 1);
+        let mut rgba = base.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        // With overlay.alpha=0, output must equal base.
+        assert!(
+            (rgba[0] as i32 - 50).abs() <= 1,
+            "R must match base; got {}",
+            rgba[0]
+        );
+    }
+
+    #[test]
+    fn overlay_node_size_mismatch_should_be_noop() {
+        let overlay = vec![200u8; 8]; // 2 pixels
+        let node = OverlayNode::new(overlay, 2, 1);
+        let original = vec![50u8, 80, 120, 255];
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1); // size mismatch
+        assert_eq!(rgba, original);
+    }
+}

--- a/crates/ff-render/src/nodes/scale.rs
+++ b/crates/ff-render/src/nodes/scale.rs
@@ -1,0 +1,251 @@
+use super::RenderNodeCpu;
+
+/// Resampling algorithm for [`ScaleNode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ScaleAlgorithm {
+    /// Bilinear — fast, good quality for moderate scaling (default).
+    #[default]
+    Bilinear,
+    /// Bicubic — medium quality.
+    Bicubic,
+    /// Lanczos — high quality, best for downscaling.
+    Lanczos,
+}
+
+// ── Pipeline cache ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+struct ScalePipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+}
+
+// ── ScaleNode ─────────────────────────────────────────────────────────────────
+
+/// Resample a frame to a target resolution.
+///
+/// In Phase 1 the GPU path renders into the output texture at whatever size
+/// it was allocated — the graph allocates same-size textures, so `ScaleNode`
+/// acts as a bilinear blit pass. Full dimension-changing support (variable
+/// output texture size) is a Phase 2 addition.
+///
+/// The CPU path is a no-op; use an offline scaler (e.g. `image` crate) for
+/// CPU-side resizing.
+pub struct ScaleNode {
+    /// Target width in pixels (used as metadata; output size depends on the graph).
+    pub width: u32,
+    /// Target height in pixels.
+    pub height: u32,
+    /// Sampling algorithm.
+    pub algorithm: ScaleAlgorithm,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<ScalePipeline>,
+}
+
+impl ScaleNode {
+    #[must_use]
+    pub fn new(width: u32, height: u32, algorithm: ScaleAlgorithm) -> Self {
+        Self {
+            width,
+            height,
+            algorithm,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl Default for ScaleNode {
+    fn default() -> Self {
+        Self::new(0, 0, ScaleAlgorithm::Bilinear)
+    }
+}
+
+// ── CPU path — no-op ──────────────────────────────────────────────────────────
+
+impl RenderNodeCpu for ScaleNode {
+    fn process_cpu(&self, _rgba: &mut [u8], _w: u32, _h: u32) {
+        // CPU-side resize is not implemented in Phase 1.
+        // Use an offline scaler (e.g. `image::imageops::resize`) for CPU paths.
+    }
+}
+
+// ── GPU path ──────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wgpu")]
+impl ScaleNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &ScalePipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Scale shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/scale.wgsl").into()),
+            });
+
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Scale BGL"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Scale layout"),
+                bind_group_layouts: &[&bgl],
+                push_constant_ranges: &[],
+            });
+
+            // Use linear filtering for Bilinear (default) and Bicubic.
+            // Lanczos would require a custom kernel — Phase 3 addition.
+            let filter = match self.algorithm {
+                ScaleAlgorithm::Bilinear | ScaleAlgorithm::Bicubic | ScaleAlgorithm::Lanczos => {
+                    wgpu::FilterMode::Linear
+                }
+            };
+
+            let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                label: Some("Scale sampler"),
+                address_mode_u: wgpu::AddressMode::ClampToEdge,
+                address_mode_v: wgpu::AddressMode::ClampToEdge,
+                mag_filter: filter,
+                min_filter: filter,
+                ..Default::default()
+            });
+
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Scale pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+            ScalePipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                sampler,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for ScaleNode {
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("ScaleNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("ScaleNode::process called with no outputs");
+            return;
+        };
+
+        let pd = self.get_or_create_pipeline(ctx);
+
+        let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Scale BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&pd.sampler),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Scale pass"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Scale pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &output_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&pd.render_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..6, 0..1);
+        }
+        ctx.queue.submit(std::iter::once(encoder.finish()));
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scale_node_cpu_path_is_passthrough() {
+        let node = ScaleNode::new(100, 100, ScaleAlgorithm::Bilinear);
+        let original = vec![10u8, 20, 30, 255];
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, original, "ScaleNode CPU path must be a no-op");
+    }
+
+    #[test]
+    fn scale_algorithm_default_should_be_bilinear() {
+        assert_eq!(ScaleAlgorithm::default(), ScaleAlgorithm::Bilinear);
+    }
+}

--- a/crates/ff-render/src/nodes/scale.rs
+++ b/crates/ff-render/src/nodes/scale.rs
@@ -108,8 +108,8 @@ impl ScaleNode {
 
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Scale layout"),
-                bind_group_layouts: &[&bgl],
-                push_constant_ranges: &[],
+                bind_group_layouts: &[Some(&bgl)],
+                immediate_size: 0,
             });
 
             // Use linear filtering for Bilinear (default) and Bicubic.
@@ -134,13 +134,13 @@ impl ScaleNode {
                 layout: Some(&pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &shader,
-                    entry_point: "vs_main",
+                    entry_point: Some("vs_main"),
                     buffers: &[],
                     compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
-                    entry_point: "fs_main",
+                    entry_point: Some("fs_main"),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: wgpu::TextureFormat::Rgba8Unorm,
                         blend: None,
@@ -151,7 +151,7 @@ impl ScaleNode {
                 primitive: wgpu::PrimitiveState::default(),
                 depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -212,6 +212,7 @@ impl super::RenderNode for ScaleNode {
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &output_view,
                     resolve_target: None,
+                    depth_slice: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                         store: wgpu::StoreOp::Store,
@@ -220,6 +221,7 @@ impl super::RenderNode for ScaleNode {
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
+                multiview_mask: None,
             });
             pass.set_pipeline(&pd.render_pipeline);
             pass.set_bind_group(0, &bind_group, &[]);

--- a/crates/ff-render/src/shaders/color_grade.wgsl
+++ b/crates/ff-render/src/shaders/color_grade.wgsl
@@ -1,0 +1,66 @@
+// Full-screen quad vertex shader shared by all single-pass nodes.
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    // Two triangles covering the full NDC clip space.
+    // NDC Y is up; texture UV Y is down — mapping is inverted on Y.
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+// ── Fragment ──────────────────────────────────────────────────────────────────
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_sampler: sampler;
+@group(0) @binding(2) var<uniform> u: ColorGradeUniforms;
+
+struct ColorGradeUniforms {
+    brightness:  f32,
+    contrast:    f32,
+    saturation:  f32,
+    temperature: f32,
+    tint:        f32,
+    _pad0:       f32,
+    _pad1:       f32,
+    _pad2:       f32,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let color = textureSample(input_tex, tex_sampler, in.uv);
+    var rgb = color.rgb;
+
+    // Brightness: additive offset.
+    rgb = rgb + u.brightness;
+
+    // Contrast: pivot at 0.5.
+    rgb = (rgb - 0.5) * u.contrast + 0.5;
+
+    // Temperature (warm/cool): shift R and B in opposite directions.
+    rgb.r = rgb.r + u.temperature * 0.1;
+    rgb.b = rgb.b - u.temperature * 0.1;
+
+    // Tint (green ↔ magenta): shift G.
+    rgb.g = rgb.g + u.tint * 0.1;
+
+    // Saturation: blend toward luma (BT.709 coefficients).
+    let luma = dot(rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
+    rgb = mix(vec3<f32>(luma), rgb, u.saturation);
+
+    rgb = clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0));
+    return vec4<f32>(rgb, color.a);
+}

--- a/crates/ff-render/src/shaders/crossfade.wgsl
+++ b/crates/ff-render/src/shaders/crossfade.wgsl
@@ -1,0 +1,42 @@
+// Full-screen quad vertex shader.
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+// ── Fragment ──────────────────────────────────────────────────────────────────
+
+@group(0) @binding(0) var tex_from: texture_2d<f32>;
+@group(0) @binding(1) var tex_to:   texture_2d<f32>;
+@group(0) @binding(2) var tex_sampler: sampler;
+@group(0) @binding(3) var<uniform> u: CrossfadeUniforms;
+
+struct CrossfadeUniforms {
+    factor: f32,
+    _pad0:  f32,
+    _pad1:  f32,
+    _pad2:  f32,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let from_color = textureSample(tex_from, tex_sampler, in.uv);
+    let to_color   = textureSample(tex_to,   tex_sampler, in.uv);
+    return mix(from_color, to_color, u.factor);
+}

--- a/crates/ff-render/src/shaders/overlay.wgsl
+++ b/crates/ff-render/src/shaders/overlay.wgsl
@@ -1,0 +1,36 @@
+// Porter-Duff "src over dst" alpha compositing.
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var tex_base:    texture_2d<f32>;
+@group(0) @binding(1) var tex_overlay: texture_2d<f32>;
+@group(0) @binding(2) var tex_sampler: sampler;
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let base    = textureSample(tex_base,    tex_sampler, in.uv);
+    let overlay = textureSample(tex_overlay, tex_sampler, in.uv);
+    // src over dst: out_rgb = overlay.rgb * overlay.a + base.rgb * (1 - overlay.a)
+    let alpha_ov = overlay.a;
+    let out_rgb  = overlay.rgb * alpha_ov + base.rgb * (1.0 - alpha_ov);
+    let out_a    = alpha_ov + base.a * (1.0 - alpha_ov);
+    return vec4<f32>(out_rgb, out_a);
+}

--- a/crates/ff-render/src/shaders/scale.wgsl
+++ b/crates/ff-render/src/shaders/scale.wgsl
@@ -1,0 +1,31 @@
+// Bilinear-sampled blit — used by ScaleNode.
+// The GPU pipeline writes to whatever output texture size was created by
+// the graph, achieving resampling at no extra cost.
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var tex_sampler: sampler;
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(input_tex, tex_sampler, in.uv);
+}

--- a/crates/ff-render/src/sink/mod.rs
+++ b/crates/ff-render/src/sink/mod.rs
@@ -1,0 +1,157 @@
+use std::time::Duration;
+
+use ff_preview::FrameSink;
+
+use crate::graph::RenderGraph;
+
+// ── TextureHandle ─────────────────────────────────────────────────────────────
+
+/// A GPU texture together with its default view and dimensions.
+///
+/// Window systems (winit, egui) can blit this directly to the display
+/// surface without a CPU round-trip download.
+#[cfg(feature = "wgpu")]
+pub struct TextureHandle {
+    pub texture: wgpu::Texture,
+    pub view: wgpu::TextureView,
+    pub width: u32,
+    pub height: u32,
+}
+
+// ── GpuFrameSink ─────────────────────────────────────────────────────────────
+
+/// A [`FrameSink`] that processes each frame through a [`RenderGraph`] before
+/// forwarding to a downstream sink.
+///
+/// When the `wgpu` feature is enabled and the graph was created with a GPU
+/// context, the GPU pipeline runs. On GPU error the unprocessed frame is
+/// forwarded as a fallback.
+///
+/// When the `wgpu` feature is **not** enabled (or the graph is CPU-only), the
+/// CPU fallback pipeline runs transparently.
+///
+/// # Example
+///
+/// ```ignore
+/// let ctx = Arc::new(RenderContext::init().await?);
+/// let graph = RenderGraph::new(ctx)
+///     .push(ColorGradeNode { brightness: 0.2, ..Default::default() });
+/// let sink = GpuFrameSink::new(graph, Box::new(RgbaSink::new()));
+/// runner.set_sink(Box::new(sink));
+/// ```
+pub struct GpuFrameSink {
+    graph: RenderGraph,
+    downstream: Box<dyn FrameSink>,
+}
+
+impl GpuFrameSink {
+    /// Construct a sink that applies `graph` to every incoming frame and
+    /// forwards the result to `downstream`.
+    #[must_use]
+    pub fn new(graph: RenderGraph, downstream: Box<dyn FrameSink>) -> Self {
+        Self { graph, downstream }
+    }
+}
+
+impl FrameSink for GpuFrameSink {
+    fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
+        #[cfg(feature = "wgpu")]
+        {
+            match self.graph.process_gpu(rgba, width, height) {
+                Ok(processed) => {
+                    self.downstream.push_frame(&processed, width, height, pts);
+                    return;
+                }
+                Err(e) => {
+                    log::warn!("GpuFrameSink GPU processing failed, using CPU fallback error={e}");
+                }
+            }
+        }
+        // CPU fallback (also used when wgpu feature is disabled).
+        let processed = self.graph.process_cpu(rgba, width, height);
+        self.downstream.push_frame(&processed, width, height, pts);
+    }
+
+    fn flush(&mut self) {
+        self.downstream.flush();
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use crate::nodes::ColorGradeNode;
+
+    struct CollectSink(Arc<Mutex<Vec<Vec<u8>>>>);
+
+    impl FrameSink for CollectSink {
+        fn push_frame(&mut self, rgba: &[u8], _w: u32, _h: u32, _pts: Duration) {
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(rgba.to_vec());
+        }
+    }
+
+    #[test]
+    fn gpu_frame_sink_cpu_path_should_forward_processed_frame() {
+        // Use a CPU-only graph so no GPU device is required.
+        let graph = RenderGraph::new_cpu().push_cpu(ColorGradeNode::new(0.5, 1.0, 1.0, 0.0, 0.0));
+
+        let collected = Arc::new(Mutex::new(Vec::new()));
+        let downstream = Box::new(CollectSink(Arc::clone(&collected)));
+        let mut sink = GpuFrameSink::new(graph, downstream);
+
+        let pts = Duration::from_millis(0);
+        // When wgpu feature is enabled, process_gpu will fail (no ctx) and
+        // fall back to process_cpu — which is what we want for this test.
+        sink.push_frame(&[128u8, 128, 128, 255], 1, 1, pts);
+
+        let guard = collected
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(guard.len(), 1, "exactly one frame must be forwarded");
+        assert!(
+            guard[0][0] > 128,
+            "brightness +0.5 must increase R channel; got {}",
+            guard[0][0]
+        );
+    }
+
+    #[test]
+    fn gpu_frame_sink_flush_should_propagate_to_downstream() {
+        struct FlushTracker(Arc<Mutex<bool>>);
+        impl FrameSink for FlushTracker {
+            fn push_frame(&mut self, _: &[u8], _: u32, _: u32, _: Duration) {}
+            fn flush(&mut self) {
+                *self
+                    .0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+            }
+        }
+
+        let flushed = Arc::new(Mutex::new(false));
+        let mut sink = GpuFrameSink::new(
+            RenderGraph::new_cpu(),
+            Box::new(FlushTracker(Arc::clone(&flushed))),
+        );
+        sink.flush();
+        assert!(
+            *flushed
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            "flush must propagate to downstream"
+        );
+    }
+
+    #[test]
+    fn gpu_frame_sink_should_be_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GpuFrameSink>();
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the `ff-render` crate, a GPU compositing pipeline built on wgpu. The crate provides a `RenderGraph` that chains render nodes, executing them on the GPU when the `wgpu` feature is enabled and falling back to CPU otherwise. It integrates with `ff-preview` via `GpuFrameSink`, which applies the graph to every decoded frame before forwarding it to a downstream `FrameSink`.

## Changes

- `crates/ff-render/`: new crate with the following modules
  - `RenderContext` — owns wgpu device + queue; created via `init()` or `init_with_backend()`
  - `RenderGraph` — linear node chain; `new(ctx)` for GPU+CPU, `new_cpu()` for CPU-only
  - `RenderNode` / `RenderNodeCpu` traits — GPU and CPU processing interfaces
  - `ColorGradeNode` — brightness, contrast, saturation, temperature, tint (WGSL + CPU BT.709)
  - `CrossfadeNode` — linear blend between two frames at a given factor
  - `ScaleNode` — bilinear blit (GPU) / no-op (CPU Phase 1)
  - `OverlayNode` — Porter-Duff src-over alpha compositing
  - `GpuFrameSink` — wraps a `RenderGraph` as a `FrameSink`; GPU path with CPU fallback
  - WGSL shaders: `color_grade.wgsl`, `crossfade.wgsl`, `scale.wgsl`, `overlay.wgsl`
- `Cargo.toml` (workspace): register `ff-render`
- `crates/avio/Cargo.toml`: add `render` and `render-gpu` feature flags

## Related Issues

Closes #1027

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes