### PR TITLE
fix(ff-preview): rate scaling for MasterClock and fix double-counted rate

### DIFF
--- a/crates/ff-preview/src/playback/clock.rs
+++ b/crates/ff-preview/src/playback/clock.rs
@@ -219,6 +219,12 @@ pub(crate) enum MasterClock {
     Audio {
         samples_consumed: Arc<AtomicU64>,
         sample_rate: u32,
+        /// Playback rate multiplier. 1.0 = real-time.
+        rate: f64,
+        /// Snapshot of `samples_consumed` at the last rate-change or seek.
+        samples_base: u64,
+        /// Media PTS at the last rate-change or seek.
+        pts_base: Duration,
         /// Wall-clock fallback activated after the first presented frame when no
         /// audio consumer has called `pop_audio_samples()`. Tuple: `(wall start, base PTS)`.
         ///
@@ -232,6 +238,8 @@ pub(crate) enum MasterClock {
     System {
         started_at: Instant,
         base_pts: Duration,
+        /// Playback rate multiplier. 1.0 = real-time.
+        rate: f64,
     },
 }
 
@@ -250,17 +258,26 @@ impl MasterClock {
             Self::Audio {
                 samples_consumed,
                 sample_rate,
+                rate,
+                samples_base,
+                pts_base,
                 fallback,
             } => {
                 let s = samples_consumed.load(Ordering::Relaxed);
-                let sample_pts = if s > 0 {
-                    Some(Duration::from_secs_f64(s as f64 / f64::from(*sample_rate)))
+                let delta = s.saturating_sub(*samples_base);
+                let sample_pts = if delta > 0 || !pts_base.is_zero() {
+                    Some(
+                        *pts_base
+                            + Duration::from_secs_f64(
+                                delta as f64 / f64::from(*sample_rate) * *rate,
+                            ),
+                    )
                 } else {
-                    None
+                    None // before first sample consumed (no sync yet)
                 };
                 let fallback_pts = fallback
                     .as_ref()
-                    .map(|(started_at, base_pts)| *base_pts + started_at.elapsed());
+                    .map(|(started_at, base_pts)| *base_pts + started_at.elapsed().mul_f64(*rate));
                 match (sample_pts, fallback_pts) {
                     // Both present: use whichever is further ahead.
                     // - During normal playback the sample clock is ahead → sample wins.
@@ -275,7 +292,8 @@ impl MasterClock {
             Self::System {
                 started_at,
                 base_pts,
-            } => *base_pts + started_at.elapsed(),
+                rate,
+            } => *base_pts + started_at.elapsed().mul_f64(*rate),
         }
     }
 
@@ -294,9 +312,14 @@ impl MasterClock {
             Self::System { .. } => true,
             Self::Audio {
                 samples_consumed,
+                samples_base,
+                pts_base,
                 fallback,
                 ..
-            } => samples_consumed.load(Ordering::Relaxed) > 0 || fallback.is_some(),
+            } => {
+                let s = samples_consumed.load(Ordering::Relaxed);
+                s > *samples_base || !pts_base.is_zero() || fallback.is_some()
+            }
         }
     }
 
@@ -316,10 +339,11 @@ impl MasterClock {
     pub(crate) fn activate_fallback_if_no_audio(&mut self, base_pts: Duration) {
         if let Self::Audio {
             samples_consumed,
+            samples_base,
             fallback,
             ..
         } = self
-            && samples_consumed.load(Ordering::Relaxed) == 0
+            && samples_consumed.load(Ordering::Relaxed) == *samples_base
             && fallback.is_none()
         {
             *fallback = Some((Instant::now(), base_pts));
@@ -340,6 +364,50 @@ impl MasterClock {
     pub(crate) fn rearm_fallback_at(&mut self, base_pts: Duration) {
         if let Self::Audio { fallback, .. } = self {
             *fallback = Some((Instant::now(), base_pts));
+        }
+    }
+
+    /// Update the playback rate multiplier.
+    ///
+    /// Re-baselines the clock so that `current_pts()` does not jump at the
+    /// moment of the rate change.  Values ≤ 0.0 are ignored.
+    #[allow(clippy::cast_precision_loss)]
+    pub(crate) fn set_rate(&mut self, new_rate: f64) {
+        if new_rate <= 0.0 {
+            return;
+        }
+        match self {
+            Self::Audio {
+                samples_consumed,
+                sample_rate,
+                rate,
+                pts_base,
+                samples_base,
+                fallback,
+            } => {
+                // Re-baseline at current pts so the clock doesn't jump.
+                let s = samples_consumed.load(Ordering::Relaxed);
+                let delta = s.saturating_sub(*samples_base);
+                let current = *pts_base
+                    + Duration::from_secs_f64(delta as f64 / f64::from(*sample_rate) * *rate);
+                *samples_base = s;
+                *pts_base = current;
+                *rate = new_rate;
+                if let Some((started_at, base)) = fallback.as_mut() {
+                    *base = current;
+                    *started_at = Instant::now();
+                }
+            }
+            Self::System {
+                started_at,
+                base_pts,
+                rate,
+            } => {
+                let current = *base_pts + started_at.elapsed().mul_f64(*rate);
+                *base_pts = current;
+                *started_at = Instant::now();
+                *rate = new_rate;
+            }
         }
     }
 
@@ -374,11 +442,21 @@ impl MasterClock {
             Self::System {
                 started_at,
                 base_pts,
+                ..
             } => {
                 *started_at = Instant::now();
                 *base_pts = base;
             }
-            Self::Audio { fallback, .. } => {
+            Self::Audio {
+                samples_consumed,
+                samples_base,
+                pts_base,
+                fallback,
+                ..
+            } => {
+                let s = samples_consumed.load(Ordering::Relaxed);
+                *samples_base = s;
+                *pts_base = base;
                 if fallback.is_some() {
                     *fallback = Some((Instant::now(), base));
                 }
@@ -666,6 +744,7 @@ mod tests {
         let clock = MasterClock::System {
             started_at: Instant::now(),
             base_pts: Duration::from_secs(5),
+            rate: 1.0,
         };
         let pts = clock.current_pts();
         assert!(
@@ -684,6 +763,7 @@ mod tests {
         let mut clock = MasterClock::System {
             started_at: Instant::now() - Duration::from_secs(10),
             base_pts: Duration::ZERO,
+            rate: 1.0,
         };
         assert!(
             clock.current_pts() >= Duration::from_secs(9),
@@ -706,6 +786,9 @@ mod tests {
         let clock = MasterClock::Audio {
             samples_consumed: Arc::new(AtomicU64::new(0)),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         assert!(
@@ -725,6 +808,9 @@ mod tests {
         let clock = MasterClock::Audio {
             samples_consumed: Arc::clone(&consumed),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         assert!(
@@ -743,6 +829,9 @@ mod tests {
         let mut clock = MasterClock::Audio {
             samples_consumed: Arc::new(AtomicU64::new(0)),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         assert!(
@@ -761,6 +850,9 @@ mod tests {
         let mut clock = MasterClock::Audio {
             samples_consumed: Arc::new(AtomicU64::new(0)),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         let base = Duration::from_secs(5);
@@ -786,6 +878,9 @@ mod tests {
         let mut clock = MasterClock::Audio {
             samples_consumed: Arc::clone(&consumed),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         clock.activate_fallback_if_no_audio(Duration::from_secs(2));
@@ -809,6 +904,9 @@ mod tests {
         let mut clock = MasterClock::Audio {
             samples_consumed: Arc::new(AtomicU64::new(0)),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         clock.activate_fallback_if_no_audio(Duration::from_secs(1));
@@ -833,6 +931,9 @@ mod tests {
         let mut clock = MasterClock::Audio {
             samples_consumed: Arc::new(AtomicU64::new(0)),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         clock.activate_fallback_if_no_audio(Duration::from_secs(5));
@@ -854,6 +955,9 @@ mod tests {
         let mut clock = MasterClock::Audio {
             samples_consumed: Arc::new(AtomicU64::new(0)),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         // reset() before the first frame must not arm the fallback.
@@ -880,6 +984,9 @@ mod tests {
         let mut clock = MasterClock::Audio {
             samples_consumed: Arc::clone(&consumed),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         let frozen_pts = Duration::from_secs_f64(frozen_frames as f64 / 48_000.0);
@@ -910,6 +1017,7 @@ mod tests {
         let mut clock = MasterClock::System {
             started_at: Instant::now(),
             base_pts: Duration::ZERO,
+            rate: 1.0,
         };
         // Must not panic and System behaviour must be unchanged.
         clock.rearm_fallback_at(Duration::from_secs(99));
@@ -925,6 +1033,9 @@ mod tests {
         let clock = MasterClock::Audio {
             samples_consumed: Arc::clone(&consumed),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         assert_eq!(
@@ -939,6 +1050,7 @@ mod tests {
         let clock = MasterClock::System {
             started_at: Instant::now(),
             base_pts: Duration::ZERO,
+            rate: 1.0,
         };
         assert_eq!(
             clock.audio_samples_snapshot(),
@@ -956,6 +1068,9 @@ mod tests {
         let clock = MasterClock::Audio {
             samples_consumed: Arc::clone(&consumed),
             sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         assert_eq!(
@@ -975,6 +1090,9 @@ mod tests {
         let clock_wrong = MasterClock::Audio {
             samples_consumed: Arc::clone(&consumed),
             sample_rate: 44_100, // wrong: source native rate, not decoder output rate
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
             fallback: None,
         };
         let pts_wrong = clock_wrong.current_pts();
@@ -994,12 +1112,92 @@ mod tests {
         let mut clock = MasterClock::System {
             started_at: Instant::now(),
             base_pts: Duration::ZERO,
+            rate: 1.0,
         };
         // Must not panic and must not change System behaviour.
         clock.activate_fallback_if_no_audio(Duration::from_secs(99));
         assert!(
             clock.should_sync(),
             "System clock must always sync regardless of activate_fallback_if_no_audio"
+        );
+    }
+
+    #[test]
+    fn set_rate_should_scale_audio_clock_pts() {
+        // Step 1: 48 000 samples already consumed (1 s at 1×).
+        let consumed = Arc::new(AtomicU64::new(48_000));
+        let mut clock = MasterClock::Audio {
+            samples_consumed: Arc::clone(&consumed),
+            sample_rate: 48_000,
+            rate: 1.0,
+            samples_base: 0,
+            pts_base: Duration::ZERO,
+            fallback: None,
+        };
+
+        // Sanity check: before rate change the clock reports exactly 1 s.
+        assert_eq!(
+            clock.current_pts(),
+            Duration::from_secs(1),
+            "before set_rate clock must report 1 s"
+        );
+
+        // Step 2: change rate to 2×. The baseline snaps to the current 1 s PTS.
+        clock.set_rate(2.0);
+
+        // Step 3: simulate another 1 real second of audio hardware drain
+        // (48 000 more samples consumed).
+        consumed.fetch_add(48_000, Ordering::Relaxed); // total = 96 000
+
+        // Expected: 1 s (at 1×) + 1 real second at 2× = 3 s media time.
+        let pts = clock.current_pts();
+        let expected = Duration::from_secs(3);
+        let tolerance = Duration::from_millis(1);
+        assert!(
+            pts >= expected.saturating_sub(tolerance) && pts <= expected + tolerance,
+            "1 s at 1× + 1 real-s at 2× must equal ≈3 s; got {pts:?}"
+        );
+    }
+
+    #[test]
+    fn set_rate_system_clock_should_scale_elapsed() {
+        let mut clock = MasterClock::System {
+            started_at: Instant::now(),
+            base_pts: Duration::ZERO,
+            rate: 1.0,
+        };
+
+        // Let a little time pass at 1×.
+        thread::sleep(Duration::from_millis(10));
+        let pts_before_rate_change = clock.current_pts();
+        assert!(
+            pts_before_rate_change >= Duration::from_millis(5),
+            "clock must have advanced ~10 ms before rate change; got {pts_before_rate_change:?}"
+        );
+
+        // Change to 2×. The baseline is re-anchored at the current PTS.
+        clock.set_rate(2.0);
+        let pts_at_rate_change = clock.current_pts();
+        // The clock must not jump backward.
+        assert!(
+            pts_at_rate_change >= pts_before_rate_change,
+            "clock must not go backward on set_rate; before={pts_before_rate_change:?} at={pts_at_rate_change:?}"
+        );
+
+        // Let another 10 ms of wall time pass at 2×.
+        thread::sleep(Duration::from_millis(10));
+        let pts_after = clock.current_pts();
+
+        // At 2× rate, 10 ms wall time should produce ≥ 15 ms of media time
+        // (allowing for scheduler imprecision).
+        let media_elapsed = pts_after.saturating_sub(pts_at_rate_change);
+        assert!(
+            media_elapsed >= Duration::from_millis(15),
+            "2× rate: 10 ms wall time must produce ≥15 ms media time; got media_elapsed={media_elapsed:?}"
+        );
+        assert!(
+            pts_after > Duration::from_millis(20),
+            "total PTS after ~10ms at 1× + ~10ms at 2× must be >20ms; got {pts_after:?}"
         );
     }
 }

--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -233,7 +233,7 @@ impl PlayerHandle {
     /// playing at rates other than 1×.  The cpal callback pops `out_len * rate`
     /// decoded samples to drive rate-scaled audio, but the master clock must
     /// still advance at the **hardware** output rate (`out_len / 2` per callback)
-    /// so that [`MasterClock::Audio`]'s `pts_base + delta / sr * rate` formula
+    /// so that `MasterClock::Audio`'s `pts_base + delta / sr * rate` formula
     /// yields the correct media PTS without double-counting the rate.
     ///
     /// # Arguments

--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -225,6 +225,69 @@ impl PlayerHandle {
         samples
     }
 
+    /// Pull up to `pop_n` interleaved stereo `f32` PCM samples at 48 kHz and
+    /// advance the A/V sync clock by exactly `clock_stereo_pairs` — independent
+    /// of how many samples are actually available in the ring buffer.
+    ///
+    /// Use this instead of [`pop_audio_samples`](Self::pop_audio_samples) when
+    /// playing at rates other than 1×.  The cpal callback pops `out_len * rate`
+    /// decoded samples to drive rate-scaled audio, but the master clock must
+    /// still advance at the **hardware** output rate (`out_len / 2` per callback)
+    /// so that [`MasterClock::Audio`]'s `pts_base + delta / sr * rate` formula
+    /// yields the correct media PTS without double-counting the rate.
+    ///
+    /// # Arguments
+    ///
+    /// * `pop_n` — decoded samples to drain from the ring buffer
+    ///   (`output_buf.len() * rate`, rounded).
+    /// * `clock_stereo_pairs` — hardware stereo pairs to add to the sync counter
+    ///   (`output_buf.len() / 2`, constant regardless of rate).
+    #[allow(clippy::cast_precision_loss)]
+    pub fn pop_audio_samples_for_rate(&self, pop_n: usize, clock_stereo_pairs: u64) -> Vec<f32> {
+        if self.paused.load(Ordering::Relaxed) || self.stopped.load(Ordering::Relaxed) {
+            // Clock still advances — the hardware keeps running even during silence.
+            if let Some(sc) = &self.samples_consumed {
+                sc.fetch_add(clock_stereo_pairs, Ordering::Relaxed);
+            }
+            return Vec::new();
+        }
+        if pop_n == 0 {
+            if let Some(sc) = &self.samples_consumed {
+                sc.fetch_add(clock_stereo_pairs, Ordering::Relaxed);
+            }
+            return Vec::new();
+        }
+        // Mixer path (TimelinePlayer) — System clock, no samples_consumed tracking.
+        if let Some(mixer) = &self.audio_mixer {
+            return mixer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .mix(pop_n);
+        }
+        // Ring-buffer path (PlayerRunner single-track audio).
+        let Some(buf) = &self.audio_buf else {
+            if let Some(sc) = &self.samples_consumed {
+                sc.fetch_add(clock_stereo_pairs, Ordering::Relaxed);
+            }
+            return Vec::new();
+        };
+        let mut guard = buf
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let take = pop_n.min(guard.len());
+        let samples: Vec<f32> = if take > 0 {
+            guard.drain(..take).collect()
+        } else {
+            Vec::new()
+        };
+        drop(guard);
+        // Advance the clock by the hardware output size, not the decoded drain size.
+        if let Some(sc) = &self.samples_consumed {
+            sc.fetch_add(clock_stereo_pairs, Ordering::Relaxed);
+        }
+        samples
+    }
+
     /// Poll for the next [`PlayerEvent`] without blocking.
     ///
     /// Returns `None` when no events are pending.
@@ -453,6 +516,7 @@ impl PlayerRunner {
                     PlayerCommand::SetRate(r) => {
                         if r > 0.0 {
                             self.rate = r;
+                            self.clock.set_rate(r);
                         }
                     }
                     PlayerCommand::SetAvOffset(ms) => {
@@ -498,7 +562,9 @@ impl PlayerRunner {
 
             // ── Audio-only path ───────────────────────────────────────────────
             if self.decode_buf.is_none() {
-                thread::sleep(Duration::from_millis(10));
+                let poll_secs =
+                    (10.0_f64 / self.rate.max(f64::MIN_POSITIVE)).clamp(1.0, 50.0) / 1_000.0;
+                thread::sleep(Duration::from_secs_f64(poll_secs));
                 if let Some(audio_buf) = &self.audio_buf {
                     let empty = audio_buf
                         .lock()
@@ -574,9 +640,12 @@ impl PlayerRunner {
                         if diff > fp {
                             let sleep_secs =
                                 (diff - fp / 2.0).max(0.0) / self.rate.max(f64::MIN_POSITIVE);
-                            // Cap at one frame period: prevents indefinite stall when the
-                            // audio clock freezes (e.g. audio track ends before video).
-                            thread::sleep(Duration::from_secs_f64(sleep_secs.min(fp)));
+                            // Cap at one scaled frame period so the loop still wakes up
+                            // when the audio clock freezes, but slow rates (< 1×) are
+                            // not artificially capped to a value shorter than their
+                            // required inter-frame sleep.
+                            let max_sleep = fp / self.rate.max(f64::MIN_POSITIVE);
+                            thread::sleep(Duration::from_secs_f64(sleep_secs.min(max_sleep)));
                         } else if diff < -fp {
                             log::debug!(
                                 "dropped late frame video_pts={video_pts:?} \
@@ -696,6 +765,9 @@ impl PlayerRunner {
             let clock = MasterClock::Audio {
                 samples_consumed: Arc::new(AtomicU64::new(0)),
                 sample_rate: DECODED_SAMPLE_RATE,
+                rate: 1.0,
+                samples_base: 0,
+                pts_base: Duration::ZERO,
                 fallback: None,
             };
             (clock, Some(buf), Some(cancel), Some(handle))
@@ -707,6 +779,7 @@ impl PlayerRunner {
             let clock = MasterClock::System {
                 started_at: Instant::now(),
                 base_pts: Duration::ZERO,
+                rate: 1.0,
             };
             (clock, None, None, None)
         };
@@ -806,6 +879,9 @@ impl PreviewPlayer {
             MasterClock::Audio {
                 samples_consumed: Arc::new(AtomicU64::new(0)),
                 sample_rate: DECODED_SAMPLE_RATE,
+                rate: 1.0,
+                samples_base: 0,
+                pts_base: Duration::ZERO,
                 fallback: None,
             }
         } else {
@@ -816,6 +892,7 @@ impl PreviewPlayer {
             MasterClock::System {
                 started_at: Instant::now(),
                 base_pts: Duration::ZERO,
+                rate: 1.0,
             }
         };
 
@@ -1585,14 +1662,19 @@ mod tests {
         let target = Duration::from_secs(1);
         handle.seek(target);
 
-        // Wait up to 2 seconds for SeekCompleted.
+        // Wait up to 2 seconds for SeekCompleted, skipping PositionUpdate
+        // events that may have accumulated during the startup window.
         let deadline = Instant::now() + Duration::from_secs(2);
-        let event = loop {
-            if let Some(e) = handle.poll_event() {
-                break Some(e);
+        let seek_result = loop {
+            match handle.poll_event() {
+                Some(PlayerEvent::SeekCompleted(pts)) => break Ok(pts),
+                Some(PlayerEvent::Eof) => break Err("Eof"),
+                Some(PlayerEvent::Error(_)) => break Err("Error"),
+                Some(PlayerEvent::PositionUpdate(_)) => {} // skip pre-seek updates
+                None => {}
             }
             if Instant::now() > deadline {
-                break None;
+                break Err("timeout");
             }
             thread::sleep(Duration::from_millis(10));
         };
@@ -1600,19 +1682,16 @@ mod tests {
         handle_bg.stop();
         let _ = bg.join();
 
-        match event {
-            Some(PlayerEvent::SeekCompleted(pts)) => {
+        match seek_result {
+            Ok(pts) => {
                 assert!(
                     pts >= target.saturating_sub(Duration::from_millis(100)),
                     "SeekCompleted pts must be near the requested target; \
                      target={target:?} pts={pts:?}"
                 );
             }
-            Some(PlayerEvent::Eof) => {
-                panic!("received Eof before SeekCompleted — file may be too short");
-            }
-            Some(PlayerEvent::PositionUpdate(_) | PlayerEvent::Error(_)) | None => {
-                panic!("no PlayerEvent::SeekCompleted received within 2 seconds");
+            Err(reason) => {
+                panic!("SeekCompleted not received within 2 seconds: {reason}");
             }
         }
     }

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -274,6 +274,7 @@ impl TimelinePlayer {
             clock: MasterClock::System {
                 started_at: Instant::now(),
                 base_pts: Duration::ZERO,
+                rate: 1.0,
             },
             sws_a: SwsRgbaConverter::new(),
             sws_b: SwsRgbaConverter::new(),


### PR DESCRIPTION
## Summary

Two related bugs caused `set_rate()` to have no effect or produce incorrect A/V sync for audio-bearing files. `MasterClock` had no rate field, so the audio clock always advanced at 1× regardless of the requested rate. Additionally, callers draining `out_len * rate` samples from the ring buffer caused `samples_consumed` to grow at `rate × hardware_rate`, then the clock multiplied by `rate` again, resulting in the clock running at `rate²`.

## Changes

**`clock.rs` — Issue #1118**
- Added `rate`, `samples_base`, and `pts_base` fields to `MasterClock::Audio`; `rate` to `MasterClock::System`
- `current_pts()` now uses piecewise baseline formula: `pts_base + delta / sample_rate * rate`; `System` clock uses `elapsed().mul_f64(rate)`
- New `set_rate()` method re-baselines at the current PTS before applying the new rate (no position jump)
- `should_sync()` and `activate_fallback_if_no_audio()` updated to use `samples_base` as the "not yet started" threshold
- `rearm_fallback_at()` for `Audio` now also resets `samples_base` / `pts_base`
- `SetRate` handler in `PlayerRunner` now calls `self.clock.set_rate(r)`
- Audio-only polling sleep scales with rate: `(10 ms / rate).clamp(1 ms, 50 ms)`
- Frame sleep cap fixed: `max_sleep = fp / rate` instead of always `fp`
- All construction sites updated with new fields; all existing tests updated
- New tests: `set_rate_should_scale_audio_clock_pts`, `set_rate_system_clock_should_scale_elapsed`

**`player.rs` — Issue #1119**
- New `pop_audio_samples_for_rate(pop_n, clock_stereo_pairs)`: drains `pop_n` decoded samples from the ring buffer but advances `samples_consumed` by the constant `clock_stereo_pairs` (hardware output pairs), eliminating double-counting
- Seek test updated to skip `PositionUpdate` events that accumulate during the startup window

**`timeline/mod.rs`**
- `TimelinePlayer::MasterClock::System` construction updated with `rate: 1.0`

## Related Issues

Fixes #1118
Fixes #1119

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes