### PR TITLE
fix(ff-filter): dispatch single-stream compound FilterSteps so the realtime compositor can build Glow

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -108,6 +108,32 @@ pub(crate) unsafe fn add_and_link_step(
     index: usize,
     prefix: &str,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    // Single-stream compound steps expand to a multi-filter subgraph and must be
+    // dispatched to their dedicated builders. The single-filter path below would
+    // otherwise pass the whole subgraph string as one filter's args (e.g. create
+    // a `split` filter named "split" with args `split=2[base][hl];curves…;blend…`,
+    // failing with "No such option: split"). Callers that build a graph from a
+    // step list (single-source `FilterGraphInner`) special-case these before
+    // reaching here; callers that drive steps directly (e.g. the realtime
+    // compositor) rely on this dispatch.
+    match step {
+        FilterStep::Glow {
+            threshold,
+            radius,
+            intensity,
+        } => return add_glow_step(graph, prev_ctx, *threshold, *radius, *intensity, index),
+        FilterStep::FeatherMask { radius } => {
+            return add_feather_mask_step(graph, prev_ctx, *radius, index);
+        }
+        FilterStep::OverlayImage {
+            path,
+            x,
+            y,
+            opacity,
+        } => return add_overlay_image_step(graph, prev_ctx, path, x, y, *opacity, index),
+        _ => {}
+    }
+
     let filter_name =
         std::ffi::CString::new(step.filter_name()).map_err(|_| FilterError::BuildFailed)?;
     let filter = ff_sys::avfilter_get_by_name(filter_name.as_ptr());

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -117,6 +117,39 @@ mod tests {
     }
 
     #[test]
+    fn base_layer_with_glow_compound_effect_should_build() {
+        // Regression: `Glow` is a compound `FilterStep` (split → curves → gblur →
+        // blend). The realtime compositor drives per-layer effects through
+        // `add_and_link_step`, which must dispatch compound steps to their builders
+        // rather than create a single `split` filter with the whole subgraph as
+        // args (which failed with "No such option: split").
+        let layer = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::Glow {
+                threshold: 0.6,
+                radius: 4.0,
+                intensity: 0.5,
+            }],
+            opacity: 1.0,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = RealtimeComposer::new(&[layer])
+            .expect("Glow-effect layer graph should build once compound steps dispatch");
+        let frame = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn two_layer_composite_should_produce_rgba_frame() {
         // 4×4 RGBA base + overlay; skip-guard on FFmpeg availability.
         let layer = |op: f32| RealtimeLayer {

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -123,6 +123,25 @@ mod tests {
         // `add_and_link_step`, which must dispatch compound steps to their builders
         // rather than create a single `split` filter with the whole subgraph as
         // args (which failed with "No such option: split").
+        //
+        // Probe-gate: a no-effect base layer needs only `buffer`/`format`/
+        // `buffersink`. CI's Linux FFmpeg is built with no filters, so even that
+        // fails to build there — skip. Where it builds, the filter set is present,
+        // so the `Glow` layer *must* also build; that is the regression assertion
+        // (it fails before the fix, on any host with filters).
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
         let layer = RealtimeLayer {
             width: 8,
             height: 8,
@@ -136,7 +155,7 @@ mod tests {
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[layer])
-            .expect("Glow-effect layer graph should build once compound steps dispatch");
+            .expect("Glow compound step must dispatch and build once FFmpeg filters exist");
         let frame = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
         if composer.push_layer(0, &frame).is_err() {
             println!("Skipping: push failed (FFmpeg unavailable?)");


### PR DESCRIPTION
## Summary

`add_and_link_step` built every `FilterStep` as a *single* FFmpeg filter from `filter_name()` + `args()`. That breaks for **single-stream compound** steps (`Glow`, `FeatherMask`, `OverlayImage`), whose `filter_name()` is `"split"` and whose `args()` is a whole multi-filter subgraph — FFmpeg rejects it with `No such option: split`. Graph builders that walk a step list from a single source special-case these before reaching `add_and_link_step`, but the realtime compositor (`build_realtime_composition`) drives per-layer effects **directly** through it, so attaching a `Glow` to a clip failed to build in the timeline preview even though it renders fine on export. Found in `avio-editor-demo` while wiring the per-clip video-effects library.

## Changes

- `crates/ff-filter/src/filter_inner/build.rs`: dispatch the three single-stream compound steps (`Glow`, `FeatherMask`, `OverlayImage`) to their dedicated builders (`add_glow_step` / `add_feather_mask_step` / `add_overlay_image_step`) at the top of `add_and_link_step`, before the single-filter path. The dispatch is identical in shape to the proven single-source call sites; the single-source path already `continue`s past these steps, so there is no double handling.
- `crates/ff-filter/src/graph/composition/realtime_composer.rs`: add `base_layer_with_glow_compound_effect_should_build` — a **probe-gated** regression test. A no-effect base layer is built first; if that fails, FFmpeg has no filters (CI Linux) and the test skips. Where it builds, the filter set is present, so the `Glow` layer must also build — the regression assertion (fails before the fix on any host with filters, skips cleanly on filterless CI).

## Related Issues

Fixes #1252

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --all-features --no-deps` passes
