### PR TITLE
feat(ff-filter): extend pitch_shift() to ±24 semitones via atempo chain

### DIFF
--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -79,17 +79,19 @@ impl FilterGraph {
 
     /// Shift audio pitch by `semitones` without changing playback speed.
     ///
-    /// Range: −12.0 to +12.0 semitones. Uses `asetrate` to change the
+    /// Range: −24.0 to +24.0 semitones. Uses `asetrate` to change the
     /// decoded sample rate followed by `atempo` to restore original duration.
+    /// Beyond ±12 semitones the `atempo` compensation factor falls outside a
+    /// single instance's `[0.5, 2.0]` range and is realised by chaining.
     ///
     /// # Errors
     ///
-    /// Returns [`FilterError::Ffmpeg`] if `semitones` is outside −12.0..=12.0.
+    /// Returns [`FilterError::Ffmpeg`] if `semitones` is outside −24.0..=24.0.
     pub fn pitch_shift(&mut self, semitones: f32) -> Result<&mut Self, FilterError> {
-        if !(-12.0..=12.0).contains(&semitones) {
+        if !(-24.0..=24.0).contains(&semitones) {
             return Err(FilterError::Ffmpeg {
                 code: 0,
-                message: format!("semitones must be in -12..=12, got {semitones}"),
+                message: format!("semitones must be in -24..=24, got {semitones}"),
             });
         }
         self.inner.push_step(FilterStep::PitchShift { semitones });
@@ -386,25 +388,35 @@ mod tests {
     #[test]
     fn pitch_shift_above_range_should_return_ffmpeg_error() {
         let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
-        let result = graph.pitch_shift(13.0);
+        let result = graph.pitch_shift(24.5);
         assert!(
             matches!(result, Err(FilterError::Ffmpeg { .. })),
-            "semitones=13.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+            "semitones=24.5 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
         );
     }
 
     #[test]
     fn pitch_shift_below_range_should_return_ffmpeg_error() {
         let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
-        let result = graph.pitch_shift(-13.0);
+        let result = graph.pitch_shift(-24.5);
         assert!(
             matches!(result, Err(FilterError::Ffmpeg { .. })),
-            "semitones=-13.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+            "semitones=-24.5 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
         );
     }
 
     #[test]
     fn pitch_shift_boundary_values_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(
+            graph.pitch_shift(24.0).is_ok(),
+            "semitones=24.0 must succeed"
+        );
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(
+            graph.pitch_shift(-24.0).is_ok(),
+            "semitones=-24.0 must succeed"
+        );
         let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
         assert!(
             graph.pitch_shift(12.0).is_ok(),

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2930,10 +2930,13 @@ impl FilterGraphInner {
                 continue;
             }
 
-            // PitchShift — compound step: asetrate → atempo.
-            // asetrate changes the declared sample rate (shifting pitch); atempo
-            // restores the original duration.  The actual sample rate is resolved
-            // from buffersrc_args so the integer value is substituted literally.
+            // PitchShift — compound step: asetrate → atempo chain.
+            // asetrate changes the declared sample rate (shifting pitch); the
+            // atempo chain restores the original duration.  For |semitones| > 12
+            // the compensation factor falls outside a single atempo instance's
+            // range, so add_atempo_chain decomposes it into linked instances.
+            // The actual sample rate is resolved from buffersrc_args so the
+            // integer value is substituted literally.
             if let FilterStep::PitchShift { semitones } = step {
                 let rate = 2f64.powf(f64::from(*semitones) / 12.0);
                 let sr = parse_sample_rate_from_buffersrc(buffersrc_args);
@@ -2949,14 +2952,7 @@ impl FilterGraphInner {
                     i,
                     "pitch_asetrate",
                 )?;
-                prev_ctx = add_raw_filter_step(
-                    graph,
-                    prev_ctx,
-                    "atempo",
-                    &format!("{atempo:.6}"),
-                    i,
-                    "pitch_atempo",
-                )?;
+                prev_ctx = add_atempo_chain(graph, prev_ctx, atempo, i)?;
                 continue;
             }
 

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -801,14 +801,14 @@ pub enum FilterStep {
     /// duration.  Implemented as `asetrate` (changes the declared sample rate
     /// to shift pitch) followed by `atempo` (restores the original duration).
     ///
-    /// Range: [−12.0, 12.0]; validated by
+    /// Range: [−24.0, 24.0]; validated by
     /// [`FilterGraph::pitch_shift`](crate::FilterGraph::pitch_shift).
     ///
     /// This is a compound step — `filter_name()` returns `"asetrate"` for
     /// `validate_filter_steps`; the actual graph construction is handled by
     /// `filter_inner::build::build_audio_graph`.
     PitchShift {
-        /// Pitch shift in semitones. Range: [−12.0, 12.0].
+        /// Pitch shift in semitones. Range: [−24.0, 24.0].
         semitones: f32,
     },
 

--- a/crates/ff-filter/tests/audio_effect_tests.rs
+++ b/crates/ff-filter/tests/audio_effect_tests.rs
@@ -478,6 +478,92 @@ fn pitch_shift_12_semitones_should_produce_audio_output() {
     }
 }
 
+/// Verifies that `FilterGraph::pitch_shift(24.0)` builds and runs. The +24
+/// semitone compensation factor (atempo = 0.25) falls outside a single atempo
+/// instance and must be realised as a chain. Acceptance criterion for #1091.
+#[test]
+fn pitch_shift_plus_24_semitones_should_produce_audio_output() {
+    const SAMPLE_RATE: u32 = 48_000;
+    const SAMPLES: usize = 48_000;
+
+    let frame = make_sine_frame(440.0, SAMPLE_RATE, SAMPLES);
+
+    let mut graph = match FilterGraph::builder().build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: graph build failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = graph.pitch_shift(24.0) {
+        println!("Skipping: pitch_shift setup failed: {e}");
+        return;
+    }
+
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(FilterError::BuildFailed) => {
+            println!("Skipping: pitch shift filters not available");
+            return;
+        }
+        Err(e) => panic!("push_audio failed unexpectedly: {e}"),
+    }
+
+    match graph.pull_audio() {
+        Ok(Some(out)) => {
+            assert!(
+                out.channels() > 0,
+                "pitch_shift output must have at least one channel"
+            );
+        }
+        Ok(None) => println!("Note: pitch_shift buffered (no immediate output)"),
+        Err(e) => println!("Note: pull_audio returned: {e}"),
+    }
+}
+
+/// Verifies that `FilterGraph::pitch_shift(-24.0)` builds and runs. The −24
+/// semitone compensation factor (atempo = 4.0) also requires the atempo chain
+/// path. Acceptance criterion for #1091.
+#[test]
+fn pitch_shift_minus_24_semitones_should_produce_audio_output() {
+    const SAMPLE_RATE: u32 = 48_000;
+    const SAMPLES: usize = 48_000;
+
+    let frame = make_sine_frame(440.0, SAMPLE_RATE, SAMPLES);
+
+    let mut graph = match FilterGraph::builder().build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: graph build failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = graph.pitch_shift(-24.0) {
+        println!("Skipping: pitch_shift setup failed: {e}");
+        return;
+    }
+
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(FilterError::BuildFailed) => {
+            println!("Skipping: pitch shift filters not available");
+            return;
+        }
+        Err(e) => panic!("push_audio failed unexpectedly: {e}"),
+    }
+
+    match graph.pull_audio() {
+        Ok(Some(out)) => {
+            assert!(
+                out.channels() > 0,
+                "pitch_shift output must have at least one channel"
+            );
+        }
+        Ok(None) => println!("Note: pitch_shift buffered (no immediate output)"),
+        Err(e) => println!("Note: pull_audio returned: {e}"),
+    }
+}
+
 // ── time_stretch ──────────────────────────────────────────────────────────────
 
 /// Verifies that `FilterGraph::time_stretch()` accepts audio and produces


### PR DESCRIPTION
## Objective

- `pitch_shift()` only accepted ±12 semitones, where the compensating `atempo` factor sits exactly on a single instance's `[0.5, 2.0]` limit.
- ±24 semitones drives the factor to `0.25` or `4.0`, which a single `atempo` node cannot express, so the wider musical range (needed for 音MAD work) was unavailable.

## Solution

- Widen the validated range to `-24.0..=24.0` (validation, error message, and doc comments).
- Replace the single `atempo` node in the `PitchShift` build path with `add_atempo_chain` (already used by `TimeStretch`), which decomposes an arbitrary factor into linked instances. Existing ±12 inputs are unchanged, since `decompose_atempo` yields the same single-node chain there.
- Update the existing validation unit tests (`13.0` is now valid, so the out-of-range cases move to ±24.5) and add probe-gated integration tests for both ±24 boundaries, exercising the two distinct chain shapes (`[0.5, 0.5]` and `[4.0]`).

Closes #1091