### PR TITLE
docs: enable all features on docs.rs

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -29,6 +29,7 @@ srt      = ["ff-decode/srt", "ff-stream/srt"]
 serde    = ["ff-filter/serde"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-common/Cargo.toml
+++ b/crates/ff-common/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "media", "common"]
 categories = ["multimedia::video", "multimedia::audio"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-decode/Cargo.toml
+++ b/crates/ff-decode/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "media", "decode"]
 categories = ["multimedia::video", "multimedia::audio"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-encode/Cargo.toml
+++ b/crates/ff-encode/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "media", "encode"]
 categories = ["multimedia::video", "multimedia::audio"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-filter/Cargo.toml
+++ b/crates/ff-filter/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["multimedia::video", "multimedia::audio"]
 serde = ["dep:serde"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-format/Cargo.toml
+++ b/crates/ff-format/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "media", "format"]
 categories = ["multimedia::video", "multimedia::audio"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "pipeline", "transcode"]
 categories = ["multimedia::video", "multimedia::audio"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "preview", "playback"]
 categories = ["multimedia::video", "multimedia::audio"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-probe/Cargo.toml
+++ b/crates/ff-probe/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "media", "probe"]
 categories = ["multimedia::video", "multimedia::audio"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["video", "gpu", "wgpu", "compositing", "rendering"]
 categories = ["multimedia::video"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/crates/ff-stream/Cargo.toml
+++ b/crates/ff-stream/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["multimedia::video", "multimedia::encoding"]
 srt = []
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/crates/ff-sys/Cargo.toml
+++ b/crates/ff-sys/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["external-ffi-bindings", "multimedia::video", "multimedia::audio"]
 doctest = false
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]


### PR DESCRIPTION
## Summary
- adds `all-features = true` to each crate with docs.rs metadata
- keeps the existing `--cfg docsrs` rustdoc args unchanged

Fixes #1206.

## Testing
- `git diff --check`
- `cargo metadata --all-features --no-deps --format-version 1`
- `cargo doc --all-features --no-deps` started but did not complete before the 10 minute local timeout while compiling dependencies