### PR TITLE
feat(ff-filter,ff-pipeline): add lavfi overlay support to TimelineBuilder

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -90,6 +90,7 @@ fn main() {
     let mut video_graph = match MultiTrackComposer::new(args.width, args.height)
         .add_layer(VideoLayer {
             source: args.base.clone(),
+            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -106,6 +107,7 @@ fn main() {
         })
         .add_layer(VideoLayer {
             source: args.overlay.clone(),
+            input_format: None,
             x: AnimatedValue::Static(f64::from(overlay_x)),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(0.5),

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -123,15 +123,6 @@ pub(super) unsafe fn build_video_composition(
     let mut saved_chain: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
 
     for (idx, layer) in layers.iter().enumerate() {
-        // On Windows, paths contain backslashes and a drive-letter colon
-        // (e.g. "D:\…").  FFmpeg's filter-option parser uses ":" as a
-        // key=value separator, so the colon must be escaped as "\:".
-        // Forward-slashes are safe on all platforms.
-        let path = layer
-            .source
-            .to_string_lossy()
-            .replace('\\', "/")
-            .replace(':', "\\:");
         let is_last = idx == layer_count - 1;
 
         // ── movie= source ─────────────────────────────────────────────────────
@@ -142,7 +133,22 @@ pub(super) unsafe fn build_video_composition(
         let Ok(movie_name) = CString::new(format!("movie{idx}")) else {
             bail!(graph, "CString::new failed for movie name");
         };
-        let Ok(movie_args) = CString::new(format!("filename={path}")) else {
+        // When input_format is "lavfi", source is a filtergraph string opened via
+        // FFmpeg's lavfi virtual demuxer; escape "\" and ":" for the option parser.
+        // For regular files, normalise Windows backslashes and escape the drive colon.
+        let movie_args_str = if layer.input_format.as_deref() == Some("lavfi") {
+            let lavfi_str = layer.source.to_string_lossy();
+            let escaped = lavfi_str.replace('\\', "\\\\").replace(':', "\\:");
+            format!("filename={escaped}:format_name=lavfi")
+        } else {
+            let path = layer
+                .source
+                .to_string_lossy()
+                .replace('\\', "/")
+                .replace(':', "\\:");
+            format!("filename={path}")
+        };
+        let Ok(movie_args) = CString::new(movie_args_str) else {
             bail!(graph, "CString::new failed for movie args");
         };
         let mut movie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
@@ -160,7 +166,7 @@ pub(super) unsafe fn build_video_composition(
                 format!("failed to create movie filter layer={idx} code={ret}")
             );
         }
-        log::debug!("video composition layer={idx} movie source path={path}");
+        log::debug!("video composition layer={idx} movie source");
         let mut chain_end = movie_ctx;
 
         // ── Optional trim + setpts ────────────────────────────────────────────

--- a/crates/ff-filter/src/graph/composition/multi_track_composer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_composer.rs
@@ -41,8 +41,16 @@ pub struct ClipTransition {
 /// the value at `Duration::ZERO`; per-frame updates are added in issue #363.
 #[derive(Debug, Clone)]
 pub struct VideoLayer {
-    /// Source media file path.
+    /// Source media file path, or a `lavfi` filtergraph string when
+    /// [`input_format`](Self::input_format) is `Some("lavfi")`.
     pub source: PathBuf,
+    /// Optional `FFmpeg` input format name passed to the `movie` filter.
+    ///
+    /// When `Some("lavfi")`, `source` is interpreted as a filtergraph string
+    /// (e.g. `"color=s=1920x1080:c=black@0.0,drawtext=text='Title'"`) and opened
+    /// via `FFmpeg`'s `lavfi` virtual demuxer. When `None` (the default), `source`
+    /// is opened as an ordinary media file.
+    pub input_format: Option<String>,
     /// X offset on the canvas in pixels (top-left origin).
     pub x: AnimatedValue<f64>,
     /// Y offset on the canvas in pixels.
@@ -98,6 +106,7 @@ pub struct VideoLayer {
 /// let mut graph = MultiTrackComposer::new(1920, 1080)
 ///     .add_layer(VideoLayer {
 ///         source: "clip.mp4".into(),
+///         input_format: None,
 ///         x: AnimatedValue::Static(0.0),
 ///         y: AnimatedValue::Static(0.0),
 ///         scale_x: AnimatedValue::Static(1.0),
@@ -109,6 +118,8 @@ pub struct VideoLayer {
 ///         in_point: None,
 ///         out_point: None,
 ///         in_transition: None,
+///         blend_mode: BlendMode::Normal,
+///         effects: vec![],
 ///     })
 ///     .build()?;
 ///
@@ -257,6 +268,7 @@ mod tests {
         let result = MultiTrackComposer::new(0, 1080)
             .add_layer(VideoLayer {
                 source: "clip.mp4".into(),
+                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -281,6 +293,7 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 0)
             .add_layer(VideoLayer {
                 source: "clip.mp4".into(),
+                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -313,6 +326,7 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent_640x480.mp4".into(),
+                input_format: None,
                 x: AnimatedValue::Static(100.0),
                 y: AnimatedValue::Static(100.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -353,6 +367,7 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent.mp4".into(),
+                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -383,6 +398,7 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent.mp4".into(),
+                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),

--- a/crates/ff-filter/tests/animation_integration_test.rs
+++ b/crates/ff-filter/tests/animation_integration_test.rs
@@ -147,6 +147,7 @@ fn bezier_position_animation_should_match_reference_curve() {
     let mut composer = match MultiTrackComposer::new(CANVAS_W, CANVAS_H)
         .add_layer(VideoLayer {
             source: bg_path.clone(),
+            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -163,6 +164,7 @@ fn bezier_position_animation_should_match_reference_curve() {
         })
         .add_layer(VideoLayer {
             source: marker_path.clone(),
+            input_format: None,
             x: AnimatedValue::Track(bezier_track),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -82,6 +82,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
     let mut composer = match MultiTrackComposer::new(CANVAS_W, CANVAS_H)
         .add_layer(VideoLayer {
             source: src1_path.clone(),
+            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -98,6 +99,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
         })
         .add_layer(VideoLayer {
             source: src2_path.clone(),
+            input_format: None,
             x: AnimatedValue::Static(160.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -114,6 +116,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
         })
         .add_layer(VideoLayer {
             source: src3_path.clone(),
+            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(134.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -560,6 +563,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
     let mut composer = match MultiTrackComposer::new(W, H)
         .add_layer(VideoLayer {
             source: bg_path.clone(),
+            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -576,6 +580,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
         })
         .add_layer(VideoLayer {
             source: layer_path.clone(),
+            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -830,6 +835,7 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
     let mut composer = match MultiTrackComposer::new(W, H)
         .add_layer(VideoLayer {
             source: src_path.clone(),
+            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -69,6 +69,15 @@ pub struct Timeline {
     ///
     /// Supported properties: `volume`, `pan`.
     pub(crate) audio_animations: HashMap<String, AnimationTrack<f64>>,
+    /// Optional `lavfi` filtergraph string composited as the topmost video layer.
+    ///
+    /// When set, a [`VideoLayer`] with `input_format = Some("lavfi")` is added above
+    /// all regular video tracks. Use `FFmpeg` `drawtext` syntax to render text titles:
+    ///
+    /// ```text
+    /// color=s=1920x1080:c=black@0.0,drawtext=text='Hello':fontsize=48:fontcolor=white
+    /// ```
+    pub(crate) lavfi_overlay: Option<String>,
 }
 
 impl Timeline {
@@ -186,6 +195,7 @@ impl Timeline {
             audio_tracks,
             video_animations,
             audio_animations,
+            lavfi_overlay,
         } = self;
 
         let nv = video_tracks.len();
@@ -287,6 +297,7 @@ impl Timeline {
 
                     composer = composer.add_layer(VideoLayer {
                         source: clip.source.clone(),
+                        input_format: None,
                         x: va(track_idx, "x", 0.0),
                         y: va(track_idx, "y", 0.0),
                         scale_x: va(track_idx, "scale_x", 1.0),
@@ -320,6 +331,28 @@ impl Timeline {
                     prev_end_by_track.insert(track_idx, end_secs);
                 }
             }
+            // Lavfi overlay sits above all regular tracks.
+            if let Some(ref lavfi_str) = lavfi_overlay {
+                use ff_filter::BlendMode;
+                composer = composer.add_layer(VideoLayer {
+                    source: std::path::PathBuf::from(lavfi_str),
+                    input_format: Some("lavfi".to_string()),
+                    x: AnimatedValue::Static(0.0),
+                    y: AnimatedValue::Static(0.0),
+                    scale_x: AnimatedValue::Static(1.0),
+                    scale_y: AnimatedValue::Static(1.0),
+                    rotation: AnimatedValue::Static(0.0),
+                    opacity: AnimatedValue::Static(1.0),
+                    blend_mode: BlendMode::Normal,
+                    z_order: u32::try_from(nv).unwrap_or(u32::MAX),
+                    time_offset: Duration::ZERO,
+                    in_point: None,
+                    out_point: None,
+                    in_transition: None,
+                    effects: vec![],
+                });
+            }
+
             video_graph = Some(composer.build().map_err(PipelineError::Filter)?);
         }
 
@@ -486,6 +519,8 @@ pub struct TimelineBuilder {
     audio_tracks: Vec<Vec<Clip>>,
     video_animations: HashMap<String, AnimationTrack<f64>>,
     audio_animations: HashMap<String, AnimationTrack<f64>>,
+    /// See [`TimelineBuilder::lavfi_overlay`].
+    lavfi_overlay: Option<String>,
 }
 
 impl Default for TimelineBuilder {
@@ -505,6 +540,7 @@ impl TimelineBuilder {
             audio_tracks: Vec::new(),
             video_animations: HashMap::new(),
             audio_animations: HashMap::new(),
+            lavfi_overlay: None,
         }
     }
 
@@ -581,6 +617,30 @@ impl TimelineBuilder {
         }
     }
 
+    /// Sets an `FFmpeg` `lavfi` filtergraph string that is composited as the topmost
+    /// video layer during rendering.
+    ///
+    /// The string is interpreted by `FFmpeg`'s `lavfi` virtual demuxer via the `movie`
+    /// filter's `format_name=lavfi` option. Use `drawtext` to render text titles, or
+    /// chain multiple filter expressions with `,`:
+    ///
+    /// ```ignore
+    /// builder.lavfi_overlay(
+    ///     "color=s=1920x1080:c=black@0.0,\
+    ///      drawtext=text='Hello World':fontsize=48:fontcolor=white:\
+    ///      x=(w-text_w)/2:y=(h-text_h)/2"
+    /// )
+    /// ```
+    ///
+    /// When not set (the default) no overlay is added and the rendering path is unchanged.
+    #[must_use]
+    pub fn lavfi_overlay(self, filter: impl Into<String>) -> Self {
+        Self {
+            lavfi_overlay: Some(filter.into()),
+            ..self
+        }
+    }
+
     /// Builds the [`Timeline`].
     ///
     /// # Errors
@@ -604,6 +664,7 @@ impl TimelineBuilder {
             audio_tracks: self.audio_tracks,
             video_animations: self.video_animations,
             audio_animations: self.audio_animations,
+            lavfi_overlay: self.lavfi_overlay,
         })
     }
 


### PR DESCRIPTION
## Summary

Adds `TimelineBuilder::lavfi_overlay()` so callers can composite an FFmpeg `lavfi` filtergraph string (e.g. `drawtext`) as the topmost video layer during rendering, without pre-encoding a title clip to a video file. The underlying change is a new `input_format: Option<String>` field on `VideoLayer` that, when set to `"lavfi"`, switches the `movie` filter source from a regular file path to a virtual lavfi demuxer.

## Changes

- **`ff-filter`** (`multi_track_composer.rs`): `VideoLayer` gains `input_format: Option<String>`; `None` = regular file (default), `Some("lavfi")` = FFmpeg lavfi virtual demuxer input; all existing `VideoLayer` literals in tests and examples updated with `input_format: None`
- **`ff-filter`** (`composition_inner.rs`): movie filter args conditioned on `input_format` — lavfi path appends `:format_name=lavfi` and escapes `\` and `:` for the option parser; regular-file path unchanged
- **`ff-pipeline`** (`timeline.rs`): `Timeline` and `TimelineBuilder` gain `lavfi_overlay: Option<String>`; `TimelineBuilder::lavfi_overlay(filter)` sets the string; `render()` appends a `VideoLayer { input_format: Some("lavfi"), z_order: nv, … }` above all regular tracks when the field is set

## Related Issues

Closes #1162

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes