### PR TITLE
chore: release v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.3] - 2026-05-05
+
+### Added
+
+#### ff-pipeline
+- `Clip::volume_db` and `Clip::with_volume_db()`: per-clip audio gain in decibels applied at both export and real-time preview ([#1142](https://github.com/itsakeyfut/avio/issues/1142))
+- `Clip::fade_in`, `Clip::fade_out`, and `Clip::with_audio_fades()`: per-clip audio fade-in/fade-out with live preview envelope ([#1144](https://github.com/itsakeyfut/avio/issues/1144), [#1145](https://github.com/itsakeyfut/avio/issues/1145), [#1146](https://github.com/itsakeyfut/avio/issues/1146))
+- `Clip::brightness`, `Clip::contrast`, `Clip::saturation`, and `Clip::with_color_correction()`: per-clip RGB color correction wired through the `eq` filter on export and `VideoLayer::effects` in preview ([#1150](https://github.com/itsakeyfut/avio/issues/1150))
+- `Clip::speed` and `Clip::with_speed()`: per-clip variable-speed playback; video uses `setpts+fps`, audio uses an `asetrate+aresample+aeval` chain to avoid `atempo` NaN artifacts at high speeds ([#1153](https://github.com/itsakeyfut/avio/issues/1153))
+
+#### ff-filter
+- `VideoLayer::effects`: per-layer `Vec<FilterStep>` applied before the xfade compositor node, enabling per-clip GPU effects in multi-track export ([#1150](https://github.com/itsakeyfut/avio/issues/1150))
+- `FilterStep::Speed { factor }`: new variant; video path inserts `setpts=PTS/factor` + `fps=30`, audio path uses the new asetrate/aresample chain ([#1153](https://github.com/itsakeyfut/avio/issues/1153))
+- `add_asetrate_resample_chain`: new `pub(crate)` helper that builds an `apad→asetrate→aresample→aeval` chain for NaN-free high-speed audio; `decompose_atempo` max raised from 2.0 to 100.0 (FFmpeg 4.0+ cap) ([#1153](https://github.com/itsakeyfut/avio/issues/1153))
+
+#### ff-preview
+- `PlayerHandle::set_rate()` with negative values: reverse playback via per-frame `seek_coarse`, muted audio, and seamless forward-recovery on direction change ([#1136](https://github.com/itsakeyfut/avio/issues/1136), [#1137](https://github.com/itsakeyfut/avio/issues/1137), [#1138](https://github.com/itsakeyfut/avio/issues/1138))
+- `update_timeline()` on `PlayerHandle`: hot-reload a modified `Timeline` layout without restarting the runner ([#1131](https://github.com/itsakeyfut/avio/issues/1131))
+- `ClipState::speed` in `TimelineRunner`: PTS remapping for variable-speed clips with per-chunk linear audio resampling ([#1154](https://github.com/itsakeyfut/avio/issues/1154))
+
+### Fixed
+
+#### ff-preview
+- Frame-stepping while paused: a single decoded frame is now presented to the sink after a seek command arrives while the player is paused ([#1140](https://github.com/itsakeyfut/avio/issues/1140))
+- `SwrContext` was re-allocated on every audio frame, causing crackling; it is now cached and reused across frames ([#1116](https://github.com/itsakeyfut/avio/issues/1116))
+- `MasterClock` was not re-anchored on `Play`, causing accumulated pause-drift to skew A/V sync after long pauses ([#1130](https://github.com/itsakeyfut/avio/issues/1130))
+- `MasterClock` rate scaling was applied twice in `pop_audio_samples`, causing double-speed audio at rates other than 1× ([#1118](https://github.com/itsakeyfut/avio/issues/1118), [#1119](https://github.com/itsakeyfut/avio/issues/1119))
+- `TimelinePlayer` did not composite secondary video tracks (V2/V3) or mix audio-only tracks (A1/A2); both are now handled ([#1121](https://github.com/itsakeyfut/avio/issues/1121), [#1122](https://github.com/itsakeyfut/avio/issues/1122))
+- Overlay z-order was inverted: V1 (primary) is now rendered as foreground, V2/V3 as background ([#1124](https://github.com/itsakeyfut/avio/issues/1124))
+- `TimelineRunner` froze when a gap before the first clip was encountered, stale audio threads were not cancelled on seek, and audio started prematurely for clips beginning after a pre-roll gap ([#1148](https://github.com/itsakeyfut/avio/issues/1148))
+- Partial `in_point`/`out_point` trim bounds caused filter graph build failures; stale audio decoder threads were not cancelled on clip transition ([#1133](https://github.com/itsakeyfut/avio/issues/1133), [#1134](https://github.com/itsakeyfut/avio/issues/1134))
+
+#### ff-encode
+- Audio stream in exported files was missing extradata, causing some players to reject the file; `avcodec_parameters_from_context` is now used after codec open ([#1126](https://github.com/itsakeyfut/avio/issues/1126))
+- Encoder produced truncated audio because sample frames were pushed without buffering; `AVAudioFifo` now accumulates samples to exactly `frame_size` before encoding ([#1127](https://github.com/itsakeyfut/avio/issues/1127), [#1128](https://github.com/itsakeyfut/avio/issues/1128))
+
+#### ff-decode
+- `SwrContext` was re-created on every audio frame, causing audio crackling during `AudioDecoder` iteration ([#1116](https://github.com/itsakeyfut/avio/issues/1116))
+
+---
+
 ## [0.14.2] - 2026-04-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,18 +12,18 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.14.2" }
-ff-common   = { path = "crates/ff-common",   version = "0.14.2" }
-ff-format   = { path = "crates/ff-format",   version = "0.14.2" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.14.2" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.14.2" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.14.2" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.14.2" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.2" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.14.2" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.14.2" }
-ff-render   = { path = "crates/ff-render",   version = "0.14.2" }
-avio        = { path = "crates/avio",         version = "0.14.2" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.14.3" }
+ff-common   = { path = "crates/ff-common",   version = "0.14.3" }
+ff-format   = { path = "crates/ff-format",   version = "0.14.3" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.14.3" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.14.3" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.14.3" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.14.3" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.3" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.14.3" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.14.3" }
+ff-render   = { path = "crates/ff-render",   version = "0.14.3" }
+avio        = { path = "crates/avio",         version = "0.14.3" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.14.2 to 0.14.3 and documents all changes in CHANGELOG.md. This patch release captures bug fixes and incremental API additions surfaced during avio-editor-demo development.

## Changes

- `Cargo.toml`: workspace version 0.14.2 → 0.14.3; all intra-workspace dependency pins updated
- `CHANGELOG.md`: new `[0.14.3]` entry covering 15 merged PRs (#1117–#1155)

## Related Issues

Fixes #1116 #1118 #1119 #1121 #1122 #1124 #1126 #1127 #1128 #1130 #1131 #1133 #1134 #1136 #1137 #1138 #1140 #1142 #1144 #1145 #1146 #1148 #1150 #1153 #1154

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes