### PR TITLE
feat(ff-pipeline,ff-preview): per-clip audio fade-in/fade-out

### DIFF
--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -53,6 +53,23 @@ pub struct Clip {
     ///
     /// Defaults to `0.0`.
     pub volume_db: f64,
+    /// Audio fade-in duration at the start of the clip (`Duration::ZERO` = no fade).
+    ///
+    /// When non-zero, a linear ramp from silence to the clip's volume level is
+    /// applied over this duration, starting at the clip's in-point.
+    ///
+    /// Defaults to `Duration::ZERO`.
+    pub fade_in: Duration,
+    /// Audio fade-out duration at the end of the clip (`Duration::ZERO` = no fade).
+    ///
+    /// When non-zero, a linear ramp from the clip's volume level to silence is
+    /// applied over this duration, ending at the clip's out-point.
+    /// Requires `out_point` to be set or the source file to be probeable so the
+    /// `afade` start offset can be computed. Omitted with `log::warn!` at render
+    /// time if the clip duration cannot be determined.
+    ///
+    /// Defaults to `Duration::ZERO`.
+    pub fade_out: Duration,
 }
 
 impl Clip {
@@ -67,6 +84,8 @@ impl Clip {
             transition: None,
             transition_duration: Duration::ZERO,
             volume_db: 0.0,
+            fade_in: Duration::ZERO,
+            fade_out: Duration::ZERO,
         }
     }
 
@@ -135,6 +154,54 @@ impl Clip {
     pub fn volume(self, db: f64) -> Self {
         Self {
             volume_db: db,
+            ..self
+        }
+    }
+
+    /// Sets the audio fade-in duration and returns the updated clip.
+    ///
+    /// The fade starts at the beginning of the clip and ramps from silence to the
+    /// clip's volume level over `duration`. `Duration::ZERO` disables the fade.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    /// use std::time::Duration;
+    ///
+    /// let clip = Clip::new("narration.wav").with_fade_in(Duration::from_secs(2));
+    /// assert_eq!(clip.fade_in, Duration::from_secs(2));
+    /// ```
+    #[must_use]
+    pub fn with_fade_in(self, duration: Duration) -> Self {
+        Self {
+            fade_in: duration,
+            ..self
+        }
+    }
+
+    /// Sets the audio fade-out duration and returns the updated clip.
+    ///
+    /// The fade starts `duration` before the end of the clip and ramps to silence.
+    /// Requires `out_point` to be set or the source file to be probeable; omitted
+    /// with `log::warn!` at render time if the clip duration cannot be determined.
+    /// `Duration::ZERO` disables the fade.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    /// use std::time::Duration;
+    ///
+    /// let clip = Clip::new("narration.wav")
+    ///     .trim(Duration::from_secs(0), Duration::from_secs(10))
+    ///     .with_fade_out(Duration::from_secs(1));
+    /// assert_eq!(clip.fade_out, Duration::from_secs(1));
+    /// ```
+    #[must_use]
+    pub fn with_fade_out(self, duration: Duration) -> Self {
+        Self {
+            fade_out: duration,
             ..self
         }
     }
@@ -214,5 +281,38 @@ mod tests {
     fn clip_volume_positive_should_set_volume_db() {
         let clip = Clip::new("audio.wav").volume(3.0);
         assert_eq!(clip.volume_db, 3.0);
+    }
+
+    #[test]
+    fn clip_new_should_default_fade_fields_to_zero() {
+        let clip = Clip::new("audio.wav");
+        assert_eq!(clip.fade_in, Duration::ZERO);
+        assert_eq!(clip.fade_out, Duration::ZERO);
+    }
+
+    #[test]
+    fn clip_with_fade_in_should_set_fade_in() {
+        let clip = Clip::new("audio.wav").with_fade_in(Duration::from_secs(2));
+        assert_eq!(clip.fade_in, Duration::from_secs(2));
+        assert_eq!(clip.fade_out, Duration::ZERO);
+    }
+
+    #[test]
+    fn clip_with_fade_out_should_set_fade_out() {
+        let clip = Clip::new("audio.wav")
+            .trim(Duration::ZERO, Duration::from_secs(10))
+            .with_fade_out(Duration::from_secs(1));
+        assert_eq!(clip.fade_out, Duration::from_secs(1));
+        assert_eq!(clip.fade_in, Duration::ZERO);
+    }
+
+    #[test]
+    fn clip_fade_in_and_fade_out_can_be_chained() {
+        let clip = Clip::new("audio.wav")
+            .trim(Duration::ZERO, Duration::from_secs(10))
+            .with_fade_in(Duration::from_millis(500))
+            .with_fade_out(Duration::from_millis(500));
+        assert_eq!(clip.fade_in, Duration::from_millis(500));
+        assert_eq!(clip.fade_out, Duration::from_millis(500));
     }
 }

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -12,7 +12,8 @@ use std::time::{Duration, Instant};
 use ff_decode::VideoDecoder;
 use ff_encode::VideoEncoder;
 use ff_filter::{
-    AnimatedValue, AnimationTrack, AudioTrack, MultiTrackAudioMixer, MultiTrackComposer, VideoLayer,
+    AnimatedValue, AnimationTrack, AudioTrack, FilterStep, MultiTrackAudioMixer,
+    MultiTrackComposer, VideoLayer,
 };
 use ff_format::ChannelLayout;
 
@@ -311,12 +312,60 @@ impl Timeline {
                     } else {
                         AnimatedValue::Static(clip.volume_db)
                     };
+
+                    let mut effects: Vec<FilterStep> = Vec::new();
+
+                    if clip.fade_in > Duration::ZERO {
+                        effects.push(FilterStep::AFadeIn {
+                            start: 0.0,
+                            duration: clip.fade_in.as_secs_f64(),
+                        });
+                    }
+
+                    if clip.fade_out > Duration::ZERO {
+                        // Resolve effective duration to compute the afade start offset.
+                        let eff_dur: Option<Duration> = clip.duration().or_else(|| {
+                            VideoDecoder::open(&clip.source).build().ok().map(|d| {
+                                let total = d.duration();
+                                match clip.in_point {
+                                    Some(ip) => total.saturating_sub(ip),
+                                    None => total,
+                                }
+                            })
+                        });
+                        match eff_dur {
+                            Some(dur) if dur > clip.fade_out => {
+                                // saturating_sub is safe: the guard ensures dur > fade_out.
+                                let start = dur.saturating_sub(clip.fade_out).as_secs_f64();
+                                effects.push(FilterStep::AFadeOut {
+                                    start,
+                                    duration: clip.fade_out.as_secs_f64(),
+                                });
+                            }
+                            Some(_) => {
+                                log::warn!(
+                                    "fade_out ({:.3}s) >= clip duration — skipping fade_out \
+                                     for {}",
+                                    clip.fade_out.as_secs_f64(),
+                                    clip.source.display(),
+                                );
+                            }
+                            None => {
+                                log::warn!(
+                                    "cannot determine clip duration — skipping fade_out \
+                                     for {}",
+                                    clip.source.display(),
+                                );
+                            }
+                        }
+                    }
+
                     mixer = mixer.add_track(AudioTrack {
                         source: clip.source.clone(),
                         volume,
                         pan: aa(track_idx, "pan", 0.0),
                         time_offset: clip.timeline_offset,
-                        effects: vec![],
+                        effects,
                         sample_rate: 48_000,
                         channel_layout: ff_format::ChannelLayout::Stereo,
                     });

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -46,6 +46,8 @@ use crate::playback::sink::FrameSink;
 const CHANNEL_CAP: usize = 64;
 /// Back-pressure limit for the audio decode thread (mono samples).
 const AUDIO_MAX_BUF: usize = 96_000;
+/// Sample rate used for all audio decode threads.
+const AUDIO_SAMPLE_RATE: f64 = 48_000.0;
 
 // ── ClipState ─────────────────────────────────────────────────────────────────
 
@@ -90,6 +92,28 @@ struct OverlayLayer {
     rgba: Vec<u8>,
 }
 
+// ── AudioFadeConfig ───────────────────────────────────────────────────────────
+
+/// Fade-in / fade-out parameters forwarded to [`spawn_audio_track_thread`].
+#[derive(Clone, Copy)]
+struct AudioFadeConfig {
+    fade_in: Duration,
+    fade_out: Duration,
+    /// Effective clip duration — used to position the fade-out start offset.
+    clip_dur: Duration,
+    /// Source-file PTS at which the clip starts (used to offset the envelope on seek).
+    in_point: Duration,
+}
+
+impl AudioFadeConfig {
+    const NONE: Self = Self {
+        fade_in: Duration::ZERO,
+        fade_out: Duration::ZERO,
+        clip_dur: Duration::ZERO,
+        in_point: Duration::ZERO,
+    };
+}
+
 // ── AudioOnlyTrack ────────────────────────────────────────────────────────────
 
 /// One dedicated audio-only clip (from an A1/A2/… track) inside [`TimelineRunner`].
@@ -98,6 +122,12 @@ struct AudioOnlyTrack {
     timeline_start: Duration,
     timeline_end: Duration,
     in_point: Duration,
+    /// Per-clip audio fade-in duration (`Duration::ZERO` = no fade).
+    fade_in: Duration,
+    /// Per-clip audio fade-out duration (`Duration::ZERO` = no fade).
+    fade_out: Duration,
+    /// Effective clip duration — used to position the fade-out ramp.
+    clip_dur: Duration,
     handle: AudioTrackHandle,
     cancel: Option<Arc<AtomicBool>>,
     thread: Option<JoinHandle<()>>,
@@ -117,6 +147,12 @@ impl AudioOnlyTrack {
             from_pts,
             self.handle.clone(),
             Arc::clone(&cancel),
+            AudioFadeConfig {
+                fade_in: self.fade_in,
+                fade_out: self.fade_out,
+                clip_dur: self.clip_dur,
+                in_point: self.in_point,
+            },
         );
         self.cancel = Some(cancel);
         self.thread = Some(t);
@@ -325,6 +361,9 @@ impl TimelinePlayer {
                         timeline_start,
                         timeline_end,
                         in_point: in_pt,
+                        fade_in: clip.fade_in,
+                        fade_out: clip.fade_out,
+                        clip_dur,
                         handle,
                         cancel: None,
                         thread: None,
@@ -383,6 +422,9 @@ impl TimelinePlayer {
                     timeline_start,
                     timeline_end,
                     in_point: in_pt,
+                    fade_in: clip.fade_in,
+                    fade_out: clip.fade_out,
+                    clip_dur,
                     handle,
                     cancel: None,
                     thread: None,
@@ -413,7 +455,13 @@ impl TimelinePlayer {
                 let source = clip_states[0].source.clone();
                 let in_pt = clip_states[0].in_point;
                 let cancel = Arc::new(AtomicBool::new(false));
-                let thread = spawn_audio_track_thread(source, in_pt, handle, Arc::clone(&cancel));
+                let thread = spawn_audio_track_thread(
+                    source,
+                    in_pt,
+                    handle,
+                    Arc::clone(&cancel),
+                    AudioFadeConfig::NONE,
+                );
                 (Some(cancel), Some(thread))
             } else {
                 (None, None)
@@ -1387,7 +1435,13 @@ impl TimelineRunner {
 
         let source = self.clips[clip_idx].source.clone();
         let cancel = Arc::new(AtomicBool::new(false));
-        let thread = spawn_audio_track_thread(source, start_pts, handle, Arc::clone(&cancel));
+        let thread = spawn_audio_track_thread(
+            source,
+            start_pts,
+            handle,
+            Arc::clone(&cancel),
+            AudioFadeConfig::NONE,
+        );
         self.active_audio_cancel = Some(cancel);
         self.active_audio_thread = Some(thread);
     }
@@ -1411,6 +1465,7 @@ fn spawn_audio_track_thread(
     start_pts: Duration,
     track: AudioTrackHandle,
     cancel: Arc<AtomicBool>,
+    fades: AudioFadeConfig,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let mut decoder = match AudioDecoder::open(&path)
@@ -1432,6 +1487,14 @@ fn spawn_audio_track_thread(
             log::warn!("timeline audio seek failed pts={start_pts:?} error={e}");
         }
 
+        let fade_in_secs = fades.fade_in.as_secs_f64();
+        let fade_out_secs = fades.fade_out.as_secs_f64();
+        let total_secs = fades.clip_dur.as_secs_f64();
+        // Elapsed time at thread start due to seeking past in_point.
+        let seek_offset_secs = start_pts.saturating_sub(fades.in_point).as_secs_f64();
+        let apply_fades = fade_in_secs > 0.0 || fade_out_secs > 0.0;
+        let mut samples_pushed: u64 = 0;
+
         loop {
             if cancel.load(Ordering::Acquire) {
                 break;
@@ -1448,7 +1511,41 @@ fn spawn_audio_track_thread(
                     if let Some(samples) = frame.as_f32()
                         && !samples.is_empty()
                     {
-                        track.push_samples(samples);
+                        if apply_fades {
+                            let mut buf: Vec<f32> = samples.to_vec();
+                            for (i, s) in buf.iter_mut().enumerate() {
+                                // u64→f64 loses precision for very large sample counts
+                                // (>2^52 samples ≈ 1.9M years at 48 kHz); acceptable here.
+                                #[allow(clippy::cast_precision_loss)]
+                                let pos_secs = seek_offset_secs
+                                    + (samples_pushed + i as u64) as f64 / AUDIO_SAMPLE_RATE;
+
+                                // f64→f32: gain values are in [0.0, 1.0]; truncation is inaudible.
+                                #[allow(clippy::cast_possible_truncation)]
+                                let gain_in = if fade_in_secs > 0.0 && pos_secs < fade_in_secs {
+                                    (pos_secs / fade_in_secs) as f32
+                                } else {
+                                    1.0_f32
+                                };
+
+                                #[allow(clippy::cast_possible_truncation)]
+                                let gain_out = if fade_out_secs > 0.0
+                                    && total_secs > 0.0
+                                    && pos_secs >= total_secs - fade_out_secs
+                                {
+                                    let elapsed = pos_secs - (total_secs - fade_out_secs);
+                                    (1.0 - elapsed / fade_out_secs).clamp(0.0, 1.0) as f32
+                                } else {
+                                    1.0_f32
+                                };
+
+                                *s *= gain_in * gain_out;
+                            }
+                            samples_pushed += buf.len() as u64;
+                            track.push_samples(&buf);
+                        } else {
+                            track.push_samples(samples);
+                        }
                     }
                 }
                 Ok(None) => break,


### PR DESCRIPTION
## Summary

Adds `fade_in` and `fade_out` duration fields to `Clip` and wires them through both the
export pipeline (`Timeline::render_with_progress`) and the live preview
(`TimelinePlayer` / `spawn_audio_track_thread`). Previously the `AudioTrack::effects`
vec was always empty and `spawn_audio_track_thread` applied no gain envelope, so fades
set on a `Clip` were silently ignored in both paths.

## Changes

- **`Clip` (`ff-pipeline`)**: added `fade_in: Duration` and `fade_out: Duration` fields
  (default `Duration::ZERO`), initialized in `Clip::new()`; added `with_fade_in()` and
  `with_fade_out()` consuming builder methods with doc-tests; added 4 unit tests covering
  defaults, chaining, and independence of the two fields.
- **`Timeline::render_with_progress` (`ff-pipeline`)**: imports `FilterStep`; builds
  `effects: Vec<FilterStep>` per clip — `AFadeIn` when `fade_in > ZERO`, `AFadeOut` when
  `fade_out > ZERO` using effective duration resolved via `Clip::duration()` or
  `VideoDecoder::open`; emits `log::warn!` and skips the effect if duration cannot be
  determined or fade exceeds clip length.
- **`TimelinePlayer` / `spawn_audio_track_thread` (`ff-preview`)**: added
  `AudioFadeConfig` (`Copy` struct grouping `fade_in`, `fade_out`, `clip_dur`,
  `in_point`); `AudioOnlyTrack` carries these fields and passes them through
  `start_at()`; the audio thread applies a per-sample linear gain envelope using
  `f64` arithmetic (seek-position-aware ramp), gated by `apply_fades` to preserve the
  zero-copy path when no fades are configured; added `AUDIO_SAMPLE_RATE` module constant
  and `AudioFadeConfig::NONE` sentinel for the video-clip audio call sites.

## Related Issues

Closes #1144
Closes #1145
Fixes #1146

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes