### PR TITLE
fix(ff-preview): invert overlay z-order — V1 foreground, V2/V3 background

### DIFF
--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -734,7 +734,8 @@ impl TimelineRunner {
 
                     let a_ok = self.sws_a.convert(&frame, &mut self.rgba_a);
 
-                    // ── Composite overlay layers (V2, V3, …) over rgba_a ──────
+                    // ── Composite overlay layers: V1 is foreground, V2/V3… are background ──
+                    // Phase 1: drain each overlay layer to update its decoded rgba buffer.
                     if a_ok {
                         for layer in &mut self.overlay_layers {
                             let maybe_cidx = layer.clips.iter().position(|c| {
@@ -747,7 +748,6 @@ impl TimelineRunner {
                                 let _ = layer.clips[cidx].decode_buf.seek(local);
                                 layer.active = cidx;
                             }
-                            // Drain overlay frames until we catch up to timeline_pts.
                             while let FrameResult::Frame(f) =
                                 layer.clips[cidx].decode_buf.pop_frame()
                             {
@@ -756,16 +756,41 @@ impl TimelineRunner {
                                 let tl_start = layer.clips[cidx].timeline_start;
                                 let v2_pts = tl_start + f_pts.saturating_sub(clip_in);
                                 if v2_pts + Duration::from_millis(50) >= timeline_pts {
-                                    if layer.sws.convert(&f, &mut layer.rgba) {
-                                        timeline_inner::composite_over(
-                                            &mut self.rgba_a,
-                                            &layer.rgba,
-                                        );
-                                    }
+                                    layer.sws.convert(&f, &mut layer.rgba);
                                     break;
                                 }
-                                // Frame is older than current position — drain.
                             }
+                        }
+                    }
+                    // Phase 2: build composite — deepest background layer first, V1 on top.
+                    if a_ok {
+                        let base_idx = self
+                            .overlay_layers
+                            .iter()
+                            .enumerate()
+                            .rev()
+                            .find(|(_, l)| !l.rgba.is_empty())
+                            .map(|(i, _)| i);
+                        if let Some(base) = base_idx {
+                            // Seed the background buffer with the deepest layer.
+                            self.blend_buf
+                                .resize(self.overlay_layers[base].rgba.len(), 0);
+                            self.blend_buf
+                                .copy_from_slice(&self.overlay_layers[base].rgba);
+                            // Composite shallower background layers on top (from base-1 to V2).
+                            for i in (0..base).rev() {
+                                if !self.overlay_layers[i].rgba.is_empty() {
+                                    let layer_rgba = self.overlay_layers[i].rgba.clone();
+                                    timeline_inner::composite_over(
+                                        &mut self.blend_buf,
+                                        &layer_rgba,
+                                    );
+                                }
+                            }
+                            // Composite V1 on top of the background.
+                            timeline_inner::composite_over(&mut self.blend_buf, &self.rgba_a);
+                            // blend_buf now holds the final composite; make it the active frame.
+                            std::mem::swap(&mut self.rgba_a, &mut self.blend_buf);
                         }
                     }
 


### PR DESCRIPTION
## Summary

`TimelineRunner` was compositing V2/V3 overlay layers on top of V1, which is the opposite of standard NLE z-order convention (Premiere Pro, Final Cut Pro, DaVinci Resolve). V1 should always be the topmost / foreground layer, with V2, V3, … serving as progressively deeper background layers revealed only where V1 is transparent or spatially reduced.

## Changes

The compositing step in `TimelineRunner::run()` is split into two phases:

- **Phase 1** (unchanged): drains each overlay layer's decode buffer and updates `layer.rgba` without compositing inline
- **Phase 2** (new): builds the composite in correct z-order
  1. Seeds `blend_buf` with the deepest non-empty overlay layer (V_N = most background)
  2. Composites shallower layers toward V2 in order
  3. Composites V1 (`rgba_a`) on top as the foreground
  4. Swaps `blend_buf` ↔ `rgba_a` so the rest of the pipeline sees the composited result

`blend_buf` is reused (it was already a field on `TimelineRunner` for crossfade transitions), so no new allocations are needed.

## Related Issues

Fixes #1124

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes