### PR TITLE
docs: document the MSRV policy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,7 @@ If you're unsure where to start, feel free to open an issue and ask.
 - [Commit Messages](#commit-messages)
 - [Code Style](#code-style)
 - [Testing](#testing)
+- [Minimum Supported Rust Version (MSRV)](#minimum-supported-rust-version-msrv)
 - [Documentation](#documentation)
 - [FFmpeg Notes](#ffmpeg-notes)
 - [License](#license)
@@ -209,6 +210,24 @@ For crates with feature flags, also test without default features:
 ```sh
 cargo test -p ff-decode --no-default-features
 ```
+
+---
+
+## Minimum Supported Rust Version (MSRV)
+
+Develop and test on the **latest stable** toolchain. The MSRV is the oldest Rust release avio
+still compiles on, currently **1.93.0**, verified by CI.
+
+- The MSRV is a floor, not the toolchain you build with. It does not track new compiler
+  releases automatically; the project can stay on a given MSRV across many Rust releases.
+- A recent MSRV is intentional: while the project is young it lets us use current APIs without
+  policing per-version availability. The trade-off is that downstream users must be on a
+  reasonably recent toolchain.
+- The MSRV is raised only deliberately (adopting a newer std/language API, or a dependency
+  requiring it), only in a minor release, and always recorded in the CHANGELOG. It may be
+  lowered later if broader adoption warrants; lowering it is not a breaking change.
+
+In a contribution, please avoid APIs newer than the MSRV so the CI MSRV job stays green.
 
 ---
 


### PR DESCRIPTION
## Objective

- Resolve the MSRV policy decision so contributors and users know how avio treats its minimum supported Rust version.

## Solution

- Add a "Minimum Supported Rust Version (MSRV)" section to CONTRIBUTING: develop on the latest stable toolchain; the MSRV (`1.93.0`) is a floor that does not track compiler releases; it is raised only deliberately, in a minor release, with a CHANGELOG note, and may be lowered later (a non-breaking change).
- Decision: keep `1.93.0` as an intentional, recent MSRV. This matches avio's domain peers (gstreamer-rs `1.92`, wgpu workspace `1.93`) and its own dependency floor (wgpu library `1.87`); no `Cargo.toml` change is needed.

Closes #1320