### PR TITLE
ci: add Dependabot config for cargo and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot: weekly, grouped update PRs for Rust deps and GitHub Actions.
+# Minor + patch updates are grouped per ecosystem to reduce PR noise; major
+# updates open individual PRs so they get reviewed. Targets the default branch
+# (main). See #1204.
+version: 2
+updates:
+  # Rust workspace dependencies
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - T-Maintenance
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used across .github/workflows/. Dependabot updates both tag
+  # refs (e.g. @v4) and SHA pins (bumping the `# vX` comment).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - T-Maintenance
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so Dependabot opens weekly, grouped update PRs for the `cargo` and `github-actions` ecosystems. This keeps dependencies current, surfaces security patches early, and keeps the SHA-pinned actions in `release.yml`/`audit.yml` fresh.

## Changes

- `.github/dependabot.yml` (version 2):
  - `cargo` and `github-actions` ecosystems, both weekly, targeting the default branch (`main`).
  - Minor + patch updates grouped into one PR per ecosystem to reduce noise; major updates open individual PRs so they get reviewed.
  - `commit-message.prefix` (`chore(deps)` / `ci(deps)`) keeps Dependabot PRs conventional-commit-compliant; `T-Maintenance` label for triage.

## Notes

- The `cargo` updater is partial here because `Cargo.lock` is gitignored (library convention): without a committed lockfile it only opens PRs for updates that fall outside the manifest requirement (major bumps for caret deps) or for security advisories — it can't track within-range minor/patch. The `github-actions` ecosystem is fully effective. Full within-range cargo tracking would require committing `Cargo.lock` (a separate policy decision, out of scope).
- Branch-pinned actions (`dtolnay/rust-toolchain@master`/`@nightly`) have no version to bump and are left alone.

## Related Issues

Closes #1204

## Test Plan

Config-only change (no Rust touched). Dependabot schema is validated by GitHub after merge (Insights → Dependency graph → Dependabot).

- [x] `.github/dependabot.yml` validated as well-formed YAML (version 2, both ecosystems, weekly, grouped)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes