### PR TITLE
ci: build docs job via DOCS_RS stubs (drop FFmpeg build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,56 +227,23 @@ jobs:
           DOCS_RS: "1"
 
   # --------------------------------------------------------------------------
-  # Docs
+  # Docs — `cargo doc` with `-D warnings` catches doc warnings and broken
+  # intra-doc links before they reach main. DOCS_RS=1 makes ff-sys/build.rs skip
+  # bindgen and use the checked-in stub bindings, so docs build with no FFmpeg —
+  # the same path docs.rs uses, so this job also guards the docs.rs build. The
+  # docsrs-stubs job keeps the stubs complete, so intra-doc-link resolution here
+  # matches a real build.
   # --------------------------------------------------------------------------
   docs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install build dependencies
-        run: sudo apt-get install -y nasm pkg-config libclang-dev
-      - name: Cache FFmpeg 7.x
-        id: cache-ffmpeg
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.FFMPEG_PREFIX }}
-          key: ffmpeg-${{ env.FFMPEG_VERSION }}-ubuntu-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml') }}
-      - name: Build FFmpeg 7.x from source
-        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: |
-          wget -q https://ffmpeg.org/releases/ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          tar xf ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          cd ffmpeg-${{ env.FFMPEG_VERSION }}
-          ./configure \
-            --prefix=${{ env.FFMPEG_PREFIX }} \
-            --disable-programs \
-            --disable-doc \
-            --disable-everything \
-            --enable-avcodec \
-            --enable-avformat \
-            --enable-avutil \
-            --enable-swscale \
-            --enable-swresample \
-            --enable-avfilter \
-            --enable-decoder=h264,aac,mp3,flac,vorbis,opus,pcm_s16le,pcm_f32le \
-            --enable-encoder=aac,pcm_s16le,mpeg4 \
-            --enable-demuxer=mov,mp4,matroska,mp3,flac,ogg,wav,srt \
-            --enable-muxer=ipod,mp4,mov,matroska \
-            --enable-parser=h264,aac,mpegaudio,flac,vorbis,opus \
-            --enable-protocol=file \
-            --enable-shared \
-            --disable-static
-          make -j$(nproc)
-          sudo make install
-      - name: Set FFmpeg environment
-        run: |
-          echo "PKG_CONFIG_PATH=${{ env.FFMPEG_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${{ env.FFMPEG_PREFIX }}/lib" >> $GITHUB_ENV
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.93.0"
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --all-features --no-deps
         env:
+          DOCS_RS: "1"
           RUSTDOCFLAGS: -D warnings


### PR DESCRIPTION
## Summary

The CI `docs` job already runs `cargo doc --all-features --no-deps` with `RUSTDOCFLAGS="-D warnings"` (the original ask of #1208), but it built FFmpeg 7.1 from source (~10 min) just to satisfy `ff-sys`'s bindgen. This switches the job to `DOCS_RS=1`, which makes `ff-sys/build.rs` skip bindgen and use the checked-in stub bindings — so docs build with no FFmpeg, the same path docs.rs uses. The job is faster and now also guards the docs.rs build.

## Changes

- `.github/workflows/ci.yml` (`docs` job): remove the FFmpeg install/cache/build/env steps; add `DOCS_RS: "1"` to the `cargo doc` step. `RUSTDOCFLAGS: -D warnings` (doc warnings + broken intra-doc links → error) and the PR/`main`-push triggers are unchanged. Net −33 lines.
- The top-level `FFMPEG_VERSION` / `FFMPEG_PREFIX` env stays — the clippy/test/no-tokio jobs still use it.

Doc-link resolution remains equivalent because the `docsrs-stubs` job keeps the stub bindings complete; verified locally with `DOCS_RS=1 RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` (all 12 crates pass).

## Related Issues

Resolves #1208

(The issue's acceptance criteria were already met by the pre-existing `docs` job; this PR keeps them satisfied while making the job FFmpeg-free and docs.rs-path-guarding.)

## Test Plan

CI-only change (no Rust touched; Rust gates unaffected vs. green `main`).

- [x] `DOCS_RS=1 RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` passes (all 12 crates)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `ci.yml` validated as well-formed YAML