### PR TITLE
feat(ff-filter): CompositeOp enum + Composite filter step (Porter-Duff)

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -265,11 +265,11 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 #[cfg(feature = "filter")]
 pub use ff_filter::{
     AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
-    BlendMode, ClipJoiner, ClipTransition, DrawTextOptions, Easing, EqBand, FilterError,
-    FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile,
-    Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
-    ProxySource, QualityMetrics, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap,
-    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    BlendMode, ClipJoiner, ClipTransition, CompositeOp, DrawTextOptions, Easing, EqBand,
+    FilterError, FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe,
+    LensProfile, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer,
+    NoiseType, ProxySource, QualityMetrics, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer,
+    ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/composite.rs
+++ b/crates/ff-filter/src/composite.rs
@@ -1,0 +1,46 @@
+//! Porter-Duff alpha-compositing operators.
+
+// ── CompositeOp ────────────────────────────────────────────────────────────────
+
+/// Porter-Duff alpha-compositing operator for combining two video layers.
+///
+/// Unlike [`BlendMode`](crate::BlendMode) (which operates on pixel values), these
+/// operators combine layers by their alpha channels. At least the top layer must
+/// carry an alpha channel (e.g. `rgba` or `yuva420p`).
+///
+/// There is no `blend all_mode` token for Porter-Duff compositing, so this type
+/// has no `FfmpegToken` impl; each operator maps to a specific `FFmpeg` construction
+/// (`overlay` or `blend` with a per-channel expression) in the filter graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompositeOp {
+    /// Top layer rendered over the bottom (standard alpha compositing).
+    ///
+    /// Built via `overlay=format=auto:shortest=1`.
+    #[default]
+    Over,
+
+    /// Bottom layer rendered over the top; `Over` with the inputs swapped.
+    ///
+    /// Built via `overlay` with swapped input order.
+    Under,
+
+    /// Top layer masked by the bottom layer's alpha (intersection).
+    ///
+    /// Built via `blend` with `c0_expr='B*A/255'`.
+    In,
+
+    /// Top layer visible only where the bottom layer is transparent.
+    ///
+    /// Built via `blend` with `c0_expr='B*(255-A)/255'`.
+    Out,
+
+    /// Top layer placed atop the bottom; visible only where the bottom is opaque.
+    ///
+    /// Built via `blend` with `c0_expr='B*A/255 + A*(255-B)/255'`.
+    Atop,
+
+    /// Pixels from exactly one layer (XOR of opaque regions).
+    ///
+    /// Built via `blend` with `c0_expr='B*(255-A)/255 + A*(255-B)/255'`.
+    Xor,
+}

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -8,6 +8,7 @@ use std::ptr::NonNull;
 use std::time::Duration;
 
 use crate::blend::BlendMode;
+use crate::composite::CompositeOp;
 use crate::error::FilterError;
 use crate::graph::filter_step::FilterStep;
 use crate::graph::types::{EqBand, HwAccel};
@@ -1219,6 +1220,60 @@ pub(super) unsafe fn add_blend_expr_step(
 ///
 /// `graph` and `prev_ctx` must be valid pointers owned by the same
 /// `AVFilterGraph`.
+// ── Composite compound step ───────────────────────────────────────────────────
+/// Builds a Porter-Duff composite step from a [`CompositeOp`], dispatching to the
+/// shared blend construction helpers. This is the single `CompositeOp`-keyed
+/// construction site, used by both [`FilterStep::Composite`] and the legacy
+/// `BlendMode::PorterDuff*` arms (so the two paths build identical graphs).
+///
+/// # Safety
+///
+/// `graph`, `bottom_ctx`, and `top_src_ctx` must be valid pointers owned by the
+/// same `AVFilterGraph`.
+// One more argument (`op`) than the 7-arg blend helpers it forwards to.
+#[allow(clippy::too_many_arguments)]
+pub(super) unsafe fn add_composite_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    bottom_ctx: *mut ff_sys::AVFilterContext,
+    top_src_ctx: *mut ff_sys::AVFilterContext,
+    top_steps: &[FilterStep],
+    op: CompositeOp,
+    opacity: f32,
+    alpha: AlphaMode,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    match op {
+        CompositeOp::Over => add_blend_normal_step(
+            graph,
+            bottom_ctx,
+            top_src_ctx,
+            top_steps,
+            opacity,
+            alpha,
+            index,
+        ),
+        CompositeOp::Under => add_blend_under_step(
+            graph,
+            bottom_ctx,
+            top_src_ctx,
+            top_steps,
+            opacity,
+            alpha,
+            index,
+        ),
+        CompositeOp::In | CompositeOp::Out | CompositeOp::Atop | CompositeOp::Xor => {
+            let expr = match op {
+                CompositeOp::In => "B*A/255",
+                CompositeOp::Out => "B*(255-A)/255",
+                CompositeOp::Atop => "B*A/255 + A*(255-B)/255",
+                CompositeOp::Xor => "B*(255-A)/255 + A*(255-B)/255",
+                _ => unreachable!(),
+            };
+            add_blend_expr_step(graph, bottom_ctx, top_src_ctx, top_steps, expr, index)
+        }
+    }
+}
+
 // ── Glow compound step ────────────────────────────────────────────────────────
 /// Insert the glow / bloom compound step.
 ///
@@ -2119,13 +2174,13 @@ impl FilterGraphInner {
                 continue;
             }
 
-            // Blend (Normal / PorterDuffOver) — both use overlay=format=auto:shortest=1.
+            // Blend (Normal) — overlay=format=auto:shortest=1.
             //   prev → [bottom]overlay=format=auto:shortest=1 ← [top][ccm]
             // where [top] is in1 with the top builder's steps applied.
-            // Unimplemented modes are caught by build() before reaching here.
+            // Porter-Duff modes are routed through the Composite-shared arm below.
             if let FilterStep::Blend {
                 top,
-                mode: BlendMode::Normal | BlendMode::PorterDuffOver,
+                mode: BlendMode::Normal,
                 opacity,
                 alpha,
             } = step
@@ -2211,10 +2266,18 @@ impl FilterGraphInner {
                 continue;
             }
 
-            // Blend (PorterDuffUnder) — overlay with swapped input order.
+            // Blend (Porter-Duff modes) — delegate to the shared CompositeOp
+            // construction so the legacy BlendMode path and the new Composite path
+            // build identical graphs (#1221). BlendMode itself is left untouched.
             if let FilterStep::Blend {
                 top,
-                mode: BlendMode::PorterDuffUnder,
+                mode:
+                    mode @ (BlendMode::PorterDuffOver
+                    | BlendMode::PorterDuffUnder
+                    | BlendMode::PorterDuffIn
+                    | BlendMode::PorterDuffOut
+                    | BlendMode::PorterDuffAtop
+                    | BlendMode::PorterDuffXor),
                 opacity,
                 alpha,
             } = step
@@ -2222,11 +2285,21 @@ impl FilterGraphInner {
                 let Some(top_src) = src_ctxs.get(1).and_then(|o| *o) else {
                     bail!(FilterError::BuildFailed)
                 };
-                prev_ctx = match add_blend_under_step(
+                let op = match mode {
+                    BlendMode::PorterDuffOver => CompositeOp::Over,
+                    BlendMode::PorterDuffUnder => CompositeOp::Under,
+                    BlendMode::PorterDuffIn => CompositeOp::In,
+                    BlendMode::PorterDuffOut => CompositeOp::Out,
+                    BlendMode::PorterDuffAtop => CompositeOp::Atop,
+                    BlendMode::PorterDuffXor => CompositeOp::Xor,
+                    _ => unreachable!(),
+                };
+                prev_ctx = match add_composite_step(
                     graph,
                     prev_ctx,
                     top_src.as_ptr(),
                     top.steps(),
+                    op,
                     *opacity,
                     *alpha,
                     i,
@@ -2237,33 +2310,25 @@ impl FilterGraphInner {
                 continue;
             }
 
-            // Blend (PorterDuffIn / PorterDuffOut / PorterDuffAtop / PorterDuffXor) — expression-based blend.
-            if let FilterStep::Blend {
+            // Composite — Porter-Duff alpha compositing via the shared construction.
+            if let FilterStep::Composite {
+                op,
                 top,
-                mode:
-                    mode @ (BlendMode::PorterDuffIn
-                    | BlendMode::PorterDuffOut
-                    | BlendMode::PorterDuffAtop
-                    | BlendMode::PorterDuffXor),
-                ..
+                opacity,
+                alpha,
             } = step
             {
                 let Some(top_src) = src_ctxs.get(1).and_then(|o| *o) else {
                     bail!(FilterError::BuildFailed)
                 };
-                let expr = match mode {
-                    BlendMode::PorterDuffIn => "B*A/255",
-                    BlendMode::PorterDuffOut => "B*(255-A)/255",
-                    BlendMode::PorterDuffAtop => "B*A/255 + A*(255-B)/255",
-                    BlendMode::PorterDuffXor => "B*(255-A)/255 + A*(255-B)/255",
-                    _ => unreachable!(),
-                };
-                prev_ctx = match add_blend_expr_step(
+                prev_ctx = match add_composite_step(
                     graph,
                     prev_ctx,
                     top_src.as_ptr(),
                     top.steps(),
-                    expr,
+                    *op,
+                    *opacity,
+                    *alpha,
                     i,
                 ) {
                     Ok(ctx) => ctx,

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -254,6 +254,7 @@ impl FilterGraphInner {
                     | FilterStep::XFade { .. }
                     | FilterStep::JoinWithDissolve { .. }
                     | FilterStep::Blend { .. }
+                    | FilterStep::Composite { .. }
                     | FilterStep::AlphaMatte { .. }
             ) {
                 return 2;

--- a/crates/ff-filter/src/graph/builder/video/compositing.rs
+++ b/crates/ff-filter/src/graph/builder/video/compositing.rs
@@ -2,9 +2,40 @@
 
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::composite::CompositeOp;
 use ff_format::AlphaMode;
 
 impl FilterGraphBuilder {
+    /// Composite a `top` layer over `self` (the bottom) using a Porter-Duff
+    /// [`CompositeOp`], `opacity`, and [`AlphaMode`].
+    ///
+    /// The bottom stream is `self`; the top stream is pushed on input slot 1.
+    /// `opacity` is clamped to `[0.0, 1.0]`; it affects only `Over`/`Under`
+    /// (the expression operators ignore it). `alpha` selects how the top layer's
+    /// alpha is interpreted by the `overlay` filter (`alpha=`);
+    /// [`AlphaMode::Straight`] matches `FFmpeg`'s default.
+    ///
+    /// This is the dedicated alpha-compositing entry point, separate from
+    /// [`blend`](FilterGraphBuilder::blend) (which carries the pixel-value
+    /// [`BlendMode`] modes); both build the same graphs for the Porter-Duff cases.
+    #[must_use]
+    pub fn composite(
+        mut self,
+        top: FilterGraphBuilder,
+        op: CompositeOp,
+        opacity: f32,
+        alpha: AlphaMode,
+    ) -> Self {
+        let opacity = opacity.clamp(0.0, 1.0);
+        self.steps.push(FilterStep::Composite {
+            op,
+            top: Box::new(top),
+            opacity,
+            alpha,
+        });
+        self
+    }
+
     /// Blend a `top` layer over `self` (the bottom) using the given [`BlendMode`],
     /// `opacity`, and [`AlphaMode`].
     ///

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -10,6 +10,7 @@ use super::types::{
 
 use crate::animation::AnimatedValue;
 use crate::blend::BlendMode;
+use crate::composite::CompositeOp;
 use ff_format::{AlphaMode, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, PixelFormat};
 
 /// Escapes a filesystem path for use as a value inside an `FFmpeg` filter
@@ -483,6 +484,29 @@ pub enum FilterStep {
         /// How the two layers are combined.
         mode: BlendMode,
         /// Opacity of the top layer in `[0.0, 1.0]`; 1.0 = fully opaque.
+        opacity: f32,
+        /// How the top layer's alpha is interpreted by the `overlay` filter
+        /// (`alpha=`). [`AlphaMode::Straight`] is the `FFmpeg` default.
+        alpha: AlphaMode,
+    },
+
+    /// Composite a `top` layer over the current stream (bottom) using a
+    /// Porter-Duff alpha-compositing [`CompositeOp`].
+    ///
+    /// This is a compound, two-input step (slot 0 = bottom, slot 1 = top with
+    /// the `top` builder's steps applied). It shares its `FFmpeg` construction with
+    /// the legacy `BlendMode::PorterDuff*` arms: `Over`/`Under` use `overlay`,
+    /// the rest use `blend` with a per-channel expression.
+    ///
+    /// `Box<FilterGraphBuilder>` breaks the otherwise-recursive type, following
+    /// the same pattern as [`FilterStep::Blend`].
+    Composite {
+        /// The Porter-Duff operator combining the two layers.
+        op: CompositeOp,
+        /// Filter pipeline for the top (foreground) layer.
+        top: Box<FilterGraphBuilder>,
+        /// Opacity of the top layer in `[0.0, 1.0]`; 1.0 = fully opaque.
+        /// Only affects `Over`/`Under` (the expression operators ignore it).
         opacity: f32,
         /// How the top layer's alpha is interpreted by the `overlay` filter
         /// (`alpha=`). [`AlphaMode::Straight`] is the `FFmpeg` default.
@@ -965,6 +989,15 @@ impl FilterStep {
             // for validate_filter_steps.  Unimplemented modes are caught by
             // build() before validate_filter_steps is reached.
             Self::Blend { .. } => "overlay",
+            // Composite shares the Blend construction: Over/Under use overlay,
+            // the expression operators use blend. validate_filter_steps only
+            // needs a real filter name to probe existence.
+            Self::Composite { op, .. } => match op {
+                CompositeOp::Over | CompositeOp::Under => "overlay",
+                CompositeOp::In | CompositeOp::Out | CompositeOp::Atop | CompositeOp::Xor => {
+                    "blend"
+                }
+            },
             Self::ChromaKey { .. } => "chromakey",
             Self::ColorKey { .. } => "colorkey",
             Self::SpillSuppress { .. } => "hue",
@@ -1293,6 +1326,10 @@ impl FilterStep {
             // bypassed in favour of add_blend_normal_step).  Provided for
             // completeness using the Normal-mode overlay args.
             Self::Blend { .. } => "format=auto:shortest=1".to_string(),
+            // args() for Composite is not consumed by add_and_link_step (bypassed
+            // for this compound two-input step); provided here only to satisfy the
+            // exhaustive match.
+            Self::Composite { .. } => String::new(),
             Self::ChromaKey {
                 color,
                 similarity,

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -34,6 +34,7 @@
 pub mod analysis;
 pub mod animation;
 pub mod blend;
+pub mod composite;
 pub mod effects;
 pub mod error;
 mod filter_inner;
@@ -42,6 +43,7 @@ pub mod graph;
 pub use analysis::{LoudnessMeter, LoudnessResult, QualityMetrics};
 pub use animation::{AnimatedValue, AnimationEntry, AnimationTrack, Easing, Keyframe, Lerp};
 pub use blend::BlendMode;
+pub use composite::CompositeOp;
 pub use effects::{
     AnalyzeOptions, Interpolation, LensProfile, NoiseType, StabilizeOptions, Stabilizer,
 };

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -10,8 +10,8 @@
 #![allow(clippy::unwrap_used)]
 
 use ff_filter::{
-    BlendMode, DrawTextOptions, FilterError, FilterGraph, FilterGraphBuilder, HwAccel, Rgb,
-    ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
+    BlendMode, CompositeOp, DrawTextOptions, FilterError, FilterGraph, FilterGraphBuilder, HwAccel,
+    Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
 use ff_format::{
     AlphaMode, AudioFrame, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, PixelFormat,
@@ -2484,6 +2484,301 @@ fn porter_duff_out_should_produce_black_where_bottom_is_white() {
     assert!(
         avg < 10.0,
         "PorterDuffOut with white bottom should produce black output (avg={avg})"
+    );
+}
+
+// ── CompositeOp (Porter-Duff via the new Composite step) ──────────────────────
+//
+// These mirror the `porter_duff_*` tests above but drive the new
+// `FilterGraphBuilder::composite()` path. Both paths share `add_composite_step`,
+// so identical assertions confirm the Composite step builds the same graphs as
+// the legacy `BlendMode::PorterDuff*` arms (#1221 acceptance criterion).
+
+#[test]
+fn composite_over_opaque_top_should_cover_bottom() {
+    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+    let mut graph = match FilterGraph::builder()
+        .trim(0.0, 5.0)
+        .composite(top, CompositeOp::Over, 1.0, AlphaMode::Straight)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let bottom = make_solid_yuv_frame(64, 64, 100);
+    let top_frame = make_solid_yuv_frame(64, 64, 200);
+    match graph.push_video(0, &bottom) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &top_frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame)");
+    let luma = out.plane(0).expect("Y plane must exist");
+    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
+    assert!(
+        avg > 160.0,
+        "Composite Over with opaque top should cover the bottom (avg={avg})"
+    );
+}
+
+#[test]
+fn composite_over_semitransparent_should_blend_correctly() {
+    // opacity=0.5 inserts colorchannelmixer=aa=0.5 on the top layer — same graph
+    // as blend(PorterDuffOver, 0.5).
+    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+    let mut graph = match FilterGraph::builder()
+        .trim(0.0, 5.0)
+        .composite(top, CompositeOp::Over, 0.5, AlphaMode::Straight)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let bottom = make_solid_yuv_frame(64, 64, 100);
+    let top_frame = make_solid_yuv_frame(64, 64, 200);
+    match graph.push_video(0, &bottom) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &top_frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame)");
+    assert_eq!(out.width(), 64, "output width must match input");
+    assert_eq!(out.height(), 64, "output height must match input");
+}
+
+#[test]
+fn composite_under_should_place_bottom_over_top() {
+    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+    let mut graph = match FilterGraph::builder()
+        .trim(0.0, 5.0)
+        .composite(top, CompositeOp::Under, 1.0, AlphaMode::Straight)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let bottom = make_solid_yuv_frame(64, 64, 200);
+    let top_frame = make_solid_yuv_frame(64, 64, 100);
+    match graph.push_video(0, &bottom) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &top_frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame)");
+    assert_eq!(out.width(), 64, "output width must match input");
+    assert_eq!(out.height(), 64, "output height must match input");
+}
+
+#[test]
+fn composite_in_should_produce_black_where_bottom_is_black() {
+    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+    let mut graph = match FilterGraph::builder()
+        .trim(0.0, 5.0)
+        .composite(top, CompositeOp::In, 1.0, AlphaMode::Straight)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let bottom = make_solid_yuv_frame(64, 64, 0);
+    let top_frame = make_solid_yuv_frame(64, 64, 200);
+    match graph.push_video(0, &bottom) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &top_frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame)");
+    let luma = out.plane(0).expect("Y plane must exist");
+    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
+    assert!(
+        avg < 10.0,
+        "Composite In with black bottom should produce black output (avg={avg})"
+    );
+}
+
+#[test]
+fn composite_atop_should_use_bottom_alpha_for_output() {
+    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+    let mut graph = match FilterGraph::builder()
+        .trim(0.0, 5.0)
+        .composite(top, CompositeOp::Atop, 1.0, AlphaMode::Straight)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let bottom = make_solid_yuv_frame(64, 64, 100);
+    let top_frame = make_solid_yuv_frame(64, 64, 200);
+    match graph.push_video(0, &bottom) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &top_frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame)");
+    let luma = out.plane(0).expect("Y plane must exist");
+    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
+    assert!(
+        avg > 85.0 && avg < 115.0,
+        "Composite Atop output luma should equal bottom luma (~100), got avg={avg}"
+    );
+}
+
+#[test]
+fn composite_xor_identical_shapes_should_produce_zero_alpha() {
+    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+    let mut graph = match FilterGraph::builder()
+        .trim(0.0, 5.0)
+        .composite(top, CompositeOp::Xor, 1.0, AlphaMode::Straight)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let bottom = make_solid_yuv_frame(64, 64, 255);
+    let top_frame = make_solid_yuv_frame(64, 64, 255);
+    match graph.push_video(0, &bottom) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &top_frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame)");
+    let luma = out.plane(0).expect("Y plane must exist");
+    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
+    assert!(
+        avg < 10.0,
+        "Composite Xor of identical full-luma shapes should produce black (avg={avg})"
+    );
+}
+
+#[test]
+fn composite_out_should_produce_black_where_bottom_is_white() {
+    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+    let mut graph = match FilterGraph::builder()
+        .trim(0.0, 5.0)
+        .composite(top, CompositeOp::Out, 1.0, AlphaMode::Straight)
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let bottom = make_solid_yuv_frame(64, 64, 255);
+    let top_frame = make_solid_yuv_frame(64, 64, 200);
+    match graph.push_video(0, &bottom) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    match graph.push_video(1, &top_frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame)");
+    let luma = out.plane(0).expect("Y plane must exist");
+    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
+    assert!(
+        avg < 10.0,
+        "Composite Out with white bottom should produce black output (avg={avg})"
     );
 }
 


### PR DESCRIPTION
## Summary

Introduces a dedicated `CompositeOp` type for Porter-Duff alpha compositing, separating it from the overloaded `BlendMode` enum (Track 2, #1218). This is the **additive, non-breaking foundation** (PR-C): it adds the type and wires its build path while leaving `BlendMode` completely untouched. The later breaking PR-D (#1219) removes the `BlendMode::PorterDuff*` variants and relies on this foundation.

## Changes

- **`crates/ff-filter/src/composite.rs` (new)** — `CompositeOp { Over (default), Under, In, Out, Atop, Xor }`. No `FfmpegToken` impl (Porter-Duff has no `blend all_mode` token); each operator documents its FFmpeg construction.
- **Re-exports** — `pub use composite::CompositeOp` in `ff-filter/src/lib.rs`; added to the `avio` facade re-export list.
- **`FilterStep::Composite { op, top, opacity, alpha }`** — mirrors `FilterStep::Blend`. `filter_name()` returns `overlay` for `Over`/`Under` and `blend` for the expression operators; it is a 2-input compound step (added to `video_input_count`).
- **`FilterGraphBuilder::composite(top, op, opacity, alpha)`** — mirrors `blend()`.
- **Shared construction** — new `add_composite_step()` dispatches a `CompositeOp` to the three existing blend helpers (`overlay` / swapped `overlay` / `blend c0_expr`). Both `FilterStep::Composite` and the legacy `BlendMode::PorterDuff*` arms now route through it, so the two paths build identical graphs. The three `unsafe` helpers are unchanged.
- **Tests** — seven `composite_*` tests mirror the existing `porter_duff_*` tests via `.composite(...)` with identical assertions, proving graph-equivalence; the existing `porter_duff_*` (Blend) tests remain green, proving the refactor is non-breaking.

The issue's Scope line was corrected from `Composite { op }` to `{ op, top, opacity, alpha }` (the "same graphs" acceptance criterion requires `top`/`opacity`/`alpha` — e.g. `opacity<1.0` inserts `colorchannelmixer=aa=`). `BlendMode` is left fully intact.

## Related Issues

Closes #1221

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes