### PR TITLE
feat(ff-decode): add BpmResult type and DecodeError::BpmDetectionFailed

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -239,7 +239,7 @@ pub use ff_probe::{ProbeError, open};
 pub use ff_common::{PooledBuffer, VecPool};
 #[cfg(feature = "decode")]
 pub use ff_decode::{
-    AudioDecoder, AudioDecoderBuilder, BlackFrameDetector, DecodeError, FrameExtractor,
+    AudioDecoder, AudioDecoderBuilder, BlackFrameDetector, BpmResult, DecodeError, FrameExtractor,
     FrameHistogram, FramePool, HardwareAccel, Histogram, HistogramExtractor, ImageDecoder,
     ImageDecoderBuilder, KeyframeEnumerator, RgbParade, SceneDetector, ScopeAnalyzer, SeekMode,
     SilenceDetector, SilenceRange, ThumbnailSelector, VideoDecoder, VideoDecoderBuilder,

--- a/crates/ff-decode/src/analysis/bpm_detector.rs
+++ b/crates/ff-decode/src/analysis/bpm_detector.rs
@@ -1,0 +1,35 @@
+//! BPM (tempo) detection result type.
+//!
+//! This module defines [`BpmResult`], the public output type for BPM detection.
+//! The detector itself (spectral flux + autocorrelation) is added separately.
+
+use std::time::Duration;
+
+/// Result of BPM (beats-per-minute) detection over an audio stream.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BpmResult {
+    /// Detected tempo in beats per minute.
+    pub bpm: f64,
+    /// Timestamp of each detected beat, measured from the start of the file.
+    pub beats: Vec<Duration>,
+    /// Detection confidence in `[0.0, 1.0]`; values below `0.4` indicate an
+    /// ambiguous rhythm.
+    pub confidence: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bpm_result_should_hold_fields() {
+        let result = BpmResult {
+            bpm: 128.0,
+            beats: vec![Duration::from_millis(0), Duration::from_millis(469)],
+            confidence: 0.9,
+        };
+        assert!((result.bpm - 128.0).abs() < f64::EPSILON);
+        assert_eq!(result.beats.len(), 2);
+        assert!(result.confidence > 0.4);
+    }
+}

--- a/crates/ff-decode/src/analysis/mod.rs
+++ b/crates/ff-decode/src/analysis/mod.rs
@@ -6,6 +6,7 @@
 
 pub(crate) mod analysis_inner;
 mod black_frame_detector;
+mod bpm_detector;
 mod histogram_extractor;
 mod keyframe_enumerator;
 mod scene_detector;
@@ -13,6 +14,7 @@ mod silence_detector;
 mod waveform_analyzer;
 
 pub use black_frame_detector::BlackFrameDetector;
+pub use bpm_detector::BpmResult;
 pub use histogram_extractor::{FrameHistogram, HistogramExtractor};
 pub use keyframe_enumerator::KeyframeEnumerator;
 pub use scene_detector::SceneDetector;

--- a/crates/ff-decode/src/error.rs
+++ b/crates/ff-decode/src/error.rs
@@ -236,6 +236,16 @@ pub enum DecodeError {
         /// Human-readable description of why the analysis failed.
         reason: String,
     },
+
+    /// BPM detection failed for a structural reason.
+    ///
+    /// Returned by the BPM detector when tempo cannot be estimated (e.g. no
+    /// audio stream, or a clip too short to analyse).
+    #[error("BPM detection failed: {reason}")]
+    BpmDetectionFailed {
+        /// Human-readable description of why BPM detection failed.
+        reason: String,
+    },
 }
 
 impl DecodeError {
@@ -405,7 +415,8 @@ impl DecodeError {
             | Self::UnsupportedResolution { .. }
             | Self::StreamCorrupted { .. }
             | Self::NoFrameAtTimestamp { .. }
-            | Self::AnalysisFailed { .. } => false,
+            | Self::AnalysisFailed { .. }
+            | Self::BpmDetectionFailed { .. } => false,
         }
     }
 
@@ -453,7 +464,8 @@ impl DecodeError {
             | Self::ConnectionFailed { .. }
             | Self::Io(_)
             | Self::StreamCorrupted { .. }
-            | Self::AnalysisFailed { .. } => true,
+            | Self::AnalysisFailed { .. }
+            | Self::BpmDetectionFailed { .. } => true,
             Self::DecodingFailed { .. }
             | Self::SeekFailed { .. }
             | Self::NetworkTimeout { .. }
@@ -862,6 +874,31 @@ mod tests {
     fn analysis_failed_should_be_fatal_and_not_recoverable() {
         let e = DecodeError::AnalysisFailed {
             reason: "zero interval".to_string(),
+        };
+        assert!(e.is_fatal());
+        assert!(!e.is_recoverable());
+    }
+
+    #[test]
+    fn bpm_detection_failed_should_display_correctly() {
+        let e = DecodeError::BpmDetectionFailed {
+            reason: "no audio stream".to_string(),
+        };
+        let msg = e.to_string();
+        assert!(
+            msg.contains("BPM detection failed"),
+            "unexpected message: {msg}"
+        );
+        assert!(
+            msg.contains("no audio stream"),
+            "expected reason in message: {msg}"
+        );
+    }
+
+    #[test]
+    fn bpm_detection_failed_should_be_fatal_and_not_recoverable() {
+        let e = DecodeError::BpmDetectionFailed {
+            reason: "clip too short".to_string(),
         };
         assert!(e.is_fatal());
         assert!(!e.is_recoverable());

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -116,8 +116,8 @@ pub(crate) use shared::network;
 
 // Re-exports for convenience
 pub use analysis::{
-    BlackFrameDetector, FrameHistogram, HistogramExtractor, KeyframeEnumerator, SceneDetector,
-    SilenceDetector, SilenceRange, WaveformAnalyzer, WaveformSample,
+    BlackFrameDetector, BpmResult, FrameHistogram, HistogramExtractor, KeyframeEnumerator,
+    SceneDetector, SilenceDetector, SilenceRange, WaveformAnalyzer, WaveformSample,
 };
 pub use audio::{AudioDecoder, AudioDecoderBuilder};
 pub use error::DecodeError;


### PR DESCRIPTION
## Objective

- The upcoming BPM detector (spectral flux + autocorrelation, v0.16.0) needs a public output type and a dedicated error variant before its logic can be implemented.

## Solution

- Add `BpmResult { bpm: f64, beats: Vec<Duration>, confidence: f32 }` in `analysis/bpm_detector.rs`, re-exported from `ff_decode` and through the avio facade.
- Add `DecodeError::BpmDetectionFailed { reason }` (message `"BPM detection failed: {reason}"`) for structural detection failures, classified as fatal / not recoverable like `AnalysisFailed` and wired into the exhaustive `is_fatal` / `is_recoverable` matches.
- No detector logic yet; that lands in a separate issue.

Closes #1093