### PR TITLE
docs: update install version examples to 0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ff-probe  = "0.14"
-ff-decode = "0.14"
-ff-encode = "0.14"
+ff-probe  = "0.15"
+ff-decode = "0.15"
+ff-encode = "0.15"
 
 # Or use the facade crate for everything
-avio = "0.14"
+avio = "0.15"
 ```
 
 ### Prerequisites

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -14,16 +14,16 @@ to only the capabilities you need via feature flags.
 ```toml
 [dependencies]
 # Default: probe + decode + encode + hwaccel
-avio = "0.14"
+avio = "0.15"
 
 # Add filtering
-avio = { version = "0.14", features = ["filter"] }
+avio = { version = "0.15", features = ["filter"] }
 
 # Full streaming stack (implies pipeline, which implies filter)
-avio = { version = "0.14", features = ["stream"] }
+avio = { version = "0.15", features = ["stream"] }
 
 # Async decode/encode (requires tokio runtime)
-avio = { version = "0.14", features = ["tokio"] }
+avio = { version = "0.15", features = ["tokio"] }
 ```
 
 ## Feature Flags

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -24,13 +24,13 @@
 //! ```toml
 //! # Default: probe + decode + encode
 //! [dependencies]
-//! avio = "0.14"
+//! avio = "0.15"
 //!
 //! # Add filtering
-//! avio = { version = "0.14", features = ["filter"] }
+//! avio = { version = "0.15", features = ["filter"] }
 //!
 //! # Full stack (implies filter + pipeline)
-//! avio = { version = "0.14", features = ["stream"] }
+//! avio = { version = "0.15", features = ["stream"] }
 //! ```
 //!
 //! # Quick Start

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -8,8 +8,8 @@ Decode video and audio frames without managing codec contexts, packet queues, or
 
 ```toml
 [dependencies]
-ff-decode = "0.14"
-ff-format = "0.14"
+ff-decode = "0.15"
+ff-format = "0.15"
 ```
 
 ## Video Decoding
@@ -191,7 +191,7 @@ let mut decoder = VideoDecoder::open("video.mp4")
 
 ```toml
 [dependencies]
-ff-decode = { version = "0.14", features = ["tokio"] }
+ff-decode = { version = "0.15", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoDecoder` and `AudioDecoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -8,12 +8,12 @@ Encode video and audio to any format with a builder chain. The encoder validates
 
 ```toml
 [dependencies]
-ff-encode = "0.14"
-ff-format = "0.14"
+ff-encode = "0.15"
+ff-format = "0.15"
 
 # Enable GPL-licensed encoders (libx264, libx265).
 # Requires GPL compliance or MPEG LA licensing in your project.
-# ff-encode = { version = "0.14", features = ["gpl"] }
+# ff-encode = { version = "0.15", features = ["gpl"] }
 ```
 
 By default, only LGPL-compatible encoders are enabled.
@@ -328,7 +328,7 @@ Enable the `gpl` feature to add libx264 and libx265. This changes the license te
 
 ```toml
 [dependencies]
-ff-encode = { version = "0.14", features = ["tokio"] }
+ff-encode = { version = "0.15", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoEncoder`, `AudioEncoder`, and `ImageEncoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-filter/README.md
+++ b/crates/ff-filter/README.md
@@ -8,7 +8,7 @@ Apply video and audio transformations without writing FFmpeg filter-graph string
 
 ```toml
 [dependencies]
-ff-filter = "0.14"
+ff-filter = "0.15"
 ```
 
 ## Building a Filter Chain

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -8,7 +8,7 @@ Wire decode, filter, and encode into a single configured pipeline. Instead of ma
 
 ```toml
 [dependencies]
-ff-pipeline = "0.14"
+ff-pipeline = "0.15"
 ```
 
 ## Building a Pipeline

--- a/crates/ff-preview/README.md
+++ b/crates/ff-preview/README.md
@@ -8,13 +8,13 @@ Real-time video preview and proxy workflow for Rust. Provides frame-accurate see
 
 ```toml
 [dependencies]
-ff-preview = "0.14"
+ff-preview = "0.15"
 
 # Enable async support
-ff-preview = { version = "0.14", features = ["tokio"] }
+ff-preview = { version = "0.15", features = ["tokio"] }
 
 # Enable proxy generation
-ff-preview = { version = "0.14", features = ["proxy"] }
+ff-preview = { version = "0.15", features = ["proxy"] }
 ```
 
 ## Quick Start

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -8,7 +8,7 @@ Read media file metadata with one function call. No knowledge of container forma
 
 ```toml
 [dependencies]
-ff-probe = "0.14"
+ff-probe = "0.15"
 ```
 
 ## Quick Start

--- a/crates/ff-render/README.md
+++ b/crates/ff-render/README.md
@@ -8,10 +8,10 @@ GPU compositing pipeline for real-time video preview, built on [wgpu]. Apply per
 
 ```toml
 [dependencies]
-ff-render = "0.14"
+ff-render = "0.15"
 
 # Enable GPU processing (requires wgpu-compatible hardware)
-ff-render = { version = "0.14", features = ["wgpu"] }
+ff-render = { version = "0.15", features = ["wgpu"] }
 ```
 
 ## Feature Flags

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -9,7 +9,7 @@ point it at an input file, and receive a standards-compliant package ready for C
 
 ```toml
 [dependencies]
-ff-stream = "0.14"
+ff-stream = "0.15"
 ```
 
 ## HLS Output


### PR DESCRIPTION
## Summary

Updates the install-instruction version strings from `0.14` to `0.15` across the workspace READMEs and the `avio` crate-level doc, so the published v0.15.0 crates show the correct dependency line on crates.io and docs.rs. Companion to the `v0.15.0` release bump (#1234).

## Changes

- `crates/avio/src/lib.rs`: `avio = "0.14"` → `"0.15"` in the crate-level install examples
- `README.md` and `crates/{avio,ff-decode,ff-encode,ff-filter,ff-pipeline,ff-preview,ff-probe,ff-render,ff-stream}/README.md`: install version `0.14` → `0.15`

## Related Issues

Release documentation for the v0.15.0 milestone; no associated issue.

## Test Plan

Documentation-only change (install version strings).

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes (avio crate-level doc)