### PR TITLE
docs(readme): align the tagline with the repo description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # avio
 
-Safe Rust bindings over FFmpeg for building video editors: decode, encode, filter, compose, and stream.
+A safe, high-level Rust API over FFmpeg for building media applications: decode, encode, filter, compose, and stream.
 
 [![Crates.io](https://img.shields.io/crates/v/avio.svg)](https://crates.io/crates/avio)
 [![Docs.rs](https://docs.rs/avio/badge.svg)](https://docs.rs/avio)

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -4,7 +4,7 @@
 [![Docs.rs](https://docs.rs/avio/badge.svg)](https://docs.rs/avio)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-Safe Rust bindings over FFmpeg: decode, encode, filter, compose, and stream.
+A safe, high-level Rust API over FFmpeg for building media applications: decode, encode, filter, compose, and stream.
 
 `avio` is the facade crate for the `ff-*` crate family. Depend on a single crate and opt into the capabilities you need via feature flags. See the [main repository](https://github.com/itsakeyfut/avio) for full context.
 


### PR DESCRIPTION
## Objective

- The README tagline said "Safe Rust bindings over FFmpeg for building video editors", which no longer matches the GitHub repo description.

## Solution

- Use the same one-line summary as the repo description: "A safe, high-level Rust API over FFmpeg for building media applications: decode, encode, filter, compose, and stream."
- Applied to the root README and the avio facade crate README.