### PR TITLE
feat(ff-filter): animated scale (zoom/resize) via self-animating expression

### DIFF
--- a/crates/ff-filter/src/animation/track.rs
+++ b/crates/ff-filter/src/animation/track.rs
@@ -129,6 +129,61 @@ impl AnimationTrack<f64> {
             .push(Keyframe::new(start, from, easing))
             .push(Keyframe::new(end, to, Easing::Linear))
     }
+
+    /// Compiles this track into an `FFmpeg` expression in terms of `var` (typically
+    /// `"t"`, the frame PTS in seconds) that reproduces [`value_at`](Self::value_at):
+    /// the value is held before the first and after the last keyframe, and
+    /// piecewise-interpolated (with per-segment easing) in between.
+    ///
+    /// For self-animating `eval=frame` filters (`scale`, `rotate`): the same
+    /// expression is placed in both the preview and export graphs, so the value
+    /// animates identically without `send_command`. Commas are `\,`-escaped for use in
+    /// a filter argument. `Easing::Bezier` falls back to linear in the expression.
+    pub fn to_ffmpeg_expr(&self, var: &str) -> String {
+        let ks = &self.keyframes;
+        match ks.len() {
+            0 => return "0".to_string(),
+            1 => return format!("{:.6}", ks[0].value),
+            _ => {}
+        }
+        // Innermost branch: hold the last value once `var` passes the last keyframe.
+        let mut expr = format!("{:.6}", ks[ks.len() - 1].value);
+        // Wrap each segment from last to first: if(lt(var, t_next), seg, rest).
+        for i in (0..ks.len() - 1).rev() {
+            let (a, b) = (&ks[i], &ks[i + 1]);
+            let t1 = b.timestamp.as_secs_f64();
+            let seg = segment_expr(
+                var,
+                a.timestamp.as_secs_f64(),
+                t1,
+                a.value,
+                b.value,
+                &a.easing,
+            );
+            expr = format!("if(lt({var}\\,{t1:.6})\\,{seg}\\,{expr})");
+        }
+        // Hold the first value before the first keyframe.
+        let t0 = ks[0].timestamp.as_secs_f64();
+        format!("if(lt({var}\\,{t0:.6})\\,{:.6}\\,{expr})", ks[0].value)
+    }
+}
+
+/// `FFmpeg` expression for one eased segment `[t0, t1)`:
+/// `v0 + (v1-v0)*ease((var-t0)/(t1-t0))`. Commas are `\,`-escaped for a filter arg.
+/// The easing formulas mirror [`Easing::apply`]; `Bezier` falls back to linear.
+fn segment_expr(var: &str, t0: f64, t1: f64, v0: f64, v1: f64, easing: &Easing) -> String {
+    let dt = (t1 - t0).max(1e-9);
+    // Normalised progress u = (var - t0) / (t1 - t0).
+    let u = format!("(({var}-{t0:.6})/{dt:.6})");
+    let eased = match easing {
+        // Hold: stay at v0 for the whole segment; the next `lt` guard jumps to v1.
+        Easing::Hold => "0".to_string(),
+        Easing::Linear | Easing::Bezier { .. } => u,
+        Easing::EaseIn => format!("pow({u}\\,3)"),
+        Easing::EaseOut => format!("(1-pow((1-{u})\\,3))"),
+        Easing::EaseInOut => format!("(3*pow({u}\\,2)-2*pow({u}\\,3))"),
+    };
+    format!("({v0:.6}+({v1:.6}-{v0:.6})*{eased})")
 }
 
 impl<T: Lerp> Default for AnimationTrack<T> {
@@ -245,6 +300,43 @@ mod tests {
         assert!(
             (long_after - 20.0).abs() < f64::EPSILON,
             "expected 20.0 long after end, got {long_after}"
+        );
+    }
+
+    #[test]
+    fn to_ffmpeg_expr_single_keyframe_is_constant() {
+        let track = AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 42.0, Easing::Linear));
+        assert_eq!(track.to_ffmpeg_expr("t"), "42.000000");
+    }
+
+    #[test]
+    fn to_ffmpeg_expr_two_keyframes_guards_and_interpolates() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 100.0, Easing::Linear));
+        let e = track.to_ffmpeg_expr("t");
+        // Before-first guard, segment-boundary guard (commas escaped), and end value.
+        assert!(
+            e.contains("if(lt(t\\,0.000000)"),
+            "before-first guard missing: {e}"
+        );
+        assert!(
+            e.contains("if(lt(t\\,2.000000)"),
+            "segment guard missing: {e}"
+        );
+        assert!(e.contains("100.000000"), "end value missing: {e}");
+        // Linear segment references normalised progress over the 2s span.
+        assert!(e.contains("/2.000000"), "span normalisation missing: {e}");
+    }
+
+    #[test]
+    fn to_ffmpeg_expr_ease_in_uses_cubic() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0, Easing::EaseIn))
+            .push(Keyframe::new(Duration::from_secs(1), 1.0, Easing::Linear));
+        assert!(
+            track.to_ffmpeg_expr("t").contains("pow("),
+            "ease-in should use pow()"
         );
     }
 }

--- a/crates/ff-filter/src/graph/builder/video/geometry.rs
+++ b/crates/ff-filter/src/graph/builder/video/geometry.rs
@@ -96,6 +96,27 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Scale (resize / zoom) with optionally animated `width`/`height` (pixels).
+    ///
+    /// Unlike [`crop_animated`](Self::crop_animated) (which uses `send_command`), this
+    /// **self-animates** via `scale=eval=frame` with the tracks compiled to
+    /// `t`-expressions, so no [`AnimationEntry`] is registered — the same expression
+    /// drives preview and export identically. A `Static` side is a constant.
+    #[must_use]
+    pub fn scale_animated(
+        mut self,
+        width: AnimatedValue<f64>,
+        height: AnimatedValue<f64>,
+        algorithm: ScaleAlgorithm,
+    ) -> Self {
+        self.steps.push(FilterStep::ScaleAnimated {
+            width,
+            height,
+            algorithm,
+        });
+        self
+    }
+
     /// Overlay a second input stream at position `(x, y)`.
     #[must_use]
     pub fn overlay(mut self, x: i32, y: i32) -> Self {

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -1009,4 +1009,78 @@ mod tests {
             "the crop window should slide from the red half to the blue half: r0={r0} r1={r1}"
         );
     }
+
+    #[test]
+    fn animated_scale_effect_resizes_the_output_across_pts() {
+        // A base layer with a `ScaleAnimated` whose width shrinks 8→4 across 1s. The
+        // self-animating `scale=eval=frame` expression re-evaluates the width per frame,
+        // so the composited output width is 8 at PTS 0 and 4 at PTS 1s. Proves #1297's
+        // expression-driven scale animates (and builds — this FFmpeg's scale supports
+        // eval=frame). Probe-gated.
+        use crate::animation::{AnimatedValue, AnimationTrack, Easing, Keyframe};
+        use crate::graph::types::ScaleAlgorithm;
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let width = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 8.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(1), 4.0, Easing::Linear));
+        let base = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::ScaleAnimated {
+                width: AnimatedValue::Track(width),
+                height: AnimatedValue::Static(8.0),
+                algorithm: ScaleAlgorithm::Bilinear,
+            }],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = RealtimeComposer::new(&[base])
+            .expect("animated-scale base must build once FFmpeg filters exist");
+
+        let sample = |composer: &mut RealtimeComposer, pts: Duration| -> Option<u32> {
+            let mut f = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+            f.set_timestamp(Timestamp::from_duration(pts, Rational::new(1, 1_000_000)));
+            composer.push_layer(0, &f).ok()?;
+            Some(composer.pull().ok()??.width())
+        };
+
+        let Some(w0) = sample(&mut composer, Duration::ZERO) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        let Some(w1) = sample(&mut composer, Duration::from_secs(1)) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        assert!(
+            w0 > w1,
+            "the scaled output width should shrink across PTS: w0={w0} w1={w1}"
+        );
+    }
 }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -231,6 +231,22 @@ pub enum FilterStep {
         /// Blur radius (standard deviation). Must evaluate to ≥ 0.0 at `Duration::ZERO`.
         sigma: AnimatedValue<f64>,
     },
+    /// Scale (resize / zoom) with optionally animated width/height, in pixels.
+    ///
+    /// Unlike `crop`, `scale` cannot be driven by `send_command` (its output size is
+    /// fixed at init); instead this **self-animates** via `scale=eval=frame` with the
+    /// width/height tracks compiled to `t`-expressions
+    /// ([`AnimationTrack::to_ffmpeg_expr`](crate::animation::AnimationTrack::to_ffmpeg_expr)).
+    /// The same expression is placed in both the preview and export graphs, so it
+    /// animates identically. When both are `Static` it renders a plain static `scale`.
+    ScaleAnimated {
+        /// Target width in pixels (expression when a `Track`).
+        width: AnimatedValue<f64>,
+        /// Target height in pixels (expression when a `Track`).
+        height: AnimatedValue<f64>,
+        /// Resampling algorithm (`flags=`).
+        algorithm: ScaleAlgorithm,
+    },
     /// Sharpen or blur via unsharp mask (luma + chroma strength).
     ///
     /// Positive values sharpen; negative values blur. Valid range for each
@@ -1028,6 +1044,7 @@ impl FilterStep {
             Self::PolygonMatte { .. } => "geq",
             Self::CropAnimated { .. } => "crop",
             Self::GBlurAnimated { .. } => "gblur",
+            Self::ScaleAnimated { .. } => "scale",
             Self::MotionBlur { .. } => "tblend",
             Self::LensCorrection { .. } => "lenscorrection",
             Self::FilmGrain { .. } => "noise",
@@ -1522,6 +1539,32 @@ impl FilterStep {
             Self::GBlurAnimated { sigma } => {
                 let s0 = sigma.value_at(Duration::ZERO);
                 format!("sigma={s0}")
+            }
+            Self::ScaleAnimated {
+                width,
+                height,
+                algorithm,
+            } => {
+                let flags = algorithm.as_flags_str();
+                let animated = matches!(width, AnimatedValue::Track(_))
+                    || matches!(height, AnimatedValue::Track(_));
+                if animated {
+                    // Self-animate via per-frame expressions. A Static side is a
+                    // constant expression; a Track side compiles to a `t`-expression.
+                    let expr = |v: &AnimatedValue<f64>| match v {
+                        AnimatedValue::Track(t) => t.to_ffmpeg_expr("t"),
+                        AnimatedValue::Static(s) => format!("{s:.6}"),
+                    };
+                    format!(
+                        "w={}:h={}:flags={flags}:eval=frame",
+                        expr(width),
+                        expr(height)
+                    )
+                } else {
+                    let w0 = width.value_at(Duration::ZERO);
+                    let h0 = height.value_at(Duration::ZERO);
+                    format!("w={w0}:h={h0}:flags={flags}")
+                }
             }
             Self::MotionBlur {
                 shutter_angle_degrees,


### PR DESCRIPTION
## Objective

- No per-clip animated scale: PiP resize and Ken Burns zoom need the layer to scale over time, but `scale` cannot be driven by `send_command` (its output size is fixed at init).
- Provide animated scale that works identically in export and the realtime preview.

## Solution

- This FFmpeg's `scale` supports `eval=frame` (verified), so scale **self-animates** via a per-frame expression rather than `send_command`.
- `AnimationTrack::to_ffmpeg_expr(var)` compiles a track into a piecewise `t`-expression (linear / ease-in / ease-out / ease-in-out / hold; `Bezier` → linear; commas `\,`-escaped for a filter arg) — reusable for rotation.
- New `FilterStep::ScaleAnimated { width, height, algorithm }` renders `scale=eval=frame:w=EXPR:h=EXPR:flags=..` when animated (a static pair renders a plain `scale`). It registers no `AnimationEntry`, so it flows through the existing `add_and_link_step` effect path unchanged (both composition builders).
- Builder `scale_animated`; a probe-gated realtime test asserts the output resizes across PTS; plus expression-compiler unit tests.

Because the same expression is placed in both graphs, scale animates identically in preview and export by construction. Combine with the crop pan from #1294 for Ken Burns.

Part of #1290
Closes #1297