### PR TITLE
feat(ff-filter): surface *Animated per-clip effects from composition builders

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -108,6 +108,7 @@ pub(crate) unsafe fn add_and_link_step(
     step: &FilterStep,
     index: usize,
     prefix: &str,
+    animations: &mut Vec<AnimationEntry>,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
     // Single-stream compound steps expand to a multi-filter subgraph and must be
     // dispatched to their dedicated builders. The single-filter path below would
@@ -242,6 +243,12 @@ pub(crate) unsafe fn add_and_link_step(
     if ret < 0 {
         return Err(FilterError::BuildFailed);
     }
+
+    // Surface any per-frame animation the step carries (e.g. `CropAnimated`), keyed to
+    // this filter's instance name so the graph's tick can `send_command` it. Empty for
+    // non-animated steps. (The standalone `FilterGraphBuilder` registers these itself.)
+    animations.extend(step.animation_entries(&format!("{prefix}{index}")));
+
     Ok(step_ctx)
 }
 
@@ -1069,7 +1076,14 @@ pub(crate) unsafe fn add_blend_normal_step(
         ) {
             continue;
         }
-        top_ctx = add_and_link_step(graph, top_ctx, step, index * 1000 + j, "blend_top")?;
+        top_ctx = add_and_link_step(
+            graph,
+            top_ctx,
+            step,
+            index * 1000 + j,
+            "blend_top",
+            animations,
+        )?;
     }
 
     // 2. Attenuate the top layer's alpha via colorchannelmixer when opacity < 1.0
@@ -1249,7 +1263,15 @@ pub(crate) unsafe fn add_blend_photographic_step(
         ) {
             continue;
         }
-        top_ctx = add_and_link_step(graph, top_ctx, step, index * 1000 + j, "blend_top")?;
+        // Non-Normal blend paths don't surface effect animation (discarded sink).
+        top_ctx = add_and_link_step(
+            graph,
+            top_ctx,
+            step,
+            index * 1000 + j,
+            "blend_top",
+            &mut Vec::new(),
+        )?;
     }
 
     // 2. Create the blend filter.
@@ -1345,7 +1367,15 @@ pub(super) unsafe fn add_blend_under_step(
         ) {
             continue;
         }
-        top_ctx = add_and_link_step(graph, top_ctx, step, index * 1000 + j, "blend_top")?;
+        // Non-Normal blend paths don't surface effect animation (discarded sink).
+        top_ctx = add_and_link_step(
+            graph,
+            top_ctx,
+            step,
+            index * 1000 + j,
+            "blend_top",
+            &mut Vec::new(),
+        )?;
     }
 
     // 2. When opacity < 1.0, attenuate the bottom (background) layer's alpha channel.
@@ -1468,7 +1498,15 @@ pub(super) unsafe fn add_blend_expr_step(
         ) {
             continue;
         }
-        top_ctx = add_and_link_step(graph, top_ctx, step, index * 1000 + j, "blend_top")?;
+        // Non-Normal blend paths don't surface effect animation (discarded sink).
+        top_ctx = add_and_link_step(
+            graph,
+            top_ctx,
+            step,
+            index * 1000 + j,
+            "blend_top",
+            &mut Vec::new(),
+        )?;
     }
 
     // 2. Create the blend filter with the expression.
@@ -1936,7 +1974,14 @@ pub(super) unsafe fn add_alphamerge_step(
         ) {
             continue;
         }
-        matte_ctx = add_and_link_step(graph, matte_ctx, step, index * 1000 + j, "matte")?;
+        matte_ctx = add_and_link_step(
+            graph,
+            matte_ctx,
+            step,
+            index * 1000 + j,
+            "matte",
+            &mut Vec::new(),
+        )?;
     }
 
     // 2. Create the alphamerge filter.
@@ -2610,7 +2655,16 @@ impl FilterGraphInner {
                 }
                 _ => ("step", i),
             };
-            prev_ctx = match add_and_link_step(graph, prev_ctx, step, step_index, step_prefix) {
+            // The standalone builder registers animation entries in its builder
+            // methods (crop_animated, …), so discard the ones surfaced here.
+            prev_ctx = match add_and_link_step(
+                graph,
+                prev_ctx,
+                step,
+                step_index,
+                step_prefix,
+                &mut Vec::new(),
+            ) {
                 Ok(ctx) => ctx,
                 Err(e) => bail!(e),
             };
@@ -2973,7 +3027,7 @@ impl FilterGraphInner {
                 continue;
             }
 
-            prev_ctx = add_and_link_step(graph, prev_ctx, step, i, "astep")?;
+            prev_ctx = add_and_link_step(graph, prev_ctx, step, i, "astep", &mut Vec::new())?;
 
             // ConcatAudio consumes n input pads; link src_ctxs[1..n-1] to pads 1..n-1.
             if let FilterStep::ConcatAudio { n } = step {

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -506,6 +506,7 @@ pub(super) unsafe fn build_video_composition(
                 step,
                 combined_idx,
                 "veff",
+                &mut animations,
             );
             match result {
                 Ok(ctx) => {
@@ -1162,13 +1163,26 @@ pub(super) unsafe fn build_realtime_composition(
         src_ctxs.push(Some(NonNull::new_unchecked(ctx)));
     }
 
+    // Animation entries registered by per-layer opacity/position tracks and by
+    // `*Animated` per-clip effects. When non-empty the graph is returned animated so
+    // the per-frame tick drives them. Declared before the base-effects loop so base
+    // (V1) effect animations (e.g. Ken Burns `CropAnimated`) are collected too.
+    let mut animations: Vec<AnimationEntry> = Vec::new();
+
     // ── Base = layer 0's buffersrc with its effects applied ───────────────────
     let Some(base_src) = src_ctxs[0] else {
         bail!(graph, "layer 0 buffersrc missing");
     };
     let mut acc = base_src.as_ptr();
     for (j, step) in layers[0].effects.iter().enumerate() {
-        acc = match crate::filter_inner::add_and_link_step(graph, acc, step, j, "rt_base") {
+        acc = match crate::filter_inner::add_and_link_step(
+            graph,
+            acc,
+            step,
+            j,
+            "rt_base",
+            &mut animations,
+        ) {
             Ok(c) => c,
             Err(e) => bail!(graph, format!("base layer effect failed: {e:?}")),
         };
@@ -1180,9 +1194,6 @@ pub(super) unsafe fn build_realtime_composition(
     let (canvas_w, canvas_h) = (layers[0].width, layers[0].height);
 
     // ── Composite layers 1.. onto the accumulator ─────────────────────────────
-    // Animation entries registered by per-layer opacity tracks (Normal blend). When
-    // non-empty the graph is returned animated so the per-frame tick drives them.
-    let mut animations: Vec<AnimationEntry> = Vec::new();
     for idx in 1..layers.len() {
         let layer = &layers[idx];
         let Some(top_src) = src_ctxs[idx] else {
@@ -1753,7 +1764,15 @@ pub(super) unsafe fn build_audio_mix(
                     combined_idx,
                 )
             } else {
-                crate::filter_inner::add_and_link_step(graph, chain_end, step, combined_idx, "eff")
+                // Audio mix path: `animation_entries` is empty for audio steps.
+                crate::filter_inner::add_and_link_step(
+                    graph,
+                    chain_end,
+                    step,
+                    combined_idx,
+                    "eff",
+                    &mut Vec::new(),
+                )
             };
             if let Ok(ctx) = result {
                 chain_end = ctx;

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -922,4 +922,91 @@ mod tests {
             "overlay should slide in and cover the red base, dropping R: r0={r0} r1={r1}"
         );
     }
+
+    #[test]
+    fn animated_crop_effect_moves_the_cropped_region_across_pts() {
+        // A base layer whose left half is red and right half is blue, cropped to a
+        // 4-wide window whose x slides 0→4 across 1s. At PTS 0 the window shows the red
+        // half; at PTS 1s it shows the blue half. Proves a `CropAnimated` per-clip
+        // effect surfaces an AnimationEntry from `add_and_link_step` and animates via
+        // `send_command` (the #1294 plumbing that unblocks Ken Burns). Probe-gated.
+        use crate::animation::{AnimatedValue, AnimationTrack, Easing, Keyframe};
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let x_track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(1), 4.0, Easing::Linear));
+        let base = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::CropAnimated {
+                x: AnimatedValue::Track(x_track),
+                y: AnimatedValue::Static(0.0),
+                width: AnimatedValue::Static(4.0),
+                height: AnimatedValue::Static(8.0),
+            }],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = RealtimeComposer::new(&[base])
+            .expect("animated-crop base must build once FFmpeg filters exist");
+
+        // Left half (cols 0..4) red, right half (cols 4..8) blue.
+        let mut data = vec![0u8; 8 * 8 * 4];
+        for row in 0..8 {
+            for col in 0..8 {
+                let p = (row * 8 + col) * 4;
+                if col < 4 {
+                    data[p] = 255; // R
+                } else {
+                    data[p + 2] = 255; // B
+                }
+                data[p + 3] = 255; // opaque
+            }
+        }
+        let sample = |composer: &mut RealtimeComposer, pts: Duration| -> Option<u8> {
+            let mut f = VideoFrame::from_rgba(8, 8, data.clone()).unwrap();
+            f.set_timestamp(Timestamp::from_duration(pts, Rational::new(1, 1_000_000)));
+            composer.push_layer(0, &f).ok()?;
+            Some(composer.pull().ok()??.to_rgba()?[0])
+        };
+
+        let Some(r0) = sample(&mut composer, Duration::ZERO) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        let Some(r1) = sample(&mut composer, Duration::from_secs(1)) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        assert!(
+            r0 > r1 + 100,
+            "the crop window should slide from the red half to the blue half: r0={r0} r1={r1}"
+        );
+    }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -8,7 +8,7 @@ use super::types::{
     DrawTextOptions, EqBand, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
 
-use crate::animation::AnimatedValue;
+use crate::animation::{AnimatedValue, AnimationEntry, AnimationTrack, Keyframe};
 use crate::blend::BlendMode;
 use crate::composite::CompositeOp;
 use ff_format::{AlphaMode, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, PixelFormat};
@@ -1513,6 +1513,10 @@ impl FilterStep {
                 let y0 = y.value_at(Duration::ZERO);
                 let w0 = width.value_at(Duration::ZERO);
                 let h0 = height.value_at(Duration::ZERO);
+                // No `eval=frame`: this FFmpeg's `crop` has no `eval` option and already
+                // re-evaluates the x/y position expressions per frame, so `send_command`
+                // updates to x/y take effect. (w/h are fixed at init — animate pan, not
+                // zoom, via crop; zoom is done by scaling.)
                 format!("x={x0}:y={y0}:w={w0}:h={h0}")
             }
             Self::GBlurAnimated { sigma } => {
@@ -1635,6 +1639,105 @@ impl FilterStep {
             ),
         }
     }
+
+    /// Animation entries this step contributes for per-frame `send_command`, when it
+    /// is an animated variant with `Track` params.
+    ///
+    /// `node_name` must equal the filter instance name created for this step (the
+    /// `send_command` target). Returns empty for non-animated steps and for `Static`
+    /// params. Used by [`crate::filter_inner::add_and_link_step`] to surface effect
+    /// animations to the composition builders; the standalone [`FilterGraphBuilder`]
+    /// registers the equivalent entries in its own builder methods.
+    pub(crate) fn animation_entries(&self, node_name: &str) -> Vec<AnimationEntry> {
+        let mut entries = Vec::new();
+        match self {
+            Self::CropAnimated {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                push_scalar_entry(&mut entries, node_name, "x", x);
+                push_scalar_entry(&mut entries, node_name, "y", y);
+                push_scalar_entry(&mut entries, node_name, "w", width);
+                push_scalar_entry(&mut entries, node_name, "h", height);
+            }
+            Self::GBlurAnimated { sigma } => {
+                push_scalar_entry(&mut entries, node_name, "sigma", sigma);
+            }
+            Self::EqAnimated {
+                brightness,
+                contrast,
+                saturation,
+                gamma,
+            } => {
+                push_scalar_entry(&mut entries, node_name, "brightness", brightness);
+                push_scalar_entry(&mut entries, node_name, "contrast", contrast);
+                push_scalar_entry(&mut entries, node_name, "saturation", saturation);
+                push_scalar_entry(&mut entries, node_name, "gamma", gamma);
+            }
+            Self::ColorBalanceAnimated { lift, gamma, gain } => {
+                push_tuple_entries(&mut entries, node_name, ["rs", "gs", "bs"], lift);
+                push_tuple_entries(&mut entries, node_name, ["rm", "gm", "bm"], gamma);
+                push_tuple_entries(&mut entries, node_name, ["rh", "gh", "bh"], gain);
+            }
+            _ => {}
+        }
+        entries
+    }
+}
+
+/// Pushes an [`AnimationEntry`] for a scalar animated param when it is a `Track`.
+fn push_scalar_entry(
+    entries: &mut Vec<AnimationEntry>,
+    node_name: &str,
+    param: &'static str,
+    av: &AnimatedValue<f64>,
+) {
+    if let AnimatedValue::Track(track) = av {
+        entries.push(AnimationEntry {
+            node_name: node_name.to_owned(),
+            param,
+            track: track.clone(),
+            suffix: "",
+        });
+    }
+}
+
+/// Pushes three per-channel [`AnimationEntry`]s for a `(R, G, B)` tuple animated param
+/// when it is a `Track`, splitting the tuple track into one scalar track per channel.
+fn push_tuple_entries(
+    entries: &mut Vec<AnimationEntry>,
+    node_name: &str,
+    params: [&'static str; 3],
+    av: &AnimatedValue<(f64, f64, f64)>,
+) {
+    let AnimatedValue::Track(track) = av else {
+        return;
+    };
+    for (i, param) in params.into_iter().enumerate() {
+        let scalar = track
+            .keyframes()
+            .iter()
+            .fold(AnimationTrack::new(), |t, kf| {
+                let v = match i {
+                    0 => kf.value.0,
+                    1 => kf.value.1,
+                    _ => kf.value.2,
+                };
+                t.push(Keyframe {
+                    timestamp: kf.timestamp,
+                    value: v,
+                    easing: kf.easing.clone(),
+                })
+            });
+        entries.push(AnimationEntry {
+            node_name: node_name.to_owned(),
+            param,
+            track: scalar,
+            suffix: "",
+        });
+    }
 }
 
 #[cfg(test)]
@@ -1728,5 +1831,48 @@ mod tests {
             color_trc: None,
         };
         assert_eq!(step.args(), "");
+    }
+
+    #[test]
+    fn animation_entries_maps_only_track_params_to_the_node() {
+        use crate::animation::{AnimatedValue, AnimationTrack, Easing, Keyframe};
+        let ramp = || {
+            AnimationTrack::new()
+                .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+                .push(Keyframe::new(Duration::from_secs(1), 10.0, Easing::Linear))
+        };
+        // Only x and h are Track → exactly two entries, both on the given node.
+        let step = FilterStep::CropAnimated {
+            x: AnimatedValue::Track(ramp()),
+            y: AnimatedValue::Static(0.0),
+            width: AnimatedValue::Static(4.0),
+            height: AnimatedValue::Track(ramp()),
+        };
+        let entries = step.animation_entries("veff0");
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| e.node_name == "veff0"));
+        let params: Vec<&str> = entries.iter().map(|e| e.param).collect();
+        assert!(params.contains(&"x") && params.contains(&"h"));
+
+        // A fully static animated step registers nothing.
+        let static_step = FilterStep::CropAnimated {
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            width: AnimatedValue::Static(4.0),
+            height: AnimatedValue::Static(8.0),
+        };
+        assert!(static_step.animation_entries("veff0").is_empty());
+
+        // A non-animated step never contributes entries.
+        assert!(
+            FilterStep::Crop {
+                x: 0,
+                y: 0,
+                width: 4,
+                height: 8,
+            }
+            .animation_entries("veff0")
+            .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## Objective

- Per-clip `*Animated` effects (`CropAnimated`, `GBlurAnimated`, `EqAnimated`, `ColorBalanceAnimated`) do not animate when used as composition layer effects: `add_and_link_step` returned only the filter context, so the composition builders had no `AnimationEntry`s to register.
- Foundation for keyframed geometry/effects in export and preview (Ken Burns pan).

## Solution

- Add `FilterStep::animation_entries(node_name)` mapping each animated variant's `Track` params to `AnimationEntry`s (crop x/y/w/h, gblur sigma, eq brightness/contrast/saturation/gamma, colorbalance tuple split per channel).
- `add_and_link_step` now takes `&mut Vec<AnimationEntry>` and pushes the step's entries keyed to its instance name (`{prefix}{index}`); both composition builders collect them — export effects (`veff`), realtime base (`rt_base`) and the Normal-blend overlay top-steps (`blend_top`). Non-Normal blend / matte / audio / single-source paths pass a throwaway sink (the standalone `FilterGraphBuilder` registers entries in its own builder methods).
- Probe-gated realtime test asserts an animated crop pans across PTS; plus an `animation_entries` unit test.

Note: this FFmpeg's `crop` has no `eval` option — x/y (pan) are commandable per-frame, but w/h (zoom) are fixed at init, so zoom will be implemented via `scale` rather than crop w/h.

Part of #1290
Closes #1294