### PR TITLE
fix(avio): add missing ProxySource re-export

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -268,8 +268,8 @@ pub use ff_filter::{
     BlendMode, ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile, Lerp,
     LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
-    QualityMetrics, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator,
-    VideoLayer, XfadeTransition, YadifMode,
+    ProxySource, QualityMetrics, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap,
+    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`ProxySource` was added to `ff-filter` in PR #1181 and re-exported from `ff-filter::lib` and `ff-filter::graph::mod`, but was not added to the `avio` facade crate's `#[cfg(feature = "filter")]` re-export block. Users of the `avio` crate who needed `ProxySource` (e.g. to construct `VideoLayer::proxy`) had to import from `ff-filter` directly.

## Changes

- `avio/src/lib.rs`: `ProxySource` added to the `#[cfg(feature = "filter")] pub use ff_filter` block

## Related Issues

Resolves #1181

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes