### PR TITLE
ci: add cargo-deny supply-chain checks

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,30 @@
+name: Audit
+
+# Supply-chain checks via cargo-deny: RustSec advisories, license policy,
+# banned/duplicate crates, and allowed sources (config in deny.toml). Runs on
+# PRs, pushes to main, and weekly. cargo-deny reads `cargo metadata` only — no
+# build and no FFmpeg required.
+#
+# Third-party actions are pinned to a full commit SHA (tag noted in a comment).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 1" # Mondays 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+        with:
+          command: check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,54 @@
+# cargo-deny configuration — supply-chain checks for the avio workspace.
+#
+# Run locally with `cargo deny check`; CI runs it on PRs, pushes to main, and
+# weekly (.github/workflows/audit.yml). cargo-deny reads `cargo metadata` only —
+# it never builds, so no FFmpeg is required.
+
+[graph]
+# Check the full feature surface — render-gpu / tokio / stream pull extra deps
+# that the default feature set would miss.
+all-features = true
+
+[advisories]
+version = 2
+# RustSec advisory DB (default source). Vulnerabilities fail the check.
+# `unmaintained = "workspace"` flags only unmaintained crates that are direct
+# workspace dependencies, not transitive ones — pinning the policy explicitly so
+# it doesn't drift with cargo-deny's default and avoiding surprise CI failures
+# from abandoned-but-stable transitive deps. Yanked crates only warn: they are
+# often yanked for non-security reasons and Cargo.lock is regenerated fresh in CI.
+yanked = "warn"
+unmaintained = "workspace"
+ignore = []
+
+[licenses]
+version = 2
+# Permissive licenses compatible with the project's dual MIT-OR-Apache-2.0
+# license. Anything not listed (GPL / LGPL / MPL / AGPL / …) is denied. This set
+# is derived from the current all-features dependency tree: it includes the
+# single-option licenses Zlib / BSD-3-Clause / ISC / CC0-1.0 and Unicode-3.0,
+# which the clause `(MIT OR Apache-2.0) AND Unicode-3.0` makes mandatory.
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "Unlicense",
+]
+
+[bans]
+# Transitive duplicate versions are unavoidable in this tree (libc, regex,
+# hashbrown, itertools, memchr, foldhash, rustc-hash) — warn rather than fail.
+multiple-versions = "warn"
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Adds automated supply-chain checking via `cargo deny` so every PR and a weekly schedule guard the dependency tree against RustSec advisories, license drift (a copyleft dep slipping into the dual MIT-OR-Apache-2.0 project), banned/duplicate crates, and unexpected sources. Config/CI only — no Rust changes, and the new job needs no FFmpeg (cargo-deny reads `cargo metadata`, never builds).

## Changes

- `deny.toml` (root, schema version 2):
  - `[licenses]` permissive allow-list **derived from the actual all-features dependency tree** (MIT, Apache-2.0, BSD-2/3-Clause, ISC, Zlib, Unicode-3.0, CC0-1.0, Unlicense); everything else (GPL/LGPL/MPL/AGPL/…) is denied. Includes the single-option licenses and `Unicode-3.0` required by the `(MIT OR Apache-2.0) AND Unicode-3.0` clause.
  - `[advisories]` v2: vulnerabilities fail; `unmaintained = "workspace"` (only direct workspace deps); `yanked = "warn"`.
  - `[bans]` `multiple-versions = "warn"` (transitive duplicates are unavoidable), `wildcards = "deny"`.
  - `[sources]` restricted to crates.io.
- `.github/workflows/audit.yml`: runs `cargo deny check` on push/PR to `main`, weekly (`0 0 * * 1`), and `workflow_dispatch`. `permissions: contents: read`; third-party actions pinned to commit SHAs.

## Related Issues

Closes #1205

## Test Plan

Config/CI-only change (no Rust touched; Rust gates unaffected vs. green `main`).

- [x] `cargo deny check` passes (advisories / bans / licenses / sources all ok, exit 0)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `audit.yml` validated as well-formed YAML