### PR TITLE
chore: silence unsafe_code and unused_import warnings in tests and example

### DIFF
--- a/crates/ff-decode/tests/memory_usage_tests.rs
+++ b/crates/ff-decode/tests/memory_usage_tests.rs
@@ -9,6 +9,8 @@
 
 // Tests are allowed to use unwrap() for simplicity
 #![allow(clippy::unwrap_used)]
+// Platform memory queries require the Win32 process API.
+#![allow(unsafe_code)]
 
 use std::path::PathBuf;
 use std::time::Duration;

--- a/crates/ff-encode/examples/list_encoders.rs
+++ b/crates/ff-encode/examples/list_encoders.rs
@@ -2,6 +2,9 @@
 //!
 //! This example shows which video encoders are available in the current FFmpeg build.
 
+// Querying FFmpeg for available encoders requires unsafe FFI calls.
+#![allow(unsafe_code)]
+
 fn main() {
     unsafe {
         ff_sys::ensure_initialized();

--- a/crates/ff-stream/tests/live_abr_ladder_tests.rs
+++ b/crates/ff-stream/tests/live_abr_ladder_tests.rs
@@ -12,7 +12,7 @@
 mod fixtures;
 
 use ff_format::{PixelFormat, PooledBuffer, Timestamp, VideoFrame};
-use ff_stream::{AbrRendition, LiveAbrFormat, LiveAbrLadder, StreamError, StreamOutput};
+use ff_stream::{AbrRendition, LiveAbrLadder, StreamError, StreamOutput};
 use fixtures::{DirGuard, tmp_dir};
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary

Silence the unsafe_code and unused_imports warnings emitted during cargo test / cargo build for two test targets and one example.

## Changes
- crates/ff-decode/tests/memory_usage_test.rs: add #![allow(unsafe_code)]
- crates/ff-decode/tests/list_encoders.rs: add #![allow(unsafe_code)]
- crates/ff-stream/tests/live_abr_ladder_tests.rs: remove the unused LiveAbrFormat import

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
