### PR TITLE
feat(ff-filter,ff-pipeline): per-clip brightness/contrast/saturation via eq filter

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -101,6 +101,7 @@ fn main() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .add_layer(VideoLayer {
             source: args.overlay.clone(),
@@ -115,6 +116,7 @@ fn main() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .build()
     {

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -440,6 +440,25 @@ pub(super) unsafe fn build_video_composition(
             chain_end = ccm_ctx;
         }
 
+        // ── Per-layer video effects ───────────────────────────────────────────
+        for (eff_idx, step) in layer.effects.iter().enumerate() {
+            let combined_idx = idx * 1000 + eff_idx;
+            let result = crate::filter_inner::add_and_link_step(
+                graph,
+                chain_end,
+                step,
+                combined_idx,
+                "veff",
+            );
+            match result {
+                Ok(ctx) => chain_end = ctx,
+                Err(e) => bail!(
+                    graph,
+                    format!("failed to apply video effect layer={idx} eff={eff_idx}: {e}")
+                ),
+            }
+        }
+
         // ── xfade (when this layer has an in_transition) ──────────────────────
         if let Some(ref t) = layer.in_transition {
             if !saved_chain.is_null() {

--- a/crates/ff-filter/src/graph/composition/multi_track_composer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_composer.rs
@@ -65,6 +65,12 @@ pub struct VideoLayer {
     /// Transition applied at the start of this layer (from the preceding layer on the same z-order).
     /// `None` = hard cut. Set by [`MultiTrackComposer::join_with_dissolve`].
     pub in_transition: Option<ClipTransition>,
+    /// Per-layer video filter steps applied to this layer's decoded stream before compositing.
+    ///
+    /// Applied in order after trim/setpts/scale/rotate/opacity and before the `overlay` node.
+    /// Typical use: `FilterStep::Eq { brightness, contrast, saturation }` for per-clip color
+    /// correction. An empty `Vec` (the default) is a no-op.
+    pub effects: Vec<crate::graph::filter_step::FilterStep>,
 }
 
 // ── MultiTrackComposer ────────────────────────────────────────────────────────
@@ -255,6 +261,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                effects: vec![],
             })
             .build();
         assert!(
@@ -277,6 +284,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                effects: vec![],
             })
             .build();
         assert!(
@@ -307,6 +315,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                effects: vec![],
             })
             .build();
         if let Err(FilterError::CompositionFailed { ref reason }) = result {
@@ -345,6 +354,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                effects: vec![],
             })
             .build();
         assert!(result.is_err(), "expected error (nonexistent file)");
@@ -373,6 +383,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                effects: vec![],
             })
             .build();
         if let Err(FilterError::CompositionFailed { ref reason }) = result {

--- a/crates/ff-filter/tests/animation_integration_test.rs
+++ b/crates/ff-filter/tests/animation_integration_test.rs
@@ -158,6 +158,7 @@ fn bezier_position_animation_should_match_reference_curve() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .add_layer(VideoLayer {
             source: marker_path.clone(),
@@ -172,6 +173,7 @@ fn bezier_position_animation_should_match_reference_curve() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .build()
     {

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -93,6 +93,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .add_layer(VideoLayer {
             source: src2_path.clone(),
@@ -107,6 +108,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .add_layer(VideoLayer {
             source: src3_path.clone(),
@@ -121,6 +123,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .build()
     {
@@ -565,6 +568,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .add_layer(VideoLayer {
             source: layer_path.clone(),
@@ -579,6 +583,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .build()
     {
@@ -831,6 +836,7 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            effects: vec![],
         })
         .build()
     {

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -70,6 +70,21 @@ pub struct Clip {
     ///
     /// Defaults to `Duration::ZERO`.
     pub fade_out: Duration,
+    /// Per-clip brightness adjustment. Range: −1.0..=1.0. Default: 0.0 (no change).
+    ///
+    /// Applied via the `eq` video filter during `Timeline::render()`.
+    /// Neutral value (`0.0`) produces bit-identical output to the no-eq path.
+    pub brightness: f32,
+    /// Per-clip contrast adjustment. Range: 0.0..=3.0. Default: 1.0 (no change).
+    ///
+    /// Applied via the `eq` video filter during `Timeline::render()`.
+    /// Neutral value (`1.0`) produces bit-identical output to the no-eq path.
+    pub contrast: f32,
+    /// Per-clip saturation adjustment. Range: 0.0..=3.0. Default: 1.0 (no change).
+    ///
+    /// Applied via the `eq` video filter during `Timeline::render()`.
+    /// Neutral value (`1.0`) produces bit-identical output to the no-eq path.
+    pub saturation: f32,
 }
 
 impl Clip {
@@ -86,6 +101,9 @@ impl Clip {
             volume_db: 0.0,
             fade_in: Duration::ZERO,
             fade_out: Duration::ZERO,
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
         }
     }
 
@@ -206,6 +224,37 @@ impl Clip {
         }
     }
 
+    /// Sets per-clip color correction and returns the updated clip.
+    ///
+    /// The three parameters map directly to the `FFmpeg` `eq` filter:
+    /// - `brightness`: −1.0..=1.0, where `0.0` is no change.
+    /// - `contrast`:    0.0..=3.0, where `1.0` is no change.
+    /// - `saturation`:  0.0..=3.0, where `1.0` is no change.
+    ///
+    /// Neutral values (`brightness = 0.0`, `contrast = 1.0`, `saturation = 1.0`)
+    /// produce bit-identical output to the no-eq render path — the `eq` filter is
+    /// only inserted when at least one value differs from its neutral default.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    ///
+    /// let clip = Clip::new("scene.mp4").with_color_correction(0.1, 1.2, 0.9);
+    /// assert_eq!(clip.brightness, 0.1);
+    /// assert_eq!(clip.contrast, 1.2);
+    /// assert_eq!(clip.saturation, 0.9);
+    /// ```
+    #[must_use]
+    pub fn with_color_correction(self, brightness: f32, contrast: f32, saturation: f32) -> Self {
+        Self {
+            brightness,
+            contrast,
+            saturation,
+            ..self
+        }
+    }
+
     /// Returns `out_point - in_point` when both are `Some`, otherwise `None`.
     ///
     /// Does not open the source file.
@@ -314,5 +363,21 @@ mod tests {
             .with_fade_out(Duration::from_millis(500));
         assert_eq!(clip.fade_in, Duration::from_millis(500));
         assert_eq!(clip.fade_out, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn clip_new_should_default_color_correction_to_neutral() {
+        let clip = Clip::new("video.mp4");
+        assert_eq!(clip.brightness, 0.0);
+        assert_eq!(clip.contrast, 1.0);
+        assert_eq!(clip.saturation, 1.0);
+    }
+
+    #[test]
+    fn clip_with_color_correction_should_set_fields() {
+        let clip = Clip::new("scene.mp4").with_color_correction(0.1, 1.2, 0.9);
+        assert_eq!(clip.brightness, 0.1);
+        assert_eq!(clip.contrast, 1.2);
+        assert_eq!(clip.saturation, 0.9);
     }
 }

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -262,6 +262,18 @@ impl Timeline {
                         composer = composer.join_with_dissolve(prev_end, dur_secs, kind);
                     }
 
+                    let mut layer_effects: Vec<FilterStep> = Vec::new();
+                    #[allow(clippy::float_cmp)]
+                    let neutral =
+                        clip.brightness == 0.0 && clip.contrast == 1.0 && clip.saturation == 1.0;
+                    if !neutral {
+                        layer_effects.push(FilterStep::Eq {
+                            brightness: clip.brightness,
+                            contrast: clip.contrast,
+                            saturation: clip.saturation,
+                        });
+                    }
+
                     composer = composer.add_layer(VideoLayer {
                         source: clip.source.clone(),
                         x: va(track_idx, "x", 0.0),
@@ -275,6 +287,7 @@ impl Timeline {
                         in_point: clip.in_point,
                         out_point: clip.out_point,
                         in_transition: None, // set by join_with_dissolve via add_layer
+                        effects: layer_effects,
                     });
 
                     // Track how many seconds this clip contributes, so the next


### PR DESCRIPTION
## Summary

Adds per-clip color correction (brightness, contrast, saturation) to the render pipeline.
`VideoLayer` gains an `effects: Vec<FilterStep>` field mirroring `AudioTrack::effects`,
and `Clip` gains three color-correction fields wired to `FilterStep::Eq` in
`Timeline::render()`. Neutral values produce bit-identical output to the no-eq path.

## Changes

- **`VideoLayer` (`ff-filter`)**: added `effects: Vec<FilterStep>` field; all existing
  `VideoLayer` struct literals in tests, integration tests, and examples updated with
  `effects: vec![]`.
- **`composition_inner.rs` (`ff-filter`)**: inserted a per-layer effects loop after the
  opacity/color-matrix node and before the `xfade` node, using `add_and_link_step` with
  index `idx * 1000 + eff_idx` and label prefix `"veff"` — mirrors the audio mixing path.
- **`Clip` (`ff-pipeline`)**: added `brightness: f32` (default `0.0`), `contrast: f32`
  (default `1.0`), `saturation: f32` (default `1.0`) fields; added `with_color_correction(b,
  c, s)` consuming builder method with a doc-test; `Clip::new()` sets neutral defaults;
  added 2 unit tests covering defaults and the builder.
- **`Timeline::render_with_progress` (`ff-pipeline`)**: builds `layer_effects` per clip;
  pushes `FilterStep::Eq` only when the values are non-neutral (guarded by
  `#[allow(clippy::float_cmp)]`); passes `effects: layer_effects` to `VideoLayer`.

## Related Issues

Closes #1150

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes