### PR TITLE
feat(ff-pipeline): reusable VideoEffectRenderer for clip preview

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -280,7 +280,7 @@ pub use ff_filter::{
 pub use ff_pipeline::{
     AudioPipeline, Clip, EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder,
     PipelineError, Progress, ProgressCallback, ThumbnailPipeline, Timeline, TimelineBuilder,
-    VideoPipeline,
+    VideoEffectRenderer, VideoPipeline,
 };
 
 // ── stream feature ────────────────────────────────────────────────────────────

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -253,24 +253,37 @@ impl Clip {
     /// behave identically to the export — then back to its original pixel format,
     /// so the returned frame has the same format as `frame`.
     ///
+    /// This is a one-shot convenience that builds a fresh [`VideoEffectRenderer`]
+    /// per call. For real-time preview, build a [`video_effect_renderer`] once and
+    /// reuse it across frames to avoid rebuilding the filter graph (and re-loading
+    /// any `lut3d` file) every frame.
+    ///
+    /// [`video_effect_renderer`]: Self::video_effect_renderer
+    ///
     /// # Errors
     ///
     /// Returns [`PipelineError::Filter`] if the filter graph cannot be built or
     /// the frame cannot be processed.
     pub fn apply_video_effects(&self, frame: &VideoFrame) -> Result<VideoFrame, PipelineError> {
-        let in_format = frame.format();
-        let mut builder =
-            FilterGraph::builder().format(vec![PixelFormat::Yuv420p], vec![], vec![], vec![]);
-        for step in self.video_effect_chain() {
-            builder = builder.add_step(step);
-        }
-        let mut graph = builder
-            .format(vec![in_format], vec![], vec![], vec![])
-            .build()?;
-        graph.push_video(0, frame)?;
-        graph
-            .pull_video()?
-            .ok_or(PipelineError::Filter(ff_filter::FilterError::ProcessFailed))
+        self.video_effect_renderer(frame.format())?.render(frame)
+    }
+
+    /// Builds a reusable [`VideoEffectRenderer`] for this clip's effect chain.
+    ///
+    /// Hold the returned renderer and call [`VideoEffectRenderer::render`] per
+    /// frame to avoid rebuilding the filter graph (and re-loading any `lut3d`
+    /// file) on every frame — the right choice for real-time preview. Frames
+    /// passed to `render` must be in `input_format`. For a one-shot apply, use
+    /// [`apply_video_effects`](Self::apply_video_effects).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PipelineError::Filter`] if the filter graph cannot be built.
+    pub fn video_effect_renderer(
+        &self,
+        input_format: PixelFormat,
+    ) -> Result<VideoEffectRenderer, PipelineError> {
+        VideoEffectRenderer::new(self, input_format)
     }
 
     /// Attaches an audio [`FilterStep`] to this clip and returns the updated clip.
@@ -519,6 +532,64 @@ impl Clip {
     }
 }
 
+/// Reusable single-frame renderer for a [`Clip`]'s video effect chain.
+///
+/// Built once via [`Clip::video_effect_renderer`]; holds one [`FilterGraph`]
+/// configured with the same `yuv420p` working space and [`Clip::video_effect_chain`]
+/// that `Timeline::render()` uses, so a host preview matches the exported result.
+/// Feed frames through [`render`](Self::render) repeatedly — the graph (and any
+/// `lut3d` `.cube` file it loads) is built once, not per frame, which is the right
+/// choice for real-time preview.
+///
+/// All frames passed to `render` must share the pixel format (the `input_format`
+/// given at construction) and the dimensions of the first rendered frame. Build a
+/// new renderer if the grade, format, or frame size changes.
+pub struct VideoEffectRenderer {
+    graph: FilterGraph,
+}
+
+impl VideoEffectRenderer {
+    /// Builds a renderer for `clip`'s current effect chain. Frames passed to
+    /// [`render`](Self::render) must be in `input_format`; the output is returned
+    /// in the same format.
+    ///
+    /// The graph itself is configured lazily from the first frame's dimensions on
+    /// the initial [`render`](Self::render) call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PipelineError::Filter`] if the filter graph cannot be built.
+    pub fn new(clip: &Clip, input_format: PixelFormat) -> Result<Self, PipelineError> {
+        let mut builder =
+            FilterGraph::builder().format(vec![PixelFormat::Yuv420p], vec![], vec![], vec![]);
+        for step in clip.video_effect_chain() {
+            builder = builder.add_step(step);
+        }
+        let graph = builder
+            .format(vec![input_format], vec![], vec![], vec![])
+            .build()?;
+        Ok(Self { graph })
+    }
+
+    /// Applies the effect chain to one frame, reusing the built graph.
+    ///
+    /// `frame` must match the `input_format` and dimensions established by the
+    /// first rendered frame. The returned frame has the same pixel format as the
+    /// input. The frame's own timestamp is forwarded to the graph (as
+    /// `Timeline::render()` does); the effect chain is pixel-domain and does not
+    /// depend on PTS ordering.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PipelineError::Filter`] if the frame cannot be processed.
+    pub fn render(&mut self, frame: &VideoFrame) -> Result<VideoFrame, PipelineError> {
+        self.graph.push_video(0, frame)?;
+        self.graph
+            .pull_video()?
+            .ok_or(PipelineError::Filter(ff_filter::FilterError::ProcessFailed))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -742,6 +813,34 @@ mod tests {
                 assert_eq!(out.height(), 4);
             }
             Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
+    fn video_effect_renderer_should_reuse_graph_across_frames() {
+        // One renderer built once, fed several frames — exercises graph reuse
+        // without rebuilding. Skip-guard on FFmpeg availability.
+        let clip = Clip::new("v.mp4").with_color_correction(0.1, 1.1, 1.0);
+        let mut renderer = match clip.video_effect_renderer(PixelFormat::Rgba) {
+            Ok(r) => r,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        for _ in 0..3 {
+            let frame = VideoFrame::from_rgba(4, 4, vec![128u8; 4 * 4 * 4]).unwrap();
+            match renderer.render(&frame) {
+                Ok(out) => {
+                    assert_eq!(out.format(), PixelFormat::Rgba);
+                    assert_eq!(out.width(), 4);
+                    assert_eq!(out.height(), 4);
+                }
+                Err(e) => {
+                    println!("Skipping: {e}");
+                    return;
+                }
+            }
         }
     }
 }

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -62,7 +62,7 @@ pub mod timeline;
 pub mod video_pipeline;
 
 pub use audio_pipeline::AudioPipeline;
-pub use clip::Clip;
+pub use clip::{Clip, VideoEffectRenderer};
 pub use encoder_config::{EncoderConfig, EncoderConfigBuilder};
 pub use error::PipelineError;
 pub use ff_filter::{BlendMode, XfadeTransition};


### PR DESCRIPTION
## Summary

`Clip::apply_video_effects` rebuilt a fresh `FilterGraph` on every call, which is wasteful for a host driving a real-time preview at ~60 fps — and with a `lut3d` effect it re-read and re-parsed the `.cube` file every frame. This adds a stateful, reusable `VideoEffectRenderer` that builds the graph once (with the same `yuv420p` working space and `video_effect_chain()` as the export path) and feeds many frames through it, so a host can cache it and rebuild only when the grade changes.

## Changes

- Add `VideoEffectRenderer` to `ff-pipeline` (`clip.rs`): owns one built `FilterGraph` and exposes `render(&frame) -> frame`, reusing the graph across calls with no per-frame allocation.
- Add `Clip::video_effect_renderer(input_format)` to build the renderer from a clip.
- Reimplement `Clip::apply_video_effects` as a thin one-shot wrapper over `VideoEffectRenderer`, so the `yuv420p` framing and effect chain are defined in exactly one place.
- Re-export `VideoEffectRenderer` from `ff-pipeline` and the `avio` facade.
- Add a test that builds one renderer and feeds several frames through it, asserting each `render` succeeds and preserves the input format and dimensions.

## Related Issues

Closes #1213

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes