### PR TITLE
fix(ff-filter,ff-pipeline): proxy export, audio filter allowlist, audio graph lifetime

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -90,6 +90,7 @@ fn main() {
     let mut video_graph = match MultiTrackComposer::new(args.width, args.height)
         .add_layer(VideoLayer {
             source: args.base.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
@@ -107,6 +108,7 @@ fn main() {
         })
         .add_layer(VideoLayer {
             source: args.overlay.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(f64::from(overlay_x)),
             y: AnimatedValue::Static(0.0),

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2650,6 +2650,31 @@ impl FilterGraphInner {
                 continue;
             }
 
+            // Only audio-relevant simple steps reach the generic builder. The
+            // compound audio steps (Speed, ParametricEq, ReverbIr, …) are handled
+            // above with `continue`. Any step that reaches here and is NOT in this
+            // allow-list is video-only (e.g. Scale, Crop, Eq); applying a video
+            // filter to the audio buffersrc causes a "Media type mismatch" failure
+            // at graph config time, so skip it.
+            if !matches!(
+                step,
+                FilterStep::AFadeIn { .. }
+                    | FilterStep::AFadeOut { .. }
+                    | FilterStep::Volume(_)
+                    | FilterStep::Amix(_)
+                    | FilterStep::AReverse
+                    | FilterStep::ANoiseGate { .. }
+                    | FilterStep::ACompressor { .. }
+                    | FilterStep::StereoToMono
+                    | FilterStep::ChannelMap { .. }
+                    | FilterStep::ConcatAudio { .. }
+                    | FilterStep::NoiseReduce { .. }
+                    | FilterStep::NoiseReduceProfile { .. }
+            ) {
+                log::debug!("audio graph: skipping non-audio step {step:?}");
+                continue;
+            }
+
             prev_ctx = add_and_link_step(graph, prev_ctx, step, i, "astep")?;
 
             // ConcatAudio consumes n input pads; link src_ctxs[1..n-1] to pads 1..n-1.

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -108,8 +108,14 @@ pub(crate) fn validate_filter_steps(steps: &[FilterStep]) -> Result<(), FilterEr
 /// All fields start as `None`; they are populated lazily on the first
 /// `push_video` / `push_audio` call.
 pub(crate) struct FilterGraphInner {
-    /// The `AVFilterGraph` itself (`None` until the first push call).
+    /// The primary `AVFilterGraph` (`None` until the first push call). Holds the
+    /// video graph when both video and audio are used, or the audio graph for an
+    /// audio-only pipeline.
     graph: Option<NonNull<ff_sys::AVFilterGraph>>,
+    /// Secondary `AVFilterGraph` holding the audio chain when a video graph already
+    /// occupies [`graph`](Self::graph). Video and audio are built into separate
+    /// `AVFilterGraph` allocations; both must be kept alive (and freed in `Drop`).
+    audio_graph: Option<NonNull<ff_sys::AVFilterGraph>>,
     /// One `AVFilterContext` per input slot (video or audio buffersrc).
     src_ctxs: Vec<Option<NonNull<ff_sys::AVFilterContext>>>,
     /// Sink context for video output.
@@ -153,6 +159,7 @@ impl FilterGraphInner {
     pub(crate) fn new(steps: Vec<FilterStep>, hw: Option<HwAccel>) -> Self {
         Self {
             graph: None,
+            audio_graph: None,
             src_ctxs: Vec::new(),
             vsink_ctx: None,
             asink_ctx: None,
@@ -191,6 +198,7 @@ impl FilterGraphInner {
     ) -> Self {
         Self {
             graph: Some(graph),
+            audio_graph: None,
             src_ctxs: Vec::new(),
             vsink_ctx: Some(vsink_ctx),
             asink_ctx: None,
@@ -219,6 +227,7 @@ impl FilterGraphInner {
     ) -> Self {
         Self {
             graph: Some(graph),
+            audio_graph: None,
             src_ctxs: Vec::new(),
             vsink_ctx: None,
             asink_ctx: Some(asink_ctx),

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -315,11 +315,14 @@ impl FilterGraphInner {
                 self.hw.as_ref(),
             ) {
                 Ok((src_ctxs, asink_ctx)) => {
+                    // The audio contexts (src_ctxs, asink_ctx) live inside `graph_nn`.
+                    // When a video graph already occupies `self.graph`, keep the audio
+                    // graph in `self.audio_graph` — freeing it here would leave the
+                    // audio contexts dangling and segfault on the next pull_audio.
                     if self.graph.is_none() {
                         self.graph = Some(graph_nn);
                     } else {
-                        let mut raw = graph_nn.as_ptr();
-                        ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(raw));
+                        self.audio_graph = Some(graph_nn);
                     }
                     let video_slots = self.src_ctxs.len();
                     self.src_ctxs.resize(video_slots + num_inputs, None);
@@ -631,6 +634,15 @@ impl Drop for FilterGraphInner {
             // `vsink_ctx`, and `asink_ctx` must NOT be freed individually.
             // Filter contexts that held `av_buffer_ref` refs to `hw_device_ctx`
             // release those refs here as well.
+            unsafe {
+                let mut raw = ptr.as_ptr();
+                ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(raw));
+            }
+        }
+        // Free the secondary audio graph when present (built when both video and
+        // audio chains are used). Its filter contexts are freed along with it.
+        if let Some(ptr) = self.audio_graph.take() {
+            // SAFETY: non-null `NonNull`, sole owner; frees its attached contexts.
             unsafe {
                 let mut raw = ptr.as_ptr();
                 ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(raw));

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -141,8 +141,12 @@ pub(super) unsafe fn build_video_composition(
             let escaped = lavfi_str.replace('\\', "\\\\").replace(':', "\\:");
             format!("filename={escaped}:format_name=lavfi")
         } else {
-            let path = layer
-                .source
+            // Decode from the proxy file when one is set; otherwise the original source.
+            let decode_path = match &layer.proxy {
+                Some(p) => p.path.as_path(),
+                None => layer.source.as_path(),
+            };
+            let path = decode_path
                 .to_string_lossy()
                 .replace('\\', "/")
                 .replace(':', "\\:");
@@ -168,6 +172,43 @@ pub(super) unsafe fn build_video_composition(
         }
         log::debug!("video composition layer={idx} movie source");
         let mut chain_end = movie_ctx;
+
+        // ── Proxy upscale ─────────────────────────────────────────────────────
+        // When decoding from a proxy, scale the low-resolution frames up to the
+        // original source resolution immediately, so trim/effects/compositing
+        // all operate as if the original were used.
+        if let Some(proxy) = &layer.proxy {
+            let scale_filter = ff_sys::avfilter_get_by_name(c"scale".as_ptr());
+            if scale_filter.is_null() {
+                bail!(graph, "filter not found: scale");
+            }
+            let Ok(ps_name) = CString::new(format!("proxy_scale{idx}")) else {
+                bail!(graph, "CString::new failed for proxy scale name");
+            };
+            let Ok(ps_args) = CString::new(format!("{}:{}", proxy.width, proxy.height)) else {
+                bail!(graph, "CString::new failed for proxy scale args");
+            };
+            let mut ps_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+            let ret = ff_sys::avfilter_graph_create_filter(
+                &raw mut ps_ctx,
+                scale_filter,
+                ps_name.as_ptr(),
+                ps_args.as_ptr(),
+                std::ptr::null_mut(),
+                graph,
+            );
+            if ret < 0 {
+                bail!(
+                    graph,
+                    format!("failed to create proxy scale filter layer={idx} code={ret}")
+                );
+            }
+            let ret = ff_sys::avfilter_link(chain_end, 0, ps_ctx, 0);
+            if ret < 0 {
+                bail!(graph, format!("link failed: movie→proxy_scale layer={idx}"));
+            }
+            chain_end = ps_ctx;
+        }
 
         // ── Optional trim + setpts ────────────────────────────────────────────
         let trim_spec: Option<String> = match (layer.in_point, layer.out_point) {

--- a/crates/ff-filter/src/graph/composition/mod.rs
+++ b/crates/ff-filter/src/graph/composition/mod.rs
@@ -17,6 +17,6 @@ mod video_concatenator;
 
 pub use audio_concatenator::AudioConcatenator;
 pub use clip_joiner::ClipJoiner;
-pub use multi_track_composer::{ClipTransition, MultiTrackComposer, VideoLayer};
+pub use multi_track_composer::{ClipTransition, MultiTrackComposer, ProxySource, VideoLayer};
 pub use multi_track_mixer::{AudioTrack, MultiTrackAudioMixer};
 pub use video_concatenator::VideoConcatenator;

--- a/crates/ff-filter/src/graph/composition/multi_track_composer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_composer.rs
@@ -28,6 +28,24 @@ pub struct ClipTransition {
     pub duration_secs: f64,
 }
 
+// ── ProxySource ───────────────────────────────────────────────────────────────
+
+/// A low-resolution proxy substitute for a [`VideoLayer`]'s source.
+///
+/// When set on [`VideoLayer::proxy`], frames are decoded from [`path`](Self::path)
+/// instead of the layer's `source`, then scaled up to `width` × `height` (the
+/// original source resolution) before any other processing. This lets callers
+/// render from small proxy files for speed while producing full-resolution output.
+#[derive(Debug, Clone)]
+pub struct ProxySource {
+    /// Path to the proxy media file to decode from.
+    pub path: PathBuf,
+    /// Original source width, in pixels. Decoded proxy frames are scaled to this.
+    pub width: u32,
+    /// Original source height, in pixels. Decoded proxy frames are scaled to this.
+    pub height: u32,
+}
+
 // ── VideoLayer ────────────────────────────────────────────────────────────────
 
 /// A single video layer in a [`MultiTrackComposer`] composition.
@@ -44,6 +62,13 @@ pub struct VideoLayer {
     /// Source media file path, or a `lavfi` filtergraph string when
     /// [`input_format`](Self::input_format) is `Some("lavfi")`.
     pub source: PathBuf,
+    /// Optional low-resolution proxy to decode from instead of `source`.
+    ///
+    /// When `Some`, frames are decoded from the proxy and scaled up to the
+    /// original source resolution before trim/effects/compositing, so the
+    /// output is identical in size to a non-proxy render. Ignored when
+    /// [`input_format`](Self::input_format) is `Some("lavfi")`.
+    pub proxy: Option<ProxySource>,
     /// Optional `FFmpeg` input format name passed to the `movie` filter.
     ///
     /// When `Some("lavfi")`, `source` is interpreted as a filtergraph string
@@ -106,6 +131,7 @@ pub struct VideoLayer {
 /// let mut graph = MultiTrackComposer::new(1920, 1080)
 ///     .add_layer(VideoLayer {
 ///         source: "clip.mp4".into(),
+///         proxy: None,
 ///         input_format: None,
 ///         x: AnimatedValue::Static(0.0),
 ///         y: AnimatedValue::Static(0.0),
@@ -268,6 +294,7 @@ mod tests {
         let result = MultiTrackComposer::new(0, 1080)
             .add_layer(VideoLayer {
                 source: "clip.mp4".into(),
+                proxy: None,
                 input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
@@ -293,6 +320,7 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 0)
             .add_layer(VideoLayer {
                 source: "clip.mp4".into(),
+                proxy: None,
                 input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
@@ -326,6 +354,7 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent_640x480.mp4".into(),
+                proxy: None,
                 input_format: None,
                 x: AnimatedValue::Static(100.0),
                 y: AnimatedValue::Static(100.0),
@@ -361,12 +390,51 @@ mod tests {
     }
 
     #[test]
+    fn video_layer_with_proxy_should_insert_scale_filter() {
+        // When a proxy is set, a scale filter is inserted right after the movie
+        // source to upscale to the original resolution. Build fails (nonexistent
+        // file) but must NOT fail at "filter not found: scale".
+        let result = MultiTrackComposer::new(1920, 1080)
+            .add_layer(VideoLayer {
+                source: "nonexistent.mp4".into(),
+                proxy: Some(ProxySource {
+                    path: "nonexistent_proxy_quarter.mp4".into(),
+                    width: 1920,
+                    height: 1080,
+                }),
+                input_format: None,
+                x: AnimatedValue::Static(0.0),
+                y: AnimatedValue::Static(0.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                opacity: AnimatedValue::Static(1.0),
+                z_order: 0,
+                time_offset: Duration::ZERO,
+                in_point: None,
+                out_point: None,
+                in_transition: None,
+                blend_mode: BlendMode::Normal,
+                effects: vec![],
+            })
+            .build();
+        assert!(result.is_err(), "expected error (nonexistent proxy file)");
+        if let Err(FilterError::CompositionFailed { ref reason }) = result {
+            assert!(
+                !reason.contains("filter not found: scale"),
+                "scale filter must exist and be created for proxy upscale; got: {reason}"
+            );
+        }
+    }
+
+    #[test]
     fn video_layer_with_positive_offset_should_insert_setpts() {
         // setpts_offset is inserted when time_offset > 0.
         // Build fails (nonexistent file) but NOT at "filter not found: setpts".
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent.mp4".into(),
+                proxy: None,
                 input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
@@ -398,6 +466,7 @@ mod tests {
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
                 source: "nonexistent.mp4".into(),
+                proxy: None,
                 input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -10,7 +10,7 @@ pub mod types;
 pub use builder::FilterGraphBuilder;
 pub use composition::{
     AudioConcatenator, AudioTrack, ClipJoiner, ClipTransition, MultiTrackAudioMixer,
-    MultiTrackComposer, VideoConcatenator, VideoLayer,
+    MultiTrackComposer, ProxySource, VideoConcatenator, VideoLayer,
 };
 pub use filter_step::FilterStep;
 pub use graph::FilterGraph;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -49,5 +49,6 @@ pub use error::FilterError;
 pub use graph::{
     AudioConcatenator, AudioTrack, ClipJoiner, ClipTransition, DrawTextOptions, EqBand,
     FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, MultiTrackAudioMixer, MultiTrackComposer,
-    Rgb, ScaleAlgorithm, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    ProxySource, Rgb, ScaleAlgorithm, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition,
+    YadifMode,
 };

--- a/crates/ff-filter/tests/animation_integration_test.rs
+++ b/crates/ff-filter/tests/animation_integration_test.rs
@@ -147,6 +147,7 @@ fn bezier_position_animation_should_match_reference_curve() {
     let mut composer = match MultiTrackComposer::new(CANVAS_W, CANVAS_H)
         .add_layer(VideoLayer {
             source: bg_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
@@ -164,6 +165,7 @@ fn bezier_position_animation_should_match_reference_curve() {
         })
         .add_layer(VideoLayer {
             source: marker_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Track(bezier_track),
             y: AnimatedValue::Static(0.0),

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -82,6 +82,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
     let mut composer = match MultiTrackComposer::new(CANVAS_W, CANVAS_H)
         .add_layer(VideoLayer {
             source: src1_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
@@ -99,6 +100,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
         })
         .add_layer(VideoLayer {
             source: src2_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(160.0),
             y: AnimatedValue::Static(0.0),
@@ -116,6 +118,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
         })
         .add_layer(VideoLayer {
             source: src3_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(134.0),
@@ -567,6 +570,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
     let mut composer = match MultiTrackComposer::new(W, H)
         .add_layer(VideoLayer {
             source: bg_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
@@ -584,6 +588,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
         })
         .add_layer(VideoLayer {
             source: layer_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
@@ -841,6 +846,7 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
     let mut composer = match MultiTrackComposer::new(W, H)
         .add_layer(VideoLayer {
             source: src_path.clone(),
+            proxy: None,
             input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -115,6 +115,25 @@ pub struct Clip {
     /// assert_eq!(clip.speed, 2.0);
     /// ```
     pub speed: f64,
+    /// Optional low-resolution proxy file to decode from instead of `source`.
+    ///
+    /// When `Some`, `Timeline::render()` decodes video frames from this proxy and
+    /// scales them up to the original `source` resolution, producing full-resolution
+    /// output while rendering from a smaller, faster-to-decode file. The original
+    /// `source` must still be probeable so its resolution can be determined; if the
+    /// probe fails, the proxy is ignored and `source` is used directly.
+    ///
+    /// Defaults to `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    ///
+    /// let clip = Clip::new("scene.mp4").proxy("scene_proxy_quarter.mp4");
+    /// assert!(clip.proxy.is_some());
+    /// ```
+    pub proxy: Option<PathBuf>,
 }
 
 impl Clip {
@@ -137,6 +156,19 @@ impl Clip {
             opacity: 1.0,
             blend_mode: BlendMode::Normal,
             speed: 1.0,
+            proxy: None,
+        }
+    }
+
+    /// Sets a low-resolution proxy file to decode from and returns the updated clip.
+    ///
+    /// During `Timeline::render()` frames are decoded from `proxy` and scaled up to
+    /// the original `source` resolution. See [`Clip::proxy`](Self::proxy).
+    #[must_use]
+    pub fn proxy(self, proxy: impl AsRef<Path>) -> Self {
+        Self {
+            proxy: Some(proxy.as_ref().to_path_buf()),
+            ..self
         }
     }
 

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -13,7 +13,7 @@ use ff_decode::VideoDecoder;
 use ff_encode::VideoEncoder;
 use ff_filter::{
     AnimatedValue, AnimationTrack, AudioTrack, FilterStep, MultiTrackAudioMixer,
-    MultiTrackComposer, VideoLayer,
+    MultiTrackComposer, ProxySource, VideoLayer,
 };
 use ff_format::ChannelLayout;
 
@@ -295,8 +295,30 @@ impl Timeline {
                         va(track_idx, "opacity", 1.0)
                     };
 
+                    // When a proxy is set, probe the original source resolution so
+                    // the decoded proxy frames can be scaled back up to full size.
+                    // If the probe fails the proxy is ignored (original used directly).
+                    let proxy =
+                        clip.proxy.as_ref().and_then(|proxy_path| {
+                            match VideoDecoder::open(&clip.source).build() {
+                                Ok(dec) => Some(ProxySource {
+                                    path: proxy_path.clone(),
+                                    width: dec.width(),
+                                    height: dec.height(),
+                                }),
+                                Err(e) => {
+                                    log::warn!(
+                                        "proxy ignored: cannot probe source {} resolution: {e}",
+                                        clip.source.display()
+                                    );
+                                    None
+                                }
+                            }
+                        });
+
                     composer = composer.add_layer(VideoLayer {
                         source: clip.source.clone(),
+                        proxy,
                         input_format: None,
                         x: va(track_idx, "x", 0.0),
                         y: va(track_idx, "y", 0.0),
@@ -336,6 +358,7 @@ impl Timeline {
                 use ff_filter::BlendMode;
                 composer = composer.add_layer(VideoLayer {
                     source: std::path::PathBuf::from(lavfi_str),
+                    proxy: None,
                     input_format: Some("lavfi".to_string()),
                     x: AnimatedValue::Static(0.0),
                     y: AnimatedValue::Static(0.0),


### PR DESCRIPTION
## Summary

Fixes three related bugs that prevented proxy-based editing workflows from functioning correctly. Clips with a proxy file now decode from the proxy and scale up to the original resolution on export. Video-only filter steps no longer pollute the audio graph (fixing "Media type mismatch"). The audio `AVFilterGraph` is no longer freed while its contexts are still live (fixing `STATUS_ACCESS_VIOLATION`).

## Changes

- **`ff-pipeline`** (`clip.rs`): `Clip` gains `proxy: Option<PathBuf>` and `Clip::proxy()` builder; `Timeline::render()` probes the original source resolution when a proxy is set and constructs a `ProxySource` forwarded to `VideoLayer`
- **`ff-filter`** (`multi_track_composer.rs`): new `ProxySource { path, width, height }` struct; `VideoLayer` gains `proxy: Option<ProxySource>`; unit test `video_layer_with_proxy_should_insert_scale_filter` verifies the `scale` filter is created; all existing `VideoLayer` literals updated with `proxy: None`
- **`ff-filter`** (`composition_inner.rs`): when `layer.proxy` is set, the `movie` source uses the proxy path; a `scale=W:H` filter node is inserted immediately after to upscale frames to the original resolution before any other processing
- **`ff-filter`** (`filter_inner/build.rs`): added an audio-only allowlist guard before `add_and_link_step` in the audio graph builder; video-only steps (Scale, Crop, Eq, etc.) are skipped with a `debug!` log instead of causing "Media type mismatch" at graph config time
- **`ff-filter`** (`filter_inner/mod.rs`, `push_pull.rs`): `FilterGraphInner` gains `audio_graph: Option<NonNull<AVFilterGraph>>`; when a video graph already occupies `self.graph`, the audio graph is stored separately instead of being freed; `Drop` frees both graphs in the correct order

## Related Issues

Fixes #1178
Fixes #1179
Fixes #1180

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes