### PR TITLE
fix(ff-preview): present preview frame after seek while paused

### DIFF
--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -614,6 +614,7 @@ impl PlayerRunner {
             }
 
             // ── Apply pending seek ────────────────────────────────────────────
+            let had_seek = pending_seek.is_some();
             if let Some(pts) = pending_seek {
                 // Invalidate the frame cache when seeking outside its range.
                 if let Some(cache) = &mut self.frame_cache {
@@ -630,6 +631,32 @@ impl PlayerRunner {
                 self.clock.reset(pts);
                 self.restart_audio_from(pts);
                 let _ = self.event_tx.try_send(PlayerEvent::SeekCompleted(pts));
+            }
+
+            // When a seek arrives while paused, present one preview frame so
+            // the sink reflects the new position without resuming playback.
+            if had_seek
+                && self.paused.load(Ordering::Acquire)
+                && let Some(buf) = self.decode_buf.as_mut()
+            {
+                let deadline = std::time::Instant::now() + Duration::from_millis(300);
+                loop {
+                    match buf.pop_frame() {
+                        FrameResult::Frame(f) => {
+                            self.present_frame(&f);
+                            let pts = f.timestamp().as_duration();
+                            let _ = self.event_tx.try_send(PlayerEvent::PositionUpdate(pts));
+                            break;
+                        }
+                        FrameResult::Seeking(_) => {
+                            if std::time::Instant::now() > deadline {
+                                break;
+                            }
+                            thread::sleep(Duration::from_millis(2));
+                        }
+                        FrameResult::Eof => break,
+                    }
+                }
             }
 
             // Surface non-fatal decode errors from the background thread.

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -627,11 +627,48 @@ impl TimelineRunner {
             }
 
             // ── Apply pending seek ────────────────────────────────────────────
+            let had_seek = pending_seek.is_some();
             if let Some(target) = pending_seek {
                 self.seek_timeline(target)?;
                 self.clock.reset(target);
                 self.resume_pts = target;
                 let _ = self.event_tx.try_send(PlayerEvent::SeekCompleted(target));
+            }
+
+            // When a seek arrives while paused, present one preview frame so
+            // the sink reflects the new position without resuming playback.
+            if had_seek && self.paused.load(Ordering::Acquire) {
+                let active = self.active;
+                let deadline = std::time::Instant::now() + Duration::from_millis(300);
+                loop {
+                    match self.clips[active].decode_buf.pop_frame() {
+                        FrameResult::Frame(f) => {
+                            let f_pts = f.timestamp().as_duration();
+                            let tl_pts = self.clips[active].timeline_start
+                                + f_pts.saturating_sub(self.clips[active].in_point);
+                            let w = f.width();
+                            let h = f.height();
+                            if self.sws_a.convert(&f, &mut self.rgba_a)
+                                && let Some(sink) = self.sink.as_mut()
+                            {
+                                sink.push_frame(&self.rgba_a, w, h, tl_pts);
+                            }
+                            self.current_pts.store(
+                                u64::try_from(tl_pts.as_micros()).unwrap_or(u64::MAX),
+                                Ordering::Relaxed,
+                            );
+                            let _ = self.event_tx.try_send(PlayerEvent::PositionUpdate(tl_pts));
+                            break;
+                        }
+                        FrameResult::Seeking(_) => {
+                            if std::time::Instant::now() > deadline {
+                                break;
+                            }
+                            thread::sleep(Duration::from_millis(2));
+                        }
+                        FrameResult::Eof => break,
+                    }
+                }
             }
 
             // ── Error events from active clip ─────────────────────────────────


### PR DESCRIPTION
## Summary

`PlayerRunner` and `TimelineRunner` both failed to push a frame to the `FrameSink` when
`seek()` was called while paused. The decode buffer was repositioned correctly but the
paused guard fired before any frame was decoded, so the display stayed frozen. This broke
frame-by-frame stepping (J/L while paused in JKL transport).

## Changes

- **Root cause**: after applying a pending seek, both runners immediately hit the
  `if self.paused { continue }` guard without ever calling `pop_frame`, so the sink
  received no visual update.
- **Fix (`player.rs`)**: added `had_seek` flag; after the seek block, if paused and a
  decode buffer exists, drain one frame with a 300 ms deadline and push it via
  `present_frame` + `PositionUpdate` event before falling through to the paused sleep.
- **Fix (`timeline/mod.rs`)**: same pattern — `had_seek` flag; if paused after seek,
  drain one frame from `clips[active].decode_buf`, convert through `sws_a`, push to
  sink, update `current_pts`, and emit `PositionUpdate`. Runner stays paused after
  delivering the single preview frame.

## Related Issues

Fixes #1140

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes