### PR TITLE
feat(pipeline): per-clip overlay position with keyframe animation

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -975,36 +975,78 @@ fn overlay_alpha_suffix(alpha: AlphaMode) -> &'static str {
     }
 }
 
+/// Parameters for [`add_blend_normal_step`]: opacity + overlay position, each with an
+/// optional animation track, plus the top layer's alpha interpretation.
+#[derive(Clone, Copy)]
+pub(crate) struct NormalBlendParams<'a> {
+    /// Static opacity in `[0.0, 1.0]` (build-time initial value).
+    pub opacity: f32,
+    /// Optional opacity track; forces a commandable `colorchannelmixer` node even at 1.0.
+    pub opacity_track: Option<&'a AnimationTrack<f64>>,
+    /// Static overlay position (pixels) of the top layer's top-left on the canvas.
+    pub x: f64,
+    /// See [`x`](Self::x).
+    pub y: f64,
+    /// Optional position tracks; force `overlay:eval=frame` + commandable `x`/`y`.
+    pub x_track: Option<&'a AnimationTrack<f64>>,
+    /// See [`x_track`](Self::x_track).
+    pub y_track: Option<&'a AnimationTrack<f64>>,
+    /// Top-layer alpha interpretation for the overlay.
+    pub alpha: AlphaMode,
+}
+
+impl NormalBlendParams<'_> {
+    /// A static, un-positioned, un-animated overlay (opacity + alpha only) — used by
+    /// the single-source blend paths that do not composite onto a canvas at a position.
+    pub fn static_opacity(opacity: f32, alpha: AlphaMode) -> Self {
+        Self {
+            opacity,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            alpha,
+        }
+    }
+}
+
 /// Insert a Normal-mode blend compound step.
 ///
 /// The top layer's `top_steps` are first applied to `top_src_ctx` (the `in1`
-/// buffersrc), then optionally followed by `colorchannelmixer=aa=<opacity>` when
-/// `opacity < 1.0`.  The result is composited onto `bottom_ctx` using
-/// `overlay=format=auto:shortest=1`.
+/// buffersrc), then optionally followed by `colorchannelmixer=aa=<opacity>` when the
+/// opacity is < 1.0 or animated.  The result is composited onto `bottom_ctx` using
+/// `overlay=<x>:<y>:shortest=1:format=auto`.
 ///
 /// ```text
 /// [in1]top_steps...[top_processed]
-/// [top_processed]colorchannelmixer=aa=<opacity>[top_faded]   ← when opacity < 1.0
-/// [bottom_ctx][top_faded]overlay=format=auto:shortest=1[out]
+/// [top_processed]colorchannelmixer=aa=<opacity>[top_faded]   ← when opacity < 1.0/animated
+/// [bottom_ctx][top_faded]overlay=<x>:<y>:shortest=1:format=auto[out]
 /// ```
 ///
 /// # Safety
 ///
 /// `graph`, `bottom_ctx`, and `top_src_ctx` must be valid pointers owned by the
 /// same `AVFilterGraph`.
-#[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn add_blend_normal_step(
     graph: *mut ff_sys::AVFilterGraph,
     bottom_ctx: *mut ff_sys::AVFilterContext,
     top_src_ctx: *mut ff_sys::AVFilterContext,
     top_steps: &[FilterStep],
-    opacity: f32,
-    opacity_track: Option<&AnimationTrack<f64>>,
-    alpha: AlphaMode,
+    params: &NormalBlendParams,
     index: usize,
     animations: &mut Vec<AnimationEntry>,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
     use std::ffi::CString;
+    let NormalBlendParams {
+        opacity,
+        opacity_track,
+        x,
+        y,
+        x_track,
+        y_track,
+        alpha,
+    } = *params;
 
     // 1. Chain the top builder's steps starting from the in1 buffersrc.
     let mut top_ctx = top_src_ctx;
@@ -1092,7 +1134,23 @@ pub(crate) unsafe fn add_blend_normal_step(
     }
     let overlay_name =
         CString::new(format!("blend_overlay{index}")).map_err(|_| FilterError::BuildFailed)?;
-    let overlay_args_str = format!("format=auto:shortest=1{}", overlay_alpha_suffix(alpha));
+    // Position the overlay at (x, y). `eval=frame` is added only when a position track
+    // is present, so the un-animated x=0,y=0 case is byte-identical to the prior
+    // `format=auto:shortest=1` overlay (overlay defaults to 0,0).
+    #[allow(clippy::cast_possible_truncation)]
+    let overlay_args_str = {
+        let ox = x.round() as i64;
+        let oy = y.round() as i64;
+        let eval = if x_track.is_some() || y_track.is_some() {
+            ":eval=frame"
+        } else {
+            ""
+        };
+        format!(
+            "{ox}:{oy}:shortest=1:format=auto{eval}{}",
+            overlay_alpha_suffix(alpha)
+        )
+    };
     let overlay_args =
         CString::new(overlay_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
     let mut overlay_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
@@ -1119,6 +1177,24 @@ pub(crate) unsafe fn add_blend_normal_step(
     let ret = ff_sys::avfilter_link(top_ctx, 0, overlay_ctx, 1);
     if ret < 0 {
         return Err(FilterError::BuildFailed);
+    }
+
+    // Register position animations so the graph's per-frame tick drives overlay x/y.
+    if let Some(track) = x_track {
+        animations.push(AnimationEntry {
+            node_name: format!("blend_overlay{index}"),
+            param: "x",
+            track: track.clone(),
+            suffix: "",
+        });
+    }
+    if let Some(track) = y_track {
+        animations.push(AnimationEntry {
+            node_name: format!("blend_overlay{index}"),
+            param: "y",
+            track: track.clone(),
+            suffix: "",
+        });
     }
 
     log::debug!("filter blend_normal expanded opacity={opacity} index={index}");
@@ -1489,15 +1565,13 @@ pub(super) unsafe fn add_composite_step(
                 index,
             ),
             // Over (overlay=format=auto:shortest=1). The single-source composite path
-            // does not animate opacity, so no track and a discarded animations sink.
+            // does not animate opacity/position, so a static params + discarded sink.
             _ => add_blend_normal_step(
                 graph,
                 bottom_ctx,
                 top_src_ctx,
                 top_steps,
-                opacity,
-                None,
-                alpha,
+                &NormalBlendParams::static_opacity(opacity, alpha),
                 index,
                 &mut Vec::new(),
             ),
@@ -2436,9 +2510,7 @@ impl FilterGraphInner {
                     prev_ctx,
                     top_src.as_ptr(),
                     top.steps(),
-                    *opacity,
-                    None,
-                    *alpha,
+                    &NormalBlendParams::static_opacity(*opacity, *alpha),
                     i,
                     &mut Vec::new(),
                 ) {

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -19,7 +19,9 @@ mod push_pull;
 
 pub(crate) use build::add_and_link_step;
 pub(crate) use build::add_asetrate_resample_chain;
-pub(crate) use build::{add_blend_normal_step, add_blend_photographic_step, video_buffersrc_args};
+pub(crate) use build::{
+    NormalBlendParams, add_blend_normal_step, add_blend_photographic_step, video_buffersrc_args,
+};
 pub(crate) use convert::pixel_format_to_av;
 
 use std::ptr::NonNull;

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1197,14 +1197,21 @@ pub(super) unsafe fn build_realtime_composition(
         });
         top_steps.extend(layer.effects.iter().cloned());
         acc = if layer.blend_mode == BlendMode::Normal {
+            let params = crate::filter_inner::NormalBlendParams {
+                opacity: layer.opacity,
+                opacity_track: layer.opacity_track.as_ref(),
+                x: layer.x,
+                y: layer.y,
+                x_track: layer.x_track.as_ref(),
+                y_track: layer.y_track.as_ref(),
+                alpha: ff_format::AlphaMode::Straight,
+            };
             match crate::filter_inner::add_blend_normal_step(
                 graph,
                 acc,
                 top_src.as_ptr(),
                 &top_steps,
-                layer.opacity,
-                layer.opacity_track.as_ref(),
-                ff_format::AlphaMode::Straight,
+                &params,
                 idx,
                 &mut animations,
             ) {

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -49,6 +49,17 @@ pub struct RealtimeLayer {
     /// alpha. `None` keeps the static [`opacity`](Self::opacity). No effect on the
     /// base layer 0 (apply animated base opacity host-side).
     pub opacity_track: Option<AnimationTrack<f64>>,
+    /// Static overlay position (pixels) on the canvas. Maps to the `overlay` filter's
+    /// `x`/`y` (Normal blend only). Default `(0.0, 0.0)`. No effect on the base layer 0.
+    pub x: f64,
+    /// See [`x`](Self::x).
+    pub y: f64,
+    /// Optional keyframe tracks animating the overlay X / Y position (Normal blend).
+    /// When `Some`, the `overlay` node is created with `:eval=frame` and registered for
+    /// per-frame `send_command`. `None` keeps the static [`x`](Self::x)/[`y`](Self::y).
+    pub x_track: Option<AnimationTrack<f64>>,
+    /// See [`x_track`](Self::x_track).
+    pub y_track: Option<AnimationTrack<f64>>,
     /// How this layer blends with the layer below. [`BlendMode::Normal`] uses
     /// `overlay`; other modes use `blend=all_mode=<token>`.
     pub blend_mode: BlendMode,
@@ -162,6 +173,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
@@ -180,6 +195,10 @@ mod tests {
             }],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[layer])
@@ -207,6 +226,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::with_canvas(&[base], Some((1080, 1920))) {
@@ -259,6 +282,10 @@ mod tests {
             ],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -302,6 +329,10 @@ mod tests {
             }],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -336,6 +367,10 @@ mod tests {
             effects: vec![],
             opacity: op,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[layer(1.0), layer(0.5)]) {
@@ -374,6 +409,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let top = RealtimeLayer {
@@ -383,6 +422,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Screen,
         };
         let mut composer = match RealtimeComposer::new(&[base, top]) {
@@ -433,6 +476,10 @@ mod tests {
             ],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -499,6 +546,10 @@ mod tests {
             }],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -553,6 +604,10 @@ mod tests {
             }],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
@@ -592,6 +647,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
@@ -608,6 +667,10 @@ mod tests {
             }],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[base])
@@ -641,6 +704,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
@@ -659,6 +726,10 @@ mod tests {
             }],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[base])
@@ -693,6 +764,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
@@ -710,6 +785,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let top = RealtimeLayer {
@@ -719,6 +798,10 @@ mod tests {
             effects: vec![],
             opacity: 1.0,
             opacity_track: Some(track),
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
         };
         let mut composer = RealtimeComposer::new(&[base, top])
@@ -750,6 +833,93 @@ mod tests {
         assert!(
             r1 > r0 + 100,
             "opacity ramp should brighten the composite across PTS: r0={r0} r1={r1}"
+        );
+    }
+
+    #[test]
+    fn animated_position_track_moves_overlay_across_pts() {
+        // A blue top layer slides in from off-screen-right (x=8, over an 8-wide canvas)
+        // to fully covering (x=0) across 1s, over a red base. At PTS 0 the composite is
+        // red (top off-screen); at PTS 1s it is blue (top covers). Proves the realtime
+        // overlay honors an animated x position via `send_command`. Probe-gated.
+        use crate::animation::{AnimationTrack, Easing, Keyframe};
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let x_track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 8.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(1), 0.0, Easing::Linear));
+        let base = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let top = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 8.0,
+            y: 0.0,
+            x_track: Some(x_track),
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = RealtimeComposer::new(&[base, top])
+            .expect("animated-position composite must build once FFmpeg filters exist");
+
+        let stamped = |rgba: Vec<u8>, pts: Duration| -> VideoFrame {
+            let mut f = VideoFrame::from_rgba(8, 8, rgba).unwrap();
+            f.set_timestamp(Timestamp::from_duration(pts, Rational::new(1, 1_000_000)));
+            f
+        };
+        let red = |pts| stamped([255u8, 0, 0, 255].repeat(64), pts);
+        let blue = |pts| stamped([0u8, 0, 255, 255].repeat(64), pts);
+        let sample = |composer: &mut RealtimeComposer, pts: Duration| -> Option<u8> {
+            composer.push_layer(0, &red(pts)).ok()?;
+            composer.push_layer(1, &blue(pts)).ok()?;
+            Some(composer.pull().ok()??.to_rgba()?[0])
+        };
+
+        let Some(r0) = sample(&mut composer, Duration::ZERO) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        let Some(r1) = sample(&mut composer, Duration::from_secs(1)) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        assert!(
+            r0 > r1 + 100,
+            "overlay should slide in and cover the red base, dropping R: r0={r0} r1={r1}"
         );
     }
 }

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -112,6 +112,25 @@ pub struct Clip {
     /// Takes precedence over the static [`opacity`](Self::opacity) when set.
     /// Defaults to `None` (use the static `opacity`).
     pub opacity_track: Option<AnimationTrack<f64>>,
+    /// Static overlay position (pixels) of this clip's top-left on the canvas.
+    ///
+    /// Maps to the `overlay` filter's `x`/`y`. Default `(0.0, 0.0)`. Meaningful for
+    /// overlay (non-base) layers — a Picture-in-Picture placement.
+    pub x: f64,
+    /// See [`x`](Self::x).
+    pub y: f64,
+    /// Optional keyframe tracks animating the overlay X / Y position over time.
+    ///
+    /// When `Some`, `Timeline::render()` maps them to the clip's
+    /// [`VideoLayer::x`/`y`](ff_filter::VideoLayer) as
+    /// [`AnimatedValue::Track`](ff_filter::AnimatedValue), driving the `overlay`
+    /// filter's `x`/`y` per frame (`:eval=frame` + `send_command`). Keyframe
+    /// timestamps are **timeline-global** (the composition graph's output PTS).
+    ///
+    /// Take precedence over the static [`x`](Self::x)/[`y`](Self::y). Default `None`.
+    pub x_track: Option<AnimationTrack<f64>>,
+    /// See [`x_track`](Self::x_track).
+    pub y_track: Option<AnimationTrack<f64>>,
     /// Blend mode for compositing this clip over the layer(s) below it.
     /// Default: [`BlendMode::Normal`] (standard alpha-over composite).
     ///
@@ -197,6 +216,10 @@ impl Clip {
             saturation: 1.0,
             opacity: 1.0,
             opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
             blend_mode: BlendMode::Normal,
             composite_op: CompositeOp::Over,
             speed: 1.0,
@@ -339,6 +362,10 @@ impl Clip {
             effects: self.video_effect_chain(),
             opacity: self.opacity,
             opacity_track: self.opacity_track.clone(),
+            x: self.x,
+            y: self.y,
+            x_track: self.x_track.clone(),
+            y_track: self.y_track.clone(),
             blend_mode: self.blend_mode,
         }
     }
@@ -566,6 +593,67 @@ impl Clip {
     pub fn with_opacity_track(self, track: AnimationTrack<f64>) -> Self {
         Self {
             opacity_track: Some(track),
+            ..self
+        }
+    }
+
+    /// Sets the static overlay position (pixels) of this clip on the canvas.
+    ///
+    /// Maps to the `overlay` filter's `x`/`y` — a Picture-in-Picture placement for an
+    /// overlay layer. Superseded by [`with_x_track`](Self::with_x_track) /
+    /// [`with_y_track`](Self::with_y_track) when a track is set.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    ///
+    /// let clip = Clip::new("pip.mp4").with_position(320.0, 180.0);
+    /// assert_eq!((clip.x, clip.y), (320.0, 180.0));
+    /// ```
+    #[must_use]
+    pub fn with_position(self, x: f64, y: f64) -> Self {
+        Self { x, y, ..self }
+    }
+
+    /// Animates the overlay X position with a keyframe track (timeline-global time).
+    ///
+    /// Drives the `overlay` filter's `x` per frame (`:eval=frame` + `send_command`).
+    /// Takes precedence over the static [`x`](Self::x).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ff_pipeline::Clip;
+    /// use ff_filter::{AnimationTrack, Easing};
+    /// use std::time::Duration;
+    ///
+    /// let sweep = AnimationTrack::fade(
+    ///     0.0,
+    ///     640.0,
+    ///     Duration::ZERO,
+    ///     Duration::from_secs(2),
+    ///     Easing::Linear,
+    /// );
+    /// let clip = Clip::new("pip.mp4").with_x_track(sweep);
+    /// assert!(clip.x_track.is_some());
+    /// ```
+    #[must_use]
+    pub fn with_x_track(self, track: AnimationTrack<f64>) -> Self {
+        Self {
+            x_track: Some(track),
+            ..self
+        }
+    }
+
+    /// Animates the overlay Y position with a keyframe track (timeline-global time).
+    ///
+    /// Drives the `overlay` filter's `y` per frame (`:eval=frame` + `send_command`).
+    /// Takes precedence over the static [`y`](Self::y).
+    #[must_use]
+    pub fn with_y_track(self, track: AnimationTrack<f64>) -> Self {
+        Self {
+            y_track: Some(track),
             ..self
         }
     }
@@ -879,6 +967,35 @@ mod tests {
         let stored = clip.opacity_track.expect("track stored");
         // Midpoint of a 0→1 linear ramp is 0.5.
         assert!((stored.value_at(Duration::from_millis(500)) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clip_new_should_default_position_to_zero() {
+        let clip = Clip::new("video.mp4");
+        assert_eq!((clip.x, clip.y), (0.0, 0.0));
+        assert!(clip.x_track.is_none() && clip.y_track.is_none());
+    }
+
+    #[test]
+    fn clip_with_position_should_set_x_y() {
+        let clip = Clip::new("pip.mp4").with_position(100.0, 50.0);
+        assert_eq!((clip.x, clip.y), (100.0, 50.0));
+    }
+
+    #[test]
+    fn clip_with_x_track_should_store_track() {
+        use ff_filter::{AnimationTrack, Easing};
+        let track = AnimationTrack::fade(
+            0.0,
+            640.0,
+            Duration::ZERO,
+            Duration::from_secs(2),
+            Easing::Linear,
+        );
+        let clip = Clip::new("pip.mp4").with_x_track(track);
+        let stored = clip.x_track.expect("x track stored");
+        // Midpoint of a 0→640 linear sweep is 320.
+        assert!((stored.value_at(Duration::from_secs(1)) - 320.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -313,6 +313,25 @@ impl Timeline {
                         va(track_idx, "opacity", 1.0)
                     };
 
+                    // Per-clip position: an explicit keyframe track wins, then a static
+                    // non-zero position, then any track-level animation.
+                    #[allow(clippy::float_cmp)]
+                    let clip_x = if let Some(track) = &clip.x_track {
+                        AnimatedValue::Track(track.clone())
+                    } else if clip.x != 0.0 {
+                        AnimatedValue::Static(clip.x)
+                    } else {
+                        va(track_idx, "x", 0.0)
+                    };
+                    #[allow(clippy::float_cmp)]
+                    let clip_y = if let Some(track) = &clip.y_track {
+                        AnimatedValue::Track(track.clone())
+                    } else if clip.y != 0.0 {
+                        AnimatedValue::Static(clip.y)
+                    } else {
+                        va(track_idx, "y", 0.0)
+                    };
+
                     // When a proxy is set, probe the original source resolution so
                     // the decoded proxy frames can be scaled back up to full size.
                     // If the probe fails the proxy is ignored (original used directly).
@@ -338,8 +357,8 @@ impl Timeline {
                         source: clip.source.clone(),
                         proxy,
                         input_format: None,
-                        x: va(track_idx, "x", 0.0),
-                        y: va(track_idx, "y", 0.0),
+                        x: clip_x,
+                        y: clip_y,
                         scale_x: va(track_idx, "scale_x", 1.0),
                         scale_y: va(track_idx, "scale_y", 1.0),
                         rotation: va(track_idx, "rotation", 0.0),

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -698,6 +698,10 @@ impl TimelineRunner {
                                         effects: Vec::new(),
                                         opacity: 1.0,
                                         opacity_track: None,
+                                        x: 0.0,
+                                        y: 0.0,
+                                        x_track: None,
+                                        y_track: None,
                                         blend_mode: BlendMode::Normal,
                                     };
                                     match VideoFrame::from_rgba(gw, gh, self.gap_buf.clone()) {


### PR DESCRIPTION
## Objective

- `Clip` cannot position an overlay (PiP): export reads x/y only from the track-level animation map, and the realtime preview composites every overlay at a hardcoded `0:0`.
- Animate overlay X/Y per clip, identically in export and preview.

## Solution

- `Clip` gains `x`/`y` + `x_track`/`y_track` and `with_position`/`with_x_track`/`with_y_track`. `Timeline::render` maps them to `VideoLayer::x`/`y` (export already positions the overlay and registers `overlay{idx}` x/y with `:eval=frame`).
- `RealtimeLayer` gains the same fields (threaded via `Clip::realtime_layer`). `add_blend_normal_step` takes a `NormalBlendParams` struct (opacity + position + tracks + alpha, dropping it under the arg limit) and now positions the overlay at `{x}:{y}`, adds `:eval=frame`, and registers `blend_overlay{idx}` x/y when a track is present. Un-animated `x=0,y=0` is byte-identical to the prior overlay.
- Base-layer (V1) position stays export-only in the preview (nothing composites behind the base). Genuine PiP scale-down is separate (scale).
- Probe-gated realtime test asserts the composite changes as the overlay slides across PTS.

Part of #1290
Closes #1293