### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.1] - 2026-08-07
+
+This release unifies the preview and export compositing paths on a single `RealtimeComposer` and ships the fixes uncovered along the way, plus the `wgpu` 30 upgrade for the GPU renderer.
+
+### Changed
+
+#### ff-render
+- Update `wgpu` from 29 to 30: `RequestAdapterOptions` gains an `apply_limit_buckets` field and `BufferSlice::get_mapped_range` now returns a `Result` ([#1256](https://github.com/itsakeyfut/avio/issues/1256))
+
+### Added
+
+#### ff-filter / ff-pipeline / ff-preview
+- Unify preview and export compositing on a single `RealtimeComposer`, so `Timeline::render()` and the timeline preview no longer drift between two independent multi-track compositor implementations ([#1215](https://github.com/itsakeyfut/avio/issues/1215))
+
+#### avio
+- Re-export the `render` feature surface on the `avio` facade under the `render` namespace ([#1170](https://github.com/itsakeyfut/avio/issues/1170))
+
+### Fixed
+
+#### ff-filter
+- `add_and_link_step` failed on compound `FilterStep`s, so the realtime compositor could not build `Glow` ([#1252](https://github.com/itsakeyfut/avio/issues/1252))
+- `MultiTrackComposer` non-`Normal` blend modes failed to configure when layers differed in size ([#1248](https://github.com/itsakeyfut/avio/issues/1248))
+- Multi-track export hung forever because `blend`/`composite` layers omitted `eof_action` against the infinite canvas ([#1250](https://github.com/itsakeyfut/avio/issues/1250))
+- `MultiTrackComposer` canvas was hardcoded to 30 fps, stretching non-30fps exports and desyncing audio and video ([#1251](https://github.com/itsakeyfut/avio/issues/1251))
+
+#### ff-preview
+- Timeline preview dropped dimension-changing base-layer effects (`Crop` / `Scale` / `Pad`) by pushing the decoded `width` / `height` for a resized frame, freezing the monitor while audio kept playing ([#1260](https://github.com/itsakeyfut/avio/issues/1260))
+- Timeline preview overlay and gap-fill layers played too fast — one source frame was consumed per present instead of by PTS ([#1249](https://github.com/itsakeyfut/avio/issues/1249))
+
+---
+
 ## [0.15.0] - 2026-06-13
 
 This release canonicalizes avio's public enums to FFmpeg's filter-argument tokens. **Breaking:** the colour metadata types and `BlendMode` are redesigned, and Porter-Duff compositing is separated into a new `CompositeOp` type.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,18 +12,18 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.15.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.15.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.15.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.15.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.15.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.15.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.15.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.15.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.15.0" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.15.0" }
-ff-render   = { path = "crates/ff-render",   version = "0.15.0" }
-avio        = { path = "crates/avio",         version = "0.15.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.15.1" }
+ff-common   = { path = "crates/ff-common",   version = "0.15.1" }
+ff-format   = { path = "crates/ff-format",   version = "0.15.1" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.15.1" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.15.1" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.15.1" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.15.1" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.15.1" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.15.1" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.15.1" }
+ff-render   = { path = "crates/ff-render",   version = "0.15.1" }
+avio        = { path = "crates/avio",         version = "0.15.1" }
 
 # Error handling
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.15.0 to 0.15.1 and records the release in CHANGELOG.md. Files-only release (no tag / publish in this PR).

## Changes

- `Cargo.toml`: workspace version 0.15.0 → 0.15.1; all 12 intra-workspace pins updated
- `CHANGELOG.md`: add `[0.15.1]` entry (Changed / Added / Fixed) covering the RealtimeComposer preview/export unification, `avio` render re-exports, the `wgpu` 29→30 upgrade, and the compositor fixes shipped since v0.15.0
- Install-version strings unchanged — the minor stays `0.15`, so `"0.15"` already resolves to `0.15.1`

## Related Issues

Release of the accumulated post-v0.15.0 work (issues #1215, #1170, #1256, #1252, #1248, #1250, #1251, #1260, #1249 — all already merged/closed via their own PRs). No closing keyword; those issues are already closed.

## Test Plan

- [x] `cargo build --workspace` passes (pins resolve)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc -p avio --all-features --no-deps` passes