### PR TITLE
chore: add CODEOWNERS for automatic PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners — GitHub auto-requests review from these owners on every PR.
+# https://docs.github.com/articles/about-code-owners
+
+* @itsakeyfut


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` with a catch-all owner so GitHub auto-requests review from the maintainer on pull requests — useful now that the repo accepts outside contributions (external PRs auto-request the maintainer's review).

## Changes

- `.github/CODEOWNERS`: `* @itsakeyfut` (catch-all). Per-area lines were intentionally omitted while the project is solo-maintained; they can be added when co-maintainers join.

## Notes

- GitHub does not request review from a PR's own author, so this primarily affects external-contributor PRs.
- Validated with `gh api repos/itsakeyfut/avio/codeowners/errors` → 0 errors (syntax valid, `@itsakeyfut` recognized as an owner with access).

## Related Issues

Closes #1207

## Test Plan

Repository-config file (no Rust touched; Rust gates unaffected).

- [x] `.github/CODEOWNERS` validated via GitHub's `codeowners/errors` API (0 errors)