### PR TITLE
chore(examples): add avio-only end-to-end editing verification harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build workspace with DOCS_RS=1 (no FFmpeg needed)
-        run: cargo build --workspace
+        # Exclude the publish=false example harness: its src/bin/* link FFmpeg,
+        # which the DOCS_RS stub build does not provide. It is never published to
+        # docs.rs, and the test jobs compile its binaries with real FFmpeg.
+        run: cargo build --workspace --exclude avio-examples
         env:
           DOCS_RS: "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/*"]
+members = ["crates/*", "examples"]
 resolver = "2"
 
 [workspace.package]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,28 @@
+# User-perspective, self-verifying end-to-end scripts that exercise avio's
+# video-editing surface through the public `avio` facade only. This crate depends
+# on avio the way a downstream consumer would (a dependency line + explicit
+# features), so a failing script isolates the problem to avio (no egui, no demo).
+#
+# It is intentionally NOT published and does NOT inherit the workspace lints: a
+# real consumer does not adopt avio's internal `unwrap_used`/`pedantic` policy.
+[package]
+name = "avio-examples"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+# Features mirror what avio-editor-demo enables, so this doubles as a
+# consumer-POV smoke test of that feature combination.
+avio = { path = "../crates/avio", features = [
+    "decode",
+    "encode",
+    "filter",
+    "pipeline",
+    "preview",
+    "preview-proxy",
+    "tokio",
+    "serde",
+] }
+tempfile = "3"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,7 @@ name = "avio-examples"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,67 @@
+# avio-examples
+
+Self-verifying, end-to-end scripts that exercise avio's **video-editing** surface
+through the public `avio` facade only.
+
+## Why this exists
+
+Gaps in avio were found by building
+[avio-editor-demo](https://github.com/itsakeyfut/avio-editor-demo) (egui), but when a
+problem occurred it was hard to tell whether the bug was in the demo, in egui, or in avio.
+avio-editor-demo is a thin wrapper over avio, so the same editing features can be verified
+against **avio alone**.
+
+This crate depends on `avio` the way a downstream consumer would (a dependency line plus
+explicit features), so each script uses only the public API. When a script fails, the
+problem is isolated to avio: no egui, no demo. `publish = false`.
+
+This is distinct from `crates/avio/examples/`, which are the shipped, docs.rs teaching
+examples. The scripts here are a dev harness: add a feature, add a script, run it, read
+`PASS`/`FAIL`.
+
+## Running
+
+Each script generates a small synthetic clip by default, so it runs with no setup:
+
+```bash
+cargo run -p avio-examples --bin single_clip_import
+cargo run -p avio-examples --bin single_clip_export
+```
+
+Point a script at a real media file, and keep the temp files for inspection:
+
+```bash
+cargo run -p avio-examples --bin single_clip_export -- --input path/to/clip.mp4 --keep
+```
+
+Flags (shared by all scripts):
+
+| Flag | Meaning |
+|---|---|
+| `--input <file>` / `-i <file>` | Run against a real media file instead of a synthetic clip |
+| `--keep` | Do not delete generated temp files on exit |
+
+A script prints one line per check and exits non-zero if any check fails.
+
+## Capability index
+
+| Editing feature | Script | Status |
+|---|---|---|
+| Import a clip (probe + decode) | `single_clip_import` | done |
+| Export a clip (Timeline render) | `single_clip_export` | done |
+| Trim | `single_clip_trim` | TODO |
+| Multi-track composition / PiP + blend | `multitrack_compose` | TODO |
+| Transitions (`XfadeTransition`) | `transitions` | TODO |
+| Keyframe animation (`AnimationTrack`) | `keyframe_animation` | TODO |
+| Per-clip effects (`FilterStep`) | `effect_<name>` | TODO |
+| Preview matches export | `preview_matches_export` | TODO |
+| Audio mix + per-clip volume/fades | `audio_mix` | TODO |
+| Ken Burns pan & zoom | `ken_burns` | TODO (after #1295) |
+
+## Adding a script
+
+1. Add `src/bin/<name>.rs` with `fn main() -> avio_examples::BoxResult<()>`.
+2. Use `avio_examples::{parse_args, resolve_input}` to obtain an input clip and
+   `avio_examples::Report` to record `check(label, ok)` assertions.
+3. Assemble the feature via the `avio::` public API and assert the expected result.
+4. Add a row to the capability index above.

--- a/examples/src/bin/single_clip_export.rs
+++ b/examples/src/bin/single_clip_export.rs
@@ -1,0 +1,80 @@
+//! Verify exporting a single clip: place it on a one-clip [`Timeline`], render it,
+//! then re-probe the output and check its dimensions and duration.
+//!
+//! This exercises the export path (decode -> compose -> encode) against avio alone
+//! through the public facade.
+//!
+//! ```bash
+//! cargo run -p avio-examples --bin single_clip_export            # synthetic clip
+//! cargo run -p avio-examples --bin single_clip_export -- --input clip.mp4 --keep
+//! ```
+
+use avio::{Clip, EncoderConfig, Timeline};
+use avio_examples::{BoxResult, Report, parse_args, resolve_input};
+
+fn main() -> BoxResult<()> {
+    let args = parse_args();
+    let tmp = tempfile::tempdir()?;
+    let input = resolve_input(&args, tmp.path())?;
+
+    // ── Probe input for canvas dimensions + duration ──────────────────────────
+    let in_info = avio::open(&input)?;
+    let in_video = in_info.video_streams();
+    let Some(v) = in_video.first() else {
+        return Err("input has no video stream".into());
+    };
+    let (canvas_w, canvas_h, fps) = (v.width(), v.height(), v.fps());
+    let in_duration = in_info.duration();
+
+    // ── Build a single-clip timeline and render ───────────────────────────────
+    let output = tmp.path().join("export.mp4");
+    let timeline = Timeline::builder()
+        .canvas(canvas_w, canvas_h)
+        .frame_rate(fps)
+        .video_track(vec![Clip::new(&input)])
+        .build()?;
+    println!(
+        "rendering 1 clip {canvas_w}x{canvas_h} {fps:.2}fps -> {}",
+        output.display()
+    );
+    timeline.render(&output, EncoderConfig::builder().build())?;
+
+    // ── Verify the rendered output ────────────────────────────────────────────
+    let size = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+    let mut report = Report::new("single_clip_export");
+    report.check("output file is non-empty", size > 0);
+
+    match avio::open(&output) {
+        Ok(out_info) => {
+            let out_video = out_info.video_streams();
+            let out_primary = out_video.first();
+            let (out_w, out_h) = out_primary.map_or((0, 0), |v| (v.width(), v.height()));
+            let out_duration = out_info.duration();
+            let dur_tolerance = (in_duration.as_secs_f64() * 0.1).max(0.5);
+            println!(
+                "output: {out_w}x{out_h} dur={:.3}s size={size}B (input dur={:.3}s)",
+                out_duration.as_secs_f64(),
+                in_duration.as_secs_f64()
+            );
+            report.check("output has a video stream", out_primary.is_some());
+            report.check(
+                "output dims match canvas",
+                out_w == canvas_w && out_h == canvas_h,
+            );
+            report.check(
+                "output duration near input duration",
+                (out_duration.as_secs_f64() - in_duration.as_secs_f64()).abs() <= dur_tolerance,
+            );
+        }
+        Err(e) => {
+            println!("  (could not re-probe output: {e})");
+            report.check("output is probeable", false);
+        }
+    }
+
+    if args.keep {
+        let kept = tmp.keep();
+        println!("kept temp dir: {}", kept.display());
+    }
+    report.finish()
+}

--- a/examples/src/bin/single_clip_import.rs
+++ b/examples/src/bin/single_clip_import.rs
@@ -1,0 +1,74 @@
+//! Verify importing a single clip: probe its metadata, then decode every frame,
+//! and check that probe and decode agree and that frames actually come out.
+//!
+//! This is the most basic editing operation ("bring a source clip in"), exercised
+//! against avio alone through the public facade.
+//!
+//! ```bash
+//! cargo run -p avio-examples --bin single_clip_import            # synthetic clip
+//! cargo run -p avio-examples --bin single_clip_import -- --input clip.mp4 --keep
+//! ```
+
+use std::time::Duration;
+
+use avio::VideoDecoder;
+use avio_examples::{BoxResult, Report, parse_args, resolve_input};
+
+fn main() -> BoxResult<()> {
+    let args = parse_args();
+    let tmp = tempfile::tempdir()?;
+    let input = resolve_input(&args, tmp.path())?;
+
+    // ── Probe metadata ────────────────────────────────────────────────────────
+    let info = avio::open(&input)?;
+    let video = info.video_streams();
+    let primary = video.first();
+    let (probe_w, probe_h, probe_fps) =
+        primary.map_or((0, 0, 0.0), |v| (v.width(), v.height(), v.fps()));
+    let duration = info.duration();
+
+    // ── Decode every frame ────────────────────────────────────────────────────
+    let mut decoder = VideoDecoder::open(&input).build()?;
+    let dec_w = decoder.width();
+    let dec_h = decoder.height();
+    let mut frames: u64 = 0;
+    let mut first_dims: Option<(u32, u32)> = None;
+    while let Some(frame) = decoder.decode_one()? {
+        if first_dims.is_none() {
+            first_dims = Some((frame.width(), frame.height()));
+        }
+        frames += 1;
+    }
+
+    let expected = (duration.as_secs_f64() * probe_fps).round() as i64;
+    let tolerance = (expected / 5).max(2);
+    println!(
+        "probe: {probe_w}x{probe_h} {probe_fps:.2}fps dur={:.3}s | decoded {frames} frames (expected ~{expected})",
+        duration.as_secs_f64()
+    );
+
+    // ── Verify ────────────────────────────────────────────────────────────────
+    let mut report = Report::new("single_clip_import");
+    report.check("primary video stream present", primary.is_some());
+    report.check("probe fps > 0", probe_fps > 0.0);
+    report.check("probe duration > 0", duration > Duration::ZERO);
+    report.check(
+        "probe dims match decoder dims",
+        probe_w == dec_w && probe_h == dec_h,
+    );
+    report.check("decoded at least one frame", frames > 0);
+    report.check(
+        "first frame dims match stream dims",
+        first_dims == Some((dec_w, dec_h)),
+    );
+    report.check(
+        "decoded frame count near duration*fps",
+        (frames as i64 - expected).abs() <= tolerance,
+    );
+
+    if args.keep {
+        let kept = tmp.keep();
+        println!("kept temp dir: {}", kept.display());
+    }
+    report.finish()
+}

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,0 +1,256 @@
+//! Shared helpers for the avio editing verification scripts.
+//!
+//! Everything here goes through the public [`avio`] facade only, exactly as a
+//! downstream consumer would use it. The helpers cover the two things every
+//! script needs: obtaining an input clip (synthetic by default, `--input`
+//! override), and reporting pass/fail checks.
+
+use std::path::{Path, PathBuf};
+
+use avio::{
+    BitrateMode, PixelFormat, PooledBuffer, Rational, Timestamp, VideoCodec, VideoEncoder,
+    VideoFrame,
+};
+
+/// Convenience result type for the scripts (`fn main() -> BoxResult<()>`).
+pub type BoxResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Parameters for a generated synthetic clip.
+#[derive(Debug, Clone, Copy)]
+pub struct SynthSpec {
+    /// Frame width in pixels (kept even for `yuv420p`).
+    pub width: u32,
+    /// Frame height in pixels (kept even for `yuv420p`).
+    pub height: u32,
+    /// Frame rate in frames per second.
+    pub fps: f64,
+    /// Clip length in seconds.
+    pub seconds: u64,
+}
+
+impl Default for SynthSpec {
+    fn default() -> Self {
+        // Small and fast: a 2-second 640x360 clip is enough to exercise the
+        // decode/compose/encode paths without a slow encode.
+        Self {
+            width: 640,
+            height: 360,
+            fps: 30.0,
+            seconds: 2,
+        }
+    }
+}
+
+impl SynthSpec {
+    /// Number of frames this spec produces.
+    #[must_use]
+    pub fn frame_count(&self) -> u64 {
+        (self.seconds as f64 * self.fps).round() as u64
+    }
+}
+
+/// Generates a synthetic video clip at `path`: a background hue that sweeps over
+/// time with a moving white scanline, so consecutive frames differ.
+///
+/// Mirrors the proven pattern in `crates/ff-encode/examples/gen_bench_asset.rs`,
+/// but driven entirely through the `avio` facade.
+///
+/// # Errors
+///
+/// Returns an error if the encoder cannot be built, a frame cannot be created,
+/// or encoding/finalising fails.
+pub fn generate_synth_clip(path: &Path, spec: &SynthSpec) -> BoxResult<()> {
+    if spec.width == 0 || spec.height == 0 {
+        return Err("synth clip requires non-zero width and height".into());
+    }
+    let mut encoder = VideoEncoder::create(path)
+        .video(spec.width, spec.height, spec.fps)
+        .video_codec(VideoCodec::H264) // falls back to an LGPL codec without the `gpl` feature
+        .bitrate_mode(BitrateMode::Crf(23))
+        .build()?;
+
+    let stride = spec.width as usize * 4; // RGBA
+    let total_frames = spec.frame_count().max(1);
+    let time_base = Rational::new(1, spec.fps as i32);
+
+    for i in 0..total_frames {
+        let hue = (i as f32 / total_frames as f32) * 360.0;
+        let (r, g, b) = hue_to_rgb(hue);
+        let scanline_y = (i as usize * spec.height as usize / total_frames as usize)
+            .min(spec.height as usize - 1);
+
+        let mut pixels = vec![0u8; stride * spec.height as usize];
+        for y in 0..spec.height as usize {
+            for x in 0..spec.width as usize {
+                let base = y * stride + x * 4;
+                let (pr, pg, pb) = if y == scanline_y {
+                    (255, 255, 255)
+                } else {
+                    (r, g, b)
+                };
+                pixels[base] = pr;
+                pixels[base + 1] = pg;
+                pixels[base + 2] = pb;
+                pixels[base + 3] = 255;
+            }
+        }
+
+        let frame = VideoFrame::new(
+            vec![PooledBuffer::standalone(pixels)],
+            vec![stride],
+            spec.width,
+            spec.height,
+            PixelFormat::Rgba,
+            Timestamp::new(i as i64, time_base),
+            i % 30 == 0, // I-frame every 30 frames
+        )?;
+        encoder.push_video(&frame)?;
+    }
+
+    encoder.finish()?;
+    Ok(())
+}
+
+/// Parsed command-line arguments shared by all scripts.
+#[derive(Debug, Default)]
+pub struct Args {
+    /// Optional real media file to run against instead of a synthetic clip.
+    pub input: Option<PathBuf>,
+    /// Keep generated temp files instead of deleting them on exit.
+    pub keep: bool,
+}
+
+/// Parses `--input <file>` / `-i <file>` and `--keep` from the process args.
+#[must_use]
+pub fn parse_args() -> Args {
+    let mut args = Args::default();
+    let mut it = std::env::args().skip(1);
+    while let Some(flag) = it.next() {
+        match flag.as_str() {
+            "--input" | "-i" => args.input = it.next().map(PathBuf::from),
+            "--keep" => args.keep = true,
+            other => eprintln!("warning: ignoring unknown argument: {other}"),
+        }
+    }
+    args
+}
+
+/// Returns the input clip to run against: the caller-provided `--input` file if
+/// set, otherwise a freshly generated synthetic clip written under `dir`.
+///
+/// # Errors
+///
+/// Returns an error if a synthetic clip is needed but cannot be generated.
+pub fn resolve_input(args: &Args, dir: &Path) -> BoxResult<PathBuf> {
+    if let Some(path) = &args.input {
+        println!("input: {} (provided)", path.display());
+        return Ok(path.clone());
+    }
+    let spec = SynthSpec::default();
+    let path = dir.join("synth_clip.mp4");
+    println!(
+        "input: generating synthetic clip {}x{} {}fps {}s -> {}",
+        spec.width,
+        spec.height,
+        spec.fps,
+        spec.seconds,
+        path.display()
+    );
+    generate_synth_clip(&path, &spec)?;
+    Ok(path)
+}
+
+/// Accumulates named pass/fail checks and turns the overall result into a
+/// process exit status (an `Err` from [`finish`](Report::finish) makes
+/// `fn main() -> BoxResult<()>` exit non-zero).
+pub struct Report {
+    name: String,
+    all_ok: bool,
+}
+
+impl Report {
+    /// Starts a report for the named script.
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        println!("=== {name} ===");
+        Self {
+            name: name.to_owned(),
+            all_ok: true,
+        }
+    }
+
+    /// Records one check, printing `[PASS]`/`[FAIL]` and updating the total.
+    pub fn check(&mut self, label: &str, ok: bool) {
+        println!("  [{}] {label}", if ok { "PASS" } else { "FAIL" });
+        self.all_ok &= ok;
+    }
+
+    /// Prints the overall verdict and returns `Ok` only if every check passed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error (so the process exits non-zero) if any check failed.
+    pub fn finish(self) -> BoxResult<()> {
+        if self.all_ok {
+            println!("{}: PASS", self.name);
+            Ok(())
+        } else {
+            Err(format!("{}: FAIL", self.name).into())
+        }
+    }
+}
+
+/// Converts a hue angle (0-360 degrees) to an sRGB triplet (saturation = value = 1).
+fn hue_to_rgb(hue: f32) -> (u8, u8, u8) {
+    let h = hue.rem_euclid(360.0);
+    let i = (h / 60.0) as u32;
+    let f = h / 60.0 - i as f32;
+    let (r, g, b) = match i {
+        0 => (1.0, f, 0.0),
+        1 => (1.0 - f, 1.0, 0.0),
+        2 => (0.0, 1.0, f),
+        3 => (0.0, 1.0 - f, 1.0),
+        4 => (f, 0.0, 1.0),
+        _ => (1.0, 0.0, 1.0 - f),
+    };
+    ((r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_should_be_ok_when_all_checks_pass() {
+        let mut r = Report::new("t");
+        r.check("a", true);
+        r.check("b", true);
+        assert!(r.finish().is_ok());
+    }
+
+    #[test]
+    fn report_should_be_err_when_any_check_fails() {
+        let mut r = Report::new("t");
+        r.check("a", true);
+        r.check("b", false);
+        assert!(r.finish().is_err());
+    }
+
+    #[test]
+    fn synth_spec_default_should_be_even_dims_and_positive() {
+        let s = SynthSpec::default();
+        assert_eq!(s.width % 2, 0);
+        assert_eq!(s.height % 2, 0);
+        assert!(s.fps > 0.0);
+        assert!(s.seconds > 0);
+        assert_eq!(s.frame_count(), 60);
+    }
+
+    #[test]
+    fn hue_to_rgb_should_wrap_and_stay_in_range() {
+        for deg in [0.0, 60.0, 120.0, 359.0, 360.0, 720.0, -30.0] {
+            let (r, g, b) = hue_to_rgb(deg);
+            let _ = (r, g, b); // u8 is always in range; exercises the wrap path
+        }
+    }
+}


### PR DESCRIPTION
## Objective

- Gaps in avio were found by building avio-editor-demo (egui), but when a problem occurred it was hard to isolate demo vs egui vs avio.
- The demo is a thin wrapper over avio, so editing features can be verified against avio alone. Provide a place to do that and grow it as features are added.

## Solution

- Add a root `examples/` workspace member (`avio-examples`, `publish = false`) that depends on `avio` as an external consumer (dependency line + explicit features) and uses only the public facade, so a failure isolates the problem to avio.
- Each script obtains an input clip (synthetic by default, `--input <file>` to use real media), assembles a feature, and asserts `PASS`/`FAIL` (non-zero exit on failure).
- Seed two scripts: `single_clip_import` (probe + decode) and `single_clip_export` (single-clip `Timeline` render), plus shared helpers in `src/lib.rs` (synthetic media generation, argument parsing, a pass/fail reporter) with pure-logic unit tests.
- Add `examples/README.md` with a capability index ("editing feature -> script -> status") for the growth model.
- The crate intentionally does not inherit the workspace lints, matching how a downstream consumer builds; CI still lints and builds it via `--all`/`--all-features`.

Closes #1324