### PR TITLE
feat(ff-filter): setparams FilterStep to apply ColorPrimaries / ColorTransfer

### DIFF
--- a/crates/ff-filter/src/graph/builder/video/color.rs
+++ b/crates/ff-filter/src/graph/builder/video/color.rs
@@ -3,6 +3,7 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 use crate::animation::{AnimationTrack, Keyframe};
+use ff_format::{ColorPrimaries, ColorRange, ColorSpace, ColorTransfer};
 
 // ── Tuple-track projection helper ─────────────────────────────────────────────
 
@@ -48,6 +49,38 @@ fn push_tuple_track_entries(
 }
 
 impl FilterGraphBuilder {
+    /// Tag the stream's colour metadata via the `setparams` filter.
+    ///
+    /// Emits `colorspace=` / `range=` / `color_primaries=` / `color_trc=` from the colour enums
+    /// using their `FFmpeg`-canonical tokens. Each argument is included only when it is `Some`
+    /// **and** yields a token (`Unknown` → skipped); an all-`None` call is a no-op (no step added).
+    ///
+    /// Unlike the `format` filter, `setparams` carries `color_primaries` and `color_trc`, so this
+    /// is the step that actually applies [`ColorPrimaries`] / [`ColorTransfer`] to a graph.
+    #[must_use]
+    pub fn set_params(
+        mut self,
+        color_space: Option<ColorSpace>,
+        color_range: Option<ColorRange>,
+        color_primaries: Option<ColorPrimaries>,
+        color_trc: Option<ColorTransfer>,
+    ) -> Self {
+        // No point adding a no-op setparams step when nothing is set.
+        if color_space.is_some()
+            || color_range.is_some()
+            || color_primaries.is_some()
+            || color_trc.is_some()
+        {
+            self.steps.push(FilterStep::SetParams {
+                color_space,
+                color_range,
+                color_primaries,
+                color_trc,
+            });
+        }
+        self
+    }
+
     /// Apply HDR-to-SDR tone mapping using the given `algorithm`.
     #[must_use]
     pub fn tone_map(mut self, algorithm: ToneMap) -> Self {

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -10,7 +10,7 @@ use super::types::{
 
 use crate::animation::AnimatedValue;
 use crate::blend::BlendMode;
-use ff_format::{AlphaMode, ColorRange, ColorSpace, PixelFormat};
+use ff_format::{AlphaMode, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, PixelFormat};
 
 /// Escapes a filesystem path for use as a value inside an `FFmpeg` filter
 /// argument string (e.g. `lut3d`'s `file=` option).
@@ -36,6 +36,19 @@ pub enum FilterStep {
         pix_fmts: Vec<PixelFormat>,
         color_spaces: Vec<ColorSpace>,
         color_ranges: Vec<ColorRange>,
+    },
+
+    /// Tag the stream's colour metadata via the `setparams` filter.
+    ///
+    /// Each field is emitted only when `Some` **and** its `FfmpegToken` is
+    /// `Some` (e.g. `Unknown` → skipped), so an all-`None` step yields empty
+    /// args. This is the consumer for `ColorPrimaries` / `ColorTransfer`, whose
+    /// tokens the `format` filter has no option for.
+    SetParams {
+        color_space: Option<ColorSpace>,
+        color_range: Option<ColorRange>,
+        color_primaries: Option<ColorPrimaries>,
+        color_trc: Option<ColorTransfer>,
     },
 
     /// Trim: keep only frames in `[start, end)` seconds.
@@ -880,6 +893,7 @@ impl FilterStep {
     pub(crate) fn filter_name(&self) -> &'static str {
         match self {
             Self::Format { .. } => "format",
+            Self::SetParams { .. } => "setparams",
             Self::Trim { .. } => "trim",
             Self::Scale { .. } => "scale",
             Self::Crop { .. } => "crop",
@@ -1016,6 +1030,30 @@ impl FilterStep {
                     render("pix_fmts", pix_fmts),
                     render("color_spaces", color_spaces),
                     render("color_ranges", color_ranges),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+                .join(":")
+            }
+            Self::SetParams {
+                color_space,
+                color_range,
+                color_primaries,
+                color_trc,
+            } => {
+                // Each option is emitted from the FFmpeg-canonical `FfmpegToken`, only when the
+                // value is `Some` and yields a token (`Unknown` → `None` → skipped). All-`None`
+                // renders to the empty string.
+                fn opt<T: FfmpegToken>(key: &str, v: Option<&T>) -> Option<String> {
+                    v.and_then(FfmpegToken::ffmpeg_token)
+                        .map(|tok| format!("{key}={tok}"))
+                }
+                [
+                    opt("colorspace", color_space.as_ref()),
+                    opt("range", color_range.as_ref()),
+                    opt("color_primaries", color_primaries.as_ref()),
+                    opt("color_trc", color_trc.as_ref()),
                 ]
                 .into_iter()
                 .flatten()
@@ -1561,5 +1599,65 @@ mod tests {
         );
         assert!(args.contains("D\\:/luts/look.cube"), "got: {args}");
         assert!(args.ends_with(":interp=trilinear"));
+    }
+
+    #[test]
+    fn setparams_filter_name_should_be_setparams() {
+        let step = FilterStep::SetParams {
+            color_space: None,
+            color_range: None,
+            color_primaries: None,
+            color_trc: None,
+        };
+        assert_eq!(step.filter_name(), "setparams");
+    }
+
+    #[test]
+    fn setparams_args_should_emit_all_canonical_tokens() {
+        let step = FilterStep::SetParams {
+            color_space: Some(ColorSpace::Bt2020Ncl),
+            color_range: Some(ColorRange::Limited),
+            color_primaries: Some(ColorPrimaries::Bt2020),
+            color_trc: Some(ColorTransfer::Hlg),
+        };
+        assert_eq!(
+            step.args(),
+            "colorspace=bt2020nc:range=tv:color_primaries=bt2020:color_trc=arib-std-b67"
+        );
+    }
+
+    #[test]
+    fn setparams_args_should_emit_only_provided_options() {
+        // HDR tagging often sets just primaries + transfer.
+        let step = FilterStep::SetParams {
+            color_space: None,
+            color_range: None,
+            color_primaries: Some(ColorPrimaries::Bt2020),
+            color_trc: Some(ColorTransfer::Pq),
+        };
+        assert_eq!(step.args(), "color_primaries=bt2020:color_trc=smpte2084");
+    }
+
+    #[test]
+    fn setparams_args_should_skip_values_without_ffmpeg_token() {
+        // `Unknown` renders to no token and must be skipped, not emitted as an invalid arg.
+        let step = FilterStep::SetParams {
+            color_space: Some(ColorSpace::Unknown),
+            color_range: Some(ColorRange::Full),
+            color_primaries: Some(ColorPrimaries::Unknown),
+            color_trc: Some(ColorTransfer::Bt709),
+        };
+        assert_eq!(step.args(), "range=pc:color_trc=bt709");
+    }
+
+    #[test]
+    fn setparams_args_should_be_empty_when_all_none() {
+        let step = FilterStep::SetParams {
+            color_space: None,
+            color_range: None,
+            color_primaries: None,
+            color_trc: None,
+        };
+        assert_eq!(step.args(), "");
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -14,8 +14,8 @@ use ff_filter::{
     ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
 use ff_format::{
-    AlphaMode, AudioFrame, ColorRange, ColorSpace, PixelFormat, PooledBuffer, SampleFormat,
-    Timestamp, VideoFrame,
+    AlphaMode, AudioFrame, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, PixelFormat,
+    PooledBuffer, SampleFormat, Timestamp, VideoFrame,
 };
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
@@ -103,6 +103,48 @@ fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
         .expect("expected Some(frame) after format push");
     assert_eq!(out.width(), 64, "format must not change frame width");
     assert_eq!(out.height(), 64, "format must not change frame height");
+}
+
+#[test]
+fn setparams_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
+    // #1227: `setparams` args (colorspace=/range=/color_primaries=/color_trc=) are built from
+    // `FfmpegToken`. The graph is built lazily on the first `push_video`, so the push — not
+    // `build()` — hands the args to the real `setparams` filter (RK-001). Token *values* are
+    // guarded by the deterministic unit tests in `filter_step.rs`; this additionally checks the
+    // linked FFmpeg ACCEPTS them. CI's Linux FFmpeg has no filters compiled in (RK-002), so a
+    // baseline `setparams=range=tv` probe (a universally valid arg) separates "the `setparams`
+    // filter is unavailable" (skip) from "our tokens were rejected" (fail).
+    let frame = make_yuv420p_frame(64, 64);
+    {
+        let mut probe = FilterGraph::builder()
+            .set_params(None, Some(ColorRange::Limited), None, None)
+            .build()
+            .expect("non-empty setparams graph must build");
+        if probe.push_video(0, &frame).is_err() {
+            eprintln!("skipping: `setparams` filter not available in this FFmpeg build");
+            return;
+        }
+    }
+    // The `setparams` filter is available → the FfmpegToken args MUST be accepted.
+    let mut graph = FilterGraph::builder()
+        .set_params(
+            Some(ColorSpace::Bt2020Ncl),
+            Some(ColorRange::Limited),
+            Some(ColorPrimaries::Bt2020),
+            Some(ColorTransfer::Hlg),
+        )
+        .build()
+        .expect("non-empty setparams graph must build");
+    graph.push_video(0, &frame).expect(
+        "FFmpeg must accept the FfmpegToken args \
+         (colorspace=bt2020nc:range=tv:color_primaries=bt2020:color_trc=arib-std-b67)",
+    );
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame) after setparams push");
+    assert_eq!(out.width(), 64, "setparams must not change frame width");
+    assert_eq!(out.height(), 64, "setparams must not change frame height");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

#1217 added `FfmpegToken` impls for `ColorPrimaries` / `ColorTransfer`, but those tokens had no consumer — the `format` filter has no `color_primaries` / `color_trc` option, so primaries/transfer never reached a filter graph. This adds the consumer: a `setparams` `FilterStep` and a `FilterGraphBuilder::set_params` method that tag a stream's colour metadata by emitting `colorspace=` / `range=` / `color_primaries=` / `color_trc=` from the colour enums via `FfmpegToken`.

## Changes

- **`filter_step.rs`** — new `FilterStep::SetParams { color_space, color_range, color_primaries, color_trc }` (all `Option`); `filter_name()` → `"setparams"`; `args()` renders each value via its FFmpeg-canonical `FfmpegToken`, skipping `None`/no-token values (`Unknown` → skipped) and joining survivors with `:` (all-`None` → empty string). Mirrors the existing `Format` step's contract.
- **`builder/video/color.rs`** — `set_params(...)` builder method; like `format()`, it is a no-op (adds no step) when every argument is `None`.
- **`push_pull_tests.rs`** — probe-gated FFmpeg-acceptance test: a baseline `setparams=range=tv` graph probes filter availability (skipped on CI's filterless Linux FFmpeg), then a full tag set (`colorspace=bt2020nc:range=tv:color_primaries=bt2020:color_trc=arib-std-b67`) is pushed through a frame to confirm FFmpeg accepts the args.
- Deterministic unit tests assert the exact `args()` for full / partial / `Unknown`-skipped / all-`None` cases.

The setparams option keys (`range` / `color_primaries` / `color_trc` / `colorspace`) were verified against pinned `libavfilter/vf_setparams.c` (release/8.0). No `filter_inner` or `avio` facade changes were needed (simple single-input video step; no new public type).

## Related Issues

Closes #1227

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes