### PR TITLE
feat(ff-filter): animated rotation via self-animating expression

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -199,6 +199,15 @@ pub(crate) unsafe fn add_and_link_step(
                 "mask",
             );
         }
+        FilterStep::RotateAnimated { .. } => {
+            // A transparent `fillcolor` needs an alpha plane for `rotate` to write the
+            // exposed corners; the export path feeds yuv (no alpha), so convert to rgba
+            // first. The preview already feeds rgba (no-op). Paired with the export
+            // overlay's `format=auto` (see `layer_has_alpha_effects`) so the rotated
+            // corners composite over the layers below instead of showing black.
+            let fmt = add_raw_filter_step(graph, prev_ctx, "format", "rgba", index, "rotfmt")?;
+            return add_raw_filter_step(graph, fmt, step.filter_name(), &step.args(), index, "rot");
+        }
         _ => {}
     }
 

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -206,6 +206,27 @@ pub(crate) unsafe fn add_and_link_step(
             // overlay's `format=auto` (see `layer_has_alpha_effects`) so the rotated
             // corners composite over the layers below instead of showing black.
             let fmt = add_raw_filter_step(graph, prev_ctx, "format", "rgba", index, "rotfmt")?;
+            // Rotate on PREMULTIPLIED alpha so the edge interpolation blends toward the
+            // (premultiplied) transparent fill correctly — straight-alpha rotation
+            // blends toward transparent *black*, leaving a dark halo along the rotated
+            // edges. `unpremultiply` restores straight alpha for the overlay. Falls back
+            // to a plain rotate where those filters are unavailable.
+            let have_pm = !ff_sys::avfilter_get_by_name(c"premultiply".as_ptr()).is_null()
+                && !ff_sys::avfilter_get_by_name(c"unpremultiply".as_ptr()).is_null();
+            if have_pm {
+                let pm =
+                    add_raw_filter_step(graph, fmt, "premultiply", "inplace=1", index, "rotpm")?;
+                let rot =
+                    add_raw_filter_step(graph, pm, step.filter_name(), &step.args(), index, "rot")?;
+                return add_raw_filter_step(
+                    graph,
+                    rot,
+                    "unpremultiply",
+                    "inplace=1",
+                    index,
+                    "rotupm",
+                );
+            }
             return add_raw_filter_step(graph, fmt, step.filter_name(), &step.args(), index, "rot");
         }
         _ => {}

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -206,28 +206,44 @@ pub(crate) unsafe fn add_and_link_step(
             // overlay's `format=auto` (see `layer_has_alpha_effects`) so the rotated
             // corners composite over the layers below instead of showing black.
             let fmt = add_raw_filter_step(graph, prev_ctx, "format", "rgba", index, "rotfmt")?;
-            // Rotate on PREMULTIPLIED alpha so the edge interpolation blends toward the
-            // (premultiplied) transparent fill correctly — straight-alpha rotation
-            // blends toward transparent *black*, leaving a dark halo along the rotated
-            // edges. `unpremultiply` restores straight alpha for the overlay. Falls back
-            // to a plain rotate where those filters are unavailable.
+            // `rotate` has no anti-aliasing, so its edges come out visibly stair-stepped.
+            // Supersample around it — upscale 2x, rotate, then Lanczos-downscale — so the
+            // downscale averages the jagged edges away. Do it on PREMULTIPLIED alpha so
+            // every resample (upscale, rotate, downscale) blends toward the premultiplied
+            // transparent fill correctly; straight-alpha would blend toward transparent
+            // *black* and leave a dark halo along the edges. `unpremultiply` restores
+            // straight alpha for the overlay. Falls back to a plain rotate where the
+            // premultiply filters are unavailable.
             let have_pm = !ff_sys::avfilter_get_by_name(c"premultiply".as_ptr()).is_null()
                 && !ff_sys::avfilter_get_by_name(c"unpremultiply".as_ptr()).is_null();
-            if have_pm {
-                let pm =
-                    add_raw_filter_step(graph, fmt, "premultiply", "inplace=1", index, "rotpm")?;
-                let rot =
-                    add_raw_filter_step(graph, pm, step.filter_name(), &step.args(), index, "rot")?;
-                return add_raw_filter_step(
-                    graph,
-                    rot,
-                    "unpremultiply",
-                    "inplace=1",
-                    index,
-                    "rotupm",
-                );
-            }
-            return add_raw_filter_step(graph, fmt, step.filter_name(), &step.args(), index, "rot");
+            let pre = if have_pm {
+                add_raw_filter_step(graph, fmt, "premultiply", "inplace=1", index, "rotpm")?
+            } else {
+                fmt
+            };
+            let up = add_raw_filter_step(
+                graph,
+                pre,
+                "scale",
+                "w=iw*2:h=ih*2:flags=lanczos",
+                index,
+                "rotup",
+            )?;
+            let rot =
+                add_raw_filter_step(graph, up, step.filter_name(), &step.args(), index, "rot")?;
+            let down = add_raw_filter_step(
+                graph,
+                rot,
+                "scale",
+                "w=iw/2:h=ih/2:flags=lanczos",
+                index,
+                "rotdown",
+            )?;
+            return if have_pm {
+                add_raw_filter_step(graph, down, "unpremultiply", "inplace=1", index, "rotupm")
+            } else {
+                Ok(down)
+            };
         }
         _ => {}
     }

--- a/crates/ff-filter/src/graph/builder/video/geometry.rs
+++ b/crates/ff-filter/src/graph/builder/video/geometry.rs
@@ -117,6 +117,22 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Rotate with an optionally animated `angle` (degrees), filling exposed corners
+    /// with `fill_color` (e.g. `"black"`, or `"none"` for transparent).
+    ///
+    /// **Self-animates** via `rotate=angle=EXPR` (the `angle` option is re-evaluated per
+    /// frame), so no [`AnimationEntry`] is registered — the same expression drives
+    /// preview and export. A `Static` angle renders a plain rotate. Output stays the
+    /// input size (corners clipped / filled).
+    #[must_use]
+    pub fn rotate_animated(mut self, angle: AnimatedValue<f64>, fill_color: &str) -> Self {
+        self.steps.push(FilterStep::RotateAnimated {
+            angle,
+            fill_color: fill_color.to_owned(),
+        });
+        self
+    }
+
     /// Overlay a second input stream at position `(x, y)`.
     #[must_use]
     pub fn overlay(mut self, x: i32, y: i32) -> Self {

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -418,6 +418,10 @@ pub(super) unsafe fn build_video_composition(
                     | FilterStep::PolygonMatte { .. }
                     | FilterStep::FeatherMask { .. }
                     | FilterStep::AlphaMatte { .. }
+                    // `rotate` with a transparent fill leaves alpha in the exposed
+                    // corners; the overlay must blend it (`:format=auto`) so the layers
+                    // below show through instead of the corners rendering as black.
+                    | FilterStep::RotateAnimated { .. }
             )
         });
 

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -1168,4 +1168,95 @@ mod tests {
             "180° rotation should turn the white half away from the top-left: r0={r0} r1={r1}"
         );
     }
+
+    #[test]
+    fn rotate_transparent_fill_shows_layer_below_in_corners() {
+        // A blue top layer rotated 45° with a transparent fill, over a red base. At 45°
+        // the fixed 8×8 output's corners fall outside the rotated square and are filled
+        // transparently, so the top-left composites to the red base — not black. Proves
+        // `RotateAnimated` fillcolor=none + the overlay honoring that alpha (rgba
+        // conversion + `:format=auto`). Probe-gated.
+        use crate::animation::AnimatedValue;
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let base = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let top = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::RotateAnimated {
+                angle: AnimatedValue::Static(45.0),
+                fill_color: "none".to_string(),
+            }],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = match RealtimeComposer::new(&[base, top]) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+
+        let red = VideoFrame::from_rgba(8, 8, [255u8, 0, 0, 255].repeat(64)).unwrap();
+        let mut blue = VideoFrame::from_rgba(8, 8, [0u8, 0, 255, 255].repeat(64)).unwrap();
+        blue.set_timestamp(Timestamp::from_duration(
+            Duration::ZERO,
+            Rational::new(1, 1_000_000),
+        ));
+        if composer.push_layer(0, &red).is_err() || composer.push_layer(1, &blue).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                let rgba = out.to_rgba().expect("rgba");
+                // Top-left corner: exposed by the 45° rotation → transparent → red base.
+                assert!(
+                    rgba[0] > 100 && rgba[2] < 100,
+                    "rotated corner should show the red base, not black: rgba={:?}",
+                    &rgba[0..4]
+                );
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
 }

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -1083,4 +1083,89 @@ mod tests {
             "the scaled output width should shrink across PTS: w0={w0} w1={w1}"
         );
     }
+
+    #[test]
+    fn animated_rotate_effect_turns_content_across_pts() {
+        // A base layer whose left half is white and right half is black, rotated by a
+        // `RotateAnimated` angle 0°→180° across 1s. At PTS 0 the top-left pixel is white;
+        // at PTS 1s (180°) the frame is turned, so the top-left shows the (black) right
+        // half. Proves the self-animating `rotate=angle=EXPR(t)` turns per frame.
+        // Probe-gated.
+        use crate::animation::{AnimatedValue, AnimationTrack, Easing, Keyframe};
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let angle = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(1), 180.0, Easing::Linear));
+        let base = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::RotateAnimated {
+                angle: AnimatedValue::Track(angle),
+                fill_color: "black".to_string(),
+            }],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = RealtimeComposer::new(&[base])
+            .expect("animated-rotate base must build once FFmpeg filters exist");
+
+        // Left half (cols 0..4) white, right half (cols 4..8) black.
+        let mut data = vec![0u8; 8 * 8 * 4];
+        for row in 0..8 {
+            for col in 0..8 {
+                let p = (row * 8 + col) * 4;
+                if col < 4 {
+                    data[p] = 255;
+                    data[p + 1] = 255;
+                    data[p + 2] = 255;
+                }
+                data[p + 3] = 255;
+            }
+        }
+        let sample = |composer: &mut RealtimeComposer, pts: Duration| -> Option<u8> {
+            let mut f = VideoFrame::from_rgba(8, 8, data.clone()).unwrap();
+            f.set_timestamp(Timestamp::from_duration(pts, Rational::new(1, 1_000_000)));
+            composer.push_layer(0, &f).ok()?;
+            Some(composer.pull().ok()??.to_rgba()?[0])
+        };
+
+        let Some(r0) = sample(&mut composer, Duration::ZERO) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        let Some(r1) = sample(&mut composer, Duration::from_secs(1)) else {
+            println!("Skipping: push/pull failed (FFmpeg unavailable?)");
+            return;
+        };
+        assert!(
+            r0 > r1 + 100,
+            "180° rotation should turn the white half away from the top-left: r0={r0} r1={r1}"
+        );
+    }
 }

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -1259,4 +1259,95 @@ mod tests {
             Err(e) => println!("Skipping: {e}"),
         }
     }
+
+    #[test]
+    fn rotate_over_base_reveals_base_through_forcescale_and_canvas() {
+        // Mirrors the DEMO's real preview path more closely than the 8×8 test above:
+        // the overlay is a DIFFERENT size than the base (so `build_realtime_composition`
+        // prepends a non-identity `Scale{canvas, Fast}` force-scale before the rotate),
+        // and a project canvas is set (adding the fit-to-canvas letterbox pass). The
+        // rotated overlay's transparent corners must still composite to the red base.
+        use crate::animation::AnimatedValue;
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 16,
+            height: 16,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let base = RealtimeLayer {
+            width: 16,
+            height: 16,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        // Overlay is 32×24 (≠ base 16×16) → real force-scale to canvas before rotate.
+        let top = RealtimeLayer {
+            width: 32,
+            height: 24,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::RotateAnimated {
+                angle: AnimatedValue::Static(45.0),
+                fill_color: "none".to_string(),
+            }],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let mut composer = match RealtimeComposer::with_canvas(&[base, top], Some((16, 16))) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+
+        let red = VideoFrame::from_rgba(16, 16, [255u8, 0, 0, 255].repeat(256)).unwrap();
+        let mut blue = VideoFrame::from_rgba(32, 24, [0u8, 0, 255, 255].repeat(32 * 24)).unwrap();
+        blue.set_timestamp(Timestamp::from_duration(
+            Duration::ZERO,
+            Rational::new(1, 1_000_000),
+        ));
+        if composer.push_layer(0, &red).is_err() || composer.push_layer(1, &blue).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                let rgba = out.to_rgba().expect("rgba");
+                assert!(
+                    rgba[0] > 100 && rgba[2] < 100,
+                    "rotated corner should show the red base, not black: rgba={:?}",
+                    &rgba[0..4]
+                );
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
 }

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -1261,6 +1261,83 @@ mod tests {
     }
 
     #[test]
+    fn rotate_over_base_640x360_canvas_none_reveals_base() {
+        // Exactly the demo's real config: V1 base 640×360 + V2 overlay 640×360, both
+        // same size (identity force-scale), RotateAnimated, canvas=None (aspect Original).
+        // Asserts the rotated corner reveals the red base.
+        use crate::animation::AnimatedValue;
+        use ff_format::{Rational, Timestamp};
+        use std::time::Duration;
+
+        let probe = RealtimeLayer {
+            width: 640,
+            height: 360,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+        let mk = |effects: Vec<FilterStep>| RealtimeLayer {
+            width: 640,
+            height: 360,
+            pixel_format: PixelFormat::Rgba,
+            effects,
+            opacity: 1.0,
+            opacity_track: None,
+            x: 0.0,
+            y: 0.0,
+            x_track: None,
+            y_track: None,
+            blend_mode: BlendMode::Normal,
+        };
+        let base = mk(vec![]);
+        let top = mk(vec![FilterStep::RotateAnimated {
+            angle: AnimatedValue::Static(30.0),
+            fill_color: "none".to_string(),
+        }]);
+        let mut composer = match RealtimeComposer::new(&[base, top]) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        let red = VideoFrame::from_rgba(640, 360, [255u8, 0, 0, 255].repeat(640 * 360)).unwrap();
+        let mut blue =
+            VideoFrame::from_rgba(640, 360, [0u8, 0, 255, 255].repeat(640 * 360)).unwrap();
+        blue.set_timestamp(Timestamp::from_duration(
+            Duration::ZERO,
+            Rational::new(1, 1_000_000),
+        ));
+        if composer.push_layer(0, &red).is_err() || composer.push_layer(1, &blue).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                let rgba = out.to_rgba().expect("rgba");
+                // Top-left corner exposed by the 30° rotation → should be the red base.
+                assert!(
+                    rgba[0] > 100 && rgba[2] < 100,
+                    "640x360 canvas=None: rotated corner should show red base, not black: rgba={:?}",
+                    &rgba[0..4]
+                );
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn rotate_over_base_reveals_base_through_forcescale_and_canvas() {
         // Mirrors the DEMO's real preview path more closely than the 8×8 test above:
         // the overlay is a DIFFERENT size than the base (so `build_realtime_composition`

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -247,6 +247,21 @@ pub enum FilterStep {
         /// Resampling algorithm (`flags=`).
         algorithm: ScaleAlgorithm,
     },
+    /// Rotate with an optionally animated angle (degrees), filling exposed corners
+    /// with `fill_color`.
+    ///
+    /// `rotate`'s `angle` option is an expression re-evaluated every frame, so this
+    /// **self-animates** via `rotate=angle=EXPR`: the angle track is compiled to a
+    /// `t`-expression ([`AnimationTrack::to_ffmpeg_expr`](crate::animation::AnimationTrack::to_ffmpeg_expr))
+    /// and converted degrees→radians. The same expression drives preview and export.
+    /// Output size stays `iw`×`ih` (corners clipped / filled). `Static` → a plain
+    /// rotate.
+    RotateAnimated {
+        /// Rotation angle in **degrees** (clockwise); an expression when a `Track`.
+        angle: AnimatedValue<f64>,
+        /// Colour for exposed corners (e.g. `"black"`, `"none"` for transparent).
+        fill_color: String,
+    },
     /// Sharpen or blur via unsharp mask (luma + chroma strength).
     ///
     /// Positive values sharpen; negative values blur. Valid range for each
@@ -1045,6 +1060,7 @@ impl FilterStep {
             Self::CropAnimated { .. } => "crop",
             Self::GBlurAnimated { .. } => "gblur",
             Self::ScaleAnimated { .. } => "scale",
+            Self::RotateAnimated { .. } => "rotate",
             Self::MotionBlur { .. } => "tblend",
             Self::LensCorrection { .. } => "lenscorrection",
             Self::FilmGrain { .. } => "noise",
@@ -1566,6 +1582,17 @@ impl FilterStep {
                     format!("w={w0}:h={h0}:flags={flags}")
                 }
             }
+            Self::RotateAnimated { angle, fill_color } => match angle {
+                // `rotate` re-evaluates `angle` per frame, so a Track self-animates.
+                // Compile the degrees track to a `t`-expression, converted to radians.
+                AnimatedValue::Track(track) => {
+                    let deg = track.to_ffmpeg_expr("t");
+                    format!("angle=({deg})*PI/180:fillcolor={fill_color}")
+                }
+                AnimatedValue::Static(deg) => {
+                    format!("angle={}:fillcolor={fill_color}", deg.to_radians())
+                }
+            },
             Self::MotionBlur {
                 shutter_angle_degrees,
                 ..


### PR DESCRIPTION
## Objective

- No per-clip animated rotation. Provide rotation that animates over time, identically in export and the realtime preview.

## Solution

- The `rotate` filter re-evaluates its `angle` option every frame, so rotation **self-animates** via `rotate=angle=EXPR` — reusing the track-to-expression compiler (`AnimationTrack::to_ffmpeg_expr`) from the animated scale work.
- New `FilterStep::RotateAnimated { angle, fill_color }`: a `Track` angle compiles to a `t`-expression converted degrees→radians (`angle=(EXPR)*PI/180`); a `Static` angle renders a plain rotate (matching `FilterStep::Rotate`). It registers no `AnimationEntry`, so it flows through the existing `add_and_link_step` effect path (both composition builders).
- Output size stays the input size (corners clipped / filled — same as static `rotate`). Builder `rotate_animated`; a probe-gated realtime test asserts a 180° turn moves content across PTS.

Because the same expression is placed in both graphs, rotation animates identically in preview and export by construction. Combine with position/scale for a full PiP transform.

Part of #1290
Closes #1296