### PR TITLE
refactor(avio): add render feature re-exports to avio facade

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -330,6 +330,32 @@ pub use ff_preview::AsyncPreviewPlayer;
 #[cfg(feature = "preview-proxy")]
 pub use ff_preview::{ProxyGenerator, ProxyJob, ProxyResolution};
 
+// ── render feature ────────────────────────────────────────────────────────────
+//
+// GPU compositing (`ff-render`). Namespaced under `avio::render` rather than
+// re-exported flat because several node types share names with the `filter`
+// feature (`BlendMode`, `ScaleAlgorithm`); a flat re-export would collide.
+// Enabling `render` also enables `preview` (see Cargo.toml).
+#[cfg(feature = "render")]
+pub mod render {
+    //! GPU compositing pipeline (`ff-render`).
+    //!
+    //! These types are namespaced (`avio::render::*`) because `BlendMode` and
+    //! `ScaleAlgorithm` would otherwise collide with the `filter` feature's
+    //! re-exports of the same names.
+    pub use ff_render::{
+        AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,
+        GpuFrameSink, LumaMaskNode, OverlayNode, RenderError, RenderGraph, RenderNodeCpu,
+        ScaleAlgorithm, ScaleNode, ShapeMaskNode, TransformNode, YuvFormat, YuvUploadNode,
+    };
+
+    // wgpu-gated in ff-render → reachable only with avio's `render-gpu` feature.
+    #[cfg(feature = "render-gpu")]
+    pub use ff_render::{
+        Compositor, FrameLayer, LayerTransform, RenderContext, RenderNode, TextureHandle,
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -682,5 +708,37 @@ mod tests {
         let _: ProxyResolution = ProxyResolution::Half;
         let _: ProxyResolution = ProxyResolution::Quarter;
         let _: ProxyResolution = ProxyResolution::Eighth;
+    }
+
+    // ── render feature ────────────────────────────────────────────────────────
+
+    #[cfg(feature = "render")]
+    #[test]
+    fn render_core_types_should_be_accessible() {
+        // The ungated ff-render surface is namespaced under `avio::render`.
+        let _: render::RenderError = render::RenderError::Composite {
+            message: "test".into(),
+        };
+        let _: render::RenderGraph = render::RenderGraph::new_cpu();
+        let _: render::BlendMode = render::BlendMode::Normal;
+        let _: render::ScaleAlgorithm = render::ScaleAlgorithm::Bilinear;
+    }
+
+    // BlendMode / ScaleAlgorithm exist under both `filter` and `render`; with both
+    // features on, the namespacing must keep them distinct (no collision).
+    #[cfg(all(feature = "render", feature = "filter"))]
+    #[test]
+    fn render_and_filter_blend_mode_should_not_collide() {
+        let _: BlendMode = BlendMode::Normal;
+        let _: render::BlendMode = render::BlendMode::Normal;
+    }
+
+    #[cfg(feature = "render-gpu")]
+    #[test]
+    fn render_gpu_types_should_be_accessible() {
+        // wgpu-gated types are reachable only under `render-gpu`; verify name
+        // resolution without constructing a GPU device.
+        let _ = std::mem::size_of::<render::Compositor>();
+        let _ = std::mem::size_of::<render::RenderContext>();
     }
 }


### PR DESCRIPTION
## Summary

The `avio` facade declared the `render` / `render-gpu` features (backed by `ff-render`) but exposed no public surface for them — enabling `render` produced no usable types from `avio`, forcing a direct `ff-render` dependency. This PR adds the missing re-export block, completing the facade pattern for the render feature.

## Changes

- `crates/avio/src/lib.rs`: add a `#[cfg(feature = "render")] pub mod render` block re-exporting the full `ff-render` public surface — 18 ungated types (incl. `RenderError`, `RenderGraph`, `BlendMode`, `ScaleAlgorithm`, all node types, `GpuFrameSink`, `RenderNodeCpu`) plus 6 wgpu-gated types (`Compositor`, `FrameLayer`, `LayerTransform`, `RenderContext`, `RenderNode`, `TextureHandle`) gated on `render-gpu`. The two groups mirror `ff-render`'s own `#[cfg(feature = "wgpu")]` gating exactly.
- Added three smoke tests, including `render_and_filter_blend_mode_should_not_collide` as a regression guard for the name collision described below.

## Design note — namespaced, not flat

The re-export is **namespaced under `avio::render`** rather than flattened into the crate root (a deliberate, intentional deviation from the issue's flat "mirror preview" suggestion). `ff-render` exposes `BlendMode` and `ScaleAlgorithm`, which **collide by name** with the same-named types `avio` already re-exports under the `filter` feature. A flat re-export would fail `cargo check --all-features` with `E0252`. Namespacing avoids the collision structurally, keeps ~24 render-specific types out of the crate root, and has zero migration cost since the surface is new. The rationale is documented inline on the module.

## Related Issues

Resolves #1170

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes
