### PR TITLE
chore(ci): move to stable toolchain and overhaul CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,11 +36,13 @@ Before contributing, make sure you have the following installed:
 **Rust toolchain**
 
 ```sh
-rustup toolchain install 1.93.0
+rustup toolchain install stable
 rustup component add rustfmt clippy
 ```
 
-The MSRV (Minimum Supported Rust Version) is **1.93.0**.
+Develop on the current stable toolchain. The MSRV (Minimum Supported Rust
+Version) is **1.93.0**; CI verifies the workspace still compiles on it, so
+avoid APIs newer than 1.93.0.
 
 **FFmpeg development libraries** (version **7.x required**)
 

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -1,0 +1,78 @@
+name: Setup FFmpeg (Linux)
+description: >
+  Install build dependencies and a cached, source-built FFmpeg 7.x on Linux,
+  then export PKG_CONFIG_PATH / LD_LIBRARY_PATH so ff-sys can link against it.
+  The tarball is verified against a pinned SHA-256 so a poisoned cache or
+  mirror cannot substitute a different FFmpeg build. Linux-only: macOS uses
+  Homebrew and Windows uses vcpkg, handled inline by the calling jobs.
+
+inputs:
+  version:
+    description: FFmpeg release version to build.
+    required: false
+    default: "7.1"
+  prefix:
+    description: Install prefix for the built FFmpeg.
+    required: false
+    default: /opt/ffmpeg7
+  sha256:
+    description: Expected SHA-256 of the FFmpeg source tarball.
+    required: false
+    default: 40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
+
+runs:
+  using: composite
+  steps:
+    - name: Install build dependencies
+      shell: bash
+      run: sudo apt-get install -y nasm pkg-config libclang-dev
+
+    - name: Cache FFmpeg ${{ inputs.version }}
+      id: cache-ffmpeg
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ inputs.prefix }}
+        # Keyed on the verified tarball hash so a poisoned cache cannot
+        # substitute a different FFmpeg build.
+        key: ffmpeg-${{ inputs.version }}-${{ inputs.sha256 }}-ubuntu-${{ runner.arch }}
+
+    - name: Build FFmpeg ${{ inputs.version }} from source
+      if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        FFMPEG_VERSION: ${{ inputs.version }}
+        FFMPEG_PREFIX: ${{ inputs.prefix }}
+        FFMPEG_SHA256: ${{ inputs.sha256 }}
+      run: |
+        set -euo pipefail
+        wget -q "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        echo "${FFMPEG_SHA256}  ffmpeg-${FFMPEG_VERSION}.tar.xz" | sha256sum -c -
+        tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        cd "ffmpeg-${FFMPEG_VERSION}"
+        ./configure \
+          --prefix="${FFMPEG_PREFIX}" \
+          --disable-programs \
+          --disable-doc \
+          --disable-everything \
+          --enable-avcodec \
+          --enable-avformat \
+          --enable-avutil \
+          --enable-swscale \
+          --enable-swresample \
+          --enable-avfilter \
+          --enable-decoder=h264,aac,mp3,flac,vorbis,opus,pcm_s16le,pcm_f32le \
+          --enable-encoder=aac,pcm_s16le,mpeg4 \
+          --enable-demuxer=mov,mp4,matroska,mp3,flac,ogg,wav,srt \
+          --enable-muxer=ipod,mp4,mov,matroska \
+          --enable-parser=h264,aac,mpegaudio,flac,vorbis,opus \
+          --enable-protocol=file \
+          --enable-shared \
+          --disable-static
+        make -j"$(nproc)"
+        sudo make install
+
+    - name: Export FFmpeg environment
+      shell: bash
+      run: |
+        echo "PKG_CONFIG_PATH=${{ inputs.prefix }}/lib/pkgconfig" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=${{ inputs.prefix }}/lib" >> "$GITHUB_ENV"

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -45,7 +45,10 @@ runs:
         FFMPEG_SHA256: ${{ inputs.sha256 }}
       run: |
         set -euo pipefail
-        wget -q "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+        # Retry: on a cold cache several jobs fetch concurrently and ffmpeg.org
+        # occasionally refuses a connection (wget exits 4). Back off and retry.
+        wget -q --tries=5 --retry-connrefused --waitretry=15 --timeout=30 \
+          "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
         echo "${FFMPEG_SHA256}  ffmpeg-${FFMPEG_VERSION}.tar.xz" | sha256sum -c -
         tar xf "ffmpeg-${FFMPEG_VERSION}.tar.xz"
         cd "ffmpeg-${FFMPEG_VERSION}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on the same PR/branch; never cancel pushes to main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  FFMPEG_VERSION: "7.1"
-  FFMPEG_PREFIX: /opt/ffmpeg7
 
 jobs:
   # --------------------------------------------------------------------------
@@ -21,68 +24,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93.0"
           components: rustfmt
       - run: cargo fmt --all -- --check
 
   # --------------------------------------------------------------------------
-  # Clippy (FFmpeg headers required for bindgen)
+  # Clippy on the full feature set (FFmpeg headers required for bindgen)
   # --------------------------------------------------------------------------
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Install build dependencies
-        run: sudo apt-get install -y nasm pkg-config libclang-dev
-      - name: Cache FFmpeg 7.x
-        id: cache-ffmpeg
-        uses: actions/cache@v6
+      - uses: ./.github/actions/setup-ffmpeg
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          path: ${{ env.FFMPEG_PREFIX }}
-          key: ffmpeg-${{ env.FFMPEG_VERSION }}-ubuntu-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml') }}
-      - name: Build FFmpeg 7.x from source
-        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: |
-          wget -q https://ffmpeg.org/releases/ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          tar xf ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          cd ffmpeg-${{ env.FFMPEG_VERSION }}
-          ./configure \
-            --prefix=${{ env.FFMPEG_PREFIX }} \
-            --disable-programs \
-            --disable-doc \
-            --disable-everything \
-            --enable-avcodec \
-            --enable-avformat \
-            --enable-avutil \
-            --enable-swscale \
-            --enable-swresample \
-            --enable-avfilter \
-            --enable-decoder=h264,aac,mp3,flac,vorbis,opus,pcm_s16le,pcm_f32le \
-            --enable-encoder=aac,pcm_s16le,mpeg4 \
-            --enable-demuxer=mov,mp4,matroska,mp3,flac,ogg,wav,srt \
-            --enable-muxer=ipod,mp4,mov,matroska \
-            --enable-parser=h264,aac,mpegaudio,flac,vorbis,opus \
-            --enable-protocol=file \
-            --enable-shared \
-            --disable-static
-          make -j$(nproc)
-          sudo make install
-      - name: Set FFmpeg environment
-        run: |
-          echo "PKG_CONFIG_PATH=${{ env.FFMPEG_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${{ env.FFMPEG_PREFIX }}/lib" >> $GITHUB_ENV
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.93.0"
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all --all-features -- -D warnings
 
   # --------------------------------------------------------------------------
-  # Tests
+  # Tests on Linux + macOS (full feature set)
   # --------------------------------------------------------------------------
   test:
     name: Test (${{ matrix.os }})
@@ -94,117 +57,86 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install build dependencies (Linux)
+      - name: Setup FFmpeg (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y nasm pkg-config libclang-dev
+        uses: ./.github/actions/setup-ffmpeg
 
-      - name: Cache FFmpeg 7.x (Linux)
-        if: runner.os == 'Linux'
-        id: cache-ffmpeg
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.FFMPEG_PREFIX }}
-          key: ffmpeg-${{ env.FFMPEG_VERSION }}-ubuntu-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml') }}
-
-      - name: Build FFmpeg 7.x from source (Linux)
-        if: runner.os == 'Linux' && steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: |
-          wget -q https://ffmpeg.org/releases/ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          tar xf ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          cd ffmpeg-${{ env.FFMPEG_VERSION }}
-          ./configure \
-            --prefix=${{ env.FFMPEG_PREFIX }} \
-            --disable-programs \
-            --disable-doc \
-            --disable-everything \
-            --enable-avcodec \
-            --enable-avformat \
-            --enable-avutil \
-            --enable-swscale \
-            --enable-swresample \
-            --enable-avfilter \
-            --enable-decoder=h264,aac,mp3,flac,vorbis,opus,pcm_s16le,pcm_f32le \
-            --enable-encoder=aac,pcm_s16le,mpeg4 \
-            --enable-demuxer=mov,mp4,matroska,mp3,flac,ogg,wav,srt \
-            --enable-muxer=ipod,mp4,mov,matroska \
-            --enable-parser=h264,aac,mpegaudio,flac,vorbis,opus \
-            --enable-protocol=file \
-            --enable-shared \
-            --disable-static
-          make -j$(nproc)
-          sudo make install
-
-      - name: Set FFmpeg environment (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          echo "PKG_CONFIG_PATH=${{ env.FFMPEG_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${{ env.FFMPEG_PREFIX }}/lib" >> $GITHUB_ENV
-
-      - name: Install FFmpeg 7.x (macOS)
+      - name: Install FFmpeg (macOS)
         if: runner.os == 'macOS'
         run: brew install ffmpeg pkg-config
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.93.0"
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all --all-features
 
   # --------------------------------------------------------------------------
-  # Sync-only build: verify the tokio feature can be disabled cleanly
+  # Tests on Windows (MSVC). FFmpeg comes from vcpkg, matching ff-sys's
+  # documented Windows build path; libclang comes from the runner's LLVM.
+  # Default features only: the GPL (libx264/x265) and GPU (wgpu) features need
+  # libraries not present in the default vcpkg FFmpeg build.
   # --------------------------------------------------------------------------
-  no-tokio-feature:
-    name: No tokio feature (sync API only)
+  test-windows:
+    name: Test (windows)
+    runs-on: windows-latest
+    env:
+      VCPKG_ROOT: C:\vcpkg
+      LIBCLANG_PATH: C:\Program Files\LLVM\bin
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache vcpkg FFmpeg
+        id: cache-vcpkg
+        uses: actions/cache@v6
+        with:
+          path: C:\vcpkg\installed
+          key: vcpkg-ffmpeg-x64-windows-v1
+
+      - name: Install FFmpeg via vcpkg
+        if: steps.cache-vcpkg.outputs.cache-hit != 'true'
+        run: vcpkg install ffmpeg:x64-windows
+
+      - name: Add FFmpeg DLLs to PATH
+        shell: bash
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  # --------------------------------------------------------------------------
+  # MSRV: verify the crate still compiles on the declared minimum (Cargo.toml
+  # `rust-version`). Default features only — this is the core promise; the
+  # optional wgpu/gpl features may depend on crates with a newer MSRV. `check`
+  # only: clippy lints are version-specific and belong on the stable job.
+  # --------------------------------------------------------------------------
+  msrv:
+    name: MSRV (1.93.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Install build dependencies
-        run: sudo apt-get install -y nasm pkg-config libclang-dev
-      - name: Cache FFmpeg 7.x
-        id: cache-ffmpeg
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.FFMPEG_PREFIX }}
-          key: ffmpeg-${{ env.FFMPEG_VERSION }}-ubuntu-${{ runner.arch }}-${{ hashFiles('.github/workflows/ci.yml') }}
-      - name: Build FFmpeg 7.x from source
-        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: |
-          wget -q https://ffmpeg.org/releases/ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          tar xf ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          cd ffmpeg-${{ env.FFMPEG_VERSION }}
-          ./configure \
-            --prefix=${{ env.FFMPEG_PREFIX }} \
-            --disable-programs \
-            --disable-doc \
-            --disable-everything \
-            --enable-avcodec \
-            --enable-avformat \
-            --enable-avutil \
-            --enable-swscale \
-            --enable-swresample \
-            --enable-avfilter \
-            --enable-decoder=h264,aac,mp3,flac,vorbis,opus,pcm_s16le,pcm_f32le \
-            --enable-encoder=aac,pcm_s16le,mpeg4 \
-            --enable-demuxer=mov,mp4,matroska,mp3,flac,ogg,wav,srt \
-            --enable-muxer=ipod,mp4,mov,matroska \
-            --enable-parser=h264,aac,mpegaudio,flac,vorbis,opus \
-            --enable-protocol=file \
-            --enable-shared \
-            --disable-static
-          make -j$(nproc)
-          sudo make install
-      - name: Set FFmpeg environment
-        run: |
-          echo "PKG_CONFIG_PATH=${{ env.FFMPEG_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${{ env.FFMPEG_PREFIX }}/lib" >> $GITHUB_ENV
+      - uses: ./.github/actions/setup-ffmpeg
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.93.0"
-          components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --workspace --no-default-features
-      - run: cargo test --workspace --no-default-features
-      - run: cargo clippy --workspace --no-default-features -- -D warnings
+      - run: cargo check --workspace
+
+  # --------------------------------------------------------------------------
+  # Feature isolation: verify every crate feature compiles on its own (and the
+  # no-default-features baseline). Replaces the ad-hoc "no tokio feature" job.
+  # --------------------------------------------------------------------------
+  features:
+    name: Feature powerset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-ffmpeg
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo hack check --workspace --each-feature --no-dev-deps
 
   # --------------------------------------------------------------------------
   # docs.rs stubs: verify docsrs_stubs.rs compiles for all workspace crates.
@@ -217,9 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.93.0"
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build workspace with DOCS_RS=1 (no FFmpeg needed)
         run: cargo build --workspace
@@ -239,11 +169,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.93.0"
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --all-features --no-deps
         env:
           DOCS_RS: "1"
           RUSTDOCFLAGS: -D warnings
+
+  # --------------------------------------------------------------------------
+  # Aggregation gate: a single required check for branch protection. Passes
+  # only if every job above succeeded. Referencing just this check keeps branch
+  # protection stable as jobs are added or renamed.
+  # --------------------------------------------------------------------------
+  ci-success:
+    name: CI Success
+    if: always()
+    needs:
+      - fmt
+      - clippy
+      - test
+      - test-windows
+      - msrv
+      - features
+      - docsrs-stubs
+      - docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - name: Success
+        run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,11 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
   # --------------------------------------------------------------------------
-  # Aggregation gate: a single required check for branch protection. Passes
+  # Aggregation gate: the single required check for branch protection. Passes
   # only if every job above succeeded. Referencing just this check keeps branch
   # protection stable as jobs are added or renamed.
   # --------------------------------------------------------------------------
-  ci-success:
-    name: CI Success
+  ci:
     if: always()
     needs:
       - fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           tool: cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - run: cargo hack check --workspace --each-feature --no-dev-deps
+      - run: cargo hack check --workspace --each-feature --no-dev-deps --keep-going
 
   # --------------------------------------------------------------------------
   # docs.rs stubs: verify docsrs_stubs.rs compiles for all workspace crates.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,38 +70,25 @@ jobs:
       - run: cargo test --all --all-features
 
   # --------------------------------------------------------------------------
-  # Tests on Windows (MSVC). FFmpeg comes from vcpkg, matching ff-sys's
-  # documented Windows build path; libclang comes from the runner's LLVM.
-  # Default features only: the GPL (libx264/x265) and GPU (wgpu) features need
-  # libraries not present in the default vcpkg FFmpeg build.
+  # Windows (MSVC) compile check. FFmpeg is deliberately NOT installed here:
+  # building it via vcpkg takes ~20 minutes and dominates CI time. DOCS_RS=1
+  # makes ff-sys/build.rs skip bindgen/vcpkg and use the checked-in stub
+  # bindings, so this stays fast (a Rust-only compile) while still verifying
+  # the Windows-specific (cfg(windows)) code paths on the MSVC target.
+  # Running the real FFmpeg-linked test suite on Windows is left to local
+  # development, which already uses vcpkg per CONTRIBUTING.
   # --------------------------------------------------------------------------
-  test-windows:
-    name: Test (windows)
+  check-windows:
+    name: Check (windows)
     runs-on: windows-latest
-    env:
-      VCPKG_ROOT: C:\vcpkg
-      LIBCLANG_PATH: C:\Program Files\LLVM\bin
     steps:
       - uses: actions/checkout@v7
-
-      - name: Cache vcpkg FFmpeg
-        id: cache-vcpkg
-        uses: actions/cache@v6
-        with:
-          path: C:\vcpkg\installed
-          key: vcpkg-ffmpeg-x64-windows-v1
-
-      - name: Install FFmpeg via vcpkg
-        if: steps.cache-vcpkg.outputs.cache-hit != 'true'
-        run: vcpkg install ffmpeg:x64-windows
-
-      - name: Add FFmpeg DLLs to PATH
-        shell: bash
-        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
-
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      - name: Compile the workspace with DOCS_RS=1 (no FFmpeg needed)
+        run: cargo check --workspace
+        env:
+          DOCS_RS: "1"
 
   # --------------------------------------------------------------------------
   # MSRV: verify the crate still compiles on the declared minimum (Cargo.toml
@@ -188,7 +175,7 @@ jobs:
       - fmt
       - clippy
       - test
-      - test-windows
+      - check-windows
       - msrv
       - features
       - docsrs-stubs

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,9 +7,9 @@ on:
     - cron: '0 3 * * 1'   # weekly on Monday at 03:00 UTC
   workflow_dispatch:
 
-env:
-  FFMPEG_VERSION: "7.1"
-  FFMPEG_PREFIX: /opt/ffmpeg7
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   fuzz:
@@ -25,46 +25,8 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 
-      - name: Install build dependencies
-        run: sudo apt-get install -y nasm pkg-config libclang-dev
-
-      - name: Cache FFmpeg 7.x
-        id: cache-ffmpeg
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.FFMPEG_PREFIX }}
-          key: ffmpeg-${{ env.FFMPEG_VERSION }}-ubuntu-${{ runner.arch }}-${{ hashFiles('.github/workflows/fuzz.yml') }}
-
-      - name: Build FFmpeg 7.x from source
-        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: |
-          wget -q https://ffmpeg.org/releases/ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          tar xf ffmpeg-${{ env.FFMPEG_VERSION }}.tar.xz
-          cd ffmpeg-${{ env.FFMPEG_VERSION }}
-          ./configure \
-            --prefix=${{ env.FFMPEG_PREFIX }} \
-            --disable-programs \
-            --disable-doc \
-            --disable-everything \
-            --enable-avcodec \
-            --enable-avformat \
-            --enable-avutil \
-            --enable-swscale \
-            --enable-swresample \
-            --enable-avfilter \
-            --enable-decoder=h264,aac,mp3,flac,vorbis,opus,pcm_s16le,pcm_f32le \
-            --enable-demuxer=mov,mp4,matroska,mp3,flac,ogg,wav,srt \
-            --enable-parser=h264,aac,mpegaudio,flac,vorbis,opus \
-            --enable-protocol=file \
-            --enable-shared \
-            --disable-static
-          make -j$(nproc)
-          sudo make install
-
-      - name: Set FFmpeg environment
-        run: |
-          echo "PKG_CONFIG_PATH=${{ env.FFMPEG_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${{ env.FFMPEG_PREFIX }}/lib" >> $GITHUB_ENV
+      - name: Setup FFmpeg
+        uses: ./.github/actions/setup-ffmpeg
 
       - name: Fuzz ff-decode open_video
         run: cargo +nightly fuzz run open_video -- -max_total_time=60

--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -30,7 +30,7 @@ ff-pipeline = { workspace = true, optional = true }
 default  = []
 tokio    = ["dep:tokio"]
 proxy    = ["dep:ff-encode", "dep:ff-filter", "dep:ff-pipeline"]
-timeline = ["dep:ff-pipeline"]
+timeline = ["dep:ff-pipeline", "dep:ff-filter"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.97.1"
-components = ["rustfmt", "clippy", "rust-analyzer"]
-targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]


### PR DESCRIPTION
## Objective

- CI was too slow, and the repo pinned an exact toolchain via `rust-toolchain.toml`, which froze contributors and caused clippy churn on every bump. Move to a stable-toolchain model and cut CI time.

## Solution

- Remove `rust-toolchain.toml`; run CI on stable. Keep the MSRV (1.93.0) declared in `Cargo.toml`, verified by its own check job.
- Windows now runs a fast `DOCS_RS=1` compile check instead of a ~20 min vcpkg FFmpeg build.
- Replace the no-tokio job with `cargo hack --each-feature`, which caught a missing `ff-filter` dependency in ff-preview's `timeline` feature (fixed here).
- Extract the FFmpeg source build into a composite action; add a single `ci` aggregation gate and concurrency cancellation.