### PR TITLE
feat(ff-filter): add FilterError::GplRequired variant

### DIFF
--- a/crates/ff-filter/src/error.rs
+++ b/crates/ff-filter/src/error.rs
@@ -60,6 +60,17 @@ pub enum FilterError {
         /// Human-readable reason for the failure.
         reason: String,
     },
+
+    /// A function requires a GPL-licensed `FFmpeg` filter but the `gpl` feature
+    /// flag is not enabled.
+    ///
+    /// Enable the `gpl` feature in `Cargo.toml` and ensure your distribution
+    /// complies with the GPL licence before using this function.
+    #[error("GPL-licensed feature required: {feature} (enable the `gpl` feature flag)")]
+    GplRequired {
+        /// Name of the filter or capability that requires GPL.
+        feature: &'static str,
+    },
 }
 
 #[cfg(test)]
@@ -114,6 +125,17 @@ mod tests {
             reason: "file not found".to_string(),
         };
         assert_eq!(err.to_string(), "analysis failed: file not found");
+    }
+
+    #[test]
+    fn gpl_required_should_display_feature_name() {
+        let err = FilterError::GplRequired {
+            feature: "rubberband",
+        };
+        assert_eq!(
+            err.to_string(),
+            "GPL-licensed feature required: rubberband (enable the `gpl` feature flag)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- Functions that need a GPL-licensed FFmpeg filter (e.g. `rubberband`) have no typed error to return when the `gpl` feature flag is disabled, forcing a generic `Ffmpeg`/`InvalidConfig` string.

## Solution

- Add `FilterError::GplRequired { feature: &'static str }` whose message names the required feature and points at the `gpl` flag.
- No function returns it yet; it is wired up alongside the GPL-gated features that need it.
- Add a unit test asserting the `Display` output includes the feature name.

Closes #1100