### PR TITLE
docs(roadmap): renumber milestones +1 for v0.15.0 release

### DIFF
--- a/docs/roadmap/v0-15-0/ROADMAP.md
+++ b/docs/roadmap/v0-15-0/ROADMAP.md
@@ -1,50 +1,38 @@
-# v0.15.0 — 音MAD Support (Pitch Shift & BPM Detection)
+# v0.15.0 — FFmpeg Token Canonicalization (Color Types & Compositing)
 
-**Goal**: Extend audio processing capabilities to cover the key primitives required for Oto-MAD production on Niconico Douga: a wider pitch-shift range for mapping voice clips to musical notes across two octaves, and a BPM/beat detector that returns per-beat timestamps suitable for direct placement of clips on a `Timeline`.
+**Goal**: Make avio's public enums map exactly to the canonical filter-argument tokens FFmpeg accepts, closing the gap between human-readable `name()` labels and the strings emitted into filter graphs. Two enum families are redesigned: the colour metadata types (`ColorSpace` / `ColorPrimaries` / `ColorTransfer`) become FFmpeg-canonical, and the conflated `BlendMode` enum is split along its two orthogonal axes — colour blend modes (`BlendMode` = `blend all_mode`) and Porter-Duff alpha-compositing operators (a new `CompositeOp` type).
 
 **Prerequisite**: v0.14.0 complete.
 
-**Crates in scope**: `ff-filter`, `ff-decode`, `avio`
+**Crates in scope**: `ff-format`, `ff-filter`, `ff-pipeline`, `avio`
 
 ---
 
 ## Requirements
 
-### Pitch Shift — ±24 Semitone Range
+### FfmpegToken — canonical token vs human-readable name
 
-- `FilterGraph::pitch_shift(semitones)` accepts values in `[-24.0, 24.0]` (±2 octaves).
-- Pitch shifting is performed without changing playback duration (pitch-only, not tape-speed).
-- The implementation chains multiple `atempo` filter instances when the compensation factor falls outside the single-instance range `[0.5, 2.0]`, reusing the same `add_atempo_chain` helper used by `TimeStretch`.
-- Values outside `[-24.0, 24.0]` return `Err(FilterError::Ffmpeg { .. })`.
-- Audio quality is comparable to the existing ±12 semitone range (WSOLA via `atempo`).
+- Public enums emitted into FFmpeg filter arguments expose a canonical token via an `FfmpegToken` trait, kept distinct from the human-readable `name()`.
+- The `format` / `setparams` / `blend` / `overlay` filter-argument builders use `ffmpeg_token()`, never `name()`, so every generated graph string is one FFmpeg actually accepts.
+- A token audit records, per enum, the FFmpeg source of truth (pinned C such as `vf_blend.c`, the `AVColorSpace` / `AVColorPrimaries` / `AVColorTransferCharacteristic` tables) so future variants can be verified against it.
 
-### BPM Detection and Beat Timestamps
+### Colour metadata types — FFmpeg-canonical
 
-- A `BpmDetector` struct detects the tempo and per-beat timestamps from an audio file.
-- The public API follows the consuming-builder pattern used by `SilenceDetector`:
+- `ColorSpace`, `ColorPrimaries`, and `ColorTransfer` cover the curated set of FFmpeg-canonical variants used in real footage, each with a 1:1 `FfmpegToken`.
+- Variant names follow FFmpeg's canonical naming: a conflated `Bt601` is split into `Bt470bg` / `Smpte170m`; `Bt2020` into `Bt2020Ncl` / `Bt2020Cl`; transfer uses `arib-std-b67` (HLG) and `smpte2084` (PQ) tokens.
+- A `setparams` filter step consumes `ColorPrimaries` / `ColorTransfer` (and colorspace / range) so colour metadata can be tagged on a stream; the `format` filter no longer emits options it does not support.
 
-  ```rust
-  BpmDetector::new("track.mp3")
-      .bpm_range(60.0, 200.0)
-      .run()  →  Result<BpmResult, DecodeError>
-  ```
+### BlendMode — colour blend only, exact `blend all_mode`
 
-- `BpmResult` contains:
-  - `bpm: f64` — detected tempo in beats per minute
-  - `beats: Vec<Duration>` — timestamp of each detected beat from the start of the file
-  - `confidence: f32` — detection confidence in `[0.0, 1.0]`; values below `0.4` indicate ambiguous rhythm
+- `BlendMode` maps 1:1 onto FFmpeg's `blend` `all_mode` token set (full canonical coverage) with an all-`Some` `FfmpegToken` (no unmapped variants).
+- Photographic-only: the Porter-Duff operators and the unimplemented HSL modes are removed from `BlendMode`.
 
-- The algorithm is pure Rust (no additional C dependencies):
-  1. Decode the audio file to mono f32 PCM at 22 050 Hz via the existing FFmpeg decode path
-  2. Detect onsets using **spectral flux** (half-wave rectified frame-energy derivative with adaptive threshold)
-  3. Estimate BPM via **normalized autocorrelation** of the onset envelope, searching within `[bpm_min, bpm_max]`
-  4. Generate beat timestamps by stepping forward from the first onset at the estimated interval, snapping to nearby onset peaks
+### CompositeOp — Porter-Duff alpha compositing
 
-- If the pure-Rust implementation does not meet the ±2 BPM accuracy threshold established by the integration tests, the algorithm internals (`detect_onsets`, `estimate_bpm`) are replaced with `aubio` C library bindings. The public API (`BpmDetector` / `BpmResult`) remains unchanged.
-
-- `BpmDetector` and `BpmResult` are re-exported from `avio` under the `decode` feature flag.
-
-- Primary use case: map detected beat timestamps to `Clip::timeline_offset` values for beat-synchronized video cutting.
+- A new `CompositeOp` enum (`Over`, `Under`, `In`, `Out`, `Atop`, `Xor`) expresses alpha-coverage compositing, which has no `all_mode` token and is built via `overlay` / expression-based `blend`.
+- `Over` is the default and preserves existing behaviour (the previous `Normal` / `PorterDuffOver` redundancy is resolved).
+- A `Composite` filter step plus `Clip::composite_op` / `VideoLayer::composite_op` route the operator through the `Timeline` → `MultiTrackComposer` compositing path, orthogonal to the colour `blend_mode`.
+- `CompositeOp` and `BlendMode` are re-exported from `avio`.
 
 ---
 
@@ -52,21 +40,20 @@
 
 | Topic | Decision |
 |---|---|
-| Pitch shift range | ±24 semitones (2 octaves); covers typical Oto-MAD note range without needing external quality libraries |
-| Pitch shift implementation | Extend existing `asetrate` + `add_atempo_chain` path; no rubberband dependency |
-| BPM algorithm | Pure Rust spectral flux + autocorrelation; no C dependency beyond FFmpeg |
-| BPM fallback | If accuracy < ±2 BPM on reference track, migrate internals to aubio (API unchanged) |
-| BPM output granularity | `bpm` + `Vec<Duration>` beats + `confidence`; beat array enables direct `Timeline` placement |
-| Analysis sample rate | 22 050 Hz mono f32; sufficient for onset detection, reduces memory and CPU vs 44 100 Hz |
+| name vs token | `name()` stays human-readable; a separate `FfmpegToken::ffmpeg_token()` provides the canonical FFmpeg string used in filter args |
+| Colour enum scope | Curated FFmpeg-canonical variants (not the full pixfmt table); names follow FFmpeg's canonical spelling |
+| Colour tagging | `setparams` carries primaries / transfer / colorspace / range; `format` is restricted to options it actually supports |
+| Blend vs composite | Two orthogonal axes: `BlendMode` = colour (`blend all_mode`), `CompositeOp` = alpha coverage (`overlay` / `all_expr`) |
+| Default compositing | `CompositeOp::Over` is the default and is byte-identical to the prior overlay path |
+| Breaking change | Accepted pre-1.0; existing graphs for retained modes are unchanged |
 
 ---
 
 ## Definition of Done
 
-- `pitch_shift(24.0)` and `pitch_shift(-24.0)` succeed; `pitch_shift(24.5)` returns `Err`
-- Integration test: `pitch_shift(+24.0)` on a 220 Hz sine wave produces output frequency within ±5% of 880 Hz
-- `BpmDetector` returns BPM within ±2 on a reference 120 BPM click-track fixture
-- `BpmDetector::run()` returns `Err(DecodeError::BpmDetectionFailed { .. })` for a missing file
-- `avio::BpmDetector` and `avio::BpmResult` are accessible under the `decode` feature flag
+- Every `format` / `setparams` / `blend` / `overlay` argument string is built from `ffmpeg_token()` and accepted by a probe-gated real-FFmpeg test
+- `ColorSpace` / `ColorPrimaries` / `ColorTransfer` expose canonical `FfmpegToken` values verified against pinned FFmpeg C source
+- `BlendMode` covers the full `blend all_mode` set with an all-`Some` `FfmpegToken`; Porter-Duff and HSL removed
+- `CompositeOp` (`Over` default) routes through `Clip` / `Timeline` and is re-exported from `avio`; the default path stays byte-identical
 - `cargo clippy --workspace -- -D warnings` clean
 - `cargo test --workspace` passes

--- a/docs/roadmap/v0-16-0/ROADMAP.md
+++ b/docs/roadmap/v0-16-0/ROADMAP.md
@@ -1,66 +1,50 @@
-# v0.16.0 — Professional Interchange & GPU Acceleration
+# v0.16.0 — 音MAD Support (Pitch Shift & BPM Detection)
 
-**Goal**: Enable round-trip interoperability with industry-standard NLE tools (Final Cut Pro, Premiere Pro, DaVinci Resolve, Avid) via EDL and FCPXML, add OMF/AAF audio project support, and provide GPU-accelerated filter processing for real-time capable throughput.
+**Goal**: Extend audio processing capabilities to cover the key primitives required for Oto-MAD production on Niconico Douga: a wider pitch-shift range for mapping voice clips to musical notes across two octaves, and a BPM/beat detector that returns per-beat timestamps suitable for direct placement of clips on a `Timeline`.
 
 **Prerequisite**: v0.15.0 complete.
 
-**Crates in scope**: `ff-interchange` (new crate), `ff-filter`, `ff-decode`, `ff-encode`
+**Crates in scope**: `ff-filter`, `ff-decode`, `avio`
 
 ---
 
 ## Requirements
 
-### EDL (Edit Decision List) Support
+### Pitch Shift — ±24 Semitone Range
 
-- An EDL file (CMX 3600 format) can be parsed into a Rust data structure representing the cut list: clip source, in/out points, record in/out points, and transition type.
-- An EDL can be exported from a clip list assembled in the library.
-- EDL round-trip: import → reconstruct timeline → export produces a semantically equivalent EDL.
-- Supported EDL event types: cut, dissolve, wipe (basic).
-- Reel names are preserved through import/export.
-- Common use case: conforming an offline edit (proxy) to online (full-res) material.
+- `FilterGraph::pitch_shift(semitones)` accepts values in `[-24.0, 24.0]` (±2 octaves).
+- Pitch shifting is performed without changing playback duration (pitch-only, not tape-speed).
+- The implementation chains multiple `atempo` filter instances when the compensation factor falls outside the single-instance range `[0.5, 2.0]`, reusing the same `add_atempo_chain` helper used by `TimeStretch`.
+- Values outside `[-24.0, 24.0]` return `Err(FilterError::Ffmpeg { .. })`.
+- Audio quality is comparable to the existing ±12 semitone range (WSOLA via `atempo`).
 
-### Final Cut Pro XML (FCPXML) Support
+### BPM Detection and Beat Timestamps
 
-- An FCPXML file (version 1.9 and 1.10) can be parsed into a Rust data structure representing the project: sequences, clips, asset references, basic effects, and markers.
-- An FCPXML can be exported from a project assembled in the library.
-- Asset references (file paths) are resolved relative to a configurable media root.
-- Supported FCPXML elements: `project`, `sequence`, `clip`, `audio-clip`, `title` (basic), `marker`, `chapter-marker`, `transition`.
-- Common use case: exporting a cut list from a Rust application for finishing in Final Cut Pro.
+- A `BpmDetector` struct detects the tempo and per-beat timestamps from an audio file.
+- The public API follows the consuming-builder pattern used by `SilenceDetector`:
 
-### Premiere Pro / DaVinci Resolve XML
+  ```rust
+  BpmDetector::new("track.mp3")
+      .bpm_range(60.0, 200.0)
+      .run()  →  Result<BpmResult, DecodeError>
+  ```
 
-- A Premiere Pro-compatible XML (based on the Final Cut Pro 7 XML schema) can be exported, enabling import into Premiere Pro and DaVinci Resolve.
-- Supported elements: sequences, video/audio tracks, clips, in/out points, basic transitions.
+- `BpmResult` contains:
+  - `bpm: f64` — detected tempo in beats per minute
+  - `beats: Vec<Duration>` — timestamp of each detected beat from the start of the file
+  - `confidence: f32` — detection confidence in `[0.0, 1.0]`; values below `0.4` indicate ambiguous rhythm
 
-### OMF / AAF (Audio Post-Production)
+- The algorithm is pure Rust (no additional C dependencies):
+  1. Decode the audio file to mono f32 PCM at 22 050 Hz via the existing FFmpeg decode path
+  2. Detect onsets using **spectral flux** (half-wave rectified frame-energy derivative with adaptive threshold)
+  3. Estimate BPM via **normalized autocorrelation** of the onset envelope, searching within `[bpm_min, bpm_max]`
+  4. Generate beat timestamps by stepping forward from the first onset at the estimated interval, snapping to nearby onset peaks
 
-- An OMF (Open Media Framework) or AAF (Advanced Authoring Format) file can be exported containing the audio tracks from a project, suitable for delivery to a Pro Tools or Nuendo audio post session.
-- Clip metadata (reel name, timecode, sample rate) is preserved.
-- Audio media can be embedded in the OMF or referenced externally.
-- Common use case: sending a picture-locked timeline's audio to a mixer for final audio post.
+- If the pure-Rust implementation does not meet the ±2 BPM accuracy threshold established by the integration tests, the algorithm internals (`detect_onsets`, `estimate_bpm`) are replaced with `aubio` C library bindings. The public API (`BpmDetector` / `BpmResult`) remains unchanged.
 
-### GPU-Accelerated Filter Processing
+- `BpmDetector` and `BpmResult` are re-exported from `avio` under the `decode` feature flag.
 
-- The following commonly used filters can be executed on the GPU when a compatible device is available, falling back to CPU when not:
-  - Scale / resize
-  - Color correction (brightness, contrast, saturation, curves)
-  - 3D LUT application
-  - Overlay / composite
-  - Blur (Gaussian)
-- GPU acceleration is available via:
-  - **CUDA** (NVIDIA): requires FFmpeg built with `--enable-cuda-llvm`
-  - **VideoToolbox** (Apple Silicon / macOS): hardware-native
-  - **VAAPI** (Linux / Intel / AMD): requires `--enable-vaapi`
-- GPU acceleration is opt-in: enabled by passing `GpuAccel::Cuda` / `GpuAccel::VideoToolbox` / `GpuAccel::Vaapi` to the filter graph builder.
-- When the selected GPU device is unavailable, the library transparently falls back to the CPU path and logs `log::warn!("gpu_accel unavailable, falling back to cpu device={:?}")`.
-- GPU texture output: a `GpuFrameSink` variant allows delivering decoded + filtered frames as GPU-resident textures (CUDA device memory or Metal textures) to avoid a GPU→CPU→GPU round-trip in render pipelines.
-
-### Hardware-Accelerated Encode with GPU Filters
-
-- A pipeline of GPU-decoded → GPU-filtered → GPU-encoded is supported end-to-end without any CPU round-trip for the pixel data, using:
-  - NVIDIA: `h264_nvenc` / `hevc_nvenc` / `av1_nvenc` after CUDA filter graph
-  - Apple: `h264_videotoolbox` / `hevc_videotoolbox` after VideoToolbox decode
-- This enables real-time 4K transcoding with filter application on supported hardware.
+- Primary use case: map detected beat timestamps to `Clip::timeline_offset` values for beat-synchronized video cutting.
 
 ---
 
@@ -68,20 +52,21 @@
 
 | Topic | Decision |
 |---|---|
-| New crate | `ff-interchange`: pure-Rust parser/writer for EDL, FCPXML, Premiere XML, OMF/AAF; no FFmpeg dependency |
-| EDL format | CMX 3600 (industry standard); additional formats added if demand arises |
-| FCPXML version | 1.9 and 1.10 (current as of 2025); older versions handled on best-effort basis |
-| OMF/AAF | Export-only at this stage; import is complex and deferred |
-| GPU filter backend | libavfilter CUDA/VAAPI graph; VideoToolbox via `vf_scale_vt` |
-| GPU fallback | Silent CPU fallback with `log::warn!`; no error returned for missing GPU |
-| GPU texture sink | Optional; behind `gpu-sink` feature flag |
+| Pitch shift range | ±24 semitones (2 octaves); covers typical Oto-MAD note range without needing external quality libraries |
+| Pitch shift implementation | Extend existing `asetrate` + `add_atempo_chain` path; no rubberband dependency |
+| BPM algorithm | Pure Rust spectral flux + autocorrelation; no C dependency beyond FFmpeg |
+| BPM fallback | If accuracy < ±2 BPM on reference track, migrate internals to aubio (API unchanged) |
+| BPM output granularity | `bpm` + `Vec<Duration>` beats + `confidence`; beat array enables direct `Timeline` placement |
+| Analysis sample rate | 22 050 Hz mono f32; sufficient for onset detection, reduces memory and CPU vs 44 100 Hz |
 
 ---
 
 ## Definition of Done
 
-- EDL round-trip test: CMX 3600 file imported, timeline reconstructed, re-exported, and diff'd against original (ignoring whitespace)
-- FCPXML export test: exported file opens in Final Cut Pro without errors
-- Premiere XML import tested in DaVinci Resolve
-- GPU scale filter (CUDA or VAAPI) produces pixel-identical output to CPU path on a test frame
-- GPU end-to-end pipeline (decode → filter → encode, no CPU copy) completes a 1080p transcode in CI
+- `pitch_shift(24.0)` and `pitch_shift(-24.0)` succeed; `pitch_shift(24.5)` returns `Err`
+- Integration test: `pitch_shift(+24.0)` on a 220 Hz sine wave produces output frequency within ±5% of 880 Hz
+- `BpmDetector` returns BPM within ±2 on a reference 120 BPM click-track fixture
+- `BpmDetector::run()` returns `Err(DecodeError::BpmDetectionFailed { .. })` for a missing file
+- `avio::BpmDetector` and `avio::BpmResult` are accessible under the `decode` feature flag
+- `cargo clippy --workspace -- -D warnings` clean
+- `cargo test --workspace` passes

--- a/docs/roadmap/v0-17-0/ROADMAP.md
+++ b/docs/roadmap/v0-17-0/ROADMAP.md
@@ -1,77 +1,66 @@
-# v0.17.0 — API Finalization
+# v0.17.0 — Professional Interchange & GPU Acceleration
 
-**Goal**: Freeze the public API surface across all crates, eliminate all remaining design debt, complete documentation and examples, and establish performance baselines — making the library ready for v1.0.0 declaration once real-world adoption has been validated.
+**Goal**: Enable round-trip interoperability with industry-standard NLE tools (Final Cut Pro, Premiere Pro, DaVinci Resolve, Avid) via EDL and FCPXML, add OMF/AAF audio project support, and provide GPU-accelerated filter processing for real-time capable throughput.
 
 **Prerequisite**: v0.16.0 complete.
 
-**Crates in scope**: All crates
+**Crates in scope**: `ff-interchange` (new crate), `ff-filter`, `ff-decode`, `ff-encode`
 
 ---
 
 ## Requirements
 
-### API Freeze Preparation
+### EDL (Edit Decision List) Support
 
-- All public enums and error types that may gain new variants in future versions carry `#[non_exhaustive]`.
-  - Applied to: `VideoCodec`, `AudioCodec`, `PixelFormat`, `SampleFormat`, `ChannelLayout`, `ColorSpace`, `HwAccel`, `GpuAccel`, `EncodeError`, `DecodeError`, `FilterError`, `StreamError`, `PreviewError`, `InterchangeError`.
-  - Excluded from: small, closed enums where exhaustive matching is part of the contract (e.g., `BitrateMode`, `H264Profile`, `BlendMode`).
-- Every public API that was superseded or renamed during v0.x carries `#[deprecated]` with a `/// Use [replacement] instead.` doc comment.
-- The MSRV is pinned to Rust 1.85.0 (minimum for edition 2024) and recorded in every crate's `[package] rust-version` field.
-- `Cargo.toml` `[package] edition = "2024"` is confirmed for all crates.
-- A breaking-change policy is documented in `CONTRIBUTING.md`: semver minor for additive changes, semver major for removals or signature changes, `#[deprecated]` with one minor-version grace period before removal.
+- An EDL file (CMX 3600 format) can be parsed into a Rust data structure representing the cut list: clip source, in/out points, record in/out points, and transition type.
+- An EDL can be exported from a clip list assembled in the library.
+- EDL round-trip: import → reconstruct timeline → export produces a semantically equivalent EDL.
+- Supported EDL event types: cut, dissolve, wipe (basic).
+- Reel names are preserved through import/export.
+- Common use case: conforming an offline edit (proxy) to online (full-res) material.
 
-### Documentation
+### Final Cut Pro XML (FCPXML) Support
 
-- `#![warn(missing_docs)]` is enabled on all crates and produces zero warnings.
-- Every `pub` function, type, field, and variant has a doc comment.
-- Every primary API entry point has a `# Examples` section with a working, tested code snippet (`cargo test --doc`).
-- All `# Safety` sections on `unsafe fn` items and `unsafe impl` blocks are present and accurate.
-- `cargo doc --workspace --no-deps` produces zero warnings.
-- `docs.rs` renders all public items with no missing sections.
+- An FCPXML file (version 1.9 and 1.10) can be parsed into a Rust data structure representing the project: sequences, clips, asset references, basic effects, and markers.
+- An FCPXML can be exported from a project assembled in the library.
+- Asset references (file paths) are resolved relative to a configurable media root.
+- Supported FCPXML elements: `project`, `sequence`, `clip`, `audio-clip`, `title` (basic), `marker`, `chapter-marker`, `transition`.
+- Common use case: exporting a cut list from a Rust application for finishing in Final Cut Pro.
 
-### Cookbook Examples
+### Premiere Pro / DaVinci Resolve XML
 
-The following end-to-end examples are provided under the workspace `examples/` directory, each covering a distinct real-world use case:
+- A Premiere Pro-compatible XML (based on the Final Cut Pro 7 XML schema) can be exported, enabling import into Premiere Pro and DaVinci Resolve.
+- Supported elements: sequences, video/audio tracks, clips, in/out points, basic transitions.
 
-- `examples/transcode.rs` — re-encode a file to a different codec and container
-- `examples/thumbnails.rs` — extract thumbnails at regular intervals
-- `examples/sprite_sheet.rs` — generate a thumbnail sprite sheet for a video player scrub bar
-- `examples/filter_trim_scale.rs` — trim a clip to a time range and resize it
-- `examples/filter_overlay.rs` — composite a logo PNG over a video with opacity
-- `examples/two_pass_encode.rs` — two-pass H.264 encode for accurate bitrate targeting
-- `examples/metadata_chapters.rs` — read and write container metadata and chapter marks
-- `examples/subtitle_passthrough.rs` — copy a subtitle stream into a new output file
-- `examples/hls_output.rs` — package a video file as a static HLS stream
-- `examples/abr_ladder.rs` — produce a multi-rendition HLS ABR ladder
-- `examples/live_stream.rs` — ingest from RTSP and push to an RTMP server
-- `examples/color_grade.rs` — apply a 3D LUT and primary color correction
-- `examples/concat_clips.rs` — join multiple clips with a cross-dissolve transition
-- `examples/green_screen.rs` — chroma key composite over a background
-- `examples/keyframe_fade.rs` — animate opacity and position with Bezier easing
-- `examples/realtime_preview.rs` — drive a real-time preview loop using `ff-preview`
-- `examples/proxy_workflow.rs` — generate proxies, edit with them, export with originals
-- `examples/stabilize.rs` — two-pass video stabilization
-- `examples/mix_audio.rs` — mix a voice-over with background music, with ducking
-- `examples/export_fcpxml.rs` — export a clip list as FCPXML for Final Cut Pro
-- `examples/full_pipeline.rs` — decode → color grade → composite → encode end-to-end
+### OMF / AAF (Audio Post-Production)
 
-### Performance Benchmarks
+- An OMF (Open Media Framework) or AAF (Advanced Authoring Format) file can be exported containing the audio tracks from a project, suitable for delivery to a Pro Tools or Nuendo audio post session.
+- Clip metadata (reel name, timecode, sample rate) is preserved.
+- Audio media can be embedded in the OMF or referenced externally.
+- Common use case: sending a picture-locked timeline's audio to a mixer for final audio post.
 
-- `benches/decode_bench.rs` — 1080p decode throughput (fps) for H.264, H.265, AV1, ProRes.
-- `benches/encode_bench.rs` — 1080p encode throughput (fps) and file size for H.264, H.265, AV1.
-- `benches/filter_bench.rs` — processing time per frame for: scale, crop, overlay, 3D LUT, chroma key, blur.
-- `benches/preview_bench.rs` — `ff-preview` playback loop: frames delivered on time at 1080p/30.
-- `benches/animation_bench.rs` — keyframe interpolation throughput (evaluations/sec for a 100-keyframe track).
-- A baseline result table is committed to `benches/README.md` and updated with each release.
+### GPU-Accelerated Filter Processing
 
-### API Consistency Audit
+- The following commonly used filters can be executed on the GPU when a compatible device is available, falling back to CPU when not:
+  - Scale / resize
+  - Color correction (brightness, contrast, saturation, curves)
+  - 3D LUT application
+  - Overlay / composite
+  - Blur (Gaussian)
+- GPU acceleration is available via:
+  - **CUDA** (NVIDIA): requires FFmpeg built with `--enable-cuda-llvm`
+  - **VideoToolbox** (Apple Silicon / macOS): hardware-native
+  - **VAAPI** (Linux / Intel / AMD): requires `--enable-vaapi`
+- GPU acceleration is opt-in: enabled by passing `GpuAccel::Cuda` / `GpuAccel::VideoToolbox` / `GpuAccel::Vaapi` to the filter graph builder.
+- When the selected GPU device is unavailable, the library transparently falls back to the CPU path and logs `log::warn!("gpu_accel unavailable, falling back to cpu device={:?}")`.
+- GPU texture output: a `GpuFrameSink` variant allows delivering decoded + filtered frames as GPU-resident textures (CUDA device memory or Metal textures) to avoid a GPU→CPU→GPU round-trip in render pipelines.
 
-- The builder pattern is confirmed uniform across all crates: consuming builders (`self`), all validation in `build()`.
-- Error type hierarchy is audited against `docs/dev/error-handling.md`: no `anyhow` in library code, all FFmpeg errors wrapped with context.
-- Every `*Inner` type that may cross thread boundaries carries an explicit `unsafe impl Send` (and `unsafe impl Sync` where appropriate) with a `// SAFETY:` comment.
-- No `unwrap()` or `expect()` remains in library source (`src/`); only in tests and examples.
-- `cargo clippy --workspace -- -D warnings` is clean on stable Rust.
-- `cargo fmt --check` passes.
+### Hardware-Accelerated Encode with GPU Filters
+
+- A pipeline of GPU-decoded → GPU-filtered → GPU-encoded is supported end-to-end without any CPU round-trip for the pixel data, using:
+  - NVIDIA: `h264_nvenc` / `hevc_nvenc` / `av1_nvenc` after CUDA filter graph
+  - Apple: `h264_videotoolbox` / `hevc_videotoolbox` after VideoToolbox decode
+- This enables real-time 4K transcoding with filter application on supported hardware.
 
 ---
 
@@ -79,21 +68,20 @@ The following end-to-end examples are provided under the workspace `examples/` d
 
 | Topic | Decision |
 |---|---|
-| `#[non_exhaustive]` scope | Error types and major enums; excluded from small closed enums where exhaustive matching is useful |
-| MSRV | Rust 1.85.0 — minimum for edition 2024 |
-| Benchmarks | criterion (already a dev-dep); results committed to repo |
-| Examples | Workspace root `examples/`; all examples compile in CI |
-| Doc tests | `cargo test --doc --workspace` runs all `# Examples` blocks in CI |
+| New crate | `ff-interchange`: pure-Rust parser/writer for EDL, FCPXML, Premiere XML, OMF/AAF; no FFmpeg dependency |
+| EDL format | CMX 3600 (industry standard); additional formats added if demand arises |
+| FCPXML version | 1.9 and 1.10 (current as of 2025); older versions handled on best-effort basis |
+| OMF/AAF | Export-only at this stage; import is complex and deferred |
+| GPU filter backend | libavfilter CUDA/VAAPI graph; VideoToolbox via `vf_scale_vt` |
+| GPU fallback | Silent CPU fallback with `log::warn!`; no error returned for missing GPU |
+| GPU texture sink | Optional; behind `gpu-sink` feature flag |
 
 ---
 
 ## Definition of Done
 
-- All requirements above fulfilled
-- `cargo doc --workspace --no-deps` emits zero warnings
-- All 21 cookbook examples compile and run successfully against sample media files in CI
-- `cargo test --doc --workspace` passes
-- Benchmark baseline recorded in `benches/README.md`
-- MSRV verified: `cargo +1.85.0 build --workspace` succeeds
-- `cargo clippy --workspace -- -D warnings` clean
-- `cargo fmt --check` clean
+- EDL round-trip test: CMX 3600 file imported, timeline reconstructed, re-exported, and diff'd against original (ignoring whitespace)
+- FCPXML export test: exported file opens in Final Cut Pro without errors
+- Premiere XML import tested in DaVinci Resolve
+- GPU scale filter (CUDA or VAAPI) produces pixel-identical output to CPU path on a test frame
+- GPU end-to-end pipeline (decode → filter → encode, no CPU copy) completes a 1080p transcode in CI

--- a/docs/roadmap/v0-18-0/ROADMAP.md
+++ b/docs/roadmap/v0-18-0/ROADMAP.md
@@ -1,0 +1,99 @@
+# v0.18.0 — API Finalization
+
+**Goal**: Freeze the public API surface across all crates, eliminate all remaining design debt, complete documentation and examples, and establish performance baselines — making the library ready for v1.0.0 declaration once real-world adoption has been validated.
+
+**Prerequisite**: v0.17.0 complete.
+
+**Crates in scope**: All crates
+
+---
+
+## Requirements
+
+### API Freeze Preparation
+
+- All public enums and error types that may gain new variants in future versions carry `#[non_exhaustive]`.
+  - Applied to: `VideoCodec`, `AudioCodec`, `PixelFormat`, `SampleFormat`, `ChannelLayout`, `ColorSpace`, `HwAccel`, `GpuAccel`, `EncodeError`, `DecodeError`, `FilterError`, `StreamError`, `PreviewError`, `InterchangeError`.
+  - Excluded from: small, closed enums where exhaustive matching is part of the contract (e.g., `BitrateMode`, `H264Profile`, `BlendMode`).
+- Every public API that was superseded or renamed during v0.x carries `#[deprecated]` with a `/// Use [replacement] instead.` doc comment.
+- The MSRV is pinned to Rust 1.85.0 (minimum for edition 2024) and recorded in every crate's `[package] rust-version` field.
+- `Cargo.toml` `[package] edition = "2024"` is confirmed for all crates.
+- A breaking-change policy is documented in `CONTRIBUTING.md`: semver minor for additive changes, semver major for removals or signature changes, `#[deprecated]` with one minor-version grace period before removal.
+
+### Documentation
+
+- `#![warn(missing_docs)]` is enabled on all crates and produces zero warnings.
+- Every `pub` function, type, field, and variant has a doc comment.
+- Every primary API entry point has a `# Examples` section with a working, tested code snippet (`cargo test --doc`).
+- All `# Safety` sections on `unsafe fn` items and `unsafe impl` blocks are present and accurate.
+- `cargo doc --workspace --no-deps` produces zero warnings.
+- `docs.rs` renders all public items with no missing sections.
+
+### Cookbook Examples
+
+The following end-to-end examples are provided under the workspace `examples/` directory, each covering a distinct real-world use case:
+
+- `examples/transcode.rs` — re-encode a file to a different codec and container
+- `examples/thumbnails.rs` — extract thumbnails at regular intervals
+- `examples/sprite_sheet.rs` — generate a thumbnail sprite sheet for a video player scrub bar
+- `examples/filter_trim_scale.rs` — trim a clip to a time range and resize it
+- `examples/filter_overlay.rs` — composite a logo PNG over a video with opacity
+- `examples/two_pass_encode.rs` — two-pass H.264 encode for accurate bitrate targeting
+- `examples/metadata_chapters.rs` — read and write container metadata and chapter marks
+- `examples/subtitle_passthrough.rs` — copy a subtitle stream into a new output file
+- `examples/hls_output.rs` — package a video file as a static HLS stream
+- `examples/abr_ladder.rs` — produce a multi-rendition HLS ABR ladder
+- `examples/live_stream.rs` — ingest from RTSP and push to an RTMP server
+- `examples/color_grade.rs` — apply a 3D LUT and primary color correction
+- `examples/concat_clips.rs` — join multiple clips with a cross-dissolve transition
+- `examples/green_screen.rs` — chroma key composite over a background
+- `examples/keyframe_fade.rs` — animate opacity and position with Bezier easing
+- `examples/realtime_preview.rs` — drive a real-time preview loop using `ff-preview`
+- `examples/proxy_workflow.rs` — generate proxies, edit with them, export with originals
+- `examples/stabilize.rs` — two-pass video stabilization
+- `examples/mix_audio.rs` — mix a voice-over with background music, with ducking
+- `examples/export_fcpxml.rs` — export a clip list as FCPXML for Final Cut Pro
+- `examples/full_pipeline.rs` — decode → color grade → composite → encode end-to-end
+
+### Performance Benchmarks
+
+- `benches/decode_bench.rs` — 1080p decode throughput (fps) for H.264, H.265, AV1, ProRes.
+- `benches/encode_bench.rs` — 1080p encode throughput (fps) and file size for H.264, H.265, AV1.
+- `benches/filter_bench.rs` — processing time per frame for: scale, crop, overlay, 3D LUT, chroma key, blur.
+- `benches/preview_bench.rs` — `ff-preview` playback loop: frames delivered on time at 1080p/30.
+- `benches/animation_bench.rs` — keyframe interpolation throughput (evaluations/sec for a 100-keyframe track).
+- A baseline result table is committed to `benches/README.md` and updated with each release.
+
+### API Consistency Audit
+
+- The builder pattern is confirmed uniform across all crates: consuming builders (`self`), all validation in `build()`.
+- Error type hierarchy is audited against `docs/dev/error-handling.md`: no `anyhow` in library code, all FFmpeg errors wrapped with context.
+- Every `*Inner` type that may cross thread boundaries carries an explicit `unsafe impl Send` (and `unsafe impl Sync` where appropriate) with a `// SAFETY:` comment.
+- No `unwrap()` or `expect()` remains in library source (`src/`); only in tests and examples.
+- `cargo clippy --workspace -- -D warnings` is clean on stable Rust.
+- `cargo fmt --check` passes.
+
+---
+
+## Design Decisions
+
+| Topic | Decision |
+|---|---|
+| `#[non_exhaustive]` scope | Error types and major enums; excluded from small closed enums where exhaustive matching is useful |
+| MSRV | Rust 1.85.0 — minimum for edition 2024 |
+| Benchmarks | criterion (already a dev-dep); results committed to repo |
+| Examples | Workspace root `examples/`; all examples compile in CI |
+| Doc tests | `cargo test --doc --workspace` runs all `# Examples` blocks in CI |
+
+---
+
+## Definition of Done
+
+- All requirements above fulfilled
+- `cargo doc --workspace --no-deps` emits zero warnings
+- All 21 cookbook examples compile and run successfully against sample media files in CI
+- `cargo test --doc --workspace` passes
+- Benchmark baseline recorded in `benches/README.md`
+- MSRV verified: `cargo +1.85.0 build --workspace` succeeds
+- `cargo clippy --workspace -- -D warnings` clean
+- `cargo fmt --check` clean

--- a/docs/roadmap/v1-0-0/ROADMAP.md
+++ b/docs/roadmap/v1-0-0/ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Goal**: Semver-stable public API suitable for production use across all crates.
 
-**Prerequisite**: v0.16.0 complete, with demonstrated real-world adoption (at least one publicly released application built on this library).
+**Prerequisite**: v0.17.0 complete, with demonstrated real-world adoption (at least one publicly released application built on this library).
 
 ---
 


### PR DESCRIPTION
## Summary

The v0.15.0 release carries the FFmpeg token-canonicalization work (color type redesign, BlendMode/CompositeOp split, format/setparams token fixes) — a coherent set of breaking changes that, under Cargo's `0.x` compatibility rules, requires a minor bump rather than a patch. Since the `v0.15.0` slot was previously reserved for the 音MAD/BPM milestone, every planned milestone from `v0.15.0` onward is shifted +1, and a new `v0.15.0` roadmap is added for the token-canonicalization release.

## Changes

- Add `docs/roadmap/v0-15-0/ROADMAP.md` — FFmpeg Token Canonicalization (Color Types & Compositing): `FfmpegToken` (token vs `name()`), FFmpeg-canonical `ColorSpace`/`ColorPrimaries`/`ColorTransfer`, `BlendMode` = `blend all_mode`, and the Porter-Duff `CompositeOp` split.
- Renumber the following roadmaps +1 (directory + embedded title/`Prerequisite`):
  - `v0-15-0` → `v0-16-0` (音MAD / BPM; prerequisite `v0.14.0` → `v0.15.0`)
  - `v0-16-0` → `v0-17-0` (Professional Interchange & GPU; prerequisite `v0.15.0` → `v0.16.0`)
  - `v0-17-0` → `v0-18-0` (API Finalization; prerequisite `v0.16.0` → `v0.17.0`)
- `v1-0-0/ROADMAP.md`: prerequisite `v0.16.0` → `v0.17.0` (still references the Interchange & GPU milestone).

GitHub milestones were renamed to match (`v0.15.0`–`v0.20.0`); a new `v0.15.0` milestone groups the 20 issues shipped in this release.

## Related Issues

N/A — release-management documentation; no associated issue. (`v1.0.0` milestone is unaffected.)

## Test Plan

Documentation-only change (Markdown under `docs/roadmap/`); no Rust code is touched.

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo doc --all-features --no-deps` passes
- [x] `cargo test --all` unaffected — code tree identical to the merged green `main`