### PR TITLE
feat(ff-filter): add force_style to SubtitlesSrt

### DIFF
--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -390,7 +390,7 @@ impl FilterGraphBuilder {
                     });
                 }
             }
-            if let FilterStep::SubtitlesSrt { path } = step {
+            if let FilterStep::SubtitlesSrt { path, .. } = step {
                 let ext = Path::new(path)
                     .extension()
                     .and_then(|e| e.to_str())

--- a/crates/ff-filter/src/graph/builder/video/text.rs
+++ b/crates/ff-filter/src/graph/builder/video/text.rs
@@ -57,6 +57,21 @@ impl FilterGraphBuilder {
     pub fn subtitles_srt(mut self, srt_path: &str) -> Self {
         self.steps.push(FilterStep::SubtitlesSrt {
             path: srt_path.to_owned(),
+            force_style: None,
+        });
+        self
+    }
+
+    /// Burn SRT subtitles with an ASS style override (`force_style`).
+    ///
+    /// Identical to [`subtitles_srt`](Self::subtitles_srt) but passes
+    /// `force_style` to the `subtitles` filter, e.g.
+    /// `"Fontsize=24,PrimaryColour=&H00FFFFFF&,Alignment=2"`.
+    #[must_use]
+    pub fn subtitles_srt_styled(mut self, srt_path: &str, force_style: &str) -> Self {
+        self.steps.push(FilterStep::SubtitlesSrt {
+            path: srt_path.to_owned(),
+            force_style: Some(force_style.to_owned()),
         });
         self
     }
@@ -254,6 +269,7 @@ mod tests {
     fn filter_step_subtitles_srt_should_produce_correct_filter_name() {
         let step = FilterStep::SubtitlesSrt {
             path: "subs.srt".to_owned(),
+            force_style: None,
         };
         assert_eq!(step.filter_name(), "subtitles");
     }
@@ -262,8 +278,21 @@ mod tests {
     fn filter_step_subtitles_srt_should_produce_correct_args() {
         let step = FilterStep::SubtitlesSrt {
             path: "subs.srt".to_owned(),
+            force_style: None,
         };
         assert_eq!(step.args(), "filename=subs.srt");
+    }
+
+    #[test]
+    fn filter_step_subtitles_srt_force_style_appended_to_args() {
+        let step = FilterStep::SubtitlesSrt {
+            path: "subs.srt".to_owned(),
+            force_style: Some("Fontsize=24,PrimaryColour=&H00FFFFFF&,Alignment=2".to_owned()),
+        };
+        assert_eq!(
+            step.args(),
+            "filename=subs.srt:force_style='Fontsize=24,PrimaryColour=&H00FFFFFF&,Alignment=2'"
+        );
     }
 
     #[test]
@@ -272,6 +301,7 @@ mod tests {
         // option parser: backslashes → '/', drive colon → '\:'.
         let step = FilterStep::SubtitlesSrt {
             path: r"C:\subs\ep1.srt".to_owned(),
+            force_style: None,
         };
         assert_eq!(step.args(), r"filename=C\:/subs/ep1.srt");
         let step = FilterStep::SubtitlesAss {

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -505,4 +505,56 @@ mod tests {
             Err(e) => println!("Skipping: {e}"),
         }
     }
+
+    #[test]
+    fn base_layer_with_srt_subtitles_builds_and_pulls() {
+        // Diagnostic/regression: a base layer carrying `SubtitlesSrt` (a generic,
+        // PTS-dependent filter) must build in the realtime composer and pull a
+        // frame — this is the path the demo preview uses (#138). Requires an
+        // FFmpeg built with libass; skip if the `subtitles` filter is absent.
+        unsafe {
+            if ff_sys::avfilter_get_by_name(c"subtitles".as_ptr()).is_null() {
+                println!("Skipping: subtitles filter unavailable (no libass)");
+                return;
+            }
+        }
+        // Write a tiny .srt whose first cue covers t=0 (pushed frame pts=0).
+        let srt = std::env::temp_dir().join("avio_rt_subs_test.srt");
+        if std::fs::write(&srt, "1\n00:00:00,000 --> 00:00:05,000\nhello subtitle\n").is_err() {
+            println!("Skipping: could not write temp .srt");
+            return;
+        }
+        let base = RealtimeLayer {
+            width: 320,
+            height: 240,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::SubtitlesSrt {
+                path: srt.to_string_lossy().into_owned(),
+                force_style: Some("Fontsize=24,PrimaryColour=&H00FFFFFF&,Alignment=2".to_owned()),
+            }],
+            opacity: 1.0,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = match RealtimeComposer::new(&[base]) {
+            Ok(c) => c,
+            Err(e) => {
+                // Build failure here is the bug we are hunting for (#138 preview).
+                panic!("realtime composer failed to build subtitles layer: {e}");
+            }
+        };
+        let frame = VideoFrame::from_rgba(320, 240, vec![40u8; 320 * 240 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                assert_eq!(out.format(), PixelFormat::Rgba);
+                assert_eq!(out.width(), 320);
+                assert_eq!(out.height(), 240);
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => panic!("pull failed for subtitles layer: {e}"),
+        }
+    }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -292,6 +292,11 @@ pub enum FilterStep {
     SubtitlesSrt {
         /// Absolute or relative path to the `.srt` file.
         path: String,
+        /// Optional ASS style override for the `subtitles` filter's `force_style`
+        /// option, e.g. `"Fontsize=24,PrimaryColour=&H00FFFFFF&,Alignment=2"`.
+        /// `None` uses the file's default styling. (The `ass` filter has no
+        /// `force_style`; ASS files carry their own styles.)
+        force_style: Option<String>,
     },
     /// Burn-in ASS/SSA styled subtitles using the `ass` filter.
     SubtitlesAss {
@@ -1322,10 +1327,21 @@ impl FilterStep {
                 let loop_count = (*duration * 25.0) as i64;
                 format!("loop={loop_count}:size=1:start={start}")
             }
-            Self::SubtitlesSrt { path } | Self::SubtitlesAss { path } => {
+            Self::SubtitlesSrt { path, force_style } => {
                 // Escape for the filter's `:`-separated option parser: normalise
                 // backslashes to `/` and escape the drive colon, else an absolute
                 // Windows path (`C:\subs.srt`) breaks parsing at the colon.
+                let escaped = path.replace('\\', "/").replace(':', "\\:");
+                match force_style {
+                    Some(fs) if !fs.is_empty() => {
+                        // Single-quote the style value so its `,`/`=` are read as
+                        // one option value by the parser.
+                        format!("filename={escaped}:force_style='{fs}'")
+                    }
+                    _ => format!("filename={escaped}"),
+                }
+            }
+            Self::SubtitlesAss { path } => {
                 let escaped = path.replace('\\', "/").replace(':', "\\:");
                 format!("filename={escaped}")
             }


### PR DESCRIPTION
## Summary

`FilterStep::SubtitlesSrt` exposed only the file path, so SRT subtitles burned via the `subtitles` filter could not be styled. This adds an optional `force_style` (the `subtitles` filter's own `force_style` option — an ASS style string), so callers can override font size, colour, and position. The `ass` filter has no `force_style` (ASS files carry their own styles), so this is SRT-only.

## Changes

- **`graph/filter_step.rs`**: `SubtitlesSrt` gains `force_style: Option<String>`. `args()` splits the previously-combined SRT/ASS arm; SRT keeps the path escaping and appends `:force_style='<fs>'` when `Some(non-empty)`, ASS unchanged.
- **`graph/builder/video/text.rs`**: new `subtitles_srt_styled(path, force_style)`; existing `subtitles_srt(path)` stays (`force_style: None`), backward compatible. Test updates + a `force_style` args test.
- **`graph/builder/mod.rs`**: validation destructures `{ path, .. }`.
- **`graph/composition/realtime_composer.rs`**: probe-gated regression test that a base layer carrying `SubtitlesSrt` builds in the realtime composer and pulls a frame (the preview path). Skips cleanly when the `subtitles` filter is absent (FFmpeg without libass), asserts build+pull when present.
- No new `ff-sys` symbols; docsrs stub set unchanged.

## Related Issues

Fixes #1275

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes