### PR TITLE
feat(ff-pipeline): add Clip::volume_db for per-clip audio gain

### DIFF
--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -47,9 +47,9 @@ pub struct Clip {
     pub transition_duration: Duration,
     /// Per-clip volume adjustment in dB applied during audio mixing (`0.0` = unity gain).
     ///
-    /// This value is independent of any track-level volume animation set via
-    /// [`TimelineBuilder::audio_animation`]. When non-zero the clip's own gain
-    /// overrides the track-level value; set to `0.0` to defer to the track level.
+    /// This value is independent of any track-level volume animation. When non-zero
+    /// the clip's own gain overrides the track-level value; set to `0.0` to defer
+    /// to the track level.
     ///
     /// Defaults to `0.0`.
     pub volume_db: f64,

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -45,6 +45,14 @@ pub struct Clip {
     pub transition: Option<XfadeTransition>,
     /// Duration of the transition overlap. Ignored when `transition` is `None`.
     pub transition_duration: Duration,
+    /// Per-clip volume adjustment in dB applied during audio mixing (`0.0` = unity gain).
+    ///
+    /// This value is independent of any track-level volume animation set via
+    /// [`TimelineBuilder::audio_animation`]. When non-zero the clip's own gain
+    /// overrides the track-level value; set to `0.0` to defer to the track level.
+    ///
+    /// Defaults to `0.0`.
+    pub volume_db: f64,
 }
 
 impl Clip {
@@ -58,6 +66,7 @@ impl Clip {
             metadata: HashMap::new(),
             transition: None,
             transition_duration: Duration::ZERO,
+            volume_db: 0.0,
         }
     }
 
@@ -104,6 +113,28 @@ impl Clip {
         Self {
             transition: Some(kind),
             transition_duration: duration,
+            ..self
+        }
+    }
+
+    /// Sets the per-clip volume adjustment in dB and returns the updated clip.
+    ///
+    /// `0.0` is unity gain (no change). Positive values increase volume; negative
+    /// values reduce it. When set to a non-zero value this overrides the track-level
+    /// volume animation for this clip during rendering.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    ///
+    /// let clip = Clip::new("narration.wav").volume(-6.0);
+    /// assert_eq!(clip.volume_db, -6.0);
+    /// ```
+    #[must_use]
+    pub fn volume(self, db: f64) -> Self {
+        Self {
+            volume_db: db,
             ..self
         }
     }
@@ -165,5 +196,23 @@ mod tests {
     fn clip_duration_should_return_difference_when_both_points_set() {
         let clip = Clip::new("video.mp4").trim(Duration::from_secs(2), Duration::from_secs(10));
         assert_eq!(clip.duration(), Some(Duration::from_secs(8)));
+    }
+
+    #[test]
+    fn clip_new_should_default_volume_db_to_zero() {
+        let clip = Clip::new("audio.wav");
+        assert_eq!(clip.volume_db, 0.0);
+    }
+
+    #[test]
+    fn clip_volume_should_set_volume_db() {
+        let clip = Clip::new("audio.wav").volume(-6.0);
+        assert_eq!(clip.volume_db, -6.0);
+    }
+
+    #[test]
+    fn clip_volume_positive_should_set_volume_db() {
+        let clip = Clip::new("audio.wav").volume(3.0);
+        assert_eq!(clip.volume_db, 3.0);
     }
 }

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -303,9 +303,17 @@ impl Timeline {
             let mut mixer = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo);
             for (track_idx, track) in audio_tracks.iter().enumerate() {
                 for clip in track {
+                    // Per-clip volume_db overrides the track-level animation when non-zero.
+                    // This lets callers set independent gain on each clip without needing
+                    // one audio track per clip.
+                    let volume = if clip.volume_db == 0.0 {
+                        aa(track_idx, "volume", 0.0)
+                    } else {
+                        AnimatedValue::Static(clip.volume_db)
+                    };
                     mixer = mixer.add_track(AudioTrack {
                         source: clip.source.clone(),
-                        volume: aa(track_idx, "volume", 0.0),
+                        volume,
                         pan: aa(track_idx, "pan", 0.0),
                         time_offset: clip.timeline_offset,
                         effects: vec![],

--- a/crates/ff-preview/src/audio/mod.rs
+++ b/crates/ff-preview/src/audio/mod.rs
@@ -31,10 +31,14 @@ pub struct AudioTrackHandle {
 }
 
 impl AudioTrackHandle {
-    /// Set per-track volume. Clamped to `[0.0, 1.0]`.
+    /// Set per-track volume.
+    ///
+    /// `1.0` = unity gain. Values above `1.0` amplify; values below reduce.
+    /// Negative values are clamped to `0.0` (silence). The mixer output is
+    /// always clipped to `[-1.0, 1.0]`, so amplification may cause saturation
+    /// on loud signals.
     pub fn set_volume(&self, v: f32) {
-        self.volume
-            .store(v.clamp(0.0, 1.0).to_bits(), Ordering::Relaxed);
+        self.volume.store(v.max(0.0).to_bits(), Ordering::Relaxed);
     }
 
     /// Set stereo pan. Clamped to `[-1.0` (full left) `.. +1.0` (full right)`]`.
@@ -356,16 +360,31 @@ mod tests {
     }
 
     #[test]
-    fn audio_track_handle_set_volume_should_clamp_to_zero_one() {
+    fn audio_track_handle_set_volume_above_one_should_amplify() {
         let mut mixer = AudioMixer::new(48_000);
         let track = mixer.add_track();
-        track.set_volume(2.0); // should clamp to 1.0
+        track.set_volume(2.0);
+        track.set_pan(-1.0); // full left for determinism
+        track.push_samples(&[0.4]);
+        let out = mixer.mix(2); // 1 stereo frame
+        // L = 0.4 * 2.0 = 0.8 (below clip threshold).
+        assert!(
+            (out[0] - 0.8).abs() < 1e-5,
+            "volume 2.0 should amplify to 0.8; got {}",
+            out[0]
+        );
+    }
+
+    #[test]
+    fn audio_track_handle_set_negative_volume_should_be_silent() {
+        let mut mixer = AudioMixer::new(48_000);
+        let track = mixer.add_track();
+        track.set_volume(-1.0); // clamped to 0.0
         track.push_samples(&[1.0]);
         let out = mixer.mix(2);
-        // With volume clamped to 1.0 and center pan, L = cos(π/4) ≈ 0.707.
         assert!(
-            out[0] <= 1.0,
-            "volume clamped to 1.0 must not exceed gain 1.0"
+            out.iter().all(|&s| s.abs() < 1e-6),
+            "negative volume must be silent"
         );
     }
 

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -372,6 +372,12 @@ impl TimelinePlayer {
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .add_track();
+                // Apply per-clip gain (dB → linear).
+                if clip.volume_db != 0.0 {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let linear = 10.0_f64.powf(clip.volume_db / 20.0) as f32;
+                    handle.set_volume(linear);
+                }
                 audio_only_tracks.push(AudioOnlyTrack {
                     source: clip.source.clone(),
                     timeline_start,


### PR DESCRIPTION
## Summary

Adds `Clip::volume_db: f64` so callers can set independent gain on individual clips. Applies it in both the export render path (via `AudioTrack.volume`) and the real-time preview path (via `AudioTrackHandle::set_volume()`). Also lifts the `1.0` upper bound on `AudioTrackHandle::set_volume()` to allow amplification.

## Changes

- `crates/ff-pipeline/src/clip.rs`: added `volume_db: f64` (default `0.0`) + `Clip::volume(db)` builder method + doc-test + 3 unit tests
- `crates/ff-pipeline/src/timeline.rs`: `AudioTrack::volume` uses `AnimatedValue::Static(clip.volume_db)` when the clip override is non-zero; falls back to track-level animation when `0.0`
- `crates/ff-preview/src/audio/mod.rs`: `AudioTrackHandle::set_volume()` now allows values above `1.0` (amplification); only clamps at `0.0` (silence floor). Updated tests accordingly.
- `crates/ff-preview/src/timeline/mod.rs`: `TimelineRunner` applies `clip.volume_db` (converted from dB to linear) to the `AudioOnlyTrack` handle immediately after construction so real-time preview respects per-clip gain

## Related Issues

Closes #1142

## Test Plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes