### PR TITLE
feat: per-clip audio volume automation (export + realtime preview)

### DIFF
--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -58,6 +58,10 @@ pub struct Clip {
     ///
     /// Defaults to `0.0`.
     pub volume_db: f64,
+    /// Per-clip **volume automation** track (dB), evaluated in **timeline-global**
+    /// time (the mix graph's output PTS). Takes precedence over the static
+    /// [`volume_db`](Self::volume_db) when set. Defaults to `None`.
+    pub volume_track: Option<AnimationTrack<f64>>,
     /// Audio fade-in duration at the start of the clip (`Duration::ZERO` = no fade).
     ///
     /// When non-zero, a linear ramp from silence to the clip's volume level is
@@ -209,6 +213,7 @@ impl Clip {
             transition: None,
             transition_duration: Duration::ZERO,
             volume_db: 0.0,
+            volume_track: None,
             fade_in: Duration::ZERO,
             fade_out: Duration::ZERO,
             brightness: 0.0,
@@ -457,6 +462,18 @@ impl Clip {
     pub fn volume(self, db: f64) -> Self {
         Self {
             volume_db: db,
+            ..self
+        }
+    }
+
+    /// Sets a per-clip **volume automation** track (dB) and returns the updated clip.
+    ///
+    /// The track is evaluated in **timeline-global** time and takes precedence over
+    /// the static [`volume`](Self::volume) / [`volume_db`](Self::volume_db) when set.
+    #[must_use]
+    pub fn with_volume_track(self, track: AnimationTrack<f64>) -> Self {
+        Self {
+            volume_track: Some(track),
             ..self
         }
     }
@@ -996,6 +1013,22 @@ mod tests {
         let stored = clip.x_track.expect("x track stored");
         // Midpoint of a 0→640 linear sweep is 320.
         assert!((stored.value_at(Duration::from_secs(1)) - 320.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clip_with_volume_track_should_store_track() {
+        use ff_filter::{AnimationTrack, Easing};
+        let track = AnimationTrack::fade(
+            0.0,
+            -12.0,
+            Duration::ZERO,
+            Duration::from_secs(2),
+            Easing::Linear,
+        );
+        let clip = Clip::new("narration.wav").with_volume_track(track);
+        let stored = clip.volume_track.expect("volume track stored");
+        // Midpoint of a 0→-12 dB linear sweep is -6 dB.
+        assert!((stored.value_at(Duration::from_secs(1)) - (-6.0)).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -427,10 +427,12 @@ impl Timeline {
                     // Per-clip volume_db overrides the track-level animation when non-zero.
                     // This lets callers set independent gain on each clip without needing
                     // one audio track per clip.
-                    let volume = if clip.volume_db == 0.0 {
-                        aa(track_idx, "volume", 0.0)
-                    } else {
-                        AnimatedValue::Static(clip.volume_db)
+                    // A per-clip volume track takes precedence over the static
+                    // volume_db, which in turn overrides the track-level animation.
+                    let volume = match &clip.volume_track {
+                        Some(track) => AnimatedValue::Track(track.clone()),
+                        None if clip.volume_db != 0.0 => AnimatedValue::Static(clip.volume_db),
+                        None => aa(track_idx, "volume", 0.0),
                     };
 
                     let mut effects: Vec<FilterStep> = Vec::new();

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -269,6 +269,7 @@ impl TimelinePlayer {
                         fade_out: clip.fade_out,
                         clip_dur,
                         handle,
+                        volume_track: clip.volume_track.clone(),
                         cancel: None,
                         thread: None,
                     });
@@ -320,8 +321,10 @@ impl TimelinePlayer {
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .add_track();
-                // Apply per-clip gain (dB → linear).
-                if clip.volume_db != 0.0 {
+                // Apply per-clip gain (dB → linear). A volume_track (animated) takes
+                // precedence and is driven per-tick by the runner, so only apply the
+                // static gain when no track is present.
+                if clip.volume_track.is_none() && clip.volume_db != 0.0 {
                     #[allow(clippy::cast_possible_truncation)]
                     let linear = 10.0_f64.powf(clip.volume_db / 20.0) as f32;
                     handle.set_volume(linear);
@@ -335,6 +338,7 @@ impl TimelinePlayer {
                     fade_out: clip.fade_out,
                     clip_dur,
                     handle,
+                    volume_track: clip.volume_track.clone(),
                     cancel: None,
                     thread: None,
                 });

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -590,6 +590,22 @@ impl TimelineRunner {
                             // not play this track's buffered audio past clip end.
                             at.handle.clear();
                         }
+                        // Per-clip volume automation: evaluate the dB envelope at the
+                        // timeline PTS and update the mixer track gain each tick.
+                        if should_run && let Some(track) = &at.volume_track {
+                            #[allow(clippy::cast_possible_truncation)]
+                            let linear = 10f32.powf(track.value_at(timeline_pts) as f32 / 20.0);
+                            at.handle.set_volume(linear);
+                        }
+                    }
+
+                    // Primary-track volume automation for the active clip.
+                    if let Some(handle) = &self.clips[active].audio_track
+                        && let Some(track) = &self.clips[active].clip.volume_track
+                    {
+                        #[allow(clippy::cast_possible_truncation)]
+                        let linear = 10f32.powf(track.value_at(timeline_pts) as f32 / 20.0);
+                        handle.set_volume(linear);
                     }
 
                     // Update shared current_pts and resume anchor.

--- a/crates/ff-preview/src/timeline/state.rs
+++ b/crates/ff-preview/src/timeline/state.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+use ff_filter::AnimationTrack;
 use ff_format::VideoFrame;
 use ff_pipeline::Clip;
 
@@ -122,6 +123,9 @@ pub(super) struct AudioOnlyTrack {
     /// Effective clip duration — used to position the fade-out ramp.
     pub(super) clip_dur: Duration,
     pub(super) handle: AudioTrackHandle,
+    /// Per-clip volume automation (dB, timeline-global). When `Some`, the runner
+    /// updates `handle`'s volume each tick; overrides the static one-shot gain.
+    pub(super) volume_track: Option<AnimationTrack<f64>>,
     pub(super) cancel: Option<Arc<AtomicBool>>,
     pub(super) thread: Option<JoinHandle<()>>,
 }


### PR DESCRIPTION
## Objective

- Support per-clip **volume automation** (a rubber-band envelope) so volume can rise/fall *within* a single clip, in both the exported mix and the realtime preview.
- avio gap: per-clip animation was not exposed for audio — only a static `volume_db` and a per-*track* volume animation existed.

## Solution

- **`Clip`**: add `volume_track: Option<AnimationTrack<f64>>` (dB, timeline-global) + `with_volume_track` builder, mirroring `opacity_track`. Takes precedence over the static `volume_db`.
- **Export** (`ff-pipeline/timeline.rs`): prefer the per-clip track → `AudioTrack.volume = AnimatedValue::Track`. The mixer already registers a `volume` `AnimationEntry`, so the exported mix animates per-frame (sample-accurate); no new graph plumbing.
- **Realtime preview** (`ff-preview`): `AudioOnlyTrack` carries the track; the runner evaluates it at the timeline PTS each tick and updates the mixer track gain via `set_volume` (the primary clip reads `ClipState.clip.volume_track`). The static one-shot gain applies only when no track is present.
- Test: `clip_with_volume_track_should_store_track`.

Closes #1316