### PR TITLE
feat(ff-pipeline): Clip/Timeline composite-op support

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -104,6 +104,7 @@ fn main() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -122,6 +123,7 @@ fn main() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .build()

--- a/crates/ff-filter/src/composite.rs
+++ b/crates/ff-filter/src/composite.rs
@@ -44,3 +44,53 @@ pub enum CompositeOp {
     /// Built via `blend` with `c0_expr='B*(255-A)/255 + A*(255-B)/255'`.
     Xor,
 }
+
+impl CompositeOp {
+    /// Returns the `FFmpeg` `blend` `all_expr` formula for the expression-based
+    /// operators (`In`/`Out`/`Atop`/`Xor`), or `None` for `Over`/`Under` which
+    /// are built with the `overlay` filter rather than `blend`.
+    ///
+    /// In the formula, `A` is the bottom pixel and `B` is the top pixel. This is
+    /// the single source of these formulas, shared by the `Composite` filter step
+    /// and the `MultiTrackComposer` canvas compositing.
+    #[must_use]
+    pub(crate) fn blend_all_expr(self) -> Option<&'static str> {
+        match self {
+            Self::Over | Self::Under => None,
+            Self::In => Some("B*A/255"),
+            Self::Out => Some("B*(255-A)/255"),
+            Self::Atop => Some("B*A/255 + A*(255-B)/255"),
+            Self::Xor => Some("B*(255-A)/255 + A*(255-B)/255"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CompositeOp;
+
+    #[test]
+    fn blend_all_expr_should_be_none_for_overlay_built_operators() {
+        assert_eq!(CompositeOp::Over.blend_all_expr(), None);
+        assert_eq!(CompositeOp::Under.blend_all_expr(), None);
+    }
+
+    #[test]
+    fn blend_all_expr_should_return_porter_duff_formula_for_expression_operators() {
+        assert_eq!(CompositeOp::In.blend_all_expr(), Some("B*A/255"));
+        assert_eq!(CompositeOp::Out.blend_all_expr(), Some("B*(255-A)/255"));
+        assert_eq!(
+            CompositeOp::Atop.blend_all_expr(),
+            Some("B*A/255 + A*(255-B)/255")
+        );
+        assert_eq!(
+            CompositeOp::Xor.blend_all_expr(),
+            Some("B*(255-A)/255 + A*(255-B)/255")
+        );
+    }
+
+    #[test]
+    fn composite_op_should_default_to_over() {
+        assert_eq!(CompositeOp::default(), CompositeOp::Over);
+    }
+}

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -1242,35 +1242,31 @@ pub(super) unsafe fn add_composite_step(
     alpha: AlphaMode,
     index: usize,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
-    match op {
-        CompositeOp::Over => add_blend_normal_step(
-            graph,
-            bottom_ctx,
-            top_src_ctx,
-            top_steps,
-            opacity,
-            alpha,
-            index,
-        ),
-        CompositeOp::Under => add_blend_under_step(
-            graph,
-            bottom_ctx,
-            top_src_ctx,
-            top_steps,
-            opacity,
-            alpha,
-            index,
-        ),
-        CompositeOp::In | CompositeOp::Out | CompositeOp::Atop | CompositeOp::Xor => {
-            let expr = match op {
-                CompositeOp::In => "B*A/255",
-                CompositeOp::Out => "B*(255-A)/255",
-                CompositeOp::Atop => "B*A/255 + A*(255-B)/255",
-                CompositeOp::Xor => "B*(255-A)/255 + A*(255-B)/255",
-                _ => unreachable!(),
-            };
-            add_blend_expr_step(graph, bottom_ctx, top_src_ctx, top_steps, expr, index)
-        }
+    // `blend_all_expr` is `Some` for In/Out/Atop/Xor (built via `blend all_expr`),
+    // `None` for Over/Under (built via the `overlay` filter).
+    match op.blend_all_expr() {
+        Some(expr) => add_blend_expr_step(graph, bottom_ctx, top_src_ctx, top_steps, expr, index),
+        None => match op {
+            CompositeOp::Under => add_blend_under_step(
+                graph,
+                bottom_ctx,
+                top_src_ctx,
+                top_steps,
+                opacity,
+                alpha,
+                index,
+            ),
+            // Over (overlay=format=auto:shortest=1).
+            _ => add_blend_normal_step(
+                graph,
+                bottom_ctx,
+                top_src_ctx,
+                top_steps,
+                opacity,
+                alpha,
+                index,
+            ),
+        },
     }
 }
 

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -14,6 +14,7 @@ use ff_format::ChannelLayout;
 
 use crate::animation::{AnimatedValue, AnimationEntry};
 use crate::blend::BlendMode;
+use crate::composite::CompositeOp;
 use crate::error::FilterError;
 use crate::filter_inner::FilterGraphInner;
 use crate::graph::FfmpegToken;
@@ -388,7 +389,12 @@ pub(super) unsafe fn build_video_composition(
         let opacity_initial = layer.opacity.value_at(Duration::ZERO).clamp(0.0, 1.0);
         // True for any Normal-mode layer whose opacity may be < 1.0 (static or animated).
         // Both cases require yuva420p + colorchannelmixer so the overlay can use alpha blending.
-        let needs_alpha = !use_blend_filter && (is_animated_opacity || opacity_initial < 1.0);
+        // Only the default overlay path (composite_op == Over, Normal blend) needs the
+        // colorchannelmixer alpha pre-step; a non-Over Porter-Duff op handles its own
+        // opacity (via `all_opacity` for the expression operators) in its own branch.
+        let needs_alpha = !use_blend_filter
+            && matches!(layer.composite_op, CompositeOp::Over)
+            && (is_animated_opacity || opacity_initial < 1.0);
 
         if needs_alpha {
             // ── format=yuva420p: add alpha plane before colorchannelmixer ─────
@@ -588,6 +594,224 @@ pub(super) unsafe fn build_video_composition(
         if skip_overlay[idx] {
             // The next layer will xfade from this one; defer the overlay.
             saved_chain = chain_end;
+        } else if layer.composite_op != CompositeOp::Over {
+            // ── Porter-Duff alpha compositing (#1222) ─────────────────────────────
+            //
+            // A non-`Over` composite op drives this layer's compositing; the colour
+            // `blend_mode` is not additionally applied. `A` = bottom (canvas) = pad 0,
+            // `B` = top (layer) = pad 1.
+            if let Some(expr) = layer.composite_op.blend_all_expr() {
+                // In/Out/Atop/Xor → `blend all_expr=<expr>`. Normalise the layer to
+                // yuv420p so both blend inputs share a format (as the photographic
+                // blend branch does). Opacity is forwarded via `all_opacity`.
+                let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+                if fmt_filter.is_null() {
+                    bail!(graph, "filter not found: format (composite pre-norm)");
+                }
+                let Ok(cfmt_name) = CString::new(format!("composite_fmt{idx}")) else {
+                    bail!(graph, "CString::new failed for composite format name");
+                };
+                let mut cfmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                let ret = ff_sys::avfilter_graph_create_filter(
+                    &raw mut cfmt_ctx,
+                    fmt_filter,
+                    cfmt_name.as_ptr(),
+                    c"yuv420p".as_ptr(),
+                    std::ptr::null_mut(),
+                    graph,
+                );
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!("failed to create composite format filter layer={idx} code={ret}")
+                    );
+                }
+                let ret = ff_sys::avfilter_link(chain_end, 0, cfmt_ctx, 0);
+                if ret < 0 {
+                    bail!(graph, format!("link failed: →composite_fmt layer={idx}"));
+                }
+                chain_end = cfmt_ctx;
+
+                let blend_filter = ff_sys::avfilter_get_by_name(c"blend".as_ptr());
+                if blend_filter.is_null() {
+                    bail!(graph, "filter not found: blend (composite)");
+                }
+                let Ok(cbl_name) = CString::new(format!("composite_blend{idx}")) else {
+                    bail!(graph, "CString::new failed for composite blend name");
+                };
+                let cbl_args_str = if (opacity_initial - 1.0).abs() < f64::from(f32::EPSILON) {
+                    format!("all_expr={expr}")
+                } else {
+                    format!("all_expr={expr}:all_opacity={opacity_initial:.6}")
+                };
+                let Ok(cbl_args) = CString::new(cbl_args_str.as_str()) else {
+                    bail!(graph, "CString::new failed for composite blend args");
+                };
+                let mut cblend_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                let ret = ff_sys::avfilter_graph_create_filter(
+                    &raw mut cblend_ctx,
+                    blend_filter,
+                    cbl_name.as_ptr(),
+                    cbl_args.as_ptr(),
+                    std::ptr::null_mut(),
+                    graph,
+                );
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!(
+                            "failed to create composite blend layer={idx} args={cbl_args_str} code={ret}"
+                        )
+                    );
+                }
+                let ret = ff_sys::avfilter_link(prev_ctx, 0, cblend_ctx, 0);
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!("link failed: base→composite_blend[0] layer={idx}")
+                    );
+                }
+                let ret = ff_sys::avfilter_link(chain_end, 0, cblend_ctx, 1);
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!("link failed: layer→composite_blend[1] layer={idx}")
+                    );
+                }
+                log::debug!(
+                    "video composition layer={idx} composite_op={:?} opacity={opacity_initial:.3}",
+                    layer.composite_op
+                );
+                prev_ctx = cblend_ctx;
+            } else {
+                // Under → `overlay` with swapped pads: layer = pad 0 (bottom),
+                // canvas = pad 1 (top), so the canvas composites over the layer.
+                //
+                // When opacity < 1.0, attenuate the layer's (pad 0) alpha via
+                // colorchannelmixer before the swapped overlay — mirroring
+                // `add_blend_under_step` so both Under paths handle opacity the
+                // same way. The overlay below must use `format=auto` (not the
+                // `yuv420` default, which carries no alpha) for the attenuated
+                // alpha to survive. Animated opacity on a non-Over layer is not
+                // tracked here; the initial value is used, consistent with the
+                // expression operators above.
+                if opacity_initial < 1.0 {
+                    let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+                    if fmt_filter.is_null() {
+                        bail!(graph, "filter not found: format (composite under opacity)");
+                    }
+                    let Ok(ufmt_name) = CString::new(format!("composite_under_fmt{idx}")) else {
+                        bail!(graph, "CString::new failed for composite under format name");
+                    };
+                    let mut ufmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                    let ret = ff_sys::avfilter_graph_create_filter(
+                        &raw mut ufmt_ctx,
+                        fmt_filter,
+                        ufmt_name.as_ptr(),
+                        c"yuva420p".as_ptr(),
+                        std::ptr::null_mut(),
+                        graph,
+                    );
+                    if ret < 0 {
+                        bail!(
+                            graph,
+                            format!(
+                                "failed to create composite under format filter layer={idx} code={ret}"
+                            )
+                        );
+                    }
+                    let ret = ff_sys::avfilter_link(chain_end, 0, ufmt_ctx, 0);
+                    if ret < 0 {
+                        bail!(
+                            graph,
+                            format!("link failed: →composite_under_fmt layer={idx}")
+                        );
+                    }
+                    chain_end = ufmt_ctx;
+
+                    let ccm_filter = ff_sys::avfilter_get_by_name(c"colorchannelmixer".as_ptr());
+                    if ccm_filter.is_null() {
+                        bail!(
+                            graph,
+                            "filter not found: colorchannelmixer (composite under)"
+                        );
+                    }
+                    let Ok(uccm_name) = CString::new(format!("composite_under_ccm{idx}")) else {
+                        bail!(graph, "CString::new failed for composite under ccm name");
+                    };
+                    let Ok(uccm_args) = CString::new(format!("aa={opacity_initial:.6}")) else {
+                        bail!(graph, "CString::new failed for composite under ccm args");
+                    };
+                    let mut uccm_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                    let ret = ff_sys::avfilter_graph_create_filter(
+                        &raw mut uccm_ctx,
+                        ccm_filter,
+                        uccm_name.as_ptr(),
+                        uccm_args.as_ptr(),
+                        std::ptr::null_mut(),
+                        graph,
+                    );
+                    if ret < 0 {
+                        bail!(
+                            graph,
+                            format!(
+                                "failed to create composite under colorchannelmixer layer={idx} code={ret}"
+                            )
+                        );
+                    }
+                    let ret = ff_sys::avfilter_link(chain_end, 0, uccm_ctx, 0);
+                    if ret < 0 {
+                        bail!(
+                            graph,
+                            format!("link failed: →composite_under_ccm layer={idx}")
+                        );
+                    }
+                    chain_end = uccm_ctx;
+                }
+
+                let eof_action = if is_last { "endall" } else { "pass" };
+                let overlay_filter = ff_sys::avfilter_get_by_name(c"overlay".as_ptr());
+                if overlay_filter.is_null() {
+                    bail!(graph, "filter not found: overlay (composite under)");
+                }
+                let Ok(uov_name) = CString::new(format!("composite_under{idx}")) else {
+                    bail!(graph, "CString::new failed for composite under name");
+                };
+                let Ok(uov_args) = CString::new(format!("0:0:eof_action={eof_action}:format=auto"))
+                else {
+                    bail!(graph, "CString::new failed for composite under args");
+                };
+                let mut uov_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                let ret = ff_sys::avfilter_graph_create_filter(
+                    &raw mut uov_ctx,
+                    overlay_filter,
+                    uov_name.as_ptr(),
+                    uov_args.as_ptr(),
+                    std::ptr::null_mut(),
+                    graph,
+                );
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!("failed to create composite under overlay layer={idx} code={ret}")
+                    );
+                }
+                let ret = ff_sys::avfilter_link(chain_end, 0, uov_ctx, 0);
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!("link failed: layer→under_overlay[0] layer={idx}")
+                    );
+                }
+                let ret = ff_sys::avfilter_link(prev_ctx, 0, uov_ctx, 1);
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!("link failed: base→under_overlay[1] layer={idx}")
+                    );
+                }
+                prev_ctx = uov_ctx;
+            }
         } else if use_blend_filter {
             // ── Photographic blend mode (Multiply, Screen, Overlay, etc.) ────────
             //

--- a/crates/ff-filter/src/graph/composition/multi_track_composer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_composer.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use crate::animation::AnimatedValue;
 use crate::blend::BlendMode;
+use crate::composite::CompositeOp;
 use crate::error::FilterError;
 use crate::graph::graph::FilterGraph;
 use crate::graph::types::{Rgb, XfadeTransition};
@@ -104,7 +105,23 @@ pub struct VideoLayer {
     /// [`BlendMode::Normal`] uses the `FFmpeg` `overlay` filter (standard alpha-over composite).
     /// All other modes use the `FFmpeg` `blend` filter with the corresponding `all_mode`.
     /// Defaults to [`BlendMode::Normal`].
+    ///
+    /// Colour blend only — applies when [`composite_op`](Self::composite_op) is
+    /// [`CompositeOp::Over`]. For a non-`Over` composite op the layer is composited
+    /// by the Porter-Duff operator and `blend_mode` is not additionally applied.
     pub blend_mode: BlendMode,
+    /// Porter-Duff alpha-compositing operator for placing this layer over the
+    /// canvas. Defaults to [`CompositeOp::Over`] (standard alpha-over).
+    ///
+    /// `Over` keeps the existing [`blend_mode`](Self::blend_mode) compositing
+    /// (overlay / `blend all_mode`). `Under`/`In`/`Out`/`Atop`/`Xor` composite the
+    /// layer via the corresponding Porter-Duff construction (the colour
+    /// `blend_mode` is not applied in that case).
+    ///
+    /// For a non-`Over` op, [`opacity`](Self::opacity) uses its initial value
+    /// only — animated opacity is not tracked per-frame on these paths (the
+    /// `blend all_opacity` / `overlay` alpha is set once at build time).
+    pub composite_op: CompositeOp,
     /// Per-layer video filter steps applied to this layer's decoded stream before compositing.
     ///
     /// Applied in order after trim/setpts/scale/rotate/opacity and before the `overlay` node.
@@ -145,6 +162,7 @@ pub struct VideoLayer {
 ///         out_point: None,
 ///         in_transition: None,
 ///         blend_mode: BlendMode::Normal,
+///         composite_op: CompositeOp::Over,
 ///         effects: vec![],
 ///     })
 ///     .build()?;
@@ -308,6 +326,7 @@ mod tests {
                 out_point: None,
                 in_transition: None,
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 effects: vec![],
             })
             .build();
@@ -334,6 +353,7 @@ mod tests {
                 out_point: None,
                 in_transition: None,
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 effects: vec![],
             })
             .build();
@@ -368,6 +388,7 @@ mod tests {
                 out_point: None,
                 in_transition: None,
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 effects: vec![],
             })
             .build();
@@ -415,6 +436,7 @@ mod tests {
                 out_point: None,
                 in_transition: None,
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 effects: vec![],
             })
             .build();
@@ -448,6 +470,7 @@ mod tests {
                 out_point: None,
                 in_transition: None,
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 effects: vec![],
             })
             .build();
@@ -480,6 +503,7 @@ mod tests {
                 out_point: None,
                 in_transition: None,
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 effects: vec![],
             })
             .build();

--- a/crates/ff-filter/tests/animation_integration_test.rs
+++ b/crates/ff-filter/tests/animation_integration_test.rs
@@ -161,6 +161,7 @@ fn bezier_position_animation_should_match_reference_curve() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -179,6 +180,7 @@ fn bezier_position_animation_should_match_reference_curve() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .build()

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -96,6 +96,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -114,6 +115,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -132,6 +134,7 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .build()
@@ -584,6 +587,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .add_layer(VideoLayer {
@@ -602,6 +606,7 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .build()
@@ -860,6 +865,7 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
             out_point: None,
             in_transition: None,
             blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
             effects: vec![],
         })
         .build()
@@ -889,4 +895,107 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
         "composition graph must deliver yuv420p frames; got {:?}",
         frame.format()
     );
+}
+
+// ── #1222: non-Over CompositeOp layer compositing ──────────────────────────────
+
+/// A layer with a non-`Over` `composite_op` (here `In`) composites via the
+/// Porter-Duff `blend all_expr` construction. Uses a `lavfi` source so no fixture
+/// file is needed. Probe-gated: CI's Linux FFmpeg has no filters compiled in, so
+/// `build`/`pull` failure → skip (RK-002).
+#[test]
+fn composite_op_in_layer_should_build_and_produce_frame() {
+    let layer = VideoLayer {
+        source: "color=c=white:s=64x64:r=25:d=1".into(),
+        proxy: None,
+        input_format: Some("lavfi".to_string()),
+        x: AnimatedValue::Static(0.0),
+        y: AnimatedValue::Static(0.0),
+        scale_x: AnimatedValue::Static(1.0),
+        scale_y: AnimatedValue::Static(1.0),
+        rotation: AnimatedValue::Static(0.0),
+        opacity: AnimatedValue::Static(1.0),
+        z_order: 0,
+        time_offset: Duration::ZERO,
+        in_point: None,
+        out_point: None,
+        in_transition: None,
+        blend_mode: ff_filter::BlendMode::Normal,
+        composite_op: ff_filter::CompositeOp::In,
+        effects: vec![],
+    };
+    let mut graph = match MultiTrackComposer::new(64, 64).add_layer(layer).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: MultiTrackComposer::build failed: {e}");
+            return;
+        }
+    };
+    match graph.pull_video() {
+        Ok(Some(frame)) => {
+            assert_eq!(
+                frame.width(),
+                64,
+                "composite In must not change frame width"
+            );
+            assert_eq!(
+                frame.height(),
+                64,
+                "composite In must not change frame height"
+            );
+        }
+        Ok(None) => println!("Skipping: composite graph produced no frame"),
+        Err(e) => println!("Skipping: pull_video failed: {e}"),
+    }
+}
+
+/// A layer with `composite_op = Under` composites via the swapped-pad `overlay`
+/// construction (canvas over layer) — a distinct code path from the `blend
+/// all_expr` operators. `opacity = 0.5` additionally exercises the
+/// colorchannelmixer alpha pre-step and `format=auto` overlay. Probe-gated like
+/// the `In` test above (RK-002).
+#[test]
+fn composite_op_under_layer_with_opacity_should_build_and_produce_frame() {
+    let layer = VideoLayer {
+        source: "color=c=white:s=64x64:r=25:d=1".into(),
+        proxy: None,
+        input_format: Some("lavfi".to_string()),
+        x: AnimatedValue::Static(0.0),
+        y: AnimatedValue::Static(0.0),
+        scale_x: AnimatedValue::Static(1.0),
+        scale_y: AnimatedValue::Static(1.0),
+        rotation: AnimatedValue::Static(0.0),
+        opacity: AnimatedValue::Static(0.5),
+        z_order: 0,
+        time_offset: Duration::ZERO,
+        in_point: None,
+        out_point: None,
+        in_transition: None,
+        blend_mode: ff_filter::BlendMode::Normal,
+        composite_op: ff_filter::CompositeOp::Under,
+        effects: vec![],
+    };
+    let mut graph = match MultiTrackComposer::new(64, 64).add_layer(layer).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: MultiTrackComposer::build failed: {e}");
+            return;
+        }
+    };
+    match graph.pull_video() {
+        Ok(Some(frame)) => {
+            assert_eq!(
+                frame.width(),
+                64,
+                "composite Under must not change frame width"
+            );
+            assert_eq!(
+                frame.height(),
+                64,
+                "composite Under must not change frame height"
+            );
+        }
+        Ok(None) => println!("Skipping: composite Under graph produced no frame"),
+        Err(e) => println!("Skipping: pull_video failed: {e}"),
+    }
 }

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use ff_filter::{BlendMode, FilterGraph, FilterStep, XfadeTransition};
+use ff_filter::{BlendMode, CompositeOp, FilterGraph, FilterStep, XfadeTransition};
 use ff_format::{PixelFormat, VideoFrame};
 
 use crate::error::PipelineError;
@@ -102,7 +102,17 @@ pub struct Clip {
     ///
     /// [`BlendMode::Normal`] uses `FFmpeg`'s `overlay` filter. All other variants use `FFmpeg`'s
     /// `blend` filter with the corresponding `all_mode`.
+    ///
+    /// Colour blend only — applies when [`composite_op`](Self::composite_op) is
+    /// [`CompositeOp::Over`] (the default).
     pub blend_mode: BlendMode,
+    /// Porter-Duff alpha-compositing operator for placing this clip over the layer(s) below.
+    /// Default: [`CompositeOp::Over`] (standard alpha-over).
+    ///
+    /// Independent of [`blend_mode`](Self::blend_mode): `Over` keeps the colour-blend
+    /// compositing, while `Under`/`In`/`Out`/`Atop`/`Xor` composite the clip via the
+    /// corresponding Porter-Duff operator (the colour `blend_mode` is not applied then).
+    pub composite_op: CompositeOp,
     /// Per-clip playback speed multiplier. Range: 0.1..=100.0. Default: 1.0 (normal speed).
     ///
     /// Applied via `setpts=PTS/{speed}` on the video stream and a chain of `atempo` filters
@@ -172,6 +182,7 @@ impl Clip {
             saturation: 1.0,
             opacity: 1.0,
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
             speed: 1.0,
             proxy: None,
             video_effects: Vec::new(),
@@ -500,6 +511,28 @@ impl Clip {
         }
     }
 
+    /// Sets the Porter-Duff [`CompositeOp`] for this clip and returns the updated clip.
+    ///
+    /// Independent of [`with_blend_mode`](Self::with_blend_mode); the default is
+    /// [`CompositeOp::Over`] (standard alpha-over).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    /// use ff_filter::CompositeOp;
+    ///
+    /// let clip = Clip::new("overlay.mp4").with_composite_op(CompositeOp::Atop);
+    /// assert_eq!(clip.composite_op, CompositeOp::Atop);
+    /// ```
+    #[must_use]
+    pub fn with_composite_op(self, op: CompositeOp) -> Self {
+        Self {
+            composite_op: op,
+            ..self
+        }
+    }
+
     /// Sets the per-clip playback speed multiplier and returns the updated clip.
     ///
     /// Values greater than `1.0` produce fast motion; values less than `1.0` produce slow
@@ -742,6 +775,30 @@ mod tests {
     fn clip_with_opacity_should_clamp_below_zero() {
         let clip = Clip::new("overlay.mp4").with_opacity(-0.5);
         assert_eq!(clip.opacity, 0.0);
+    }
+
+    #[test]
+    fn clip_new_should_default_composite_op_to_over() {
+        use ff_filter::CompositeOp;
+        let clip = Clip::new("video.mp4");
+        assert_eq!(clip.composite_op, CompositeOp::Over);
+    }
+
+    #[test]
+    fn clip_with_composite_op_should_set_composite_op() {
+        use ff_filter::CompositeOp;
+        let clip = Clip::new("overlay.mp4").with_composite_op(CompositeOp::Atop);
+        assert_eq!(clip.composite_op, CompositeOp::Atop);
+    }
+
+    #[test]
+    fn clip_blend_mode_and_composite_op_are_independent() {
+        use ff_filter::{BlendMode, CompositeOp};
+        let clip = Clip::new("overlay.mp4")
+            .with_blend_mode(BlendMode::Multiply)
+            .with_composite_op(CompositeOp::Atop);
+        assert_eq!(clip.blend_mode, BlendMode::Multiply);
+        assert_eq!(clip.composite_op, CompositeOp::Atop);
     }
 
     #[test]

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -65,7 +65,7 @@ pub use audio_pipeline::AudioPipeline;
 pub use clip::{Clip, VideoEffectRenderer};
 pub use encoder_config::{EncoderConfig, EncoderConfigBuilder};
 pub use error::PipelineError;
-pub use ff_filter::{BlendMode, XfadeTransition};
+pub use ff_filter::{BlendMode, CompositeOp, XfadeTransition};
 pub use pipeline::{Pipeline, PipelineBuilder};
 pub use progress::{Progress, ProgressCallback};
 pub use thumbnail::ThumbnailPipeline;

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -321,6 +321,7 @@ impl Timeline {
                         rotation: va(track_idx, "rotation", 0.0),
                         opacity: clip_opacity,
                         blend_mode: clip.blend_mode,
+                        composite_op: clip.composite_op,
                         z_order: u32::try_from(track_idx).unwrap_or(u32::MAX),
                         time_offset: clip.timeline_offset,
                         in_point: clip.in_point,
@@ -349,7 +350,7 @@ impl Timeline {
             }
             // Lavfi overlay sits above all regular tracks.
             if let Some(ref lavfi_str) = lavfi_overlay {
-                use ff_filter::BlendMode;
+                use ff_filter::{BlendMode, CompositeOp};
                 composer = composer.add_layer(VideoLayer {
                     source: std::path::PathBuf::from(lavfi_str),
                     proxy: None,
@@ -361,6 +362,7 @@ impl Timeline {
                     rotation: AnimatedValue::Static(0.0),
                     opacity: AnimatedValue::Static(1.0),
                     blend_mode: BlendMode::Normal,
+                    composite_op: CompositeOp::Over,
                     z_order: u32::try_from(nv).unwrap_or(u32::MAX),
                     time_offset: Duration::ZERO,
                     in_point: None,


### PR DESCRIPTION
## Summary

Adds an explicit `composite_op: CompositeOp` (default `Over`) to `Clip`, kept orthogonal to the now colour-only `blend_mode: BlendMode`, and routes it through `Timeline` → `MultiTrackComposer` → `composition_inner` canvas compositing. This is the final Track 2 piece that completes the relocation of Porter-Duff alpha compositing out of `BlendMode` (started in #1219). `composite_op == Over` leaves every existing graph byte-identical.

## Changes

- `ff-pipeline`: add `Clip::composite_op` field, `Clip::with_composite_op` builder (default `Over`), route `composite_op` through `Timeline` into `VideoLayer`, and re-export `CompositeOp` from `ff_pipeline`.
- `ff-filter`: add `VideoLayer::composite_op`; add a non-`Over` Porter-Duff branch to per-layer compositing in `composition_inner` — `Under` uses `overlay` with swapped pads (canvas over layer); `In`/`Out`/`Atop`/`Xor` use `blend all_expr=<expr>`. Gate the `colorchannelmixer` alpha pre-step to `Over` so each op owns its own opacity handling.
- `ff-filter`: centralise the Porter-Duff `all_expr` formulas in `CompositeOp::blend_all_expr()`, shared by the `Composite` filter step (`add_composite_step`) and the canvas compositing path (single source).
- `Under` now honours layer opacity: for `opacity < 1.0` the layer's alpha is attenuated via `colorchannelmixer` before the swapped `overlay` (which uses `format=auto`, since the `yuv420` overlay default carries no alpha), mirroring `add_blend_under_step` so both `Under` paths behave identically.
- Tests: `Clip` unit tests (default `Over`, builder, independence from `blend_mode`); a deterministic `blend_all_expr` unit test (FFmpeg-independent, runs on CI); probe-gated composition acceptance tests for `In` and for `Under` with `opacity = 0.5`.

## Related Issues

Closes #1222

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes