### PR TITLE
feat(ff-render): add Compositor high-level multi-layer GPU composition API

### DIFF
--- a/crates/ff-render/src/compositor/compositor_inner.rs
+++ b/crates/ff-render/src/compositor/compositor_inner.rs
@@ -1,0 +1,451 @@
+use std::sync::Arc;
+
+use ff_format::{PixelFormat, VideoFrame};
+
+use crate::context::RenderContext;
+use crate::error::RenderError;
+use crate::nodes::composite::{
+    fullscreen_pipeline, linear_sampler, submit_render_pass, two_tex_sampler_uniform_bgl,
+    upload_rgba_texture,
+};
+use crate::nodes::{BlendMode, RenderNode, TransformNode};
+
+use super::FrameLayer;
+
+// ── CompositorGraph ───────────────────────────────────────────────────────────
+
+/// Internal GPU state for the compositor.
+///
+/// Holds the blend shader pipeline and a reusable `TransformNode`. Built once
+/// per unique layer count and reused across frames.
+pub(super) struct CompositorGraph {
+    blend_pipeline: wgpu::RenderPipeline,
+    blend_bgl: wgpu::BindGroupLayout,
+    blend_sampler: wgpu::Sampler,
+    blend_uniform_buf: wgpu::Buffer,
+    transform_node: TransformNode,
+}
+
+impl CompositorGraph {
+    pub(super) fn build(
+        ctx: &Arc<RenderContext>,
+        _layer_count: usize,
+        _width: u32,
+        _height: u32,
+    ) -> Self {
+        let device = &ctx.device;
+
+        let blend_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Compositor blend shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/blend.wgsl").into()),
+        });
+        let blend_bgl = two_tex_sampler_uniform_bgl(device, "Compositor blend");
+        let blend_pipeline =
+            fullscreen_pipeline(device, &blend_shader, "Compositor blend", &blend_bgl);
+        let blend_sampler = linear_sampler(device, "Compositor blend");
+        let blend_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Compositor blend uniforms"),
+            size: 16,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            blend_pipeline,
+            blend_bgl,
+            blend_sampler,
+            blend_uniform_buf,
+            transform_node: TransformNode::default(),
+        }
+    }
+
+    pub(super) fn composite(
+        &mut self,
+        ctx: &Arc<RenderContext>,
+        layers: &[FrameLayer],
+        w: u32,
+        h: u32,
+    ) -> Result<wgpu::Texture, RenderError> {
+        let mut canvas = create_canvas(ctx, w, h);
+
+        for layer in layers {
+            let (fw, fh) = layer.frame.resolution();
+            let rgba = frame_to_rgba(&layer.frame)?;
+            let src_tex = upload_rgba_texture(ctx, &rgba, fw, fh, "Compositor src");
+
+            let layer_tex = if layer.transform.is_identity() {
+                src_tex
+            } else {
+                let xfm_tex = create_output_tex(ctx, w, h);
+                self.transform_node.translate = [layer.transform.x, layer.transform.y];
+                self.transform_node.rotate = layer.transform.rotation;
+                self.transform_node.scale = [layer.transform.scale_x, layer.transform.scale_y];
+                self.transform_node.process(&[&src_tex], &[&xfm_tex], ctx);
+                xfm_tex
+            };
+
+            let new_canvas = create_output_tex(ctx, w, h);
+            blend_textures(
+                ctx,
+                &self.blend_pipeline,
+                &self.blend_bgl,
+                &self.blend_sampler,
+                &self.blend_uniform_buf,
+                &canvas,
+                &layer_tex,
+                &new_canvas,
+                layer.blend_mode,
+                layer.opacity,
+            );
+            canvas = new_canvas;
+        }
+
+        Ok(canvas)
+    }
+}
+
+// ── Frame → RGBA conversion ───────────────────────────────────────────────────
+
+/// Convert any supported `VideoFrame` to a dense RGBA byte buffer.
+///
+/// Uses BT.601 coefficients for YUV formats (matching `YuvUploadNode`).
+/// Returns `RenderError::UnsupportedFormat` for unrecognised formats.
+fn frame_to_rgba(frame: &VideoFrame) -> Result<Vec<u8>, RenderError> {
+    let w = frame.width() as usize;
+    let h = frame.height() as usize;
+
+    match frame.format() {
+        PixelFormat::Rgba => {
+            let plane = frame.plane(0).ok_or_else(|| RenderError::Composite {
+                message: "Rgba frame: missing plane 0".to_string(),
+            })?;
+            let stride = frame.stride(0).unwrap_or(w * 4);
+            let row = w * 4;
+            if stride == row {
+                Ok(plane[..row * h].to_vec())
+            } else {
+                let mut out = Vec::with_capacity(row * h);
+                for r in 0..h {
+                    out.extend_from_slice(&plane[r * stride..r * stride + row]);
+                }
+                Ok(out)
+            }
+        }
+        PixelFormat::Bgra => {
+            let plane = frame.plane(0).ok_or_else(|| RenderError::Composite {
+                message: "Bgra frame: missing plane 0".to_string(),
+            })?;
+            let stride = frame.stride(0).unwrap_or(w * 4);
+            let mut out = Vec::with_capacity(w * h * 4);
+            for r in 0..h {
+                let base = r * stride;
+                for px in 0..w {
+                    let i = base + px * 4;
+                    out.push(plane[i + 2]); // R (was B)
+                    out.push(plane[i + 1]); // G
+                    out.push(plane[i]); // B (was R)
+                    out.push(plane[i + 3]); // A
+                }
+            }
+            Ok(out)
+        }
+        PixelFormat::Rgb24 => {
+            let plane = frame.plane(0).ok_or_else(|| RenderError::Composite {
+                message: "Rgb24 frame: missing plane 0".to_string(),
+            })?;
+            let stride = frame.stride(0).unwrap_or(w * 3);
+            let mut out = Vec::with_capacity(w * h * 4);
+            for r in 0..h {
+                let base = r * stride;
+                for px in 0..w {
+                    let i = base + px * 3;
+                    out.push(plane[i]);
+                    out.push(plane[i + 1]);
+                    out.push(plane[i + 2]);
+                    out.push(255);
+                }
+            }
+            Ok(out)
+        }
+        PixelFormat::Bgr24 => {
+            let plane = frame.plane(0).ok_or_else(|| RenderError::Composite {
+                message: "Bgr24 frame: missing plane 0".to_string(),
+            })?;
+            let stride = frame.stride(0).unwrap_or(w * 3);
+            let mut out = Vec::with_capacity(w * h * 4);
+            for r in 0..h {
+                let base = r * stride;
+                for px in 0..w {
+                    let i = base + px * 3;
+                    out.push(plane[i + 2]); // R (was B)
+                    out.push(plane[i + 1]); // G
+                    out.push(plane[i]); // B (was R)
+                    out.push(255);
+                }
+            }
+            Ok(out)
+        }
+        PixelFormat::Yuv420p => yuv_to_rgba(frame, 2, 2),
+        PixelFormat::Yuv422p => yuv_to_rgba(frame, 2, 1),
+        PixelFormat::Yuv444p => yuv_to_rgba(frame, 1, 1),
+        other => Err(RenderError::UnsupportedFormat {
+            format: format!("{other:?}"),
+        }),
+    }
+}
+
+/// Inline BT.601 YCbCr → RGBA conversion for planar 8-bit YUV formats.
+///
+/// `chroma_x_div` / `chroma_y_div` are the horizontal / vertical subsampling
+/// divisors (e.g. 2/2 for 4:2:0, 2/1 for 4:2:2, 1/1 for 4:4:4).
+#[allow(
+    clippy::many_single_char_names,
+    clippy::similar_names,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn yuv_to_rgba(
+    frame: &VideoFrame,
+    chroma_x_div: usize,
+    chroma_y_div: usize,
+) -> Result<Vec<u8>, RenderError> {
+    let w = frame.width() as usize;
+    let h = frame.height() as usize;
+
+    let y_plane = frame.plane(0).ok_or_else(|| RenderError::Composite {
+        message: "YUV frame: missing Y plane".to_string(),
+    })?;
+    let u_plane = frame.plane(1).ok_or_else(|| RenderError::Composite {
+        message: "YUV frame: missing U plane".to_string(),
+    })?;
+    let v_plane = frame.plane(2).ok_or_else(|| RenderError::Composite {
+        message: "YUV frame: missing V plane".to_string(),
+    })?;
+
+    let y_stride = frame.stride(0).unwrap_or(w);
+    let u_stride = frame.stride(1).unwrap_or(w.div_ceil(chroma_x_div));
+    let v_stride = frame.stride(2).unwrap_or(w.div_ceil(chroma_x_div));
+
+    let mut out = Vec::with_capacity(w * h * 4);
+    for row in 0..h {
+        for col in 0..w {
+            let y = f32::from(y_plane[row * y_stride + col]) / 255.0;
+            let u = f32::from(u_plane[(row / chroma_y_div) * u_stride + col / chroma_x_div])
+                / 255.0
+                - 0.5;
+            let v = f32::from(v_plane[(row / chroma_y_div) * v_stride + col / chroma_x_div])
+                / 255.0
+                - 0.5;
+            let r = (y + 1.402 * v).clamp(0.0, 1.0);
+            let g = (y - 0.344_136 * u - 0.714_136 * v).clamp(0.0, 1.0);
+            let b = (y + 1.772 * u).clamp(0.0, 1.0);
+            out.push((r * 255.0 + 0.5) as u8);
+            out.push((g * 255.0 + 0.5) as u8);
+            out.push((b * 255.0 + 0.5) as u8);
+            out.push(255);
+        }
+    }
+    Ok(out)
+}
+
+// ── GPU helpers ───────────────────────────────────────────────────────────────
+
+/// Create a black `Rgba8Unorm` canvas texture suitable as a render target.
+fn create_canvas(ctx: &Arc<RenderContext>, w: u32, h: u32) -> wgpu::Texture {
+    ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Compositor canvas"),
+        size: wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    })
+}
+
+/// Create an intermediate output texture (same usage flags as the canvas).
+fn create_output_tex(ctx: &Arc<RenderContext>, w: u32, h: u32) -> wgpu::Texture {
+    ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Compositor output"),
+        size: wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    })
+}
+
+/// Run one blend shader pass: `base + overlay → output`.
+#[allow(clippy::too_many_arguments)]
+fn blend_textures(
+    ctx: &Arc<RenderContext>,
+    pipeline: &wgpu::RenderPipeline,
+    bgl: &wgpu::BindGroupLayout,
+    sampler: &wgpu::Sampler,
+    uniform_buf: &wgpu::Buffer,
+    base_tex: &wgpu::Texture,
+    overlay_tex: &wgpu::Texture,
+    output_tex: &wgpu::Texture,
+    mode: BlendMode,
+    opacity: f32,
+) {
+    let mode_bytes = (mode as u32).to_le_bytes();
+    let opac_bytes = opacity.to_le_bytes();
+    let uniforms: [u8; 16] = [
+        mode_bytes[0],
+        mode_bytes[1],
+        mode_bytes[2],
+        mode_bytes[3],
+        opac_bytes[0],
+        opac_bytes[1],
+        opac_bytes[2],
+        opac_bytes[3],
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ];
+    ctx.queue.write_buffer(uniform_buf, 0, &uniforms);
+
+    let base_view = base_tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let ov_view = overlay_tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let out_view = output_tex.create_view(&wgpu::TextureViewDescriptor::default());
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Compositor blend BG"),
+        layout: bgl,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&base_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(&ov_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::Sampler(sampler),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: uniform_buf.as_entire_binding(),
+            },
+        ],
+    });
+
+    submit_render_pass(ctx, pipeline, &bind_group, &out_view, "Compositor blend");
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_format::{PixelFormat, PooledBuffer, Timestamp, VideoFrame};
+
+    fn rgba_frame(w: u32, h: u32) -> VideoFrame {
+        VideoFrame::empty(w, h, PixelFormat::Rgba).expect("test frame")
+    }
+
+    fn yuv420_frame(w: u32, h: u32) -> VideoFrame {
+        VideoFrame::empty(w, h, PixelFormat::Yuv420p).expect("test yuv frame")
+    }
+
+    fn rgb24_frame(w: u32, h: u32) -> VideoFrame {
+        let stride = w as usize * 3;
+        let data = vec![100u8, 150, 200].repeat(w as usize * h as usize);
+        VideoFrame::new(
+            vec![PooledBuffer::standalone(data)],
+            vec![stride],
+            w,
+            h,
+            PixelFormat::Rgb24,
+            Timestamp::default(),
+            false,
+        )
+        .expect("rgb24 frame")
+    }
+
+    fn bgra_frame(w: u32, h: u32) -> VideoFrame {
+        let stride = w as usize * 4;
+        let mut data = vec![0u8; stride * h as usize];
+        for px in 0..w as usize * h as usize {
+            data[px * 4] = 10; // B
+            data[px * 4 + 1] = 20; // G
+            data[px * 4 + 2] = 30; // R
+            data[px * 4 + 3] = 255; // A
+        }
+        VideoFrame::new(
+            vec![PooledBuffer::standalone(data)],
+            vec![stride],
+            w,
+            h,
+            PixelFormat::Bgra,
+            Timestamp::default(),
+            false,
+        )
+        .expect("bgra frame")
+    }
+
+    #[test]
+    fn frame_to_rgba_rgba_should_return_correct_size() {
+        let frame = rgba_frame(4, 4);
+        let result = frame_to_rgba(&frame).expect("Rgba must succeed");
+        assert_eq!(result.len(), 4 * 4 * 4, "output must be w*h*4 bytes");
+    }
+
+    #[test]
+    fn frame_to_rgba_yuv420p_should_produce_rgba_output() {
+        let frame = yuv420_frame(4, 4);
+        let result = frame_to_rgba(&frame).expect("Yuv420p must succeed");
+        assert_eq!(result.len(), 4 * 4 * 4, "YUV output must be w*h*4 bytes");
+        // All pixels should have alpha=255.
+        for chunk in result.chunks_exact(4) {
+            assert_eq!(chunk[3], 255, "YUV output alpha must be 255");
+        }
+    }
+
+    #[test]
+    fn frame_to_rgba_rgb24_should_add_opaque_alpha() {
+        let frame = rgb24_frame(2, 2);
+        let result = frame_to_rgba(&frame).expect("Rgb24 must succeed");
+        assert_eq!(result.len(), 2 * 2 * 4);
+        for chunk in result.chunks_exact(4) {
+            assert_eq!(chunk[0], 100, "R must be 100");
+            assert_eq!(chunk[1], 150, "G must be 150");
+            assert_eq!(chunk[2], 200, "B must be 200");
+            assert_eq!(chunk[3], 255, "alpha must be 255");
+        }
+    }
+
+    #[test]
+    fn frame_to_rgba_bgra_should_swap_channels() {
+        let frame = bgra_frame(1, 1);
+        let result = frame_to_rgba(&frame).expect("Bgra must succeed");
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0], 30, "R must come from BGRA.r (index 2)");
+        assert_eq!(result[1], 20, "G stays");
+        assert_eq!(result[2], 10, "B must come from BGRA.b (index 0)");
+        assert_eq!(result[3], 255, "A stays");
+    }
+}

--- a/crates/ff-render/src/compositor/mod.rs
+++ b/crates/ff-render/src/compositor/mod.rs
@@ -1,0 +1,238 @@
+#[cfg(feature = "wgpu")]
+mod compositor_inner;
+
+use ff_format::VideoFrame;
+
+use crate::nodes::BlendMode;
+
+// ── LayerTransform ────────────────────────────────────────────────────────────
+
+/// 2D affine transform parameters for a compositor layer.
+///
+/// All values use UV-space coordinates where 0.0 is no change. The default
+/// (identity) transform leaves the layer centred and unscaled.
+#[derive(Debug, Clone)]
+pub struct LayerTransform {
+    /// Horizontal UV-space offset (positive = shift right). Default: `0.0`.
+    pub x: f32,
+    /// Vertical UV-space offset (positive = shift down). Default: `0.0`.
+    pub y: f32,
+    /// Horizontal scale factor (`1.0` = no change). Default: `1.0`.
+    pub scale_x: f32,
+    /// Vertical scale factor (`1.0` = no change). Default: `1.0`.
+    pub scale_y: f32,
+    /// Counter-clockwise rotation in radians. Default: `0.0`.
+    pub rotation: f32,
+}
+
+impl Default for LayerTransform {
+    fn default() -> Self {
+        Self {
+            x: 0.0,
+            y: 0.0,
+            scale_x: 1.0,
+            scale_y: 1.0,
+            rotation: 0.0,
+        }
+    }
+}
+
+impl LayerTransform {
+    /// Returns `true` when this transform is the identity (no visual change).
+    #[must_use]
+    pub fn is_identity(&self) -> bool {
+        self.x.abs() < 1e-6
+            && self.y.abs() < 1e-6
+            && (self.scale_x - 1.0).abs() < 1e-6
+            && (self.scale_y - 1.0).abs() < 1e-6
+            && self.rotation.abs() < 1e-6
+    }
+}
+
+// ── FrameLayer ────────────────────────────────────────────────────────────────
+
+/// A single layer in the composition stack.
+pub struct FrameLayer {
+    /// Source video frame (uploaded to GPU by [`Compositor`]).
+    pub frame: VideoFrame,
+    /// 2D affine transform applied before compositing.
+    pub transform: LayerTransform,
+    /// Blend mode used when compositing this layer over layers below.
+    pub blend_mode: BlendMode,
+    /// Layer opacity (`0.0` = transparent, `1.0` = fully opaque).
+    pub opacity: f32,
+    /// Z-order — lower values are further back. Layers are sorted ascending
+    /// by this field before compositing.
+    pub z_order: i32,
+}
+
+// ── Compositor ────────────────────────────────────────────────────────────────
+
+/// Stateful high-level multi-layer GPU compositor.
+///
+/// Accepts a list of [`FrameLayer`]s, sorts them by [`FrameLayer::z_order`],
+/// uploads each frame to the GPU, applies per-layer transforms and blend modes,
+/// and returns the composited [`wgpu::Texture`].
+///
+/// The wgpu render pipeline is built on the first call to
+/// [`composite`](Self::composite) and reused across frames. It is rebuilt only
+/// when the number of layers changes.
+///
+/// # Thread safety
+///
+/// `Compositor` is [`Send`] and can be moved to a background thread. When
+/// multiple threads need to share a compositor, wrap it in
+/// `Arc<Mutex<Compositor>>`.
+///
+/// Requires the `wgpu` feature.
+#[cfg(feature = "wgpu")]
+pub struct Compositor {
+    ctx: std::sync::Arc<crate::context::RenderContext>,
+    width: u32,
+    height: u32,
+    graph: Option<compositor_inner::CompositorGraph>,
+    last_layer_count: usize,
+}
+
+#[cfg(feature = "wgpu")]
+impl Compositor {
+    /// Create a compositor targeting the given output resolution.
+    #[must_use]
+    pub fn new(
+        ctx: std::sync::Arc<crate::context::RenderContext>,
+        width: u32,
+        height: u32,
+    ) -> Self {
+        Self {
+            ctx,
+            width,
+            height,
+            graph: None,
+            last_layer_count: 0,
+        }
+    }
+
+    /// Composite `layers` into a single [`wgpu::Texture`].
+    ///
+    /// Layers are sorted by [`FrameLayer::z_order`] before compositing
+    /// (ascending — lowest `z_order` is the bottom layer).
+    ///
+    /// The wgpu pipeline is built on the first call and cached; it is rebuilt
+    /// only when `layers.len()` changes between calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RenderError`](crate::error::RenderError) on GPU texture
+    /// creation failure, unsupported pixel format, or render failure.
+    pub fn composite(
+        &mut self,
+        layers: &mut [FrameLayer],
+    ) -> Result<wgpu::Texture, crate::error::RenderError> {
+        layers.sort_unstable_by_key(|l| l.z_order);
+
+        let need_rebuild = self.graph.is_none() || self.last_layer_count != layers.len();
+        if need_rebuild {
+            self.graph = Some(compositor_inner::CompositorGraph::build(
+                &self.ctx,
+                layers.len(),
+                self.width,
+                self.height,
+            ));
+            self.last_layer_count = layers.len();
+        }
+
+        let Some(graph) = self.graph.as_mut() else {
+            return Err(crate::error::RenderError::Composite {
+                message: "compositor graph not initialized".to_string(),
+            });
+        };
+        graph.composite(&self.ctx, layers, self.width, self.height)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_format::{PixelFormat, VideoFrame};
+
+    fn make_frame() -> VideoFrame {
+        VideoFrame::empty(2, 2, PixelFormat::Rgba).expect("test frame")
+    }
+
+    #[test]
+    fn layer_transform_default_should_be_identity() {
+        let t = LayerTransform::default();
+        assert!(
+            t.is_identity(),
+            "default LayerTransform must be the identity"
+        );
+    }
+
+    #[test]
+    fn layer_transform_nonzero_x_should_not_be_identity() {
+        let t = LayerTransform {
+            x: 0.1,
+            ..Default::default()
+        };
+        assert!(
+            !t.is_identity(),
+            "LayerTransform with non-zero x must not be identity"
+        );
+    }
+
+    #[test]
+    fn frame_layer_should_construct_with_defaults() {
+        let layer = FrameLayer {
+            frame: make_frame(),
+            transform: LayerTransform::default(),
+            blend_mode: BlendMode::Normal,
+            opacity: 1.0,
+            z_order: 0,
+        };
+        assert_eq!(layer.z_order, 0);
+        assert!((layer.opacity - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn compositor_layers_should_sort_by_z_order() {
+        let mut layers = vec![
+            FrameLayer {
+                frame: make_frame(),
+                transform: LayerTransform::default(),
+                blend_mode: BlendMode::Normal,
+                opacity: 1.0,
+                z_order: 3,
+            },
+            FrameLayer {
+                frame: make_frame(),
+                transform: LayerTransform::default(),
+                blend_mode: BlendMode::Normal,
+                opacity: 1.0,
+                z_order: 1,
+            },
+            FrameLayer {
+                frame: make_frame(),
+                transform: LayerTransform::default(),
+                blend_mode: BlendMode::Normal,
+                opacity: 1.0,
+                z_order: 2,
+            },
+        ];
+        layers.sort_unstable_by_key(|l| l.z_order);
+        let z_orders: Vec<i32> = layers.iter().map(|l| l.z_order).collect();
+        assert_eq!(
+            z_orders,
+            vec![1, 2, 3],
+            "layers must sort ascending by z_order"
+        );
+    }
+
+    #[cfg(feature = "wgpu")]
+    #[test]
+    fn compositor_should_be_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Compositor>();
+    }
+}

--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -62,10 +62,14 @@ pub mod nodes;
 pub mod sink;
 
 #[cfg(feature = "wgpu")]
+pub mod compositor;
+#[cfg(feature = "wgpu")]
 pub mod context;
 
 // ── Top-level re-exports ─────────────────────────────────────────────────────
 
+#[cfg(feature = "wgpu")]
+pub use compositor::{Compositor, FrameLayer, LayerTransform};
 pub use error::RenderError;
 pub use graph::RenderGraph;
 pub use nodes::{

--- a/crates/ff-render/src/nodes/composite.rs
+++ b/crates/ff-render/src/nodes/composite.rs
@@ -1361,7 +1361,7 @@ mod tests {
 // ── GPU helpers (shared) ──────────────────────────────────────────────────────
 
 #[cfg(feature = "wgpu")]
-fn linear_sampler(device: &wgpu::Device, label: &str) -> wgpu::Sampler {
+pub(crate) fn linear_sampler(device: &wgpu::Device, label: &str) -> wgpu::Sampler {
     device.create_sampler(&wgpu::SamplerDescriptor {
         label: Some(&format!("{label} sampler")),
         address_mode_u: wgpu::AddressMode::ClampToEdge,
@@ -1374,7 +1374,10 @@ fn linear_sampler(device: &wgpu::Device, label: &str) -> wgpu::Sampler {
 
 /// Build a BGL with one texture + one sampler + one uniform buffer.
 #[cfg(feature = "wgpu")]
-fn one_tex_sampler_uniform_bgl(device: &wgpu::Device, label: &str) -> wgpu::BindGroupLayout {
+pub(crate) fn one_tex_sampler_uniform_bgl(
+    device: &wgpu::Device,
+    label: &str,
+) -> wgpu::BindGroupLayout {
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some(&format!("{label} BGL")),
         entries: &[
@@ -1410,7 +1413,10 @@ fn one_tex_sampler_uniform_bgl(device: &wgpu::Device, label: &str) -> wgpu::Bind
 
 /// Build a BGL with two textures + one sampler + one uniform buffer.
 #[cfg(feature = "wgpu")]
-fn two_tex_sampler_uniform_bgl(device: &wgpu::Device, label: &str) -> wgpu::BindGroupLayout {
+pub(crate) fn two_tex_sampler_uniform_bgl(
+    device: &wgpu::Device,
+    label: &str,
+) -> wgpu::BindGroupLayout {
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some(&format!("{label} BGL")),
         entries: &[
@@ -1455,7 +1461,7 @@ fn two_tex_sampler_uniform_bgl(device: &wgpu::Device, label: &str) -> wgpu::Bind
 }
 
 #[cfg(feature = "wgpu")]
-fn fullscreen_pipeline(
+pub(crate) fn fullscreen_pipeline(
     device: &wgpu::Device,
     shader: &wgpu::ShaderModule,
     label: &str,
@@ -1494,7 +1500,7 @@ fn fullscreen_pipeline(
 }
 
 #[cfg(feature = "wgpu")]
-fn upload_rgba_texture(
+pub(crate) fn upload_rgba_texture(
     ctx: &crate::context::RenderContext,
     data: &[u8],
     width: u32,
@@ -1538,7 +1544,7 @@ fn upload_rgba_texture(
 }
 
 #[cfg(feature = "wgpu")]
-fn submit_render_pass(
+pub(crate) fn submit_render_pass(
     ctx: &crate::context::RenderContext,
     pipeline: &wgpu::RenderPipeline,
     bind_group: &wgpu::BindGroup,


### PR DESCRIPTION
## Summary

Adds `Compositor`, a stateful high-level multi-layer GPU composition API for `ff-render`. It accepts a list of `FrameLayer`s, sorts them by `z_order`, uploads each `VideoFrame` to the GPU, applies per-layer affine transforms and blend modes via reusable wgpu pipelines, and returns the composited `wgpu::Texture`. The pipeline is cached and only rebuilt when the layer count changes.

## Changes

- `compositor/mod.rs` — new `LayerTransform` (UV-space affine params + `is_identity()`), `FrameLayer` (frame + transform + blend + opacity + z_order), and `Compositor` (stateful compositor with cached `CompositorGraph`)
- `compositor/compositor_inner.rs` — GPU internals: `CompositorGraph` (blend pipeline + `TransformNode` reuse), `frame_to_rgba()` (Rgba / Bgra / Rgb24 / Bgr24 / Yuv420p / Yuv422p / Yuv444p via BT.601), `blend_textures()` helper, canvas/output texture helpers
- `nodes/composite.rs` — made 6 GPU helpers `pub(crate)` (`linear_sampler`, `two_tex_sampler_uniform_bgl`, `fullscreen_pipeline`, `upload_rgba_texture`, `submit_render_pass`, `one_tex_sampler_uniform_bgl`) so `compositor_inner` can reuse them without duplication
- `lib.rs` — added `pub mod compositor` and re-exports for `Compositor`, `FrameLayer`, `LayerTransform` under `wgpu` feature
- 9 new tests: `LayerTransform` identity checks, `FrameLayer` construction, z_order sort, `Send` bound, and 4 `frame_to_rgba` format conversion tests

## Related Issues

Closes #1042

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes