### PR TITLE
test(ff-filter): unit and integration tests for ±24 semitone pitch_shift()

### DIFF
--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -386,7 +386,25 @@ mod tests {
     }
 
     #[test]
-    fn pitch_shift_above_range_should_return_ffmpeg_error() {
+    fn pitch_shift_24_semitones_up_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(
+            graph.pitch_shift(24.0).is_ok(),
+            "semitones=24.0 must succeed"
+        );
+    }
+
+    #[test]
+    fn pitch_shift_24_semitones_down_should_succeed() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(
+            graph.pitch_shift(-24.0).is_ok(),
+            "semitones=-24.0 must succeed"
+        );
+    }
+
+    #[test]
+    fn pitch_shift_above_24_should_return_ffmpeg_error() {
         let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
         let result = graph.pitch_shift(24.5);
         assert!(
@@ -396,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    fn pitch_shift_below_range_should_return_ffmpeg_error() {
+    fn pitch_shift_below_minus_24_should_return_ffmpeg_error() {
         let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
         let result = graph.pitch_shift(-24.5);
         assert!(
@@ -407,16 +425,6 @@ mod tests {
 
     #[test]
     fn pitch_shift_boundary_values_should_succeed() {
-        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
-        assert!(
-            graph.pitch_shift(24.0).is_ok(),
-            "semitones=24.0 must succeed"
-        );
-        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
-        assert!(
-            graph.pitch_shift(-24.0).is_ok(),
-            "semitones=-24.0 must succeed"
-        );
         let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
         assert!(
             graph.pitch_shift(12.0).is_ok(),

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -499,6 +499,27 @@ impl FilterGraphInner {
         }
     }
 
+    /// Signal end-of-stream to every audio `buffersrc`, so buffering filters
+    /// (e.g. `atempo`) flush their pending output for the following
+    /// [`pull_audio`](Self::pull_audio) drain. No-op if the audio graph has not
+    /// been built yet (nothing has been pushed).
+    pub(crate) fn flush_audio(&mut self) {
+        if self.asink_ctx.is_none() {
+            return;
+        }
+        let audio_inputs = self.audio_input_count();
+        let video_slots = self.src_ctxs.len().saturating_sub(audio_inputs);
+        for slot in 0..audio_inputs {
+            if let Some(src_ctx) = self.src_ctxs.get(video_slots + slot).and_then(|opt| *opt) {
+                // SAFETY: `src_ctx` is a valid audio buffersrc owned by this
+                // graph; `av_buffersrc_close` signals EOF on it.
+                unsafe {
+                    ff_sys::av_buffersrc_close(src_ctx.as_ptr(), ff_sys::AV_NOPTS_VALUE, 0u32);
+                }
+            }
+        }
+    }
+
     // ── Two-pass loudness normalization ──────────────────────────────────────
 
     /// Run EBU R128 two-pass loudness normalization over `self.loudness_buf`:

--- a/crates/ff-filter/src/graph/graph.rs
+++ b/crates/ff-filter/src/graph/graph.rs
@@ -179,4 +179,16 @@ impl FilterGraph {
     pub fn pull_audio(&mut self) -> Result<Option<AudioFrame>, FilterError> {
         self.inner.pull_audio()
     }
+
+    /// Signal end-of-stream to the audio graph, flushing output still buffered
+    /// inside filters such as `atempo` (used by `pitch_shift` / `time_stretch`).
+    ///
+    /// Call this once after the final [`push_audio`](Self::push_audio) and
+    /// before draining the remaining frames with
+    /// [`pull_audio`](Self::pull_audio). A WSOLA filter like `atempo` holds its
+    /// tail until EOF, so without a flush the last frames never emerge. No-op if
+    /// no audio has been pushed yet.
+    pub fn flush_audio(&mut self) {
+        self.inner.flush_audio();
+    }
 }

--- a/crates/ff-filter/tests/audio_effect_tests.rs
+++ b/crates/ff-filter/tests/audio_effect_tests.rs
@@ -564,6 +564,118 @@ fn pitch_shift_minus_24_semitones_should_produce_audio_output() {
     }
 }
 
+/// Estimate the dominant (fundamental) frequency of a mono sample buffer via
+/// autocorrelation. `sample_rate` is the rate the samples were captured at.
+/// Returns `None` if the buffer is too short to cover the search range.
+fn dominant_frequency(samples: &[f32], sample_rate: u32) -> Option<f64> {
+    let sr = f64::from(sample_rate);
+    // Search 100 Hz..2000 Hz, which brackets both 220 Hz and 880 Hz.
+    let min_lag = (sr / 2000.0).floor() as usize;
+    let max_lag = (sr / 100.0).ceil() as usize;
+    if max_lag <= min_lag || samples.len() <= max_lag * 2 {
+        return None;
+    }
+    // Remove DC offset so the autocorrelation is not dominated by a bias.
+    let mean = samples.iter().map(|&s| f64::from(s)).sum::<f64>() / samples.len() as f64;
+    let centered: Vec<f64> = samples.iter().map(|&s| f64::from(s) - mean).collect();
+
+    let mut best_lag = min_lag;
+    let mut best_corr = f64::MIN;
+    for lag in min_lag..=max_lag {
+        let mut corr = 0.0;
+        for i in 0..centered.len() - lag {
+            corr += centered[i] * centered[i + lag];
+        }
+        if corr > best_corr {
+            best_corr = corr;
+            best_lag = lag;
+        }
+    }
+    Some(sr / best_lag as f64)
+}
+
+/// Verifies that `pitch_shift(24.0)` (+2 octaves) actually multiplies the
+/// fundamental frequency by four: a 220 Hz sine becomes ~880 Hz. Uses
+/// autocorrelation on the filtered output rather than an FFT (no FFT crate in
+/// the workspace; `astats` reports level, not pitch). Acceptance criterion for
+/// issue #1092.
+#[test]
+fn pitch_shift_24_semitones_should_double_frequency_twice() {
+    const SAMPLE_RATE: u32 = 48_000;
+    const SAMPLES: usize = 48_000; // 1 second of 220 Hz
+
+    let frame = make_sine_frame(220.0, SAMPLE_RATE, SAMPLES);
+
+    // `pitch_shift` is a post-build effect, and `build()` rejects an empty
+    // graph, so seed a transparent `volume(0.0)` (0 dB = x1.0) step. That makes
+    // the graph non-empty without altering the signal's frequency.
+    let mut graph = match FilterGraph::builder().volume(0.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: graph build failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = graph.pitch_shift(24.0) {
+        println!("Skipping: pitch_shift setup failed: {e}");
+        return;
+    }
+
+    match graph.push_audio(0, &frame) {
+        Ok(()) => {}
+        Err(FilterError::BuildFailed) => {
+            println!("Skipping: pitch shift filters not available");
+            return;
+        }
+        Err(e) => panic!("push_audio failed unexpectedly: {e}"),
+    }
+
+    // atempo (WSOLA) holds its tail until EOF, so flush before draining.
+    graph.flush_audio();
+
+    // Drain all available output, collecting channel-0 samples and the output
+    // sample rate (asetrate shifts it, so `pitch_shift` output is not 48 kHz).
+    let mut mono: Vec<f32> = Vec::new();
+    let mut out_rate: Option<u32> = None;
+    while let Ok(Some(out)) = graph.pull_audio() {
+        if out_rate.is_none() {
+            out_rate = Some(out.sample_rate());
+        }
+        if let Some(s) = out.as_f32() {
+            // Packed interleaved stereo: take the left channel.
+            mono.extend(s.iter().step_by(2));
+        } else if let Some(s) = out.channel_as_f32(0) {
+            mono.extend_from_slice(s);
+        }
+    }
+
+    let Some(rate) = out_rate else {
+        println!("Skipping: no output frame produced (buffered)");
+        return;
+    };
+    if mono.len() < 8192 {
+        println!(
+            "Skipping: too few output samples ({}) to measure",
+            mono.len()
+        );
+        return;
+    }
+
+    // Analyse a middle window to avoid WSOLA edge transients and keep the
+    // autocorrelation cheap.
+    let window = 16_384.min(mono.len());
+    let start = (mono.len() - window) / 2;
+    let freq = dominant_frequency(&mono[start..start + window], rate)
+        .expect("window is large enough for the search range");
+
+    let expected = 880.0;
+    let tolerance = expected * 0.05;
+    assert!(
+        (freq - expected).abs() <= tolerance,
+        "pitch_shift(24.0) of 220 Hz must yield ~880 Hz (±5%), measured {freq:.1} Hz at {rate} Hz"
+    );
+}
+
 // ── time_stretch ──────────────────────────────────────────────────────────────
 
 /// Verifies that `FilterGraph::time_stretch()` accepts audio and produces


### PR DESCRIPTION
## Objective

- #1091 extended `pitch_shift()` to ±24 semitones; this adds the boundary unit tests and a real frequency-accuracy integration test for it.
- The obvious in-memory integration test could not run: `atempo` (WSOLA) buffers its output until end-of-stream, and the public `push_audio`/`pull_audio` API had no way to signal EOF, so any such test only ever skipped.

## Solution

- Rename/split the boundary unit tests into the four mandated names (`..._up`/`..._down_should_succeed`, `..._above_24`/`..._below_minus_24_should_return_ffmpeg_error`); keep 12/0 mid-range coverage in a separate test, no duplicated assertions.
- Add `pitch_shift_24_semitones_should_double_frequency_twice`: push a 220 Hz sine through `pitch_shift(24.0)` and measure the output fundamental via autocorrelation, asserting ~880 Hz (±5%). No FFT crate exists in the workspace and `astats` reports level not pitch, so autocorrelation is used.
- Add `FilterGraph::flush_audio()` (closes each audio buffersrc via `av_buffersrc_close`, mirroring `normalize.rs`) so buffering filters can be drained; the test seeds a transparent `volume(0.0)` step so the graph builds, then push → flush → drain.

Follow-up #1312 tracks applying the same pattern to the existing atempo integration tests that currently skip.

Closes #1092