### PR TITLE
fix(ff-filter): escape remaining movie filter paths

### DIFF
--- a/crates/ff-filter/src/analysis/analysis_inner.rs
+++ b/crates/ff-filter/src/analysis/analysis_inner.rs
@@ -257,8 +257,16 @@ pub(super) unsafe fn compute_ssim_unsafe(
         }};
     }
 
-    let ref_str = reference.to_string_lossy();
-    let dist_str = distorted.to_string_lossy();
+    // Escape paths for the movie filter's `:`-separated option parser (Windows
+    // drive colons / backslashes would otherwise break parsing).
+    let ref_str = reference
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
+    let dist_str = distorted
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
 
     let ref_args =
         CString::new(format!("filename={ref_str}")).map_err(|_| FilterError::AnalysisFailed {
@@ -471,8 +479,16 @@ pub(super) unsafe fn compute_psnr_unsafe(
         }};
     }
 
-    let ref_str = reference.to_string_lossy();
-    let dist_str = distorted.to_string_lossy();
+    // Escape paths for the movie filter's `:`-separated option parser (Windows
+    // drive colons / backslashes would otherwise break parsing).
+    let ref_str = reference
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
+    let dist_str = distorted
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
 
     let ref_args =
         CString::new(format!("filename={ref_str}")).map_err(|_| FilterError::AnalysisFailed {

--- a/crates/ff-filter/src/effects/effects_inner.rs
+++ b/crates/ff-filter/src/effects/effects_inner.rs
@@ -60,9 +60,17 @@ pub(super) unsafe fn analyze_vidstab_unsafe(
         });
     }
 
-    // Build CString args before allocating the graph.
-    let input_str = input.to_string_lossy();
-    let trf_str = output_trf.to_string_lossy();
+    // Build CString args before allocating the graph. Escape paths for the
+    // filter's `:`-separated option parser (movie `filename=` and vidstabdetect
+    // `result=`): Windows drive colons / backslashes would otherwise break it.
+    let input_str = input
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
+    let trf_str = output_trf
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
 
     let movie_args =
         CString::new(format!("filename={input_str}")).map_err(|_| FilterError::Ffmpeg {
@@ -294,8 +302,17 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     }
 
     // ── Build CString arguments before allocating the graph ───────────────────
-    let input_str = input.to_string_lossy();
-    let trf_str = trf_path.to_string_lossy();
+    // Escape paths for the filter's `:`-separated option parser (movie
+    // `filename=` and vidstabtransform `input=`): Windows drive colons /
+    // backslashes would otherwise break it.
+    let input_str = input
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
+    let trf_str = trf_path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace(':', "\\:");
 
     let movie_args =
         CString::new(format!("filename={input_str}")).map_err(|_| FilterError::Ffmpeg {


### PR DESCRIPTION
## Summary

Completes the filter-path escaping started for `subtitles`/`amovie` (#1271). The last unescaped `movie=` sources in `ff-filter` — video-quality metrics and both stabilizer passes — built their `filename=` (and vidstab `result=`/`input=`) arguments by raw interpolation, so an absolute Windows path (`D:\clip.mp4`) split at the drive colon and the filter failed to initialise. With this, all path-bearing filter arguments across `ff-filter` / `ff-decode` / `ff-encode` are escaped.

## Changes

- **Root cause**: filter arguments are a `:`-separated option list; an unescaped `D:\…` splits at the colon. Fix: normalise `\` → `/` and escape `:` → `\:` (the convention already used in `composition_inner`, `ff-decode`, `ff-encode`).
- **Quality metrics** (`analysis/analysis_inner.rs`): escape `reference` / `distorted` (`movie=filename=…`) in both quality functions.
- **Stabilization** (`effects/effects_inner.rs`): escape the `movie` `filename=` input **and** the `.trf` transform-data path — the latter is a filter option (`vidstabdetect result=` / `vidstabtransform input=`), so it has the same bug — in both passes.
- No new `ff-sys` symbols; docsrs stub set unchanged.

These are internal unsafe FFI graph builders with no pure surface to unit-test in isolation (same as the already-escaped `composition_inner` sites); the identical transformation is covered by the existing `escape_movie_path` helper test and the build/clippy gate.

## Related Issues

Fixes #1273

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes