### PR TITLE
fix(avio): re-export ClipTransition from the filter feature block

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -265,9 +265,9 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 #[cfg(feature = "filter")]
 pub use ff_filter::{
     AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
-    BlendMode, ClipJoiner, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
-    FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile, Lerp,
-    LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
+    BlendMode, ClipJoiner, ClipTransition, DrawTextOptions, Easing, EqBand, FilterError,
+    FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile,
+    Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
     ProxySource, QualityMetrics, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap,
     VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };
@@ -509,6 +509,16 @@ mod tests {
     fn filter_error_should_be_accessible() {
         let _: FilterError = FilterError::BuildFailed;
         let _: FilterError = FilterError::ProcessFailed;
+    }
+
+    #[cfg(feature = "filter")]
+    #[test]
+    fn filter_clip_transition_should_be_accessible() {
+        let _: ClipTransition = ClipTransition {
+            kind: XfadeTransition::Dissolve,
+            offset_secs: 0.0,
+            duration_secs: 1.0,
+        };
     }
 
     // ── pipeline feature ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`ClipTransition` is a public type exported from `ff-filter`, but the `avio` facade's `#[cfg(feature = "filter")]` re-export block omitted it. Downstream crates using the facade with the `filter` feature had to add a direct `ff-filter` dependency just to name `ClipTransition` — this PR adds it to the facade so the dependency isn't needed.

## Changes

- `avio/src/lib.rs`: added `ClipTransition` to the `#[cfg(feature = "filter")] pub use ff_filter` re-export block (alphabetically, after `ClipJoiner`)
- Added a `filter_clip_transition_should_be_accessible` regression test that constructs a `ClipTransition` via the facade re-export

## Related Issues

Resolves #1169

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes