### PR TITLE
fix(ff-filter): escape subtitles and amovie filter paths

### DIFF
--- a/crates/ff-filter/src/analysis/analysis_inner.rs
+++ b/crates/ff-filter/src/analysis/analysis_inner.rs
@@ -45,7 +45,12 @@ pub(super) unsafe fn measure_loudness_unsafe(path: &Path) -> Result<LoudnessResu
         }};
     }
 
-    let path_str = path.to_string_lossy();
+    // Escape for the amovie filter's `:`-separated option parser (Windows drive
+    // colons / backslashes would otherwise break parsing).
+    let path_str = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
     let amovie_args =
         CString::new(format!("filename={path_str}")).map_err(|_| FilterError::AnalysisFailed {
             reason: "path contains null byte".to_string(),

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -735,13 +735,14 @@ mod tests {
 
 // ── Overlay image compound step ───────────────────────────────────────────────
 
-/// Escapes a filesystem path for a `movie` filter `filename=` argument.
+/// Escapes a filesystem path for a `movie` / `amovie` filter `filename=`
+/// argument.
 ///
-/// The `movie` filter's arguments are a `:`-separated option list, so a raw
-/// Windows path (`D:\dir\logo.png`) would be split at the drive colon and fail
-/// to parse. Normalise backslashes to `/` (accepted on Windows) and escape any
-/// remaining `:` as `\:`. Mirrors the convention used for regular-file `movie`
-/// sources in `composition_inner`.
+/// These filters' arguments are a `:`-separated option list, so a raw Windows
+/// path (`D:\dir\logo.png`) would be split at the drive colon and fail to parse.
+/// Normalise backslashes to `/` (accepted on Windows) and escape any remaining
+/// `:` as `\:`. Mirrors the convention used for regular-file `movie` sources in
+/// `composition_inner`.
 fn escape_movie_path(path: &str) -> String {
     path.replace('\\', "/").replace(':', "\\:")
 }
@@ -2920,7 +2921,9 @@ pub(super) unsafe fn add_reverb_ir_step(
     }
     let amovie_name =
         CString::new(format!("reverb_amovie{index}")).map_err(|_| FilterError::BuildFailed)?;
-    let amovie_args_str = format!("filename={ir_path}");
+    // Escape the IR path for the amovie filter's `:`-separated option parser
+    // (Windows drive colons / backslashes would otherwise break parsing).
+    let amovie_args_str = format!("filename={}", escape_movie_path(ir_path));
     let amovie_args =
         CString::new(amovie_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
     let mut amovie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();

--- a/crates/ff-filter/src/graph/builder/video/text.rs
+++ b/crates/ff-filter/src/graph/builder/video/text.rs
@@ -267,6 +267,20 @@ mod tests {
     }
 
     #[test]
+    fn filter_step_subtitles_args_escape_windows_path() {
+        // A Windows absolute path must be escaped for the filter's `:`-separated
+        // option parser: backslashes → '/', drive colon → '\:'.
+        let step = FilterStep::SubtitlesSrt {
+            path: r"C:\subs\ep1.srt".to_owned(),
+        };
+        assert_eq!(step.args(), r"filename=C\:/subs/ep1.srt");
+        let step = FilterStep::SubtitlesAss {
+            path: r"D:\subs\ep1.ass".to_owned(),
+        };
+        assert_eq!(step.args(), r"filename=D\:/subs/ep1.ass");
+    }
+
+    #[test]
     fn builder_subtitles_srt_with_wrong_extension_should_return_invalid_config() {
         let result = FilterGraph::builder()
             .subtitles_srt("subtitles.vtt")

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -1323,7 +1323,11 @@ impl FilterStep {
                 format!("loop={loop_count}:size=1:start={start}")
             }
             Self::SubtitlesSrt { path } | Self::SubtitlesAss { path } => {
-                format!("filename={path}")
+                // Escape for the filter's `:`-separated option parser: normalise
+                // backslashes to `/` and escape the drive colon, else an absolute
+                // Windows path (`C:\subs.srt`) breaks parsing at the colon.
+                let escaped = path.replace('\\', "/").replace(':', "\\:");
+                format!("filename={escaped}")
             }
             // args() for OverlayImage returns the overlay positional args (x:y).
             // These are not consumed by add_and_link_step (which is bypassed for


### PR DESCRIPTION
## Summary

Several path-taking filters built their `filename=` argument by raw interpolation, so an absolute Windows path (`C:\subs.srt`, `D:\ir.wav`) broke the filter option parser at the drive colon and filter creation failed. This escapes the path for the `subtitles`/`ass` and `amovie` sources, matching the convention already used for `movie`/`amovie` in `composition_inner`.

## Changes

- **Root cause**: filter arguments are a `:`-separated option list (parsed by `av_get_token` in `avfilter_init_str`); an unescaped `C:\…` splits at the colon and the trailing `\…` is read as a bogus option. Fix: normalise `\` → `/` (accepted on Windows) and escape any remaining `:` as `\:`.
- **subtitles / ass** (`graph/filter_step.rs`): escape the path in `FilterStep::args()` — the value flows straight into `avfilter_graph_create_filter` via the generic `add_and_link_step` path, so single-pass escaping here is correct.
- **reverb IR amovie** (`filter_inner/build.rs`, `add_reverb_ir_step`): reuse the `escape_movie_path` helper (its doc broadened to cover `movie` / `amovie`).
- **loudness amovie** (`analysis/analysis_inner.rs`, ebur128): normalise/escape inline.
- Already-correct sites left as-is: `composition_inner` movie/amovie (main video, audio, concat) and ff-decode `silencedetect` already escape — this is why timeline preview/export work on Windows.
- No new `ff-sys` symbols; docsrs stub set unchanged.
- **Tests**: `filter_step_subtitles_args_escape_windows_path` asserts SRT + ASS Windows-path escaping; existing plain-name subtitles args tests still pass.

Remaining unescaped plain `movie=` sources (VMAF/SSIM metrics, `vidstabdetect`, GIF/preview, ff-decode video analysis) are the same bug class but out of scope here; noted for a follow-up.

## Related Issues

Fixes #1271

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes