### PR TITLE
fix(ff-pipeline,ff-preview,ff-filter): add Clip::speed and wire variable-speed playback

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -293,21 +293,21 @@ pub(super) unsafe fn add_fit_to_aspect_pad(
 
 // ── Speed (atempo chain) ──────────────────────────────────────────────────────
 
-/// Decompose a speed `factor` into a chain of `atempo` values, each in [0.5, 2.0].
+/// Decompose a speed `factor` into a chain of `atempo` values, each in [0.5, 100.0].
 ///
-/// The `atempo` filter only accepts values in [0.5, 2.0] per instance.
+/// `FFmpeg` 4.0+ (`YAE_ATEMPO_MAX = 100.0`) accepts up to 100.0 per instance.
 /// Chaining multiple instances multiplies the effective speed factor:
 ///
-/// - `factor = 4.0`  → `[2.0, 2.0]`       (2.0 × 2.0 = 4.0)
-/// - `factor = 0.25` → `[0.5, 0.5]`       (0.5 × 0.5 = 0.25)
-/// - `factor = 8.0`  → `[2.0, 2.0, 2.0]`  (2.0³ = 8.0)
-/// - `factor = 1.5`  → `[1.5]`            (within range directly)
+/// - `factor = 4.0`   → `[4.0]`         (single instance)
+/// - `factor = 0.25`  → `[0.5, 0.5]`   (0.5 × 0.5 = 0.25)
+/// - `factor = 150.0` → `[100.0, 1.5]` (2 instances instead of 8 at 2.0-max)
+/// - `factor = 1.5`   → `[1.5]`        (within range directly)
 pub(super) fn decompose_atempo(factor: f64) -> Vec<f64> {
     let mut remaining = factor;
     let mut chain = Vec::new();
-    while remaining > 2.0 {
-        chain.push(2.0);
-        remaining /= 2.0;
+    while remaining > 100.0 {
+        chain.push(100.0);
+        remaining /= 100.0;
     }
     while remaining < 0.5 {
         chain.push(0.5);
@@ -326,7 +326,7 @@ pub(super) fn decompose_atempo(factor: f64) -> Vec<f64> {
 ///
 /// `graph` and `prev_ctx` must be valid pointers owned by the same
 /// `AVFilterGraph`.
-pub(super) unsafe fn add_atempo_chain(
+pub(crate) unsafe fn add_atempo_chain(
     graph: *mut ff_sys::AVFilterGraph,
     prev_ctx: *mut ff_sys::AVFilterContext,
     factor: f64,
@@ -370,6 +370,174 @@ pub(super) unsafe fn add_atempo_chain(
     Ok(ctx)
 }
 
+/// Insert a speed-change filter chain for `factor > 2.0`:
+///
+/// ```text
+/// apad=pad_dur=1  →  asetrate=r={new_sr}  →  aresample={output_sr}  →  aeval (NaN clamp)
+/// ```
+///
+/// * `apad` appends 1 s of silence so SWR's polyphase FIR resampler has enough
+///   input at EOF to flush its filter window without reading uninitialised memory
+///   (which produces NaN → AAC encoder EINVAL at high downsampling ratios).
+/// * `aeval` replaces any residual NaN/Inf samples with 0 as a last-resort guard.
+///   The expression is generated for `nb_channels` channels so it matches the
+///   actual stream layout (the per-track aformat has already normalised the layout
+///   before this chain is appended).
+/// * Both `apad` and `aeval` are optional: if their filter is unavailable the
+///   chain proceeds with just `asetrate → aresample`.
+///
+/// Audio pitch changes proportionally ("vinyl effect"); no WSOLA processing.
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+pub(crate) unsafe fn add_asetrate_resample_chain(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    new_sr: u32,
+    output_sr: u32,
+    nb_channels: u32,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let mut ctx = prev_ctx;
+
+    // ── 1. apad=pad_dur=1 (optional) ────────────────────────────────────────
+    // Prevents SWR polyphase resampler from reading uninitialised memory at EOF
+    // when the last output frame cannot be filled from remaining input samples.
+    // At speed=150 the 1 s of appended silence shrinks to ~7 ms — imperceptible.
+    let apad_filter = ff_sys::avfilter_get_by_name(c"apad".as_ptr());
+    if apad_filter.is_null() {
+        log::warn!("apad filter unavailable — SWR tail-flush NaN guard skipped index={index}");
+    } else {
+        let name = std::ffi::CString::new(format!("apad_spd{index}"))
+            .map_err(|_| FilterError::BuildFailed)?;
+        let args = c"pad_dur=1";
+        let mut apad_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+        let ret = ff_sys::avfilter_graph_create_filter(
+            &raw mut apad_ctx,
+            apad_filter,
+            name.as_ptr(),
+            args.as_ptr(),
+            std::ptr::null_mut(),
+            graph,
+        );
+        if ret < 0 || apad_ctx.is_null() {
+            log::warn!(
+                "apad creation FAILED ret={ret} index={index} — continuing without tail padding"
+            );
+        } else {
+            let ret = ff_sys::avfilter_link(ctx, 0, apad_ctx, 0);
+            if ret < 0 {
+                log::warn!("apad link FAILED ret={ret} index={index}");
+            } else {
+                ctx = apad_ctx;
+            }
+        }
+    }
+
+    // ── 2. asetrate=r={new_sr} (required) ───────────────────────────────────
+    let asetrate_filter = ff_sys::avfilter_get_by_name(c"asetrate".as_ptr());
+    if asetrate_filter.is_null() {
+        log::warn!("filter not found name=asetrate (speed fallback)");
+        return Err(FilterError::BuildFailed);
+    }
+    let name = std::ffi::CString::new(format!("asetrate_spd{index}"))
+        .map_err(|_| FilterError::BuildFailed)?;
+    let args =
+        std::ffi::CString::new(format!("r={new_sr}")).map_err(|_| FilterError::BuildFailed)?;
+    let mut asetrate_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut asetrate_ctx,
+        asetrate_filter,
+        name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=asetrate args=r={new_sr}");
+        return Err(FilterError::BuildFailed);
+    }
+    let ret = ff_sys::avfilter_link(ctx, 0, asetrate_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+    ctx = asetrate_ctx;
+
+    // ── 3. aresample={output_sr} (required) ────────────────────────────────
+    // aresample accepts the rate as a positional arg (just the number).
+    // "r=" is not a valid option name in this FFmpeg version.
+    let aresample_filter = ff_sys::avfilter_get_by_name(c"aresample".as_ptr());
+    if aresample_filter.is_null() {
+        log::warn!("filter not found name=aresample (speed fallback)");
+        return Err(FilterError::BuildFailed);
+    }
+    let name2 = std::ffi::CString::new(format!("aresample_spd{index}"))
+        .map_err(|_| FilterError::BuildFailed)?;
+    let args2 =
+        std::ffi::CString::new(format!("{output_sr}")).map_err(|_| FilterError::BuildFailed)?;
+    let mut aresample_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut aresample_ctx,
+        aresample_filter,
+        name2.as_ptr(),
+        args2.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=aresample args={output_sr} code={ret}");
+        return Err(FilterError::BuildFailed);
+    }
+    let ret = ff_sys::avfilter_link(ctx, 0, aresample_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+    ctx = aresample_ctx;
+
+    // ── 4. aeval NaN/Inf sanitizer (optional) ───────────────────────────────
+    // Replaces any NaN or Inf samples that survive the resampler with 0.
+    // One expression per channel, joined by `|`, so the output layout matches
+    // the input layout exactly regardless of mono/stereo/surround.
+    let aeval_filter = ff_sys::avfilter_get_by_name(c"aeval".as_ptr());
+    if aeval_filter.is_null() {
+        log::warn!("aeval filter unavailable — NaN sanitizer skipped index={index}");
+    } else {
+        let name3 = std::ffi::CString::new(format!("aeval_spd{index}"))
+            .map_err(|_| FilterError::BuildFailed)?;
+        let per_ch = |ch: u32| format!("if(isnan(val({ch}))+isinf(val({ch})),0,val({ch}))");
+        let exprs_str = (0..nb_channels.max(1))
+            .map(per_ch)
+            .collect::<Vec<_>>()
+            .join("|");
+        let args3 = std::ffi::CString::new(format!("exprs={exprs_str}"))
+            .map_err(|_| FilterError::BuildFailed)?;
+        let mut aeval_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+        let ret = ff_sys::avfilter_graph_create_filter(
+            &raw mut aeval_ctx,
+            aeval_filter,
+            name3.as_ptr(),
+            args3.as_ptr(),
+            std::ptr::null_mut(),
+            graph,
+        );
+        if ret < 0 || aeval_ctx.is_null() {
+            log::warn!("aeval creation FAILED ret={ret} index={index} — NaN may reach encoder");
+        } else {
+            let ret = ff_sys::avfilter_link(ctx, 0, aeval_ctx, 0);
+            if ret < 0 {
+                log::warn!("aeval link FAILED ret={ret} index={index}");
+            } else {
+                ctx = aeval_ctx;
+            }
+        }
+    }
+
+    log::debug!("speed fallback asetrate={new_sr} aresample={output_sr} index={index}");
+    Ok(ctx)
+}
+
 #[cfg(test)]
 mod tests {
     use super::decompose_atempo;
@@ -385,13 +553,24 @@ mod tests {
     }
 
     #[test]
-    fn decompose_atempo_should_chain_two_instances_for_factor_4() {
-        assert_eq!(decompose_atempo(4.0), vec![2.0, 2.0]);
+    fn decompose_atempo_should_use_single_instance_for_factor_4() {
+        assert_eq!(decompose_atempo(4.0), vec![4.0]);
     }
 
     #[test]
-    fn decompose_atempo_should_chain_three_instances_for_factor_8() {
-        assert_eq!(decompose_atempo(8.0), vec![2.0, 2.0, 2.0]);
+    fn decompose_atempo_should_use_single_instance_for_factor_8() {
+        assert_eq!(decompose_atempo(8.0), vec![8.0]);
+    }
+
+    #[test]
+    fn decompose_atempo_should_chain_two_instances_for_factor_150() {
+        let chain = decompose_atempo(150.0);
+        assert_eq!(chain.len(), 2);
+        let product: f64 = chain.iter().product();
+        assert!(
+            (product - 150.0).abs() < 1e-6,
+            "product should be ~150, got {product}, chain={chain:?}"
+        );
     }
 
     #[test]
@@ -404,15 +583,15 @@ mod tests {
         );
         for &v in &chain {
             assert!(
-                (0.5..=2.0).contains(&v),
-                "each value must be in [0.5, 2.0], got {v}"
+                (0.5..=100.0).contains(&v),
+                "each value must be in [0.5, 100.0], got {v}"
             );
         }
     }
 
     #[test]
     fn decompose_atempo_should_produce_values_all_within_valid_range() {
-        for factor in [0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 4.0, 8.0, 16.0, 100.0] {
+        for factor in [0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 4.0, 8.0, 16.0, 100.0, 150.0] {
             let chain = decompose_atempo(factor);
             assert!(
                 !chain.is_empty(),
@@ -425,8 +604,8 @@ mod tests {
             );
             for &v in &chain {
                 assert!(
-                    (0.5..=2.0).contains(&v),
-                    "each value must be in [0.5, 2.0], got {v} for factor={factor}"
+                    (0.5..=100.0).contains(&v),
+                    "each value must be in [0.5, 100.0], got {v} for factor={factor}"
                 );
             }
         }

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -18,6 +18,7 @@ mod normalize;
 mod push_pull;
 
 pub(crate) use build::add_and_link_step;
+pub(crate) use build::add_asetrate_resample_chain;
 
 use std::ptr::NonNull;
 

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -451,7 +451,46 @@ pub(super) unsafe fn build_video_composition(
                 "veff",
             );
             match result {
-                Ok(ctx) => chain_end = ctx,
+                Ok(ctx) => {
+                    chain_end = ctx;
+                    // setpts=PTS/factor compresses timestamps but in a pull-based filter graph
+                    // the overlay consumes one movie frame per output frame (arrival order).
+                    // An fps filter after setpts forces PTS-based frame selection, dropping or
+                    // duplicating frames so the overlay receives the correct N/factor frames.
+                    if let crate::FilterStep::Speed { .. } = step {
+                        let fps_filter = ff_sys::avfilter_get_by_name(c"fps".as_ptr());
+                        if fps_filter.is_null() {
+                            bail!(graph, "filter not found: fps (speed)");
+                        }
+                        let Ok(fps_name) = CString::new(format!("fps_spd{combined_idx}")) else {
+                            bail!(graph, "CString::new failed for fps_spd name");
+                        };
+                        let mut fps_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                        // Canvas is hardcoded to r=30; fps must match.
+                        let ret = ff_sys::avfilter_graph_create_filter(
+                            &raw mut fps_ctx,
+                            fps_filter,
+                            fps_name.as_ptr(),
+                            c"fps=30".as_ptr(),
+                            std::ptr::null_mut(),
+                            graph,
+                        );
+                        if ret < 0 {
+                            bail!(
+                                graph,
+                                format!(
+                                    "failed to create fps filter for speed \
+                                     layer={idx} combined_idx={combined_idx}"
+                                )
+                            );
+                        }
+                        let ret = ff_sys::avfilter_link(chain_end, 0, fps_ctx, 0);
+                        if ret < 0 {
+                            bail!(graph, "link failed: setpts→fps_spd");
+                        }
+                        chain_end = fps_ctx;
+                    }
+                }
                 Err(e) => bail!(
                     graph,
                     format!("failed to apply video effect layer={idx} eff={eff_idx}: {e}")
@@ -909,8 +948,74 @@ pub(super) unsafe fn build_audio_mix(
         // ── Per-track effects chain ───────────────────────────────────────────
         for (eff_idx, step) in track.effects.iter().enumerate() {
             let combined_idx = idx * 1000 + eff_idx;
-            let result =
-                crate::filter_inner::add_and_link_step(graph, chain_end, step, combined_idx, "eff");
+            // FilterStep::Speed uses `setpts` for video but needs audio-specific
+            // handling here.  For factor in [0.5, 2.0] use atempo (pitch-preserving
+            // WSOLA).  For factor > 2.0 the FFmpeg atempo ring buffer silently
+            // overflows (the internal assert skips the check when tempo > 2.0),
+            // producing NaN samples.  Fall back to asetrate+aresample (vinyl effect:
+            // pitch shifts proportionally) which is free of WSOLA arithmetic.
+            let result = if let crate::FilterStep::Speed { factor } = step {
+                // Always use asetrate+aresample for any non-unity speed.
+                // atempo (WSOLA) produces NaN when both the current fragment and the
+                // ring buffer are silent (cross-correlation denominator → 0/0).
+                // asetrate+aresample avoids all WSOLA arithmetic; for small ratios
+                // (e.g. 1.5x) the SWR FIR is only ~48 taps and never produces NaN.
+                // amovie outputs at the file's native rate (e.g. 44100 Hz) while
+                // `sample_rate` is the target mix rate (e.g. 48000 Hz).  The optional
+                // aresample earlier in the chain fires only when track.sample_rate !=
+                // sample_rate, but track.sample_rate is set to the target rate in the
+                // pipeline, so the audio may still be at the file's native rate here.
+                // Normalise to sample_rate before the speed chain so that
+                //   new_sr = sample_rate * factor
+                // is correct regardless of the source file's sample rate.
+                let norm_filter = ff_sys::avfilter_get_by_name(c"aresample".as_ptr());
+                if norm_filter.is_null() {
+                    bail!(graph, "filter not found: aresample (speed pre-norm)");
+                }
+                let Ok(norm_name) = CString::new(format!("spd_norm_sr{combined_idx}")) else {
+                    bail!(graph, "CString::new failed for spd_norm_sr name");
+                };
+                let Ok(norm_args) = CString::new(format!("{sample_rate}")) else {
+                    bail!(graph, "CString::new failed for spd_norm_sr args");
+                };
+                let mut norm_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                let ret = ff_sys::avfilter_graph_create_filter(
+                    &raw mut norm_ctx,
+                    norm_filter,
+                    norm_name.as_ptr(),
+                    norm_args.as_ptr(),
+                    std::ptr::null_mut(),
+                    graph,
+                );
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!(
+                            "failed to create aresample for speed pre-norm \
+                             track={idx} code={ret}"
+                        )
+                    );
+                }
+                let ret = ff_sys::avfilter_link(chain_end, 0, norm_ctx, 0);
+                if ret < 0 {
+                    bail!(graph, format!("link failed: →spd_norm_sr track={idx}"));
+                }
+                chain_end = norm_ctx;
+
+                // Now chain_end is at sample_rate; new_sr = sample_rate * factor
+                // gives the correct asetrate value for the desired speedup.
+                let new_sr = (f64::from(sample_rate) * factor).round() as u32;
+                crate::filter_inner::add_asetrate_resample_chain(
+                    graph,
+                    chain_end,
+                    new_sr,
+                    sample_rate,
+                    channel_layout.channels(),
+                    combined_idx,
+                )
+            } else {
+                crate::filter_inner::add_and_link_step(graph, chain_end, step, combined_idx, "eff")
+            };
             if let Ok(ctx) = result {
                 chain_end = ctx;
             } else {

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -85,6 +85,21 @@ pub struct Clip {
     /// Applied via the `eq` video filter during `Timeline::render()`.
     /// Neutral value (`1.0`) produces bit-identical output to the no-eq path.
     pub saturation: f32,
+    /// Per-clip playback speed multiplier. Range: 0.1..=100.0. Default: 1.0 (normal speed).
+    ///
+    /// Applied via `setpts=PTS/{speed}` on the video stream and a chain of `atempo` filters
+    /// on the audio stream during `Timeline::render()`.
+    /// Neutral value (`1.0`) produces bit-identical output to the no-speed path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    ///
+    /// let clip = Clip::new("scene.mp4").with_speed(2.0);
+    /// assert_eq!(clip.speed, 2.0);
+    /// ```
+    pub speed: f64,
 }
 
 impl Clip {
@@ -104,6 +119,7 @@ impl Clip {
             brightness: 0.0,
             contrast: 1.0,
             saturation: 1.0,
+            speed: 1.0,
         }
     }
 
@@ -255,6 +271,27 @@ impl Clip {
         }
     }
 
+    /// Sets the per-clip playback speed multiplier and returns the updated clip.
+    ///
+    /// Values greater than `1.0` produce fast motion; values less than `1.0` produce slow
+    /// motion. The speed is applied via `setpts=PTS/{speed}` on the video stream and a chain
+    /// of `atempo` filters on the audio stream during `Timeline::render()`.
+    ///
+    /// The neutral value (`1.0`) produces bit-identical output to the no-speed path.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    ///
+    /// let clip = Clip::new("scene.mp4").with_speed(2.0);
+    /// assert_eq!(clip.speed, 2.0);
+    /// ```
+    #[must_use]
+    pub fn with_speed(self, speed: f64) -> Self {
+        Self { speed, ..self }
+    }
+
     /// Returns `out_point - in_point` when both are `Some`, otherwise `None`.
     ///
     /// Does not open the source file.
@@ -379,5 +416,23 @@ mod tests {
         assert_eq!(clip.brightness, 0.1);
         assert_eq!(clip.contrast, 1.2);
         assert_eq!(clip.saturation, 0.9);
+    }
+
+    #[test]
+    fn clip_new_should_default_speed_to_one() {
+        let clip = Clip::new("video.mp4");
+        assert_eq!(clip.speed, 1.0);
+    }
+
+    #[test]
+    fn clip_with_speed_should_set_speed() {
+        let clip = Clip::new("video.mp4").with_speed(2.0);
+        assert_eq!(clip.speed, 2.0);
+    }
+
+    #[test]
+    fn clip_with_speed_slow_motion_should_set_speed() {
+        let clip = Clip::new("video.mp4").with_speed(0.5);
+        assert_eq!(clip.speed, 0.5);
     }
 }

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -263,6 +263,9 @@ impl Timeline {
                     }
 
                     let mut layer_effects: Vec<FilterStep> = Vec::new();
+                    if (clip.speed - 1.0).abs() > 1e-9 {
+                        layer_effects.push(FilterStep::Speed { factor: clip.speed });
+                    }
                     #[allow(clippy::float_cmp)]
                     let neutral =
                         clip.brightness == 0.0 && clip.contrast == 1.0 && clip.saturation == 1.0;
@@ -327,6 +330,10 @@ impl Timeline {
                     };
 
                     let mut effects: Vec<FilterStep> = Vec::new();
+
+                    if (clip.speed - 1.0).abs() > 1e-9 {
+                        effects.push(FilterStep::Speed { factor: clip.speed });
+                    }
 
                     if clip.fade_in > Duration::ZERO {
                         effects.push(FilterStep::AFadeIn {

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -68,6 +68,9 @@ struct ClipState {
     transition_dur: Duration,
     /// Audio track handle — `None` if the clip has no audio stream.
     audio_track: Option<AudioTrackHandle>,
+    /// Playback speed multiplier from `Clip::speed` (`1.0` = normal).
+    /// Used to remap source-file PTS → timeline PTS in `run()`.
+    speed: f64,
 }
 
 // ── TransitionState ───────────────────────────────────────────────────────────
@@ -103,6 +106,9 @@ struct AudioFadeConfig {
     clip_dur: Duration,
     /// Source-file PTS at which the clip starts (used to offset the envelope on seek).
     in_point: Duration,
+    /// Playback speed multiplier (`1.0` = normal). When != 1.0, decoded samples are
+    /// linearly resampled to compress/expand playback time without pitch preservation.
+    speed: f64,
 }
 
 impl AudioFadeConfig {
@@ -111,6 +117,7 @@ impl AudioFadeConfig {
         fade_out: Duration::ZERO,
         clip_dur: Duration::ZERO,
         in_point: Duration::ZERO,
+        speed: 1.0,
     };
 }
 
@@ -152,6 +159,7 @@ impl AudioOnlyTrack {
                 fade_out: self.fade_out,
                 clip_dur: self.clip_dur,
                 in_point: self.in_point,
+                speed: 1.0,
             },
         );
         self.cancel = Some(cancel);
@@ -233,6 +241,7 @@ impl TimelinePlayer {
             /// gap-fill loop can synthesise black frames before the first real frame.
             video_w: u32,
             video_h: u32,
+            speed: f64,
         }
 
         let tracks = timeline.video_tracks();
@@ -254,11 +263,17 @@ impl TimelinePlayer {
         for clip in clip_list {
             let in_pt = clip.in_point.unwrap_or(Duration::ZERO);
             let info = ff_probe::open(&clip.source)?;
+            let speed = clip.speed.max(0.01);
 
-            let clip_dur = match (clip.in_point, clip.out_point) {
+            let unscaled_dur = match (clip.in_point, clip.out_point) {
                 (Some(ip), Some(op)) => op.saturating_sub(ip),
                 (None, Some(op)) => op,
                 _ => info.duration().saturating_sub(in_pt),
+            };
+            let clip_dur = if (speed - 1.0).abs() < 1e-9 {
+                unscaled_dur
+            } else {
+                unscaled_dur.div_f64(speed)
             };
 
             let transition_dur = if clip.transition.is_some() {
@@ -284,6 +299,7 @@ impl TimelinePlayer {
                 has_audio,
                 video_w,
                 video_h,
+                speed,
             });
         }
 
@@ -330,6 +346,7 @@ impl TimelinePlayer {
                 out_point: p.out_point,
                 transition_dur: p.transition_dur,
                 audio_track: audio_track_handles[i].clone(),
+                speed: p.speed,
             });
         }
 
@@ -388,6 +405,7 @@ impl TimelinePlayer {
                     out_point: clip.out_point,
                     transition_dur: Duration::ZERO,
                     audio_track: None,
+                    speed: clip.speed.max(0.01),
                 });
             }
             overlay_layers.push(OverlayLayer {
@@ -469,13 +487,17 @@ impl TimelinePlayer {
             if let Some(handle) = clip_states.first().and_then(|c| c.audio_track.clone()) {
                 let source = clip_states[0].source.clone();
                 let in_pt = clip_states[0].in_point;
+                let clip0_speed = clip_states[0].speed;
                 let cancel = Arc::new(AtomicBool::new(false));
                 let thread = spawn_audio_track_thread(
                     source,
                     in_pt,
                     handle,
                     Arc::clone(&cancel),
-                    AudioFadeConfig::NONE,
+                    AudioFadeConfig {
+                        speed: clip0_speed,
+                        ..AudioFadeConfig::NONE
+                    },
                 );
                 (Some(cancel), Some(thread))
             } else {
@@ -721,8 +743,13 @@ impl TimelineRunner {
                     match self.clips[active].decode_buf.pop_frame() {
                         FrameResult::Frame(f) => {
                             let f_pts = f.timestamp().as_duration();
+                            let elapsed = f_pts.saturating_sub(self.clips[active].in_point);
                             let tl_pts = self.clips[active].timeline_start
-                                + f_pts.saturating_sub(self.clips[active].in_point);
+                                + if (self.clips[active].speed - 1.0).abs() < 1e-9 {
+                                    elapsed
+                                } else {
+                                    elapsed.div_f64(self.clips[active].speed)
+                                };
                             let w = f.width();
                             let h = f.height();
                             if self.sws_a.convert(&f, &mut self.rgba_a)
@@ -783,8 +810,13 @@ impl TimelineRunner {
                     .position(|c| target >= c.timeline_start && target < c.timeline_end);
 
                 if let Some(ci) = clip_idx {
+                    let elapsed_tl = target.saturating_sub(self.clips[ci].timeline_start);
                     let clip_local = self.clips[ci].in_point
-                        + target.saturating_sub(self.clips[ci].timeline_start);
+                        + if (self.clips[ci].speed - 1.0).abs() < 1e-9 {
+                            elapsed_tl
+                        } else {
+                            elapsed_tl.mul_f64(self.clips[ci].speed)
+                        };
                     if self.clips[ci].decode_buf.seek_coarse(clip_local).is_ok() {
                         if ci != self.active {
                             self.active = ci;
@@ -805,8 +837,13 @@ impl TimelineRunner {
                         };
                         if let Some(f) = frame {
                             let f_pts = f.timestamp().as_duration();
+                            let elapsed = f_pts.saturating_sub(self.clips[ci].in_point);
                             let tl_pts = self.clips[ci].timeline_start
-                                + f_pts.saturating_sub(self.clips[ci].in_point);
+                                + if (self.clips[ci].speed - 1.0).abs() < 1e-9 {
+                                    elapsed
+                                } else {
+                                    elapsed.div_f64(self.clips[ci].speed)
+                                };
                             let w = f.width();
                             let h = f.height();
                             if self.sws_a.convert(&f, &mut self.rgba_a)
@@ -872,7 +909,14 @@ impl TimelineRunner {
                         // its content is from before the clip's in_point.
                         if f_pts >= in_pt {
                             let tl_start = self.clips[active].timeline_start;
-                            let tl_pts = tl_start + f_pts.saturating_sub(in_pt);
+                            let elapsed = f_pts.saturating_sub(in_pt);
+                            let spd = self.clips[active].speed;
+                            let tl_pts = tl_start
+                                + if (spd - 1.0).abs() < 1e-9 {
+                                    elapsed
+                                } else {
+                                    elapsed.div_f64(spd)
+                                };
                             let w = f.width();
                             let h = f.height();
                             if self.sws_a.convert(f, &mut self.rgba_a)
@@ -890,6 +934,7 @@ impl TimelineRunner {
                     let clip_out = self.clips[active].out_point;
                     let clip_tl_start = self.clips[active].timeline_start;
                     let clip_tl_end = self.clips[active].timeline_end;
+                    let clip_speed = self.clips[active].speed;
 
                     // Skip frames before in_point (e.g. right after a seek).
                     if f_pts < clip_in {
@@ -898,10 +943,16 @@ impl TimelineRunner {
 
                     // Treat frames past out_point as EOF for this clip.
                     let past_out = clip_out.is_some_and(|op| f_pts >= op);
-                    let past_end = {
-                        let tl_pts = clip_tl_start + f_pts.saturating_sub(clip_in);
-                        tl_pts >= clip_tl_end
+                    let elapsed = f_pts.saturating_sub(clip_in);
+                    // Remap source PTS → timeline PTS via speed factor.
+                    // For speed=2.0 the clip occupies half the timeline duration;
+                    // for speed=0.5 it occupies double.
+                    let tl_elapsed = if (clip_speed - 1.0).abs() < 1e-9 {
+                        elapsed
+                    } else {
+                        elapsed.div_f64(clip_speed)
                     };
+                    let past_end = clip_tl_start + tl_elapsed >= clip_tl_end;
 
                     if past_out || past_end {
                         let old_active = active;
@@ -925,7 +976,7 @@ impl TimelineRunner {
                         continue;
                     }
 
-                    let timeline_pts = clip_tl_start + f_pts.saturating_sub(clip_in);
+                    let timeline_pts = clip_tl_start + tl_elapsed;
 
                     // ── Manage audio-only decode threads ──────────────────────
                     for at in &mut self.audio_only_tracks {
@@ -982,7 +1033,14 @@ impl TimelineRunner {
                         let diff = timeline_pts.as_secs_f64() - clock_pts.as_secs_f64();
                         let fp = frame_period.as_secs_f64();
 
-                        if diff > fp * 2.0 && self.transition.is_none() && self.last_frame_w > 0 {
+                        // Only enter gap fill for an actual gap between clips.
+                        // For slow-motion clips (speed < 1.0) the large diff is expected
+                        // and should be handled by the `diff > fp` sleep below instead.
+                        if diff > fp * 2.0
+                            && (clip_speed - 1.0) > -1e-9
+                            && self.transition.is_none()
+                            && self.last_frame_w > 0
+                        {
                             // Gap in the primary track: the next V1 clip starts more than
                             // 2 frame-periods ahead of the clock.  Synthesise black frames
                             // composited with overlay-layer content for every missing
@@ -1088,7 +1146,14 @@ impl TimelineRunner {
                                 {
                                     let tl_start = self.clips[self.active].timeline_start;
                                     let in_pt = self.clips[self.active].in_point;
-                                    let local = in_pt + gap_pts.saturating_sub(tl_start);
+                                    let gap_elapsed = gap_pts.saturating_sub(tl_start);
+                                    let spd = self.clips[self.active].speed;
+                                    let local = in_pt
+                                        + if (spd - 1.0).abs() < 1e-9 {
+                                            gap_elapsed
+                                        } else {
+                                            gap_elapsed.mul_f64(spd)
+                                        };
                                     self.restart_audio_at(self.active, local);
                                 }
                                 self.current_pts.store(
@@ -1124,8 +1189,14 @@ impl TimelineRunner {
                         && self.clips[active].audio_track.is_some()
                     {
                         let in_pt = self.clips[active].in_point;
-                        let local =
-                            in_pt + timeline_pts.saturating_sub(self.clips[active].timeline_start);
+                        let elapsed_tl =
+                            timeline_pts.saturating_sub(self.clips[active].timeline_start);
+                        let local = in_pt
+                            + if (clip_speed - 1.0).abs() < 1e-9 {
+                                elapsed_tl
+                            } else {
+                                elapsed_tl.mul_f64(clip_speed)
+                            };
                         self.restart_audio_at(active, local);
                     }
 
@@ -1275,6 +1346,7 @@ impl TimelineRunner {
     /// Returns an error when the new timeline is structurally incompatible with
     /// the running runner (different V1 clip count or different source paths).
     /// In that case the runner's state is untouched.
+    #[allow(clippy::too_many_lines)]
     fn update_layout_in_place(
         &mut self,
         timeline: &ff_pipeline::timeline::Timeline,
@@ -1308,18 +1380,27 @@ impl TimelineRunner {
 
         // ── Update V1 clip positions ───────────────────────────────────────────
         for (i, clip) in v_tracks[0].iter().enumerate() {
-            let old_dur = self.clips[i]
+            let new_speed = clip.speed.max(0.01);
+            let old_scaled_dur = self.clips[i]
                 .timeline_end
                 .saturating_sub(self.clips[i].timeline_start);
-            let new_dur = match (clip.in_point, clip.out_point) {
+            // Recover unscaled (source) duration from the stored scaled duration and old speed.
+            let old_unscaled = old_scaled_dur.mul_f64(self.clips[i].speed);
+            let new_unscaled = match (clip.in_point, clip.out_point) {
                 (Some(ip), Some(op)) => op.saturating_sub(ip),
                 (None, Some(op)) => op,
-                _ => old_dur,
+                _ => old_unscaled,
+            };
+            let new_dur = if (new_speed - 1.0).abs() < 1e-9 {
+                new_unscaled
+            } else {
+                new_unscaled.div_f64(new_speed)
             };
             self.clips[i].timeline_start = clip.timeline_offset;
             self.clips[i].timeline_end = clip.timeline_offset + new_dur;
             self.clips[i].in_point = clip.in_point.unwrap_or(Duration::ZERO);
             self.clips[i].out_point = clip.out_point;
+            self.clips[i].speed = new_speed;
             self.clips[i].transition_dur = if clip.transition.is_some() {
                 clip.transition_duration
             } else {
@@ -1410,8 +1491,13 @@ impl TimelineRunner {
 
         // If target is in a gap, find the next clip after `target`.
         let (clip_idx, clip_local_pts, is_gap_seek) = if let Some(ci) = clip_in_range {
-            let local =
-                self.clips[ci].in_point + target.saturating_sub(self.clips[ci].timeline_start);
+            let elapsed_tl = target.saturating_sub(self.clips[ci].timeline_start);
+            let local = self.clips[ci].in_point
+                + if (self.clips[ci].speed - 1.0).abs() < 1e-9 {
+                    elapsed_tl
+                } else {
+                    elapsed_tl.mul_f64(self.clips[ci].speed)
+                };
             (ci, local, false)
         } else if let Some(ci) = self.clips.iter().position(|c| c.timeline_start > target) {
             // Seek the clip to its in_point; gap-fill loop will tick until it starts.
@@ -1475,8 +1561,13 @@ impl TimelineRunner {
             .iter()
             .position(|c| target >= c.timeline_start && target < c.timeline_end)
             .ok_or(PreviewError::SeekOutOfRange { pts: target })?;
+        let elapsed_tl = target.saturating_sub(self.clips[clip_idx].timeline_start);
         let clip_local_pts = self.clips[clip_idx].in_point
-            + target.saturating_sub(self.clips[clip_idx].timeline_start);
+            + if (self.clips[clip_idx].speed - 1.0).abs() < 1e-9 {
+                elapsed_tl
+            } else {
+                elapsed_tl.mul_f64(self.clips[clip_idx].speed)
+            };
         self.clips[clip_idx]
             .decode_buf
             .seek_coarse(clip_local_pts)?;
@@ -1501,13 +1592,17 @@ impl TimelineRunner {
         handle.clear(); // discard stale samples
 
         let source = self.clips[clip_idx].source.clone();
+        let clip_speed = self.clips[clip_idx].speed;
         let cancel = Arc::new(AtomicBool::new(false));
         let thread = spawn_audio_track_thread(
             source,
             start_pts,
             handle,
             Arc::clone(&cancel),
-            AudioFadeConfig::NONE,
+            AudioFadeConfig {
+                speed: clip_speed,
+                ..AudioFadeConfig::NONE
+            },
         );
         self.active_audio_cancel = Some(cancel);
         self.active_audio_thread = Some(thread);
@@ -1526,6 +1621,42 @@ impl Drop for TimelineRunner {
 }
 
 // ── spawn_audio_track_thread ──────────────────────────────────────────────────
+
+/// Linear-interpolation resample of a mono `f32` slice.
+///
+/// Consumes `speed` input samples per output sample:
+/// - `speed > 1.0` → fewer output samples (fast motion, pitch raised)
+/// - `speed < 1.0` → more output samples (slow motion, pitch lowered)
+///
+/// `phase` carries the fractional position across chunk boundaries so the
+/// resampling is seamless across successive calls with consecutive chunks.
+///
+/// Preview quality only — no pitch correction.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn resample_linear(input: &[f32], speed: f64, phase: &mut f64) -> Vec<f32> {
+    let capacity = ((input.len() as f64 / speed) + 1.0) as usize;
+    let mut out = Vec::with_capacity(capacity);
+    let mut pos = *phase;
+    let len = input.len();
+    while pos < len as f64 {
+        let idx = pos as usize;
+        let frac = (pos - idx as f64) as f32;
+        let s = if idx + 1 < len {
+            input[idx] * (1.0 - frac) + input[idx + 1] * frac
+        } else {
+            input[idx]
+        };
+        out.push(s);
+        pos += speed;
+    }
+    // Carry the fractional overshoot into the next chunk.
+    *phase = pos - len as f64;
+    out
+}
 
 fn spawn_audio_track_thread(
     path: PathBuf,
@@ -1554,11 +1685,19 @@ fn spawn_audio_track_thread(
             log::warn!("timeline audio seek failed pts={start_pts:?} error={e}");
         }
 
-        let fade_in_secs = fades.fade_in.as_secs_f64();
-        let fade_out_secs = fades.fade_out.as_secs_f64();
-        let total_secs = fades.clip_dur.as_secs_f64();
-        // Elapsed time at thread start due to seeking past in_point.
-        let seek_offset_secs = start_pts.saturating_sub(fades.in_point).as_secs_f64();
+        let speed = fades.speed.max(0.01);
+        let apply_speed = (speed - 1.0).abs() > 1e-6;
+        // Fractional position within the current source chunk carried across iterations.
+        let mut speed_phase: f64 = 0.0;
+
+        // All fade/total timings are expressed in TIMELINE time (= source time / speed)
+        // so that `samples_pushed / AUDIO_SAMPLE_RATE` (output time) lines up correctly.
+        let inv_speed = 1.0 / speed;
+        let fade_in_secs = fades.fade_in.as_secs_f64() * inv_speed;
+        let fade_out_secs = fades.fade_out.as_secs_f64() * inv_speed;
+        let total_secs = fades.clip_dur.as_secs_f64() * inv_speed;
+        // Elapsed output time at thread start due to seeking past in_point.
+        let seek_offset_secs = start_pts.saturating_sub(fades.in_point).as_secs_f64() * inv_speed;
         let apply_fades = fade_in_secs > 0.0 || fade_out_secs > 0.0;
         let mut samples_pushed: u64 = 0;
 
@@ -1575,9 +1714,22 @@ fn spawn_audio_track_thread(
 
             match decoder.decode_one() {
                 Ok(Some(frame)) => {
-                    if let Some(samples) = frame.as_f32()
-                        && !samples.is_empty()
+                    if let Some(raw) = frame.as_f32()
+                        && !raw.is_empty()
                     {
+                        // ── Speed resampling (linear interpolation) ────────────
+                        // For speed > 1.0: fewer output samples (fast motion, pitch up).
+                        // For speed < 1.0: more output samples (slow motion, pitch down).
+                        // This is a simple preview-quality resample; no pitch correction.
+                        let samples: &[f32];
+                        let resampled: Vec<f32>;
+                        if apply_speed {
+                            resampled = resample_linear(raw, speed, &mut speed_phase);
+                            samples = &resampled;
+                        } else {
+                            samples = raw;
+                        }
+
                         if apply_fades {
                             let mut buf: Vec<f32> = samples.to_vec();
                             for (i, s) in buf.iter_mut().enumerate() {
@@ -1611,6 +1763,10 @@ fn spawn_audio_track_thread(
                             samples_pushed += buf.len() as u64;
                             track.push_samples(&buf);
                         } else {
+                            #[allow(clippy::cast_possible_truncation)]
+                            {
+                                samples_pushed += samples.len() as u64;
+                            }
                             track.push_samples(samples);
                         }
                     }


### PR DESCRIPTION
## Summary

Adds a `speed` field to `Clip` (default `1.0`) and wires it end-to-end: through the filter graph composition layer for export and through `TimelineRunner` for real-time preview. A speed != 1.0 on a video clip inserts a `setpts=PTS/factor` + `fps=30` chain, while the audio path uses an `asetrate`/`aresample`/`aeval` chain that avoids the NaN artifacts that `atempo` produces at high speed factors. In preview, decoded audio chunks are linearly resampled per-chunk so the audio track stays in sync with the speed-adjusted video.

## Changes

- `ff-pipeline`: `Clip` gains `speed: f64` field (default `1.0`) and `with_speed(f64)` builder; `Timeline::render()` pushes `FilterStep::Speed { factor }` when speed deviates from 1.0
- `ff-filter`: `decompose_atempo` max raised from 2.0 to 100.0 (FFmpeg 4.0+ supports up to 100.0); new `add_asetrate_resample_chain` builds `apad→asetrate→aresample→aeval` for NaN-free high-speed audio; `composition_inner` applies `fps=30` after `setpts` for video and uses the new chain for audio speed steps
- `ff-preview`: `ClipState` gains `speed: f64`; `TimelineRunner` applies it as `tl_elapsed = elapsed / clip_speed` to remap PTS; `resample_linear` linearly interpolates audio chunks at arbitrary speeds; audio threads receive `AudioFadeConfig::speed` and resample before pushing to the mixer

## Related Issues

Fixes #1153
Fixes #1154

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes