### PR TITLE
feat(ff-preview): honor explicit Timeline canvas in the realtime preview

### DIFF
--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1080,6 +1080,7 @@ pub(super) unsafe fn build_video_composition(
 /// Follows the same avfilter ownership rules as [`build_video_composition`].
 pub(super) unsafe fn build_realtime_composition(
     layers: &[super::realtime_composer::RealtimeLayer],
+    canvas: Option<(u32, u32)>,
 ) -> Result<FilterGraph, FilterError> {
     use std::ffi::CString;
 
@@ -1199,6 +1200,73 @@ pub(super) unsafe fn build_realtime_composition(
                 Err(e) => bail!(graph, format!("blend failed layer={idx}: {e:?}")),
             }
         };
+    }
+
+    // ── Optional fit-to-canvas ────────────────────────────────────────────────
+    // When a project canvas is set, letterbox/pillarbox the composited result to
+    // exactly `canvas_w × canvas_h` so the preview frame matches the project's
+    // output aspect. Runtime expressions (`force_original_aspect_ratio`,
+    // `(ow-iw)/2`) keep this correct regardless of the accumulator's actual size
+    // (per-clip effects may have resized it).
+    if let Some((canvas_w, canvas_h)) = canvas {
+        let scale_filter = ff_sys::avfilter_get_by_name(c"scale".as_ptr());
+        if scale_filter.is_null() {
+            bail!(graph, "filter not found: scale (fit-to-canvas)");
+        }
+        let Ok(fit_args) = CString::new(format!(
+            "w={canvas_w}:h={canvas_h}:force_original_aspect_ratio=decrease:force_divisible_by=2"
+        )) else {
+            bail!(graph, "CString::new failed for fit-to-canvas scale args");
+        };
+        let mut fit_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+        let ret = ff_sys::avfilter_graph_create_filter(
+            &raw mut fit_ctx,
+            scale_filter,
+            c"canvas_fit".as_ptr(),
+            fit_args.as_ptr(),
+            std::ptr::null_mut(),
+            graph,
+        );
+        if ret < 0 {
+            bail!(
+                graph,
+                format!("failed to create fit-to-canvas scale code={ret}")
+            );
+        }
+        let ret = ff_sys::avfilter_link(acc, 0, fit_ctx, 0);
+        if ret < 0 {
+            bail!(graph, "link failed: composite→canvas_fit");
+        }
+
+        let pad_filter = ff_sys::avfilter_get_by_name(c"pad".as_ptr());
+        if pad_filter.is_null() {
+            bail!(graph, "filter not found: pad (fit-to-canvas)");
+        }
+        let Ok(pad_args) = CString::new(format!(
+            "{canvas_w}:{canvas_h}:(ow-iw)/2:(oh-ih)/2:color=black"
+        )) else {
+            bail!(graph, "CString::new failed for fit-to-canvas pad args");
+        };
+        let mut pad_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+        let ret = ff_sys::avfilter_graph_create_filter(
+            &raw mut pad_ctx,
+            pad_filter,
+            c"canvas_pad".as_ptr(),
+            pad_args.as_ptr(),
+            std::ptr::null_mut(),
+            graph,
+        );
+        if ret < 0 {
+            bail!(
+                graph,
+                format!("failed to create fit-to-canvas pad code={ret}")
+            );
+        }
+        let ret = ff_sys::avfilter_link(fit_ctx, 0, pad_ctx, 0);
+        if ret < 0 {
+            bail!(graph, "link failed: canvas_fit→canvas_pad");
+        }
+        acc = pad_ctx;
     }
 
     // ── format=rgba: constrain output for direct read-back ────────────────────

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -68,11 +68,28 @@ impl RealtimeComposer {
     /// Returns [`FilterError::CompositionFailed`] when `layers` is empty or the
     /// underlying `FFmpeg` graph cannot be built.
     pub fn new(layers: &[RealtimeLayer]) -> Result<Self, FilterError> {
+        Self::with_canvas(layers, None)
+    }
+
+    /// Like [`new`](Self::new), but composites onto a fixed project canvas: the
+    /// output is letterboxed/pillarboxed to `canvas = (width, height)` so the
+    /// composited frame matches the project's output aspect. `None` composites at
+    /// the base layer's own size (identical to [`new`](Self::new)).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::CompositionFailed`] when `layers` is empty or the
+    /// underlying `FFmpeg` graph cannot be built.
+    pub fn with_canvas(
+        layers: &[RealtimeLayer],
+        canvas: Option<(u32, u32)>,
+    ) -> Result<Self, FilterError> {
         let layer_count = layers.len();
         // SAFETY: all raw-pointer operations in `build_realtime_composition`
         // follow the avfilter ownership rules; the returned graph owns every
         // context it created.
-        let graph = unsafe { super::composition_inner::build_realtime_composition(layers)? };
+        let graph =
+            unsafe { super::composition_inner::build_realtime_composition(layers, canvas)? };
         Ok(Self { graph, layer_count })
     }
 
@@ -163,6 +180,42 @@ mod tests {
         }
         match composer.pull() {
             Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
+    fn with_canvas_letterboxes_output_to_canvas_size() {
+        // A 640×360 (16:9) base composited onto a 1080×1920 (9:16) canvas must
+        // produce a 1080×1920 frame (letterboxed), not the base's own size.
+        let base = RealtimeLayer {
+            width: 640,
+            height: 360,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = match RealtimeComposer::with_canvas(&[base], Some((1080, 1920))) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        let frame = VideoFrame::from_rgba(640, 360, vec![120u8; 640 * 360 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                assert_eq!(out.width(), 1080);
+                assert_eq!(out.height(), 1920);
+                let rgba = out.to_rgba().expect("rgba");
+                assert_eq!(rgba.len(), 1080 * 1920 * 4);
+            }
             Ok(None) => println!("Skipping: no frame produced"),
             Err(e) => println!("Skipping: {e}"),
         }

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -53,6 +53,10 @@ use crate::progress::Progress;
 pub struct Timeline {
     pub(crate) canvas_width: u32,
     pub(crate) canvas_height: u32,
+    /// `true` when the caller set the canvas via [`TimelineBuilder::canvas`] (as
+    /// opposed to it being auto-probed from the first clip). Lets consumers such
+    /// as the real-time preview know a deliberate output aspect was requested.
+    pub(crate) canvas_explicit: bool,
     pub(crate) frame_rate: f64,
     /// `video_tracks[track_idx][clip_idx]`; track 0 = bottom layer.
     pub(crate) video_tracks: Vec<Vec<Clip>>,
@@ -94,6 +98,18 @@ impl Timeline {
     /// Returns the canvas height in pixels.
     pub fn canvas_height(&self) -> u32 {
         self.canvas_height
+    }
+
+    /// Returns the canvas dimensions **only when explicitly set** via
+    /// [`TimelineBuilder::canvas`], or `None` when they were auto-probed from the
+    /// first clip. Consumers that reframe to a deliberate output aspect (e.g. the
+    /// real-time preview) use this to distinguish an intended canvas from a default.
+    pub fn explicit_canvas(&self) -> Option<(u32, u32)> {
+        if self.canvas_explicit {
+            Some((self.canvas_width, self.canvas_height))
+        } else {
+            None
+        }
     }
 
     /// Returns the frame rate in frames per second.
@@ -190,6 +206,7 @@ impl Timeline {
         let Timeline {
             canvas_width,
             canvas_height,
+            canvas_explicit: _,
             frame_rate,
             video_tracks,
             audio_tracks,
@@ -683,11 +700,13 @@ impl TimelineBuilder {
             return Err(PipelineError::NoInput);
         }
 
+        let canvas_explicit = self.canvas_width.is_some() && self.canvas_height.is_some();
         let (canvas_width, canvas_height, frame_rate) = self.resolve_canvas_and_fps()?;
 
         Ok(Timeline {
             canvas_width,
             canvas_height,
+            canvas_explicit,
             frame_rate,
             video_tracks: self.video_tracks,
             audio_tracks: self.audio_tracks,

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -426,6 +426,7 @@ impl TimelinePlayer {
             active_audio_thread: initial_audio_thread,
             composer: None,
             composer_key: Vec::new(),
+            canvas: timeline.explicit_canvas(),
         };
 
         let handle = PlayerHandle::for_timeline(

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -84,6 +84,11 @@ pub struct TimelineRunner {
     /// Identifies the composer's current configuration as
     /// `(layer_id, active_clip_idx, width, height)` per layer. Rebuild on change.
     pub(super) composer_key: Vec<(usize, usize, u32, u32)>,
+    /// Project output canvas, when the timeline set one explicitly. When `Some`,
+    /// every composited frame is letterboxed to these dimensions so the preview
+    /// matches the project's output aspect. `None` composites at the base clip's
+    /// own size (legacy behaviour).
+    pub(super) canvas: Option<(u32, u32)>,
 }
 
 impl TimelineRunner {
@@ -179,7 +184,7 @@ impl TimelineRunner {
             key.push((li + 1, oc.active, ow, oh));
         }
         if self.composer.is_none() || self.composer_key != key {
-            self.composer = RealtimeComposer::new(&specs).ok();
+            self.composer = RealtimeComposer::with_canvas(&specs, self.canvas).ok();
             self.composer_key = if self.composer.is_some() {
                 key
             } else {
@@ -628,8 +633,11 @@ impl TimelineRunner {
                             // composited with overlay-layer content for every missing
                             // frame period so that V2 overlays and audio-only tracks
                             // remain live during the gap.
-                            let gw = self.last_frame_w;
-                            let gh = self.last_frame_h;
+                            // With an explicit canvas, fill gaps at the canvas size so
+                            // the preview frame size stays constant across gaps.
+                            let (gw, gh) = self
+                                .canvas
+                                .unwrap_or((self.last_frame_w, self.last_frame_h));
                             let n = (gw * gh * 4) as usize;
                             'gap: loop {
                                 // Drain incoming commands.


### PR DESCRIPTION
## Summary

The real-time preview (`TimelineRunner`) ignored the `Timeline` canvas — it composited onto the primary clip's decoded dimensions and never read the canvas, so a project's output aspect (9:16, 1:1, 4:5, …) could not be previewed even though export honored it. This makes the preview letterbox/pillarbox the composited frame to an explicitly-set canvas, so the preview frame size matches the project's output aspect.

## Changes

- **`ff-pipeline`**: `Timeline` now records whether the canvas was set explicitly via `TimelineBuilder::canvas` (`canvas_explicit`) and exposes `Timeline::explicit_canvas() -> Option<(u32, u32)>`. Returns `None` when the canvas was auto-probed from the first clip, so a defaulted canvas does not change behaviour.
- **`ff-filter`**: added `RealtimeComposer::with_canvas(layers, Option<(w, h)>)`; `new` delegates with `None` (unchanged). `build_realtime_composition` appends, when a canvas is set, a `scale(force_original_aspect_ratio=decrease:force_divisible_by=2)` + centre-`pad` at the tail of the composite. Runtime expressions keep it correct regardless of the accumulator's actual size (per-clip effects may have resized it).
- **`ff-preview`**: `TimelineRunner` stores `canvas: Option<(u32, u32)>` (from `timeline.explicit_canvas()` in `TimelinePlayer::open`), passes it to `RealtimeComposer::with_canvas`, and fills inter-clip gaps at the canvas size. `composite_frame` already returns the real output dimensions, so canvas-sized frames reach the sink.
- Policy is a fit (letterbox/pillarbox) to the canvas; per-clip fit/fill remains a caller concern.
- Test: `with_canvas_letterboxes_output_to_canvas_size` (16:9 base → 1080×1920 letterboxed output). The `canvas = None` path is unchanged.

## Related Issues

Closes #1263

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes