### PR TITLE
chore(ff-encode,ff-preview): fix bench compilation errors from API changes

### DIFF
--- a/crates/ff-encode/benches/encode_bench.rs
+++ b/crates/ff-encode/benches/encode_bench.rs
@@ -46,7 +46,6 @@ fn bench_encode_single_frame(c: &mut Criterion) {
             || {
                 let output_path = bench_output_path("bench_single_frame.mp4");
                 let encoder = VideoEncoder::create(&output_path)
-                    .expect("Failed to create encoder builder")
                     .video(640, 480, 30.0)
                     .video_codec(VideoCodec::Mpeg4)
                     .preset(Preset::Ultrafast)
@@ -81,7 +80,6 @@ fn bench_encode_multiple_frames(c: &mut Criterion) {
                         let output_path =
                             bench_output_path(&format!("bench_{}_frames.mp4", frame_count));
                         let encoder = VideoEncoder::create(&output_path)
-                            .expect("Failed to create encoder builder")
                             .video(640, 480, 30.0)
                             .video_codec(VideoCodec::Mpeg4)
                             .preset(Preset::Ultrafast)
@@ -121,12 +119,12 @@ fn bench_encode_resolutions(c: &mut Criterion) {
         group.bench_with_input(
             BenchmarkId::from_parameter(name),
             &(*width, *height),
-            |b, &(width, height)| {
+            |b, dims: &(u32, u32)| {
+                let (width, height) = *dims;
                 b.iter_batched(
                     || {
                         let output_path = bench_output_path(&format!("bench_{}.mp4", name));
                         let encoder = VideoEncoder::create(&output_path)
-                            .expect("Failed to create encoder builder")
                             .video(width, height, 30.0)
                             .video_codec(VideoCodec::Mpeg4)
                             .preset(Preset::Ultrafast)
@@ -169,7 +167,6 @@ fn bench_encode_presets(c: &mut Criterion) {
                 || {
                     let output_path = bench_output_path(&format!("bench_{}.mp4", name));
                     let encoder = VideoEncoder::create(&output_path)
-                        .expect("Failed to create encoder builder")
                         .video(640, 480, 30.0)
                         .video_codec(VideoCodec::Mpeg4)
                         .preset(preset)
@@ -202,7 +199,6 @@ fn bench_encoder_creation(c: &mut Criterion) {
         b.iter(|| {
             let output_path = bench_output_path("bench_creation.mp4");
             let encoder = VideoEncoder::create(black_box(&output_path))
-                .expect("Failed to create encoder builder")
                 .video(640, 480, 30.0)
                 .video_codec(VideoCodec::Mpeg4)
                 .preset(Preset::Ultrafast)
@@ -223,7 +219,6 @@ fn bench_complete_workflow(c: &mut Criterion) {
         b.iter(|| {
             let output_path = bench_output_path("bench_workflow.mp4");
             let mut encoder = VideoEncoder::create(black_box(&output_path))
-                .expect("Failed to create encoder builder")
                 .video(640, 480, 30.0)
                 .video_codec(VideoCodec::Mpeg4)
                 .preset(Preset::Ultrafast)

--- a/crates/ff-preview/benches/preview_bench.rs
+++ b/crates/ff-preview/benches/preview_bench.rs
@@ -91,15 +91,17 @@ fn bench_1080p_sync_playback(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let buf = Arc::new(Mutex::new(Vec::<(Instant, Duration)>::new()));
-                let player = PreviewPlayer::open(&path).expect("failed to open player");
-                (player, buf)
+                let (runner, handle) = PreviewPlayer::open(&path)
+                    .expect("failed to open player")
+                    .split();
+                (runner, handle, buf)
             },
-            |(mut player, buf)| {
-                player.set_sink(Box::new(TimingSink {
+            |(mut runner, handle, buf)| {
+                runner.set_sink(Box::new(TimingSink {
                     buf: Arc::clone(&buf),
                 }));
-                player.play();
-                let _ = player.run();
+                handle.play();
+                let _ = runner.run();
 
                 // 30 fps → ~33 ms per frame
                 let frame_period = Duration::from_secs_f64(1.0 / 30.0);
@@ -151,16 +153,16 @@ fn bench_1080p_async_playback(c: &mut Criterion) {
                 let p = path.clone();
                 rt.block_on(async move {
                     let _ = tokio::task::spawn_blocking(move || {
-                        let mut player = match PreviewPlayer::open(&p) {
-                            Ok(player) => player,
+                        let (mut runner, handle) = match PreviewPlayer::open(&p) {
+                            Ok(player) => player.split(),
                             Err(e) => {
                                 println!("skip: {e}");
                                 return;
                             }
                         };
-                        player.set_sink(Box::new(TimingSink { buf: buf_inner }));
-                        player.play();
-                        let _ = player.run();
+                        runner.set_sink(Box::new(TimingSink { buf: buf_inner }));
+                        handle.play();
+                        let _ = runner.run();
                     })
                     .await;
                 });


### PR DESCRIPTION
## Summary

Two bench files failed to compile with `cargo check --all-targets` due to API changes that were never reflected in the bench code. `encode_bench.rs` called `.expect()` on `VideoEncoderBuilder` (which is now returned directly by `VideoEncoder::create()`, not wrapped in `Result`), and `preview_bench.rs` still used the old monolithic `PreviewPlayer` API that was split into `PlayerRunner` + `PlayerHandle` in PR #1021.

## Changes

- **`ff-encode/benches/encode_bench.rs`**: removed `.expect("Failed to create encoder builder")` from all 6 `VideoEncoder::create(...)` call sites — the builder is returned directly and the call is infallible; fixed E0282 type-inference failure in `bench_encode_resolutions` by changing `|b, &(width, height)|` to `|b, dims: &(u32, u32)|` with explicit destructuring inside the closure body
- **`ff-preview/benches/preview_bench.rs`**: updated sync bench (`bench_1080p_sync_playback`) to call `PreviewPlayer::open(...).split()` in the setup closure and return `(runner, handle, buf)`; measurement closure now calls `runner.set_sink()`, `handle.play()`, `runner.run()`; async bench (`bench_1080p_async_playback`) updated equivalently inside `spawn_blocking`

## Related Issues

Closes #1189
Closes #1190

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes