### PR TITLE
fix(ff-decode): handle negative linesize in video/image frame extraction

### DIFF
--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -31,6 +31,7 @@ use ff_sys::{
 
 use crate::error::DecodeError;
 use crate::shared::guards_inner::{AvCodecContextGuard, AvFormatContextGuard};
+use crate::shared::plane_inner::plane_row_ptr;
 
 // ── ImageDecoderInner ─────────────────────────────────────────────────────────
 
@@ -354,7 +355,6 @@ impl ImageDecoderInner {
             match format {
                 PixelFormat::Rgba | PixelFormat::Bgra => {
                     let bytes_per_pixel = 4_usize;
-                    let stride = (*frame).linesize[0] as usize;
                     let row_w = w * bytes_per_pixel;
                     let mut buf = vec![0u8; row_w * h];
                     let src = (*frame).data[0];
@@ -364,9 +364,10 @@ impl ImageDecoderInner {
                             message: "Null plane data for packed format".to_string(),
                         });
                     }
+                    let src_linesize = (*frame).linesize[0];
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
-                            src.add(row * stride),
+                            plane_row_ptr(src, src_linesize, row),
                             buf[row * row_w..].as_mut_ptr(),
                             row_w,
                         );
@@ -376,7 +377,6 @@ impl ImageDecoderInner {
                 }
                 PixelFormat::Rgb24 | PixelFormat::Bgr24 => {
                     let bytes_per_pixel = 3_usize;
-                    let stride = (*frame).linesize[0] as usize;
                     let row_w = w * bytes_per_pixel;
                     let mut buf = vec![0u8; row_w * h];
                     let src = (*frame).data[0];
@@ -386,9 +386,10 @@ impl ImageDecoderInner {
                             message: "Null plane data for packed format".to_string(),
                         });
                     }
+                    let src_linesize = (*frame).linesize[0];
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
-                            src.add(row * stride),
+                            plane_row_ptr(src, src_linesize, row),
                             buf[row * row_w..].as_mut_ptr(),
                             row_w,
                         );
@@ -397,7 +398,6 @@ impl ImageDecoderInner {
                     strides.push(row_w);
                 }
                 PixelFormat::Gray8 => {
-                    let stride = (*frame).linesize[0] as usize;
                     let mut buf = vec![0u8; w * h];
                     let src = (*frame).data[0];
                     if src.is_null() {
@@ -406,9 +406,10 @@ impl ImageDecoderInner {
                             message: "Null plane data for Gray8".to_string(),
                         });
                     }
+                    let src_linesize = (*frame).linesize[0];
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
-                            src.add(row * stride),
+                            plane_row_ptr(src, src_linesize, row),
                             buf[row * w..].as_mut_ptr(),
                             w,
                         );
@@ -418,7 +419,6 @@ impl ImageDecoderInner {
                 }
                 PixelFormat::Yuv420p | PixelFormat::Nv12 | PixelFormat::Nv21 => {
                     // Y plane (full size).
-                    let y_stride = (*frame).linesize[0] as usize;
                     let mut y_buf = vec![0u8; w * h];
                     let y_src = (*frame).data[0];
                     if y_src.is_null() {
@@ -427,9 +427,10 @@ impl ImageDecoderInner {
                             message: "Null Y plane".to_string(),
                         });
                     }
+                    let y_src_linesize = (*frame).linesize[0];
                     for row in 0..h {
                         ptr::copy_nonoverlapping(
-                            y_src.add(row * y_stride),
+                            plane_row_ptr(y_src, y_src_linesize, row),
                             y_buf[row * w..].as_mut_ptr(),
                             w,
                         );
@@ -440,13 +441,13 @@ impl ImageDecoderInner {
                     if matches!(format, PixelFormat::Nv12 | PixelFormat::Nv21) {
                         // Interleaved UV plane (half height).
                         let uv_h = h / 2;
-                        let uv_stride = (*frame).linesize[1] as usize;
                         let mut uv_buf = vec![0u8; w * uv_h];
                         let uv_src = (*frame).data[1];
                         if !uv_src.is_null() {
+                            let uv_src_linesize = (*frame).linesize[1];
                             for row in 0..uv_h {
                                 ptr::copy_nonoverlapping(
-                                    uv_src.add(row * uv_stride),
+                                    plane_row_ptr(uv_src, uv_src_linesize, row),
                                     uv_buf[row * w..].as_mut_ptr(),
                                     w,
                                 );
@@ -459,13 +460,13 @@ impl ImageDecoderInner {
                         let uv_w = w / 2;
                         let uv_h = h / 2;
                         for plane_idx in 1..=2usize {
-                            let uv_stride = (*frame).linesize[plane_idx] as usize;
                             let mut uv_buf = vec![0u8; uv_w * uv_h];
                             let uv_src = (*frame).data[plane_idx];
                             if !uv_src.is_null() {
+                                let uv_src_linesize = (*frame).linesize[plane_idx];
                                 for row in 0..uv_h {
                                     ptr::copy_nonoverlapping(
-                                        uv_src.add(row * uv_stride),
+                                        plane_row_ptr(uv_src, uv_src_linesize, row),
                                         uv_buf[row * uv_w..].as_mut_ptr(),
                                         uv_w,
                                     );
@@ -481,13 +482,13 @@ impl ImageDecoderInner {
                     let uv_w = w / 2;
                     let plane_dims = [(w, h), (uv_w, h), (uv_w, h)];
                     for (plane_idx, (pw, ph)) in plane_dims.iter().enumerate() {
-                        let stride = (*frame).linesize[plane_idx] as usize;
                         let mut buf = vec![0u8; pw * ph];
                         let src = (*frame).data[plane_idx];
                         if !src.is_null() {
+                            let src_linesize = (*frame).linesize[plane_idx];
                             for row in 0..*ph {
                                 ptr::copy_nonoverlapping(
-                                    src.add(row * stride),
+                                    plane_row_ptr(src, src_linesize, row),
                                     buf[row * pw..].as_mut_ptr(),
                                     *pw,
                                 );
@@ -500,13 +501,13 @@ impl ImageDecoderInner {
                 PixelFormat::Yuv444p => {
                     // All three planes are full size.
                     for plane_idx in 0..3usize {
-                        let stride = (*frame).linesize[plane_idx] as usize;
                         let mut buf = vec![0u8; w * h];
                         let src = (*frame).data[plane_idx];
                         if !src.is_null() {
+                            let src_linesize = (*frame).linesize[plane_idx];
                             for row in 0..h {
                                 ptr::copy_nonoverlapping(
-                                    src.add(row * stride),
+                                    plane_row_ptr(src, src_linesize, row),
                                     buf[row * w..].as_mut_ptr(),
                                     w,
                                 );

--- a/crates/ff-decode/src/shared/mod.rs
+++ b/crates/ff-decode/src/shared/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod guards_inner;
 mod hardware;
 pub(crate) mod network;
+pub(crate) mod plane_inner;
 mod seek;
 
 pub use hardware::HardwareAccel;

--- a/crates/ff-decode/src/shared/plane_inner.rs
+++ b/crates/ff-decode/src/shared/plane_inner.rs
@@ -1,0 +1,76 @@
+//! Shared low-level helper for reading decoded `AVFrame` plane rows.
+//!
+//! All `unsafe` for plane-pointer arithmetic is isolated here per the project's
+//! unsafe-code convention (`*_inner.rs` files only).
+
+#![allow(unsafe_code)]
+#![allow(clippy::cast_possible_wrap)]
+
+/// Returns the source pointer for row `y` of an `AVFrame` plane, matching
+/// `FFmpeg`'s `av_image_copy` invariant `row_y = data + y * linesize` for
+/// **both** scan directions.
+///
+/// `FFmpeg` signals bottom-up scan order with a **negative** `linesize`
+/// (e.g. `vflip`-processed frames, some hardware decoders): `data` points at the
+/// first byte of the *top* row (row 0), which sits at the *highest* address, and
+/// each subsequent row lives at a *lower* address. The signed step
+/// `data + y * linesize` yields the correct top-down row for both signs.
+///
+/// Casting `linesize` to `usize` first is wrong twice over (issue #1174): a
+/// negative value wraps to a huge stride (out-of-bounds read), and stepping a
+/// magnitude stride forward from the first row reverses row order (a vertical
+/// flip). The signed offset here avoids both.
+///
+/// # Safety
+///
+/// `data` must be non-null and point to a plane whose row `y` is in bounds. The
+/// plane occupies `[data + (rows-1)*linesize, data]` for a negative `linesize`
+/// (i.e. `data` is the last, highest-address byte's row start), or
+/// `[data, data + rows*linesize)` for a positive one.
+#[inline]
+#[must_use]
+pub(crate) unsafe fn plane_row_ptr(data: *const u8, linesize: i32, y: usize) -> *const u8 {
+    // SAFETY: the caller guarantees `data` is non-null and row `y` is within the
+    // plane, so `data + y * linesize` stays in bounds for either scan direction.
+    unsafe { data.offset(y as isize * linesize as isize) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plane_row_ptr;
+
+    #[test]
+    fn positive_linesize_should_walk_rows_top_down() {
+        let mem = [10u8, 20, 30];
+        let data = mem.as_ptr();
+        // SAFETY: rows 0..3 map to offsets 0,1,2 — all in bounds of `mem`.
+        let got: Vec<u8> = (0..3)
+            .map(|y| unsafe { *plane_row_ptr(data, 1, y) })
+            .collect();
+        assert_eq!(got, [10, 20, 30]);
+    }
+
+    #[test]
+    fn negative_linesize_should_walk_rows_top_down_without_flip() {
+        // Bottom-up frame (e.g. after `vflip`): `data` points at the top row,
+        // which sits at the HIGHEST address; lower rows are at lower addresses.
+        let mem = [10u8, 20, 30];
+        // SAFETY: index 2 is the last element of `mem`.
+        let data = unsafe { mem.as_ptr().add(2) };
+        // Correct top-down order per `av_image_copy` (row_y = data + y*linesize)
+        // is mem[2], mem[1], mem[0] == [30, 20, 10] — NOT the flipped [10,20,30].
+        // SAFETY: rows 0..3 map to offsets 0,-1,-2 — all in bounds of `mem`.
+        let got: Vec<u8> = (0..3)
+            .map(|y| unsafe { *plane_row_ptr(data, -1, y) })
+            .collect();
+        assert_eq!(got, [30, 20, 10]);
+    }
+
+    #[test]
+    fn row_zero_should_return_base_pointer() {
+        let mem = [7u8; 4];
+        let data = mem.as_ptr();
+        // SAFETY: y=0 yields a zero offset regardless of linesize sign.
+        assert_eq!(unsafe { plane_row_ptr(data, -13, 0) }, data);
+    }
+}

--- a/crates/ff-decode/src/video/decoder_inner/decoding.rs
+++ b/crates/ff-decode/src/video/decoder_inner/decoding.rs
@@ -2,6 +2,7 @@ use super::{
     AVFrame, Arc, DecodeError, Duration, OutputScale, PixelFormat, PooledBuffer, Rational,
     Timestamp, VideoDecoderInner, VideoFrame, ptr,
 };
+use crate::shared::plane_inner::plane_row_ptr;
 
 impl VideoDecoderInner {
     /// Decodes the next video frame.
@@ -289,7 +290,8 @@ impl VideoDecoderInner {
             match format {
                 PixelFormat::Rgba | PixelFormat::Bgra | PixelFormat::Rgb24 | PixelFormat::Bgr24 => {
                     // Packed formats - single plane
-                    let stride = (*frame).linesize[0] as usize;
+                    let src = (*frame).data[0];
+                    let src_linesize = (*frame).linesize[0];
                     let bytes_per_pixel = if matches!(format, PixelFormat::Rgba | PixelFormat::Bgra)
                     {
                         BYTES_PER_PIXEL_RGBA
@@ -301,9 +303,8 @@ impl VideoDecoderInner {
                     let mut plane_data = self.allocate_buffer(buffer_size);
 
                     for y in 0..height as usize {
-                        let src_offset = y * stride;
                         let dst_offset = y * row_size;
-                        let src_ptr = (*frame).data[0].add(src_offset);
+                        let src_ptr = plane_row_ptr(src, src_linesize, y);
                         let plane_slice = plane_data.as_mut();
                         // SAFETY: We copy exactly `row_size` bytes per row. The source pointer
                         // is valid (from FFmpeg frame data), destination has sufficient capacity
@@ -331,10 +332,11 @@ impl VideoDecoderInner {
                     let y_stride = width as usize;
                     let y_size = y_stride * height as usize;
                     let mut y_data = self.allocate_buffer(y_size);
+                    let y_src = (*frame).data[0];
+                    let y_src_linesize = (*frame).linesize[0];
                     for y in 0..height as usize {
-                        let src_offset = y * (*frame).linesize[0] as usize;
                         let dst_offset = y * y_stride;
-                        let src_ptr = (*frame).data[0].add(src_offset);
+                        let src_ptr = plane_row_ptr(y_src, y_src_linesize, y);
                         let y_slice = y_data.as_mut();
                         // SAFETY: Copying Y plane row-by-row. Source is valid FFmpeg data,
                         // destination has sufficient capacity, no overlap.
@@ -351,10 +353,11 @@ impl VideoDecoderInner {
                     let u_stride = chroma_width as usize;
                     let u_size = u_stride * chroma_height as usize;
                     let mut u_data = self.allocate_buffer(u_size);
+                    let u_src = (*frame).data[1];
+                    let u_src_linesize = (*frame).linesize[1];
                     for y in 0..chroma_height as usize {
-                        let src_offset = y * (*frame).linesize[1] as usize;
                         let dst_offset = y * u_stride;
-                        let src_ptr = (*frame).data[1].add(src_offset);
+                        let src_ptr = plane_row_ptr(u_src, u_src_linesize, y);
                         let u_slice = u_data.as_mut();
                         // SAFETY: Copying U (chroma) plane row-by-row. Valid source,
                         // sufficient destination capacity, no overlap.
@@ -371,10 +374,11 @@ impl VideoDecoderInner {
                     let v_stride = chroma_width as usize;
                     let v_size = v_stride * chroma_height as usize;
                     let mut v_data = self.allocate_buffer(v_size);
+                    let v_src = (*frame).data[2];
+                    let v_src_linesize = (*frame).linesize[2];
                     for y in 0..chroma_height as usize {
-                        let src_offset = y * (*frame).linesize[2] as usize;
                         let dst_offset = y * v_stride;
-                        let src_ptr = (*frame).data[2].add(src_offset);
+                        let src_ptr = plane_row_ptr(v_src, v_src_linesize, y);
                         let v_slice = v_data.as_mut();
                         // SAFETY: Copying V (chroma) plane row-by-row. Valid source,
                         // sufficient destination capacity, no overlap.
@@ -391,11 +395,12 @@ impl VideoDecoderInner {
                     // Single plane grayscale
                     let stride = width as usize;
                     let mut plane_data = self.allocate_buffer(stride * height as usize);
+                    let src = (*frame).data[0];
+                    let src_linesize = (*frame).linesize[0];
 
                     for y in 0..height as usize {
-                        let src_offset = y * (*frame).linesize[0] as usize;
                         let dst_offset = y * stride;
-                        let src_ptr = (*frame).data[0].add(src_offset);
+                        let src_ptr = plane_row_ptr(src, src_linesize, y);
                         let plane_slice = plane_data.as_mut();
                         // SAFETY: Copying grayscale plane row-by-row. Valid source,
                         // sufficient destination capacity, no overlap.
@@ -416,10 +421,11 @@ impl VideoDecoderInner {
                     // Y plane
                     let y_stride = width as usize;
                     let mut y_data = self.allocate_buffer(y_stride * height as usize);
+                    let y_src = (*frame).data[0];
+                    let y_src_linesize = (*frame).linesize[0];
                     for y in 0..height as usize {
-                        let src_offset = y * (*frame).linesize[0] as usize;
                         let dst_offset = y * y_stride;
-                        let src_ptr = (*frame).data[0].add(src_offset);
+                        let src_ptr = plane_row_ptr(y_src, y_src_linesize, y);
                         let y_slice = y_data.as_mut();
                         // SAFETY: Copying Y plane (semi-planar) row-by-row. Valid source,
                         // sufficient destination capacity, no overlap.
@@ -435,10 +441,11 @@ impl VideoDecoderInner {
                     // UV plane
                     let uv_stride = width as usize;
                     let mut uv_data = self.allocate_buffer(uv_stride * uv_height as usize);
+                    let uv_src = (*frame).data[1];
+                    let uv_src_linesize = (*frame).linesize[1];
                     for y in 0..uv_height as usize {
-                        let src_offset = y * (*frame).linesize[1] as usize;
                         let dst_offset = y * uv_stride;
-                        let src_ptr = (*frame).data[1].add(src_offset);
+                        let src_ptr = plane_row_ptr(uv_src, uv_src_linesize, y);
                         let uv_slice = uv_data.as_mut();
                         // SAFETY: Copying interleaved UV plane (semi-planar) row-by-row.
                         // Valid source, sufficient destination capacity, no overlap.
@@ -458,12 +465,12 @@ impl VideoDecoderInner {
                     let size = row_size * height as usize;
 
                     for plane_idx in 0..3usize {
-                        let src_linesize = (*frame).linesize[plane_idx] as usize;
+                        let src = (*frame).data[plane_idx];
+                        let src_linesize = (*frame).linesize[plane_idx];
                         let mut plane_data = self.allocate_buffer(size);
                         for y in 0..height as usize {
-                            let src_offset = y * src_linesize;
                             let dst_offset = y * row_size;
-                            let src_ptr = (*frame).data[plane_idx].add(src_offset);
+                            let src_ptr = plane_row_ptr(src, src_linesize, y);
                             let dst_slice = plane_data.as_mut();
                             // SAFETY: Copying one row of a planar float plane. Source is valid
                             // FFmpeg frame data, destination has sufficient capacity, no overlap.


### PR DESCRIPTION
## Objective

- The video and image decoders cast `AVFrame::linesize[i]` straight to `usize` in every plane-extraction loop. FFmpeg uses a negative `linesize` for bottom-up scan order (vflip'd frames, some hardware decoders, malformed streams); the bare cast wraps it to a huge value, so the row offset overflows and `copy_nonoverlapping` reads unmapped memory (UB).

## Solution

- Route all 16 cast sites through one shared helper, `plane_row_ptr`, which computes each row's source pointer with a signed step `data + y * linesize`, matching FFmpeg's `av_image_copy` invariant for both scan directions.
- This removes the out-of-bounds read and returns the plane in correct top-down order instead of vertically flipped. A code review caught that the initial `unsigned_abs()` + step-back approach (mirroring `ff-filter`'s `convert.rs`) reproduced a latent vertical flip; the signed-step helper fixes both.
- Image null-plane handling (error vs zero-fill) is preserved unchanged.
- Add unit tests for the top-down walk on positive and negative `linesize`, the negative case guarding against the flip regression.
- The same latent flip in `ff-filter`'s `convert.rs` is tracked separately in #1306.

Fixes #1174