### PR TITLE
fix(ff-filter): crop view read-back overruns parent buffer (segfault)

### DIFF
--- a/crates/ff-filter/src/filter_inner/convert.rs
+++ b/crates/ff-filter/src/filter_inner/convert.rs
@@ -261,26 +261,50 @@ pub(super) unsafe fn av_frame_to_video_frame(raw_frame: *const AVFrame) -> Resul
             return Err(());
         }
         let linesize_raw = (*raw_frame).linesize[i];
-        // Some filters (e.g. `vflip`) produce frames with a negative linesize to
-        // indicate a bottom-up scan order. `data[i]` then points to the last row,
-        // and each successive row is at a lower address. We take the absolute
-        // stride, seek back to the first row, and copy the contiguous data block.
         let stride = linesize_raw.unsigned_abs() as usize;
         let rows = plane_height(format, i, height as usize);
-        let byte_count = stride * rows;
-        let data_ptr = if linesize_raw < 0 {
-            // SAFETY: The full plane is `stride * rows` bytes.  With a negative
-            // linesize `data[i]` sits at the start of the *last* row; offsetting
-            // by `linesize_raw * (rows - 1)` steps back to the first row so we
-            // can read the whole block in one contiguous slice.
-            src_ptr.offset(linesize_raw as isize * (rows as isize - 1))
+
+        let data = if linesize_raw < 0 {
+            // Some filters (e.g. `vflip`) produce frames with a negative linesize to
+            // indicate a bottom-up scan order. `data[i]` then points to the last row,
+            // and each successive row is at a lower address. Seek back to the first
+            // row and copy the whole contiguous block (preserved behaviour).
+            //
+            // SAFETY: with a negative linesize `data[i]` sits at the start of the
+            // *last* row; offsetting by `linesize_raw * (rows - 1)` steps back to the
+            // first row so the `stride * rows` slice covers the full plane.
+            let data_ptr = src_ptr.offset(linesize_raw as isize * (rows as isize - 1));
+            std::slice::from_raw_parts(data_ptr, stride * rows).to_vec()
         } else {
-            src_ptr
+            // Positive linesize: copy only the *valid* bytes of each row, not the
+            // full padded `stride`. A `crop` filter returns a view whose `data[i]`
+            // is offset into a larger parent allocation while `linesize` stays the
+            // parent's; reading `stride * rows` from the offset pointer would run
+            // past the parent buffer by the offset and segfault (issue: large crop
+            // offset after an up-scale). Reading `row_bytes ≤ stride` per row keeps
+            // the last row within bounds. `stride` is preserved so downstream stride
+            // math is unchanged; inter-row padding is left zeroed (never read).
+            let row_bytes = {
+                let n = ff_sys::av_image_get_linesize((*raw_frame).format, width as i32, i as i32);
+                if n > 0 {
+                    (n as usize).min(stride)
+                } else {
+                    stride
+                }
+            };
+            let mut buf = vec![0u8; stride * rows];
+            for row in 0..rows {
+                // SAFETY: source row `row` starts at `src_ptr + row * stride` and has
+                // at least `row_bytes` valid bytes; the dst slice is inside `buf`.
+                std::ptr::copy_nonoverlapping(
+                    src_ptr.add(row * stride),
+                    buf.as_mut_ptr().add(row * stride),
+                    row_bytes,
+                );
+            }
+            buf
         };
 
-        // SAFETY: `av_frame_get_buffer` / `av_buffersink_get_frame` guarantees
-        // at least `stride * rows` bytes starting at `data_ptr`.
-        let data = std::slice::from_raw_parts(data_ptr, byte_count).to_vec();
         planes.push(PooledBuffer::standalone(data));
         strides.push(stride);
     }

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -222,6 +222,57 @@ mod tests {
     }
 
     #[test]
+    fn base_layer_large_scale_then_offset_crop_does_not_overrun() {
+        // Regression: a large up-`Scale` followed by a `Crop` with a large centre
+        // offset used to segfault when reading back the composited frame — the crop
+        // view's `data[i]` is offset into the scaled buffer while its linesize stays
+        // the parent's, so copying `stride * rows` overran the buffer by the offset.
+        // 640×360 → scale 3412×1920 → crop 1080×1920 at x=1166 (centre).
+        let base = RealtimeLayer {
+            width: 640,
+            height: 360,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![
+                FilterStep::Scale {
+                    width: 3412,
+                    height: 1920,
+                    algorithm: crate::graph::types::ScaleAlgorithm::Bicubic,
+                },
+                FilterStep::Crop {
+                    x: 1166,
+                    y: 0,
+                    width: 1080,
+                    height: 1920,
+                },
+            ],
+            opacity: 1.0,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = match RealtimeComposer::new(&[base]) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        let frame = VideoFrame::from_rgba(640, 360, vec![120u8; 640 * 360 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                assert_eq!(out.width(), 1080);
+                assert_eq!(out.height(), 1920);
+                let rgba = out.to_rgba().expect("rgba");
+                assert_eq!(rgba.len(), 1080 * 1920 * 4);
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn two_layer_composite_should_produce_rgba_frame() {
         // 4×4 RGBA base + overlay; skip-guard on FFmpeg availability.
         let layer = |op: f32| RealtimeLayer {

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -714,6 +714,14 @@ pub unsafe fn av_buffersink_get_time_base(_ctx: *const AVFilterContext) -> AVRat
     AVRational { num: 0, den: 1 }
 }
 
+pub unsafe fn av_image_get_linesize(
+    _pix_fmt: AVPixelFormat,
+    _width: c_int,
+    _plane: c_int,
+) -> c_int {
+    0
+}
+
 /// Stub `avformat` wrapper module.
 pub mod avformat {
     use std::os::raw::c_int;


### PR DESCRIPTION
## Summary

Reading a filtered video frame back into a `VideoFrame` could segfault (or silently return corrupt pixels) when the last filter was a `crop` positioned with a large offset — e.g. an up-`scale` followed by a centre `crop`. The read-back assumed the frame's data was a single contiguous block starting at `data[i]`, but a `crop` returns a *view*.

## Changes

- **Root cause** (`crates/ff-filter/src/filter_inner/convert.rs`, `av_frame_to_video_frame`): `crop` offsets `data[i]` into the parent (e.g. scaled) allocation while leaving `linesize` at the parent's value. The read-back copied `stride * rows` bytes from the offset `data[i]`, running past the parent buffer by the offset — a small offset lands in adjacent mapped memory (no crash, wrong pixels); a large one hits an unmapped page and segfaults. `x = 0` happened to read exactly to the buffer end, so it never crashed.
- **Fix**: for a positive `linesize`, copy only each row's valid bytes — `av_image_get_linesize(fmt, width, plane)`, clamped to `stride` — instead of the full padded `stride`, so the final row stays within the parent buffer. `stride` is preserved (downstream stride math unchanged) and inter-row padding is left zeroed (it is never read). The negative-`linesize` path (e.g. `vflip`) is unchanged.
- **Test**: `base_layer_large_scale_then_offset_crop_does_not_overrun` in `realtime_composer.rs` drives `Scale{3412,1920}` + `Crop{x:1166,y:0,1080,1920}` on a 640×360 input and asserts a 1080×1920 frame is produced without crashing (probe-gated on FFmpeg availability).

## Related Issues

Fixes #1264

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes