### PR TITLE
chore: stop ignoring SESSION.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ Desktop.ini
 /docs/dev/
 /docs/roadmap/tasks/
 
-# Claude session file
-/SESSION.md
-
 # Claude Code — personal use only, not shared with contributors
 /CLAUDE.md
 /.claude/


### PR DESCRIPTION
## Objective

- Stop git-ignoring `SESSION.md`.

## Solution

- Remove the `/SESSION.md` entry from `.gitignore`.