### PR TITLE
chore(metadata): refine crates.io categories and keywords

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -7,8 +7,8 @@ description = "Safe, high-level audio/video/image processing for Rust — backen
 license.workspace = true
 readme = "README.md"
 repository.workspace = true
-keywords = ["video", "audio", "ffmpeg", "multimedia", "codec"]
-categories = ["multimedia::video", "multimedia::audio", "multimedia::encoding"]
+keywords = ["video", "audio", "ffmpeg", "codec", "async"]
+categories = ["multimedia::video", "multimedia::audio", "multimedia::encoding", "api-bindings", "asynchronous"]
 
 [features]
 default = ["probe", "decode", "encode", "hwaccel"]

--- a/crates/ff-decode/Cargo.toml
+++ b/crates/ff-decode/Cargo.toml
@@ -7,8 +7,8 @@ description = "Video and audio decoding - the Rust way"
 license.workspace = true
 readme = "README.md"
 repository.workspace = true
-keywords = ["video", "audio", "ffmpeg", "media", "decode"]
-categories = ["multimedia::video", "multimedia::audio"]
+keywords = ["video", "audio", "ffmpeg", "decode", "async"]
+categories = ["multimedia::video", "multimedia::audio", "multimedia::images", "api-bindings", "asynchronous"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ff-encode/Cargo.toml
+++ b/crates/ff-encode/Cargo.toml
@@ -7,8 +7,8 @@ description = "Video and audio encoding - the Rust way"
 license.workspace = true
 readme = "README.md"
 repository.workspace = true
-keywords = ["video", "audio", "ffmpeg", "media", "encode"]
-categories = ["multimedia::video", "multimedia::audio"]
+keywords = ["video", "audio", "ffmpeg", "encode", "async"]
+categories = ["multimedia::video", "multimedia::audio", "multimedia::images", "api-bindings", "asynchronous"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ff-filter/Cargo.toml
+++ b/crates/ff-filter/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 keywords = ["video", "audio", "ffmpeg", "filter", "effect"]
-categories = ["multimedia::video", "multimedia::audio"]
+categories = ["multimedia::video", "multimedia::audio", "api-bindings"]
 
 [features]
 serde = ["dep:serde"]

--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 keywords = ["video", "audio", "ffmpeg", "pipeline", "transcode"]
-categories = ["multimedia::video", "multimedia::audio"]
+categories = ["multimedia::video", "multimedia::audio", "api-bindings"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -7,8 +7,8 @@ description = "Real-time video/audio preview and proxy workflow"
 license.workspace = true
 readme = "README.md"
 repository.workspace = true
-keywords = ["video", "audio", "ffmpeg", "preview", "playback"]
-categories = ["multimedia::video", "multimedia::audio"]
+keywords = ["video", "audio", "ffmpeg", "preview", "async"]
+categories = ["multimedia::video", "multimedia::audio", "api-bindings", "asynchronous"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ff-probe/Cargo.toml
+++ b/crates/ff-probe/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 keywords = ["video", "audio", "ffmpeg", "media", "probe"]
-categories = ["multimedia::video", "multimedia::audio"]
+categories = ["multimedia::video", "multimedia::audio", "multimedia::images", "api-bindings"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 keywords = ["video", "gpu", "wgpu", "compositing", "rendering"]
-categories = ["multimedia::video"]
+categories = ["multimedia::video", "rendering"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ff-stream/Cargo.toml
+++ b/crates/ff-stream/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 readme = "README.md"
 repository.workspace = true
 keywords = ["video", "ffmpeg", "hls", "dash", "streaming"]
-categories = ["multimedia::video", "multimedia::encoding"]
+categories = ["multimedia::video", "multimedia::encoding", "api-bindings", "network-programming"]
 
 [features]
 srt = []


### PR DESCRIPTION
## Objective

- Improve discoverability of the `ff-*` / `avio` crates on crates.io. Several crates were under-categorized (e.g. `ff-render` had only `multimedia::video`; no crate advertised its FFmpeg-binding, image, streaming, or async nature), so users browsing relevant categories were unlikely to find them.

## Solution

- `api-bindings` for the crates that idiomatically wrap FFmpeg's C API (ff-probe/decode/encode/filter/pipeline/stream/preview, avio).
- `multimedia::images` for the crates that also handle still images (ff-probe/decode/encode).
- `rendering` for ff-render (GPU compositing via wgpu).
- `network-programming` for ff-stream (HLS/DASH streaming output).
- `asynchronous` category + `async` keyword for the crates exposing async APIs behind the `tokio` feature (ff-decode/encode/preview, avio).
- Keyword changes stay within the 5-keyword limit by dropping generic/redundant terms (`media`, `playback`, `multimedia`) in favour of `async`. All categories are valid crates.io slugs; metadata-only, no code change.