### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.1] - 2026-04-21
+
+### Fixed
+
+- `MasterClock::Audio::should_sync()` returned `false` indefinitely when no audio consumer was connected, causing video to play at decoder speed instead of real time ([#1105](https://github.com/itsakeyfut/avio/issues/1105))
+- `avio` facade was missing re-exports for `PlayerCommand`, `HardwareAccel` (preview-only), `TimelinePlayer`, and `TimelineRunner` under the `preview` feature ([#1106](https://github.com/itsakeyfut/avio/issues/1106))
+
+---
+
 ## [0.14.0] - 2026-04-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,18 +12,18 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.14.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.14.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.14.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.14.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.14.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.14.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.14.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.14.0" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.14.0" }
-ff-render   = { path = "crates/ff-render",   version = "0.14.0" }
-avio        = { path = "crates/avio",         version = "0.14.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.14.1" }
+ff-common   = { path = "crates/ff-common",   version = "0.14.1" }
+ff-format   = { path = "crates/ff-format",   version = "0.14.1" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.14.1" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.14.1" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.14.1" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.14.1" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.1" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.14.1" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.14.1" }
+ff-render   = { path = "crates/ff-render",   version = "0.14.1" }
+avio        = { path = "crates/avio",         version = "0.14.1" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.14.0 to 0.14.1. This patch release contains two bug fixes discovered while building a video editor demo with the preview API.

## Changes

- `Cargo.toml`: workspace version 0.14.0 → 0.14.1; all intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.14.1]` entry with fixed items

## Related Issues

Fixes #1105
Fixes #1106

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes