### PR TITLE
chore: release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.2] - 2026-04-22
+
+### Fixed
+
+- `MasterClock::Audio` used the file's native sample rate (e.g. 44,100 Hz) instead of the decoder's fixed output rate (48,000 Hz), causing audio to play at ~1.088× speed ([#1110](https://github.com/itsakeyfut/avio/issues/1110))
+- `MasterClock::Audio` froze when the audio track ended before the video track, stalling `PlayerRunner::run()` indefinitely; fixed via wall-clock fallback re-arm on stall detection ([#1112](https://github.com/itsakeyfut/avio/issues/1112))
+- `spawn_audio_thread` silently dropped samples when the ring buffer was full on Windows (where `sleep(1 ms)` ≈ 10 ms), causing audio to play at ~2.3× speed; fixed by retrying until all samples are pushed ([#1114](https://github.com/itsakeyfut/avio/issues/1114))
+
+---
+
 ## [0.14.1] - 2026-04-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,18 +12,18 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.14.1" }
-ff-common   = { path = "crates/ff-common",   version = "0.14.1" }
-ff-format   = { path = "crates/ff-format",   version = "0.14.1" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.14.1" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.14.1" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.14.1" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.14.1" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.1" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.14.1" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.14.1" }
-ff-render   = { path = "crates/ff-render",   version = "0.14.1" }
-avio        = { path = "crates/avio",         version = "0.14.1" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.14.2" }
+ff-common   = { path = "crates/ff-common",   version = "0.14.2" }
+ff-format   = { path = "crates/ff-format",   version = "0.14.2" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.14.2" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.14.2" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.14.2" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.14.2" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.2" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.14.2" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.14.2" }
+ff-render   = { path = "crates/ff-render",   version = "0.14.2" }
+avio        = { path = "crates/avio",         version = "0.14.2" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.14.1 to 0.14.2 and documents all changes in CHANGELOG.md.

## Changes

- `Cargo.toml`: workspace version 0.14.1 → 0.14.2; all intra-workspace dependency pins updated
- `CHANGELOG.md`: add `[0.14.2]` entry covering three audio playback bug fixes

## Related Issues

Fixes #1110
Fixes #1112
Fixes #1114

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes