### PR TITLE
refactor(ff-format): FFmpeg-correct ColorSpace / ColorPrimaries / ColorTransfer

### DIFF
--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -214,7 +214,7 @@ let mut encoder = VideoEncoder::create("output.mkv")
     .video_codec(VideoCodec::H265)
     .pixel_format(PixelFormat::Yuv420p10le)
     .color_transfer(ColorTransfer::Hlg)
-    .color_space(ColorSpace::Bt2020)
+    .color_space(ColorSpace::Bt2020Ncl)
     .color_primaries(ColorPrimaries::Bt2020)
     .build()?;
 ```

--- a/crates/avio/examples/encode/hdr10_encode.rs
+++ b/crates/avio/examples/encode/hdr10_encode.rs
@@ -127,7 +127,7 @@ fn main() {
         println!("Mode:   HLG colour tags (no MaxCLL/MaxFALL side data)");
         enc_builder = enc_builder
             .color_transfer(ColorTransfer::Hlg)
-            .color_space(ColorSpace::Bt2020)
+            .color_space(ColorSpace::Bt2020Ncl)
             .color_primaries(ColorPrimaries::Bt2020);
     } else {
         // ── HDR10 static metadata ─────────────────────────────────────────────

--- a/crates/ff-decode/src/video/decoder_inner/format_convert.rs
+++ b/crates/ff-decode/src/video/decoder_inner/format_convert.rs
@@ -49,12 +49,22 @@ impl VideoDecoderInner {
     pub(super) fn convert_color_space(space: AVColorSpace) -> ColorSpace {
         if space == ff_sys::AVColorSpace_AVCOL_SPC_BT709 {
             ColorSpace::Bt709
-        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_BT470BG
-            || space == ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M
-        {
-            ColorSpace::Bt601
+        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_BT470BG {
+            ColorSpace::Bt470bg
+        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M {
+            ColorSpace::Smpte170m
+        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_SMPTE240M {
+            ColorSpace::Smpte240m
+        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_FCC {
+            ColorSpace::Fcc
+        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_YCGCO {
+            ColorSpace::Ycgco
         } else if space == ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL {
-            ColorSpace::Bt2020
+            ColorSpace::Bt2020Ncl
+        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_BT2020_CL {
+            ColorSpace::Bt2020Cl
+        } else if space == ff_sys::AVColorSpace_AVCOL_SPC_RGB {
+            ColorSpace::Rgb
         } else {
             log::warn!(
                 "color_space unsupported, falling back to Bt709 requested={space} fallback=Bt709"
@@ -81,10 +91,18 @@ impl VideoDecoderInner {
     pub(super) fn convert_color_primaries(primaries: AVColorPrimaries) -> ColorPrimaries {
         if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_BT709 {
             ColorPrimaries::Bt709
-        } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG
-            || primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M
-        {
-            ColorPrimaries::Bt601
+        } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG {
+            ColorPrimaries::Bt470bg
+        } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M {
+            ColorPrimaries::Smpte170m
+        } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE240M {
+            ColorPrimaries::Smpte240m
+        } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_FILM {
+            ColorPrimaries::Film
+        } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE431 {
+            ColorPrimaries::DciP3
+        } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE432 {
+            ColorPrimaries::DisplayP3
         } else if primaries == ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020 {
             ColorPrimaries::Bt2020
         } else {

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -533,18 +533,18 @@ mod tests {
     }
 
     #[test]
-    fn color_space_bt470bg_yields_bt601() {
+    fn color_space_bt470bg_yields_bt470bg() {
         assert_eq!(
             VideoDecoderInner::convert_color_space(ff_sys::AVColorSpace_AVCOL_SPC_BT470BG),
-            ColorSpace::Bt601
+            ColorSpace::Bt470bg
         );
     }
 
     #[test]
-    fn color_space_smpte170m_yields_bt601() {
+    fn color_space_smpte170m_yields_smpte170m() {
         assert_eq!(
             VideoDecoderInner::convert_color_space(ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M),
-            ColorSpace::Bt601
+            ColorSpace::Smpte170m
         );
     }
 
@@ -552,7 +552,7 @@ mod tests {
     fn color_space_bt2020_ncl() {
         assert_eq!(
             VideoDecoderInner::convert_color_space(ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL),
-            ColorSpace::Bt2020
+            ColorSpace::Bt2020Ncl
         );
     }
 
@@ -605,20 +605,20 @@ mod tests {
     }
 
     #[test]
-    fn color_primaries_bt470bg_yields_bt601() {
+    fn color_primaries_bt470bg_yields_bt470bg() {
         assert_eq!(
             VideoDecoderInner::convert_color_primaries(ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG),
-            ColorPrimaries::Bt601
+            ColorPrimaries::Bt470bg
         );
     }
 
     #[test]
-    fn color_primaries_smpte170m_yields_bt601() {
+    fn color_primaries_smpte170m_yields_smpte170m() {
         assert_eq!(
             VideoDecoderInner::convert_color_primaries(
                 ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M
             ),
-            ColorPrimaries::Bt601
+            ColorPrimaries::Smpte170m
         );
     }
 

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -265,7 +265,7 @@ let mut encoder = VideoEncoder::create("output.mkv")
     .video_codec(VideoCodec::H265)
     .pixel_format(PixelFormat::Yuv420p10le)
     .color_transfer(ColorTransfer::Hlg)
-    .color_space(ColorSpace::Bt2020)
+    .color_space(ColorSpace::Bt2020Ncl)
     .color_primaries(ColorPrimaries::Bt2020)
     .build()?;
 ```

--- a/crates/ff-encode/src/video/encoder_inner/color.rs
+++ b/crates/ff-encode/src/video/encoder_inner/color.rs
@@ -79,9 +79,14 @@ pub(super) fn color_space_to_av(cs: ff_format::ColorSpace) -> ff_sys::AVColorSpa
     use ff_format::ColorSpace;
     match cs {
         ColorSpace::Bt709 => ff_sys::AVColorSpace_AVCOL_SPC_BT709,
-        ColorSpace::Bt601 => ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M,
-        ColorSpace::Bt2020 => ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL,
-        ColorSpace::DciP3 | ColorSpace::Srgb => ff_sys::AVColorSpace_AVCOL_SPC_RGB,
+        ColorSpace::Bt470bg => ff_sys::AVColorSpace_AVCOL_SPC_BT470BG,
+        ColorSpace::Smpte170m => ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M,
+        ColorSpace::Smpte240m => ff_sys::AVColorSpace_AVCOL_SPC_SMPTE240M,
+        ColorSpace::Fcc => ff_sys::AVColorSpace_AVCOL_SPC_FCC,
+        ColorSpace::Ycgco => ff_sys::AVColorSpace_AVCOL_SPC_YCGCO,
+        ColorSpace::Bt2020Ncl => ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL,
+        ColorSpace::Bt2020Cl => ff_sys::AVColorSpace_AVCOL_SPC_BT2020_CL,
+        ColorSpace::Rgb => ff_sys::AVColorSpace_AVCOL_SPC_RGB,
         ColorSpace::Unknown => ff_sys::AVColorSpace_AVCOL_SPC_UNSPECIFIED,
         _ => ff_sys::AVColorSpace_AVCOL_SPC_UNSPECIFIED,
     }
@@ -94,11 +99,16 @@ pub(super) fn color_transfer_to_av(
     use ff_format::ColorTransfer;
     match trc {
         ColorTransfer::Bt709 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_BT709,
+        ColorTransfer::Gamma22 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_GAMMA22,
+        ColorTransfer::Gamma28 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_GAMMA28,
+        ColorTransfer::Smpte170m => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTE170M,
+        ColorTransfer::Smpte240m => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTE240M,
+        ColorTransfer::Linear => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_LINEAR,
+        ColorTransfer::Srgb => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_IEC61966_2_1,
         ColorTransfer::Bt2020_10 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_BT2020_10,
         ColorTransfer::Bt2020_12 => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_BT2020_12,
-        ColorTransfer::Hlg => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_ARIB_STD_B67,
         ColorTransfer::Pq => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084,
-        ColorTransfer::Linear => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_LINEAR,
+        ColorTransfer::Hlg => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_ARIB_STD_B67,
         ColorTransfer::Unknown => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_UNSPECIFIED,
         _ => ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_UNSPECIFIED,
     }
@@ -109,7 +119,12 @@ pub(super) fn color_primaries_to_av(cp: ff_format::ColorPrimaries) -> ff_sys::AV
     use ff_format::ColorPrimaries;
     match cp {
         ColorPrimaries::Bt709 => ff_sys::AVColorPrimaries_AVCOL_PRI_BT709,
-        ColorPrimaries::Bt601 => ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M,
+        ColorPrimaries::Bt470bg => ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG,
+        ColorPrimaries::Smpte170m => ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M,
+        ColorPrimaries::Smpte240m => ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE240M,
+        ColorPrimaries::Film => ff_sys::AVColorPrimaries_AVCOL_PRI_FILM,
+        ColorPrimaries::DciP3 => ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE431,
+        ColorPrimaries::DisplayP3 => ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE432,
         ColorPrimaries::Bt2020 => ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020,
         ColorPrimaries::Unknown => ff_sys::AVColorPrimaries_AVCOL_PRI_UNSPECIFIED,
         _ => ff_sys::AVColorPrimaries_AVCOL_PRI_UNSPECIFIED,

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -915,17 +915,17 @@ mod tests {
     }
 
     #[test]
-    fn color_space_to_av_bt2020_should_return_bt2020_ncl() {
+    fn color_space_to_av_bt2020_ncl_should_return_bt2020_ncl() {
         assert_eq!(
-            color::color_space_to_av(ff_format::ColorSpace::Bt2020),
+            color::color_space_to_av(ff_format::ColorSpace::Bt2020Ncl),
             ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL
         );
     }
 
     #[test]
-    fn color_space_to_av_dcip3_should_return_rgb() {
+    fn color_space_to_av_rgb_should_return_rgb() {
         assert_eq!(
-            color::color_space_to_av(ff_format::ColorSpace::DciP3),
+            color::color_space_to_av(ff_format::ColorSpace::Rgb),
             ff_sys::AVColorSpace_AVCOL_SPC_RGB
         );
     }

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -1886,7 +1886,7 @@ fn hlg_color_transfer_on_h265_should_produce_valid_output() {
         .video_codec(VideoCodec::H265)
         .bitrate_mode(BitrateMode::Crf(28))
         .preset(Preset::Ultrafast)
-        .color_space(ColorSpace::Bt2020)
+        .color_space(ColorSpace::Bt2020Ncl)
         .color_transfer(ColorTransfer::Hlg)
         .color_primaries(ColorPrimaries::Bt2020)
         .build();

--- a/crates/ff-filter/src/graph/builder/video/format.rs
+++ b/crates/ff-filter/src/graph/builder/video/format.rs
@@ -37,7 +37,7 @@ mod tests {
     fn filter_step_format_should_produce_correct_args() {
         let step = FilterStep::Format {
             pix_fmts: vec![PixelFormat::Rgba, PixelFormat::Yuv420p],
-            color_spaces: vec![ColorSpace::Srgb],
+            color_spaces: vec![ColorSpace::Rgb],
             color_ranges: vec![ColorRange::Limited],
         };
         assert_eq!(step.filter_name(), "format");
@@ -49,11 +49,11 @@ mod tests {
 
     #[test]
     fn format_args_should_skip_values_without_ffmpeg_token() {
-        // `Other` (no static pix_fmt token), `Bt601` (needs the #1217 split) and `Unknown`
+        // `Other` (no static pix_fmt token), `Unknown` colour space and `Unknown`
         // range all return `None` and must be skipped rather than emitting invalid tokens.
         let step = FilterStep::Format {
             pix_fmts: vec![PixelFormat::Other(123), PixelFormat::Yuv420p],
-            color_spaces: vec![ColorSpace::Bt601, ColorSpace::Bt2020],
+            color_spaces: vec![ColorSpace::Unknown, ColorSpace::Bt2020Ncl],
             color_ranges: vec![ColorRange::Unknown],
         };
         assert_eq!(step.args(), "pix_fmts=yuv420p:color_spaces=bt2020nc");
@@ -61,12 +61,12 @@ mod tests {
 
     #[test]
     fn format_args_should_be_empty_when_all_values_lack_tokens() {
-        // Edge case: if every supplied value renders to `None` (e.g. `Other` pix fmt + `Bt601`
+        // Edge case: if every supplied value renders to `None` (e.g. `Other` pix fmt + `Unknown`
         // colour space + `Unknown` range), `args()` is the empty string. Documented so the
         // empty-args `format` step stays a visible, tested behaviour.
         let step = FilterStep::Format {
             pix_fmts: vec![PixelFormat::Other(1)],
-            color_spaces: vec![ColorSpace::Bt601],
+            color_spaces: vec![ColorSpace::Unknown],
             color_ranges: vec![ColorRange::Unknown],
         };
         assert_eq!(step.args(), "");

--- a/crates/ff-filter/src/graph/ffmpeg_token/format.rs
+++ b/crates/ff-filter/src/graph/ffmpeg_token/format.rs
@@ -1,6 +1,6 @@
 #![forbid(clippy::wildcard_enum_match_arm)]
 
-use ff_format::{AlphaMode, ColorRange, ColorSpace, PixelFormat};
+use ff_format::{AlphaMode, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, PixelFormat};
 
 use crate::graph::FfmpegToken;
 
@@ -22,11 +22,55 @@ impl FfmpegToken for ColorSpace {
         // color_space_names[] (format filter color_spaces=): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c
         Some(match self {
             Self::Bt709 => "bt709",
-            Self::Bt2020 => "bt2020nc",
-            Self::Srgb => "gbr",
-            // TODO(#1217): split `Bt601` into `bt470bg` (625) / `smpte170m` (525); skip until then.
-            Self::Bt601 => return None,
-            Self::DciP3 => return None,
+            Self::Bt470bg => "bt470bg",
+            Self::Smpte170m => "smpte170m",
+            Self::Bt2020Ncl => "bt2020nc",
+            Self::Bt2020Cl => "bt2020c",
+            Self::Rgb => "gbr",
+            Self::Fcc => "fcc",
+            Self::Smpte240m => "smpte240m",
+            Self::Ycgco => "ycgco",
+            Self::Unknown | _ => {
+                return None;
+            }
+        })
+    }
+}
+
+impl FfmpegToken for ColorPrimaries {
+    fn ffmpeg_token(&self) -> Option<&'static str> {
+        // color_primaries_names[] (setparams color_primaries=): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c
+        Some(match self {
+            Self::Bt709 => "bt709",
+            Self::Bt470bg => "bt470bg",
+            Self::Smpte170m => "smpte170m",
+            Self::Smpte240m => "smpte240m",
+            Self::Film => "film",
+            Self::DciP3 => "smpte431",
+            Self::DisplayP3 => "smpte432",
+            Self::Bt2020 => "bt2020",
+            Self::Unknown | _ => {
+                return None;
+            }
+        })
+    }
+}
+
+impl FfmpegToken for ColorTransfer {
+    fn ffmpeg_token(&self) -> Option<&'static str> {
+        // color_transfer_names[] (setparams color_trc=): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c
+        Some(match self {
+            Self::Bt709 => "bt709",
+            Self::Gamma22 => "gamma22",
+            Self::Gamma28 => "gamma28",
+            Self::Smpte170m => "smpte170m",
+            Self::Smpte240m => "smpte240m",
+            Self::Linear => "linear",
+            Self::Srgb => "iec61966-2-1",
+            Self::Bt2020_10 => "bt2020-10",
+            Self::Bt2020_12 => "bt2020-12",
+            Self::Pq => "smpte2084",
+            Self::Hlg => "arib-std-b67",
             Self::Unknown | _ => {
                 return None;
             }

--- a/crates/ff-filter/src/graph/ffmpeg_token/format.rs
+++ b/crates/ff-filter/src/graph/ffmpeg_token/format.rs
@@ -118,3 +118,55 @@ impl FfmpegToken for AlphaMode {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These deterministic string-equality tests are the only regression guard for the
+    // colour-token mappings until the setparams consumer lands (#1227); they assert the
+    // FFmpeg-canonical token, which deliberately differs from `name()` (e.g. `gbr` vs `rgb`).
+
+    #[test]
+    fn color_space_should_emit_canonical_tokens() {
+        assert_eq!(ColorSpace::Bt709.ffmpeg_token(), Some("bt709"));
+        assert_eq!(ColorSpace::Bt470bg.ffmpeg_token(), Some("bt470bg"));
+        assert_eq!(ColorSpace::Smpte170m.ffmpeg_token(), Some("smpte170m"));
+        assert_eq!(ColorSpace::Bt2020Ncl.ffmpeg_token(), Some("bt2020nc"));
+        assert_eq!(ColorSpace::Bt2020Cl.ffmpeg_token(), Some("bt2020c"));
+        assert_eq!(ColorSpace::Rgb.ffmpeg_token(), Some("gbr"));
+        assert_eq!(ColorSpace::Fcc.ffmpeg_token(), Some("fcc"));
+        assert_eq!(ColorSpace::Smpte240m.ffmpeg_token(), Some("smpte240m"));
+        assert_eq!(ColorSpace::Ycgco.ffmpeg_token(), Some("ycgco"));
+        assert_eq!(ColorSpace::Unknown.ffmpeg_token(), None);
+    }
+
+    #[test]
+    fn color_primaries_should_emit_canonical_tokens() {
+        assert_eq!(ColorPrimaries::Bt709.ffmpeg_token(), Some("bt709"));
+        assert_eq!(ColorPrimaries::Bt470bg.ffmpeg_token(), Some("bt470bg"));
+        assert_eq!(ColorPrimaries::Smpte170m.ffmpeg_token(), Some("smpte170m"));
+        assert_eq!(ColorPrimaries::Smpte240m.ffmpeg_token(), Some("smpte240m"));
+        assert_eq!(ColorPrimaries::Film.ffmpeg_token(), Some("film"));
+        assert_eq!(ColorPrimaries::DciP3.ffmpeg_token(), Some("smpte431"));
+        assert_eq!(ColorPrimaries::DisplayP3.ffmpeg_token(), Some("smpte432"));
+        assert_eq!(ColorPrimaries::Bt2020.ffmpeg_token(), Some("bt2020"));
+        assert_eq!(ColorPrimaries::Unknown.ffmpeg_token(), None);
+    }
+
+    #[test]
+    fn color_transfer_should_emit_canonical_tokens() {
+        assert_eq!(ColorTransfer::Bt709.ffmpeg_token(), Some("bt709"));
+        assert_eq!(ColorTransfer::Gamma22.ffmpeg_token(), Some("gamma22"));
+        assert_eq!(ColorTransfer::Gamma28.ffmpeg_token(), Some("gamma28"));
+        assert_eq!(ColorTransfer::Smpte170m.ffmpeg_token(), Some("smpte170m"));
+        assert_eq!(ColorTransfer::Smpte240m.ffmpeg_token(), Some("smpte240m"));
+        assert_eq!(ColorTransfer::Linear.ffmpeg_token(), Some("linear"));
+        assert_eq!(ColorTransfer::Srgb.ffmpeg_token(), Some("iec61966-2-1"));
+        assert_eq!(ColorTransfer::Bt2020_10.ffmpeg_token(), Some("bt2020-10"));
+        assert_eq!(ColorTransfer::Bt2020_12.ffmpeg_token(), Some("bt2020-12"));
+        assert_eq!(ColorTransfer::Pq.ffmpeg_token(), Some("smpte2084"));
+        assert_eq!(ColorTransfer::Hlg.ffmpeg_token(), Some("arib-std-b67"));
+        assert_eq!(ColorTransfer::Unknown.ffmpeg_token(), None);
+    }
+}

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -89,7 +89,7 @@ fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
     let mut graph = FilterGraph::builder()
         .format(
             vec![PixelFormat::Yuv420p],
-            vec![ColorSpace::Bt2020],
+            vec![ColorSpace::Bt2020Ncl],
             vec![ColorRange::Limited],
         )
         .build()

--- a/crates/ff-format/README.md
+++ b/crates/ff-format/README.md
@@ -34,7 +34,7 @@ use ff_format::{ColorTransfer, ColorSpace, ColorPrimaries, ColorRange};
 
 // Tag a stream as HLG broadcast HDR.
 let transfer  = ColorTransfer::Hlg;
-let space     = ColorSpace::Bt2020;
+let space     = ColorSpace::Bt2020Ncl;
 let primaries = ColorPrimaries::Bt2020;
 let range     = ColorRange::Limited;
 

--- a/crates/ff-format/src/color.rs
+++ b/crates/ff-format/src/color.rs
@@ -27,24 +27,32 @@ use std::fmt;
 /// # Common Usage
 ///
 /// - **BT.709**: HD content (720p, 1080p)
-/// - **BT.601**: SD content (480i, 576i)
-/// - **BT.2020**: UHD/HDR content (4K, 8K)
-/// - **sRGB**: Computer graphics, web content
+/// - **BT.470BG / SMPTE-170M**: SD content (576i PAL / 480i NTSC)
+/// - **BT.2020 NCL / CL**: UHD/HDR content (4K, 8K)
+/// - **RGB**: Identity matrix for RGB/GBR content
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
 pub enum ColorSpace {
-    /// ITU-R BT.709 - HD television standard (most common for HD video)
+    /// ITU-R BT.709 — HD television matrix (most common for HD video)
     #[default]
     Bt709,
-    /// ITU-R BT.601 - SD television standard
-    Bt601,
-    /// ITU-R BT.2020 - UHD/HDR television standard
-    Bt2020,
-    /// DCI-P3 - digital cinema wide color gamut
-    DciP3,
-    /// sRGB color space - computer graphics and web
-    Srgb,
-    /// Color space is not specified or unknown
+    /// ITU-R BT.470BG — BT.601 625-line (PAL/SECAM SD) matrix
+    Bt470bg,
+    /// SMPTE 170M — BT.601 525-line (NTSC SD) matrix
+    Smpte170m,
+    /// ITU-R BT.2020 non-constant luminance — UHD/HDR matrix
+    Bt2020Ncl,
+    /// ITU-R BT.2020 constant luminance — UHD/HDR matrix
+    Bt2020Cl,
+    /// Identity / RGB (GBR planar) — no YUV matrix
+    Rgb,
+    /// FCC — legacy NTSC 1953 matrix
+    Fcc,
+    /// SMPTE 240M — legacy HD matrix
+    Smpte240m,
+    /// `YCgCo` — reversible `YCgCo` matrix
+    Ycgco,
+    /// Color space matrix is not specified or unknown
     Unknown,
 }
 
@@ -57,21 +65,25 @@ impl ColorSpace {
     /// use ff_format::color::ColorSpace;
     ///
     /// assert_eq!(ColorSpace::Bt709.name(), "bt709");
-    /// assert_eq!(ColorSpace::Bt601.name(), "bt601");
+    /// assert_eq!(ColorSpace::Bt2020Ncl.name(), "bt2020ncl");
     /// ```
     #[must_use]
     pub const fn name(&self) -> &'static str {
         match self {
             Self::Bt709 => "bt709",
-            Self::Bt601 => "bt601",
-            Self::Bt2020 => "bt2020",
-            Self::DciP3 => "dcip3",
-            Self::Srgb => "srgb",
+            Self::Bt470bg => "bt470bg",
+            Self::Smpte170m => "smpte170m",
+            Self::Bt2020Ncl => "bt2020ncl",
+            Self::Bt2020Cl => "bt2020cl",
+            Self::Rgb => "rgb",
+            Self::Fcc => "fcc",
+            Self::Smpte240m => "smpte240m",
+            Self::Ycgco => "ycgco",
             Self::Unknown => "unknown",
         }
     }
 
-    /// Returns `true` if this is an HD color space (BT.709).
+    /// Returns `true` if this is the HD matrix (BT.709).
     ///
     /// # Examples
     ///
@@ -79,56 +91,41 @@ impl ColorSpace {
     /// use ff_format::color::ColorSpace;
     ///
     /// assert!(ColorSpace::Bt709.is_hd());
-    /// assert!(!ColorSpace::Bt601.is_hd());
+    /// assert!(!ColorSpace::Smpte170m.is_hd());
     /// ```
     #[must_use]
     pub const fn is_hd(&self) -> bool {
         matches!(self, Self::Bt709)
     }
 
-    /// Returns `true` if this is an SD color space (BT.601).
+    /// Returns `true` if this is an SD matrix (BT.601: BT.470BG or SMPTE-170M).
     ///
     /// # Examples
     ///
     /// ```
     /// use ff_format::color::ColorSpace;
     ///
-    /// assert!(ColorSpace::Bt601.is_sd());
+    /// assert!(ColorSpace::Smpte170m.is_sd());
     /// assert!(!ColorSpace::Bt709.is_sd());
     /// ```
     #[must_use]
     pub const fn is_sd(&self) -> bool {
-        matches!(self, Self::Bt601)
+        matches!(self, Self::Bt470bg | Self::Smpte170m)
     }
 
-    /// Returns `true` if this is a UHD/HDR color space (BT.2020).
+    /// Returns `true` if this is a UHD/HDR matrix (BT.2020 NCL or CL).
     ///
     /// # Examples
     ///
     /// ```
     /// use ff_format::color::ColorSpace;
     ///
-    /// assert!(ColorSpace::Bt2020.is_uhd());
+    /// assert!(ColorSpace::Bt2020Ncl.is_uhd());
     /// assert!(!ColorSpace::Bt709.is_uhd());
     /// ```
     #[must_use]
     pub const fn is_uhd(&self) -> bool {
-        matches!(self, Self::Bt2020)
-    }
-
-    /// Returns `true` if this is a cinema/DCI color space (DCI-P3).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ff_format::color::ColorSpace;
-    ///
-    /// assert!(ColorSpace::DciP3.is_cinema());
-    /// assert!(!ColorSpace::Bt709.is_cinema());
-    /// ```
-    #[must_use]
-    pub const fn is_cinema(&self) -> bool {
-        matches!(self, Self::DciP3)
+        matches!(self, Self::Bt2020Ncl | Self::Bt2020Cl)
     }
 
     /// Returns `true` if the color space is unknown.
@@ -291,7 +288,8 @@ impl fmt::Display for ColorRange {
 /// # Common Usage
 ///
 /// - **BT.709**: HD content, same as sRGB primaries
-/// - **BT.601**: SD content (NTSC or PAL)
+/// - **BT.470BG / SMPTE-170M**: SD content (PAL/SECAM / NTSC)
+/// - **DCI-P3 / Display P3**: digital cinema and wide-gamut displays
 /// - **BT.2020**: Wide color gamut for UHD/HDR
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
@@ -299,8 +297,18 @@ pub enum ColorPrimaries {
     /// ITU-R BT.709 primaries (same as sRGB, most common)
     #[default]
     Bt709,
-    /// ITU-R BT.601 primaries (SD video)
-    Bt601,
+    /// ITU-R BT.470BG primaries (PAL/SECAM SD video)
+    Bt470bg,
+    /// SMPTE 170M primaries (NTSC SD video)
+    Smpte170m,
+    /// SMPTE 240M primaries (legacy HD)
+    Smpte240m,
+    /// Generic film primaries (Illuminant C)
+    Film,
+    /// DCI-P3 primaries (SMPTE RP 431-2, digital cinema)
+    DciP3,
+    /// Display P3 primaries (SMPTE EG 432-1, wide-gamut displays)
+    DisplayP3,
     /// ITU-R BT.2020 primaries (wide color gamut for UHD/HDR)
     Bt2020,
     /// Color primaries are not specified or unknown
@@ -322,13 +330,18 @@ impl ColorPrimaries {
     pub const fn name(&self) -> &'static str {
         match self {
             Self::Bt709 => "bt709",
-            Self::Bt601 => "bt601",
+            Self::Bt470bg => "bt470bg",
+            Self::Smpte170m => "smpte170m",
+            Self::Smpte240m => "smpte240m",
+            Self::Film => "film",
+            Self::DciP3 => "dci-p3",
+            Self::DisplayP3 => "display-p3",
             Self::Bt2020 => "bt2020",
             Self::Unknown => "unknown",
         }
     }
 
-    /// Returns `true` if this uses wide color gamut (BT.2020).
+    /// Returns `true` if this uses a wide color gamut (BT.2020, DCI-P3, or Display P3).
     ///
     /// # Examples
     ///
@@ -336,11 +349,12 @@ impl ColorPrimaries {
     /// use ff_format::color::ColorPrimaries;
     ///
     /// assert!(ColorPrimaries::Bt2020.is_wide_gamut());
+    /// assert!(ColorPrimaries::DciP3.is_wide_gamut());
     /// assert!(!ColorPrimaries::Bt709.is_wide_gamut());
     /// ```
     #[must_use]
     pub const fn is_wide_gamut(&self) -> bool {
-        matches!(self, Self::Bt2020)
+        matches!(self, Self::Bt2020 | Self::DciP3 | Self::DisplayP3)
     }
 
     /// Returns `true` if the color primaries are unknown.
@@ -374,6 +388,9 @@ impl fmt::Display for ColorPrimaries {
 /// # Common Usage
 ///
 /// - **`Bt709`**: Standard SDR video (HD television)
+/// - **`Gamma22`** / **`Gamma28`**: Pure power-law gamma 2.2 / 2.8 (legacy SDR)
+/// - **`Smpte170m`** / **`Smpte240m`**: SD / legacy-HD transfer characteristics
+/// - **`Srgb`**: sRGB / IEC 61966-2-1 (computer graphics, web)
 /// - **`Pq`**: HDR10 and Dolby Vision (SMPTE ST 2084 / Perceptual Quantizer)
 /// - **`Hlg`**: Hybrid Log-Gamma — broadcast-compatible HDR (ARIB STD-B67)
 /// - **`Bt2020_10`** / **`Bt2020_12`**: BT.2020 SDR at 10/12-bit depth
@@ -384,16 +401,26 @@ pub enum ColorTransfer {
     /// ITU-R BT.709 transfer characteristic (standard SDR)
     #[default]
     Bt709,
+    /// Pure power-law gamma 2.2 (assumed display gamma)
+    Gamma22,
+    /// Pure power-law gamma 2.8 (BT.470 System B/G)
+    Gamma28,
+    /// SMPTE 170M transfer characteristic (SD)
+    Smpte170m,
+    /// SMPTE 240M transfer characteristic (legacy HD)
+    Smpte240m,
+    /// Linear light transfer (no gamma)
+    Linear,
+    /// sRGB / IEC 61966-2-1 transfer characteristic
+    Srgb,
     /// ITU-R BT.2020 for 10-bit content
     Bt2020_10,
     /// ITU-R BT.2020 for 12-bit content
     Bt2020_12,
-    /// Hybrid Log-Gamma (ARIB STD-B67) — broadcast HDR
-    Hlg,
     /// Perceptual Quantizer / SMPTE ST 2084 — HDR10
     Pq,
-    /// Linear light transfer (no gamma)
-    Linear,
+    /// Hybrid Log-Gamma (ARIB STD-B67) — broadcast HDR
+    Hlg,
     /// Transfer characteristic is not specified or unknown
     Unknown,
 }
@@ -414,11 +441,16 @@ impl ColorTransfer {
     pub const fn name(&self) -> &'static str {
         match self {
             Self::Bt709 => "bt709",
+            Self::Gamma22 => "gamma22",
+            Self::Gamma28 => "gamma28",
+            Self::Smpte170m => "smpte170m",
+            Self::Smpte240m => "smpte240m",
+            Self::Linear => "linear",
+            Self::Srgb => "srgb",
             Self::Bt2020_10 => "bt2020-10",
             Self::Bt2020_12 => "bt2020-12",
-            Self::Hlg => "hlg",
             Self::Pq => "pq",
-            Self::Linear => "linear",
+            Self::Hlg => "hlg",
             Self::Unknown => "unknown",
         }
     }
@@ -589,17 +621,21 @@ mod tests {
         #[test]
         fn test_names() {
             assert_eq!(ColorSpace::Bt709.name(), "bt709");
-            assert_eq!(ColorSpace::Bt601.name(), "bt601");
-            assert_eq!(ColorSpace::Bt2020.name(), "bt2020");
-            assert_eq!(ColorSpace::DciP3.name(), "dcip3");
-            assert_eq!(ColorSpace::Srgb.name(), "srgb");
+            assert_eq!(ColorSpace::Bt470bg.name(), "bt470bg");
+            assert_eq!(ColorSpace::Smpte170m.name(), "smpte170m");
+            assert_eq!(ColorSpace::Bt2020Ncl.name(), "bt2020ncl");
+            assert_eq!(ColorSpace::Bt2020Cl.name(), "bt2020cl");
+            assert_eq!(ColorSpace::Rgb.name(), "rgb");
+            assert_eq!(ColorSpace::Fcc.name(), "fcc");
+            assert_eq!(ColorSpace::Smpte240m.name(), "smpte240m");
+            assert_eq!(ColorSpace::Ycgco.name(), "ycgco");
             assert_eq!(ColorSpace::Unknown.name(), "unknown");
         }
 
         #[test]
         fn test_display() {
             assert_eq!(format!("{}", ColorSpace::Bt709), "bt709");
-            assert_eq!(format!("{}", ColorSpace::Bt2020), "bt2020");
+            assert_eq!(format!("{}", ColorSpace::Bt2020Ncl), "bt2020ncl");
         }
 
         #[test]
@@ -613,20 +649,15 @@ mod tests {
             assert!(!ColorSpace::Bt709.is_sd());
             assert!(!ColorSpace::Bt709.is_uhd());
 
-            assert!(!ColorSpace::Bt601.is_hd());
-            assert!(ColorSpace::Bt601.is_sd());
-            assert!(!ColorSpace::Bt601.is_uhd());
+            assert!(!ColorSpace::Smpte170m.is_hd());
+            assert!(ColorSpace::Smpte170m.is_sd());
+            assert!(ColorSpace::Bt470bg.is_sd());
+            assert!(!ColorSpace::Smpte170m.is_uhd());
 
-            assert!(!ColorSpace::Bt2020.is_hd());
-            assert!(!ColorSpace::Bt2020.is_sd());
-            assert!(ColorSpace::Bt2020.is_uhd());
-        }
-
-        #[test]
-        fn dcip3_is_cinema_should_return_true() {
-            assert!(ColorSpace::DciP3.is_cinema());
-            assert!(!ColorSpace::Bt709.is_cinema());
-            assert!(!ColorSpace::Bt2020.is_cinema());
+            assert!(!ColorSpace::Bt2020Ncl.is_hd());
+            assert!(!ColorSpace::Bt2020Ncl.is_sd());
+            assert!(ColorSpace::Bt2020Ncl.is_uhd());
+            assert!(ColorSpace::Bt2020Cl.is_uhd());
         }
 
         #[test]
@@ -638,7 +669,7 @@ mod tests {
         #[test]
         fn test_debug() {
             assert_eq!(format!("{:?}", ColorSpace::Bt709), "Bt709");
-            assert_eq!(format!("{:?}", ColorSpace::Srgb), "Srgb");
+            assert_eq!(format!("{:?}", ColorSpace::Rgb), "Rgb");
         }
 
         #[test]
@@ -646,13 +677,13 @@ mod tests {
             use std::collections::HashSet;
 
             assert_eq!(ColorSpace::Bt709, ColorSpace::Bt709);
-            assert_ne!(ColorSpace::Bt709, ColorSpace::Bt601);
+            assert_ne!(ColorSpace::Bt709, ColorSpace::Smpte170m);
 
             let mut set = HashSet::new();
             set.insert(ColorSpace::Bt709);
-            set.insert(ColorSpace::Bt601);
+            set.insert(ColorSpace::Smpte170m);
             assert!(set.contains(&ColorSpace::Bt709));
-            assert!(!set.contains(&ColorSpace::Bt2020));
+            assert!(!set.contains(&ColorSpace::Bt2020Ncl));
         }
 
         #[test]
@@ -732,7 +763,12 @@ mod tests {
         #[test]
         fn test_names() {
             assert_eq!(ColorPrimaries::Bt709.name(), "bt709");
-            assert_eq!(ColorPrimaries::Bt601.name(), "bt601");
+            assert_eq!(ColorPrimaries::Bt470bg.name(), "bt470bg");
+            assert_eq!(ColorPrimaries::Smpte170m.name(), "smpte170m");
+            assert_eq!(ColorPrimaries::Smpte240m.name(), "smpte240m");
+            assert_eq!(ColorPrimaries::Film.name(), "film");
+            assert_eq!(ColorPrimaries::DciP3.name(), "dci-p3");
+            assert_eq!(ColorPrimaries::DisplayP3.name(), "display-p3");
             assert_eq!(ColorPrimaries::Bt2020.name(), "bt2020");
             assert_eq!(ColorPrimaries::Unknown.name(), "unknown");
         }
@@ -751,8 +787,10 @@ mod tests {
         #[test]
         fn test_is_wide_gamut() {
             assert!(ColorPrimaries::Bt2020.is_wide_gamut());
+            assert!(ColorPrimaries::DciP3.is_wide_gamut());
+            assert!(ColorPrimaries::DisplayP3.is_wide_gamut());
             assert!(!ColorPrimaries::Bt709.is_wide_gamut());
-            assert!(!ColorPrimaries::Bt601.is_wide_gamut());
+            assert!(!ColorPrimaries::Smpte170m.is_wide_gamut());
         }
 
         #[test]
@@ -772,7 +810,7 @@ mod tests {
             set.insert(ColorPrimaries::Bt709);
             set.insert(ColorPrimaries::Bt2020);
             assert!(set.contains(&ColorPrimaries::Bt709));
-            assert!(!set.contains(&ColorPrimaries::Bt601));
+            assert!(!set.contains(&ColorPrimaries::Smpte170m));
         }
     }
 
@@ -782,11 +820,16 @@ mod tests {
         #[test]
         fn test_names() {
             assert_eq!(ColorTransfer::Bt709.name(), "bt709");
+            assert_eq!(ColorTransfer::Gamma22.name(), "gamma22");
+            assert_eq!(ColorTransfer::Gamma28.name(), "gamma28");
+            assert_eq!(ColorTransfer::Smpte170m.name(), "smpte170m");
+            assert_eq!(ColorTransfer::Smpte240m.name(), "smpte240m");
+            assert_eq!(ColorTransfer::Linear.name(), "linear");
+            assert_eq!(ColorTransfer::Srgb.name(), "srgb");
             assert_eq!(ColorTransfer::Bt2020_10.name(), "bt2020-10");
             assert_eq!(ColorTransfer::Bt2020_12.name(), "bt2020-12");
-            assert_eq!(ColorTransfer::Hlg.name(), "hlg");
             assert_eq!(ColorTransfer::Pq.name(), "pq");
-            assert_eq!(ColorTransfer::Linear.name(), "linear");
+            assert_eq!(ColorTransfer::Hlg.name(), "hlg");
             assert_eq!(ColorTransfer::Unknown.name(), "unknown");
         }
 
@@ -819,6 +862,11 @@ mod tests {
         #[test]
         fn sdr_transfers_are_not_hdr() {
             assert!(!ColorTransfer::Bt709.is_hdr());
+            assert!(!ColorTransfer::Gamma22.is_hdr());
+            assert!(!ColorTransfer::Gamma28.is_hdr());
+            assert!(!ColorTransfer::Smpte170m.is_hdr());
+            assert!(!ColorTransfer::Smpte240m.is_hdr());
+            assert!(!ColorTransfer::Srgb.is_hdr());
             assert!(!ColorTransfer::Bt2020_10.is_hdr());
             assert!(!ColorTransfer::Bt2020_12.is_hdr());
             assert!(!ColorTransfer::Linear.is_hdr());

--- a/crates/ff-format/src/stream/video.rs
+++ b/crates/ff-format/src/stream/video.rs
@@ -451,7 +451,7 @@ mod tests {
             .duration(Duration::from_secs(120))
             .bitrate(50_000_000)
             .frame_count(7200)
-            .color_space(ColorSpace::Bt2020)
+            .color_space(ColorSpace::Bt2020Ncl)
             .color_range(ColorRange::Full)
             .color_primaries(ColorPrimaries::Bt2020)
             .build();
@@ -462,7 +462,7 @@ mod tests {
         assert_eq!(info.duration(), Some(Duration::from_secs(120)));
         assert_eq!(info.bitrate(), Some(50_000_000));
         assert_eq!(info.frame_count(), Some(7200));
-        assert_eq!(info.color_space(), ColorSpace::Bt2020);
+        assert_eq!(info.color_space(), ColorSpace::Bt2020Ncl);
         assert_eq!(info.color_range(), ColorRange::Full);
         assert_eq!(info.color_primaries(), ColorPrimaries::Bt2020);
     }

--- a/crates/ff-probe/src/probe/probe_inner/mapping.rs
+++ b/crates/ff-probe/src/probe/probe_inner/mapping.rs
@@ -61,13 +61,14 @@ pub(super) fn map_pixel_format(format: i32) -> PixelFormat {
 pub(super) fn map_color_space(color_space: ff_sys::AVColorSpace) -> ColorSpace {
     match color_space {
         ff_sys::AVColorSpace_AVCOL_SPC_BT709 => ColorSpace::Bt709,
-        ff_sys::AVColorSpace_AVCOL_SPC_BT470BG | ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M => {
-            ColorSpace::Bt601
-        }
-        ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL | ff_sys::AVColorSpace_AVCOL_SPC_BT2020_CL => {
-            ColorSpace::Bt2020
-        }
-        ff_sys::AVColorSpace_AVCOL_SPC_RGB => ColorSpace::Srgb,
+        ff_sys::AVColorSpace_AVCOL_SPC_BT470BG => ColorSpace::Bt470bg,
+        ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M => ColorSpace::Smpte170m,
+        ff_sys::AVColorSpace_AVCOL_SPC_SMPTE240M => ColorSpace::Smpte240m,
+        ff_sys::AVColorSpace_AVCOL_SPC_FCC => ColorSpace::Fcc,
+        ff_sys::AVColorSpace_AVCOL_SPC_YCGCO => ColorSpace::Ycgco,
+        ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL => ColorSpace::Bt2020Ncl,
+        ff_sys::AVColorSpace_AVCOL_SPC_BT2020_CL => ColorSpace::Bt2020Cl,
+        ff_sys::AVColorSpace_AVCOL_SPC_RGB => ColorSpace::Rgb,
         _ => {
             log::warn!(
                 "color_space has no mapping, using Unknown \
@@ -97,8 +98,12 @@ pub(super) fn map_color_range(color_range: ff_sys::AVColorRange) -> ColorRange {
 pub(super) fn map_color_primaries(color_primaries: ff_sys::AVColorPrimaries) -> ColorPrimaries {
     match color_primaries {
         ff_sys::AVColorPrimaries_AVCOL_PRI_BT709 => ColorPrimaries::Bt709,
-        ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG
-        | ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M => ColorPrimaries::Bt601,
+        ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG => ColorPrimaries::Bt470bg,
+        ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M => ColorPrimaries::Smpte170m,
+        ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE240M => ColorPrimaries::Smpte240m,
+        ff_sys::AVColorPrimaries_AVCOL_PRI_FILM => ColorPrimaries::Film,
+        ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE431 => ColorPrimaries::DciP3,
+        ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE432 => ColorPrimaries::DisplayP3,
         ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020 => ColorPrimaries::Bt2020,
         _ => {
             log::warn!(

--- a/crates/ff-probe/src/probe/probe_inner/mod.rs
+++ b/crates/ff-probe/src/probe/probe_inner/mod.rs
@@ -264,27 +264,27 @@ mod tests {
     }
 
     #[test]
-    fn test_map_color_space_bt601() {
+    fn test_map_color_space_sd() {
         let space = map_color_space(ff_sys::AVColorSpace_AVCOL_SPC_BT470BG);
-        assert_eq!(space, ColorSpace::Bt601);
+        assert_eq!(space, ColorSpace::Bt470bg);
 
         let space = map_color_space(ff_sys::AVColorSpace_AVCOL_SPC_SMPTE170M);
-        assert_eq!(space, ColorSpace::Bt601);
+        assert_eq!(space, ColorSpace::Smpte170m);
     }
 
     #[test]
     fn test_map_color_space_bt2020() {
         let space = map_color_space(ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL);
-        assert_eq!(space, ColorSpace::Bt2020);
+        assert_eq!(space, ColorSpace::Bt2020Ncl);
 
         let space = map_color_space(ff_sys::AVColorSpace_AVCOL_SPC_BT2020_CL);
-        assert_eq!(space, ColorSpace::Bt2020);
+        assert_eq!(space, ColorSpace::Bt2020Cl);
     }
 
     #[test]
-    fn test_map_color_space_srgb() {
+    fn test_map_color_space_rgb() {
         let space = map_color_space(ff_sys::AVColorSpace_AVCOL_SPC_RGB);
-        assert_eq!(space, ColorSpace::Srgb);
+        assert_eq!(space, ColorSpace::Rgb);
     }
 
     #[test]
@@ -326,12 +326,12 @@ mod tests {
     }
 
     #[test]
-    fn test_map_color_primaries_bt601() {
+    fn test_map_color_primaries_sd() {
         let primaries = map_color_primaries(ff_sys::AVColorPrimaries_AVCOL_PRI_BT470BG);
-        assert_eq!(primaries, ColorPrimaries::Bt601);
+        assert_eq!(primaries, ColorPrimaries::Bt470bg);
 
         let primaries = map_color_primaries(ff_sys::AVColorPrimaries_AVCOL_PRI_SMPTE170M);
-        assert_eq!(primaries, ColorPrimaries::Bt601);
+        assert_eq!(primaries, ColorPrimaries::Smpte170m);
     }
 
     #[test]

--- a/crates/ff-probe/tests/integration_tests.rs
+++ b/crates/ff-probe/tests/integration_tests.rs
@@ -542,12 +542,14 @@ fn test_probe_video_color_space_extraction() {
 
     // Verify color space is extracted (may be Unknown for some files)
     let color_space = video.color_space();
-    // Valid color spaces: BT.709 (HD), BT.601 (SD), BT.2020 (HDR), sRGB, or Unknown
+    // Valid color spaces: BT.709 (HD), BT.470BG/SMPTE-170M (SD), BT.2020 NCL/CL (HDR), RGB, or Unknown
     let valid_spaces = [
         ff_format::color::ColorSpace::Bt709,
-        ff_format::color::ColorSpace::Bt601,
-        ff_format::color::ColorSpace::Bt2020,
-        ff_format::color::ColorSpace::Srgb,
+        ff_format::color::ColorSpace::Bt470bg,
+        ff_format::color::ColorSpace::Smpte170m,
+        ff_format::color::ColorSpace::Bt2020Ncl,
+        ff_format::color::ColorSpace::Bt2020Cl,
+        ff_format::color::ColorSpace::Rgb,
         ff_format::color::ColorSpace::Unknown,
     ];
     assert!(
@@ -592,11 +594,14 @@ fn test_probe_video_color_primaries_extraction() {
 
     // Verify color primaries are extracted
     let color_primaries = video.color_primaries();
-    // Valid color primaries: BT.709, BT.601, BT.2020, or Unknown
+    // Valid color primaries: BT.709, BT.470BG/SMPTE-170M, BT.2020, DCI-P3, Display P3, or Unknown
     let valid_primaries = [
         ff_format::color::ColorPrimaries::Bt709,
-        ff_format::color::ColorPrimaries::Bt601,
+        ff_format::color::ColorPrimaries::Bt470bg,
+        ff_format::color::ColorPrimaries::Smpte170m,
         ff_format::color::ColorPrimaries::Bt2020,
+        ff_format::color::ColorPrimaries::DciP3,
+        ff_format::color::ColorPrimaries::DisplayP3,
         ff_format::color::ColorPrimaries::Unknown,
     ];
     assert!(
@@ -621,7 +626,7 @@ fn test_probe_video_color_info_consistency() {
 
     // Check for common consistency patterns (not strictly required, but good practice)
     // Note: Some encoders may not set all color parameters consistently
-    if color_space == ff_format::color::ColorSpace::Bt2020 {
+    if color_space.is_uhd() {
         // HDR content should have BT.2020 primaries
         // (or Unknown if encoder didn't set it)
         assert!(
@@ -647,8 +652,8 @@ fn test_probe_video_hdr_detection() {
     let color_primaries = video.color_primaries();
 
     // HDR content is indicated by BT.2020 color space or primaries
-    let is_hdr = color_space == ff_format::color::ColorSpace::Bt2020
-        || color_primaries == ff_format::color::ColorPrimaries::Bt2020;
+    let is_hdr =
+        color_space.is_uhd() || color_primaries == ff_format::color::ColorPrimaries::Bt2020;
 
     // For test files, we don't require HDR, just verify detection works
     // If HDR is detected, log it for manual verification

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -337,7 +337,11 @@ pub const AVColorPrimaries_AVCOL_PRI_BT709: AVColorPrimaries = 1;
 pub const AVColorPrimaries_AVCOL_PRI_UNSPECIFIED: AVColorPrimaries = 2;
 pub const AVColorPrimaries_AVCOL_PRI_BT470BG: AVColorPrimaries = 5;
 pub const AVColorPrimaries_AVCOL_PRI_SMPTE170M: AVColorPrimaries = 6;
+pub const AVColorPrimaries_AVCOL_PRI_SMPTE240M: AVColorPrimaries = 7;
+pub const AVColorPrimaries_AVCOL_PRI_FILM: AVColorPrimaries = 8;
 pub const AVColorPrimaries_AVCOL_PRI_BT2020: AVColorPrimaries = 9;
+pub const AVColorPrimaries_AVCOL_PRI_SMPTE431: AVColorPrimaries = 11;
+pub const AVColorPrimaries_AVCOL_PRI_SMPTE432: AVColorPrimaries = 12;
 
 // AVColorRange
 pub const AVColorRange_AVCOL_RANGE_UNSPECIFIED: AVColorRange = 0;
@@ -348,15 +352,23 @@ pub const AVColorRange_AVCOL_RANGE_JPEG: AVColorRange = 2;
 pub const AVColorSpace_AVCOL_SPC_RGB: AVColorSpace = 0;
 pub const AVColorSpace_AVCOL_SPC_BT709: AVColorSpace = 1;
 pub const AVColorSpace_AVCOL_SPC_UNSPECIFIED: AVColorSpace = 2;
+pub const AVColorSpace_AVCOL_SPC_FCC: AVColorSpace = 4;
 pub const AVColorSpace_AVCOL_SPC_BT470BG: AVColorSpace = 5;
 pub const AVColorSpace_AVCOL_SPC_SMPTE170M: AVColorSpace = 6;
+pub const AVColorSpace_AVCOL_SPC_SMPTE240M: AVColorSpace = 7;
+pub const AVColorSpace_AVCOL_SPC_YCGCO: AVColorSpace = 8;
 pub const AVColorSpace_AVCOL_SPC_BT2020_NCL: AVColorSpace = 9;
 pub const AVColorSpace_AVCOL_SPC_BT2020_CL: AVColorSpace = 10;
 
 // AVColorTransferCharacteristic
 pub const AVColorTransferCharacteristic_AVCOL_TRC_BT709: AVColorTransferCharacteristic = 1;
 pub const AVColorTransferCharacteristic_AVCOL_TRC_UNSPECIFIED: AVColorTransferCharacteristic = 2;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_GAMMA22: AVColorTransferCharacteristic = 4;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_GAMMA28: AVColorTransferCharacteristic = 5;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_SMPTE170M: AVColorTransferCharacteristic = 6;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_SMPTE240M: AVColorTransferCharacteristic = 7;
 pub const AVColorTransferCharacteristic_AVCOL_TRC_LINEAR: AVColorTransferCharacteristic = 8;
+pub const AVColorTransferCharacteristic_AVCOL_TRC_IEC61966_2_1: AVColorTransferCharacteristic = 13;
 pub const AVColorTransferCharacteristic_AVCOL_TRC_BT2020_10: AVColorTransferCharacteristic = 14;
 pub const AVColorTransferCharacteristic_AVCOL_TRC_BT2020_12: AVColorTransferCharacteristic = 15;
 pub const AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084: AVColorTransferCharacteristic = 16;

--- a/docs/specs/ffmpeg-tokens.md
+++ b/docs/specs/ffmpeg-tokens.md
@@ -1,0 +1,216 @@
+# FFmpeg Token Mapping
+
+Per-enum mapping of avio enum variants to FFmpeg tokens. `status` is `OK`/`NG`; for `NG`, `expected`
+holds the correct token, or `want to remove` for variants with no FFmpeg equivalent. Each table's
+`Reference` links the actual C source (FFmpeg `release/7.1` and `release/8.0`).
+
+## ScaleAlgorithm
+
+**Reference:** swscale `sws_flags` unit (`libswscale/options.c`) — consumed by the `scale` filter `flags=` via `ScaleAlgorithm::as_flags_str()` — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libswscale/options.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libswscale/options.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Fast | fast_bilinear | OK | - |
+| Bilinear | bilinear | OK | - |
+| Bicubic | bicubic | OK | - |
+| Lanczos | lanczos | OK | - |
+
+> Full swscale scaler set (11): `fast_bilinear, bilinear, bicubic, experimental, neighbor, area, bicublin, gauss, sinc, lanczos, spline` — avio covers 4. The Scale step emits `ScaleAlgorithm::as_flags_str()` (identical values to the `FfmpegToken` impl — a duplicate). The `libplacebo` filter (`vf_libplacebo`, `upscaler`/`downscaler`: `spline36`/`mitchell`/`ewa_lanczos`/…) is a **separate** kernel set and is **not** avio's scaler.
+
+## ToneMap
+
+**Reference:** `tonemap` filter `tonemap=` option (`tonemap` unit) — emitted via `ToneMap::as_str()` — `libavfilter/vf_tonemap.c` — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_tonemap.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_tonemap.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Hable | hable | OK | - |
+| Reinhard | reinhard | OK | - |
+| Mobius | mobius | OK | - |
+
+> Full `tonemap` set (7): `none, linear, gamma, clip, reinhard, hable, mobius` — avio covers 3. `as_str()` duplicates the `FfmpegToken` impl.
+
+## YadifMode
+
+**Reference:** `yadif` filter `mode=` option (`AV_OPT_TYPE_INT`, **range 0–3**) — emitted **numerically** via `*mode as i32` — `libavfilter/yadif_common.c` — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/yadif_common.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/yadif_common.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Frame | 0 | OK | - |
+| Field | 1 | OK | - |
+| FrameNospatial | 2 | OK | - |
+| FieldNospatial | 3 | OK | - |
+
+> avio emits `mode=0`…`mode=3` (numeric), valid because `mode` is an INT in range 0–3 (`{.i64=YADIF_MODE_SEND_FRAME}, 0, 3`). Named aliases `send_frame`/`send_field`/`send_frame_nospatial`/`send_field_nospatial` = 0/1/2/3. **Full coverage (4/4).** The `FfmpegToken` impl (`"0"`…`"3"`) duplicates the cast.
+
+## XfadeTransition
+
+**Reference:** `xfade` filter `transition=` option (`transition` unit) — emitted via `XfadeTransition::as_str()` — `libavfilter/vf_xfade.c` — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_xfade.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_xfade.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Dissolve | dissolve | OK | - |
+| Fade | fade | OK | - |
+| WipeLeft | wipeleft | OK | - |
+| WipeRight | wiperight | OK | - |
+| WipeUp | wipeup | OK | - |
+| WipeDown | wipedown | OK | - |
+| SlideLeft | slideleft | OK | - |
+| SlideRight | slideright | OK | - |
+| SlideUp | slideup | OK | - |
+| SlideDown | slidedown | OK | - |
+| CircleOpen | circleopen | OK | - |
+| CircleClose | circleclose | OK | - |
+| FadeGrays | fadegrays | OK | - |
+| Pixelize | pixelize | OK | - |
+
+> Full `xfade` transition set: **59** — avio covers 14 (enum is `#[non_exhaustive]`). `as_str()` duplicates the `FfmpegToken` impl.
+
+## BlendMode
+
+**Reference:** `libavfilter/vf_blend.c` (`all_mode` / `mode` unit) — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_blend.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_blend.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Normal | normal | OK | - |
+| Multiply | multiply | OK | - |
+| Screen | screen | OK | - |
+| Overlay | overlay | OK | - |
+| SoftLight | softlight | OK | - |
+| HardLight | hardlight | OK | - |
+| ColorDodge | dodge | OK | - |
+| ColorBurn | burn | OK | - |
+| Darken | darken | OK | - |
+| Lighten | lighten | OK | - |
+| Difference | difference | OK | - |
+| Exclusion | exclusion | OK | - |
+| Add | addition | OK | - |
+| Subtract | subtract | OK | - |
+| Hue | None | NG | want to remove |
+| Saturation | None | NG | want to remove |
+| Color | None | NG | want to remove |
+| Luminosity | None | NG | want to remove |
+
+> `PorterDuffOver/Under/In/Out/Atop/Xor` are separated into `CompositeOp` (below) — #1218.
+
+## CompositeOp
+
+**Reference:** no FFmpeg token — built via `libavfilter/vf_overlay.c` (overlay) + `libavfilter/vf_blend.c` (`c0_expr`). overlay [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_overlay.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_overlay.c) · blend [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_blend.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_blend.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Over | None | OK | - |
+| Under | None | OK | - |
+| In | None | OK | - |
+| Out | None | OK | - |
+| Atop | None | OK | - |
+| Xor | None | OK | - |
+
+## ColorRange
+
+**Reference:** `libavutil/pixdesc.c` (`color_range_names[]`, via `av_color_range_from_name`) — consumed by the `format` filter `color_ranges=` (`vf_format.c`) — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavutil/pixdesc.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Limited | tv | OK | - |
+| Full | pc | OK | - |
+| Unknown | None | OK | - |
+
+> The `format` step emits `.name()` (`Limited`→`"limited"`, `Full`→`"full"`), which `av_color_range_from_name` **rejects** — it accepts only `tv`/`pc`/`unknown` (`color_range_names[]`). The correct tokens (`tv`/`pc`) are in `FfmpegToken`, not yet wired (#1212). The `colorspace` filter `range` unit additionally accepts `mpeg`/`jpeg` aliases, but avio's consumer is the `format` filter.
+
+## ColorSpace
+
+**Reference:** `libavutil/pixdesc.c` (`color_space_names[]`, via `av_color_space_from_name`) — consumed by the `format` filter `color_spaces=` (`vf_format.c`) — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavutil/pixdesc.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Bt709 | bt709 | OK | - |
+| Bt470bg | bt470bg | OK | - |
+| Smpte170m | smpte170m | OK | - |
+| Bt2020Ncl | bt2020nc | OK | - |
+| Bt2020Cl | bt2020c | OK | - |
+| Rgb | gbr | OK | - |
+| Fcc | fcc | OK | - |
+| Smpte240m | smpte240m | OK | - |
+| Ycgco | ycgco | OK | - |
+| Unknown | None | OK | - |
+
+> Redesigned in #1217: `Bt601` split into `Bt470bg`/`Smpte170m`, `Bt2020` split into `Bt2020Ncl`/`Bt2020Cl`, `Srgb`→`Rgb` (token `gbr`), `DciP3` moved to ColorPrimaries; added `Fcc`/`Smpte240m`/`Ycgco`. `name()` is the human label; `FfmpegToken` is the canonical token above.
+
+## ColorPrimaries
+
+**Reference:** `libavfilter/vf_setparams.c` (`color_primaries` unit; tokens match `pixdesc.c color_primaries_names[]`) — planned consumer per the #1217 follow-up (the `format` filter has no `color_primaries` option) — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_setparams.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_setparams.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Bt709 | bt709 | OK | - |
+| Bt470bg | bt470bg | OK | - |
+| Smpte170m | smpte170m | OK | - |
+| Smpte240m | smpte240m | OK | - |
+| Film | film | OK | - |
+| DciP3 | smpte431 | OK | - |
+| DisplayP3 | smpte432 | OK | - |
+| Bt2020 | bt2020 | OK | - |
+| Unknown | None | OK | - |
+
+> Redesigned in #1217: `Bt601` split into `Bt470bg`/`Smpte170m`; added `Smpte240m`/`Film`/`DciP3` (token `smpte431`)/`DisplayP3` (token `smpte432`). `FfmpegToken` impl added; the setparams consumer is the #1217 follow-up.
+
+## ColorTransfer
+
+**Reference:** `libavfilter/vf_setparams.c` (`color_trc` unit; tokens match `pixdesc.c color_transfer_names[]`, incl. `arib-std-b67`/`smpte2084`) — planned consumer per the #1217 follow-up (the `format` filter has no `color_transfer` option) — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_setparams.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_setparams.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Bt709 | bt709 | OK | - |
+| Gamma22 | gamma22 | OK | - |
+| Gamma28 | gamma28 | OK | - |
+| Smpte170m | smpte170m | OK | - |
+| Smpte240m | smpte240m | OK | - |
+| Linear | linear | OK | - |
+| Srgb | iec61966-2-1 | OK | - |
+| Bt2020_10 | bt2020-10 | OK | - |
+| Bt2020_12 | bt2020-12 | OK | - |
+| Pq | smpte2084 | OK | - |
+| Hlg | arib-std-b67 | OK | - |
+| Unknown | None | OK | - |
+
+> Redesigned in #1217: `Hlg`/`Pq` keep their human names but `FfmpegToken` now emits the canonical `arib-std-b67`/`smpte2084`; added `Gamma22`/`Gamma28`/`Smpte170m`/`Smpte240m`/`Srgb` (token `iec61966-2-1`). The setparams consumer is the #1217 follow-up.
+
+## AlphaMode
+
+**Reference:** the `overlay` filter `alpha=` option (`alpha_format` unit; **single value**: `straight`/`premultiplied`) — `libavfilter/vf_overlay.c` — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_overlay.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_overlay.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Straight | straight | OK | - |
+| Premultiplied | premultiplied | OK | - |
+| Unknown | None | OK | - |
+
+> Wiring bug: the `format` step emits `format=…:alpha_modes=…`, but the `format` filter has **no** alpha option (7.1/8.0) — AlphaMode must instead drive the `overlay` `alpha=` option (a single value, not a `|`-list). Also note the `format` step uses `.name()`, not `FfmpegToken` (#1212).
+>
+> Version note: in **7.1/8.0** the `overlay` `alpha` option (`alpha_format` unit) is **`straight`/`premultiplied` only, default `straight`** (`{.i64=0}`, range 0–1). The ffmpeg.org docs' third value **`auto`** (default auto) is **master-only** — alpha was refactored there to the `alpha_mode` unit (`{.i64=AVALPHA_MODE_UNSPECIFIED}`). Not present in avio's 7.1/8.0 targets; if ever targeted, gate `auto` and map it to `AlphaMode::Unknown`.
+
+## PixelFormat
+
+**Reference:** `libavutil/pixdesc.c` (`av_pix_fmt_descriptors[]` `.name`/`.alias`, via `av_get_pix_fmt` which resolves aliases) — consumed by the `format` filter `pix_fmts=` (`vf_format.c`) — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavutil/pixdesc.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavutil/pixdesc.c)
+
+| avio variant | FFmpeg token | status | expected |
+|---|---|---|---|
+| Rgb24 | rgb24 | OK | - |
+| Rgba | rgba | OK | - |
+| Bgr24 | bgr24 | OK | - |
+| Bgra | bgra | OK | - |
+| Yuv420p | yuv420p | OK | - |
+| Yuv422p | yuv422p | OK | - |
+| Yuv444p | yuv444p | OK | - |
+| Nv12 | nv12 | OK | - |
+| Nv21 | nv21 | OK | - |
+| Yuv420p10le | yuv420p10le | OK | - |
+| Yuv422p10le | yuv422p10le | OK | - |
+| Yuv444p10le | yuv444p10le | OK | - |
+| Yuva444p10le | yuva444p10le | OK | - |
+| P010le | p010le | OK | - |
+| Gray8 | gray | OK | - |
+| Gbrpf32le | gbrpf32le | OK | - |
+| Other(u32) | None | OK | - |
+
+> The `format` step emits `.name()`, not `FfmpegToken` (#1212): `Gray8`→`"gray8"` is accepted (a valid `.alias` of `"gray"` resolved by `av_get_pix_fmt`), but `Other(_)`→`"unknown"` is **invalid** as a pix_fmt (should skip / use `av_get_pix_fmt_name(value)`).


### PR DESCRIPTION
## Summary

Redesigns the three `ff-format` colour enums so every variant maps to an FFmpeg-canonical token, with a curated (common-values) set plus an `Unknown` fallback for exotic values. Several variants previously emitted FFmpeg-rejected tokens and `DciP3` was modelled as a colour space rather than primaries; this corrects both and adds the missing `FfmpegToken` impls. This is an atomic breaking change — the enum edits touch every `AVCOL_*` mapping site, so they all land together.

## Changes

- **ff-format `color.rs`** — redesigned enums:
  - `ColorSpace`: `Bt709 / Bt470bg / Smpte170m / Bt2020Ncl / Bt2020Cl / Rgb / Fcc / Smpte240m / Ycgco / Unknown` (`Bt601` split, `Bt2020` split into NCL/CL, `Srgb`→`Rgb`, `DciP3` removed; dropped `is_cinema`, updated `is_sd`/`is_uhd`).
  - `ColorPrimaries`: added `Bt470bg / Smpte170m / Smpte240m / Film / DciP3 / DisplayP3` (replacing `Bt601`); `is_wide_gamut` now covers DCI-P3 / Display P3.
  - `ColorTransfer`: additive — `Gamma22 / Gamma28 / Smpte170m / Smpte240m / Srgb` added (`Hlg`/`Pq` names kept).
- **ff-filter `ffmpeg_token/format.rs`** — corrected `ColorSpace` tokens and added `FfmpegToken` impls for `ColorPrimaries` (incl. `smpte431`/`smpte432`) and `ColorTransfer` (incl. `arib-std-b67`/`smpte2084`/`iec61966-2-1`); added deterministic token-assertion unit tests.
- **ff-sys `docsrs_stubs.rs`** — added the newly referenced `AVCOL_*` constants (values verified against `pixfmt.h`).
- **Mapping sites** — `ff-probe` / `ff-decode` / `ff-encode` `AVColorX` ↔ avio mappings updated to the new variants, with their unit tests.
- **Tests / examples / docs** — updated `stream/video.rs`, `hdr10_encode.rs`, `push_pull_tests.rs`, probe integration tests, and the README examples; committed `docs/specs/ffmpeg-tokens.md` with the colour tables updated to the final curated variants.

## Scope notes

Two of #1217's original acceptance criteria are intentionally handled differently:

- **"Mirror all 18 `AVColorSpace` values"** → implemented as a **curated common set + `Unknown` fallback** (exotic values such as `smpte2085` / `ictcp` / `ycgco-re/ro` fall back to `Unknown`). This keeps the public API focused on the values that actually occur in practice.
- **`blend_mode_to_ffmpeg()` HSL variants → `None`** → **out of scope here; relocated to #1219** (BlendMode ↔ FFmpeg `blend all_mode` alignment, which removes Porter-Duff + HSL). It is unrelated to the colour enums and belongs with the BlendMode redesign.

## Related Issues

Resolves #1217
Closes #1198

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes