### PR TITLE
fix(ff-filter): correct format-filter tokens and wire alpha to the overlay filter

### DIFF
--- a/crates/avio/examples/filter/alpha_matte_external.rs
+++ b/crates/avio/examples/filter/alpha_matte_external.rs
@@ -25,7 +25,9 @@
 
 use std::{path::PathBuf, process};
 
-use avio::{BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder};
+use avio::{
+    AlphaMode, BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
+};
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -155,7 +157,12 @@ fn main() {
     let top_builder = FilterGraphBuilder::new();
 
     let mut blend_graph = match FilterGraph::builder()
-        .blend(top_builder, BlendMode::PorterDuffOver, 1.0)
+        .blend(
+            top_builder,
+            BlendMode::PorterDuffOver,
+            1.0,
+            AlphaMode::Straight,
+        )
         .build()
     {
         Ok(g) => g,

--- a/crates/avio/examples/filter/blend_modes_demo.rs
+++ b/crates/avio/examples/filter/blend_modes_demo.rs
@@ -18,7 +18,9 @@
 
 use std::{path::PathBuf, process};
 
-use avio::{BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder};
+use avio::{
+    AlphaMode, BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
+};
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -152,7 +154,7 @@ fn main() {
     let top_builder = FilterGraphBuilder::new();
 
     let mut graph = match FilterGraph::builder()
-        .blend(top_builder, args.mode, args.opacity)
+        .blend(top_builder, args.mode, args.opacity, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,

--- a/crates/avio/examples/filter/chroma_key_green_screen.rs
+++ b/crates/avio/examples/filter/chroma_key_green_screen.rs
@@ -20,7 +20,9 @@
 
 use std::{path::PathBuf, process};
 
-use avio::{BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder};
+use avio::{
+    AlphaMode, BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
+};
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -128,7 +130,12 @@ fn main() {
         FilterGraphBuilder::new().chromakey(&args.color, args.similarity, args.blend_factor);
 
     let mut graph = match FilterGraph::builder()
-        .blend(fg_builder, BlendMode::PorterDuffOver, 1.0)
+        .blend(
+            fg_builder,
+            BlendMode::PorterDuffOver,
+            1.0,
+            AlphaMode::Straight,
+        )
         .build()
     {
         Ok(g) => g,

--- a/crates/avio/examples/filter/luma_key_title_card.rs
+++ b/crates/avio/examples/filter/luma_key_title_card.rs
@@ -22,7 +22,9 @@
 
 use std::{path::PathBuf, process};
 
-use avio::{BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder};
+use avio::{
+    AlphaMode, BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
+};
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -138,7 +140,12 @@ fn main() {
     );
 
     let mut graph = match FilterGraph::builder()
-        .blend(title_builder, BlendMode::PorterDuffOver, 1.0)
+        .blend(
+            title_builder,
+            BlendMode::PorterDuffOver,
+            1.0,
+            AlphaMode::Straight,
+        )
         .build()
     {
         Ok(g) => g,

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -753,6 +753,15 @@ pub(super) unsafe fn add_overlay_image_step(
 
 // ── Blend Normal mode compound step ──────────────────────────────────────────
 
+/// Overlay `:alpha=` suffix for `alpha`. `Straight` is the `overlay` default (no extra arg);
+/// `Premultiplied` selects premultiplied alpha. Verified `vf_overlay.c` (7.1/8.0).
+fn overlay_alpha_suffix(alpha: AlphaMode) -> &'static str {
+    match alpha {
+        AlphaMode::Premultiplied => ":alpha=premultiplied",
+        _ => "",
+    }
+}
+
 /// Insert a Normal-mode blend compound step.
 ///
 /// The top layer's `top_steps` are first applied to `top_src_ctx` (the `in1`
@@ -770,15 +779,6 @@ pub(super) unsafe fn add_overlay_image_step(
 ///
 /// `graph`, `bottom_ctx`, and `top_src_ctx` must be valid pointers owned by the
 /// same `AVFilterGraph`.
-/// Overlay `:alpha=` suffix for `alpha`. `Straight` is the `overlay` default (no extra arg);
-/// `Premultiplied` selects premultiplied alpha. Verified `vf_overlay.c` (7.1/8.0).
-fn overlay_alpha_suffix(alpha: AlphaMode) -> &'static str {
-    match alpha {
-        AlphaMode::Premultiplied => ":alpha=premultiplied",
-        _ => "",
-    }
-}
-
 pub(super) unsafe fn add_blend_normal_step(
     graph: *mut ff_sys::AVFilterGraph,
     bottom_ctx: *mut ff_sys::AVFilterContext,

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -11,6 +11,7 @@ use crate::blend::BlendMode;
 use crate::error::FilterError;
 use crate::graph::filter_step::FilterStep;
 use crate::graph::types::{EqBand, HwAccel};
+use ff_format::AlphaMode;
 
 // ── Hardware acceleration helpers ─────────────────────────────────────────────
 
@@ -541,6 +542,18 @@ pub(crate) unsafe fn add_asetrate_resample_chain(
 #[cfg(test)]
 mod tests {
     use super::decompose_atempo;
+    use super::overlay_alpha_suffix;
+    use ff_format::AlphaMode;
+
+    #[test]
+    fn overlay_alpha_suffix_should_append_only_for_premultiplied() {
+        assert_eq!(
+            overlay_alpha_suffix(AlphaMode::Premultiplied),
+            ":alpha=premultiplied"
+        );
+        assert_eq!(overlay_alpha_suffix(AlphaMode::Straight), "");
+        assert_eq!(overlay_alpha_suffix(AlphaMode::Unknown), "");
+    }
 
     #[test]
     fn decompose_atempo_should_return_single_value_for_factor_within_range() {
@@ -757,12 +770,22 @@ pub(super) unsafe fn add_overlay_image_step(
 ///
 /// `graph`, `bottom_ctx`, and `top_src_ctx` must be valid pointers owned by the
 /// same `AVFilterGraph`.
+/// Overlay `:alpha=` suffix for `alpha`. `Straight` is the `overlay` default (no extra arg);
+/// `Premultiplied` selects premultiplied alpha. Verified `vf_overlay.c` (7.1/8.0).
+fn overlay_alpha_suffix(alpha: AlphaMode) -> &'static str {
+    match alpha {
+        AlphaMode::Premultiplied => ":alpha=premultiplied",
+        _ => "",
+    }
+}
+
 pub(super) unsafe fn add_blend_normal_step(
     graph: *mut ff_sys::AVFilterGraph,
     bottom_ctx: *mut ff_sys::AVFilterContext,
     top_src_ctx: *mut ff_sys::AVFilterContext,
     top_steps: &[FilterStep],
     opacity: f32,
+    alpha: AlphaMode,
     index: usize,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
     use std::ffi::CString;
@@ -835,7 +858,9 @@ pub(super) unsafe fn add_blend_normal_step(
     }
     let overlay_name =
         CString::new(format!("blend_overlay{index}")).map_err(|_| FilterError::BuildFailed)?;
-    let overlay_args = c"format=auto:shortest=1";
+    let overlay_args_str = format!("format=auto:shortest=1{}", overlay_alpha_suffix(alpha));
+    let overlay_args =
+        CString::new(overlay_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
     let mut overlay_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
     let ret = ff_sys::avfilter_graph_create_filter(
         &raw mut overlay_ctx,
@@ -846,14 +871,10 @@ pub(super) unsafe fn add_blend_normal_step(
         graph,
     );
     if ret < 0 {
-        log::warn!(
-            "filter creation failed name=overlay args=format=auto:shortest=1 (blend_normal)"
-        );
+        log::warn!("filter creation failed name=overlay args={overlay_args_str} (blend_normal)");
         return Err(FilterError::BuildFailed);
     }
-    log::debug!(
-        "filter added name=overlay args=format=auto:shortest=1 index={index} (blend_normal)"
-    );
+    log::debug!("filter added name=overlay args={overlay_args_str} index={index} (blend_normal)");
 
     // 4. Link: bottom → overlay[0], top → overlay[1].
     // SAFETY: bottom_ctx, top_ctx, overlay_ctx are all in the same graph.
@@ -989,6 +1010,7 @@ pub(super) unsafe fn add_blend_under_step(
     top_src_ctx: *mut ff_sys::AVFilterContext,
     top_steps: &[FilterStep],
     opacity: f32,
+    alpha: AlphaMode,
     index: usize,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
     use std::ffi::CString;
@@ -1057,7 +1079,9 @@ pub(super) unsafe fn add_blend_under_step(
     }
     let overlay_name = CString::new(format!("blend_under_overlay{index}"))
         .map_err(|_| FilterError::BuildFailed)?;
-    let overlay_args = c"format=auto:shortest=1";
+    let overlay_args_str = format!("format=auto:shortest=1{}", overlay_alpha_suffix(alpha));
+    let overlay_args =
+        CString::new(overlay_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
     let mut overlay_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
     let ret = ff_sys::avfilter_graph_create_filter(
         &raw mut overlay_ctx,
@@ -1068,12 +1092,10 @@ pub(super) unsafe fn add_blend_under_step(
         graph,
     );
     if ret < 0 {
-        log::warn!("filter creation failed name=overlay args=format=auto:shortest=1 (blend_under)");
+        log::warn!("filter creation failed name=overlay args={overlay_args_str} (blend_under)");
         return Err(FilterError::BuildFailed);
     }
-    log::debug!(
-        "filter added name=overlay args=format=auto:shortest=1 index={index} (blend_under)"
-    );
+    log::debug!("filter added name=overlay args={overlay_args_str} index={index} (blend_under)");
 
     // 4. Link (swapped vs. Normal): top → overlay[0], bottom → overlay[1].
     // SAFETY: bottom_ctx, top_ctx, overlay_ctx are all in the same graph.
@@ -2105,6 +2127,7 @@ impl FilterGraphInner {
                 top,
                 mode: BlendMode::Normal | BlendMode::PorterDuffOver,
                 opacity,
+                alpha,
             } = step
             {
                 let Some(top_src) = src_ctxs.get(1).and_then(|o| *o) else {
@@ -2116,6 +2139,7 @@ impl FilterGraphInner {
                     top_src.as_ptr(),
                     top.steps(),
                     *opacity,
+                    *alpha,
                     i,
                 ) {
                     Ok(ctx) => ctx,
@@ -2146,6 +2170,7 @@ impl FilterGraphInner {
                     | BlendMode::Color
                     | BlendMode::Luminosity),
                 opacity,
+                ..
             } = step
             {
                 let Some(top_src) = src_ctxs.get(1).and_then(|o| *o) else {
@@ -2191,6 +2216,7 @@ impl FilterGraphInner {
                 top,
                 mode: BlendMode::PorterDuffUnder,
                 opacity,
+                alpha,
             } = step
             {
                 let Some(top_src) = src_ctxs.get(1).and_then(|o| *o) else {
@@ -2202,6 +2228,7 @@ impl FilterGraphInner {
                     top_src.as_ptr(),
                     top.steps(),
                     *opacity,
+                    *alpha,
                     i,
                 ) {
                     Ok(ctx) => ctx,

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -727,6 +727,7 @@ impl FilterGraphBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ff_format::AlphaMode;
 
     #[test]
     fn builder_empty_steps_should_return_error() {
@@ -802,7 +803,7 @@ mod tests {
         let top = FilterGraphBuilder::new().trim(0.0, 5.0);
         let result = FilterGraph::builder()
             .trim(0.0, 5.0)
-            .blend(top, BlendMode::Normal, 1.0)
+            .blend(top, BlendMode::Normal, 1.0, AlphaMode::Straight)
             .build();
         assert!(
             result.is_ok(),
@@ -817,7 +818,7 @@ mod tests {
         let top = FilterGraphBuilder::new().trim(0.0, 5.0);
         let result = FilterGraph::builder()
             .trim(0.0, 5.0)
-            .blend(top, BlendMode::Normal, 0.5)
+            .blend(top, BlendMode::Normal, 0.5, AlphaMode::Straight)
             .build();
         assert!(
             result.is_ok(),
@@ -831,7 +832,7 @@ mod tests {
         let top = FilterGraphBuilder::new().trim(0.0, 5.0);
         let result = FilterGraph::builder()
             .trim(0.0, 5.0)
-            .blend(top, BlendMode::Normal, 2.5)
+            .blend(top, BlendMode::Normal, 2.5, AlphaMode::Straight)
             .build();
         assert!(
             result.is_ok(),

--- a/crates/ff-filter/src/graph/builder/video/compositing.rs
+++ b/crates/ff-filter/src/graph/builder/video/compositing.rs
@@ -2,12 +2,15 @@
 
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use ff_format::AlphaMode;
 
 impl FilterGraphBuilder {
-    /// Blend a `top` layer over `self` (the bottom) using the given [`BlendMode`]
-    /// and `opacity`.
+    /// Blend a `top` layer over `self` (the bottom) using the given [`BlendMode`],
+    /// `opacity`, and [`AlphaMode`].
     ///
-    /// `opacity` is clamped to `[0.0, 1.0]` before being stored.
+    /// `opacity` is clamped to `[0.0, 1.0]` before being stored. `alpha` selects how
+    /// the top layer's alpha is interpreted by the `overlay` filter (`alpha=`);
+    /// [`AlphaMode::Straight`] matches `FFmpeg`'s default and adds no extra argument.
     ///
     /// # Normal mode
     ///
@@ -30,12 +33,19 @@ impl FilterGraphBuilder {
     /// unimplemented mode returns
     /// [`FilterError::InvalidConfig`].
     #[must_use]
-    pub fn blend(mut self, top: FilterGraphBuilder, mode: BlendMode, opacity: f32) -> Self {
+    pub fn blend(
+        mut self,
+        top: FilterGraphBuilder,
+        mode: BlendMode,
+        opacity: f32,
+        alpha: AlphaMode,
+    ) -> Self {
         let opacity = opacity.clamp(0.0, 1.0);
         self.steps.push(FilterStep::Blend {
             top: Box::new(top),
             mode,
             opacity,
+            alpha,
         });
         self
     }

--- a/crates/ff-filter/src/graph/builder/video/format.rs
+++ b/crates/ff-filter/src/graph/builder/video/format.rs
@@ -2,29 +2,27 @@
 
 #[allow(clippy::wildcard_imports)]
 use super::*;
-use ff_format::{AlphaMode, ColorRange, ColorSpace, PixelFormat};
+use ff_format::{ColorRange, ColorSpace, PixelFormat};
 
 impl FilterGraphBuilder {
     /// Convert the video to a suitable pixel format from the given options.
+    ///
+    /// Each list is rendered with the `FFmpeg`-canonical token; values with no `FFmpeg`
+    /// equivalent are skipped. Alpha format is not a `format`-filter option — set it on the
+    /// compositing step instead (see [`FilterGraphBuilder::blend`]).
     #[must_use]
     pub fn format(
         mut self,
         pix_fmts: Vec<PixelFormat>,
         color_spaces: Vec<ColorSpace>,
         color_ranges: Vec<ColorRange>,
-        alpha_modes: Vec<AlphaMode>,
     ) -> Self {
         // This check is not required, but there's no point in adding the step if all requirements are empty.
-        if !pix_fmts.is_empty()
-            || !color_spaces.is_empty()
-            || !color_ranges.is_empty()
-            || !alpha_modes.is_empty()
-        {
+        if !pix_fmts.is_empty() || !color_spaces.is_empty() || !color_ranges.is_empty() {
             self.steps.push(FilterStep::Format {
                 pix_fmts,
                 color_spaces,
                 color_ranges,
-                alpha_modes,
             });
         }
         self
@@ -40,13 +38,24 @@ mod tests {
         let step = FilterStep::Format {
             pix_fmts: vec![PixelFormat::Rgba, PixelFormat::Yuv420p],
             color_spaces: vec![ColorSpace::Srgb],
-            color_ranges: vec![],
-            alpha_modes: vec![AlphaMode::Straight],
+            color_ranges: vec![ColorRange::Limited],
         };
         assert_eq!(step.filter_name(), "format");
         assert_eq!(
             step.args(),
-            "pix_fmts=rgba|yuv420p:color_spaces=srgb:alpha_modes=straight"
+            "pix_fmts=rgba|yuv420p:color_spaces=gbr:color_ranges=tv"
         );
+    }
+
+    #[test]
+    fn format_args_should_skip_values_without_ffmpeg_token() {
+        // `Other` (no static pix_fmt token), `Bt601` (needs the #1217 split) and `Unknown`
+        // range all return `None` and must be skipped rather than emitting invalid tokens.
+        let step = FilterStep::Format {
+            pix_fmts: vec![PixelFormat::Other(123), PixelFormat::Yuv420p],
+            color_spaces: vec![ColorSpace::Bt601, ColorSpace::Bt2020],
+            color_ranges: vec![ColorRange::Unknown],
+        };
+        assert_eq!(step.args(), "pix_fmts=yuv420p:color_spaces=bt2020nc");
     }
 }

--- a/crates/ff-filter/src/graph/builder/video/format.rs
+++ b/crates/ff-filter/src/graph/builder/video/format.rs
@@ -58,4 +58,17 @@ mod tests {
         };
         assert_eq!(step.args(), "pix_fmts=yuv420p:color_spaces=bt2020nc");
     }
+
+    #[test]
+    fn format_args_should_be_empty_when_all_values_lack_tokens() {
+        // Edge case: if every supplied value renders to `None` (e.g. `Other` pix fmt + `Bt601`
+        // colour space + `Unknown` range), `args()` is the empty string. Documented so the
+        // empty-args `format` step stays a visible, tested behaviour.
+        let step = FilterStep::Format {
+            pix_fmts: vec![PixelFormat::Other(1)],
+            color_spaces: vec![ColorSpace::Bt601],
+            color_ranges: vec![ColorRange::Unknown],
+        };
+        assert_eq!(step.args(), "");
+    }
 }

--- a/crates/ff-filter/src/graph/ffmpeg_token/format.rs
+++ b/crates/ff-filter/src/graph/ffmpeg_token/format.rs
@@ -6,7 +6,7 @@ use crate::graph::FfmpegToken;
 
 impl FfmpegToken for ColorRange {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#colorspace
+        // color_range_names[] (format filter color_ranges=): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c
         Some(match self {
             Self::Limited => "tv",
             Self::Full => "pc",
@@ -19,13 +19,14 @@ impl FfmpegToken for ColorRange {
 
 impl FfmpegToken for ColorSpace {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#colorspace
+        // color_space_names[] (format filter color_spaces=): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c
         Some(match self {
             Self::Bt709 => "bt709",
-            Self::Bt601 => "bt601",
-            Self::Bt2020 => "bt2020",
-            Self::DciP3 => return None, // TODO
-            Self::Srgb => return None,  // TODO
+            Self::Bt2020 => "bt2020nc",
+            Self::Srgb => "gbr",
+            // TODO(#1217): split `Bt601` into `bt470bg` (625) / `smpte170m` (525); skip until then.
+            Self::Bt601 => return None,
+            Self::DciP3 => return None,
             Self::Unknown | _ => {
                 return None;
             }
@@ -35,7 +36,7 @@ impl FfmpegToken for ColorSpace {
 
 impl FfmpegToken for PixelFormat {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // ffmpeg -pix_fmts
+        // av_pix_fmt_descriptors[] (format filter pix_fmts=): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c
         Some(match self {
             Self::Rgb24 => "rgb24",
             Self::Rgba => "rgba",
@@ -63,7 +64,7 @@ impl FfmpegToken for PixelFormat {
 
 impl FfmpegToken for AlphaMode {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#overlay-1
+        // overlay alpha= option (alpha_format unit): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_overlay.c
         Some(match self {
             Self::Straight => "straight",
             Self::Premultiplied => "premultiplied",

--- a/crates/ff-filter/src/graph/ffmpeg_token/mod.rs
+++ b/crates/ff-filter/src/graph/ffmpeg_token/mod.rs
@@ -10,7 +10,7 @@ pub trait FfmpegToken {
 
 impl FfmpegToken for ScaleAlgorithm {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#Scaling
+        // sws_flags unit: https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libswscale/options.c
         Some(match self {
             Self::Fast => "fast_bilinear",
             Self::Bilinear => "bilinear",
@@ -22,7 +22,7 @@ impl FfmpegToken for ScaleAlgorithm {
 
 impl FfmpegToken for ToneMap {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#Tone-mapping
+        // tonemap unit: https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_tonemap.c
         Some(match self {
             Self::Hable => "hable",
             Self::Reinhard => "reinhard",
@@ -33,7 +33,7 @@ impl FfmpegToken for ToneMap {
 
 impl FfmpegToken for YadifMode {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#yadif-1
+        // mode unit (AV_OPT_TYPE_INT, range 0-3): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/yadif_common.c
         Some(match self {
             Self::Frame => "0",
             Self::Field => "1",
@@ -45,7 +45,7 @@ impl FfmpegToken for YadifMode {
 
 impl FfmpegToken for XfadeTransition {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#xfade
+        // transition unit: https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_xfade.c
         Some(match self {
             Self::Dissolve => "dissolve",
             Self::Fade => "fade",
@@ -67,7 +67,7 @@ impl FfmpegToken for XfadeTransition {
 
 impl FfmpegToken for BlendMode {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // https://ffmpeg.org/ffmpeg-filters.html#blend-1
+        // all_mode unit: https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_blend.c
         Some(match self {
             Self::Normal => "normal",
             Self::Multiply => "multiply",

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -1005,7 +1005,6 @@ impl FilterStep {
             } => {
                 // Each option list uses the FFmpeg-canonical `FfmpegToken`, skipping values with no
                 // FFmpeg equivalent (`None`); an option is emitted only when a token survives.
-                // See docs/specs/ffmpeg-tokens.md.
                 fn render<T: FfmpegToken>(key: &str, values: &[T]) -> Option<String> {
                     let tokens: Vec<&str> = values
                         .iter()

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -1,8 +1,8 @@
 //! Internal filter step representation.
 
-use std::iter;
 use std::time::Duration;
 
+use super::FfmpegToken;
 use super::builder::FilterGraphBuilder;
 use super::types::{
     DrawTextOptions, EqBand, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
@@ -36,7 +36,6 @@ pub enum FilterStep {
         pix_fmts: Vec<PixelFormat>,
         color_spaces: Vec<ColorSpace>,
         color_ranges: Vec<ColorRange>,
-        alpha_modes: Vec<AlphaMode>,
     },
 
     /// Trim: keep only frames in `[start, end)` seconds.
@@ -472,6 +471,9 @@ pub enum FilterStep {
         mode: BlendMode,
         /// Opacity of the top layer in `[0.0, 1.0]`; 1.0 = fully opaque.
         opacity: f32,
+        /// How the top layer's alpha is interpreted by the `overlay` filter
+        /// (`alpha=`). [`AlphaMode::Straight`] is the `FFmpeg` default.
+        alpha: AlphaMode,
     },
 
     /// Remove pixels matching `color` using `FFmpeg`'s `chromakey` filter,
@@ -1000,58 +1002,26 @@ impl FilterStep {
                 pix_fmts,
                 color_spaces,
                 color_ranges,
-                alpha_modes,
             } => {
-                let mut parts = vec![];
-                if !pix_fmts.is_empty() {
-                    parts.push(
-                        iter::once("pix_fmts=")
-                            .chain(
-                                pix_fmts
-                                    .iter()
-                                    .flat_map(|pix_fmt| ["|", pix_fmt.name()])
-                                    .skip(1),
-                            )
-                            .collect::<String>(),
-                    );
+                // Each option list uses the FFmpeg-canonical `FfmpegToken`, skipping values with no
+                // FFmpeg equivalent (`None`); an option is emitted only when a token survives.
+                // See docs/specs/ffmpeg-tokens.md.
+                fn render<T: FfmpegToken>(key: &str, values: &[T]) -> Option<String> {
+                    let tokens: Vec<&str> = values
+                        .iter()
+                        .filter_map(FfmpegToken::ffmpeg_token)
+                        .collect();
+                    (!tokens.is_empty()).then(|| format!("{key}={}", tokens.join("|")))
                 }
-                if !color_spaces.is_empty() {
-                    parts.push(
-                        iter::once("color_spaces=")
-                            .chain(
-                                color_spaces
-                                    .iter()
-                                    .flat_map(|color_space| ["|", color_space.name()])
-                                    .skip(1),
-                            )
-                            .collect::<String>(),
-                    );
-                }
-                if !color_ranges.is_empty() {
-                    parts.push(
-                        iter::once("color_ranges=")
-                            .chain(
-                                color_ranges
-                                    .iter()
-                                    .flat_map(|color_range| ["|", color_range.name()])
-                                    .skip(1),
-                            )
-                            .collect::<String>(),
-                    );
-                }
-                if !alpha_modes.is_empty() {
-                    parts.push(
-                        iter::once("alpha_modes=")
-                            .chain(
-                                alpha_modes
-                                    .iter()
-                                    .flat_map(|alpha_mode| ["|", alpha_mode.name()])
-                                    .skip(1),
-                            )
-                            .collect::<String>(),
-                    );
-                }
-                parts.join(":")
+                [
+                    render("pix_fmts", pix_fmts),
+                    render("color_spaces", color_spaces),
+                    render("color_ranges", color_ranges),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+                .join(":")
             }
             Self::Trim { start, end } => format!("start={start}:end={end}"),
             Self::Scale {

--- a/crates/ff-filter/tests/blend_reference_tests.rs
+++ b/crates/ff-filter/tests/blend_reference_tests.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 use image::RgbImage;
 
 use ff_filter::{BlendMode, FilterGraph, FilterGraphBuilder};
-use ff_format::{PixelFormat, PooledBuffer, Timestamp, VideoFrame};
+use ff_format::{AlphaMode, PixelFormat, PooledBuffer, Timestamp, VideoFrame};
 
 // ── Synthetic input image generators ─────────────────────────────────────────
 
@@ -168,7 +168,7 @@ fn apply_blend(bottom: &VideoFrame, top_frame: &VideoFrame, mode: BlendMode) -> 
     let top_builder = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top_builder, mode, 1.0)
+        .blend(top_builder, mode, 1.0, AlphaMode::Straight)
         .build()
         .ok()?;
     graph.push_video(0, bottom).ok()?;

--- a/crates/ff-filter/tests/compositing_pipeline_tests.rs
+++ b/crates/ff-filter/tests/compositing_pipeline_tests.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::unwrap_used)]
 
 use ff_filter::{BlendMode, FilterGraph, FilterGraphBuilder};
-use ff_format::{PixelFormat, PooledBuffer, Timestamp, VideoFrame};
+use ff_format::{AlphaMode, PixelFormat, PooledBuffer, Timestamp, VideoFrame};
 
 /// YUV420p frame filled with a solid colour.
 fn make_yuv420p_frame(width: u32, height: u32, y: u8, u: u8, v: u8) -> VideoFrame {
@@ -56,7 +56,12 @@ fn garbage_matte_chromakey_blend_over_background_should_composite_correctly() {
         .chromakey("0x00FF00", 0.3, 0.0);
 
     let mut graph = match FilterGraph::builder()
-        .blend(fg_builder, BlendMode::PorterDuffOver, 1.0)
+        .blend(
+            fg_builder,
+            BlendMode::PorterDuffOver,
+            1.0,
+            AlphaMode::Straight,
+        )
         .build()
     {
         Ok(g) => g,

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -14,7 +14,8 @@ use ff_filter::{
     ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
 use ff_format::{
-    AlphaMode, AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame,
+    AlphaMode, AudioFrame, ColorRange, ColorSpace, PixelFormat, PooledBuffer, SampleFormat,
+    Timestamp, VideoFrame,
 };
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
@@ -62,6 +63,42 @@ fn make_yuv_frame(width: u32, height: u32, y: u8, u: u8, v: u8) -> VideoFrame {
 /// Stereo packed F32 audio frame, 1024 samples @ 48 kHz.
 fn make_audio_frame() -> AudioFrame {
     AudioFrame::empty(1024, 2, 48000, SampleFormat::F32).unwrap()
+}
+
+#[test]
+fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
+    // #1212/#1223: `format` args are built from `FfmpegToken`, so the real `format` filter
+    // must accept `color_spaces=bt2020nc:color_ranges=tv:pix_fmts=yuv420p` at graph-config
+    // time. The old `.name()` path produced `color_spaces=bt2020/srgb` and `color_ranges=limited`,
+    // which `avfilter_graph_config` rejects. `build()` runs `avfilter_graph_config`, so an
+    // invalid token name fails here rather than passing a mere string-equality check.
+    let mut graph = FilterGraph::builder()
+        .format(
+            vec![PixelFormat::Yuv420p],
+            vec![ColorSpace::Bt2020],
+            vec![ColorRange::Limited],
+        )
+        .build()
+        .expect("format graph built from FfmpegToken args must configure on linked FFmpeg");
+    let frame = make_yuv420p_frame(64, 64);
+    if graph.push_video(0, &frame).is_ok() {
+        if let Some(out) = graph.pull_video().expect("pull_video must not fail") {
+            assert_eq!(out.width(), 64, "format must not change frame width");
+            assert_eq!(out.height(), 64, "format must not change frame height");
+        }
+    }
+}
+
+#[test]
+fn blend_with_premultiplied_alpha_should_be_accepted_by_ffmpeg() {
+    // #1225: the `overlay` `alpha=premultiplied` argument must be accepted by FFmpeg.
+    // `alpha` is an INT option parsed when the filter is created, so an invalid value
+    // fails `build()`.
+    let top = FilterGraphBuilder::new();
+    FilterGraph::builder()
+        .blend(top, BlendMode::Normal, 1.0, AlphaMode::Premultiplied)
+        .build()
+        .expect("blend(Premultiplied) must build — overlay must accept alpha=premultiplied");
 }
 
 #[test]

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -67,11 +67,12 @@ fn make_audio_frame() -> AudioFrame {
 
 #[test]
 fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
-    // #1212/#1223: `format` args are built from `FfmpegToken`, so the real `format` filter
-    // must accept `color_spaces=bt2020nc:color_ranges=tv:pix_fmts=yuv420p` at graph-config
-    // time. The old `.name()` path produced `color_spaces=bt2020/srgb` and `color_ranges=limited`,
-    // which `avfilter_graph_config` rejects. `build()` runs `avfilter_graph_config`, so an
-    // invalid token name fails here rather than passing a mere string-equality check.
+    // #1212/#1223: `format` args are built from `FfmpegToken`. The FFmpeg graph is constructed
+    // lazily on the first `push_video` (see `FilterGraph::build` docs), so it is the push — not
+    // `build()` — that hands the args to the real `format` filter. The old `.name()` path produced
+    // `color_spaces=bt2020/srgb` and `color_ranges=limited`, which the filter rejects at
+    // construction; with the FfmpegToken values (`bt2020nc`/`tv`/`yuv420p`) the push must succeed.
+    // Pushing unconditionally (no `is_ok()` guard) ensures an invalid arg fails the test.
     let mut graph = FilterGraph::builder()
         .format(
             vec![PixelFormat::Yuv420p],
@@ -79,26 +80,43 @@ fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
             vec![ColorRange::Limited],
         )
         .build()
-        .expect("format graph built from FfmpegToken args must configure on linked FFmpeg");
+        .expect("non-empty format graph must build");
     let frame = make_yuv420p_frame(64, 64);
-    if graph.push_video(0, &frame).is_ok() {
-        if let Some(out) = graph.pull_video().expect("pull_video must not fail") {
-            assert_eq!(out.width(), 64, "format must not change frame width");
-            assert_eq!(out.height(), 64, "format must not change frame height");
-        }
-    }
+    graph
+        .push_video(0, &frame)
+        .expect("format push must succeed — FFmpeg must accept the FfmpegToken args");
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame) after format push");
+    assert_eq!(out.width(), 64, "format must not change frame width");
+    assert_eq!(out.height(), 64, "format must not change frame height");
 }
 
 #[test]
 fn blend_with_premultiplied_alpha_should_be_accepted_by_ffmpeg() {
-    // #1225: the `overlay` `alpha=premultiplied` argument must be accepted by FFmpeg.
-    // `alpha` is an INT option parsed when the filter is created, so an invalid value
-    // fails `build()`.
+    // #1225: the `overlay` `alpha=premultiplied` argument must be accepted by FFmpeg. The overlay
+    // filter is constructed lazily when frames are pushed (not at `build()`), so BOTH inputs must
+    // be pushed to force its construction; an invalid `alpha` value would fail the push.
     let top = FilterGraphBuilder::new();
-    FilterGraph::builder()
+    let mut graph = FilterGraph::builder()
         .blend(top, BlendMode::Normal, 1.0, AlphaMode::Premultiplied)
         .build()
-        .expect("blend(Premultiplied) must build — overlay must accept alpha=premultiplied");
+        .expect("blend graph must build");
+    let bottom = make_yuv420p_frame(64, 64);
+    let fg = make_yuv420p_frame(64, 64);
+    graph
+        .push_video(0, &bottom)
+        .expect("bottom push must succeed");
+    graph
+        .push_video(1, &fg)
+        .expect("top push must succeed — overlay must accept alpha=premultiplied");
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame) after blend push");
+    assert_eq!(out.width(), 64, "overlay must not change frame width");
+    assert_eq!(out.height(), 64, "overlay must not change frame height");
 }
 
 #[test]

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -13,7 +13,9 @@ use ff_filter::{
     BlendMode, DrawTextOptions, FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb,
     ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
-use ff_format::{AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame};
+use ff_format::{
+    AlphaMode, AudioFrame, PixelFormat, PooledBuffer, SampleFormat, Timestamp, VideoFrame,
+};
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
 fn make_yuv420p_frame(width: u32, height: u32) -> VideoFrame {
@@ -1525,7 +1527,7 @@ fn blend_multiply_black_top_should_produce_black_output() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Multiply, 1.0)
+        .blend(top, BlendMode::Multiply, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1568,7 +1570,7 @@ fn blend_multiply_white_top_should_be_identity() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Multiply, 1.0)
+        .blend(top, BlendMode::Multiply, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1611,7 +1613,7 @@ fn blend_screen_white_top_should_produce_white_output() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Screen, 1.0)
+        .blend(top, BlendMode::Screen, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1655,7 +1657,7 @@ fn blend_overlay_midgray_top_should_be_identity() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Overlay, 1.0)
+        .blend(top, BlendMode::Overlay, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1698,7 +1700,7 @@ fn blend_colordodge_should_produce_brighter_output() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::ColorDodge, 1.0)
+        .blend(top, BlendMode::ColorDodge, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1741,7 +1743,7 @@ fn blend_colorburn_should_produce_darker_output() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::ColorBurn, 1.0)
+        .blend(top, BlendMode::ColorBurn, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1784,7 +1786,7 @@ fn blend_darken_black_top_should_produce_black_output() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Darken, 1.0)
+        .blend(top, BlendMode::Darken, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1827,7 +1829,7 @@ fn blend_lighten_white_top_should_produce_white_output() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Lighten, 1.0)
+        .blend(top, BlendMode::Lighten, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1870,7 +1872,7 @@ fn blend_difference_with_self_should_produce_black() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Difference, 1.0)
+        .blend(top, BlendMode::Difference, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1913,7 +1915,7 @@ fn blend_add_black_top_should_be_identity() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Add, 1.0)
+        .blend(top, BlendMode::Add, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -1956,7 +1958,7 @@ fn blend_subtract_white_top_should_produce_black() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Subtract, 1.0)
+        .blend(top, BlendMode::Subtract, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2001,7 +2003,7 @@ fn blend_luminosity_should_preserve_base_hue_and_saturation() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::Luminosity, 1.0)
+        .blend(top, BlendMode::Luminosity, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2047,7 +2049,7 @@ fn porter_duff_over_opaque_top_should_cover_bottom() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffOver, 1.0)
+        .blend(top, BlendMode::PorterDuffOver, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2092,7 +2094,7 @@ fn porter_duff_over_semitransparent_should_blend_correctly() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffOver, 0.5)
+        .blend(top, BlendMode::PorterDuffOver, 0.5, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2135,7 +2137,7 @@ fn porter_duff_under_should_place_bottom_over_top() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffUnder, 1.0)
+        .blend(top, BlendMode::PorterDuffUnder, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2177,7 +2179,7 @@ fn porter_duff_in_should_produce_black_where_bottom_is_black() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffIn, 1.0)
+        .blend(top, BlendMode::PorterDuffIn, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2224,7 +2226,7 @@ fn porter_duff_atop_should_use_bottom_alpha_for_output() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffAtop, 1.0)
+        .blend(top, BlendMode::PorterDuffAtop, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2271,7 +2273,7 @@ fn porter_duff_xor_identical_shapes_should_produce_zero_alpha() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffXor, 1.0)
+        .blend(top, BlendMode::PorterDuffXor, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,
@@ -2317,7 +2319,7 @@ fn porter_duff_out_should_produce_black_where_bottom_is_white() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffOut, 1.0)
+        .blend(top, BlendMode::PorterDuffOut, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -67,12 +67,25 @@ fn make_audio_frame() -> AudioFrame {
 
 #[test]
 fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
-    // #1212/#1223: `format` args are built from `FfmpegToken`. The FFmpeg graph is constructed
-    // lazily on the first `push_video` (see `FilterGraph::build` docs), so it is the push — not
-    // `build()` — that hands the args to the real `format` filter. The old `.name()` path produced
-    // `color_spaces=bt2020/srgb` and `color_ranges=limited`, which the filter rejects at
-    // construction; with the FfmpegToken values (`bt2020nc`/`tv`/`yuv420p`) the push must succeed.
-    // Pushing unconditionally (no `is_ok()` guard) ensures an invalid arg fails the test.
+    // #1212/#1223: `format` args are built from `FfmpegToken`. The FFmpeg graph is built lazily on
+    // the first `push_video` (see `FilterGraph::build` docs), so the push — not `build()` — hands
+    // the args to the real `format` filter. Token *values* are guarded by the deterministic unit
+    // tests in `builder/video/format.rs`; this test additionally checks the linked FFmpeg ACCEPTS
+    // them. CI's Linux FFmpeg is built `--disable-everything` (no filters compiled in), so a
+    // baseline `format=pix_fmts=yuv420p` probe (universally valid, no conversion) separates "the
+    // `format` filter is unavailable" (skip) from "our tokens were rejected" (fail).
+    let frame = make_yuv420p_frame(64, 64);
+    {
+        let mut probe = FilterGraph::builder()
+            .format(vec![PixelFormat::Yuv420p], vec![], vec![])
+            .build()
+            .expect("non-empty format graph must build");
+        if probe.push_video(0, &frame).is_err() {
+            eprintln!("skipping: `format` filter not available in this FFmpeg build");
+            return;
+        }
+    }
+    // The `format` filter is available → the FfmpegToken args MUST be accepted (catches #1212).
     let mut graph = FilterGraph::builder()
         .format(
             vec![PixelFormat::Yuv420p],
@@ -81,10 +94,9 @@ fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
         )
         .build()
         .expect("non-empty format graph must build");
-    let frame = make_yuv420p_frame(64, 64);
     graph
         .push_video(0, &frame)
-        .expect("format push must succeed — FFmpeg must accept the FfmpegToken args");
+        .expect("FFmpeg must accept the FfmpegToken args (color_spaces=bt2020nc:color_ranges=tv)");
     let out = graph
         .pull_video()
         .expect("pull_video must not fail")
@@ -96,21 +108,43 @@ fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
 #[test]
 fn blend_with_premultiplied_alpha_should_be_accepted_by_ffmpeg() {
     // #1225: the `overlay` `alpha=premultiplied` argument must be accepted by FFmpeg. The overlay
-    // filter is constructed lazily when frames are pushed (not at `build()`), so BOTH inputs must
-    // be pushed to force its construction; an invalid `alpha` value would fail the push.
-    let top = FilterGraphBuilder::new();
-    let mut graph = FilterGraph::builder()
-        .blend(top, BlendMode::Normal, 1.0, AlphaMode::Premultiplied)
-        .build()
-        .expect("blend graph must build");
+    // filter is built lazily when frames are pushed, so both inputs must be pushed. A baseline
+    // blend (`AlphaMode::Straight`, which adds no `alpha=` arg) probes whether the overlay filter
+    // exists in this FFmpeg build (CI's Linux build has none): unavailable → skip; available → the
+    // `alpha=premultiplied` arg must be accepted.
     let bottom = make_yuv420p_frame(64, 64);
     let fg = make_yuv420p_frame(64, 64);
+    {
+        let mut probe = FilterGraph::builder()
+            .blend(
+                FilterGraphBuilder::new(),
+                BlendMode::Normal,
+                1.0,
+                AlphaMode::Straight,
+            )
+            .build()
+            .expect("non-empty blend graph must build");
+        if probe.push_video(0, &bottom).is_err() || probe.push_video(1, &fg).is_err() {
+            eprintln!("skipping: `overlay` filter not available in this FFmpeg build");
+            return;
+        }
+    }
+    // The overlay filter is available → `alpha=premultiplied` must be accepted (catches #1225).
+    let mut graph = FilterGraph::builder()
+        .blend(
+            FilterGraphBuilder::new(),
+            BlendMode::Normal,
+            1.0,
+            AlphaMode::Premultiplied,
+        )
+        .build()
+        .expect("non-empty blend graph must build");
     graph
         .push_video(0, &bottom)
         .expect("bottom push must succeed");
     graph
         .push_video(1, &fg)
-        .expect("top push must succeed — overlay must accept alpha=premultiplied");
+        .expect("overlay must accept alpha=premultiplied");
     let out = graph
         .pull_video()
         .expect("pull_video must not fail")

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -560,14 +560,11 @@ impl VideoEffectRenderer {
     ///
     /// Returns [`PipelineError::Filter`] if the filter graph cannot be built.
     pub fn new(clip: &Clip, input_format: PixelFormat) -> Result<Self, PipelineError> {
-        let mut builder =
-            FilterGraph::builder().format(vec![PixelFormat::Yuv420p], vec![], vec![], vec![]);
+        let mut builder = FilterGraph::builder().format(vec![PixelFormat::Yuv420p], vec![], vec![]);
         for step in clip.video_effect_chain() {
             builder = builder.add_step(step);
         }
-        let graph = builder
-            .format(vec![input_format], vec![], vec![], vec![])
-            .build()?;
+        let graph = builder.format(vec![input_format], vec![], vec![]).build()?;
         Ok(Self { graph })
     }
 


### PR DESCRIPTION
## Summary

The `format` video filter step built its argument string from each value's `.name()` (the human-readable label) instead of the FFmpeg-canonical `FfmpegToken`, so it emitted FFmpeg-rejected arguments (`color_spaces=srgb`, `color_ranges=limited`, …). It also pushed `alpha_modes=` into the `format` filter, which has no alpha option at all. Verified against the FFmpeg 7.1 and 8.0 C source, this wires the format args through `FfmpegToken` (skipping values with no FFmpeg equivalent), removes the bogus `alpha_modes` from `format()`, and moves the alpha format to its real consumer — the `overlay` filter's `alpha=` option.

## Changes

- **#1212** — `FilterStep::Format::args()` now renders `pix_fmts` / `color_spaces` / `color_ranges` via `filter_map(FfmpegToken::ffmpeg_token)`, emitting a key only when a token survives. `ColorSpace` tokens corrected: `Bt2020 → bt2020nc`, `Srgb → gbr`; `Bt601 → None` until the enum split (tracked in #1217). Fixed the misleading `#colorspace` doc comments to point at the actual C sources (FFmpeg 8.0 blob URLs).
- **#1223** — removed `alpha_modes` from `format()`, `FilterStep::Format`, and its emission (the `format` filter has no alpha option in 7.1/8.0); updated the two `ff-pipeline` call sites and the unit test.
- **#1225** — added `alpha: AlphaMode` to `FilterStep::Blend`; `blend()` now takes it as a 4th argument and `build.rs` appends `:alpha=premultiplied` to the overlay args only for `Premultiplied` (`Straight` is the overlay default → unchanged behaviour), via a new `overlay_alpha_suffix` helper. The photographic / expression blend paths use the `blend` filter and correctly ignore alpha. Updated the `blend()` call sites in tests and examples.

## Related Issues

Fixes #1212
Fixes #1223
Closes #1225

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes