### PR TITLE
fix(ff-pipeline,ff-filter,ff-preview): fix V1/V2 overlay compositing in preview

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -101,6 +101,7 @@ fn main() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -116,6 +117,7 @@ fn main() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .build()

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use ff_format::ChannelLayout;
 
 use crate::animation::{AnimatedValue, AnimationEntry};
+use crate::blend::BlendMode;
 use crate::error::FilterError;
 use crate::filter_inner::FilterGraphInner;
 use crate::graph::graph::FilterGraph;
@@ -20,6 +21,32 @@ use crate::graph::types::Rgb;
 
 use super::multi_track_composer::VideoLayer;
 use super::multi_track_mixer::AudioTrack;
+
+/// Maps a `BlendMode` to the `FFmpeg` `blend` filter `all_mode` name.
+///
+/// `BlendMode::Normal` is not handled here; it uses the `overlay` filter instead.
+fn blend_mode_to_ffmpeg(mode: BlendMode) -> &'static str {
+    match mode {
+        BlendMode::Multiply => "multiply",
+        BlendMode::Screen => "screen",
+        BlendMode::Overlay => "overlay",
+        BlendMode::SoftLight => "softlight",
+        BlendMode::HardLight => "hardlight",
+        BlendMode::ColorDodge => "dodge",
+        BlendMode::ColorBurn => "burn",
+        BlendMode::Darken => "darken",
+        BlendMode::Lighten => "lighten",
+        BlendMode::Difference => "difference",
+        BlendMode::Exclusion => "exclusion",
+        BlendMode::Add => "addition",
+        BlendMode::Subtract => "subtract",
+        BlendMode::Hue => "hue",
+        BlendMode::Saturation => "saturation",
+        BlendMode::Color => "color",
+        BlendMode::Luminosity => "luminosity",
+        _ => "normal",
+    }
+}
 
 // ── Video composition graph builder ──────────────────────────────────────────
 
@@ -318,19 +345,22 @@ pub(super) unsafe fn build_video_composition(
 
         // ── Optional opacity ──────────────────────────────────────────────────
         //
-        // Animated opacity: add `format=yuva420p` → `colorchannelmixer aa=<v>`
-        // so that `tick()` can update the alpha plane per-frame via send_command.
-        // The overlay filter must use `format=auto` to blend the alpha channel.
+        // For BlendMode::Normal the opacity is applied via colorchannelmixer so
+        // the overlay filter can blend the alpha channel.
         //
-        // Static opacity < 1.0: legacy path (colorchannelmixer only, no alpha
-        // conversion).  The overlay still receives a yuv420p frame which FFmpeg
-        // handles by treating the fully-opaque layer as semi-transparent via the
-        // colorchannelmixer alpha reduction.
-        let is_animated_opacity = matches!(layer.opacity, AnimatedValue::Track(_));
+        // For photographic blend modes (Multiply, Screen, etc.) opacity is
+        // forwarded to the blend filter's `all_opacity` parameter instead; the
+        // colorchannelmixer step is skipped entirely.
+        let use_blend_filter = !matches!(layer.blend_mode, BlendMode::Normal);
+        let is_animated_opacity =
+            !use_blend_filter && matches!(layer.opacity, AnimatedValue::Track(_));
         let opacity_initial = layer.opacity.value_at(Duration::ZERO).clamp(0.0, 1.0);
+        // True for any Normal-mode layer whose opacity may be < 1.0 (static or animated).
+        // Both cases require yuva420p + colorchannelmixer so the overlay can use alpha blending.
+        let needs_alpha = !use_blend_filter && (is_animated_opacity || opacity_initial < 1.0);
 
-        if is_animated_opacity {
-            // ── format=yuva420p: ensure the alpha plane exists ─────────────────
+        if needs_alpha {
+            // ── format=yuva420p: add alpha plane before colorchannelmixer ─────
             let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
             if fmt_filter.is_null() {
                 bail!(graph, "filter not found: format");
@@ -403,41 +433,6 @@ pub(super) unsafe fn build_video_composition(
                     suffix: "",
                 });
             }
-        } else if opacity_initial < 1.0 {
-            // Static opacity < 1.0: legacy path.
-            let ccm_filter = ff_sys::avfilter_get_by_name(c"colorchannelmixer".as_ptr());
-            if ccm_filter.is_null() {
-                bail!(graph, "filter not found: colorchannelmixer");
-            }
-            let Ok(ccm_name) = CString::new(format!("ccm{idx}")) else {
-                bail!(graph, "CString::new failed for colorchannelmixer name");
-            };
-            let Ok(ccm_args) = CString::new(format!("aa={opacity_initial}")) else {
-                bail!(graph, "CString::new failed for colorchannelmixer args");
-            };
-            let mut ccm_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-            let ret = ff_sys::avfilter_graph_create_filter(
-                &raw mut ccm_ctx,
-                ccm_filter,
-                ccm_name.as_ptr(),
-                ccm_args.as_ptr(),
-                std::ptr::null_mut(),
-                graph,
-            );
-            if ret < 0 {
-                bail!(
-                    graph,
-                    format!("failed to create colorchannelmixer filter layer={idx} code={ret}")
-                );
-            }
-            let ret = ff_sys::avfilter_link(chain_end, 0, ccm_ctx, 0);
-            if ret < 0 {
-                bail!(
-                    graph,
-                    format!("link failed: →colorchannelmixer layer={idx}")
-                );
-            }
-            chain_end = ccm_ctx;
         }
 
         // ── Per-layer video effects ───────────────────────────────────────────
@@ -562,8 +557,92 @@ pub(super) unsafe fn build_video_composition(
         if skip_overlay[idx] {
             // The next layer will xfade from this one; defer the overlay.
             saved_chain = chain_end;
+        } else if use_blend_filter {
+            // ── Photographic blend mode (Multiply, Screen, Overlay, etc.) ────────
+            //
+            // FFmpeg's `blend` filter takes two same-sized inputs and applies a
+            // pixel-level blend operation.  Opacity is forwarded via `all_opacity`.
+            // The `blend` filter does not support positional (x/y) placement.
+            //
+            // Normalise the layer to yuv420p so both inputs share the same format.
+            let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+            if fmt_filter.is_null() {
+                bail!(graph, "filter not found: format (blend pre-norm)");
+            }
+            let Ok(bfmt_name) = CString::new(format!("blend_fmt{idx}")) else {
+                bail!(graph, "CString::new failed for blend format name");
+            };
+            let mut bfmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+            let ret = ff_sys::avfilter_graph_create_filter(
+                &raw mut bfmt_ctx,
+                fmt_filter,
+                bfmt_name.as_ptr(),
+                c"yuv420p".as_ptr(),
+                std::ptr::null_mut(),
+                graph,
+            );
+            if ret < 0 {
+                bail!(
+                    graph,
+                    format!(
+                        "failed to create format filter (blend pre-norm) layer={idx} code={ret}"
+                    )
+                );
+            }
+            let ret = ff_sys::avfilter_link(chain_end, 0, bfmt_ctx, 0);
+            if ret < 0 {
+                bail!(graph, format!("link failed: →blend_fmt layer={idx}"));
+            }
+            chain_end = bfmt_ctx;
+
+            let blend_filter = ff_sys::avfilter_get_by_name(c"blend".as_ptr());
+            if blend_filter.is_null() {
+                bail!(graph, "filter not found: blend");
+            }
+            let Ok(bl_name) = CString::new(format!("blend{idx}")) else {
+                bail!(graph, "CString::new failed for blend name");
+            };
+            let mode_name = blend_mode_to_ffmpeg(layer.blend_mode);
+            let bl_args_str = if (opacity_initial - 1.0).abs() < f64::from(f32::EPSILON) {
+                format!("all_mode={mode_name}")
+            } else {
+                format!("all_mode={mode_name}:all_opacity={opacity_initial:.6}")
+            };
+            let Ok(bl_args) = CString::new(bl_args_str.as_str()) else {
+                bail!(graph, "CString::new failed for blend args");
+            };
+            let mut blend_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+            let ret = ff_sys::avfilter_graph_create_filter(
+                &raw mut blend_ctx,
+                blend_filter,
+                bl_name.as_ptr(),
+                bl_args.as_ptr(),
+                std::ptr::null_mut(),
+                graph,
+            );
+            if ret < 0 {
+                bail!(
+                    graph,
+                    format!(
+                        "failed to create blend filter layer={idx} args={bl_args_str} code={ret}"
+                    )
+                );
+            }
+            // blend pad 0 = bottom (base canvas), pad 1 = top (layer content)
+            let ret = ff_sys::avfilter_link(prev_ctx, 0, blend_ctx, 0);
+            if ret < 0 {
+                bail!(graph, format!("link failed: base→blend[0] layer={idx}"));
+            }
+            let ret = ff_sys::avfilter_link(chain_end, 0, blend_ctx, 1);
+            if ret < 0 {
+                bail!(graph, format!("link failed: layer→blend[1] layer={idx}"));
+            }
+            log::debug!(
+                "video composition layer={idx} blend mode={mode_name} opacity={opacity_initial:.3}"
+            );
+            prev_ctx = blend_ctx;
         } else {
-            // ── overlay ───────────────────────────────────────────────────────────
+            // ── Normal blend mode: overlay ────────────────────────────────────────
             // Last layer uses eof_action=endall so the graph terminates when that
             // layer's source ends.  Intermediate layers use pass so the canvas
             // continues while other layers are still producing.
@@ -583,11 +662,7 @@ pub(super) unsafe fn build_video_composition(
             let needs_eval_frame = matches!(layer.x, AnimatedValue::Track(_))
                 || matches!(layer.y, AnimatedValue::Track(_));
             let eval_suffix = if needs_eval_frame { ":eval=frame" } else { "" };
-            let format_suffix = if is_animated_opacity {
-                ":format=auto"
-            } else {
-                ""
-            };
+            let format_suffix = if needs_alpha { ":format=auto" } else { "" };
             let Ok(ov_args) = CString::new(format!(
                 "{lx}:{ly}:eof_action={eof_action}{eval_suffix}{format_suffix}"
             )) else {

--- a/crates/ff-filter/src/graph/composition/multi_track_composer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_composer.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::animation::AnimatedValue;
+use crate::blend::BlendMode;
 use crate::error::FilterError;
 use crate::graph::graph::FilterGraph;
 use crate::graph::types::{Rgb, XfadeTransition};
@@ -65,6 +66,12 @@ pub struct VideoLayer {
     /// Transition applied at the start of this layer (from the preceding layer on the same z-order).
     /// `None` = hard cut. Set by [`MultiTrackComposer::join_with_dissolve`].
     pub in_transition: Option<ClipTransition>,
+    /// How this layer blends with the layer(s) below it.
+    ///
+    /// [`BlendMode::Normal`] uses the `FFmpeg` `overlay` filter (standard alpha-over composite).
+    /// All other modes use the `FFmpeg` `blend` filter with the corresponding `all_mode`.
+    /// Defaults to [`BlendMode::Normal`].
+    pub blend_mode: BlendMode,
     /// Per-layer video filter steps applied to this layer's decoded stream before compositing.
     ///
     /// Applied in order after trim/setpts/scale/rotate/opacity and before the `overlay` node.
@@ -261,6 +268,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                blend_mode: BlendMode::Normal,
                 effects: vec![],
             })
             .build();
@@ -284,6 +292,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                blend_mode: BlendMode::Normal,
                 effects: vec![],
             })
             .build();
@@ -315,6 +324,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                blend_mode: BlendMode::Normal,
                 effects: vec![],
             })
             .build();
@@ -354,6 +364,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                blend_mode: BlendMode::Normal,
                 effects: vec![],
             })
             .build();
@@ -383,6 +394,7 @@ mod tests {
                 in_point: None,
                 out_point: None,
                 in_transition: None,
+                blend_mode: BlendMode::Normal,
                 effects: vec![],
             })
             .build();

--- a/crates/ff-filter/tests/animation_integration_test.rs
+++ b/crates/ff-filter/tests/animation_integration_test.rs
@@ -158,6 +158,7 @@ fn bezier_position_animation_should_match_reference_curve() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -173,6 +174,7 @@ fn bezier_position_animation_should_match_reference_curve() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .build()

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -93,6 +93,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -108,6 +109,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -123,6 +125,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .build()
@@ -568,6 +571,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -583,6 +587,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .build()
@@ -836,6 +841,7 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
             in_point: None,
             out_point: None,
             in_transition: None,
+            blend_mode: ff_filter::BlendMode::Normal,
             effects: vec![],
         })
         .build()

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ff_filter::XfadeTransition;
+use ff_filter::{BlendMode, XfadeTransition};
 
 /// A single media clip on a timeline.
 ///
@@ -85,6 +85,21 @@ pub struct Clip {
     /// Applied via the `eq` video filter during `Timeline::render()`.
     /// Neutral value (`1.0`) produces bit-identical output to the no-eq path.
     pub saturation: f32,
+    /// Per-clip overlay opacity applied when this clip is composited over a lower layer.
+    /// Range: `0.0` (fully transparent) to `1.0` (fully opaque). Default: `1.0`.
+    ///
+    /// For [`BlendMode::Normal`], opacity is applied via a `colorchannelmixer` filter before
+    /// the overlay. For photographic blend modes, it is forwarded to the `blend` filter's
+    /// `all_opacity` parameter.
+    ///
+    /// Neutral value (`1.0`) produces bit-identical output to the no-opacity path.
+    pub opacity: f32,
+    /// Blend mode for compositing this clip over the layer(s) below it.
+    /// Default: [`BlendMode::Normal`] (standard alpha-over composite).
+    ///
+    /// [`BlendMode::Normal`] uses `FFmpeg`'s `overlay` filter. All other variants use `FFmpeg`'s
+    /// `blend` filter with the corresponding `all_mode`.
+    pub blend_mode: BlendMode,
     /// Per-clip playback speed multiplier. Range: 0.1..=100.0. Default: 1.0 (normal speed).
     ///
     /// Applied via `setpts=PTS/{speed}` on the video stream and a chain of `atempo` filters
@@ -119,6 +134,8 @@ impl Clip {
             brightness: 0.0,
             contrast: 1.0,
             saturation: 1.0,
+            opacity: 1.0,
+            blend_mode: BlendMode::Normal,
             speed: 1.0,
         }
     }
@@ -267,6 +284,50 @@ impl Clip {
             brightness,
             contrast,
             saturation,
+            ..self
+        }
+    }
+
+    /// Sets the overlay opacity and returns the updated clip.
+    ///
+    /// `opacity` is clamped to `[0.0, 1.0]`.  The neutral value (`1.0`) produces
+    /// bit-identical output to the no-opacity path.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    ///
+    /// let clip = Clip::new("overlay.mp4").with_opacity(0.5);
+    /// assert_eq!(clip.opacity, 0.5);
+    /// ```
+    #[must_use]
+    pub fn with_opacity(self, opacity: f32) -> Self {
+        Self {
+            opacity: opacity.clamp(0.0, 1.0),
+            ..self
+        }
+    }
+
+    /// Sets the blend mode for compositing this clip over the layer below and returns
+    /// the updated clip.
+    ///
+    /// [`BlendMode::Normal`] (the default) uses `FFmpeg`'s `overlay` filter.  All other
+    /// variants use `FFmpeg`'s `blend` filter with the corresponding `all_mode`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    /// use ff_filter::BlendMode;
+    ///
+    /// let clip = Clip::new("overlay.mp4").with_blend_mode(BlendMode::Multiply);
+    /// assert_eq!(clip.blend_mode, BlendMode::Multiply);
+    /// ```
+    #[must_use]
+    pub fn with_blend_mode(self, mode: BlendMode) -> Self {
+        Self {
+            blend_mode: mode,
             ..self
         }
     }
@@ -434,5 +495,50 @@ mod tests {
     fn clip_with_speed_slow_motion_should_set_speed() {
         let clip = Clip::new("video.mp4").with_speed(0.5);
         assert_eq!(clip.speed, 0.5);
+    }
+
+    #[test]
+    fn clip_new_should_default_opacity_to_one() {
+        let clip = Clip::new("video.mp4");
+        assert_eq!(clip.opacity, 1.0);
+    }
+
+    #[test]
+    fn clip_with_opacity_should_set_opacity() {
+        let clip = Clip::new("overlay.mp4").with_opacity(0.5);
+        assert_eq!(clip.opacity, 0.5);
+    }
+
+    #[test]
+    fn clip_with_opacity_should_clamp_above_one() {
+        let clip = Clip::new("overlay.mp4").with_opacity(1.5);
+        assert_eq!(clip.opacity, 1.0);
+    }
+
+    #[test]
+    fn clip_with_opacity_should_clamp_below_zero() {
+        let clip = Clip::new("overlay.mp4").with_opacity(-0.5);
+        assert_eq!(clip.opacity, 0.0);
+    }
+
+    #[test]
+    fn clip_new_should_default_blend_mode_to_normal() {
+        use ff_filter::BlendMode;
+        let clip = Clip::new("video.mp4");
+        assert_eq!(clip.blend_mode, BlendMode::Normal);
+    }
+
+    #[test]
+    fn clip_with_blend_mode_should_set_blend_mode() {
+        use ff_filter::BlendMode;
+        let clip = Clip::new("overlay.mp4").with_blend_mode(BlendMode::Multiply);
+        assert_eq!(clip.blend_mode, BlendMode::Multiply);
+    }
+
+    #[test]
+    fn clip_with_blend_mode_screen_should_set_blend_mode() {
+        use ff_filter::BlendMode;
+        let clip = Clip::new("overlay.mp4").with_blend_mode(BlendMode::Screen);
+        assert_eq!(clip.blend_mode, BlendMode::Screen);
     }
 }

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -65,7 +65,7 @@ pub use audio_pipeline::AudioPipeline;
 pub use clip::Clip;
 pub use encoder_config::{EncoderConfig, EncoderConfigBuilder};
 pub use error::PipelineError;
-pub use ff_filter::XfadeTransition;
+pub use ff_filter::{BlendMode, XfadeTransition};
 pub use pipeline::{Pipeline, PipelineBuilder};
 pub use progress::{Progress, ProgressCallback};
 pub use thumbnail::ThumbnailPipeline;

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -277,6 +277,14 @@ impl Timeline {
                         });
                     }
 
+                    // Per-clip opacity overrides the track-level animation when not 1.0.
+                    #[allow(clippy::float_cmp)]
+                    let clip_opacity = if clip.opacity != 1.0 {
+                        AnimatedValue::Static(f64::from(clip.opacity))
+                    } else {
+                        va(track_idx, "opacity", 1.0)
+                    };
+
                     composer = composer.add_layer(VideoLayer {
                         source: clip.source.clone(),
                         x: va(track_idx, "x", 0.0),
@@ -284,7 +292,8 @@ impl Timeline {
                         scale_x: va(track_idx, "scale_x", 1.0),
                         scale_y: va(track_idx, "scale_y", 1.0),
                         rotation: va(track_idx, "rotation", 0.0),
-                        opacity: va(track_idx, "opacity", 1.0),
+                        opacity: clip_opacity,
+                        blend_mode: clip.blend_mode,
                         z_order: u32::try_from(track_idx).unwrap_or(u32::MAX),
                         time_offset: clip.timeline_offset,
                         in_point: clip.in_point,

--- a/crates/ff-preview/src/playback/playback_inner.rs
+++ b/crates/ff-preview/src/playback/playback_inner.rs
@@ -32,11 +32,14 @@ pub(crate) fn audio_frame_to_f32(frame: &AudioFrame) -> Vec<f32> {
 /// reused for subsequent frames with the same dimensions and source pixel format.
 /// A new context is allocated automatically when the frame geometry changes
 /// (uncommon in practice for a single file).
+///
+/// [`convert_to`](Self::convert_to) accepts explicit output dimensions so that overlay
+/// layers can be scaled to match the primary video track's canvas size before compositing.
 pub(crate) struct SwsRgbaConverter {
     /// Nullable: `null` before the first `convert` call or after a geometry change.
     ctx: *mut ff_sys::SwsContext,
-    /// Cached (width, height, format) so geometry changes can be detected.
-    cache_key: Option<(u32, u32, PixelFormat)>,
+    /// Cached `(src_w, src_h, format, dst_w, dst_h)` so geometry changes can be detected.
+    cache_key: Option<(u32, u32, PixelFormat, u32, u32)>,
 }
 
 // SAFETY: `SwsContext` is not thread-safe per the FFmpeg docs, but
@@ -53,22 +56,40 @@ impl SwsRgbaConverter {
         }
     }
 
-    /// Convert `frame` to packed RGBA and write into `dst`.
+    /// Convert `frame` to packed RGBA at its native resolution and write into `dst`.
     ///
     /// Returns `true` on success; `false` when the frame dimensions are zero or
     /// when `sws_getContext` / `sws_scale` fails (failures are logged as `warn`).
     ///
     /// `dst` is resized to `width * height * 4` bytes before writing.
     pub(crate) fn convert(&mut self, frame: &VideoFrame, dst: &mut Vec<u8>) -> bool {
-        let w = frame.width();
-        let h = frame.height();
-        if w == 0 || h == 0 {
+        self.convert_to(frame, dst, frame.width(), frame.height())
+    }
+
+    /// Convert `frame` to packed RGBA scaled to `(dst_w, dst_h)` and write into `dst`.
+    ///
+    /// When `dst_w == frame.width()` and `dst_h == frame.height()` this is identical to
+    /// [`convert`](Self::convert). When the dimensions differ, `libswscale` performs
+    /// bilinear rescaling so the output always matches the requested canvas size.
+    ///
+    /// This is used by overlay layers (V2, V3, …) to match the primary video track's
+    /// resolution before `composite_over` is applied.
+    pub(crate) fn convert_to(
+        &mut self,
+        frame: &VideoFrame,
+        dst: &mut Vec<u8>,
+        dst_w: u32,
+        dst_h: u32,
+    ) -> bool {
+        let src_w = frame.width();
+        let src_h = frame.height();
+        if src_w == 0 || src_h == 0 || dst_w == 0 || dst_h == 0 {
             return false;
         }
         let fmt = frame.format();
-        let key = (w, h, fmt);
+        let key = (src_w, src_h, fmt, dst_w, dst_h);
 
-        // Re-create the context when geometry or format changes.
+        // Re-create the context when geometry, format, or output size changes.
         if self.cache_key.as_ref() != Some(&key) {
             // SAFETY: ctx is either null or was returned by get_context; freeing
             // a null pointer is explicitly documented as safe by free_context.
@@ -80,11 +101,11 @@ impl SwsRgbaConverter {
             // SAFETY: dimensions are > 0 (checked above); formats are valid AV constants.
             match unsafe {
                 ff_sys::swscale::get_context(
-                    w as i32,
-                    h as i32,
+                    src_w as i32,
+                    src_h as i32,
                     src_fmt,
-                    w as i32,
-                    h as i32,
+                    dst_w as i32,
+                    dst_h as i32,
                     dst_fmt,
                     ff_sys::swscale::scale_flags::FAST_BILINEAR,
                 )
@@ -92,7 +113,8 @@ impl SwsRgbaConverter {
                 Ok(ctx) => self.ctx = ctx,
                 Err(code) => {
                     log::warn!(
-                        "sws_getContext failed format={fmt:?} width={w} height={h} code={code}"
+                        "sws_getContext failed format={fmt:?} src={src_w}x{src_h} \
+                         dst={dst_w}x{dst_h} code={code}"
                     );
                     return false;
                 }
@@ -100,8 +122,8 @@ impl SwsRgbaConverter {
             self.cache_key = Some(key);
         }
 
-        let rgba_stride = (w * 4) as usize;
-        let total = rgba_stride * h as usize;
+        let rgba_stride = (dst_w * 4) as usize;
+        let total = rgba_stride * dst_h as usize;
         dst.resize(total, 0u8);
 
         // Collect per-plane pointers and strides from the VideoFrame.
@@ -127,14 +149,14 @@ impl SwsRgbaConverter {
         let dst_strides: [i32; 4] = [dst_stride_val, 0, 0, 0];
 
         // SAFETY: ctx is non-null (created above); src and dst pointers are valid
-        // for the lifetime of this call; buffer sizes match width * height * 4 bytes.
+        // for the lifetime of this call; buffer sizes match dst_w * dst_h * 4 bytes.
         let result = unsafe {
             ff_sys::swscale::scale(
                 self.ctx,
                 src_ptrs.as_ptr(),
                 src_strides.as_ptr(),
                 0,
-                h as i32,
+                src_h as i32,
                 dst_ptrs.as_mut_ptr().cast::<*mut u8>(),
                 dst_strides.as_ptr(),
             )
@@ -142,7 +164,7 @@ impl SwsRgbaConverter {
         match result {
             Ok(_) => true,
             Err(code) => {
-                log::warn!("sws_scale failed width={w} height={h} code={code}");
+                log::warn!("sws_scale failed src={src_w}x{src_h} dst={dst_w}x{dst_h} code={code}");
                 false
             }
         }

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -71,6 +71,10 @@ struct ClipState {
     /// Playback speed multiplier from `Clip::speed` (`1.0` = normal).
     /// Used to remap source-file PTS → timeline PTS in `run()`.
     speed: f64,
+    /// Per-clip opacity for overlay compositing (`1.0` = fully opaque).
+    /// Applied to the RGBA alpha channel after SWS conversion so that
+    /// `composite_over` blends at the correct transparency level.
+    opacity: f32,
 }
 
 // ── TransitionState ───────────────────────────────────────────────────────────
@@ -242,6 +246,7 @@ impl TimelinePlayer {
             video_w: u32,
             video_h: u32,
             speed: f64,
+            opacity: f32,
         }
 
         let tracks = timeline.video_tracks();
@@ -300,6 +305,7 @@ impl TimelinePlayer {
                 video_w,
                 video_h,
                 speed,
+                opacity: clip.opacity.clamp(0.0, 1.0),
             });
         }
 
@@ -347,6 +353,7 @@ impl TimelinePlayer {
                 transition_dur: p.transition_dur,
                 audio_track: audio_track_handles[i].clone(),
                 speed: p.speed,
+                opacity: p.opacity,
             });
         }
 
@@ -406,6 +413,7 @@ impl TimelinePlayer {
                     transition_dur: Duration::ZERO,
                     audio_track: None,
                     speed: clip.speed.max(0.01),
+                    opacity: clip.opacity.clamp(0.0, 1.0),
                 });
             }
             overlay_layers.push(OverlayLayer {
@@ -1108,7 +1116,22 @@ impl TimelineRunner {
                                         let tl_start = layer.clips[cidx].timeline_start;
                                         let v2_pts = tl_start + f_pts.saturating_sub(clip_in);
                                         if v2_pts + Duration::from_millis(50) >= gap_pts {
-                                            layer.sws.convert(&f, &mut layer.rgba);
+                                            // Scale to V1 canvas size so sizes always match.
+                                            layer.sws.convert_to(&f, &mut layer.rgba, gw, gh);
+                                            let op = layer.clips[cidx].opacity;
+                                            if (op - 1.0).abs() > 1e-6 {
+                                                for chunk in layer.rgba.chunks_exact_mut(4) {
+                                                    #[allow(
+                                                        clippy::cast_possible_truncation,
+                                                        clippy::cast_sign_loss
+                                                    )]
+                                                    {
+                                                        chunk[3] = (f32::from(chunk[3]) * op)
+                                                            .round()
+                                                            as u8;
+                                                    }
+                                                }
+                                            }
                                             break;
                                         }
                                     }
@@ -1215,7 +1238,22 @@ impl TimelineRunner {
 
                     let a_ok = self.sws_a.convert(&frame, &mut self.rgba_a);
 
-                    // ── Composite overlay layers: V1 is foreground, V2/V3… are background ──
+                    // Apply per-clip opacity for V1: blend with black background before compositing.
+                    if a_ok {
+                        let v1_op = self.clips[active].opacity;
+                        if (v1_op - 1.0).abs() > 1e-6 {
+                            for chunk in self.rgba_a.chunks_exact_mut(4) {
+                                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                                {
+                                    chunk[0] = (f32::from(chunk[0]) * v1_op).round() as u8;
+                                    chunk[1] = (f32::from(chunk[1]) * v1_op).round() as u8;
+                                    chunk[2] = (f32::from(chunk[2]) * v1_op).round() as u8;
+                                }
+                            }
+                        }
+                    }
+
+                    // ── Composite overlay layers: V1 is background, V2/V3… are composited on top ──
                     // Phase 1: drain each overlay layer to update its decoded rgba buffer.
                     if a_ok {
                         for layer in &mut self.overlay_layers {
@@ -1237,42 +1275,44 @@ impl TimelineRunner {
                                 let tl_start = layer.clips[cidx].timeline_start;
                                 let v2_pts = tl_start + f_pts.saturating_sub(clip_in);
                                 if v2_pts + Duration::from_millis(50) >= timeline_pts {
-                                    layer.sws.convert(&f, &mut layer.rgba);
+                                    // Scale overlay to V1's canvas size so composite_over
+                                    // works even when V1 and V2 have different resolutions.
+                                    layer.sws.convert_to(
+                                        &f,
+                                        &mut layer.rgba,
+                                        self.last_frame_w,
+                                        self.last_frame_h,
+                                    );
+                                    // Apply per-clip opacity to the alpha channel so that
+                                    // composite_over() blends at the correct transparency.
+                                    let op = layer.clips[cidx].opacity;
+                                    if (op - 1.0).abs() > 1e-6 {
+                                        for chunk in layer.rgba.chunks_exact_mut(4) {
+                                            #[allow(
+                                                clippy::cast_possible_truncation,
+                                                clippy::cast_sign_loss
+                                            )]
+                                            {
+                                                chunk[3] = (f32::from(chunk[3]) * op).round() as u8;
+                                            }
+                                        }
+                                    }
                                     break;
                                 }
                             }
                         }
                     }
-                    // Phase 2: build composite — deepest background layer first, V1 on top.
-                    if a_ok {
-                        let base_idx = self
-                            .overlay_layers
-                            .iter()
-                            .enumerate()
-                            .rev()
-                            .find(|(_, l)| !l.rgba.is_empty())
-                            .map(|(i, _)| i);
-                        if let Some(base) = base_idx {
-                            // Seed the background buffer with the deepest layer.
-                            self.blend_buf
-                                .resize(self.overlay_layers[base].rgba.len(), 0);
-                            self.blend_buf
-                                .copy_from_slice(&self.overlay_layers[base].rgba);
-                            // Composite shallower background layers on top (from base-1 to V2).
-                            for i in (0..base).rev() {
-                                if !self.overlay_layers[i].rgba.is_empty() {
-                                    let layer_rgba = self.overlay_layers[i].rgba.clone();
-                                    timeline_inner::composite_over(
-                                        &mut self.blend_buf,
-                                        &layer_rgba,
-                                    );
-                                }
+                    // Phase 2: V1 is background; overlay layers (V2, V3, …) are composited on top.
+                    if a_ok && self.overlay_layers.iter().any(|l| !l.rgba.is_empty()) {
+                        self.blend_buf.resize(self.rgba_a.len(), 0);
+                        self.blend_buf.copy_from_slice(&self.rgba_a);
+                        for layer in &self.overlay_layers {
+                            if !layer.rgba.is_empty() && layer.rgba.len() == self.blend_buf.len() {
+                                let layer_rgba = layer.rgba.clone();
+                                timeline_inner::composite_over(&mut self.blend_buf, &layer_rgba);
                             }
-                            // Composite V1 on top of the background.
-                            timeline_inner::composite_over(&mut self.blend_buf, &self.rgba_a);
-                            // blend_buf now holds the final composite; make it the active frame.
-                            std::mem::swap(&mut self.rgba_a, &mut self.blend_buf);
                         }
+                        std::mem::swap(&mut self.rgba_a, &mut self.blend_buf);
                     }
 
                     if in_trans && a_ok {


### PR DESCRIPTION
## Summary

Fixes four related bugs that caused V2 overlay clips to be invisible in real-time preview when opacity < 1.0. The root causes were: missing `opacity`/`blend_mode` fields on `Clip`, inverted NLE track order (V1 was rendered on top of V2 instead of below), ignored `Clip::opacity` during SWS conversion, and `SwsRgbaConverter` always outputting at source resolution so the size-equality guard in Phase 2 silently skipped all overlay compositing when V1 and V2 had different resolutions.

## Changes

- **`ff-pipeline`** (`clip.rs`, `lib.rs`): `Clip` gains `opacity: f32` (0.0–1.0, default 1.0), `blend_mode: BlendMode` (default Normal), and builder methods `with_opacity()` / `with_blend_mode()`; `BlendMode` re-exported from `ff-pipeline`
- **`ff-filter`** (`multi_track_composer.rs`): `VideoLayer` gains `blend_mode: BlendMode`; all `VideoLayer` literals in tests and integration tests updated
- **`ff-filter`** (`composition_inner.rs`): adds `blend_mode_to_ffmpeg()` mapping; photographic blend modes (Multiply, Screen, etc.) now use FFmpeg's `blend` filter with `all_opacity`; Normal mode continues to use `overlay`; the old duplicate static-opacity path removed, replaced by unified `needs_alpha` flag
- **`ff-preview`** (`playback_inner.rs`): `SwsRgbaConverter::convert_to()` added — accepts explicit `(dst_w, dst_h)` and performs bilinear scaling so overlay frames always match V1's canvas size; cache key expanded to 5-tuple
- **`ff-preview`** (`timeline/mod.rs`): `ClipState` gains `opacity: f32`; overlay Phase 1 uses `convert_to(last_frame_w, last_frame_h)` and scales alpha by `clip.opacity`; V1 opacity applied to RGB channels (blending toward black); Phase 2 corrected — V1 is now the background, V2/V3 are composited on top in ascending track order

## Related Issues

Fixes #1157
Fixes #1158
Fixes #1159
Fixes #1160

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes