### PR TITLE
ci: release workflow via crates.io Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release
+
+# Publishes all workspace crates to crates.io via Trusted Publishing (OIDC) —
+# no long-lived API token. Triggered by pushing a version tag (e.g. v0.15.0),
+# or manually via workflow_dispatch (publish only, no GitHub Release).
+#
+# Prerequisite: each crate must have a Trusted Publisher configured on crates.io
+# (crate Settings → Trusted Publishing) pointing at:
+#   owner: itsakeyfut   repo: avio   workflow: release.yml
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  FFMPEG_VERSION: "7.1"
+  FFMPEG_PREFIX: /opt/ffmpeg7
+
+permissions:
+  contents: write # create the GitHub Release
+  id-token: write # crates.io Trusted Publishing (OIDC)
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: sudo apt-get install -y nasm pkg-config libclang-dev
+
+      - name: Cache FFmpeg 7.x
+        id: cache-ffmpeg
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.FFMPEG_PREFIX }}
+          key: ffmpeg-${{ env.FFMPEG_VERSION }}-ubuntu-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml') }}
+
+      - name: Build FFmpeg 7.x from source
+        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
+        run: |
+          wget -q https://ffmpeg.org/releases/ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
+          tar xf ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
+          cd ffmpeg-${{ env.FFMPEG_VERSION }}
+          ./configure \
+            --prefix=${{ env.FFMPEG_PREFIX }} \
+            --disable-programs \
+            --disable-doc \
+            --disable-everything \
+            --enable-avcodec \
+            --enable-avformat \
+            --enable-avutil \
+            --enable-swscale \
+            --enable-swresample \
+            --enable-avfilter \
+            --enable-decoder=h264,aac,mp3,flac,vorbis,opus,pcm_s16le,pcm_f32le \
+            --enable-encoder=aac,pcm_s16le,mpeg4 \
+            --enable-demuxer=mov,mp4,matroska,mp3,flac,ogg,wav,srt \
+            --enable-muxer=ipod,mp4,mov,matroska \
+            --enable-parser=h264,aac,mpegaudio,flac,vorbis,opus \
+            --enable-protocol=file \
+            --enable-shared \
+            --disable-static
+          make -j$(nproc)
+          sudo make install
+
+      - name: Set FFmpeg environment
+        run: |
+          echo "PKG_CONFIG_PATH=${{ env.FFMPEG_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${{ env.FFMPEG_PREFIX }}/lib" >> $GITHUB_ENV
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.93.0"
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Verify the whole workspace builds once, up front. This lets the publish
+      # step use --no-verify so all 12 uploads finish inside the 30-minute OIDC
+      # token window (a fresh per-crate verify build would risk token expiry).
+      - name: Verify workspace builds
+        run: cargo build --workspace --all-features
+
+      - name: Authenticate to crates.io (Trusted Publishing)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+          for c in ff-sys ff-common ff-format ff-probe ff-decode ff-encode \
+                   ff-filter ff-pipeline ff-preview ff-render ff-stream avio; do
+            echo "::group::Publishing $c"
+            cargo publish -p "$c" --no-verify
+            echo "::endgroup::"
+          done
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          ver="${TAG#v}"
+          awk -v ver="$ver" '
+            $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+            flag && /^## \[/ { exit }
+            flag && /^---$/ { exit }
+            flag { print }
+          ' CHANGELOG.md > release_notes.md
+          gh release create "$TAG" --title "$TAG" --notes-file release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,16 @@ name: Release
 # no long-lived API token. Triggered by pushing a version tag (e.g. v0.15.0),
 # or manually via workflow_dispatch (publish only, no GitHub Release).
 #
-# Prerequisite: each crate must have a Trusted Publisher configured on crates.io
-# (crate Settings → Trusted Publishing) pointing at:
-#   owner: itsakeyfut   repo: avio   workflow: release.yml
+# Prerequisites:
+#   - Each crate must have a Trusted Publisher configured on crates.io
+#     (crate Settings -> Trusted Publishing): owner itsakeyfut, repo avio,
+#     workflow release.yml, environment crates-io.
+#   - A GitHub environment named "crates-io" (optionally with required
+#     reviewers) gates the publish job — a workflow_dispatch run then waits
+#     for approval before any crate is published.
+#
+# Third-party actions are pinned to a full commit SHA (tag noted in a comment)
+# because this workflow holds the crates.io OIDC token and contents:write.
 
 on:
   push:
@@ -18,6 +25,7 @@ env:
   CARGO_TERM_COLOR: always
   FFMPEG_VERSION: "7.1"
   FFMPEG_PREFIX: /opt/ffmpeg7
+  FFMPEG_SHA256: 40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 
 permissions:
   contents: write # create the GitHub Release
@@ -27,23 +35,29 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # Defense-in-depth: scopes the OIDC token to this environment and lets a
+    # maintainer require manual approval for any (e.g. dispatched) run.
+    environment: crates-io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install build dependencies
         run: sudo apt-get install -y nasm pkg-config libclang-dev
 
       - name: Cache FFmpeg 7.x
         id: cache-ffmpeg
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.FFMPEG_PREFIX }}
-          key: ffmpeg-${{ env.FFMPEG_VERSION }}-ubuntu-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          # Keyed on the verified tarball hash so a poisoned cache cannot
+          # substitute a different FFmpeg build.
+          key: ffmpeg-${{ env.FFMPEG_VERSION }}-${{ env.FFMPEG_SHA256 }}-ubuntu-${{ runner.arch }}
 
       - name: Build FFmpeg 7.x from source
         if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
         run: |
           wget -q https://ffmpeg.org/releases/ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
+          echo "${FFMPEG_SHA256}  ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz" | sha256sum -c -
           tar xf ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
           cd ffmpeg-${{ env.FFMPEG_VERSION }}
           ./configure \
@@ -73,11 +87,11 @@ jobs:
           echo "PKG_CONFIG_PATH=${{ env.FFMPEG_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=${{ env.FFMPEG_PREFIX }}/lib" >> $GITHUB_ENV
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.93.0"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # Verify the whole workspace builds once, up front. This lets the publish
       # step use --no-verify so all 12 uploads finish inside the 30-minute OIDC
@@ -87,7 +101,7 @@ jobs:
 
       - name: Authenticate to crates.io (Trusted Publishing)
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
 
       - name: Publish crates in dependency order
         env:


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` to publish all 12 workspace crates to crates.io using **Trusted Publishing (OIDC)** — no long-lived API token. This replaces local `cargo publish` (which is blocked because token-based publishing is being phased out / can be disabled per-crate via Trusted Publishing enforcement).

Triggered by pushing a `v*.*.*` tag (publishes + creates a GitHub Release), or manually via `workflow_dispatch` (publish only).

## Changes

- `.github/workflows/release.yml`:
  - Builds FFmpeg 7.1 from source (cached), mirroring `ci.yml`, so `cargo publish` can build the FFI crates
  - `rust-lang/crates-io-auth-action@v1` exchanges the GitHub OIDC token for a short-lived (30-min) crates.io token
  - Runs one `cargo build --workspace --all-features` up front, then publishes each crate with `--no-verify` in dependency order (`ff-sys → … → avio`) so all uploads fit inside the token window
  - Creates a GitHub Release from the matching `CHANGELOG.md` section on tag pushes

## Follow-up required before this can run

Each crate needs a Trusted Publisher configured on crates.io (crate Settings → Trusted Publishing): owner `itsakeyfut`, repo `avio`, workflow `release.yml`.

## Related Issues

Release infrastructure; no associated issue.

## Test Plan

- [x] `release.yml` validated as well-formed YAML
- [ ] End-to-end verified on the first tagged release (`v0.15.0`)