### PR TITLE
feat(ff-preview): JKL scrubbing — reverse playback, pause-drift fix, rate propagation

### DIFF
--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -140,7 +140,11 @@ impl PlayerHandle {
 
     /// Set the playback rate.
     ///
-    /// Values ≤ 0.0 are silently ignored by the runner.
+    /// - Positive values play forward at the given speed multiplier (e.g. `2.0` = 2×).
+    /// - Negative values play in reverse at `abs(rate)` speed (e.g. `-1.0` = 1× reverse).
+    ///   Audio is muted during reverse playback and automatically resumes on the next
+    ///   positive-rate call.
+    /// - `0.0` is ignored.
     pub fn set_rate(&self, rate: f64) {
         let _ = self.cmd_tx.try_send(PlayerCommand::SetRate(rate));
     }
@@ -536,6 +540,20 @@ impl PlayerRunner {
                     PlayerCommand::Play => {
                         self.stopped.store(false, Ordering::Release);
                         self.paused.store(false, Ordering::Release);
+                        // The cpal hardware callback advances `samples_consumed` even
+                        // while paused, so `MasterClock::Audio` drifts forward during
+                        // silence. Reset the clock to the last presented video frame so
+                        // frames are not immediately dropped as "late" on resume.
+                        if self.rate > 0.0 {
+                            let pts =
+                                Duration::from_micros(self.current_pts.load(Ordering::Relaxed));
+                            if self.clock.current_pts().saturating_sub(pts)
+                                > Duration::from_millis(100)
+                            {
+                                self.clock.reset(pts);
+                                self.restart_audio_from(pts);
+                            }
+                        }
                     }
                     PlayerCommand::Pause => {
                         self.paused.store(true, Ordering::Release);
@@ -544,9 +562,46 @@ impl PlayerRunner {
                         self.stopped.store(true, Ordering::Release);
                     }
                     PlayerCommand::SetRate(r) => {
-                        if r > 0.0 {
+                        if r != 0.0 {
+                            let was_negative = self.rate < 0.0;
                             self.rate = r;
-                            self.clock.set_rate(r);
+                            if r > 0.0 {
+                                self.clock.set_rate(r);
+                                // Returning from reverse: the MasterClock kept advancing
+                                // forward during reverse playback, so its position is now
+                                // ahead of the video position. Reset it to the current
+                                // video position and re-seek the decode buffer so the
+                                // forward path resumes from the right frame.
+                                if was_negative {
+                                    let pts = Duration::from_micros(
+                                        self.current_pts.load(Ordering::Relaxed),
+                                    );
+                                    self.clock.reset(pts);
+                                    // Use coarse seek (no forward-decode discard) so the
+                                    // first video frame arrives before the audio clock
+                                    // has advanced past pts, preventing A/V drift.
+                                    if let Some(buf) = self.decode_buf.as_mut()
+                                        && let Err(e) = buf.seek_coarse(pts)
+                                    {
+                                        log::warn!(
+                                            "reverse→forward seek failed pts={pts:?} \
+                                             error={e}"
+                                        );
+                                    }
+                                    self.restart_audio_from(pts);
+                                }
+                            } else {
+                                // Entering reverse: mute audio by cancelling the decode thread
+                                // and clearing the buffer.
+                                if let Some(cancel) = &self.audio_cancel {
+                                    cancel.store(true, Ordering::Release);
+                                }
+                                if let Some(buf) = &self.audio_buf {
+                                    buf.lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .clear();
+                                }
+                            }
                         }
                     }
                     PlayerCommand::SetAvOffset(ms) => {
@@ -589,6 +644,49 @@ impl PlayerRunner {
             }
             if self.paused.load(Ordering::Acquire) {
                 thread::sleep(Duration::from_millis(5));
+                continue;
+            }
+
+            // ── Reverse playback path ─────────────────────────────────────────
+            if self.rate < 0.0 {
+                if let Some(buf) = self.decode_buf.as_mut() {
+                    let current = Duration::from_micros(self.current_pts.load(Ordering::Relaxed));
+                    // Step size = one frame at the requested speed.
+                    let step =
+                        Duration::from_secs_f64(self.rate.abs() / fps.max(f64::MIN_POSITIVE));
+                    let target = current.saturating_sub(step);
+
+                    if buf.seek_coarse(target).is_err() {
+                        break;
+                    }
+
+                    // Drain pop_frame until a decoded frame arrives (with timeout).
+                    let deadline = std::time::Instant::now() + Duration::from_millis(300);
+                    let frame = loop {
+                        match buf.pop_frame() {
+                            FrameResult::Frame(f) => break Some(f),
+                            FrameResult::Seeking(_) => {
+                                if std::time::Instant::now() > deadline {
+                                    break None;
+                                }
+                                thread::sleep(Duration::from_millis(2));
+                            }
+                            FrameResult::Eof => break None,
+                        }
+                    };
+
+                    if let Some(f) = frame {
+                        self.present_frame(&f);
+                        let pts = f.timestamp().as_duration();
+                        let _ = self.event_tx.try_send(PlayerEvent::PositionUpdate(pts));
+                    }
+
+                    if target == Duration::ZERO {
+                        // Reached the start of the clip — pause automatically.
+                        self.paused.store(true, Ordering::Release);
+                    }
+                }
+                thread::sleep(frame_period);
                 continue;
             }
 

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -574,8 +574,47 @@ impl TimelineRunner {
                         self.stopped.store(true, Ordering::Release);
                     }
                     PlayerCommand::SetRate(r) => {
-                        if r > 0.0 {
+                        if r != 0.0 {
+                            let was_negative = self.rate < 0.0;
                             self.rate = r;
+                            if r > 0.0 {
+                                self.clock.set_rate(r);
+                                if was_negative {
+                                    // Returning from reverse: rebase clock and
+                                    // restart audio from the current video position.
+                                    let pts = Duration::from_micros(
+                                        self.current_pts.load(Ordering::Relaxed),
+                                    );
+                                    self.clock.reset(pts);
+                                    self.resume_pts = pts;
+                                    if let Err(e) = self.seek_timeline_coarse(pts) {
+                                        log::warn!(
+                                            "timeline reverse→forward seek failed \
+                                             pts={pts:?} error={e}"
+                                        );
+                                    } else {
+                                        let ci = self.active;
+                                        let clip_local = self.clips[ci].in_point
+                                            + pts.saturating_sub(self.clips[ci].timeline_start);
+                                        if let Some(m) = &self.audio_mixer {
+                                            m.lock()
+                                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                                .invalidate_all();
+                                        }
+                                        self.restart_audio_at(ci, clip_local);
+                                    }
+                                }
+                            } else {
+                                // Entering reverse: silence audio.
+                                if let Some(cancel) = &self.active_audio_cancel {
+                                    cancel.store(true, Ordering::Release);
+                                }
+                                if let Some(m) = &self.audio_mixer {
+                                    m.lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .invalidate_all();
+                                }
+                            }
                         }
                     }
                     PlayerCommand::SetAvOffset(_) => {} // audio timing is system-clock driven
@@ -615,6 +654,70 @@ impl TimelineRunner {
             }
             if self.paused.load(Ordering::Acquire) {
                 thread::sleep(Duration::from_millis(5));
+                continue;
+            }
+
+            // ── Reverse playback path ─────────────────────────────────────────
+            if self.rate < 0.0 {
+                let current = Duration::from_micros(self.current_pts.load(Ordering::Relaxed));
+                let step = Duration::from_secs_f64(self.rate.abs() / fps.max(f64::MIN_POSITIVE));
+                let target = current.saturating_sub(step);
+
+                let clip_idx = self
+                    .clips
+                    .iter()
+                    .position(|c| target >= c.timeline_start && target < c.timeline_end);
+
+                if let Some(ci) = clip_idx {
+                    let clip_local = self.clips[ci].in_point
+                        + target.saturating_sub(self.clips[ci].timeline_start);
+                    if self.clips[ci].decode_buf.seek_coarse(clip_local).is_ok() {
+                        if ci != self.active {
+                            self.active = ci;
+                            self.transition = None;
+                        }
+                        let deadline = std::time::Instant::now() + Duration::from_millis(300);
+                        let frame = loop {
+                            match self.clips[ci].decode_buf.pop_frame() {
+                                FrameResult::Frame(f) => break Some(f),
+                                FrameResult::Seeking(_) => {
+                                    if std::time::Instant::now() > deadline {
+                                        break None;
+                                    }
+                                    thread::sleep(Duration::from_millis(2));
+                                }
+                                FrameResult::Eof => break None,
+                            }
+                        };
+                        if let Some(f) = frame {
+                            let f_pts = f.timestamp().as_duration();
+                            let tl_pts = self.clips[ci].timeline_start
+                                + f_pts.saturating_sub(self.clips[ci].in_point);
+                            let w = f.width();
+                            let h = f.height();
+                            if self.sws_a.convert(&f, &mut self.rgba_a)
+                                && let Some(sink) = self.sink.as_mut()
+                            {
+                                sink.push_frame(&self.rgba_a, w, h, tl_pts);
+                            }
+                            self.current_pts.store(
+                                u64::try_from(tl_pts.as_micros()).unwrap_or(u64::MAX),
+                                Ordering::Relaxed,
+                            );
+                            self.resume_pts = tl_pts;
+                            let _ = self.event_tx.try_send(PlayerEvent::PositionUpdate(tl_pts));
+                        }
+                    }
+                }
+
+                if self
+                    .clips
+                    .first()
+                    .is_some_and(|c| target < c.timeline_start)
+                {
+                    self.paused.store(true, Ordering::Release);
+                }
+                thread::sleep(frame_period);
                 continue;
             }
 
@@ -788,6 +891,12 @@ impl TimelineRunner {
                                         }
                                         PlayerCommand::Stop => {
                                             self.stopped.store(true, Ordering::Release);
+                                        }
+                                        PlayerCommand::SetRate(r) => {
+                                            if r > 0.0 {
+                                                self.rate = r;
+                                                self.clock.set_rate(r);
+                                            }
                                         }
                                         _ => {}
                                     }
@@ -1194,6 +1303,27 @@ impl TimelineRunner {
             at.stop();
         }
 
+        Ok(())
+    }
+
+    /// Coarse (I-frame only) seek variant of [`seek_timeline`].
+    ///
+    /// Does not restart audio or invalidate the mixer — caller is responsible.
+    /// Used for the reverse→forward recovery path where latency matters more
+    /// than frame-accurate positioning.
+    fn seek_timeline_coarse(&mut self, target: Duration) -> Result<(), PreviewError> {
+        let clip_idx = self
+            .clips
+            .iter()
+            .position(|c| target >= c.timeline_start && target < c.timeline_end)
+            .ok_or(PreviewError::SeekOutOfRange { pts: target })?;
+        let clip_local_pts = self.clips[clip_idx].in_point
+            + target.saturating_sub(self.clips[clip_idx].timeline_start);
+        self.clips[clip_idx]
+            .decode_buf
+            .seek_coarse(clip_local_pts)?;
+        self.active = clip_idx;
+        self.transition = None;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Implements JKL keyboard-scrubbing transport for `PlayerRunner` and `TimelineRunner`.
`set_rate` now accepts negative values for frame-accurate reverse playback, a pause-induced
clock-drift bug is fixed so that resuming after any-rate pause presents the correct frame,
and `TimelineRunner::SetRate` now propagates the new rate to `MasterClock` so fast-forward
actually works.

## Changes

- **Reverse playback (#1136)**: `set_rate(r)` now accepts `r != 0.0`; negative rates
  enter a per-frame seek-backward loop (`seek_coarse` → drain → present), mute audio,
  and auto-pause at the beginning of the clip/timeline. Returning to a positive rate
  resets the clock to the current video PTS and restarts audio.
- **Pause-drift fix (#1137)**: `PlayerRunner::Play` handler checks whether
  `MasterClock::Audio` has drifted > 100 ms ahead of the last presented video PTS
  (caused by `samples_consumed` advancing during silence) and resets the clock if so;
  the 100 ms threshold prevents spurious resync on the first `play()` call.
- **Timeline rate propagation (#1138)**: `TimelineRunner::SetRate` now calls
  `self.clock.set_rate(r)` so `MasterClock::System` advances at the requested rate;
  the gap-fill inner command loop receives the same fix; new `seek_timeline_coarse`
  helper added for the reverse→forward recovery path.
- **Format/lint**: one `collapsible_if` collapsed; `seek_timeline_coarse` long line
  wrapped to satisfy `rustfmt`.

## Related Issues

Closes #1136
Fixes #1137
Fixes #1138

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes