### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.0] - 2026-06-13
+
+This release canonicalizes avio's public enums to FFmpeg's filter-argument tokens. **Breaking:** the colour metadata types and `BlendMode` are redesigned, and Porter-Duff compositing is separated into a new `CompositeOp` type.
+
+### Changed
+
+#### ff-format
+- **Breaking:** `ColorSpace`, `ColorPrimaries`, and `ColorTransfer` redesigned to curated FFmpeg-canonical variants, each with a 1:1 `FfmpegToken` (e.g. `Bt601` split into `Bt470bg` / `Smpte170m`, `Bt2020` into `Bt2020Ncl` / `Bt2020Cl`, transfer `arib-std-b67` for HLG and `smpte2084` for PQ) ([#1217](https://github.com/itsakeyfut/avio/issues/1217), [#1198](https://github.com/itsakeyfut/avio/issues/1198))
+
+#### ff-filter
+- **Breaking:** `BlendMode` now maps 1:1 onto FFmpeg's `blend` `all_mode` token set (40 modes, `FfmpegToken` all-`Some`); the Porter-Duff operators and the unimplemented HSL modes are removed (Porter-Duff moves to `CompositeOp`) ([#1219](https://github.com/itsakeyfut/avio/issues/1219), [#1218](https://github.com/itsakeyfut/avio/issues/1218), [#1220](https://github.com/itsakeyfut/avio/issues/1220))
+
+### Added
+
+#### ff-filter
+- `CompositeOp` enum (`Over` / `Under` / `In` / `Out` / `Atop` / `Xor`) and `FilterStep::Composite` for Porter-Duff alpha compositing (built via `overlay` / expression-based `blend`) ([#1221](https://github.com/itsakeyfut/avio/issues/1221))
+- `FilterStep::SetParams` to tag colorspace / primaries / transfer / range on a stream from `ColorPrimaries` / `ColorTransfer` tokens ([#1227](https://github.com/itsakeyfut/avio/issues/1227))
+- `AlphaMode` wired to the `overlay` `alpha=` option for compositing alpha format selection ([#1225](https://github.com/itsakeyfut/avio/issues/1225))
+
+#### ff-pipeline
+- `Clip::composite_op` and `Clip::with_composite_op()` (default `Over`), routed through `Timeline` compositing; orthogonal to the colour `blend_mode` ([#1222](https://github.com/itsakeyfut/avio/issues/1222))
+- `VideoEffectRenderer`: reusable per-clip effect-chain renderer that avoids rebuilding the filter graph every frame during preview ([#1213](https://github.com/itsakeyfut/avio/issues/1213))
+- preview-render path (`Clip::apply_video_effects()`) matching `Timeline::render()` so a host can apply a clip's effect chain to a single frame ([#1202](https://github.com/itsakeyfut/avio/issues/1202))
+
+#### avio
+- `CompositeOp` and `BlendMode` re-exported; `ClipTransition` added to the `filter` feature re-export block ([#1169](https://github.com/itsakeyfut/avio/issues/1169))
+
+### Fixed
+
+#### ff-filter
+- `format` filter emitted human-readable `name()` values instead of canonical `ffmpeg_token()`, producing invalid filter arguments ([#1212](https://github.com/itsakeyfut/avio/issues/1212))
+- `format()` emitted an unsupported `alpha_modes=` option into the `format` filter; alpha is now wired to the `overlay` filter instead ([#1223](https://github.com/itsakeyfut/avio/issues/1223))
+
+### Internal
+- ff-decode: deduplicate RAII guards across the audio, image, and video `decoder_inner` files ([#1168](https://github.com/itsakeyfut/avio/issues/1168))
+- ff-render: split oversized `nodes/composite.rs` into per-node-type submodules ([#1166](https://github.com/itsakeyfut/avio/issues/1166))
+- ff-preview: split oversized player, timeline, and clock files ([#1165](https://github.com/itsakeyfut/avio/issues/1165))
+- ff-encode / ff-preview: fix bench compilation against updated APIs ([#1189](https://github.com/itsakeyfut/avio/issues/1189), [#1190](https://github.com/itsakeyfut/avio/issues/1190))
+- docs.rs: build documentation with all features enabled ([#1206](https://github.com/itsakeyfut/avio/issues/1206))
+
+---
+
 ## [0.14.4] - 2026-06-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.4"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,18 +12,18 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.14.4" }
-ff-common   = { path = "crates/ff-common",   version = "0.14.4" }
-ff-format   = { path = "crates/ff-format",   version = "0.14.4" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.14.4" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.14.4" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.14.4" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.14.4" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.14.4" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.14.4" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.14.4" }
-ff-render   = { path = "crates/ff-render",   version = "0.14.4" }
-avio        = { path = "crates/avio",         version = "0.14.4" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.15.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.15.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.15.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.15.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.15.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.15.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.15.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.15.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.15.0" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.15.0" }
+ff-render   = { path = "crates/ff-render",   version = "0.15.0" }
+avio        = { path = "crates/avio",         version = "0.15.0" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.14.4 to 0.15.0 and records the release in CHANGELOG.md. This release canonicalizes avio's public enums to FFmpeg's filter-argument tokens — a coherent set of **breaking** changes (color metadata type redesign, `BlendMode` aligned to `blend all_mode`, Porter-Duff separated into `CompositeOp`) that require a minor bump under Cargo's `0.x` compatibility rules.

## Changes

- `Cargo.toml`: workspace version 0.14.4 → 0.15.0; all 12 intra-workspace dependency pins updated
- `CHANGELOG.md`: add the `[0.15.0]` entry (Changed / Added / Fixed / Internal) covering the 20 issues shipped since v0.14.4

## Related Issues

Release of the **v0.15.0** milestone (20 issues, all merged and closed via their own PRs). Headline issues: #1217, #1198 (color tokens); #1218, #1219, #1220, #1221, #1222 (BlendMode/CompositeOp split); #1227 (setparams); #1212, #1223, #1225 (format/overlay tokens).

## Test Plan

- [x] `cargo test --all` passes (0 failed across all binaries)
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes