### PR TITLE
chore: ignore editor/IDE/OS environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,26 @@
+# Editor / IDE
+.vscode/
+.idea/
+*.iml
+.fleet/
+.zed/
+*.code-workspace
+
+# Vim / Emacs
+*.swp
+*.swo
+.*.sw[a-p]
+*~
+\#*\#
+.\#*
+
+# OS
+.DS_Store
+.AppleDouble
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
 # Ignore build artifacts and lock files
 **/target/
 
@@ -15,3 +38,6 @@
 # Claude Code — personal use only, not shared with contributors
 /CLAUDE.md
 /.claude/
+
+# Personal working notes (not shared with contributors)
+/TODO.md


### PR DESCRIPTION
## Summary

Adds common editor/IDE, Vim/Emacs, and OS environment files to `.gitignore` so local environment artifacts (e.g. `.vscode/`) no longer show up as untracked changes.

## Changes

- Editor / IDE: `.vscode/`, `.idea/`, `*.iml`, `.fleet/`, `.zed/`, `*.code-workspace`
- Vim / Emacs: swap/backup files (`*.swp`, `*.swo`, `*~`, …)
- OS: `.DS_Store`, `Thumbs.db`, `Desktop.ini`, …
- Personal working notes: `/TODO.md`

## Test Plan

- [x] `git check-ignore` confirms `.vscode/` and `TODO.md` are ignored