### PR TITLE
refactor(ff-filter): BlendMode = FFmpeg blend all_mode (40 modes)

### DIFF
--- a/crates/avio/examples/filter/alpha_matte_external.rs
+++ b/crates/avio/examples/filter/alpha_matte_external.rs
@@ -10,7 +10,7 @@
 //!    the foreground video (slot 0) with the grayscale matte (slot 1), producing
 //!    an YUVA frame where the matte's luma drives the alpha channel.
 //!
-//! 2. **Composite stage**: `FilterGraphBuilder::blend(BlendMode::PorterDuffOver)`
+//! 2. **Composite stage**: `FilterGraphBuilder::composite(CompositeOp::Over)`
 //!    places the alpha-matted foreground (slot 1) over the background (slot 0).
 //!
 //! All three inputs must share the same resolution.  The output inherits the
@@ -26,7 +26,7 @@
 use std::{path::PathBuf, process};
 
 use avio::{
-    AlphaMode, BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
+    AlphaMode, CompositeOp, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
 };
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
@@ -148,7 +148,7 @@ fn main() {
         }
     };
 
-    // ── 3. Build stage-2 graph: blend(PorterDuffOver) ─────────────────────────
+    // ── 3. Build stage-2 graph: composite(Over) ───────────────────────────────
     //
     // Stage 2 composites the alpha-matted foreground over the background:
     //   slot 0 → background video
@@ -157,12 +157,7 @@ fn main() {
     let top_builder = FilterGraphBuilder::new();
 
     let mut blend_graph = match FilterGraph::builder()
-        .blend(
-            top_builder,
-            BlendMode::PorterDuffOver,
-            1.0,
-            AlphaMode::Straight,
-        )
+        .composite(top_builder, CompositeOp::Over, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,

--- a/crates/avio/examples/filter/chroma_key_green_screen.rs
+++ b/crates/avio/examples/filter/chroma_key_green_screen.rs
@@ -5,7 +5,7 @@
 //! coloured background (default: `0x00FF00` green).  The `chromakey` filter
 //! removes that colour, turning matching pixels transparent.  The keyed
 //! foreground is then blended over the background using
-//! [`BlendMode::PorterDuffOver`].
+//! [`CompositeOp::Over`].
 //!
 //! Both input videos must have the same resolution; the output inherits the
 //! background dimensions.
@@ -21,7 +21,7 @@
 use std::{path::PathBuf, process};
 
 use avio::{
-    AlphaMode, BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
+    AlphaMode, CompositeOp, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
 };
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
@@ -130,12 +130,7 @@ fn main() {
         FilterGraphBuilder::new().chromakey(&args.color, args.similarity, args.blend_factor);
 
     let mut graph = match FilterGraph::builder()
-        .blend(
-            fg_builder,
-            BlendMode::PorterDuffOver,
-            1.0,
-            AlphaMode::Straight,
-        )
+        .composite(fg_builder, CompositeOp::Over, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,

--- a/crates/avio/examples/filter/luma_key_title_card.rs
+++ b/crates/avio/examples/filter/luma_key_title_card.rs
@@ -23,7 +23,7 @@
 use std::{path::PathBuf, process};
 
 use avio::{
-    AlphaMode, BlendMode, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
+    AlphaMode, CompositeOp, FilterGraph, FilterGraphBuilder, VideoCodec, VideoDecoder, VideoEncoder,
 };
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
@@ -140,12 +140,7 @@ fn main() {
     );
 
     let mut graph = match FilterGraph::builder()
-        .blend(
-            title_builder,
-            BlendMode::PorterDuffOver,
-            1.0,
-            AlphaMode::Straight,
-        )
+        .composite(title_builder, CompositeOp::Over, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,

--- a/crates/ff-filter/src/blend.rs
+++ b/crates/ff-filter/src/blend.rs
@@ -4,150 +4,101 @@
 
 /// Specifies how two video layers are combined during compositing.
 ///
-/// Variants are grouped into two families:
+/// Each variant corresponds **1:1** to a mode of `FFmpeg`'s `blend` filter
+/// `all_mode` option (40 modes total, matching `vf_blend.c`). [`BlendMode::Normal`]
+/// is the standard alpha-over composite, built via the `overlay` filter; every
+/// other variant is built via `blend all_mode=<token>`. The canonical token for
+/// each variant is provided by `FfmpegToken` (all variants map to a valid token).
 ///
-/// - **Photographic blend modes** (18) — operate on pixel values; both layers
-///   are typically opaque.  Implemented via `FFmpeg`'s `blend` filter with the
-///   `all_mode` option, except [`BlendMode::Normal`] which uses `overlay`.
-///
-/// - **Porter-Duff alpha compositing** (6) — operate on the alpha channel;
-///   at least the top layer must carry an alpha channel (e.g. `rgba` or
-///   `yuva420p` pixel format).
-///
-/// # Implementation status
-///
-/// All 14 arithmetic photographic modes and all 6 Porter-Duff operations are
-/// fully implemented and covered by regression tests (issues #327–#347).
-///
-/// The four HSL-space modes — [`BlendMode::Hue`], [`BlendMode::Saturation`],
-/// [`BlendMode::Color`], and [`BlendMode::Luminosity`] — are accepted by the
-/// builder but produce no output at runtime: `FFmpeg`'s `blend` filter does not
-/// include these mode names in the bundled version.  The builder returns
-/// [`FilterError::BuildFailed`](crate::FilterError) when the filter graph
-/// cannot be configured for these modes.
+/// For **Porter-Duff alpha compositing** (over / under / in / out / atop / xor)
+/// use [`CompositeOp`](crate::CompositeOp) instead — that is a separate concept
+/// (alpha channel operators, not pixel-value blend modes). Note `BlendMode::Xor`
+/// is the *arithmetic* `xor` blend, distinct from `CompositeOp::Xor`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlendMode {
-    // ── Photographic blend modes ──────────────────────────────────────────
-    /// Standard alpha-over composite (top * opacity + bottom * (1 − opacity)).
-    ///
-    /// Implemented via `FFmpeg`'s `overlay=format=auto:shortest=1`.
+    // ── Standard modes ────────────────────────────────────────────────────
+    /// Standard alpha-over composite (`top * opacity + bottom * (1 − opacity)`).
+    /// Built via `overlay=format=auto:shortest=1` (token: `normal`).
     Normal,
-
-    /// Multiply per-channel pixel values; darkens the result.
-    ///
-    /// Maps to `blend all_mode=multiply`.
+    /// Multiply per-channel pixel values; darkens. `blend all_mode=multiply`.
     Multiply,
-
-    /// Inverse of multiply; lightens the result.
-    ///
-    /// Maps to `blend all_mode=screen`.
+    /// Inverse of multiply; lightens. `blend all_mode=screen`.
     Screen,
-
-    /// Combines Multiply and Screen based on base-layer luminance.
-    ///
-    /// Maps to `blend all_mode=overlay`.
+    /// Multiply/Screen by base luminance. `blend all_mode=overlay`.
     Overlay,
-
-    /// Gentle contrast enhancement; 50 % gray top layer is identity.
-    ///
-    /// Maps to `blend all_mode=softlight`.
+    /// Gentle contrast enhancement. `blend all_mode=softlight`.
     SoftLight,
-
-    /// Harsher version of Overlay; driven by the top layer's luminance.
-    ///
-    /// Maps to `blend all_mode=hardlight`.
+    /// Harsher Overlay driven by the top layer. `blend all_mode=hardlight`.
     HardLight,
-
-    /// Brightens the base by dividing it by the inverse of the blend.
-    ///
-    /// Maps to `blend all_mode=dodge`.
+    /// Brightens the base. `blend all_mode=dodge`.
     ColorDodge,
-
-    /// Darkens the base; inverse of Color Dodge.
-    ///
-    /// Maps to `blend all_mode=burn`.
+    /// Darkens the base. `blend all_mode=burn`.
     ColorBurn,
-
-    /// Retains the darker of the two pixels per channel.
-    ///
-    /// Maps to `blend all_mode=darken`.
+    /// Keeps the darker pixel per channel. `blend all_mode=darken`.
     Darken,
-
-    /// Retains the lighter of the two pixels per channel.
-    ///
-    /// Maps to `blend all_mode=lighten`.
+    /// Keeps the lighter pixel per channel. `blend all_mode=lighten`.
     Lighten,
-
-    /// Per-channel absolute difference.  Useful for alignment verification.
-    ///
-    /// Maps to `blend all_mode=difference`.
+    /// Per-channel absolute difference. `blend all_mode=difference`.
     Difference,
-
-    /// Similar to Difference but with lower contrast in mid-tones.
-    ///
-    /// Maps to `blend all_mode=exclusion`.
+    /// Lower-contrast Difference. `blend all_mode=exclusion`.
     Exclusion,
-
-    /// Linear addition, clamped at maximum.
-    ///
-    /// Maps to `blend all_mode=addition`.
+    /// Linear addition, clamped. `blend all_mode=addition`.
     Add,
-
-    /// Linear subtraction, clamped at minimum.
-    ///
-    /// Maps to `blend all_mode=subtract`.
+    /// Linear subtraction, clamped. `blend all_mode=subtract`.
     Subtract,
 
-    /// Applies the top layer's hue to the base's saturation and luminance.
-    ///
-    /// Maps to `blend all_mode=hue`.
-    ///
-    /// **Note**: not supported by the bundled `FFmpeg` `blend` filter; graph
-    /// construction succeeds but no output frame is produced at runtime.
-    Hue,
-
-    /// Applies the top layer's saturation to the base's hue and luminance.
-    ///
-    /// Maps to `blend all_mode=saturation`.
-    ///
-    /// **Note**: not supported by the bundled `FFmpeg` `blend` filter; graph
-    /// construction succeeds but no output frame is produced at runtime.
-    Saturation,
-
-    /// Applies the top layer's hue + saturation to the base's luminance.
-    ///
-    /// Maps to `blend all_mode=color`.
-    ///
-    /// **Note**: not supported by the bundled `FFmpeg` `blend` filter; graph
-    /// construction succeeds but no output frame is produced at runtime.
-    Color,
-
-    /// Applies the top layer's luminance to the base's hue and saturation.
-    ///
-    /// Maps to `blend all_mode=luminosity`.
-    ///
-    /// **Note**: not supported by the bundled `FFmpeg` `blend` filter; graph
-    /// construction succeeds but no output frame is produced at runtime.
-    Luminosity,
-
-    // ── Porter-Duff alpha compositing ─────────────────────────────────────
-    /// Top layer rendered over the bottom (standard alpha compositing).
-    ///
-    /// Implemented via `overlay=format=auto:shortest=1`.
-    PorterDuffOver,
-
-    /// Bottom layer rendered over the top; equivalent to `Over` with inputs swapped.
-    PorterDuffUnder,
-
-    /// Top layer masked by the bottom layer's alpha (intersection).
-    PorterDuffIn,
-
-    /// Top layer visible only where the bottom layer is transparent.
-    PorterDuffOut,
-
-    /// Top layer placed atop the bottom; visible only where the bottom is opaque.
-    PorterDuffAtop,
-
-    /// Pixels from exactly one layer (XOR of opaque regions).
-    PorterDuffXor,
+    // ── Additional FFmpeg blend modes ─────────────────────────────────────
+    /// Bitwise AND of the two pixels. `blend all_mode=and`.
+    And,
+    /// Arithmetic mean of the two pixels. `blend all_mode=average`.
+    Average,
+    /// Bleach-bypass look. `blend all_mode=bleach`.
+    Bleach,
+    /// Per-channel division. `blend all_mode=divide`.
+    Divide,
+    /// Extremity (distance from mid-grey). `blend all_mode=extremity`.
+    Extremity,
+    /// Freeze. `blend all_mode=freeze`.
+    Freeze,
+    /// Geometric mean. `blend all_mode=geometric`.
+    Geometric,
+    /// Glow. `blend all_mode=glow`.
+    Glow,
+    /// Grain extract (alias of `difference128`). `blend all_mode=grainextract`.
+    GrainExtract,
+    /// Grain merge (alias of `addition128`). `blend all_mode=grainmerge`.
+    GrainMerge,
+    /// Hard mix. `blend all_mode=hardmix`.
+    HardMix,
+    /// Hard overlay. `blend all_mode=hardoverlay`.
+    HardOverlay,
+    /// Harmonic mean. `blend all_mode=harmonic`.
+    Harmonic,
+    /// Heat. `blend all_mode=heat`.
+    Heat,
+    /// Linear interpolation. `blend all_mode=interpolate`.
+    Interpolate,
+    /// Linear light. `blend all_mode=linearlight`.
+    LinearLight,
+    /// Multiply scaled by 128. `blend all_mode=multiply128`.
+    Multiply128,
+    /// Negation. `blend all_mode=negation`.
+    Negation,
+    /// Bitwise OR of the two pixels. `blend all_mode=or`.
+    Or,
+    /// Phoenix. `blend all_mode=phoenix`.
+    Phoenix,
+    /// Pin light. `blend all_mode=pinlight`.
+    PinLight,
+    /// Reflect. `blend all_mode=reflect`.
+    Reflect,
+    /// Soft difference. `blend all_mode=softdifference`.
+    SoftDifference,
+    /// Stain. `blend all_mode=stain`.
+    Stain,
+    /// Vivid light. `blend all_mode=vividlight`.
+    VividLight,
+    /// Arithmetic XOR of the two pixels. `blend all_mode=xor`.
+    /// Distinct from the Porter-Duff [`CompositeOp::Xor`](crate::CompositeOp).
+    Xor,
 }

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use crate::blend::BlendMode;
 use crate::composite::CompositeOp;
 use crate::error::FilterError;
+use crate::graph::FfmpegToken;
 use crate::graph::filter_step::FilterStep;
 use crate::graph::types::{EqBand, HwAccel};
 use ff_format::AlphaMode;
@@ -1222,9 +1223,8 @@ pub(super) unsafe fn add_blend_expr_step(
 /// `AVFilterGraph`.
 // ── Composite compound step ───────────────────────────────────────────────────
 /// Builds a Porter-Duff composite step from a [`CompositeOp`], dispatching to the
-/// shared blend construction helpers. This is the single `CompositeOp`-keyed
-/// construction site, used by both [`FilterStep::Composite`] and the legacy
-/// `BlendMode::PorterDuff*` arms (so the two paths build identical graphs).
+/// shared blend construction helpers (`overlay` for `Over`/`Under`, `blend` with
+/// a per-channel expression for the rest). Consumed by [`FilterStep::Composite`].
 ///
 /// # Safety
 ///
@@ -2203,54 +2203,19 @@ impl FilterGraphInner {
                 continue;
             }
 
-            // Blend (photographic modes: Multiply, Screen, Overlay, SoftLight, HardLight)
+            // Blend (all non-Normal modes) — built via `blend all_mode=<token>`.
+            // Normal is handled by the `overlay` arm above; every other BlendMode
+            // maps 1:1 to an all_mode token via FfmpegToken (the single source of
+            // the 40-mode mapping). Porter-Duff alpha compositing lives in the
+            // separate Composite step below.
             if let FilterStep::Blend {
-                top,
-                mode:
-                    mode @ (BlendMode::Multiply
-                    | BlendMode::Screen
-                    | BlendMode::Overlay
-                    | BlendMode::SoftLight
-                    | BlendMode::HardLight
-                    | BlendMode::ColorDodge
-                    | BlendMode::ColorBurn
-                    | BlendMode::Darken
-                    | BlendMode::Lighten
-                    | BlendMode::Difference
-                    | BlendMode::Exclusion
-                    | BlendMode::Add
-                    | BlendMode::Subtract
-                    | BlendMode::Hue
-                    | BlendMode::Saturation
-                    | BlendMode::Color
-                    | BlendMode::Luminosity),
-                opacity,
-                ..
+                top, mode, opacity, ..
             } = step
             {
                 let Some(top_src) = src_ctxs.get(1).and_then(|o| *o) else {
                     bail!(FilterError::BuildFailed)
                 };
-                let mode_name = match mode {
-                    BlendMode::Multiply => "multiply",
-                    BlendMode::Screen => "screen",
-                    BlendMode::Overlay => "overlay",
-                    BlendMode::SoftLight => "softlight",
-                    BlendMode::HardLight => "hardlight",
-                    BlendMode::ColorDodge => "dodge",
-                    BlendMode::ColorBurn => "burn",
-                    BlendMode::Darken => "darken",
-                    BlendMode::Lighten => "lighten",
-                    BlendMode::Difference => "difference",
-                    BlendMode::Exclusion => "exclusion",
-                    BlendMode::Add => "addition",
-                    BlendMode::Subtract => "subtract",
-                    BlendMode::Hue => "hue",
-                    BlendMode::Saturation => "saturation",
-                    BlendMode::Color => "color",
-                    BlendMode::Luminosity => "luminosity",
-                    _ => unreachable!(),
-                };
+                let mode_name = mode.ffmpeg_token().unwrap_or("normal");
                 prev_ctx = match add_blend_photographic_step(
                     graph,
                     prev_ctx,
@@ -2258,50 +2223,6 @@ impl FilterGraphInner {
                     top.steps(),
                     mode_name,
                     *opacity,
-                    i,
-                ) {
-                    Ok(ctx) => ctx,
-                    Err(e) => bail!(e),
-                };
-                continue;
-            }
-
-            // Blend (Porter-Duff modes) — delegate to the shared CompositeOp
-            // construction so the legacy BlendMode path and the new Composite path
-            // build identical graphs (#1221). BlendMode itself is left untouched.
-            if let FilterStep::Blend {
-                top,
-                mode:
-                    mode @ (BlendMode::PorterDuffOver
-                    | BlendMode::PorterDuffUnder
-                    | BlendMode::PorterDuffIn
-                    | BlendMode::PorterDuffOut
-                    | BlendMode::PorterDuffAtop
-                    | BlendMode::PorterDuffXor),
-                opacity,
-                alpha,
-            } = step
-            {
-                let Some(top_src) = src_ctxs.get(1).and_then(|o| *o) else {
-                    bail!(FilterError::BuildFailed)
-                };
-                let op = match mode {
-                    BlendMode::PorterDuffOver => CompositeOp::Over,
-                    BlendMode::PorterDuffUnder => CompositeOp::Under,
-                    BlendMode::PorterDuffIn => CompositeOp::In,
-                    BlendMode::PorterDuffOut => CompositeOp::Out,
-                    BlendMode::PorterDuffAtop => CompositeOp::Atop,
-                    BlendMode::PorterDuffXor => CompositeOp::Xor,
-                    _ => unreachable!(),
-                };
-                prev_ctx = match add_composite_step(
-                    graph,
-                    prev_ctx,
-                    top_src.as_ptr(),
-                    top.steps(),
-                    op,
-                    *opacity,
-                    *alpha,
                     i,
                 ) {
                     Ok(ctx) => ctx,

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -16,6 +16,7 @@ use crate::animation::{AnimatedValue, AnimationEntry};
 use crate::blend::BlendMode;
 use crate::error::FilterError;
 use crate::filter_inner::FilterGraphInner;
+use crate::graph::FfmpegToken;
 use crate::graph::graph::FilterGraph;
 use crate::graph::types::Rgb;
 
@@ -24,28 +25,11 @@ use super::multi_track_mixer::AudioTrack;
 
 /// Maps a `BlendMode` to the `FFmpeg` `blend` filter `all_mode` name.
 ///
-/// `BlendMode::Normal` is not handled here; it uses the `overlay` filter instead.
+/// Delegates to [`FfmpegToken`] (the single source of the 40-mode mapping).
+/// `BlendMode::Normal` is not normally routed here (it uses the `overlay` filter);
+/// the `"normal"` fallback is a defensive default.
 fn blend_mode_to_ffmpeg(mode: BlendMode) -> &'static str {
-    match mode {
-        BlendMode::Multiply => "multiply",
-        BlendMode::Screen => "screen",
-        BlendMode::Overlay => "overlay",
-        BlendMode::SoftLight => "softlight",
-        BlendMode::HardLight => "hardlight",
-        BlendMode::ColorDodge => "dodge",
-        BlendMode::ColorBurn => "burn",
-        BlendMode::Darken => "darken",
-        BlendMode::Lighten => "lighten",
-        BlendMode::Difference => "difference",
-        BlendMode::Exclusion => "exclusion",
-        BlendMode::Add => "addition",
-        BlendMode::Subtract => "subtract",
-        BlendMode::Hue => "hue",
-        BlendMode::Saturation => "saturation",
-        BlendMode::Color => "color",
-        BlendMode::Luminosity => "luminosity",
-        _ => "normal",
-    }
+    mode.ffmpeg_token().unwrap_or("normal")
 }
 
 // ── Video composition graph builder ──────────────────────────────────────────

--- a/crates/ff-filter/src/graph/ffmpeg_token/mod.rs
+++ b/crates/ff-filter/src/graph/ffmpeg_token/mod.rs
@@ -67,7 +67,7 @@ impl FfmpegToken for XfadeTransition {
 
 impl FfmpegToken for BlendMode {
     fn ffmpeg_token(&self) -> Option<&'static str> {
-        // all_mode unit: https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_blend.c
+        // all_mode unit (every BlendMode maps 1:1 to a token): https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_blend.c
         Some(match self {
             Self::Normal => "normal",
             Self::Multiply => "multiply",
@@ -83,16 +83,94 @@ impl FfmpegToken for BlendMode {
             Self::Exclusion => "exclusion",
             Self::Add => "addition",
             Self::Subtract => "subtract",
-            Self::Hue => return None,             // TODO
-            Self::Saturation => return None,      // TODO
-            Self::Color => return None,           // TODO
-            Self::Luminosity => return None,      // TODO
-            Self::PorterDuffOver => return None,  // TODO
-            Self::PorterDuffUnder => return None, // TODO
-            Self::PorterDuffIn => return None,    // TODO
-            Self::PorterDuffOut => return None,   // TODO
-            Self::PorterDuffAtop => return None,  // TODO
-            Self::PorterDuffXor => return None,   // TODO
+            Self::And => "and",
+            Self::Average => "average",
+            Self::Bleach => "bleach",
+            Self::Divide => "divide",
+            Self::Extremity => "extremity",
+            Self::Freeze => "freeze",
+            Self::Geometric => "geometric",
+            Self::Glow => "glow",
+            Self::GrainExtract => "grainextract",
+            Self::GrainMerge => "grainmerge",
+            Self::HardMix => "hardmix",
+            Self::HardOverlay => "hardoverlay",
+            Self::Harmonic => "harmonic",
+            Self::Heat => "heat",
+            Self::Interpolate => "interpolate",
+            Self::LinearLight => "linearlight",
+            Self::Multiply128 => "multiply128",
+            Self::Negation => "negation",
+            Self::Or => "or",
+            Self::Phoenix => "phoenix",
+            Self::PinLight => "pinlight",
+            Self::Reflect => "reflect",
+            Self::SoftDifference => "softdifference",
+            Self::Stain => "stain",
+            Self::VividLight => "vividlight",
+            Self::Xor => "xor",
         })
+    }
+}
+
+#[cfg(test)]
+mod blend_mode_token_tests {
+    use super::*;
+
+    /// Every `BlendMode` variant must emit its exact FFmpeg `blend all_mode` token
+    /// (verified against pinned `vf_blend.c`; the `all_mode` set is identical in
+    /// release/7.1 and release/8.0). No variant returns `None`.
+    #[test]
+    fn blend_mode_should_emit_all_mode_token_for_every_variant() {
+        let cases = [
+            (BlendMode::Normal, "normal"),
+            (BlendMode::Multiply, "multiply"),
+            (BlendMode::Screen, "screen"),
+            (BlendMode::Overlay, "overlay"),
+            (BlendMode::SoftLight, "softlight"),
+            (BlendMode::HardLight, "hardlight"),
+            (BlendMode::ColorDodge, "dodge"),
+            (BlendMode::ColorBurn, "burn"),
+            (BlendMode::Darken, "darken"),
+            (BlendMode::Lighten, "lighten"),
+            (BlendMode::Difference, "difference"),
+            (BlendMode::Exclusion, "exclusion"),
+            (BlendMode::Add, "addition"),
+            (BlendMode::Subtract, "subtract"),
+            (BlendMode::And, "and"),
+            (BlendMode::Average, "average"),
+            (BlendMode::Bleach, "bleach"),
+            (BlendMode::Divide, "divide"),
+            (BlendMode::Extremity, "extremity"),
+            (BlendMode::Freeze, "freeze"),
+            (BlendMode::Geometric, "geometric"),
+            (BlendMode::Glow, "glow"),
+            (BlendMode::GrainExtract, "grainextract"),
+            (BlendMode::GrainMerge, "grainmerge"),
+            (BlendMode::HardMix, "hardmix"),
+            (BlendMode::HardOverlay, "hardoverlay"),
+            (BlendMode::Harmonic, "harmonic"),
+            (BlendMode::Heat, "heat"),
+            (BlendMode::Interpolate, "interpolate"),
+            (BlendMode::LinearLight, "linearlight"),
+            (BlendMode::Multiply128, "multiply128"),
+            (BlendMode::Negation, "negation"),
+            (BlendMode::Or, "or"),
+            (BlendMode::Phoenix, "phoenix"),
+            (BlendMode::PinLight, "pinlight"),
+            (BlendMode::Reflect, "reflect"),
+            (BlendMode::SoftDifference, "softdifference"),
+            (BlendMode::Stain, "stain"),
+            (BlendMode::VividLight, "vividlight"),
+            (BlendMode::Xor, "xor"),
+        ];
+        assert_eq!(cases.len(), 40, "BlendMode must have exactly 40 modes");
+        for (mode, token) in cases {
+            assert_eq!(
+                mode.ffmpeg_token(),
+                Some(token),
+                "{mode:?} must emit token {token:?}"
+            );
+        }
     }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -494,9 +494,8 @@ pub enum FilterStep {
     /// Porter-Duff alpha-compositing [`CompositeOp`].
     ///
     /// This is a compound, two-input step (slot 0 = bottom, slot 1 = top with
-    /// the `top` builder's steps applied). It shares its `FFmpeg` construction with
-    /// the legacy `BlendMode::PorterDuff*` arms: `Over`/`Under` use `overlay`,
-    /// the rest use `blend` with a per-channel expression.
+    /// the `top` builder's steps applied). `Over`/`Under` are built with the
+    /// `overlay` filter; the rest use `blend` with a per-channel expression.
     ///
     /// `Box<FilterGraphBuilder>` breaks the otherwise-recursive type, following
     /// the same pattern as [`FilterStep::Blend`].

--- a/crates/ff-filter/tests/blend_reference_tests.rs
+++ b/crates/ff-filter/tests/blend_reference_tests.rs
@@ -1,4 +1,7 @@
-//! Golden-image regression tests for all 18 photographic blend modes.
+//! Golden-image regression tests for the 14 standard photographic blend modes.
+//!
+//! (The 4 HSL modes were removed in #1219; golden fixtures for the 26 added
+//! FFmpeg blend modes are future work.)
 //!
 //! ## Running
 //!
@@ -10,7 +13,7 @@
 //! BLEND_GENERATE_REFS=1 cargo test -p ff-filter blend_mode_reference -- --include-ignored
 //! ```
 //! This writes `tests/fixtures/blend/bottom.png`, `top.png`, and
-//! `tests/fixtures/blend/expected/<mode>.png` for all 18 modes.
+//! `tests/fixtures/blend/expected/<mode>.png` for all 14 modes.
 //!
 //! **Verify against committed references** (normal CI):
 //! ```text
@@ -207,7 +210,7 @@ fn assert_within_tolerance(actual: &RgbImage, expected: &RgbImage, tolerance: u8
 
 // ── Main test ─────────────────────────────────────────────────────────────────
 
-/// All 18 photographic blend modes verified against committed reference PNGs.
+/// The 14 standard photographic blend modes verified against committed reference PNGs.
 ///
 /// The test is marked `#[ignore]` so the base `cargo test` suite does not
 /// require fixture files to be present.  Run explicitly:
@@ -283,10 +286,6 @@ fn blend_mode_reference_images_should_match_within_tolerance() {
         ("exclusion", BlendMode::Exclusion),
         ("add", BlendMode::Add),
         ("subtract", BlendMode::Subtract),
-        ("hue", BlendMode::Hue),
-        ("saturation", BlendMode::Saturation),
-        ("color", BlendMode::Color),
-        ("luminosity", BlendMode::Luminosity),
     ];
 
     // ── Per-mode generate or compare ──────────────────────────────────────────

--- a/crates/ff-filter/tests/compositing_pipeline_tests.rs
+++ b/crates/ff-filter/tests/compositing_pipeline_tests.rs
@@ -1,12 +1,12 @@
 //! End-to-end integration test for the compositing pipeline:
-//! polygon garbage matte → chroma key → Porter-Duff Over blend.
+//! polygon garbage matte → chroma key → Porter-Duff Over composite.
 //!
 //! All frames are generated synthetically using `push_video` / `pull_video`;
 //! no fixture files are required.
 
 #![allow(clippy::unwrap_used)]
 
-use ff_filter::{BlendMode, FilterGraph, FilterGraphBuilder};
+use ff_filter::{CompositeOp, FilterGraph, FilterGraphBuilder};
 use ff_format::{AlphaMode, PixelFormat, PooledBuffer, Timestamp, VideoFrame};
 
 /// YUV420p frame filled with a solid colour.
@@ -31,7 +31,7 @@ fn make_yuv420p_frame(width: u32, height: u32, y: u8, u: u8, v: u8) -> VideoFram
 }
 
 /// End-to-end compositing pipeline:
-///   polygon_matte → chromakey → blend(PorterDuffOver, background)
+///   polygon_matte → chromakey → composite(CompositeOp::Over, background)
 ///
 /// Setup:
 /// - Foreground (slot 1): solid green frame (Y=150, U=44, V=21 ≈ 0x00FF00 in BT.601)
@@ -56,12 +56,7 @@ fn garbage_matte_chromakey_blend_over_background_should_composite_correctly() {
         .chromakey("0x00FF00", 0.3, 0.0);
 
     let mut graph = match FilterGraph::builder()
-        .blend(
-            fg_builder,
-            BlendMode::PorterDuffOver,
-            1.0,
-            AlphaMode::Straight,
-        )
+        .composite(fg_builder, CompositeOp::Over, 1.0, AlphaMode::Straight)
         .build()
     {
         Ok(g) => g,

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -2127,372 +2127,51 @@ fn blend_subtract_white_top_should_produce_black() {
 }
 
 #[test]
-fn blend_luminosity_should_preserve_base_hue_and_saturation() {
-    // Luminosity applies the top's luminance to the base's hue+saturation.
-    // With a brighter grey top (Y=200) over a darker grey bottom (Y=128),
-    // the output luma should shift toward the top's luminance (200).
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::Luminosity, 1.0, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let bottom = make_solid_yuv_frame(64, 64, 128);
-    let top_frame = make_solid_yuv_frame(64, 64, 200);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    let luma = out.plane(0).expect("Y plane must exist");
-    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
-    assert!(
-        avg > 160.0,
-        "Luminosity with brighter top should increase output luma toward top's value (avg={avg})"
-    );
-}
-
-// ── Porter-Duff Over ──────────────────────────────────────────────────────────
-
-#[test]
-fn porter_duff_over_opaque_top_should_cover_bottom() {
-    // PorterDuffOver with opacity=1.0: opaque YUV420p top covers the bottom.
-    // Uses overlay=format=auto:shortest=1 — opaque top always wins.
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffOver, 1.0, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
+fn blend_new_modes_should_be_accepted_by_ffmpeg() {
+    // #1219: the 26 added BlendMode modes share the single generic
+    // `blend all_mode=<token>` dispatch with the 14 standard modes (the only
+    // per-mode difference is the token string). A few representatives are pushed
+    // through a real graph to confirm FFmpeg accepts their tokens. Probe-gated:
+    // CI's Linux FFmpeg has no filters, so a build/push failure → skip (RK-002).
     let bottom = make_solid_yuv_frame(64, 64, 100);
     let top_frame = make_solid_yuv_frame(64, 64, 200);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
+    for mode in [
+        BlendMode::Bleach,
+        BlendMode::VividLight,
+        BlendMode::GrainMerge,
+        BlendMode::Phoenix,
+        BlendMode::HardOverlay,
+    ] {
+        let top = FilterGraphBuilder::new().trim(0.0, 5.0);
+        let mut graph = match FilterGraph::builder()
+            .trim(0.0, 5.0)
+            .blend(top, mode, 1.0, AlphaMode::Straight)
+            .build()
+        {
+            Ok(g) => g,
+            Err(e) => {
+                println!("Skipping {mode:?}: {e}");
+                return;
+            }
+        };
+        if graph.push_video(0, &bottom).is_err() || graph.push_video(1, &top_frame).is_err() {
+            println!("Skipping {mode:?}: blend filter unavailable");
             return;
         }
+        let out = graph
+            .pull_video()
+            .expect("pull_video must not fail")
+            .expect("expected Some(frame)");
+        assert_eq!(out.width(), 64, "{mode:?} must not change frame width");
+        assert_eq!(out.height(), 64, "{mode:?} must not change frame height");
     }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    let luma = out.plane(0).expect("Y plane must exist");
-    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
-    assert!(
-        avg > 160.0,
-        "PorterDuffOver with opaque top should cover the bottom (avg={avg})"
-    );
-}
-
-#[test]
-fn porter_duff_over_semitransparent_should_blend_correctly() {
-    // PorterDuffOver with opacity=0.5 inserts colorchannelmixer=aa=0.5 on the top
-    // layer, making it semi-transparent so the bottom shows through.
-    // Verifies the graph constructs and runs without error.
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffOver, 0.5, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let bottom = make_solid_yuv_frame(64, 64, 100);
-    let top_frame = make_solid_yuv_frame(64, 64, 200);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    assert_eq!(out.width(), 64, "output width must match input");
-    assert_eq!(out.height(), 64, "output height must match input");
-}
-
-// ── Porter-Duff Under ─────────────────────────────────────────────────────────
-
-#[test]
-fn porter_duff_under_should_place_bottom_over_top() {
-    // PorterDuffUnder reverses overlay input order (bottom→pad1, top→pad0), so
-    // the bottom layer composites over the top. Verify the graph builds and
-    // produces a frame with the expected dimensions.
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffUnder, 1.0, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let bottom = make_solid_yuv_frame(64, 64, 200);
-    let top_frame = make_solid_yuv_frame(64, 64, 100);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    assert_eq!(out.width(), 64, "output width must match input");
-    assert_eq!(out.height(), 64, "output height must match input");
-}
-
-// ── Porter-Duff In ────────────────────────────────────────────────────────────
-
-#[test]
-fn porter_duff_in_should_produce_black_where_bottom_is_black() {
-    // PorterDuffIn uses all_expr=B*A/255, so when the bottom luma (A) is 0,
-    // the output is 0 regardless of the top value.
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffIn, 1.0, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let bottom = make_solid_yuv_frame(64, 64, 0);
-    let top_frame = make_solid_yuv_frame(64, 64, 200);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    let luma = out.plane(0).expect("Y plane must exist");
-    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
-    assert!(
-        avg < 10.0,
-        "PorterDuffIn with black bottom should produce black output (avg={avg})"
-    );
-}
-
-// ── Porter-Duff Atop ─────────────────────────────────────────────────────────
-
-#[test]
-fn porter_duff_atop_should_use_bottom_alpha_for_output() {
-    // Atop formula: B*A/255 + A*(255-B)/255 = A*(B + 255 - B)/255 = A.
-    // The output luma always equals the bottom luma regardless of the top value.
-    // bottom=Y100, top=Y200 → avg ≈ 100 (within ±15).
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffAtop, 1.0, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let bottom = make_solid_yuv_frame(64, 64, 100);
-    let top_frame = make_solid_yuv_frame(64, 64, 200);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    let luma = out.plane(0).expect("Y plane must exist");
-    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
-    assert!(
-        avg > 85.0 && avg < 115.0,
-        "PorterDuffAtop output luma should equal bottom luma (~100), got avg={avg}"
-    );
-}
-
-// ── Porter-Duff XOR ───────────────────────────────────────────────────────────
-
-#[test]
-fn porter_duff_xor_identical_shapes_should_produce_zero_alpha() {
-    // XOR formula with A=B=255: 255*(255-255)/255 + 255*(255-255)/255 = 0.
-    // Two fully-opaque identical layers cancel each other out.
-    // bottom=Y255, top=Y255 → avg ≈ 0.
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffXor, 1.0, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let bottom = make_solid_yuv_frame(64, 64, 255);
-    let top_frame = make_solid_yuv_frame(64, 64, 255);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    let luma = out.plane(0).expect("Y plane must exist");
-    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
-    assert!(
-        avg < 10.0,
-        "PorterDuffXor of identical full-luma shapes should produce black (avg={avg})"
-    );
-}
-
-// ── Porter-Duff Out ───────────────────────────────────────────────────────────
-
-#[test]
-fn porter_duff_out_should_produce_black_where_bottom_is_white() {
-    // PorterDuffOut uses all_expr=B*(255-A)/255, so when the bottom luma (A) is
-    // 255, the output is 0 regardless of the top value.
-    let top = FilterGraphBuilder::new().trim(0.0, 5.0);
-    let mut graph = match FilterGraph::builder()
-        .trim(0.0, 5.0)
-        .blend(top, BlendMode::PorterDuffOut, 1.0, AlphaMode::Straight)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let bottom = make_solid_yuv_frame(64, 64, 255);
-    let top_frame = make_solid_yuv_frame(64, 64, 200);
-    match graph.push_video(0, &bottom) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    match graph.push_video(1, &top_frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let out = graph
-        .pull_video()
-        .expect("pull_video must not fail")
-        .expect("expected Some(frame)");
-    let luma = out.plane(0).expect("Y plane must exist");
-    let avg = luma.iter().map(|&b| b as f32).sum::<f32>() / luma.len() as f32;
-    assert!(
-        avg < 10.0,
-        "PorterDuffOut with white bottom should produce black output (avg={avg})"
-    );
 }
 
 // ── CompositeOp (Porter-Duff via the new Composite step) ──────────────────────
 //
-// These mirror the `porter_duff_*` tests above but drive the new
-// `FilterGraphBuilder::composite()` path. Both paths share `add_composite_step`,
-// so identical assertions confirm the Composite step builds the same graphs as
-// the legacy `BlendMode::PorterDuff*` arms (#1221 acceptance criterion).
+// Porter-Duff alpha compositing is driven via `FilterGraphBuilder::composite()`
+// (the `CompositeOp` API, #1221); these behavioural tests cover each operator.
+// The former `BlendMode::PorterDuff*` variants were removed in #1219.
 
 #[test]
 fn composite_over_opaque_top_should_cover_bottom() {

--- a/docs/specs/ffmpeg-tokens.md
+++ b/docs/specs/ffmpeg-tokens.md
@@ -69,28 +69,40 @@ holds the correct token, or `want to remove` for variants with no FFmpeg equival
 
 **Reference:** `libavfilter/vf_blend.c` (`all_mode` / `mode` unit) — [7.1](https://github.com/FFmpeg/FFmpeg/blob/release/7.1/libavfilter/vf_blend.c) · [8.0](https://github.com/FFmpeg/FFmpeg/blob/release/8.0/libavfilter/vf_blend.c)
 
-| avio variant | FFmpeg token | status | expected |
-|---|---|---|---|
-| Normal | normal | OK | - |
-| Multiply | multiply | OK | - |
-| Screen | screen | OK | - |
-| Overlay | overlay | OK | - |
-| SoftLight | softlight | OK | - |
-| HardLight | hardlight | OK | - |
-| ColorDodge | dodge | OK | - |
-| ColorBurn | burn | OK | - |
-| Darken | darken | OK | - |
-| Lighten | lighten | OK | - |
-| Difference | difference | OK | - |
-| Exclusion | exclusion | OK | - |
-| Add | addition | OK | - |
-| Subtract | subtract | OK | - |
-| Hue | None | NG | want to remove |
-| Saturation | None | NG | want to remove |
-| Color | None | NG | want to remove |
-| Luminosity | None | NG | want to remove |
+`BlendMode` corresponds **1:1** to the `all_mode` set (40 distinct modes; `addition128`/`difference128` are
+aliases of `grainmerge`/`grainextract`). `FfmpegToken` is **all-`Some`** (#1219). `Normal` is built via the
+`overlay` filter (alpha compositing) but its canonical token is `normal`.
 
-> `PorterDuffOver/Under/In/Out/Atop/Xor` are separated into `CompositeOp` (below) — #1218.
+| avio variant | FFmpeg token | status | | avio variant | FFmpeg token | status |
+|---|---|---|---|---|---|---|
+| Normal | normal | OK | | HardMix | hardmix | OK |
+| Multiply | multiply | OK | | HardOverlay | hardoverlay | OK |
+| Screen | screen | OK | | Harmonic | harmonic | OK |
+| Overlay | overlay | OK | | Heat | heat | OK |
+| SoftLight | softlight | OK | | Interpolate | interpolate | OK |
+| HardLight | hardlight | OK | | LinearLight | linearlight | OK |
+| ColorDodge | dodge | OK | | Multiply128 | multiply128 | OK |
+| ColorBurn | burn | OK | | Negation | negation | OK |
+| Darken | darken | OK | | Or | or | OK |
+| Lighten | lighten | OK | | Phoenix | phoenix | OK |
+| Difference | difference | OK | | PinLight | pinlight | OK |
+| Exclusion | exclusion | OK | | Reflect | reflect | OK |
+| Add | addition | OK | | SoftDifference | softdifference | OK |
+| Subtract | subtract | OK | | Stain | stain | OK |
+| And | and | OK | | VividLight | vividlight | OK |
+| Average | average | OK | | Xor | xor | OK |
+| Bleach | bleach | OK | | | | |
+| Divide | divide | OK | | | | |
+| Extremity | extremity | OK | | | | |
+| Freeze | freeze | OK | | | | |
+| Geometric | geometric | OK | | | | |
+| Glow | glow | OK | | | | |
+| GrainExtract | grainextract | OK | | | | |
+| GrainMerge | grainmerge | OK | | | | |
+
+> Porter-Duff (`PorterDuffOver/Under/In/Out/Atop/Xor`) and HSL (`Hue/Saturation/Color/Luminosity`) were **removed**
+> from `BlendMode`: Porter-Duff moved to `CompositeOp` (below, #1221); HSL had no `all_mode` token (#1219). Note
+> `BlendMode::Xor` is the arithmetic `xor` blend, distinct from the Porter-Duff `CompositeOp::Xor`.
 
 ## CompositeOp
 


### PR DESCRIPTION
## Summary

Restructures `BlendMode` (in `ff-filter`) to correspond **exactly** to FFmpeg's `blend` `all_mode` set: 40 modes, every variant mapping 1:1 to a valid token so `FfmpegToken for BlendMode` is **all-`Some`** (no `None`, no `// TODO`). Removes the 6 Porter-Duff operators (relocated to `CompositeOp` in #1221) and the 4 HSL modes (no FFmpeg equivalent — they always produced `BuildFailed`). Breaking change (acceptable pre-1.0); behaviour preserved for the existing 14 modes. This absorbs the migration of #1220.

## Changes

- **`blend.rs`** — `BlendMode` redesigned to the 40 `all_mode` modes (14 kept with unchanged names + 26 new, PascalCase of the token); doc rewritten. `BlendMode::Xor` is the arithmetic blend, distinct from `CompositeOp::Xor`.
- **`ffmpeg_token/mod.rs`** — `FfmpegToken for BlendMode` returns the exact token for all 40 (no wildcard, no `None`). New deterministic unit test asserts the token for every variant and that the count is exactly 40 (verified against pinned `vf_blend.c`).
- **Single source of truth** — the BlendMode→token mapping is now only in `FfmpegToken`. `build.rs` (the photographic blend dispatch) and `composition_inner.rs` (`blend_mode_to_ffmpeg`) now delegate to `mode.ffmpeg_token()`, deleting two duplicate 17-arm matches. The Porter-Duff `Blend` dispatch arm is removed; `Normal` keeps its `overlay` build path.
- **Migration (#1220)** — examples (`chroma_key_green_screen`, `alpha_matte_external`, `luma_key_title_card`) and the `garbage_matte` test migrated from `.blend(BlendMode::PorterDuffOver, …)` to `.composite(CompositeOp::Over, …)`; redundant `porter_duff_*` tests removed (covered by the `composite_*` tests from #1221); HSL entries dropped from `blend_reference_tests`; `docs/specs/ffmpeg-tokens.md` updated.
- A probe-gated smoke test pushes representative new modes through a real graph to confirm FFmpeg accepts their tokens.

`ff-render` has its own separate `BlendMode` (with HSL) — left untouched. No `avio` re-export change needed (the type is already re-exported).

## Related Issues

Closes #1219
Closes #1220

## Test Plan

- [x] \`cargo test --all --all-features\` passes
- [x] \`cargo clippy --all --all-features -- -D warnings\` passes
- [x] \`cargo fmt --all -- --check\` passes
- [x] \`cargo doc --all-features --no-deps\` passes