### PR TITLE
feat(ff-filter,ff-pipeline): LUT path escaping and per-clip video/audio effect chains

### DIFF
--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -9,6 +9,17 @@ use super::types::{
 use crate::animation::AnimatedValue;
 use crate::blend::BlendMode;
 
+/// Escapes a filesystem path for use as a value inside an `FFmpeg` filter
+/// argument string (e.g. `lut3d`'s `file=` option).
+///
+/// `FFmpeg`'s filter-argument parser treats `:` as an option separator and `\`
+/// as an escape character, so Windows paths like `D:\dir\file.cube` break the
+/// parser. Normalising backslashes to forward slashes (accepted on Windows) and
+/// escaping the drive colon as `\:` yields a value the parser accepts.
+pub(crate) fn escape_filter_path(path: &str) -> String {
+    path.replace('\\', "/").replace(':', "\\:")
+}
+
 // ── FilterStep ────────────────────────────────────────────────────────────────
 
 /// A single step in a filter chain.
@@ -1022,7 +1033,9 @@ impl FilterStep {
             // bypassed in favour of add_parametric_eq_chain); provided here for
             // completeness using the first band's args.
             Self::ParametricEq { bands } => bands.first().map(EqBand::args).unwrap_or_default(),
-            Self::Lut3d { path } => format!("file={path}:interp=trilinear"),
+            Self::Lut3d { path } => {
+                format!("file={}:interp=trilinear", escape_filter_path(path))
+            }
             Self::Eq {
                 brightness,
                 contrast,
@@ -1476,5 +1489,39 @@ impl FilterStep {
                 "threshold={threshold_linear}:ratio={ratio}:attack={attack_ms}:release={release_ms}"
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_filter_path_should_escape_windows_drive_path() {
+        // Backslashes → forward slashes; the drive colon is escaped as `\:` so
+        // FFmpeg's filter-arg parser does not treat it as an option separator.
+        assert_eq!(
+            escape_filter_path(r"D:\dir\look.cube"),
+            "D\\:/dir/look.cube"
+        );
+    }
+
+    #[test]
+    fn escape_filter_path_should_leave_unix_path_unchanged() {
+        assert_eq!(escape_filter_path("/home/u/look.cube"), "/home/u/look.cube");
+    }
+
+    #[test]
+    fn lut3d_args_should_escape_path() {
+        let step = FilterStep::Lut3d {
+            path: r"D:\luts\look.cube".to_string(),
+        };
+        let args = step.args();
+        assert!(
+            !args.contains(r"D:\"),
+            "raw Windows path must not appear unescaped in args: {args}"
+        );
+        assert!(args.contains("D\\:/luts/look.cube"), "got: {args}");
+        assert!(args.ends_with(":interp=trilinear"));
     }
 }

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ff_filter::{BlendMode, XfadeTransition};
+use ff_filter::{BlendMode, FilterStep, XfadeTransition};
 
 /// A single media clip on a timeline.
 ///
@@ -134,6 +134,20 @@ pub struct Clip {
     /// assert!(clip.proxy.is_some());
     /// ```
     pub proxy: Option<PathBuf>,
+    /// Ordered per-clip video filter steps applied to the clip's video layer.
+    ///
+    /// Applied during `Timeline::render()` after the built-in speed and
+    /// colour-correction steps, allowing callers to attach any video
+    /// [`FilterStep`] (e.g. `Lut3d`, `Curves`, `ChromaKey`, `GBlur`) to a
+    /// single clip. An empty vec (the default) is a no-op.
+    pub video_effects: Vec<FilterStep>,
+    /// Ordered per-clip audio filter steps applied to the clip's audio track.
+    ///
+    /// Applied during the audio mix after the built-in speed and fade steps,
+    /// allowing callers to attach any audio [`FilterStep`] (e.g. `ACompressor`,
+    /// `ParametricEq`, `NoiseReduce`) to a single clip. An empty vec (the
+    /// default) is a no-op.
+    pub audio_effects: Vec<FilterStep>,
 }
 
 impl Clip {
@@ -157,7 +171,40 @@ impl Clip {
             blend_mode: BlendMode::Normal,
             speed: 1.0,
             proxy: None,
+            video_effects: Vec::new(),
+            audio_effects: Vec::new(),
         }
+    }
+
+    /// Attaches a video [`FilterStep`] to this clip and returns the updated clip.
+    ///
+    /// Steps are applied in the order added, after the built-in speed and
+    /// colour-correction steps, during `Timeline::render()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    /// use ff_filter::FilterStep;
+    ///
+    /// let clip = Clip::new("scene.mp4")
+    ///     .with_video_effect(FilterStep::Lut3d { path: "look.cube".into() });
+    /// assert_eq!(clip.video_effects.len(), 1);
+    /// ```
+    #[must_use]
+    pub fn with_video_effect(mut self, step: FilterStep) -> Self {
+        self.video_effects.push(step);
+        self
+    }
+
+    /// Attaches an audio [`FilterStep`] to this clip and returns the updated clip.
+    ///
+    /// Steps are applied in the order added, after the built-in speed and fade
+    /// steps, during the audio mix.
+    #[must_use]
+    pub fn with_audio_effect(mut self, step: FilterStep) -> Self {
+        self.audio_effects.push(step);
+        self
     }
 
     /// Sets a low-resolution proxy file to decode from and returns the updated clip.

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -286,6 +286,9 @@ impl Timeline {
                             saturation: clip.saturation,
                         });
                     }
+                    // Caller-attached per-clip video effects run last (after the
+                    // built-in speed/colour-correction steps).
+                    layer_effects.extend(clip.video_effects.iter().cloned());
 
                     // Per-clip opacity overrides the track-level animation when not 1.0.
                     #[allow(clippy::float_cmp)]
@@ -444,6 +447,10 @@ impl Timeline {
                             }
                         }
                     }
+
+                    // Caller-attached per-clip audio effects run last (after the
+                    // built-in speed/fade steps).
+                    effects.extend(clip.audio_effects.iter().cloned());
 
                     mixer = mixer.add_track(AudioTrack {
                         source: clip.source.clone(),


### PR DESCRIPTION
## Summary

Fixes LUT export on Windows and adds general per-clip effect chain support. `FilterStep::Lut3d` was generating `file=D:\luts\look.cube:interp=trilinear` which FFmpeg's filter-argument parser misinterprets (`:` is an option separator, `\` is an escape character). The fix normalises backslashes to forward slashes and escapes the drive colon. Additionally, `Clip` now exposes `video_effects` and `audio_effects` fields with `with_video_effect()` / `with_audio_effect()` builder methods so any `FilterStep` can be attached directly to a clip.

## Changes

- **`ff-filter`** (`filter_step.rs`): new `pub(crate) escape_filter_path()` helper that normalises Windows paths for FFmpeg's filter-argument parser; `FilterStep::Lut3d` args now run through this helper; three unit tests (`escape_filter_path_should_escape_windows_drive_path`, `_leave_unix_path_unchanged`, `lut3d_args_should_escape_path`)
- **`ff-pipeline`** (`clip.rs`): `Clip` gains `video_effects: Vec<FilterStep>` and `audio_effects: Vec<FilterStep>` (default empty); `with_video_effect()` / `with_audio_effect()` consuming builders with `#[must_use]` and doc-tests
- **`ff-pipeline`** (`timeline.rs`): `render()` extends `layer_effects` with `clip.video_effects` (after built-in speed/colour-correction) and extends audio `effects` with `clip.audio_effects` (after built-in speed/fade)

## Related Issues

Fixes #1182
Closes #1186

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes