### PR TITLE
fix(ff-filter): apply FitToAspect pad in the realtime compositor

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -131,6 +131,11 @@ pub(crate) unsafe fn add_and_link_step(
             y,
             opacity,
         } => return add_overlay_image_step(graph, prev_ctx, path, x, y, *opacity, index),
+        FilterStep::FitToAspect {
+            width,
+            height,
+            color,
+        } => return add_fit_to_aspect_step(graph, prev_ctx, *width, *height, color, index),
         _ => {}
     }
 
@@ -318,6 +323,56 @@ pub(super) unsafe fn add_fit_to_aspect_pad(
         return Err(FilterError::BuildFailed);
     }
     Ok(ctx)
+}
+
+/// Build the full [`FilterStep::FitToAspect`] compound: a `scale`
+/// (`force_original_aspect_ratio=decrease`, preserving the source aspect) followed
+/// by a centre-[`pad`](add_fit_to_aspect_pad) onto the `width × height` canvas.
+///
+/// Dispatched from [`add_and_link_step`] so every caller — the single-source graph
+/// builder and the real-time compositor alike — gets both filters. (The compositor
+/// previously received only the `scale`, so the frame was never padded to the canvas.)
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same `AVFilterGraph`.
+pub(super) unsafe fn add_fit_to_aspect_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    width: u32,
+    height: u32,
+    color: &str,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let scale_filter = ff_sys::avfilter_get_by_name(c"scale".as_ptr());
+    if scale_filter.is_null() {
+        log::warn!("filter not found name=scale (fit_to_aspect)");
+        return Err(FilterError::BuildFailed);
+    }
+    let name =
+        std::ffi::CString::new(format!("fitscale{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let args_str = format!("w={width}:h={height}:force_original_aspect_ratio=decrease");
+    let args = std::ffi::CString::new(args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+
+    let mut scale_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut scale_ctx,
+        scale_filter,
+        name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=scale args={args_str}");
+        return Err(FilterError::BuildFailed);
+    }
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, scale_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    add_fit_to_aspect_pad(graph, scale_ctx, width, height, color, index)
 }
 
 // ── Speed (atempo chain) ──────────────────────────────────────────────────────
@@ -2329,20 +2384,8 @@ impl FilterGraphInner {
                 };
             }
 
-            // FitToAspect is a compound step: the scale filter (added by
-            // add_and_link_step above) preserves the source aspect ratio; the
-            // pad filter added here centres the scaled frame on the target canvas.
-            if let FilterStep::FitToAspect {
-                width,
-                height,
-                color,
-            } = step
-            {
-                prev_ctx = match add_fit_to_aspect_pad(graph, prev_ctx, *width, *height, color, i) {
-                    Ok(ctx) => ctx,
-                    Err(e) => bail!(e),
-                };
-            }
+            // FitToAspect (scale + centre-pad) is built as a single compound step
+            // by `add_and_link_step` above, so no extra pad is added here.
 
             // LumaKey with invert=true appends a geq filter that negates the
             // alpha channel, turning the "key out pixels matching threshold"

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -273,6 +273,46 @@ mod tests {
     }
 
     #[test]
+    fn base_layer_fit_to_aspect_is_scaled_and_padded() {
+        // Regression: `FitToAspect` is a compound scale+pad. The realtime compositor
+        // used to apply only the scale, so the frame was never padded to the target
+        // canvas. A 640×360 (16:9) base fitted to 1080×1920 (9:16) must be scaled to
+        // fit (1080×608) *and* padded to the full 1080×1920, not left at 1080×608.
+        let base = RealtimeLayer {
+            width: 640,
+            height: 360,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::FitToAspect {
+                width: 1080,
+                height: 1920,
+                color: "black".to_string(),
+            }],
+            opacity: 1.0,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = match RealtimeComposer::new(&[base]) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        let frame = VideoFrame::from_rgba(640, 360, vec![120u8; 640 * 360 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                assert_eq!(out.width(), 1080);
+                assert_eq!(out.height(), 1920);
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn two_layer_composite_should_produce_rgba_frame() {
         // 4×4 RGBA base + overlay; skip-guard on FFmpeg availability.
         let layer = |op: f32| RealtimeLayer {


### PR DESCRIPTION
## Summary

`FilterStep::FitToAspect` is a compound step (scale preserving AR + centre-pad), but the real-time compositor applied only the scale — the pad was dropped, so the output was the scaled-down size instead of the target canvas. A preview using `FitToAspect` therefore diverged from the (correctly padded) export.

## Changes

- **Root cause** (`crates/ff-filter/src/filter_inner/build.rs`): `add_and_link_step` dispatches the other single-stream compound steps (`Glow`, `FeatherMask`, `OverlayImage`) to dedicated builders, but `FitToAspect` fell through to the single-filter path — where `filter_name()` is `"scale"` and `args()` is only the scale arguments — so only the scale was built. The realtime compositor drives steps straight through `add_and_link_step`, so it never got the pad.
- **Fix**: added `add_fit_to_aspect_step`, which chains `scale (force_original_aspect_ratio=decrease)` → centre-`pad` (reusing `add_fit_to_aspect_pad`), and dispatched `FitToAspect` to it in `add_and_link_step`. The compound is now built in one place for every caller (single-source graph builder and realtime compositor alike).
- Removed the single-source graph builder's separate post-scale pad step, which would otherwise double-pad now that `add_and_link_step` builds the full compound.
- **Test**: `base_layer_fit_to_aspect_is_scaled_and_padded` in `realtime_composer.rs` — a 640×360 base fitted to 1080×1920 now pulls a 1080×1920 frame (scaled + padded), not 1080×608. Existing single-source `FitToAspect` tests still pass, confirming no double-pad.

## Related Issues

Fixes #1265

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes