### PR TITLE
feat(ff-filter): scale OverlayImage and escape movie filter paths

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -130,7 +130,21 @@ pub(crate) unsafe fn add_and_link_step(
             x,
             y,
             opacity,
-        } => return add_overlay_image_step(graph, prev_ctx, path, x, y, *opacity, index),
+            width,
+            height,
+        } => {
+            return add_overlay_image_step(
+                graph,
+                prev_ctx,
+                path,
+                x,
+                y,
+                *opacity,
+                width.as_deref(),
+                height.as_deref(),
+                index,
+            );
+        }
         FilterStep::FitToAspect {
             width,
             height,
@@ -625,8 +639,19 @@ pub(crate) unsafe fn add_asetrate_resample_chain(
 #[cfg(test)]
 mod tests {
     use super::decompose_atempo;
+    use super::escape_movie_path;
     use super::overlay_alpha_suffix;
     use ff_format::AlphaMode;
+
+    #[test]
+    fn escape_movie_path_escapes_windows_drive_and_backslashes() {
+        // Windows absolute path: backslashes → '/', drive colon escaped as '\:'.
+        assert_eq!(escape_movie_path(r"D:\dir\logo.png"), r"D\:/dir/logo.png");
+        // POSIX path is unchanged (no backslashes, no colon).
+        assert_eq!(escape_movie_path("/home/u/logo.png"), "/home/u/logo.png");
+        // Relative path is unchanged.
+        assert_eq!(escape_movie_path("logo.png"), "logo.png");
+    }
 
     #[test]
     fn overlay_alpha_suffix_should_append_only_for_premultiplied() {
@@ -710,6 +735,17 @@ mod tests {
 
 // ── Overlay image compound step ───────────────────────────────────────────────
 
+/// Escapes a filesystem path for a `movie` filter `filename=` argument.
+///
+/// The `movie` filter's arguments are a `:`-separated option list, so a raw
+/// Windows path (`D:\dir\logo.png`) would be split at the drive colon and fail
+/// to parse. Normalise backslashes to `/` (accepted on Windows) and escape any
+/// remaining `:` as `\:`. Mirrors the convention used for regular-file `movie`
+/// sources in `composition_inner`.
+fn escape_movie_path(path: &str) -> String {
+    path.replace('\\', "/").replace(':', "\\:")
+}
+
 /// Insert the compound `movie → lut → overlay` filter chain for an
 /// [`FilterStep::OverlayImage`] step.
 ///
@@ -726,6 +762,7 @@ mod tests {
 ///
 /// `graph` and `prev_ctx` must be valid pointers owned by the same
 /// `AVFilterGraph`.
+#[allow(clippy::too_many_arguments)]
 pub(super) unsafe fn add_overlay_image_step(
     graph: *mut ff_sys::AVFilterGraph,
     prev_ctx: *mut ff_sys::AVFilterContext,
@@ -733,6 +770,8 @@ pub(super) unsafe fn add_overlay_image_step(
     x: &str,
     y: &str,
     opacity: f32,
+    width: Option<&str>,
+    height: Option<&str>,
     index: usize,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
     use std::ffi::CString;
@@ -744,8 +783,11 @@ pub(super) unsafe fn add_overlay_image_step(
         return Err(FilterError::BuildFailed);
     }
     let movie_name = CString::new(format!("movie{index}")).map_err(|_| FilterError::BuildFailed)?;
+    // Escape the path for the `movie` filter's `:`-separated option parser: a raw
+    // Windows path (`D:\dir\logo.png`) would otherwise break at the drive colon.
+    let escaped_path = escape_movie_path(path);
     let movie_args =
-        CString::new(format!("filename={path}")).map_err(|_| FilterError::BuildFailed)?;
+        CString::new(format!("filename={escaped_path}")).map_err(|_| FilterError::BuildFailed)?;
     let mut movie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
     let ret = ff_sys::avfilter_graph_create_filter(
         &raw mut movie_ctx,
@@ -756,10 +798,10 @@ pub(super) unsafe fn add_overlay_image_step(
         graph,
     );
     if ret < 0 {
-        log::warn!("filter creation failed name=movie args=filename={path}");
+        log::warn!("filter creation failed name=movie args=filename={escaped_path}");
         return Err(FilterError::BuildFailed);
     }
-    log::debug!("filter added name=movie args=filename={path} index={index}");
+    log::debug!("filter added name=movie args=filename={escaped_path} index={index}");
 
     // 2. lut filter — scale the alpha channel: a = val * opacity.
     //    For 8-bit RGBA the `lut` filter operates per-channel; `val` is the
@@ -787,8 +829,47 @@ pub(super) unsafe fn add_overlay_image_step(
     }
     log::debug!("filter added name=lut args={lut_args_str} index={index}");
 
-    // Link: movie → lut (alpha scaling).
-    let ret = ff_sys::avfilter_link(movie_ctx, 0, lut_ctx, 0);
+    // Optional scale on the image branch: movie → scale → lut. When neither
+    // width nor height is set, link movie → lut directly (native size — the
+    // original, unscaled behaviour). When either is set, the missing dimension
+    // defaults to `-1` so the `scale` filter preserves aspect ratio.
+    let image_src_ctx = if width.is_some() || height.is_some() {
+        let scale_filter = ff_sys::avfilter_get_by_name(c"scale".as_ptr());
+        if scale_filter.is_null() {
+            log::warn!("filter not found name=scale (overlay_image)");
+            return Err(FilterError::BuildFailed);
+        }
+        let scale_name =
+            CString::new(format!("ovscale{index}")).map_err(|_| FilterError::BuildFailed)?;
+        let scale_args_str = format!("w={}:h={}", width.unwrap_or("-1"), height.unwrap_or("-1"));
+        let scale_args =
+            CString::new(scale_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+        let mut scale_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+        let ret = ff_sys::avfilter_graph_create_filter(
+            &raw mut scale_ctx,
+            scale_filter,
+            scale_name.as_ptr(),
+            scale_args.as_ptr(),
+            std::ptr::null_mut(),
+            graph,
+        );
+        if ret < 0 {
+            log::warn!("filter creation failed name=scale args={scale_args_str} (overlay_image)");
+            return Err(FilterError::BuildFailed);
+        }
+        log::debug!("filter added name=scale args={scale_args_str} index={index} (overlay_image)");
+        // Link: movie → scale.
+        let ret = ff_sys::avfilter_link(movie_ctx, 0, scale_ctx, 0);
+        if ret < 0 {
+            return Err(FilterError::BuildFailed);
+        }
+        scale_ctx
+    } else {
+        movie_ctx
+    };
+
+    // Link: image source (movie, or movie → scale) → lut (alpha scaling).
+    let ret = ff_sys::avfilter_link(image_src_ctx, 0, lut_ctx, 0);
     if ret < 0 {
         return Err(FilterError::BuildFailed);
     }
@@ -2169,9 +2250,21 @@ impl FilterGraphInner {
                 x,
                 y,
                 opacity,
+                width,
+                height,
             } = step
             {
-                prev_ctx = match add_overlay_image_step(graph, prev_ctx, path, x, y, *opacity, i) {
+                prev_ctx = match add_overlay_image_step(
+                    graph,
+                    prev_ctx,
+                    path,
+                    x,
+                    y,
+                    *opacity,
+                    width.as_deref(),
+                    height.as_deref(),
+                    i,
+                ) {
                     Ok(ctx) => ctx,
                     Err(e) => bail!(e),
                 };

--- a/crates/ff-filter/src/graph/builder/video/geometry.rs
+++ b/crates/ff-filter/src/graph/builder/video/geometry.rs
@@ -123,6 +123,36 @@ impl FilterGraphBuilder {
             x: x.to_owned(),
             y: y.to_owned(),
             opacity,
+            width: None,
+            height: None,
+        });
+        self
+    }
+
+    /// Composite a PNG image over video, scaled to `width`×`height`.
+    ///
+    /// Identical to [`overlay_image`](Self::overlay_image) but inserts a `scale`
+    /// filter on the image branch (`movie → scale → lut → overlay`), sizing the
+    /// overlay before compositing. `width`/`height` are `FFmpeg` `scale`
+    /// expression strings — e.g. `"300"`, `"iw*0.15"` — and `"-1"` preserves the
+    /// aspect ratio of the other dimension.
+    #[must_use]
+    pub fn overlay_image_scaled(
+        mut self,
+        path: &str,
+        x: &str,
+        y: &str,
+        opacity: f32,
+        width: &str,
+        height: &str,
+    ) -> Self {
+        self.steps.push(FilterStep::OverlayImage {
+            path: path.to_owned(),
+            x: x.to_owned(),
+            y: y.to_owned(),
+            opacity,
+            width: Some(width.to_owned()),
+            height: Some(height.to_owned()),
         });
         self
     }
@@ -514,6 +544,8 @@ mod tests {
             x: "10".to_owned(),
             y: "10".to_owned(),
             opacity: 1.0,
+            width: None,
+            height: None,
         };
         assert_eq!(step.filter_name(), "overlay");
     }
@@ -525,8 +557,55 @@ mod tests {
             x: "W-w-10".to_owned(),
             y: "H-h-10".to_owned(),
             opacity: 0.7,
+            width: None,
+            height: None,
         };
         assert_eq!(step.args(), "W-w-10:H-h-10");
+    }
+
+    #[test]
+    fn builder_overlay_image_defaults_to_native_size() {
+        // The plain `overlay_image` builder must not request any scaling — the
+        // image composites at its native resolution (width/height are None).
+        let steps = FilterGraph::builder()
+            .overlay_image("logo.png", "10", "10", 1.0)
+            .steps()
+            .to_vec();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            FilterStep::OverlayImage { width, height, .. } => {
+                assert!(width.is_none());
+                assert!(height.is_none());
+            }
+            other => panic!("expected OverlayImage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn builder_overlay_image_scaled_carries_size_exprs() {
+        // `overlay_image_scaled` records the scale expressions on the step; the
+        // filter name / positional args are unchanged (scale is a separate node
+        // on the image branch, built by `add_overlay_image_step`).
+        let steps = FilterGraph::builder()
+            .overlay_image_scaled("logo.png", "W-w-10", "H-h-10", 0.8, "iw*0.15", "-1")
+            .steps()
+            .to_vec();
+        assert_eq!(steps.len(), 1);
+        match &steps[0] {
+            FilterStep::OverlayImage {
+                width,
+                height,
+                opacity,
+                ..
+            } => {
+                assert_eq!(width.as_deref(), Some("iw*0.15"));
+                assert_eq!(height.as_deref(), Some("-1"));
+                assert!((*opacity - 0.8).abs() < 1e-6);
+            }
+            other => panic!("expected OverlayImage, got {other:?}"),
+        }
+        assert_eq!(steps[0].filter_name(), "overlay");
+        assert_eq!(steps[0].args(), "W-w-10:H-h-10");
     }
 
     #[test]

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -450,9 +450,10 @@ pub enum FilterStep {
     },
     /// Composite a PNG image (watermark / logo) over video with optional opacity.
     ///
-    /// This is a compound step: internally it creates a `movie` source,
-    /// a `lut` alpha-scaling filter, and an `overlay` compositing filter.
-    /// The image file is loaded once at graph construction time.
+    /// This is a compound step: internally it creates a `movie` source, an
+    /// optional `scale` filter, a `lut` alpha-scaling filter, and an `overlay`
+    /// compositing filter. The image file is loaded once at graph construction
+    /// time.
     OverlayImage {
         /// Absolute or relative path to the `.png` file.
         path: String,
@@ -462,6 +463,13 @@ pub enum FilterStep {
         y: String,
         /// Opacity 0.0 (fully transparent) to 1.0 (fully opaque).
         opacity: f32,
+        /// Optional overlay width as an `FFmpeg` `scale` expression, e.g. `"300"`
+        /// or `"iw*0.15"` (`iw`/`ih` are the overlay's own dimensions). `-1`
+        /// preserves aspect ratio. `None` keeps the image's native width.
+        width: Option<String>,
+        /// Optional overlay height as an `FFmpeg` `scale` expression. `-1`
+        /// preserves aspect ratio. `None` keeps the image's native height.
+        height: Option<String>,
     },
 
     /// Blend a `top` layer over the current stream (bottom) using the given mode.


### PR DESCRIPTION
## Summary

`FilterStep::OverlayImage` composited the PNG at its native resolution only — there was no way to size a watermark/logo relative to the frame. This adds optional `scale` on the image branch. While fixing it, the `movie` source path was found to be built unescaped, which breaks absolute Windows paths (`D:\…\logo.png`) at the drive colon; that is fixed too.

## Changes

- **OverlayImage scale**: `FilterStep::OverlayImage` gains optional `width` / `height` (`FFmpeg` `scale` expressions, e.g. `"300"` or `"iw*0.15"`; `-1` preserves aspect ratio; `None` = native size). `add_overlay_image_step` now builds `movie → scale → lut → overlay` when either is set — the missing dimension defaults to `-1` — and the original `movie → lut → overlay` otherwise. Both dispatch sites (`add_and_link_step` realtime path and the single-source export loop) thread the fields through.
- **Builder API**: new `FilterGraphBuilder::overlay_image_scaled(path, x, y, opacity, width, height)`; the existing `overlay_image` stays native (`width: None, height: None`) — backward compatible.
- **movie path escaping** (root cause: `filename={path}` was unescaped): new `escape_movie_path` helper normalises `\` → `/` and escapes `:` → `\:` (matching the regular-file `movie` convention already used in `composition_inner`), applied to the overlay `movie` source. Fixes overlay failure on absolute Windows paths; covers both preview and export via the single `add_overlay_image_step` chokepoint.
- No new `ff-sys` symbols (reuses `avfilter_get_by_name` / `_graph_create_filter` / `_link`), so the `#[cfg(docsrs)]` stub set is unchanged.
- **Tests**: `overlay_image` defaults to native size; `overlay_image_scaled` carries the size expressions (filter-name/args unchanged); `escape_movie_path` escapes Windows drive/backslashes and leaves POSIX/relative paths intact. Existing `OverlayImage` filter-name/args/validation tests still pass.

## Related Issues

Fixes #1269

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes