### PR TITLE
refactor(ff-filter): strip timeline/editorial fields from AudioTrack

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -19,7 +19,7 @@
 //!   [--width 1280] [--height 720] [--fps 30]
 //! ```
 
-use std::{path::PathBuf, process, time::Duration};
+use std::{path::PathBuf, process};
 
 use avio::{
     AnimatedValue, AudioCodec, AudioTrack, ChannelLayout, MultiTrackAudioMixer, MultiTrackComposer,
@@ -136,9 +136,6 @@ fn main() {
                 source: audio_a.clone(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(-0.2), // slight left pan
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: None,
                 effects: vec![],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,
@@ -147,9 +144,6 @@ fn main() {
                 source: audio_b.clone(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.2), // slight right pan
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: None,
                 effects: vec![],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -3064,6 +3064,8 @@ impl FilterGraphInner {
                     | FilterStep::ConcatAudio { .. }
                     | FilterStep::NoiseReduce { .. }
                     | FilterStep::NoiseReduceProfile { .. }
+                    | FilterStep::ATrim { .. }
+                    | FilterStep::AResetPts
             ) {
                 log::debug!("audio graph: skipping non-audio step {step:?}");
                 continue;

--- a/crates/ff-filter/src/graph/builder/video/core.rs
+++ b/crates/ff-filter/src/graph/builder/video/core.rs
@@ -127,6 +127,49 @@ mod tests {
     }
 
     #[test]
+    fn filter_step_atrim_should_produce_atrim_args_with_six_decimals() {
+        assert_eq!(
+            FilterStep::ATrim {
+                start: Some(10.0),
+                end: Some(30.0),
+            }
+            .filter_name(),
+            "atrim"
+        );
+        assert_eq!(
+            FilterStep::ATrim {
+                start: Some(10.0),
+                end: Some(30.0),
+            }
+            .args(),
+            "start=10.000000:end=30.000000"
+        );
+        assert_eq!(
+            FilterStep::ATrim {
+                start: Some(10.0),
+                end: None,
+            }
+            .args(),
+            "start=10.000000"
+        );
+        assert_eq!(
+            FilterStep::ATrim {
+                start: None,
+                end: Some(30.0),
+            }
+            .args(),
+            "end=30.000000"
+        );
+    }
+
+    #[test]
+    fn filter_step_areset_pts_should_produce_asetpts_pts_startpts() {
+        let step = FilterStep::AResetPts;
+        assert_eq!(step.filter_name(), "asetpts");
+        assert_eq!(step.args(), "PTS-STARTPTS");
+    }
+
+    #[test]
     fn filter_step_speed_should_produce_correct_filter_name() {
         let step = FilterStep::Speed { factor: 2.0 };
         assert_eq!(step.filter_name(), "setpts");

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1349,84 +1349,10 @@ pub(super) unsafe fn build_audio_mix(
         log::debug!("audio mix track={idx} amovie source path={path}");
         let mut chain_end = amovie_ctx;
 
-        // ── Optional atrim + asetpts (source in/out point trim) ───────────────
-        // Inserted immediately after amovie so that subsequent filters
-        // (aresample, aformat, adelay, volume, effects) see only the desired
-        // source window.  asetpts resets timestamps to zero after the trim so
-        // that adelay positions the trimmed content correctly on the timeline.
-        if track.in_point.is_some() || track.out_point.is_some() {
-            let atrim_args_str = match (track.in_point, track.out_point) {
-                (Some(ip), Some(op)) => {
-                    format!("start={:.6}:end={:.6}", ip.as_secs_f64(), op.as_secs_f64())
-                }
-                (Some(ip), None) => format!("start={:.6}", ip.as_secs_f64()),
-                (None, Some(op)) => format!("end={:.6}", op.as_secs_f64()),
-                (None, None) => unreachable!(),
-            };
-
-            let atrim_filter = ff_sys::avfilter_get_by_name(c"atrim".as_ptr());
-            if atrim_filter.is_null() {
-                bail!(graph, "filter not found: atrim");
-            }
-            let Ok(atrim_name) = CString::new(format!("atrim{idx}")) else {
-                bail!(graph, "CString::new failed for atrim name");
-            };
-            let Ok(atrim_args) = CString::new(atrim_args_str.as_str()) else {
-                bail!(graph, "CString::new failed for atrim args");
-            };
-            let mut atrim_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-            let ret = ff_sys::avfilter_graph_create_filter(
-                &raw mut atrim_ctx,
-                atrim_filter,
-                atrim_name.as_ptr(),
-                atrim_args.as_ptr(),
-                std::ptr::null_mut(),
-                graph,
-            );
-            if ret < 0 {
-                bail!(
-                    graph,
-                    format!("failed to create atrim filter track={idx} code={ret}")
-                );
-            }
-            let ret = ff_sys::avfilter_link(chain_end, 0, atrim_ctx, 0);
-            if ret < 0 {
-                bail!(graph, format!("link failed: amovie→atrim track={idx}"));
-            }
-            chain_end = atrim_ctx;
-
-            let asetpts_filter = ff_sys::avfilter_get_by_name(c"asetpts".as_ptr());
-            if asetpts_filter.is_null() {
-                bail!(graph, "filter not found: asetpts");
-            }
-            let Ok(asp_name) = CString::new(format!("atrim_setpts{idx}")) else {
-                bail!(graph, "CString::new failed for asetpts name");
-            };
-            let Ok(asp_args) = CString::new("PTS-STARTPTS") else {
-                bail!(graph, "CString::new failed for asetpts args");
-            };
-            let mut asp_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-            let ret = ff_sys::avfilter_graph_create_filter(
-                &raw mut asp_ctx,
-                asetpts_filter,
-                asp_name.as_ptr(),
-                asp_args.as_ptr(),
-                std::ptr::null_mut(),
-                graph,
-            );
-            if ret < 0 {
-                bail!(
-                    graph,
-                    format!("failed to create asetpts filter track={idx} code={ret}")
-                );
-            }
-            let ret = ff_sys::avfilter_link(chain_end, 0, asp_ctx, 0);
-            if ret < 0 {
-                bail!(graph, format!("link failed: atrim→asetpts track={idx}"));
-            }
-            chain_end = asp_ctx;
-            log::debug!("audio track trimmed track={idx} args={atrim_args_str}");
-        }
+        // Source trim (in/out) and timeline offset arrive as leading entries in
+        // `track.effects` (emitted by the engine derive: `ATrim` + `AResetPts`
+        // for the source window, `AudioDelay` for the timeline offset) and are
+        // built by the per-track effects loop below.
 
         // ── Optional aresample (sample rate conversion) ───────────────────────
         if track.sample_rate != sample_rate {
@@ -1508,44 +1434,7 @@ pub(super) unsafe fn build_audio_mix(
             );
         }
 
-        // ── Optional timeline offset ──────────────────────────────────────────
-        // adelay inserts real silence samples, which is required for correct
-        // multi-track mixing via amix (unlike asetpts, which only shifts PTS).
-        if track.time_offset > Duration::ZERO {
-            let delay_ms = track.time_offset.as_millis();
-            let adelay_filter = ff_sys::avfilter_get_by_name(c"adelay".as_ptr());
-            if adelay_filter.is_null() {
-                bail!(graph, "filter not found: adelay");
-            }
-            let Ok(ad_name) = CString::new(format!("adelay{idx}")) else {
-                bail!(graph, "CString::new failed for adelay name");
-            };
-            // all=1 applies the same delay to every channel
-            let Ok(ad_args) = CString::new(format!("{delay_ms}:all=1")) else {
-                bail!(graph, "CString::new failed for adelay args");
-            };
-            let mut ad_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-            let ret = ff_sys::avfilter_graph_create_filter(
-                &raw mut ad_ctx,
-                adelay_filter,
-                ad_name.as_ptr(),
-                ad_args.as_ptr(),
-                std::ptr::null_mut(),
-                graph,
-            );
-            if ret < 0 {
-                bail!(
-                    graph,
-                    format!("failed to create adelay filter track={idx} code={ret}")
-                );
-            }
-            let ret = ff_sys::avfilter_link(chain_end, 0, ad_ctx, 0);
-            if ret < 0 {
-                bail!(graph, format!("link failed: →adelay track={idx}"));
-            }
-            chain_end = ad_ctx;
-            log::debug!("audio track delayed track={idx} delay_ms={delay_ms}");
-        }
+        // (Timeline offset is applied via an `AudioDelay` effect in the loop below.)
 
         // ── Volume (always inserted so the node can be targeted by send_command) ─
         {

--- a/crates/ff-filter/src/graph/composition/multi_track_mixer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_mixer.rs
@@ -3,7 +3,6 @@
 #![allow(unsafe_code)]
 
 use std::path::PathBuf;
-use std::time::Duration;
 
 use ff_format::ChannelLayout;
 
@@ -30,25 +29,16 @@ pub struct AudioTrack {
     /// (`AnimatedValue::Track`) is not yet implemented; the initial value at
     /// `Duration::ZERO` is used and a warning is emitted.
     pub pan: AnimatedValue<f64>,
-    /// Start offset on the output timeline (`Duration::ZERO` = at the beginning).
-    pub time_offset: Duration,
-    /// Source in-point: start reading audio at this offset in the source file.
-    ///
-    /// When `Some`, an `atrim=start=<t>` filter is inserted immediately after
-    /// the source node so that audio before this timestamp is discarded.
-    /// `None` reads from the beginning of the file.
-    pub in_point: Option<Duration>,
-    /// Source out-point: stop reading audio at this offset in the source file.
-    ///
-    /// When `Some`, an `atrim=end=<t>` filter is inserted immediately after
-    /// the source node so that audio after this timestamp is discarded.
-    /// `None` reads to the end of the file.
-    pub out_point: Option<Duration>,
+    // Note (#1331): source trim (in/out) and timeline placement (offset) are not
+    // fields. The caller (engine derive) expresses them as leading effects —
+    // `ATrim` + `AResetPts` for the source window, `AudioDelay` for the timeline
+    // offset — so `AudioTrack` is model-free.
     /// Ordered per-track audio effect chain applied before mixing.
     ///
-    /// Each [`FilterStep`] is inserted as a filter node immediately after
-    /// the track's pan/volume chain and before the `amix` node.
-    /// Use audio-relevant variants such as [`FilterStep::Volume`],
+    /// Each [`FilterStep`] is inserted as a filter node after the track's
+    /// volume node and before the `amix` node. Any timeline trim/placement steps
+    /// the caller emits (`ATrim` + `AResetPts` + `AudioDelay`) belong at the front
+    /// of this list. Use audio-relevant variants such as [`FilterStep::Volume`],
     /// [`FilterStep::AFadeIn`], and [`FilterStep::ACompressor`].
     /// An empty vec inserts no extra nodes (zero overhead).
     pub effects: Vec<FilterStep>,
@@ -78,16 +68,12 @@ pub struct AudioTrack {
 /// ```ignore
 /// use ff_filter::MultiTrackAudioMixer;
 /// use ff_format::ChannelLayout;
-/// use std::time::Duration;
 ///
 /// let mut graph = MultiTrackAudioMixer::new(48000, ChannelLayout::Stereo)
 ///     .add_track(ff_filter::AudioTrack {
 ///         source: "music.mp3".into(),
 ///         volume: ff_filter::AnimatedValue::Static(-3.0),
 ///         pan: ff_filter::AnimatedValue::Static(0.0),
-///         time_offset: Duration::ZERO,
-///         in_point: None,
-///         out_point: None,
 ///         effects: vec![],
 ///         sample_rate: 48000,
 ///         channel_layout: ChannelLayout::Stereo,
@@ -148,6 +134,8 @@ impl MultiTrackAudioMixer {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -168,9 +156,6 @@ mod tests {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: None,
                 effects: vec![],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,
@@ -191,9 +176,6 @@ mod tests {
             source: "track.mp3".into(),
             volume: AnimatedValue::Static(0.0),
             pan: AnimatedValue::Static(0.0),
-            time_offset: Duration::ZERO,
-            in_point: None,
-            out_point: None,
             effects: vec![FilterStep::Volume(6.0)],
             sample_rate: 48_000,
             channel_layout: ChannelLayout::Stereo,
@@ -216,9 +198,6 @@ mod tests {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: None,
                 effects: vec![],
                 sample_rate: 44_100, // mismatch → aresample should be inserted
                 channel_layout: ChannelLayout::Stereo,
@@ -234,18 +213,15 @@ mod tests {
     }
 
     #[test]
-    fn audio_track_with_positive_offset_should_insert_adelay() {
-        // adelay is inserted when time_offset > 0.
+    fn audio_track_with_audio_delay_effect_should_insert_adelay() {
+        // A timeline offset is expressed by the caller as an AudioDelay effect.
         // Build fails (nonexistent file) but NOT at "filter not found: adelay".
         let result = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo)
             .add_track(AudioTrack {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::from_secs(2),
-                in_point: None,
-                out_point: None,
-                effects: vec![],
+                effects: vec![FilterStep::AudioDelay { ms: 2000.0 }],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,
             })
@@ -260,16 +236,13 @@ mod tests {
     }
 
     #[test]
-    fn zero_audio_offset_should_not_insert_extra_filters() {
-        // time_offset=ZERO must not cause adelay nodes.
+    fn track_without_timeline_effects_should_not_insert_adelay() {
+        // A track whose effects carry no AudioDelay inserts no adelay node.
         let result = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo)
             .add_track(AudioTrack {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: None,
                 effects: vec![],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,
@@ -292,9 +265,6 @@ mod tests {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: None,
                 effects: vec![],
                 sample_rate: 48_000, // matches output → no aresample
                 channel_layout: ChannelLayout::Stereo, // matches output → no aformat
@@ -330,9 +300,6 @@ mod tests {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Track(vol_track),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: None,
                 effects: vec![],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,
@@ -358,10 +325,13 @@ mod tests {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::ZERO,
-                in_point: Some(Duration::from_secs(2)),
-                out_point: Some(Duration::from_secs(6)),
-                effects: vec![],
+                effects: vec![
+                    FilterStep::ATrim {
+                        start: Some(2.0),
+                        end: Some(6.0),
+                    },
+                    FilterStep::AResetPts,
+                ],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,
             })
@@ -387,10 +357,10 @@ mod tests {
                 source: "nonexistent.mp3".into(),
                 volume: AnimatedValue::Static(0.0),
                 pan: AnimatedValue::Static(0.0),
-                time_offset: Duration::ZERO,
-                in_point: None,
-                out_point: Some(Duration::from_secs(4)),
-                effects: vec![],
+                effects: vec![FilterStep::ATrim {
+                    start: None,
+                    end: Some(4.0),
+                }],
                 sample_rate: 48_000,
                 channel_layout: ChannelLayout::Stereo,
             })
@@ -421,9 +391,6 @@ mod tests {
             source: "nonexistent.mp3".into(),
             volume: AnimatedValue::Static(0.0),
             pan: AnimatedValue::Track(pan_track),
-            time_offset: Duration::ZERO,
-            in_point: None,
-            out_point: None,
             effects: vec![],
             sample_rate: 48_000,
             channel_layout: ChannelLayout::Stereo,

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -436,6 +436,17 @@ pub enum FilterStep {
         /// Delay in milliseconds. Positive = delay; negative = advance.
         ms: f64,
     },
+    /// Audio trim: keep only samples in `[start, end)` seconds (`atrim`). Either
+    /// bound may be `None` for an open range. The audio counterpart of
+    /// [`Trim`](Self::Trim).
+    ATrim {
+        start: Option<f64>,
+        end: Option<f64>,
+    },
+    /// Reset audio timestamps to start at zero (`asetpts=PTS-STARTPTS`). Typically
+    /// follows an [`ATrim`](Self::ATrim) so a placed track's delay is applied from
+    /// zero. The audio counterpart of [`ResetPts`](Self::ResetPts).
+    AResetPts,
     /// Concatenate `n` sequential video input segments via `FFmpeg`'s `concat` filter.
     ///
     /// Requires `n` video input slots (0 through `n-1`). `n` must be ≥ 2.
@@ -1031,6 +1042,9 @@ impl FilterStep {
             // AudioDelay dispatches to adelay (positive) or atrim (negative) at
             // build time; "adelay" is returned here for validate_filter_steps only.
             Self::AudioDelay { .. } => "adelay",
+            Self::ATrim { .. } => "atrim",
+            // "asetpts" is checked at build-time (audio counterpart of ResetPts).
+            Self::AResetPts => "asetpts",
             Self::ConcatVideo { .. } | Self::ConcatAudio { .. } => "concat",
             // JoinWithDissolve is a compound step (trim+setpts → xfade ← setpts+trim);
             // "xfade" is used by validate_filter_steps as the primary filter check.
@@ -1547,6 +1561,13 @@ impl FilterStep {
                     format!("start={}", -ms / 1000.0)
                 }
             }
+            Self::ATrim { start, end } => match (start, end) {
+                (Some(s), Some(e)) => format!("start={s:.6}:end={e:.6}"),
+                (Some(s), None) => format!("start={s:.6}"),
+                (None, Some(e)) => format!("end={e:.6}"),
+                (None, None) => String::new(),
+            },
+            Self::AResetPts => "PTS-STARTPTS".to_string(),
             Self::ConcatVideo { n } => format!("n={n}:v=1:a=0"),
             Self::ConcatAudio { n } => format!("n={n}:v=0:a=1"),
             // args() for JoinWithDissolve is not used by the build loop (which is

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -140,9 +140,6 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             source: src1_path.clone(),
             volume: AnimatedValue::Static(0.0),
             pan: AnimatedValue::Static(0.0),
-            time_offset: Duration::ZERO,
-            in_point: None,
-            out_point: None,
             effects: vec![],
             sample_rate: SAMPLE_RATE,
             channel_layout: ChannelLayout::Stereo,
@@ -151,9 +148,6 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             source: src2_path.clone(),
             volume: AnimatedValue::Static(-3.0),
             pan: AnimatedValue::Static(0.0),
-            time_offset: Duration::ZERO,
-            in_point: None,
-            out_point: None,
             effects: vec![],
             sample_rate: SAMPLE_RATE,
             channel_layout: ChannelLayout::Stereo,
@@ -747,9 +741,6 @@ fn volume_automation_should_increase_audio_amplitude_over_time() {
             source: src_path.clone(),
             volume: AnimatedValue::Track(vol_track),
             pan: AnimatedValue::Static(0.0),
-            time_offset: Duration::ZERO,
-            in_point: None,
-            out_point: None,
             effects: vec![],
             sample_rate: SAMPLE_RATE,
             channel_layout: ChannelLayout::Stereo,
@@ -1017,5 +1008,51 @@ fn trim_and_offset_effects_should_build_and_produce_frame() {
         }
         Ok(None) => println!("Skipping: trim/offset graph produced no frame"),
         Err(e) => println!("Skipping: pull_video failed: {e}"),
+    }
+}
+
+// ── #1331: audio timeline trim/placement expressed as leading FilterSteps ───────
+
+/// After #1331 the engine derive emits a clip's audio source trim + timeline
+/// placement as leading `FilterStep`s (`ATrim` + `AResetPts` + `AudioDelay`)
+/// instead of `AudioTrack` fields. Verify the mixer builds that effect chain and
+/// pulls audio. Probe-gated (RK-002): build/pull failure → skip.
+#[test]
+fn audio_trim_and_offset_effects_should_build_mix_and_pull() {
+    let src = test_output_path("audio_trim_offset_src.mp4");
+    let _g = FileGuard::new(src.clone());
+    if make_source_file(&src, 64, 64, 30.0, 30, 128, 128, 128).is_none() {
+        return;
+    }
+
+    let mut mixer = match MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo)
+        .add_track(AudioTrack {
+            source: src.clone(),
+            volume: AnimatedValue::Static(0.0),
+            pan: AnimatedValue::Static(0.0),
+            effects: vec![
+                FilterStep::ATrim {
+                    start: Some(0.2),
+                    end: Some(0.8),
+                },
+                FilterStep::AResetPts,
+                FilterStep::AudioDelay { ms: 100.0 },
+            ],
+            sample_rate: 48_000,
+            channel_layout: ChannelLayout::Stereo,
+        })
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: MultiTrackAudioMixer::build failed: {e}");
+            return;
+        }
+    };
+
+    match mixer.pull_audio() {
+        Ok(Some(_frame)) => {} // produced audio through the effect chain — pass
+        Ok(None) => println!("Skipping: mixer produced no audio frame"),
+        Err(e) => println!("Skipping: pull_audio failed: {e}"),
     }
 }

--- a/crates/ff-pipeline/src/timeline.rs
+++ b/crates/ff-pipeline/src/timeline.rs
@@ -455,6 +455,24 @@ impl Timeline {
 
                     let mut effects: Vec<FilterStep> = Vec::new();
 
+                    // Timeline trim + placement, emitted as leading audio filter
+                    // steps so they precede the speed/fade/effect steps, mirroring
+                    // the old mixer node order (atrim → asetpts=PTS-STARTPTS → adelay).
+                    if clip.in_point.is_some() || clip.out_point.is_some() {
+                        effects.push(FilterStep::ATrim {
+                            start: clip.in_point.map(|d| d.as_secs_f64()),
+                            end: clip.out_point.map(|d| d.as_secs_f64()),
+                        });
+                        effects.push(FilterStep::AResetPts);
+                    }
+                    if clip.timeline_offset > Duration::ZERO {
+                        // `as_millis()` matches the old inline `adelay` (integer ms);
+                        // offset magnitudes are far below f64's exact-integer range.
+                        #[allow(clippy::cast_precision_loss)]
+                        let ms = clip.timeline_offset.as_millis() as f64;
+                        effects.push(FilterStep::AudioDelay { ms });
+                    }
+
                     if (clip.speed - 1.0).abs() > 1e-9 {
                         effects.push(FilterStep::Speed { factor: clip.speed });
                     }
@@ -512,9 +530,6 @@ impl Timeline {
                         source: clip.source.clone(),
                         volume,
                         pan: aa(track_idx, "pan", 0.0),
-                        time_offset: clip.timeline_offset,
-                        in_point: clip.in_point,
-                        out_point: clip.out_point,
                         effects,
                         sample_rate: 48_000,
                         channel_layout: ff_format::ChannelLayout::Stereo,


### PR DESCRIPTION
## Objective
- `AudioTrack` (an `ff-filter` primitive) carried editorial fields (`time_offset`, `in_point`, `out_point`), so the mixer was aware of timeline concepts. Part of #1326: make `ff-filter` a model-free primitive. Audio counterpart of #1330.

## Solution
- Add model-free audio PTS `FilterStep`s: `ATrim` (open-ended bounds) and `AResetPts` (`asetpts=PTS-STARTPTS`); reuse the existing `AudioDelay` (`adelay`) for the timeline offset.
- Strip the three editorial fields from `AudioTrack`; remove the mixer's manual `atrim`/`asetpts`/`adelay` blocks; keep `aresample`/`aformat`/`volume`/effects/`amix`. Add the new steps to the single-source audio allow-list.
- The engine derive (`Timeline::render`) emits trim/placement as leading `FilterStep`s (`ATrim` + `AResetPts` + `AudioDelay`) before the speed/fade/effect steps.
- Behaviour-preserving: emitted filter args match the old mixer and the reorderings commute, **except** a resampled (non-48 kHz) trimmed track whose resampler warm-up at the window edge differs by a sub-perceptual number of samples (`atrim` now follows `aresample`). Verified by unit tests, a probe-gated audio-mix build/pull test, and the `avio-examples` harness.

With this, `ff-filter` is model-free on both the video (#1330) and audio paths.

Closes #1331