### PR TITLE
feat(ff-preview): animate clip opacity in the realtime preview

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -7,6 +7,7 @@ use super::{
 use std::ptr::NonNull;
 use std::time::Duration;
 
+use crate::animation::{AnimationEntry, AnimationTrack};
 use crate::blend::BlendMode;
 use crate::composite::CompositeOp;
 use crate::error::FilterError;
@@ -991,14 +992,17 @@ fn overlay_alpha_suffix(alpha: AlphaMode) -> &'static str {
 ///
 /// `graph`, `bottom_ctx`, and `top_src_ctx` must be valid pointers owned by the
 /// same `AVFilterGraph`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn add_blend_normal_step(
     graph: *mut ff_sys::AVFilterGraph,
     bottom_ctx: *mut ff_sys::AVFilterContext,
     top_src_ctx: *mut ff_sys::AVFilterContext,
     top_steps: &[FilterStep],
     opacity: f32,
+    opacity_track: Option<&AnimationTrack<f64>>,
     alpha: AlphaMode,
     index: usize,
+    animations: &mut Vec<AnimationEntry>,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
     use std::ffi::CString;
 
@@ -1026,11 +1030,19 @@ pub(crate) unsafe fn add_blend_normal_step(
         top_ctx = add_and_link_step(graph, top_ctx, step, index * 1000 + j, "blend_top")?;
     }
 
-    // 2. When opacity < 1.0, attenuate the top layer's alpha channel.
-    if opacity < 1.0 {
+    // 2. Attenuate the top layer's alpha via colorchannelmixer when opacity < 1.0
+    //    OR an animation track is present. An animated track ALWAYS needs the node
+    //    (even at initial opacity 1.0) so per-frame `send_command` has a target; the
+    //    initial `aa` is the track's value at t=0. The node name `blend_ccm{index}`
+    //    is the `send_command` target registered in `animations`.
+    let initial_aa = match opacity_track {
+        Some(track) => track.value_at(Duration::ZERO),
+        None => f64::from(opacity),
+    };
+    if opacity < 1.0 || opacity_track.is_some() {
         let ccm_name =
             CString::new(format!("blend_ccm{index}")).map_err(|_| FilterError::BuildFailed)?;
-        let ccm_args_str = format!("aa={opacity}");
+        let ccm_args_str = format!("aa={initial_aa:.6}");
         let ccm_args = CString::new(ccm_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
 
         let ccm_filter = ff_sys::avfilter_get_by_name(c"colorchannelmixer".as_ptr());
@@ -1060,6 +1072,16 @@ pub(crate) unsafe fn add_blend_normal_step(
             return Err(FilterError::BuildFailed);
         }
         top_ctx = ccm_ctx;
+
+        // Register the animation so the graph's per-frame tick drives the alpha.
+        if let Some(track) = opacity_track {
+            animations.push(AnimationEntry {
+                node_name: format!("blend_ccm{index}"),
+                param: "aa",
+                track: track.clone(),
+                suffix: "",
+            });
+        }
     }
 
     // 3. Create the overlay filter.
@@ -1466,15 +1488,18 @@ pub(super) unsafe fn add_composite_step(
                 alpha,
                 index,
             ),
-            // Over (overlay=format=auto:shortest=1).
+            // Over (overlay=format=auto:shortest=1). The single-source composite path
+            // does not animate opacity, so no track and a discarded animations sink.
             _ => add_blend_normal_step(
                 graph,
                 bottom_ctx,
                 top_src_ctx,
                 top_steps,
                 opacity,
+                None,
                 alpha,
                 index,
+                &mut Vec::new(),
             ),
         },
     }
@@ -2412,8 +2437,10 @@ impl FilterGraphInner {
                     top_src.as_ptr(),
                     top.steps(),
                     *opacity,
+                    None,
                     *alpha,
                     i,
+                    &mut Vec::new(),
                 ) {
                     Ok(ctx) => ctx,
                     Err(e) => bail!(e),

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1180,6 +1180,9 @@ pub(super) unsafe fn build_realtime_composition(
     let (canvas_w, canvas_h) = (layers[0].width, layers[0].height);
 
     // ── Composite layers 1.. onto the accumulator ─────────────────────────────
+    // Animation entries registered by per-layer opacity tracks (Normal blend). When
+    // non-empty the graph is returned animated so the per-frame tick drives them.
+    let mut animations: Vec<AnimationEntry> = Vec::new();
     for idx in 1..layers.len() {
         let layer = &layers[idx];
         let Some(top_src) = src_ctxs[idx] else {
@@ -1200,8 +1203,10 @@ pub(super) unsafe fn build_realtime_composition(
                 top_src.as_ptr(),
                 &top_steps,
                 layer.opacity,
+                layer.opacity_track.as_ref(),
                 ff_format::AlphaMode::Straight,
                 idx,
+                &mut animations,
             ) {
                 Ok(c) => c,
                 Err(e) => bail!(graph, format!("normal blend failed layer={idx}: {e:?}")),
@@ -1343,8 +1348,16 @@ pub(super) unsafe fn build_realtime_composition(
     let graph_nn = NonNull::new_unchecked(graph);
     let sink_nn = NonNull::new_unchecked(sink_ctx);
     let inner = FilterGraphInner::with_prebuilt_video_inputs(graph_nn, src_ctxs, sink_nn);
-    log::info!("realtime composition graph built layers={}", layers.len());
-    Ok(FilterGraph::from_prebuilt(inner))
+    log::info!(
+        "realtime composition graph built layers={} animations={}",
+        layers.len(),
+        animations.len()
+    );
+    if animations.is_empty() {
+        Ok(FilterGraph::from_prebuilt(inner))
+    } else {
+        Ok(FilterGraph::from_prebuilt_animated(inner, animations))
+    }
 }
 
 // ── Audio mix graph builder ───────────────────────────────────────────────────

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -12,6 +12,7 @@
 
 use ff_format::{PixelFormat, VideoFrame};
 
+use crate::animation::AnimationTrack;
 use crate::blend::BlendMode;
 use crate::error::FilterError;
 use crate::graph::filter_step::FilterStep;
@@ -40,6 +41,14 @@ pub struct RealtimeLayer {
     /// Opacity in `[0.0, 1.0]`. Applied when this layer is blended onto the layer
     /// below it (no effect on the base layer 0 — apply base opacity host-side).
     pub opacity: f32,
+    /// Optional keyframe track animating this layer's opacity (Normal blend only).
+    ///
+    /// When `Some`, the `colorchannelmixer` alpha node is always created (even at
+    /// initial opacity `1.0`) and registered for per-frame `send_command`, so a host
+    /// that pushes frames stamped with the composite's timeline PTS gets an animated
+    /// alpha. `None` keeps the static [`opacity`](Self::opacity). No effect on the
+    /// base layer 0 (apply animated base opacity host-side).
+    pub opacity_track: Option<AnimationTrack<f64>>,
     /// How this layer blends with the layer below. [`BlendMode::Normal`] uses
     /// `overlay`; other modes use `blend=all_mode=<token>`.
     pub blend_mode: BlendMode,
@@ -152,6 +161,7 @@ mod tests {
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
@@ -169,6 +179,7 @@ mod tests {
                 intensity: 0.5,
             }],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[layer])
@@ -195,6 +206,7 @@ mod tests {
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::with_canvas(&[base], Some((1080, 1920))) {
@@ -246,6 +258,7 @@ mod tests {
                 },
             ],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -288,6 +301,7 @@ mod tests {
                 color: "black".to_string(),
             }],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -321,6 +335,7 @@ mod tests {
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
             opacity: op,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[layer(1.0), layer(0.5)]) {
@@ -358,6 +373,7 @@ mod tests {
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let top = RealtimeLayer {
@@ -366,6 +382,7 @@ mod tests {
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Screen,
         };
         let mut composer = match RealtimeComposer::new(&[base, top]) {
@@ -415,6 +432,7 @@ mod tests {
                 },
             ],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -480,6 +498,7 @@ mod tests {
                 height: 6,
             }],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -533,6 +552,7 @@ mod tests {
                 force_style: Some("Fontsize=24,PrimaryColour=&H00FFFFFF&,Alignment=2".to_owned()),
             }],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -571,6 +591,7 @@ mod tests {
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
@@ -586,6 +607,7 @@ mod tests {
                 invert: false,
             }],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[base])
@@ -618,6 +640,7 @@ mod tests {
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
@@ -635,6 +658,7 @@ mod tests {
                 invert: true,
             }],
             opacity: 1.0,
+            opacity_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[base])
@@ -649,5 +673,83 @@ mod tests {
             Ok(None) => println!("Skipping: no frame produced"),
             Err(e) => println!("Skipping: {e}"),
         }
+    }
+
+    #[test]
+    fn animated_opacity_track_changes_composite_across_pts() {
+        // A top layer with an opacity ramp (0→1 over 1s) over a black base: at PTS 0 the
+        // top is transparent (composite ≈ black), at PTS 1s it is opaque (composite ≈
+        // white). Proves the realtime composer registers the `blend_ccm` animation and
+        // evaluates it at each pushed frame's PTS. Probe-gated: CI Linux FFmpeg has no
+        // filters, so even a no-effect layer fails to build there — skip.
+        use crate::animation::{AnimationTrack, Easing, Keyframe};
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 4,
+            height: 4,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(1), 1.0, Easing::Linear));
+        let base = RealtimeLayer {
+            width: 4,
+            height: 4,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let top = RealtimeLayer {
+            width: 4,
+            height: 4,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: Some(track),
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = RealtimeComposer::new(&[base, top])
+            .expect("animated-opacity composite must build once FFmpeg filters exist");
+
+        // Opaque black base and opaque white top, each stamped with the query PTS.
+        let stamped = |rgba: Vec<u8>, pts: Duration| -> VideoFrame {
+            let mut f = VideoFrame::from_rgba(4, 4, rgba).unwrap();
+            f.set_timestamp(Timestamp::from_duration(pts, Rational::new(1, 1_000_000)));
+            f
+        };
+        let black = |pts| stamped([0u8, 0, 0, 255].repeat(16), pts);
+        let white = |pts| stamped([255u8, 255, 255, 255].repeat(16), pts);
+
+        let sample = |composer: &mut RealtimeComposer, pts: Duration| -> Option<u8> {
+            composer.push_layer(0, &black(pts)).ok()?;
+            composer.push_layer(1, &white(pts)).ok()?;
+            Some(composer.pull().ok()??.to_rgba()?[0])
+        };
+
+        let Some(r0) = sample(&mut composer, Duration::ZERO) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        let Some(r1) = sample(&mut composer, Duration::from_secs(1)) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        assert!(
+            r1 > r0 + 100,
+            "opacity ramp should brighten the composite across PTS: r0={r0} r1={r1}"
+        );
     }
 }

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -338,6 +338,7 @@ impl Clip {
             pixel_format,
             effects: self.video_effect_chain(),
             opacity: self.opacity,
+            opacity_track: self.opacity_track.clone(),
             blend_mode: self.blend_mode,
         }
     }

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -10,7 +10,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use ff_filter::{BlendMode, RealtimeComposer, RealtimeLayer};
-use ff_format::{PixelFormat, VideoFrame};
+use ff_format::{PixelFormat, Rational, Timestamp, VideoFrame};
 
 use crate::audio::AudioMixer;
 use crate::error::PreviewError;
@@ -167,10 +167,11 @@ impl TimelineRunner {
         &mut self,
         base_layer: RealtimeLayer,
         base_id: usize,
-        base_frame: &VideoFrame,
+        mut base_frame: VideoFrame,
         base_w: u32,
         base_h: u32,
         overlays: &[(usize, u32, u32)],
+        t: Duration,
     ) -> Option<(Vec<u8>, u32, u32)> {
         let mut specs = vec![base_layer];
         let mut key: Vec<(usize, usize, u32, u32)> = vec![(0, base_id, base_w, base_h)];
@@ -192,11 +193,19 @@ impl TimelineRunner {
             };
         }
         let composer = self.composer.as_mut()?;
-        if composer.push_layer(0, base_frame).is_err() {
+        // Stamp every pushed frame with the composite's timeline PTS so the graph's
+        // per-frame animation tick (in `push_video`) evaluates each layer's opacity
+        // track at the same time. Frames from `from_rgba` carry PTS 0 otherwise, and
+        // any registered `AnimationEntry` would be frozen at t=0.
+        let ts = Timestamp::from_duration(t, Rational::new(1, 1_000_000));
+        base_frame.set_timestamp(ts);
+        if composer.push_layer(0, &base_frame).is_err() {
             return None;
         }
         for (slot, &(li, ow, oh)) in overlays.iter().enumerate() {
-            let vf = VideoFrame::from_rgba(ow, oh, self.overlay_layers[li].rgba.clone()).ok()?;
+            let mut vf =
+                VideoFrame::from_rgba(ow, oh, self.overlay_layers[li].rgba.clone()).ok()?;
+            vf.set_timestamp(ts);
             if composer.push_layer(slot + 1, &vf).is_err() {
                 return None;
             }
@@ -687,16 +696,18 @@ impl TimelineRunner {
                                         pixel_format: PixelFormat::Rgba,
                                         effects: Vec::new(),
                                         opacity: 1.0,
+                                        opacity_track: None,
                                         blend_mode: BlendMode::Normal,
                                     };
                                     match VideoFrame::from_rgba(gw, gh, self.gap_buf.clone()) {
                                         Ok(bf) => self.composite_frame(
                                             base_layer,
                                             usize::MAX,
-                                            &bf,
+                                            bf,
                                             gw,
                                             gh,
                                             &gap_overlays,
+                                            gap_pts,
                                         ),
                                         Err(_) => None,
                                     }
@@ -799,8 +810,13 @@ impl TimelineRunner {
 
                     if a_ok {
                         // V1 per-clip opacity: pre-multiply toward black (producer-side;
-                        // the composer ignores base-layer opacity).
-                        let v1_op = self.clips[active].opacity;
+                        // the composer ignores base-layer opacity). An opacity track is
+                        // evaluated at the timeline PTS (tracks are timeline-global), so
+                        // base-layer opacity animates too.
+                        let v1_op = match self.clips[active].clip.opacity_track.as_ref() {
+                            Some(track) => track.value_at(timeline_pts).clamp(0.0, 1.0) as f32,
+                            None => self.clips[active].opacity,
+                        };
                         if (v1_op - 1.0).abs() > 1e-6 {
                             for chunk in self.rgba_a.chunks_exact_mut(4) {
                                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -842,10 +858,11 @@ impl TimelineRunner {
                             Ok(bf) => self.composite_frame(
                                 base_layer,
                                 active,
-                                &bf,
+                                bf,
                                 w,
                                 h,
                                 &active_overlays,
+                                timeline_pts,
                             ),
                             Err(_) => None,
                         };

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -163,6 +163,7 @@ impl TimelineRunner {
     /// callers must push the returned dimensions to the sink rather than the
     /// decoded ones — otherwise the buffer length no longer matches the reported
     /// size and the frame is dropped.
+    #[allow(clippy::too_many_arguments)]
     fn composite_frame(
         &mut self,
         base_layer: RealtimeLayer,
@@ -814,6 +815,8 @@ impl TimelineRunner {
                         // evaluated at the timeline PTS (tracks are timeline-global), so
                         // base-layer opacity animates too.
                         let v1_op = match self.clips[active].clip.opacity_track.as_ref() {
+                            // Value is clamped to [0.0, 1.0], so the f32 narrowing is safe.
+                            #[allow(clippy::cast_possible_truncation)]
                             Some(track) => track.value_at(timeline_pts).clamp(0.0, 1.0) as f32,
                             None => self.clips[active].opacity,
                         };


### PR DESCRIPTION
## Objective

- Opacity keyframe tracks (#1291) animate on export but not in the realtime preview, so the monitor does not match the rendered output.
- The realtime composer bakes opacity statically, registers no animations, and the frames pushed to it carry PTS 0 — so no per-frame time reaches the preview graph.

## Solution

- `RealtimeLayer` gains `opacity_track`, threaded from `Clip::realtime_layer`.
- `add_blend_normal_step` always creates the `blend_ccm{index}` node when a track is present (even at initial opacity 1.0) and surfaces an `AnimationEntry`; `build_realtime_composition` collects them and returns `from_prebuilt_animated`.
- The ff-preview runner stamps every pushed frame with the timeline PTS (`VideoFrame::set_timestamp`), so the graph's per-frame tick evaluates each layer's track at the same time; base-layer (V1) opacity, applied host-side, evaluates the track at the timeline PTS.
- Adds a probe-gated realtime test asserting the composite brightness changes across PTS (skips when FFmpeg filters are unavailable).

Part of #1290
Closes #1292