### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.0] - 2026-04-20
+
+### Added
+
+#### ff-render — new crate
+- New `ff-render` crate: GPU compositing pipeline for real-time video preview, built on [wgpu] ([#1085](https://github.com/itsakeyfut/avio/issues/1085))
+- `RenderContext`: headless wgpu device/queue initialisation (no window required) ([#1085](https://github.com/itsakeyfut/avio/issues/1085))
+- `RenderGraph`: linear chain of render nodes; CPU fallback path always available without `wgpu` feature ([#1085](https://github.com/itsakeyfut/avio/issues/1085))
+- `GpuFrameSink`: implements `ff_preview::FrameSink` for zero-copy wiring with `PlayerRunner` ([#1085](https://github.com/itsakeyfut/avio/issues/1085))
+- `ColorGradeNode`: brightness, saturation, contrast, hue shift, colour temperature ([#1085](https://github.com/itsakeyfut/avio/issues/1085))
+- `ScaleNode`: GPU-accelerated resize (Bilinear / Nearest); CPU path is passthrough ([#1085](https://github.com/itsakeyfut/avio/issues/1085))
+- `OverlayNode`, `CrossfadeNode`: static overlay composite and crossfade transition ([#1085](https://github.com/itsakeyfut/avio/issues/1085))
+- `YuvUploadNode`: native YUV plane upload (4:2:0 / 4:2:2 / 4:4:4) bypassing `sws_scale` ([#1086](https://github.com/itsakeyfut/avio/issues/1086))
+- `BlendModeNode`: 12 Photoshop-style blend modes (Multiply, Screen, Overlay, Darken, Lighten, ColorDodge, ColorBurn, HardLight, SoftLight, Difference, Exclusion, Normal) with per-node opacity ([#1087](https://github.com/itsakeyfut/avio/issues/1087))
+- `TransformNode`: UV-space translate / rotate / scale ([#1087](https://github.com/itsakeyfut/avio/issues/1087))
+- `ChromaKeyNode`: chroma key (green screen) with tolerance and softness ([#1087](https://github.com/itsakeyfut/avio/issues/1087))
+- `ShapeMaskNode`, `LumaMaskNode`, `AlphaMatteNode`: shape mask, luma-derived mask, and alpha-composite over background ([#1087](https://github.com/itsakeyfut/avio/issues/1087))
+- `Compositor`: stateful high-level multi-layer GPU compositor — sorts layers by `z_order`, applies per-layer transforms and blend modes, returns composited `wgpu::Texture` ([#1042](https://github.com/itsakeyfut/avio/issues/1042))
+- `FrameLayer` and `LayerTransform`: layer definition with transform, blend mode, opacity, and z-order ([#1042](https://github.com/itsakeyfut/avio/issues/1042))
+
+#### ff-preview
+- Split `PreviewPlayer` into `PlayerRunner` (owns the decode thread) and `PlayerHandle` (cross-thread control) for safe cross-thread use ([#1021](https://github.com/itsakeyfut/avio/issues/1021))
+- `PlayerEvent`: new `PositionUpdate` and `Error` variants for real-time status monitoring ([#1022](https://github.com/itsakeyfut/avio/issues/1022))
+- `TimelinePlayer`: real-time timeline-driven playback with per-clip ordering ([#1023](https://github.com/itsakeyfut/avio/issues/1023))
+- `FrameCache`: instant seek scrubbing via pre-decoded frame cache ([#1024](https://github.com/itsakeyfut/avio/issues/1024))
+- `AudioMixer` and `AudioTrackHandle`: multi-track audio mixing with per-track volume and mute control ([#1025](https://github.com/itsakeyfut/avio/issues/1025))
+- `HardwareAccel` integration in `PlayerRunner` and `DecodeBufferBuilder` ([#1026](https://github.com/itsakeyfut/avio/issues/1026))
+
+#### ff-decode
+- `ScopeAnalyzer::waveform()`: luminance waveform monitor — Y values per column, normalised `[0.0, 1.0]` ([#408](https://github.com/itsakeyfut/avio/issues/408))
+- `ScopeAnalyzer::vectorscope()`: Cb/Cr chroma scatter data for 4:2:0, 4:2:2, and 4:4:4 frames ([#409](https://github.com/itsakeyfut/avio/issues/409))
+- `ScopeAnalyzer::rgb_parade()`: per-channel RGB waveform (parade) — column-major normalised values ([#410](https://github.com/itsakeyfut/avio/issues/410))
+- `ScopeAnalyzer::histogram()`: 256-bin luminance and per-channel RGB histogram ([#411](https://github.com/itsakeyfut/avio/issues/411))
+- `AsyncVideoDecoderBuilder` and `AsyncAudioDecoderBuilder`: async builder API with `output_format`, `output_size`, `output_sample_rate`, and `output_channels` options ([#1005](https://github.com/itsakeyfut/avio/issues/1005))
+
+#### ff-filter
+- `Stabilizer::analyze()`: two-pass video stabilization — pass 1 via `vidstabdetect` ([#392](https://github.com/itsakeyfut/avio/issues/392))
+- `Stabilizer::transform()`: two-pass video stabilization — pass 2 via `vidstabtransform` ([#393](https://github.com/itsakeyfut/avio/issues/393))
+- `StabilizeOptions`: zoom, optzoom, and interpol builder methods ([#394](https://github.com/itsakeyfut/avio/issues/394))
+- `FilterGraph::motion_blur()`: motion blur via `tblend` shutter-angle simulation ([#395](https://github.com/itsakeyfut/avio/issues/395))
+- `FilterGraph::film_grain()`: per-frame random grain via `noise` filter with temporal seed ([#396](https://github.com/itsakeyfut/avio/issues/396))
+- `FilterGraph::lens_correction()`: radial lens distortion correction via `lenscorrection` ([#397](https://github.com/itsakeyfut/avio/issues/397))
+- `LensProfile` enum and `FilterGraph::lens_profile()`: preset and custom lens correction profiles ([#398](https://github.com/itsakeyfut/avio/issues/398))
+- `FilterGraph::fix_chromatic_aberration()`: lateral chromatic aberration correction via `rgbashift` ([#399](https://github.com/itsakeyfut/avio/issues/399))
+- `FilterGraph::glow()`: bloom / glow around bright areas via `split+curves+gblur+blend` chain ([#400](https://github.com/itsakeyfut/avio/issues/400))
+- `FilterGraph::reverb_ir()`: convolution reverb via `amovie+afir` impulse response ([#401](https://github.com/itsakeyfut/avio/issues/401))
+- `FilterGraph::reverb_echo()`: echo / reverb via `aecho` with configurable delay taps and decay ([#402](https://github.com/itsakeyfut/avio/issues/402))
+- `FilterGraph::pitch_shift()`: pitch shift in semitones via `asetrate+atempo` ([#403](https://github.com/itsakeyfut/avio/issues/403))
+- `FilterGraph::time_stretch()`: time stretch without pitch change via `atempo` chain ([#404](https://github.com/itsakeyfut/avio/issues/404))
+- `FilterGraph::speed_change()`: playback speed change via `asetrate` ([#405](https://github.com/itsakeyfut/avio/issues/405))
+- `FilterGraph::noise_reduce()` and `noise_reduce_profile()`: broadband noise reduction via `afftdn` ([#406](https://github.com/itsakeyfut/avio/issues/406))
+- `FilterGraph::duck()`: audio ducking via `sidechaincompress` ([#407](https://github.com/itsakeyfut/avio/issues/407))
+
+---
+
 ## [0.13.1] - 2026-04-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,18 +12,18 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.13.1" }
-ff-common   = { path = "crates/ff-common",   version = "0.13.1" }
-ff-format   = { path = "crates/ff-format",   version = "0.13.1" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.13.1" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.13.1" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.13.1" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.13.1" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.13.1" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.13.1" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.13.1" }
-ff-render   = { path = "crates/ff-render",   version = "0.13.1" }
-avio        = { path = "crates/avio",         version = "0.13.1" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.14.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.14.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.14.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.14.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.14.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.14.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.14.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.14.0" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.14.0" }
+ff-render   = { path = "crates/ff-render",   version = "0.14.0" }
+avio        = { path = "crates/avio",         version = "0.14.0" }
 
 # Error handling
 thiserror = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ff-probe  = "0.13"
-ff-decode = "0.13"
-ff-encode = "0.13"
+ff-probe  = "0.14"
+ff-decode = "0.14"
+ff-encode = "0.14"
 
 # Or use the facade crate for everything
-avio = "0.13"
+avio = "0.14"
 ```
 
 ### Prerequisites

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -14,16 +14,16 @@ to only the capabilities you need via feature flags.
 ```toml
 [dependencies]
 # Default: probe + decode + encode
-avio = "0.13"
+avio = "0.14"
 
 # Add filtering
-avio = { version = "0.13", features = ["filter"] }
+avio = { version = "0.14", features = ["filter"] }
 
 # Full stack (implies filter + pipeline)
-avio = { version = "0.13", features = ["stream"] }
+avio = { version = "0.14", features = ["stream"] }
 
 # Async decode/encode (requires tokio runtime)
-avio = { version = "0.13", features = ["tokio"] }
+avio = { version = "0.14", features = ["tokio"] }
 ```
 
 ## Feature Flags

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -22,13 +22,13 @@
 //! ```toml
 //! # Default: probe + decode + encode
 //! [dependencies]
-//! avio = "0.13"
+//! avio = "0.14"
 //!
 //! # Add filtering
-//! avio = { version = "0.13", features = ["filter"] }
+//! avio = { version = "0.14", features = ["filter"] }
 //!
 //! # Full stack (implies filter + pipeline)
-//! avio = { version = "0.13", features = ["stream"] }
+//! avio = { version = "0.14", features = ["stream"] }
 //! ```
 //!
 //! # Quick Start
@@ -596,7 +596,7 @@ mod tests {
     #[cfg(feature = "preview")]
     #[test]
     fn preview_rgba_types_should_be_accessible() {
-        // RgbaSink and RgbaFrame are the concrete sink/frame types added in v0.13.0.
+        // RgbaSink and RgbaFrame are the concrete sink/frame types added in v0.14.0.
         let _: Option<RgbaSink> = None;
         let _: Option<RgbaFrame> = None;
     }

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -8,8 +8,8 @@ Decode video and audio frames without managing codec contexts, packet queues, or
 
 ```toml
 [dependencies]
-ff-decode = "0.13"
-ff-format = "0.13"
+ff-decode = "0.14"
+ff-format = "0.14"
 ```
 
 ## Video Decoding
@@ -191,7 +191,7 @@ let mut decoder = VideoDecoder::open("video.mp4")
 
 ```toml
 [dependencies]
-ff-decode = { version = "0.13", features = ["tokio"] }
+ff-decode = { version = "0.14", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoDecoder` and `AudioDecoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -8,12 +8,12 @@ Encode video and audio to any format with a builder chain. The encoder validates
 
 ```toml
 [dependencies]
-ff-encode = "0.13"
-ff-format = "0.13"
+ff-encode = "0.14"
+ff-format = "0.14"
 
 # Enable GPL-licensed encoders (libx264, libx265).
 # Requires GPL compliance or MPEG LA licensing in your project.
-# ff-encode = { version = "0.13", features = ["gpl"] }
+# ff-encode = { version = "0.14", features = ["gpl"] }
 ```
 
 By default, only LGPL-compatible encoders are enabled.
@@ -326,7 +326,7 @@ Enable the `gpl` feature to add libx264 and libx265. This changes the license te
 
 ```toml
 [dependencies]
-ff-encode = { version = "0.13", features = ["tokio"] }
+ff-encode = { version = "0.14", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoEncoder`, `AudioEncoder`, and `ImageEncoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -8,7 +8,7 @@ Wire decode, filter, and encode into a single configured pipeline. Instead of ma
 
 ```toml
 [dependencies]
-ff-pipeline = "0.13"
+ff-pipeline = "0.14"
 ```
 
 ## Building a Pipeline

--- a/crates/ff-preview/README.md
+++ b/crates/ff-preview/README.md
@@ -8,13 +8,13 @@ Real-time video preview and proxy workflow for Rust. Provides frame-accurate see
 
 ```toml
 [dependencies]
-ff-preview = "0.13"
+ff-preview = "0.14"
 
 # Enable async support
-ff-preview = { version = "0.13", features = ["tokio"] }
+ff-preview = { version = "0.14", features = ["tokio"] }
 
 # Enable proxy generation
-ff-preview = { version = "0.13", features = ["proxy"] }
+ff-preview = { version = "0.14", features = ["proxy"] }
 ```
 
 ## Quick Start

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -8,7 +8,7 @@ Read media file metadata with one function call. No knowledge of container forma
 
 ```toml
 [dependencies]
-ff-probe = "0.13"
+ff-probe = "0.14"
 ```
 
 ## Quick Start

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -9,7 +9,7 @@ point it at an input file, and receive a standards-compliant package ready for C
 
 ```toml
 [dependencies]
-ff-stream = "0.13"
+ff-stream = "0.14"
 ```
 
 ## HLS Output


### PR DESCRIPTION
## Summary

Bumps the workspace version from `0.13.1` to `0.14.0` and documents all changes in `CHANGELOG.md`. This is the v0.14.0 milestone release: Advanced Effects & Audio Processing + ff-render GPU pipeline.

## Changes

- `Cargo.toml`: workspace version `0.13.1` → `0.14.0`; all intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.14.0]` entry covering all 35+ merged PRs since v0.13.1
- `README.md` and all crate READMEs: version references updated to `0.14`

## Related Issues

Closes #392
Closes #393
Closes #394
Closes #395
Closes #396
Closes #397
Closes #398
Closes #399
Closes #400
Closes #401
Closes #402
Closes #403
Closes #404
Closes #405
Closes #406
Closes #407
Closes #408
Closes #409
Closes #410
Closes #411
Closes #1005
Closes #1021
Closes #1022
Closes #1023
Closes #1024
Closes #1025
Closes #1026
Closes #1027
Closes #1040
Closes #1041
Closes #1042

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes