### PR TITLE
chore(toolchain): update Rust to 1.97.1

### DIFF
--- a/crates/ff-encode/src/video/builder/mod.rs
+++ b/crates/ff-encode/src/video/builder/mod.rs
@@ -771,10 +771,9 @@ impl VideoEncoder {
         #[allow(clippy::cast_precision_loss)]
         let current_bitrate = if !elapsed.is_zero() {
             let elapsed_secs = elapsed.as_secs();
-            if elapsed_secs > 0 {
-                (bytes_written * 8) / elapsed_secs
-            } else {
-                ((bytes_written * 8) as f64 / elapsed.as_secs_f64()) as u64
+            match (bytes_written * 8).checked_div(elapsed_secs) {
+                Some(bitrate) => bitrate,
+                None => ((bytes_written * 8) as f64 / elapsed.as_secs_f64()) as u64,
             }
         } else {
             0

--- a/crates/ff-pipeline/src/audio_pipeline.rs
+++ b/crates/ff-pipeline/src/audio_pipeline.rs
@@ -144,11 +144,7 @@ impl AudioPipeline {
             let mut adec = AudioDecoder::open(input).build()?;
             let mut last_end_secs = pts_offset_secs;
 
-            loop {
-                let Some(mut aframe) = adec.decode_one()? else {
-                    break;
-                };
-
+            while let Some(mut aframe) = adec.decode_one()? {
                 let ts = aframe.timestamp();
                 let new_pts = pts_offset_secs + ts.as_secs_f64();
                 let frame_dur = frame_duration_secs(aframe.samples(), sample_rate);

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -192,11 +192,7 @@ impl Pipeline {
 
             let mut last_frame_end_secs: f64 = pts_offset_secs;
 
-            loop {
-                let Some(mut raw_frame) = vdec.decode_one()? else {
-                    break;
-                };
-
+            while let Some(mut raw_frame) = vdec.decode_one()? {
                 // Rebase timestamp so this clip follows the previous one.
                 let ts = raw_frame.timestamp();
                 let new_pts_secs = pts_offset_secs + ts.as_secs_f64();

--- a/crates/ff-pipeline/src/video_pipeline.rs
+++ b/crates/ff-pipeline/src/video_pipeline.rs
@@ -214,11 +214,7 @@ impl VideoPipeline {
 
             let mut last_frame_end_secs: f64 = pts_offset_secs;
 
-            loop {
-                let Some(mut raw_frame) = vdec.decode_one()? else {
-                    break;
-                };
-
+            while let Some(mut raw_frame) = vdec.decode_one()? {
                 // Rebase timestamp so this clip follows the previous one.
                 let ts = raw_frame.timestamp();
                 let new_pts_secs = pts_offset_secs + ts.as_secs_f64();

--- a/crates/ff-preview/src/proxy/mod.rs
+++ b/crates/ff-preview/src/proxy/mod.rs
@@ -205,12 +205,10 @@ impl ProxyGenerator {
         let handle = std::thread::spawn(move || {
             self.generate_with_callback(move |p: &Progress| {
                 let v = p.total_frames.map_or(0u32, |total| {
-                    if total == 0 {
-                        0
-                    } else {
-                        let raw = p.frames_processed.saturating_mul(1000) / total;
+                    match p.frames_processed.saturating_mul(1000).checked_div(total) {
                         // raw is in 0..=1000 after the saturating division — fits in u32.
-                        u32::try_from(raw.min(1000)).unwrap_or(1000)
+                        Some(raw) => u32::try_from(raw.min(1000)).unwrap_or(1000),
+                        None => 0,
                     }
                 });
                 progress_clone.store(v, Ordering::Relaxed);

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -654,11 +654,9 @@ impl TimelineRunner {
                                         PlayerCommand::Stop => {
                                             self.stopped.store(true, Ordering::Release);
                                         }
-                                        PlayerCommand::SetRate(r) => {
-                                            if r > 0.0 {
-                                                self.rate = r;
-                                                self.clock.set_rate(r);
-                                            }
+                                        PlayerCommand::SetRate(r) if r > 0.0 => {
+                                            self.rate = r;
+                                            self.clock.set_rate(r);
                                         }
                                         _ => {}
                                     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
-components = ["rustfmt", "clippy"]
-targets = ["x86_64-unknown-linux-gnu"]
+channel = "1.97.1"
+components = ["rustfmt", "clippy", "rust-analyzer"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]


### PR DESCRIPTION
Bumps the pinned toolchain to **1.97.1** (from 1.93.0), adds `rust-analyzer` to components and `x86_64-pc-windows-msvc` to targets.

1.97's clippy enables a few new lints that hit existing code, fixed with no behavior change:

- `manual_checked_ops` to `checked_div` (bitrate calc, proxy progress)
- `while_let_loop` to `while let Some(..) = decode_one()?` (pipeline decode loops)
- `collapsible_match` with the guard folded into the match arm (`SetRate`)