### PR TITLE
docs: publish coding rules and the engine/primitive architecture

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,91 @@
+# avio — Concepts
+
+> avio is a safe, high-level Rust toolkit over FFmpeg for building media applications, structured as
+> a **video-editing engine** on top of a family of **model-agnostic media primitives**.
+> Design specs live in [`specs/`](./specs/); coding rules in [`rules/`](./rules/README.md).
+
+---
+
+## 1. What avio is
+
+avio is two things in one workspace:
+
+- **`avio` — the engine.** It owns an opinionated, modern editing model (`Timeline`, `Clip`, tracks,
+  per-clip effect stacks, keyframes) and derives every rendered frame from that model. If you want a
+  ready-made editing model, you build on `avio`.
+- **`ff-*` — the primitives.** `ff-sys` / `-common` / `-format` / `-probe` / `-decode` / `-encode` /
+  `-filter` / `-pipeline` / `-stream` / `-preview` / `-render` are safe, **model-agnostic** building
+  blocks (decode, encode, filter graphs, a compositor, streaming, GPU). They know nothing about
+  timelines or edits. If you want to design your **own** editing model, you build on `ff-*` and avio
+  imposes nothing on you.
+
+The safety guarantee runs through both: every unsafe FFmpeg call is encapsulated, so application
+code never needs `unsafe`.
+
+---
+
+## 2. Background and purpose
+
+- avio began as a safe FFmpeg wrapper. Gaps were found by building
+  [avio-editor-demo](https://github.com/itsakeyfut/avio-editor-demo) (an egui editor) on top of it,
+  but isolating "is this a demo, egui, or avio bug?" was hard. That motivated verifying editing
+  features against avio alone.
+- The realization: the reusable, hard, valuable part of a video editor is the **engine** (the edit
+  model, the render graph, preview/export consistency, frame accuracy, undo), not the UI. avio
+  commits to being that engine.
+- But editing apps differ in how they model an edit (AviUtl's object timeline, Premiere's tracks,
+  Final Cut's magnetic timeline). Forcing one model on everyone would be a general-purpose trap. So
+  avio splits the concern: the **engine** (`avio`) has one modern model, and the **primitives**
+  (`ff-*`) let anyone build their own.
+
+---
+
+## 3. Vision
+
+- **avio is the engine; `ff-*` is the substrate.** Product identity and design investment go into
+  the engine. The primitives stay clean and reusable.
+- **Two audiences, no conflict.** "I want a ready editing model" -> use `avio`. "I want to build my
+  own model" -> use `ff-*`. The clean separation lets avio be opinionated without locking anyone
+  out: the primitives are the escape hatch.
+- **Toward a stable 1.0**: a production-grade engine, validated by real applications built on it.
+
+---
+
+## 4. Concepts and design philosophy
+
+- **Engine vs primitive boundary.** The model (`avio`) answers "**WHAT** to edit"; the primitives
+  (`ff-*`) answer "**HOW** to execute this frame". A primitive never needs to know about time,
+  tracks, clips, edits, or history. (See [rules/design.md](./rules/design.md) and
+  [specs/engine-and-primitives.md](./specs/engine-and-primitives.md).)
+- **Immutable, declarative model -> pure derivation.** The edit state is an immutable value; the
+  render scene at time `t` is a pure function of it. This makes **preview == export structural**
+  (both paths consume the same derivation) and undo trivial (a history of versions).
+- **Safe by construction.** `unsafe` is isolated in `*_inner.rs`; the public API is entirely safe.
+- **Batteries included, but not everything.** avio covers the editing and delivery range (decode,
+  encode, filter, compose, preview, stream, GPU, analysis), not every FFmpeg feature.
+- **Borrow what is solid, build what differentiates.** FFmpeg for codecs and filters, wgpu for GPU.
+  avio builds the editing model, the derivation, preview/export consistency, and the engine's
+  correctness.
+
+---
+
+## 5. Positioning
+
+- avio sits **between low-level bindings (`ffmpeg-next`) and full frameworks (GStreamer)**: a safe,
+  batteries-included editing engine with reusable primitives underneath.
+- The shape to aim for is "the MLT / GStreamer Editing Services of the Rust world, but with a modern
+  immutable-model core and preview == export by construction."
+- The primitives also serve plain media plumbing (safe Rust decode / encode / transcode / stream), a
+  real secondary use beyond editing.
+
+---
+
+## 6. What avio does not do
+
+- The **engine** does not try to model every editing paradigm. It commits to a track + per-clip
+  effect stack + keyframe + compositing model. Node-based (Nuke-style) and magnetic-timeline
+  (Final Cut-style) models are out of scope for the engine; apps wanting those build on `ff-*`
+  directly.
+- avio does not aim to wrap every FFmpeg feature.
+- The primitives (`ff-*`) carry no editing opinions. Keeping them model-free is enforced by the
+  dependency direction (the editing model sits at the top, in `avio`), not by discipline alone.

--- a/docs/roadmap/plan.md
+++ b/docs/roadmap/plan.md
@@ -1,0 +1,227 @@
+# Long-term Roadmap Plan: v0.19.0 and Beyond
+
+This document records the planned direction for versions after v0.18.0 (API Finalization).
+It is a living reference — not a commitment — and exists so that scope decisions made in
+early 2026 are not lost between conversations.
+
+The project follows the same philosophy as wgpu and bevy: stability and feature completeness
+take priority over a quick v1.0.0. Each minor version has a clear theme, and each version
+pairs new features with stabilization of the previous version's additions.
+
+---
+
+## Design Philosophy for v0.19.0+
+
+After v0.18.0 freezes the public API surface:
+
+- All new additions must be strictly **additive** — no breaking changes to existing APIs.
+- Each version targets one of three axes:
+  1. **Professional video editing** — features that NLEs (non-linear editors) require.
+  2. **Video distribution services** — packaging, delivery, compliance, automation.
+  3. **Cross-cutting quality** — stability, benchmarks, security, new compile targets.
+- New feature groups are gated behind feature flags where they introduce heavy dependencies
+  (e.g. `ai-upscale`, `webrtc`, `wasm`).
+
+---
+
+## v0.19.0 — SMPTE Timecode & Advanced Metadata
+
+**Theme**: Precise time management required by professional editing workflows.
+
+### New Features
+- SMPTE timecode read/write (LTC, VITC, drop-frame and non-drop-frame)
+- Frame-accurate `Clip` in/out points expressed as timecode addresses
+- XMP metadata read/write (preserve camera origination metadata)
+- Nested chapters and timeline markers (`Marker` type on `Timeline`)
+
+### Stabilization Targets
+- Keyframe animation (v0.12.0): establish performance benchmarks for `AnimationTrack`
+  evaluation at 60 fps across 1 000+ keyframes
+- `Timeline` / `Clip` serde round-trip: compatibility tests ensuring project files
+  written by an older patch version load correctly in a newer patch version
+
+---
+
+## v0.20.0 — Advanced Color Science
+
+**Theme**: Log footage and ACES pipelines for cinema/broadcast-grade color work.
+
+### New Features
+- Log color space support: Sony S-Log2/3, Canon C-Log3, ARRI LogC, Blackmagic Film
+- ACES AP0/AP1 color space input and output
+- LUT chaining: multiple `.cube` files applied in sequence on a single clip
+- Gamut compression and out-of-gamut warning (clipping pixel detection)
+- False Color filter for HDR monitoring
+
+### Stabilization Targets
+- 3D LUT application (v0.9.0): precision validation against reference images (PSNR ≥ 60 dB)
+- Color metadata round-trip guarantees (color space + transfer + primaries survive
+  MKV and MP4 container round-trips as verified by ffprobe)
+
+---
+
+## v0.21.0 — Multi-camera & Synchronization
+
+**Theme**: Integrating footage from multiple cameras and recording devices.
+
+### New Features
+- Timecode-based multi-camera sync (`MulticamGroup` type in `ff-pipeline`)
+- Audio fingerprint sync for footage without timecode (cross-correlation algorithm)
+- `Timeline` multi-cam grouping: multiple angles for a single scene, switchable by cut point
+- Automatic cut-point detection from multi-cam groups (scene detection applied per-angle)
+
+### Stabilization Targets
+- `Timeline::render()` (v0.10.0): performance baseline — 1080p/30 fps render must
+  complete faster than 1× real-time on a single CPU core
+- Frame-accurate seek (`SeekMode::Exact`): guarantee frame index matches expected PTS
+  within ±1 ms across H.264, H.265, and VP9 sources
+
+---
+
+## v0.22.0 — WebRTC & Ultra-low Latency
+
+**Theme**: Real-time communication protocols for sub-second live streaming.
+
+### New Features
+- WebRTC output via WHIP (WebRTC HTTP Ingest Protocol) — behind `webrtc` feature flag
+- WebRTC input via WHEP (WebRTC HTTP Egress Protocol) — behind `webrtc` feature flag
+- Sub-second latency pipeline mode (minimal buffering, immediate segment push)
+- RTP/RTCP transport layer (required for WebRTC)
+
+### Stabilization Targets
+- RTMP/SRT output (v0.8.0): reconnect logic stability under network interruption
+- `LiveHlsOutput` / `LiveDashOutput`: 24-hour continuous stream stability test
+  (memory growth ≤ 1 MB/hour, no segment gaps > 2× segment duration)
+
+---
+
+## v0.23.0 — 360° Video & Spatial Audio
+
+**Theme**: Immersive media formats for VR and 360° playback.
+
+### New Features
+- Equirectangular ↔ cubemap projection conversion
+- 360° video metadata embedding (YouTube and Meta spatial media metadata)
+- First-person perspective crop from 360° footage (rectilinear extraction)
+- Ambisonics audio: B-format decode and encode
+- Binaural audio rendering (head-related transfer function, HRTF, for headphone output)
+
+### Stabilization Targets
+- Porter-Duff compositing (v0.11.0): numerical precision tests (all 7 operations
+  verified against reference RGBA values)
+- All 18 blend modes (v0.11.0): reference image regression suite added to CI
+
+---
+
+## v0.24.0 — AI-assisted Processing
+
+**Theme**: Optional machine-learning acceleration for common editing tasks.
+
+All AI features are gated behind opt-in feature flags and have a CPU/non-AI fallback
+so the crate remains usable without any ML runtime.
+
+### New Features
+- AI super-resolution upscaling (`ai-upscale` feature — wgpu or CUDA back-end selectable)
+- Scene classification hook: `SceneClassifier` trait for user-provided models
+  (returns hints such as `TalkingHead`, `ActionScene`, `MusicPerformance`)
+- Auto-subtitle integration point: `AutoSubtitleProvider` trait for connecting
+  external speech-to-text models (e.g. Whisper)
+- Frame interpolation for slow-motion generation (`frame-interp` feature)
+
+### Stabilization Targets
+- CI gate: building with all AI feature flags disabled must not change the public API
+  surface (checked via `cargo doc` diff)
+- Binary size baseline when all AI features are disabled (documented in `benches/README.md`)
+
+---
+
+## v0.25.0 — Broadcast & Accessibility
+
+**Theme**: Broadcast industry standards and legal compliance requirements.
+
+### New Features
+- CEA-608 / CEA-708 closed caption read and write
+- DVB / Teletext subtitle support
+- EBU R128 / ATSC A/85 loudness compliance report (LUFS, LRA, true peak as output data)
+- Broadcast-safe color check: detect and optionally clamp out-of-legal-range pixels
+- SMPTE ST 2094 dynamic HDR metadata (HDR10+ and Dolby Vision signalling)
+
+### Stabilization Targets
+- EBU R128 loudness normalization (v0.9.0): precision validation (integrated loudness
+  within ±0.1 LUFS of reference tool output)
+- HDR metadata round-trip (MKV and MP4): ST 2086 mastering display values must survive
+  a decode → re-encode cycle unchanged
+
+---
+
+## v0.26.0 — Batch Processing & Automation
+
+**Theme**: High-throughput, unattended processing for production pipelines.
+
+### New Features
+- Job queue: submit multiple transcode / filter jobs; configurable worker concurrency
+- Watch folder: directory monitor → automatic processing on new file arrival
+- Checkpoint-based resume: failed jobs restart from last completed segment
+- Batch progress reporting: overall progress + per-job progress callbacks
+- Distributed rendering hook: `RenderScheduler` trait for connecting external
+  job schedulers (e.g. Kubernetes jobs, render farms)
+
+### Stabilization Targets
+- `ff-preview` (v0.13.0): long-run stability test (8-hour playback loop, memory growth
+  ≤ 10 MB, no A/V sync drift > 1 frame)
+- Async pipeline back-pressure (v0.6.0 `tokio` feature): stress test with 100 concurrent
+  encode jobs, verify no deadlocks and bounded memory
+
+---
+
+## v0.27.0 — WebAssembly Target
+
+**Theme**: In-browser video processing without a native runtime.
+
+### New Features
+- `wasm32-unknown-unknown` compile target for `ff-format`, `ff-common`, and the
+  subtitle parser/writer (`ff-format::subtitle`)
+- Pure-Rust fallback codecs (no FFmpeg) for the wasm subset:
+  VP8/VP9 decode (via `dav1d` or pure-Rust alternative), AAC decode, GIF encode
+- `wasm-bindgen` TypeScript bindings for the wasm-compatible API subset
+- Browser-compatible I/O: `File` API / `Blob` as input/output instead of `PathBuf`
+- `no_std` compatibility for `ff-format` and `ff-common`
+
+### Stabilization Targets
+- `wasm-pack test` added to CI (runs on every PR against the wasm-compatible crates)
+- MSRV + wasm target combination guaranteed: the minimum Rust version compiles for wasm
+
+---
+
+## v1.0.0 — Stable API
+
+**Prerequisites (all must be met before tagging 1.0.0):**
+
+1. v0.27.0 is complete and all CI checks pass.
+2. At least one production video editing application and one production streaming
+   service are using avio in production (documented in README).
+3. A public commitment to semantic versioning (no breaking changes without a major bump).
+4. A stable C FFI layer so non-Rust consumers can link against avio.
+5. The MSRV is pinned and the upgrade policy is documented.
+6. All `#[non_exhaustive]` audits from v0.18.0 are confirmed still valid.
+
+---
+
+## Summary Timeline
+
+```
+v0.19  SMPTE timecode & XMP metadata          ← professional editing ①
+v0.20  Advanced color science (ACES / Log)    ← professional editing ②
+v0.21  Multi-camera sync                      ← professional editing ③
+v0.22  WebRTC & ultra-low latency             ← distribution services ①
+v0.23  360° video & spatial audio             ← new media formats
+v0.24  AI-assisted processing (opt-in)        ← emerging technology
+v0.25  Broadcast & accessibility              ← distribution services ②
+v0.26  Batch processing & automation          ← operational workflows
+v0.27  WebAssembly target                     ← new compile targets
+v1.0   Stable API
+```
+
+Each version pairs new features with explicit stabilization targets from the version
+before it. This ensures that every shipped milestone is both forward-looking and
+retrospectively verified.

--- a/docs/roadmap/v0-18-0/ROADMAP.md
+++ b/docs/roadmap/v0-18-0/ROADMAP.md
@@ -67,7 +67,7 @@ The following end-to-end examples are provided under the workspace `examples/` d
 ### API Consistency Audit
 
 - The builder pattern is confirmed uniform across all crates: consuming builders (`self`), all validation in `build()`.
-- Error type hierarchy is audited against `docs/dev/error-handling.md`: no `anyhow` in library code, all FFmpeg errors wrapped with context.
+- Error type hierarchy is audited against `docs/rules/error-handling.md`: no `anyhow` in library code, all FFmpeg errors wrapped with context.
 - Every `*Inner` type that may cross thread boundaries carries an explicit `unsafe impl Send` (and `unsafe impl Sync` where appropriate) with a `// SAFETY:` comment.
 - No `unwrap()` or `expect()` remains in library source (`src/`); only in tests and examples.
 - `cargo clippy --workspace -- -D warnings` is clean on stable Rust.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,18 @@
+# Development Rules
+
+This directory collects the conventions to follow when writing code across the avio workspace.
+
+| File | Contents |
+|---|---|
+| [rust.md](./rust.md) | Formatting, naming, module layout, concurrency, code quality |
+| [design.md](./design.md) | Engine vs primitive boundary, encapsulation, crate boundaries |
+| [error-handling.md](./error-handling.md) | Error-type design, `Result` vs panic, `thiserror` |
+| [logging.md](./logging.md) | Log levels, message format, hot-path policy |
+| [unsafe.md](./unsafe.md) | `unsafe` isolation, SAFETY comments, FFmpeg pointer/ownership |
+| [perf.md](./perf.md) | Hot-path allocation, buffer pooling, benchmarks |
+| [test.md](./test.md) | Test naming, fixtures, probe-gating, integration-test policy |
+| [gpu.md](./gpu.md) | wgpu resource lifecycle, bytemuck, color (`ff-render`) |
+| [wgsl.md](./wgsl.md) | Shader naming, struct alignment, bindings (`ff-render`) |
+
+Design specs live in [`../specs/`](../specs/). Internal review-knowledge and process docs live in
+`docs/dev/`.

--- a/docs/rules/design.md
+++ b/docs/rules/design.md
@@ -1,0 +1,101 @@
+# Design and API Conventions
+
+> How avio's architecture is enforced in code. The rationale and design of record live in
+> [`../specs/engine-and-primitives.md`](../specs/engine-and-primitives.md). This document is the
+> "how to keep the code aligned" rulebook.
+> Related: [rust.md](./rust.md), [error-handling.md](./error-handling.md),
+> [unsafe.md](./unsafe.md).
+
+---
+
+## 1. Engine vs primitive (the core boundary)
+
+avio is an **editing engine**; the `ff-*` family are **model-agnostic primitives**.
+
+- **`avio` (engine)** owns the editing model: `Timeline` / `Clip`, the model-to-scene derivation,
+  and edit history. It answers "**WHAT** to edit."
+- **`ff-*` (primitives)** are stateless executors of the current frame's work: decode, filter,
+  composite one frame, interpolate, encode. They answer "**HOW** to execute" and know nothing
+  about time, tracks, clips, edits, or history.
+- **Litmus**: does this type/function need to know TIME / TRACK / CLIP / EDIT / HISTORY to do its
+  job? Yes -> `avio` (model); No -> `ff-*` (primitive).
+- Full detail and rationale: [engine-and-primitives.md](../specs/engine-and-primitives.md).
+
+---
+
+## 2. Type placement
+
+- Define a type in the **lowest applicable crate** and re-export it upward. Never define the same
+  type in two crates. When adding a public type, also add it to `avio/src/lib.rs`.
+- **One deliberate exception**: the editing model (`Timeline` / `Clip` / edit history) is defined
+  in `avio` (the top of the graph), so that `ff-*` remain model-free by dependency direction, not
+  by discipline.
+
+---
+
+## 3. Encapsulation and `#[non_exhaustive]`
+
+- Public enums/structs in `ff-format` that may gain variants or fields over time are
+  `#[non_exhaustive]` (e.g. `PixelFormat`, `ColorSpace`, `ColorRange`, `SampleFormat`). This keeps
+  additions non-breaking and steers callers toward constructors and a wildcard match arm.
+- When matching a `#[non_exhaustive]` enum **from another crate**, a `_` arm is **required** by the
+  compiler — it is not redundant. Do not flag `Self::Unknown | _ => …` as dead code.
+
+---
+
+## 4. Builder pattern
+
+- Use a consuming builder when a type takes **3 or more optional parameters**. Required parameters
+  go on `new()` / `create()`.
+- Validation is collected in `.build()`, which returns `Result`. Setters do not validate.
+- Codecs, encoders, decoders, filter graphs, and pipelines all follow this.
+
+---
+
+## 5. FFmpeg `name()` vs `ffmpeg_token()`
+
+- A type's `name()` is a human-readable label; `FfmpegToken::ffmpeg_token()` is the canonical
+  FFmpeg token. They can differ (e.g. `ColorSpace::Bt2020` has `name()` = `"bt2020"` but the token
+  is `"bt2020nc"`), and the token may be `None` when FFmpeg has no equivalent.
+- Build filter-argument strings from `ffmpeg_token()` and **skip `None`**. Never build them from
+  `name()` — that produces arguments FFmpeg rejects.
+- Verify token sets/values against the pinned FFmpeg C source, not the HTML docs
+  (see [`../specs/ffmpeg-tokens.md`](../specs/ffmpeg-tokens.md)).
+
+---
+
+## 6. FFmpeg call order is part of the design
+
+The crate design docs (`docs/crates/{name}/design.md`) specify the exact FFmpeg call order.
+Deviating without a deliberate, documented reason is a bug, not a style choice.
+
+---
+
+## 7. Crate boundaries
+
+| Crate | Holds | Depends on |
+|---|---|---|
+| `ff-sys` | Raw bindgen FFI + safe thin wrappers | (lowest) |
+| `ff-common` | Shared memory abstractions (no FFmpeg dep) | ff-sys |
+| `ff-format` | Shared pure-Rust type system (no FFmpeg dep) | ff-common |
+| `ff-probe` | Read-only metadata extraction | ff-format |
+| `ff-decode` | Decode pipelines (video / audio / image) | ff-format |
+| `ff-encode` | Encode pipelines | ff-format |
+| `ff-filter` | libavfilter graph construction + primitive compositor | ff-format |
+| `ff-pipeline` | Decode -> filter -> encode execution pipelines | ff-filter |
+| `ff-stream` | HLS / DASH adaptive streaming output | ff-pipeline |
+| `ff-preview` | Real-time preview and proxy primitives | ff-pipeline |
+| `ff-render` | GPU compositing (wgpu) | ff-format |
+| `avio` | **Engine**: editing model + derivation + history; re-exports the primitives | all `ff-*` |
+
+Dependency direction (no cycles):
+
+```
+ff-sys -> ff-common -> ff-format -> ff-probe / ff-decode / ff-encode -> ff-filter
+       -> ff-pipeline -> ff-stream / ff-preview / ff-render -> avio (engine, top)
+```
+
+- Dependencies point **downward** only. No cycles.
+- `ff-format` and `ff-common` carry **no FFmpeg dependency** and **no `unsafe`** (pure Rust).
+- Because the editing model sits at the top (`avio`), nothing in `ff-*` can depend on it: the
+  primitives are model-free by construction.

--- a/docs/rules/error-handling.md
+++ b/docs/rules/error-handling.md
@@ -1,0 +1,106 @@
+# Error Handling
+
+> Related: [rust.md](./rust.md) (summary of the error policy). This is the detailed reference.
+
+## Principles
+
+- Implement error types with **`thiserror`** in every library crate.
+- **Do not use `anyhow` in library crates.** A consuming application (an editor built on avio, a
+  CLI tool) may use `anyhow` for contextual propagation.
+- Separate **recoverable failures (`Result`)** from **invariant violations (panic)**.
+
+---
+
+## Result or panic
+
+- **`Result` (recoverable)**: opening files, decode / encode / probe failures, any FFmpeg call
+  error, unsupported formats, network I/O.
+- **panic (invariant violation)**: a "cannot happen by construction" state. Even then, do not panic
+  on a path a caller drives frame-by-frame (the decode / filter / encode loop); return `Result` and
+  let the caller decide.
+- `unwrap()` / `expect()` are forbidden in library code and allowed only under `#[cfg(test)]`. The
+  one exception is a true, construction-guaranteed invariant, using `expect` with an
+  `// INVARIANT:` comment stating why it always holds (the same discipline as `// SAFETY:`; do not
+  abuse it).
+
+```rust
+// Bad — forbidden in library code
+let stream = info.primary_video().unwrap();
+
+// Good — propagate with ?
+let stream = info.primary_video().ok_or(ProbeError::NoVideoStream)?;
+
+// OK — a true invariant only, with a reason
+// INVARIANT: pushed just above, so the last element always exists.
+let last = self.steps.last_mut().expect("step just pushed");
+```
+
+---
+
+## Representing FFmpeg errors
+
+The negative integer error codes FFmpeg returns are kept in this form. Convert the code into a
+message with `av_strerror` in the inner layer (`*_inner.rs`).
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DecodeError {
+    #[error("ffmpeg error: {message} (code={code})")]
+    Ffmpeg { code: i32, message: String },
+    // ...
+}
+```
+
+---
+
+## Nesting errors
+
+### Wrap a lower crate's error with `#[from]`
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum PipelineError {
+    #[error("decode failed: {0}")]
+    Decode(#[from] ff_decode::DecodeError),
+
+    #[error("encode failed: {0}")]
+    Encode(#[from] ff_encode::EncodeError),
+}
+```
+
+### Carry context in fields
+
+To make it clear where a failure happened, put information such as file paths and stream indices
+in the variant's fields.
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DecodeError {
+    #[error("failed to open file: path={path}")]
+    OpenFailed { path: String },
+
+    #[error("stream not found: index={index}")]
+    StreamNotFound { index: usize },
+
+    #[error("ffmpeg error: {message} (code={code})")]
+    Ffmpeg { code: i32, message: String },
+}
+```
+
+---
+
+## Exposing error types
+
+- Each crate re-exports its own error type from the crate root with `pub use`.
+- The `avio` facade re-exports every crate's error type (e.g. `avio::DecodeError`,
+  `avio::FilterError`).
+
+---
+
+## Do not
+
+- Do not use `unwrap()` / `expect()` in library code (tests, and a true `// INVARIANT:` `expect`,
+  excepted).
+- Do not silently swallow errors. If you must ignore one, emit `log::warn!()`
+  (see [logging.md](./logging.md)).
+- Do not return string-only errors (`"something went wrong"`). Use a meaningful variant.

--- a/docs/rules/gpu.md
+++ b/docs/rules/gpu.md
@@ -1,0 +1,82 @@
+# GPU / wgpu Conventions
+
+> GPU compositing lives in `ff-render` (wgpu). Shader **code** conventions are in
+> [wgsl.md](./wgsl.md). Related: [perf.md](./perf.md), [unsafe.md](./unsafe.md).
+
+## References
+
+- [wgpu](https://docs.rs/wgpu) / [WGSL spec](https://www.w3.org/TR/WGSL/)
+- [WebGPU best practices](https://toji.dev/webgpu-best-practices/)
+
+---
+
+## 1. Device / queue ownership
+
+- A single wgpu `instance` / `adapter` / `device` / `queue`, owned once and shared for all
+  compositing work.
+- Pipelines, bind group layouts, and reusable buffers are created once and reused.
+
+## 2. Resource lifecycle and recreatability
+
+Keep every GPU resource **recreatable from a CPU-side description** (for device loss).
+
+- Pipelines, bind group layouts, buffers, and offscreen targets are regenerable from their
+  descriptors and data source.
+- Detect device loss -> recreate the device -> rebuild and re-upload all resources -> continue.
+- Do not create-and-drop per frame; reuse growable buffers (see [perf.md](./perf.md)).
+- **Label every resource** for debugging and profiling.
+
+```rust
+let buf = device.create_buffer(&wgpu::BufferDescriptor {
+    label: Some("ffrender.composite.instances"),
+    size,
+    usage,
+    mapped_at_creation: false,
+});
+```
+
+## 3. Pipelines
+
+- Cache pipelines; do not build them per frame.
+- WGSL is validated at build time (Naga), so shader errors surface early in dev.
+
+## 4. Instance data (bytemuck)
+
+- Structs sent to the GPU are `#[repr(C)]` + `bytemuck::Pod` / `Zeroable`, uploaded with
+  `cast_slice`.
+- Field order, size, and padding must match the WGSL `struct` exactly (16-byte alignment; see
+  [wgsl.md](./wgsl.md)). A mismatch is a silent rendering bug.
+- `bytemuck`'s derive is not hand-written `unsafe`; do not write byte-cast `unsafe` yourself.
+
+```rust
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct LayerInstance {
+    transform: [f32; 4], // keep field order/size in sync with the WGSL struct
+    opacity: f32,
+    _pad: [f32; 3],      // explicit padding to a 16-byte boundary
+}
+```
+
+## 5. Color
+
+- Composite video in a **linear working space**. Do not blend in an sRGB-encoded space.
+- Frame textures carry their color space: convert to the working space on sample, and encode on the
+  final output pass. Do not hardcode the working primaries.
+- Distinguish display-referred UI color from video color; do not mix them.
+
+## 6. CPU <-> GPU synchronization
+
+- Respect submission order and fences: do not sample a texture whose write has not completed.
+- Read `map_async` results only after `queue.submit` + `device.poll`.
+
+## 7. Memory
+
+- Reuse growable buffers; do not allocate GPU resources per frame (see [perf.md](./perf.md)).
+- Free textures/buffers that are no longer needed; do not leak.
+
+## 8. unsafe
+
+wgpu's API is safe: prefer the safe `create_surface` and safe resource APIs. Any hand-written
+`unsafe` (rare, e.g. a surface-from-raw-handle path) is isolated with a `// SAFETY:` comment (see
+[unsafe.md](./unsafe.md)).

--- a/docs/rules/logging.md
+++ b/docs/rules/logging.md
@@ -1,0 +1,104 @@
+# Logging
+
+> avio uses the **`log`** crate; the backend is chosen by the consumer. Related: [rust.md](./rust.md).
+
+## Principles
+
+- Use only the `log` crate (v0.4). Do not initialize a backend (`env_logger`, etc.) inside the
+  library — that is the consuming application's job.
+- Prefer a structured message format that includes `key=value` pairs.
+- Keep per-frame / hot-path work out of `info!` / `debug!` (see "Hot paths" below).
+
+---
+
+## Choosing a log level
+
+### `log::error!`
+
+Fatal errors where the process cannot reasonably continue. Generally not used in library code;
+return `Result::Err` and leave the decision to the caller.
+
+### `log::warn!`
+
+- When processing continues but a default value was used as a fallback.
+- When an implicit conversion happens, e.g. converting to an unsupported pixel format.
+
+```rust
+log::warn!(
+    "pixel_format unsupported, falling back to yuv420p \
+     requested={:?} fallback=yuv420p",
+    requested_fmt
+);
+```
+
+### `log::info!`
+
+Lifecycle events: successful codec open, hardware-acceleration initialization, pipeline start/finish.
+
+```rust
+log::info!("codec opened codec={} width={} height={}", codec_name, width, height);
+```
+
+### `log::debug!`
+
+- Immediately before/after an FFmpeg API call (arguments and return values).
+- When adding a filter to a filter graph.
+
+```rust
+log::debug!("filter added name={} args={}", filter_name, filter_args);
+```
+
+Do not log per frame here (the volume becomes enormous).
+
+### `log::trace!`
+
+Not used.
+
+---
+
+## Hot paths: validate at the boundary, do not log per frame
+
+The decode / filter / encode loop runs once per frame. Emitting `warn!` / `error!` from inside it
+on a "should not happen" condition (a missing stream, an unmapped token) floods the log and hurts
+throughput. Observe such conditions in three layers instead:
+
+1. **Validate at the boundary and reject with `Result`.** Check when data enters (open / parse /
+   `build`), and return a typed error to the caller. Keep the hot path a total function that
+   assumes validated input.
+2. **Debug-visible fallback.** If something still slips through, the hot path returns an obvious
+   default rather than panicking (do not poison the output).
+3. **Do not log** (at most one `trace!` line).
+
+```rust
+// Good: validate on build, keep the per-frame path total and quiet
+let mut graph = builder.build()?;   // boundary: invalid args rejected here
+let frame = graph.pull_video()?;    // per-frame: no warn!, no error!
+```
+
+Non-hot-path fallbacks (open / init / hardware recovery) may still `warn!` as usual.
+
+---
+
+## Message format
+
+**Prose + `key=value` pairs.** Key names are snake_case; values are printed as-is (no quotes).
+
+```
+// Good
+"codec opened codec=h264 width=1920 height=1080 fps=30"
+"filter added name=scale args=w=1280:h=720"
+
+// Bad (no key=value)
+"Codec opened successfully"
+"Failed to open file"
+```
+
+---
+
+## Do not
+
+- Do not use `println!` / `eprintln!` in library code.
+- Do not initialize a logging backend inside the library (that is the app's / test's job).
+- Do not swallow an error and log nothing. If you ignore one intentionally, emit `log::warn!`.
+- Do not emit heavy per-frame logs (`info!` / `debug!` inside the frame loop). Keep those to
+  `trace!`, or prefer boundary validation (above).

--- a/docs/rules/perf.md
+++ b/docs/rules/perf.md
@@ -1,0 +1,88 @@
+# Performance Rules
+
+> Media processing is throughput-sensitive: the decode / filter / encode loop runs once per frame,
+> often millions of times. Related: [rust.md](./rust.md), [gpu.md](./gpu.md) (GPU),
+> [test.md](./test.md) (benchmarks).
+
+## References
+
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Criterion Benchmarking](https://bheisler.github.io/criterion.rs/book/)
+
+---
+
+## Principles
+
+- Measure in release (`cargo build --release`). Do not micro-optimize on guesswork; benchmark the
+  path first.
+- The frame loop is the hot path. Keep it allocation-light.
+
+---
+
+## Hot paths (the frame loop)
+
+### Avoid per-frame heap allocation
+
+```rust
+// Bad: allocate a fresh buffer every frame
+let mut buf = vec![0u8; size];
+
+// Good: reuse a buffer across frames (clear() keeps the capacity)
+self.scratch.clear();
+self.scratch.resize(size, 0);
+```
+
+### Reuse frame buffers via the pool
+
+avio provides buffer pooling (`PooledBuffer`, `VecPool`, and the `FramePool` trait). Decode and
+conversion paths draw buffers from a pool and return them, rather than allocating fresh every frame.
+
+### Reference-count frames; do not deep-copy
+
+Share frame/packet data with `av_frame_ref` / `av_packet_ref` (in the inner layer) instead of
+copying pixel or sample data. Deep copies inside the frame loop are a common, avoidable cost.
+
+### Build once, run many
+
+Construct the `FilterGraph`, encoder, and decoder contexts **once** during initialization, then
+push frames through them. Never rebuild a filter graph or reopen a codec inside the frame loop.
+
+> `FilterGraph::build()` is lazy: it validates filter *names* and builds the FFmpeg graph on the
+> first `push`. Still build it once, outside the loop.
+
+---
+
+## GPU
+
+GPU compositing (`ff-render`) has its own discipline: reuse growable buffers, cache pipelines, batch
+uploads, do not allocate GPU resources per frame. See [gpu.md](./gpu.md).
+
+---
+
+## Benchmarks (Criterion)
+
+Put Criterion benches on the critical paths, under each crate's `benches/`.
+
+| Crate | Target |
+|---|---|
+| `ff-decode` / `ff-encode` | decode / encode throughput; format conversion (swscale) |
+| `ff-filter` | filter-graph build + per-frame push/pull |
+| `ff-render` | GPU composite pass; buffer upload |
+
+Run manually before/after a performance-relevant change:
+
+```bash
+cargo bench -p ff-encode -- --save-baseline before
+# ...make the change...
+cargo bench -p ff-encode -- --load-baseline before --save-baseline after
+```
+
+Benches are **not** run in CI; run them by hand around perf-relevant changes.
+
+---
+
+## Profiling
+
+- Coarse phase timing (decode / filter / encode / mux) via `log` timing.
+- Standard CPU profilers (`perf`, Instruments, VTune).
+- GPU: RenderDoc, wgpu timestamp queries.

--- a/docs/rules/rust.md
+++ b/docs/rules/rust.md
@@ -1,0 +1,170 @@
+# Rust Coding Standards
+
+> Scope: the whole avio workspace (`avio` engine facade + `ff-sys` / `ff-common` / `ff-format` /
+> `ff-probe` / `ff-decode` / `ff-encode` / `ff-filter` / `ff-pipeline` / `ff-stream` / `ff-preview`
+> / `ff-render`).
+> Related: [design.md](./design.md) (design / API), [error-handling.md](./error-handling.md),
+> [unsafe.md](./unsafe.md), [perf.md](./perf.md), [logging.md](./logging.md).
+
+## References
+
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+
+---
+
+## Formatting
+
+- Use `rustfmt` with its default settings.
+- CI runs `cargo fmt --check` and blocks on formatting violations.
+
+## Naming
+
+| Target | Convention | Example |
+|---|---|---|
+| Types / traits | UpperCamelCase | `VideoDecoder`, `FilterGraph` |
+| Functions / methods | snake_case | `decode_frame`, `push_video` |
+| Constants | SCREAMING_SNAKE_CASE | `MAX_BITRATE` |
+| Modules | snake_case | `decoder_inner`, `filter_inner` |
+| Files | snake_case | `decoder_inner.rs` |
+
+## Module layout
+
+```
+src/
+  lib.rs          <- public API surface (via `pub use`)
+  error.rs        <- error type definitions
+  {feature}/
+    mod.rs        <- public types/functions (safe API)
+    {feature}_inner.rs <- unsafe FFmpeg calls (`pub(crate)` only)
+```
+
+All `unsafe` FFmpeg calls live in `*_inner.rs` (see [unsafe.md](./unsafe.md)).
+
+## Builder pattern
+
+Use consuming builders (they take `self`). See [design.md](./design.md) for when a builder is
+warranted.
+
+```rust
+pub struct VideoEncoderBuilder { ... }
+
+impl VideoEncoderBuilder {
+    pub fn codec(self, codec: VideoCodec) -> Self { ... }
+    pub fn bitrate(self, bps: u64) -> Self { ... }
+    pub fn build(self) -> Result<VideoEncoder, EncodeError> { ... }
+}
+```
+
+- `.build()` always returns `Result<T, Error>`.
+- Validation is collected in `.build()`, not in the setters.
+
+## Visibility
+
+| Scope | Use |
+|---|---|
+| `pub` | Types/functions exposed outside the crate |
+| `pub(crate)` | Types/functions used only within the crate (the contents of `*_inner.rs`) |
+| `pub(super)` | Exposed only to the parent module |
+| none (private) | Module-internal only |
+
+---
+
+## Concurrency & runtime
+
+### FFmpeg contexts are `Send` but not `Sync`
+
+FFmpeg context types (`AVCodecContext`, `AVFilterGraph`, …) are not safe for concurrent access,
+but ownership can move between threads. The inner types implement `Send` only, never `Sync`
+(see [unsafe.md](./unsafe.md)). Do not share a decoder / encoder / filter graph across threads
+without external synchronization; give each thread its own.
+
+### avio is runtime-agnostic
+
+The `ff-*` crates do not hard-depend on a specific async runtime. The `tokio` feature adds thin
+async wrappers (backed by `spawn_blocking` and bounded channels); the runtime belongs to the
+application. Do not pull `tokio` into a crate's non-optional dependencies.
+
+### `rayon` for CPU-bound batches
+
+Parallel, CPU-bound batches (e.g. multi-timestamp thumbnail extraction) may use `rayon`. Each
+worker opens its **own** decoder — never share an FFmpeg context between workers. Collect the
+results, then reorder. Do not manage OS threads by hand.
+
+---
+
+## Cross-platform
+
+Keep code portable even when a feature targets one platform first.
+
+- File paths use `std::path::Path` / `PathBuf`. Never write OS separators as string literals.
+- Localize OS-specific branches (per-platform hardware backends: NVENC / QSV / AMF /
+  VideoToolbox / VAAPI) behind the existing abstractions.
+
+```rust
+// Bad — hardcoded separator
+let p = dir.to_string() + "/out.mp4";
+// Good
+let p = dir.join("out.mp4");
+```
+
+---
+
+## Code quality
+
+### Prefer iterators over manual loops
+
+```rust
+let audio_indices: Vec<_> = info.streams().iter()
+    .filter(|s| s.is_audio())
+    .map(|s| s.index())
+    .collect();
+```
+
+### Annotate non-obvious clones
+
+```rust
+// clone required: the rayon worker needs an owned 'static + Send value
+let path = source.clone();
+```
+
+### `unsafe` requires justification
+
+Every `unsafe` block has a `// SAFETY:` comment stating the invariant. Details in
+[unsafe.md](./unsafe.md).
+
+### No dead code on committed branches
+
+Remove unused `use` / functions / variables. If `#[allow(dead_code)]` is genuinely needed, add a
+reason comment.
+
+---
+
+## Comments
+
+- Comments explain **why**, not the obvious **what**.
+- Non-obvious algorithms, FFmpeg quirks, or binary layouts may use a multi-line block comment when
+  one line will not do.
+
+```rust
+// OK — non-obvious why
+// asetrate changes the declared sample rate (which shifts pitch); atempo then
+// restores the original duration.
+let rate = 2f64.powf(f64::from(semitones) / 12.0);
+
+// Bad — obvious what
+// loop over frames
+for frame in frames { ... }
+```
+
+---
+
+## Do not
+
+- Do not use `unwrap()` / `expect()` in library code (under `src/`). Allowed only under
+  `#[cfg(test)]`. The one exception is a true, construction-guaranteed invariant, using `expect`
+  with an `// INVARIANT:` comment (see [error-handling.md](./error-handling.md)); do not abuse it.
+- Do not use `println!` / `eprintln!` in library code (use `log::`, see [logging.md](./logging.md)).
+- Do not reach for `#[allow(dead_code)]` casually.
+- Do not create circular dependencies. Dependency direction and crate boundaries are in
+  [design.md](./design.md).

--- a/docs/rules/test.md
+++ b/docs/rules/test.md
@@ -1,0 +1,123 @@
+# Testing Standards
+
+> Test the observable behaviour, not the implementation. Related: [perf.md](./perf.md) (benchmarks).
+
+## References
+
+- [Rust Testing Guide](https://doc.rust-lang.org/book/ch11-00-testing.html)
+- [proptest Book](https://proptest-rs.github.io/proptest/intro.html)
+- [Criterion Book](https://bheisler.github.io/criterion.rs/book/)
+
+---
+
+## Philosophy
+
+Test **behaviour**. A good test breaks only when observable behaviour changes, not when an internal
+field is renamed. Do not mock FFmpeg — call the real API.
+
+## Naming
+
+```
+<feature>_should_<expected_result>
+```
+
+```rust
+fn decode_h264_should_return_video_frame() { ... }
+fn scale_filter_should_resize_frame_to_target_dimensions() { ... }
+fn open_nonexistent_file_should_return_error() { ... }
+```
+
+---
+
+## Test layers
+
+### 1. Unit tests (pure logic; primary)
+
+`#[cfg(test)] mod tests` in the source. Cover FFmpeg-free logic: type conversions, token mapping,
+argument-string construction, math (keyframe interpolation, atempo decomposition).
+
+Token / value regressions belong in **deterministic, build-independent string-equality unit
+tests** — they must not depend on which FFmpeg is installed.
+
+### 2. Integration tests (real FFmpeg)
+
+`crates/<crate>/tests/`. Drive the real FFmpeg API against short fixtures.
+
+**Skip when FFmpeg is unavailable:**
+
+```rust
+fn ffmpeg_available() -> bool {
+    std::process::Command::new("ffmpeg").arg("-version").output().is_ok()
+}
+```
+
+**Probe-gate filter-graph tests.** CI's Linux FFmpeg is built with no filters, so every
+filter-graph `push` returns `FilterError::BuildFailed` there. A bare `.expect()` on a push fails
+CI. Probe first and skip gracefully:
+
+```rust
+match graph.push_video(0, &frame) {
+    Ok(()) => { /* assert output ... */ }
+    Err(FilterError::BuildFailed) => { println!("skipping: filters unavailable"); return; }
+    Err(e) => panic!("unexpected: {e}"),
+}
+```
+
+Real filter-graph verification effectively runs only on a full FFmpeg build (macOS via Homebrew).
+
+**`build()` is lazy.** `FilterGraph::build()` validates filter *names* only; argument *values* are
+validated on the first `push`. A test that checks "FFmpeg accepts these args" must **push a frame**
+— `build().expect(...)` proves nothing about the arguments.
+
+### 3. Property tests (proptest)
+
+Verify invariants hold on arbitrary input (e.g. a parameter parser never panics; an interpolated
+value stays in range).
+
+### 4. Benchmarks (Criterion)
+
+See [perf.md](./perf.md). Critical paths only; not run in CI.
+
+---
+
+## Fixtures
+
+- **Small (<= 1 MB)**: commit under `tests/fixtures/`.
+- **Large (> 1 MB)**: download in CI; tests read the path from `FF_TEST_LARGE_FIXTURE_DIR`.
+
+## Integration test policy
+
+- No mocks — call the real FFmpeg API.
+- Short 1-3 second samples.
+- Independent (no ordering dependencies).
+- Use `tempfile` for temporary outputs (auto-deleted).
+
+---
+
+## What to test per crate
+
+| Crate | Focus |
+|---|---|
+| `ff-format` / `ff-common` | type conversions, token mapping (string-equality), pure logic — no FFmpeg |
+| `ff-probe` | metadata extraction against fixtures |
+| `ff-decode` / `ff-encode` | decode/encode round-trips; format conversion; seek accuracy |
+| `ff-filter` | filter-graph build + push/pull (probe-gated); token/arg strings (string-equality units) |
+| `ff-pipeline` / `ff-stream` / `ff-preview` | end-to-end pipeline against fixtures (probe-gated) |
+| `ff-render` | GPU composite output (skip when no adapter) |
+| `avio` (engine) | editing-model behaviour; the `avio-examples` harness for end-to-end verification |
+
+## What NOT to test
+
+- Third-party internals (FFmpeg, wgpu).
+- Exact pixel equality across FFmpeg builds / GPU drivers (use tolerances, or skip).
+- Trivial getters/setters.
+
+---
+
+## CI notes
+
+- `cargo test --workspace` is the gate. Integration tests self-skip where FFmpeg is unavailable, so
+  it is expected to always pass.
+- CI clippy runs **without** `--tests` / `--all-targets`, so test-only lints (`expect_used`,
+  `print_stdout`) do not gate CI. Non-test library code must stay clippy-clean; do not chase local
+  `--tests` clippy errors that CI never runs.

--- a/docs/rules/unsafe.md
+++ b/docs/rules/unsafe.md
@@ -1,0 +1,123 @@
+# Unsafe Code Conventions
+
+> avio wraps FFmpeg's C libraries, so **`unsafe` is central**: every FFmpeg call is `unsafe`. The
+> rule is not "avoid `unsafe`" but "**isolate and justify** it." Related: [rust.md](./rust.md); GPU
+> `unsafe` in [gpu.md](./gpu.md).
+
+## Principles
+
+- Isolate all `unsafe` in `*_inner.rs` files, kept `pub(crate)`. Do not leak `unsafe` out of `pub`
+  functions — the external API is entirely safe.
+- Every `unsafe` block and `unsafe impl` has a `// SAFETY:` comment stating why it is sound. An
+  `unsafe` block with no such comment must be flagged in review.
+- The pure-Rust crates (`ff-format`, `ff-common`) contain **no `unsafe`**.
+- A change that adds or alters `unsafe` triggers Tier-2 review (`/code-review-deep`).
+
+## Lints
+
+The workspace sets `unsafe_code = "warn"` (not `deny`), because the `ff-sys` FFI bindings and the
+`*_inner.rs` layer legitimately use `unsafe`. Keep it confined there; the safe layers stay
+`unsafe`-free.
+
+---
+
+## SAFETY comments
+
+Immediately before an `unsafe` block, write the soundness argument.
+
+```rust
+// SAFETY: ptr is non-null because avcodec_alloc_context3 succeeded,
+//         and we are the sole owner of this context.
+unsafe { avcodec_free_context(&mut self.ctx.as_ptr()) };
+```
+
+---
+
+## Pointer management
+
+### Null-check on the inner side
+
+When an FFmpeg function may return null, check it on the inner side and convert it into an error.
+Do not hand raw pointers to the outer layer.
+
+```rust
+// inside filter_inner.rs
+let graph = unsafe { avfilter_graph_alloc() };
+if graph.is_null() {
+    return Err(FilterError::Ffmpeg { code: -1, message: "avfilter_graph_alloc failed".into() });
+}
+```
+
+### Wrap pointers in `Option<NonNull<T>>` or a newtype
+
+Do not hold a raw `*mut AVCodecContext` as a struct field.
+
+```rust
+use std::ptr::NonNull;
+struct CodecContextPtr(NonNull<AVCodecContext>);
+```
+
+### Free in `Drop` with `take()`
+
+To prevent double frees, invalidate the pointer after freeing.
+
+```rust
+impl Drop for FilterGraphInner {
+    fn drop(&mut self) {
+        if let Some(ptr) = self.graph.take() {
+            // SAFETY: graph is non-null (guaranteed by Option), and we own it.
+            unsafe {
+                let mut raw = ptr.as_ptr();
+                avfilter_graph_free(&mut raw);
+            }
+        }
+    }
+}
+```
+
+---
+
+## FFmpeg ownership and lifetimes
+
+- Reference-count frames/packets with `av_frame_ref` / `av_packet_ref` rather than deep-copying;
+  release with the matching unref/free.
+- After freeing an FFmpeg object, null the pointer (the `Option` + `take()` pattern) so it cannot be
+  freed twice.
+- **`CString` lifetime**: when passing `CString::new(...)`'s `.as_ptr()` to FFmpeg, keep the
+  `CString` alive until the call returns. Do not let a temporary drop before the pointer is used.
+- **Error-path leaks**: on every early return / `?` / `bail!`, free any FFmpeg resource acquired
+  earlier in the same function.
+
+## FFmpeg call order
+
+The exact call order is specified per crate in `docs/crates/{name}/design.md` and is part of the
+design (see [design.md](./design.md)). Deviating is a bug.
+
+---
+
+## Send / Sync
+
+FFmpeg context types are not thread-safe for concurrent access, but moving them between threads is
+safe. Implement `Send` only.
+
+```rust
+// SAFETY: AVCodecContext is not thread-safe for concurrent access, but ownership
+//         transfer between threads is safe because Rust's ownership model
+//         guarantees exclusive access.
+unsafe impl Send for VideoDecoderInner {}
+```
+
+- Do not implement `Sync`.
+- Every `unsafe impl` has a SAFETY comment.
+
+---
+
+## Enforce `pub(crate)`
+
+Every function/type in `*_inner.rs` is `pub(crate)`. Do not expose them with `pub`.
+
+```rust
+// filter_inner.rs
+pub(crate) struct FilterGraphInner { ... }
+pub(crate) fn build_graph(...) -> Result<FilterGraphInner, FilterError> { ... }
+```

--- a/docs/rules/wgsl.md
+++ b/docs/rules/wgsl.md
@@ -1,0 +1,99 @@
+# WGSL Coding Standards
+
+> Shader **code** conventions for `ff-render`. GPU resource / pipeline conventions are in
+> [gpu.md](./gpu.md). Related: [rust.md](./rust.md) (comment policy).
+
+## References
+
+- [WGSL spec](https://www.w3.org/TR/WGSL/) / [Naga](https://github.com/gfx-rs/naga) /
+  [wgpu](https://docs.rs/wgpu)
+
+---
+
+## 1. File / module layout
+
+- Shaders live under `ff-render/src/shaders/` as `.wgsl`.
+- Shared utilities (color conversion, coordinate transforms) go in a prelude module, composed into
+  each shader. Do not copy the same math into every file.
+- Validate with Naga at build time (surface shader errors early in dev).
+
+## 2. Naming
+
+| Kind | Convention | Example |
+|---|---|---|
+| struct | PascalCase | `LayerInstance`, `Globals` |
+| function | snake_case | `to_linear`, `sample_layer` |
+| constants | UPPER_SNAKE | `PI` |
+| variables / fields | snake_case | `opacity` |
+| entry points | `vs_main` / `fs_main` | |
+
+Match the corresponding Rust type name (`LayerInstance` <-> Rust `LayerInstance`).
+
+## 3. Struct layout / alignment (most important)
+
+A WGSL `struct` must match the byte layout of its Rust `#[repr(C)]` + `bytemuck::Pod` counterpart
+([gpu.md](./gpu.md)). A mismatch is a silent rendering bug.
+
+- **16-byte alignment.** A `vec3<f32>` aligns to 16 bytes and adds 4 bytes of trailing padding —
+  pack into `vec4`, or add an explicit padding field.
+- `var<uniform>` follows strict (std140-like) alignment; array elements align to 16 bytes.
+- Cross-reference field order/size with a Rust-side comment.
+
+```wgsl
+// Matches Rust #[repr(C)] LayerInstance (field order and size kept in sync)
+struct LayerInstance {
+    transform: vec4<f32>,
+    opacity:   f32,
+    // avoid vec3; keep to 16-byte boundaries
+};
+```
+
+```wgsl
+// Bad: vec3 implicit padding shifts the next field
+struct Bad { a: vec3<f32>, b: f32 };
+```
+
+## 4. Bindings
+
+Stabilize the `@group` / `@binding` layout.
+
+- **group 0 = frame-global** (viewport, output size, time) in `Globals`.
+- **group 1 = per-batch resources** (the layer texture + sampler).
+- Instance data is passed via the vertex buffer (`@location`).
+
+```wgsl
+@group(0) @binding(0) var<uniform> globals: Globals;
+@group(1) @binding(0) var layer_tex: texture_2d<f32>;
+@group(1) @binding(1) var layer_sampler: sampler;
+```
+
+## 5. Coordinate system
+
+- Fix one convention for the y-axis direction across the project and state it in the prelude comment.
+- Convert to NDC (clip space) via `globals`.
+
+## 6. Color
+
+- Compute in **linear** inside the shader. Do not sRGB-encode in the fragment shader (a dedicated
+  output pass does the final encode).
+- Prefer premultiplied alpha; state the assumption in the prelude.
+- Input colors / textures are converted to linear on the CPU side; do not hardcode a color-space
+  conversion in the shader.
+
+## 7. Control flow / Naga portability
+
+- Keep branching minimal; favor arithmetic.
+- Do not write unbounded loops.
+- Mind backend differences (DX12 / Vulkan / Metal via Naga); do not rely on precision-dependent or
+  exotic built-ins.
+
+## 8. Comments
+
+- Explain the **why** of non-obvious math (color transforms, blends). Multi-line block comments are
+  allowed when one line will not do (see [rust.md](./rust.md)).
+- Do not restate the obvious.
+
+## 9. Testing
+
+Cover shader visual output with tolerance-based comparison against reference frames where practical
+(skip when no GPU adapter). See [test.md](./test.md).

--- a/docs/specs/engine-and-primitives.md
+++ b/docs/specs/engine-and-primitives.md
@@ -1,0 +1,119 @@
+# Engine and Primitives — avio's architecture
+
+> Status: design of record. Drives tracking issues #1326 (relocation + purification) and
+> #1327 (immutable model redesign). Internal doc.
+
+## 1. Positioning decision
+
+avio is an **editing engine**, not a general-purpose "build any editor" toolkit. The `ff-*`
+family are **model-agnostic primitives**.
+
+- **`avio` (engine)** owns the editing model: what a project/timeline/clip is, how time and
+  tracks and edits and history are organised, and how a frame is derived from that model. It is
+  opinionated by design (it commits to one editing model).
+- **`ff-*` (primitives)** own execution: decode, encode, filter, composite one frame, interpolate,
+  probe, stream. They know nothing about editing.
+
+Why this split, honestly:
+
+1. **Primary justification — engine correctness.** The North Star (below) can only guarantee
+   "preview == export" and be testable if the primitives are stateless executors of a per-frame
+   description. Purifying `ff-*` is what makes the engine correct, not a courtesy to library users.
+2. **De-risks the engine's opinion.** Because clean primitives remain, an app whose editing model
+   does not fit avio's can drop to `ff-*` and build its own. The separation is what makes "be an
+   opinionated engine" a safe bet.
+3. **Bonus — a real, modest library audience.** Safe Rust media plumbing (decode/encode/transcode/
+   stream) is a genuine `ff-*` use case (e.g. ascii-term). This is a bonus, not the reason.
+
+**Guardrail against over-engineering:** purify `ff-*` only to the depth the engine's North Star
+requires. Do not gold-plate the libraries for a speculative "build your own editor" audience. The
+engine's needs bound the purification scope.
+
+## 2. North Star (target architecture)
+
+```
+immutable/declarative editing model   (avio)
+        │  derive(model, t)  — a pure function
+        ▼
+      Scene   (a flat, model-agnostic description of one frame's work)   (ff-* type)
+        │  executed by
+        ▼
+stateless primitives: decode / filter / composite / encode   (ff-*)
+```
+
+- The **editing model** is an immutable value. Edits produce a new version.
+- **`derive(model, t) -> Scene`** is a pure function: the single source of truth for a frame.
+- **preview == export by construction**: both paths call the same `derive` and the same primitive
+  executor. Equality is structural, not maintained by hand.
+- **Undo/Redo** is a history of immutable model versions.
+
+The model's immutable redesign, the pure `derive`, and Do/Undo are implemented in **#1327**.
+Their shape is fixed here so that #1326 purifies toward the right target.
+
+## 3. Boundary principle (model vs primitive)
+
+**Litmus:** does this type/function need to know **TIME, TRACK, CLIP, EDIT, or HISTORY** to do
+its job?
+
+- **No** (it operates on the current frame's given data) → **primitive (`ff-*`)**.
+- **Yes** → **model (`avio`)**.
+
+| Belongs in `avio` (model) | Belongs in `ff-*` (primitive) |
+|---|---|
+| Timeline / Clip / tracks / clip effect stacks | FilterGraph / FilterStep |
+| model → Scene derivation, preview/export orchestration | RealtimeComposer / compositor (executes a Scene) |
+| TimelinePlayer / TimelineRunner (consume the model) | Keyframe / Easing / Lerp / AnimationTrack (interpolation math) |
+| edit history (undo) — #1327 | BlendMode / CompositeOp / XfadeTransition (enums) |
+| | decode / encode / probe / stream / EncoderConfig |
+| | Pipeline / VideoPipeline / … (execution pipelines) |
+
+## 4. The `Scene` seam
+
+`Scene` is the clean seam between engine and primitives: a flat, model-agnostic description of
+**what to render for one frame** — an ordered list of layers (each: a source frame + transform +
+opacity + blend + effect steps) plus the output canvas.
+
+- It is the **output** of `derive(model, t)` and the **input** of the primitive compositor.
+- It is a **primitive type** (`ff-*` side): any engine could produce a `Scene`.
+- Purification means moving timeline/editorial semantics **out** of primitive inputs. For example
+  today's `VideoLayer` carries `time_offset` and `in_transition` (timeline concepts); those move
+  into the engine's `derive`, and the primitive layer keeps only current-frame fields.
+
+## 5. Crate roles and dependency direction (new)
+
+```
+ff-sys → ff-common → ff-format → ff-probe / ff-decode / ff-encode → ff-filter
+       → ff-pipeline → ff-stream / ff-preview / ff-render → avio (engine, top)
+```
+
+- **The editing model lives at the top (`avio`).** Nothing in `ff-*` depends on it, so `ff-*` are
+  structurally model-free — the separation is enforced by dependency direction, not discipline.
+- `avio` stops being a facade-only crate. It defines the editing-model types (and, in #1327, the
+  derivation, immutable state, and undo). It still re-exports the `ff-*` primitives.
+- Versioning stays **lockstep** (Bevy-style); `ff-*` are public but not yet semver-frozen.
+  Independent per-crate versioning is deferred until real external demand appears.
+
+## 6. Project decomposition
+
+- **#1326 (first): relocation + purification.** Move the model to `avio`; purify `ff-*` into
+  stateless `Scene` executors; behaviour preserved. Closeable when `ff-*` hold no editing
+  semantics. Classification-first, always-green, verified by tests + the `avio-examples` harness.
+- **#1327 (after): immutable model redesign.** Rebuild the now-relocated model as an immutable
+  value with pure `derive` and Do/Undo. Its own design/spec cycle.
+
+## 7. Non-goals
+
+- Not a framework for **every** editing paradigm. avio commits to a track + per-clip effect stack
+  + keyframe + compositing model. Node-based (Nuke-style) and magnetic-timeline (FCPX-style)
+  models are out of scope for the engine; such apps use `ff-*` directly.
+- No gold-plating of `ff-*` beyond what the engine needs (see the guardrail in §1).
+
+## 8. CLAUDE.md changes (applied in P1-0)
+
+- Remove "`avio` = facade / `pub use` only / no new types".
+- State: `avio` = engine crate that owns the editing model; `ff-*` = model-agnostic primitives.
+- Add the boundary principle (litmus) and the purification guardrail.
+- Restate the dependency direction with the editing model at the top (`avio`).
+- Note the "define types in the lowest applicable crate" rule now has one deliberate exception:
+  the editing model is defined in `avio` (the top), because model-freeness of `ff-*` must be
+  enforced by dependency direction.


### PR DESCRIPTION
## Objective

- Organize the project documentation: publish the workspace coding rules and the architecture (in English), while keeping internal process docs (review-knowledge, maintenance log) private under `docs/dev/`.
- Write down the positioning decision so it does not drift: avio is an editing engine; the `ff-*` family are model-agnostic primitives.

## Solution

- Add `docs/rules/` (English): `rust`, `design`, `error-handling`, `logging`, `unsafe`, `perf`, `test`, `gpu`, `wgsl`, plus a README index. Adapted to avio's FFmpeg/FFI reality (isolated `unsafe`, hot-path logging, buffer pooling, probe-gated filter tests) rather than a generic template.
- Add `docs/concepts.md` and `docs/specs/engine-and-primitives.md`: `avio` is the engine and owns its editing model (Timeline/Clip, model-to-scene derivation, history); the `ff-*` crates are stateless, model-agnostic primitives, so a caller can build their own editing model on them without avio imposing one.
- Move the long-term roadmap to `docs/roadmap/plan.md` and fix a roadmap cross-reference.

Refs #1326