### PR TITLE
refactor(ff-filter): remove the editorial dissolve/join FilterStep

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2187,120 +2187,6 @@ pub(super) unsafe fn add_parametric_eq_chain(
     Ok(ctx)
 }
 
-// ── JoinWithDissolve compound step ────────────────────────────────────────────
-
-/// Expand a `JoinWithDissolve` step into the following compound filter graph:
-///
-/// ```text
-/// clip_a_src → trim(end=clip_a_end+dissolve_dur) → setpts → xfade[0]
-/// clip_b_src → trim(start=max(0, clip_b_start−dissolve_dur)) → setpts → xfade[1]
-/// ```
-///
-/// Returns the `xfade` filter context, which becomes the new `prev_ctx`.
-///
-/// # Safety
-///
-/// `graph`, `clip_a_src`, and `clip_b_src` must be valid non-null pointers
-/// belonging to the same `AVFilterGraph`.
-pub(super) unsafe fn add_join_with_dissolve_step(
-    graph: *mut ff_sys::AVFilterGraph,
-    clip_a_src: *mut ff_sys::AVFilterContext,
-    clip_b_src: *mut ff_sys::AVFilterContext,
-    clip_a_end: f64,
-    clip_b_start: f64,
-    dissolve_dur: f64,
-    index: usize,
-) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
-    // 1. trim_a: keep clip A frames up to clip_a_end + dissolve_dur
-    let a_trim_end = clip_a_end + dissolve_dur;
-    let trim_a = add_raw_filter_step(
-        graph,
-        clip_a_src,
-        "trim",
-        &format!("end={a_trim_end}"),
-        index,
-        "jwd_trima",
-    )?;
-
-    // 2. setpts_a: reset clip A timestamps to zero after trim
-    let setpts_a = add_raw_filter_step(
-        graph,
-        trim_a,
-        "setpts",
-        "PTS-STARTPTS",
-        index,
-        "jwd_setptsa",
-    )?;
-
-    // 3. Create xfade filter; pads are wired manually below.
-    let xfade_filter = ff_sys::avfilter_get_by_name(c"xfade".as_ptr());
-    if xfade_filter.is_null() {
-        log::warn!("filter not found name=xfade (join_with_dissolve)");
-        return Err(FilterError::BuildFailed);
-    }
-    let xfade_name = std::ffi::CString::new(format!("jwd_xfade{index}"))
-        .map_err(|_| FilterError::BuildFailed)?;
-    let xfade_args_str = format!("transition=dissolve:duration={dissolve_dur}:offset={clip_a_end}");
-    let xfade_args =
-        std::ffi::CString::new(xfade_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
-    let mut xfade_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-    // SAFETY: all pointers are valid; xfade_filter, xfade_name, and xfade_args
-    // are non-null and null-terminated.
-    let ret = ff_sys::avfilter_graph_create_filter(
-        &raw mut xfade_ctx,
-        xfade_filter,
-        xfade_name.as_ptr(),
-        xfade_args.as_ptr(),
-        std::ptr::null_mut(),
-        graph,
-    );
-    if ret < 0 {
-        log::warn!("filter creation failed name=xfade args={xfade_args_str} (join_with_dissolve)");
-        return Err(FilterError::BuildFailed);
-    }
-    log::debug!("filter added name=xfade args={xfade_args_str} (join_with_dissolve)");
-
-    // Link setpts_a (clip A chain) → xfade[0]
-    // SAFETY: setpts_a and xfade_ctx belong to the same graph; pad indices valid.
-    let ret = ff_sys::avfilter_link(setpts_a, 0, xfade_ctx, 0);
-    if ret < 0 {
-        return Err(FilterError::BuildFailed);
-    }
-
-    // 4. trim_b: keep clip B frames from max(0, clip_b_start - dissolve_dur)
-    let b_trim_start = (clip_b_start - dissolve_dur).max(0.0);
-    let trim_b = add_raw_filter_step(
-        graph,
-        clip_b_src,
-        "trim",
-        &format!("start={b_trim_start}"),
-        index,
-        "jwd_trimb",
-    )?;
-
-    // 5. setpts_b: reset clip B timestamps to zero after trim
-    let setpts_b = add_raw_filter_step(
-        graph,
-        trim_b,
-        "setpts",
-        "PTS-STARTPTS",
-        index,
-        "jwd_setptsb",
-    )?;
-
-    // Link setpts_b (clip B chain) → xfade[1]
-    // SAFETY: setpts_b and xfade_ctx belong to the same graph; pad index 1 is valid for xfade.
-    let ret = ff_sys::avfilter_link(setpts_b, 0, xfade_ctx, 1);
-    if ret < 0 {
-        return Err(FilterError::BuildFailed);
-    }
-
-    log::debug!(
-        "filter join_with_dissolve expanded dissolve_dur={dissolve_dur} offset={clip_a_end}"
-    );
-    Ok(xfade_ctx)
-}
-
 // ── Graph orchestrators ───────────────────────────────────────────────────────
 
 use super::FilterGraphInner;
@@ -2501,34 +2387,6 @@ impl FilterGraphInner {
                     *opacity,
                     width.as_deref(),
                     height.as_deref(),
-                    i,
-                ) {
-                    Ok(ctx) => ctx,
-                    Err(e) => bail!(e),
-                };
-                continue;
-            }
-
-            // JoinWithDissolve is a compound step that expands to:
-            //   prev → trim_a → setpts_a → xfade[0]
-            //   in1  → trim_b → setpts_b → xfade[1]
-            // It bypasses the standard add_and_link_step path entirely.
-            if let FilterStep::JoinWithDissolve {
-                clip_a_end,
-                clip_b_start,
-                dissolve_dur,
-            } = step
-            {
-                let Some(b_src) = src_ctxs.get(1).and_then(|o| *o) else {
-                    bail!(FilterError::BuildFailed)
-                };
-                prev_ctx = match add_join_with_dissolve_step(
-                    graph,
-                    prev_ctx,
-                    b_src.as_ptr(),
-                    *clip_a_end,
-                    *clip_b_start,
-                    *dissolve_dur,
                     i,
                 ) {
                     Ok(ctx) => ctx,
@@ -2901,10 +2759,7 @@ impl FilterGraphInner {
             // Video-only steps; skip them in the audio graph.
             if matches!(
                 step,
-                FilterStep::Reverse
-                    | FilterStep::ConcatVideo { .. }
-                    | FilterStep::JoinWithDissolve { .. }
-                    | FilterStep::Blend { .. }
+                FilterStep::Reverse | FilterStep::ConcatVideo { .. } | FilterStep::Blend { .. }
             ) {
                 continue;
             }

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -243,16 +243,15 @@ impl FilterGraphInner {
 
     /// Returns the number of video input slots required by the configured steps.
     ///
-    /// Returns 2 when [`FilterStep::Overlay`], [`FilterStep::XFade`], or
-    /// [`FilterStep::JoinWithDissolve`] is present (each needs a main stream on
-    /// slot 0 and a secondary stream on slot 1), 1 otherwise.
+    /// Returns 2 when [`FilterStep::Overlay`] or [`FilterStep::XFade`] is present
+    /// (each needs a main stream on slot 0 and a secondary stream on slot 1),
+    /// 1 otherwise.
     pub(super) fn video_input_count(&self) -> usize {
         for step in &self.steps {
             if matches!(
                 step,
                 FilterStep::Overlay { .. }
                     | FilterStep::XFade { .. }
-                    | FilterStep::JoinWithDissolve { .. }
                     | FilterStep::Blend { .. }
                     | FilterStep::Composite { .. }
                     | FilterStep::AlphaMatte { .. }

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -252,25 +252,6 @@ impl FilterGraphBuilder {
                     reason: format!("xfade duration {duration} must be > 0.0"),
                 });
             }
-            if let FilterStep::JoinWithDissolve {
-                dissolve_dur,
-                clip_a_end,
-                ..
-            } = step
-            {
-                if *dissolve_dur <= 0.0 {
-                    return Err(FilterError::InvalidConfig {
-                        reason: format!(
-                            "join_with_dissolve dissolve_dur={dissolve_dur} must be > 0.0"
-                        ),
-                    });
-                }
-                if *clip_a_end <= 0.0 {
-                    return Err(FilterError::InvalidConfig {
-                        reason: format!("join_with_dissolve clip_a_end={clip_a_end} must be > 0.0"),
-                    });
-                }
-            }
             if let FilterStep::ANoiseGate {
                 attack_ms,
                 release_ms,

--- a/crates/ff-filter/src/graph/builder/video/transitions.rs
+++ b/crates/ff-filter/src/graph/builder/video/transitions.rs
@@ -66,34 +66,6 @@ impl FilterGraphBuilder {
         });
         self
     }
-
-    /// Join two video streams with a cross-dissolve transition.
-    ///
-    /// Requires two video input slots: push clip A frames to slot 0 and clip B
-    /// frames to slot 1.  Internally expands to
-    /// `trim` + `setpts` → `xfade` ← `setpts` + `trim`.
-    ///
-    /// - `clip_a_end_sec`: timestamp (seconds) where clip A ends. Must be > 0.0.
-    /// - `clip_b_start_sec`: timestamp (seconds) where clip B content starts
-    ///   (before the overlap region).
-    /// - `dissolve_dur_sec`: cross-dissolve overlap length in seconds. Must be > 0.0.
-    ///
-    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
-    /// `dissolve_dur_sec ≤ 0.0` or `clip_a_end_sec ≤ 0.0`.
-    #[must_use]
-    pub fn join_with_dissolve(
-        mut self,
-        clip_a_end_sec: f64,
-        clip_b_start_sec: f64,
-        dissolve_dur_sec: f64,
-    ) -> Self {
-        self.steps.push(FilterStep::JoinWithDissolve {
-            clip_a_end: clip_a_end_sec,
-            clip_b_start: clip_b_start_sec,
-            dissolve_dur: dissolve_dur_sec,
-        });
-        self
-    }
 }
 
 #[cfg(test)]
@@ -366,74 +338,6 @@ mod tests {
         assert!(
             matches!(result, Err(FilterError::InvalidConfig { .. })),
             "expected InvalidConfig for negative duration, got {result:?}"
-        );
-    }
-
-    #[test]
-    fn filter_step_join_with_dissolve_should_have_correct_filter_name() {
-        let step = FilterStep::JoinWithDissolve {
-            clip_a_end: 4.0,
-            clip_b_start: 1.0,
-            dissolve_dur: 1.0,
-        };
-        assert_eq!(step.filter_name(), "xfade");
-    }
-
-    #[test]
-    fn filter_step_join_with_dissolve_should_produce_correct_args() {
-        let step = FilterStep::JoinWithDissolve {
-            clip_a_end: 4.0,
-            clip_b_start: 1.0,
-            dissolve_dur: 1.0,
-        };
-        assert_eq!(
-            step.args(),
-            "transition=dissolve:duration=1:offset=4",
-            "args must match xfade format for join_with_dissolve"
-        );
-    }
-
-    #[test]
-    fn builder_join_with_dissolve_valid_should_build_successfully() {
-        let result = FilterGraph::builder()
-            .join_with_dissolve(4.0, 1.0, 1.0)
-            .build();
-        assert!(
-            result.is_ok(),
-            "join_with_dissolve(4.0, 1.0, 1.0) must build successfully, got {result:?}"
-        );
-    }
-
-    #[test]
-    fn builder_join_with_dissolve_with_zero_dissolve_dur_should_return_invalid_config() {
-        let result = FilterGraph::builder()
-            .join_with_dissolve(4.0, 1.0, 0.0)
-            .build();
-        assert!(
-            matches!(result, Err(FilterError::InvalidConfig { .. })),
-            "expected InvalidConfig for dissolve_dur=0.0, got {result:?}"
-        );
-    }
-
-    #[test]
-    fn builder_join_with_dissolve_with_negative_dissolve_dur_should_return_invalid_config() {
-        let result = FilterGraph::builder()
-            .join_with_dissolve(4.0, 1.0, -1.0)
-            .build();
-        assert!(
-            matches!(result, Err(FilterError::InvalidConfig { .. })),
-            "expected InvalidConfig for dissolve_dur=-1.0, got {result:?}"
-        );
-    }
-
-    #[test]
-    fn builder_join_with_dissolve_with_zero_clip_a_end_should_return_invalid_config() {
-        let result = FilterGraph::builder()
-            .join_with_dissolve(0.0, 1.0, 1.0)
-            .build();
-        assert!(
-            matches!(result, Err(FilterError::InvalidConfig { .. })),
-            "expected InvalidConfig for clip_a_end=0.0, got {result:?}"
         );
     }
 }

--- a/crates/ff-filter/src/graph/composition/audio_concatenator.rs
+++ b/crates/ff-filter/src/graph/composition/audio_concatenator.rs
@@ -1,4 +1,4 @@
-//! Sequential audio clip concatenation.
+//! Sequential audio input concatenation.
 
 #![allow(unsafe_code)]
 
@@ -11,7 +11,7 @@ use crate::graph::graph::FilterGraph;
 
 // ── AudioConcatenator ─────────────────────────────────────────────────────────
 
-/// Concatenates multiple audio clips into a single seamless output stream.
+/// Concatenates multiple audio inputs into a single seamless output stream.
 ///
 /// Each clip is loaded via an `amovie=` source node.  When
 /// [`output_format`](Self::output_format) is set, an `aresample` and/or
@@ -34,16 +34,16 @@ use crate::graph::graph::FilterGraph;
 /// }
 /// ```
 pub struct AudioConcatenator {
-    clips: Vec<PathBuf>,
+    inputs: Vec<PathBuf>,
     output_sample_rate: Option<u32>,
     output_channel_layout: Option<ChannelLayout>,
 }
 
 impl AudioConcatenator {
     /// Creates a new concatenator for the given clip paths.
-    pub fn new(clips: Vec<impl AsRef<std::path::Path>>) -> Self {
+    pub fn new(inputs: Vec<impl AsRef<std::path::Path>>) -> Self {
         Self {
-            clips: clips
+            inputs: inputs
                 .into_iter()
                 .map(|p| p.as_ref().to_path_buf())
                 .collect(),
@@ -66,16 +66,16 @@ impl AudioConcatenator {
         }
     }
 
-    /// Builds a source-only [`FilterGraph`] that concatenates all clips.
+    /// Builds a source-only [`FilterGraph`] that concatenates all inputs.
     ///
     /// # Errors
     ///
-    /// - [`FilterError::CompositionFailed`] — no clips were provided, or an
+    /// - [`FilterError::CompositionFailed`] — no inputs were provided, or an
     ///   underlying `FFmpeg` graph-construction call failed.
     pub fn build(self) -> Result<FilterGraph, FilterError> {
-        if self.clips.is_empty() {
+        if self.inputs.is_empty() {
             return Err(FilterError::CompositionFailed {
-                reason: "no clips".to_string(),
+                reason: "no inputs".to_string(),
             });
         }
         // SAFETY: avfilter_graph_alloc / avfilter_graph_create_filter /
@@ -87,7 +87,7 @@ impl AudioConcatenator {
         // - NonNull::new_unchecked() is called only after ret >= 0 checks.
         unsafe {
             super::composition_inner::build_audio_concat(
-                &self.clips,
+                &self.inputs,
                 self.output_sample_rate,
                 self.output_channel_layout,
             )
@@ -101,17 +101,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn audio_concatenator_empty_clips_should_err() {
+    fn audio_concatenator_empty_inputs_should_err() {
         let result = AudioConcatenator::new(Vec::<PathBuf>::new()).build();
         assert!(
             matches!(result, Err(FilterError::CompositionFailed { .. })),
-            "expected CompositionFailed for empty clips, got {result:?}"
+            "expected CompositionFailed for empty inputs, got {result:?}"
         );
     }
 
     #[test]
-    fn audio_concatenator_three_clips_should_build_successfully() {
-        // Build with three nonexistent clips.  Graph construction of individual
+    fn audio_concatenator_three_inputs_should_build_successfully() {
+        // Build with three nonexistent inputs.  Graph construction of individual
         // filter nodes (amovie, concat, abuffersink) should succeed; failure
         // only at avfilter_graph_config (file not found) is expected.
         //

--- a/crates/ff-filter/src/graph/composition/clip_joiner.rs
+++ b/crates/ff-filter/src/graph/composition/clip_joiner.rs
@@ -1,4 +1,4 @@
-//! Cross-dissolve join of two video clips.
+//! Cross-dissolve join of two video inputs.
 
 #![allow(unsafe_code)]
 
@@ -10,16 +10,16 @@ use crate::graph::graph::FilterGraph;
 
 // ── ClipJoiner ────────────────────────────────────────────────────────────────
 
-/// Joins two video clips with a cross-dissolve transition.
+/// Joins two video inputs with a cross-dissolve transition.
 ///
-/// Each clip is loaded via a `movie=` source node.  The last
-/// `dissolve_duration` seconds of clip A overlap with the first
-/// `dissolve_duration` seconds of clip B, producing an output shorter than
+/// Each input is loaded via a `movie=` source node.  The last
+/// `dissolve_duration` seconds of input A overlap with the first
+/// `dissolve_duration` seconds of input B, producing an output shorter than
 /// simple concatenation by `dissolve_duration`.
 ///
 /// When `dissolve_duration` is [`Duration::ZERO`] the clips are concatenated
 /// without a transition (equivalent to
-/// [`VideoConcatenator::new(vec![clip_a, clip_b]).build()`]).
+/// [`VideoConcatenator::new(vec![input_a, input_b]).build()`]).
 ///
 /// # Errors
 ///
@@ -41,8 +41,8 @@ use crate::graph::graph::FilterGraph;
 /// }
 /// ```
 pub struct ClipJoiner {
-    clip_a: PathBuf,
-    clip_b: PathBuf,
+    input_a: PathBuf,
+    input_b: PathBuf,
     dissolve_duration: Duration,
 }
 
@@ -52,13 +52,13 @@ impl ClipJoiner {
     /// `dissolve_duration` is the length of the cross-dissolve overlap.
     /// Pass [`Duration::ZERO`] for plain concatenation (no transition).
     pub fn new(
-        clip_a: impl AsRef<std::path::Path>,
-        clip_b: impl AsRef<std::path::Path>,
+        input_a: impl AsRef<std::path::Path>,
+        input_b: impl AsRef<std::path::Path>,
         dissolve_duration: Duration,
     ) -> Self {
         Self {
-            clip_a: clip_a.as_ref().to_path_buf(),
-            clip_b: clip_b.as_ref().to_path_buf(),
+            input_a: input_a.as_ref().to_path_buf(),
+            input_b: input_b.as_ref().to_path_buf(),
             dissolve_duration,
         }
     }
@@ -76,7 +76,11 @@ impl ClipJoiner {
         //         all pointers are null-checked; resources are freed on every
         //         error path.
         unsafe {
-            super::composition_inner::build_dissolve_join(&self.clip_a, &self.clip_b, dissolve_sec)
+            super::composition_inner::build_dissolve_join(
+                &self.input_a,
+                &self.input_b,
+                dissolve_sec,
+            )
         }
     }
 }
@@ -87,7 +91,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn join_with_dissolve_exceeding_clip_duration_should_err() {
+    fn clip_joiner_dissolve_exceeding_input_duration_should_err() {
         // dissolve_duration (9999 s) exceeds any realistic clip.  With
         // nonexistent files the probe itself returns CompositionFailed, which
         // also satisfies the assertion.  With real files the duration check
@@ -100,7 +104,7 @@ mod tests {
     }
 
     #[test]
-    fn join_with_dissolve_should_reduce_total_duration() {
+    fn clip_joiner_dissolve_should_reduce_total_duration() {
         // With nonexistent files the probe step returns CompositionFailed.
         // This test verifies: (a) no panic, (b) the error is CompositionFailed
         // (not an unexpected variant), and (c) the `xfade` filter exists in the
@@ -108,7 +112,7 @@ mod tests {
         // we skip instead of failing, matching the pattern used by the concat
         // tests).
         let result =
-            ClipJoiner::new("clip_a.mp4", "clip_b.mp4", Duration::from_millis(500)).build();
+            ClipJoiner::new("input_a.mp4", "input_b.mp4", Duration::from_millis(500)).build();
         assert!(result.is_err(), "expected error (probe or graph failure)");
         if let Err(FilterError::CompositionFailed { ref reason }) = result {
             if reason.contains("filter not found: xfade")

--- a/crates/ff-filter/src/graph/composition/video_concatenator.rs
+++ b/crates/ff-filter/src/graph/composition/video_concatenator.rs
@@ -1,4 +1,4 @@
-//! Sequential video clip concatenation.
+//! Sequential video input concatenation.
 
 #![allow(unsafe_code)]
 
@@ -9,11 +9,11 @@ use crate::graph::graph::FilterGraph;
 
 // ── VideoConcatenator ─────────────────────────────────────────────────────────
 
-/// Concatenates multiple video clips into a single seamless output stream.
+/// Concatenates multiple video inputs into a single seamless output stream.
 ///
 /// Each clip is loaded via a `movie=` source node.  When
 /// [`output_resolution`](Self::output_resolution) is set, a `scale` filter is
-/// inserted per clip to normalise all clips to a common resolution before
+/// inserted per clip to normalise all inputs to a common resolution before
 /// concatenation.  A single clip skips the `concat` filter and passes through
 /// directly.
 ///
@@ -34,16 +34,16 @@ use crate::graph::graph::FilterGraph;
 /// }
 /// ```
 pub struct VideoConcatenator {
-    clips: Vec<PathBuf>,
+    inputs: Vec<PathBuf>,
     output_width: Option<u32>,
     output_height: Option<u32>,
 }
 
 impl VideoConcatenator {
     /// Creates a new concatenator for the given clip paths.
-    pub fn new(clips: Vec<impl AsRef<std::path::Path>>) -> Self {
+    pub fn new(inputs: Vec<impl AsRef<std::path::Path>>) -> Self {
         Self {
-            clips: clips
+            inputs: inputs
                 .into_iter()
                 .map(|p| p.as_ref().to_path_buf())
                 .collect(),
@@ -63,16 +63,16 @@ impl VideoConcatenator {
         }
     }
 
-    /// Builds a source-only [`FilterGraph`] that concatenates all clips.
+    /// Builds a source-only [`FilterGraph`] that concatenates all inputs.
     ///
     /// # Errors
     ///
-    /// - [`FilterError::CompositionFailed`] — no clips were provided, or an
+    /// - [`FilterError::CompositionFailed`] — no inputs were provided, or an
     ///   underlying `FFmpeg` graph-construction call failed.
     pub fn build(self) -> Result<FilterGraph, FilterError> {
-        if self.clips.is_empty() {
+        if self.inputs.is_empty() {
             return Err(FilterError::CompositionFailed {
-                reason: "no clips".to_string(),
+                reason: "no inputs".to_string(),
             });
         }
         // SAFETY: all raw pointer operations follow the avfilter ownership rules:
@@ -84,7 +84,7 @@ impl VideoConcatenator {
         // - NonNull::new_unchecked() is called only after ret >= 0 checks.
         unsafe {
             super::composition_inner::build_video_concat(
-                &self.clips,
+                &self.inputs,
                 self.output_width,
                 self.output_height,
             )
@@ -98,17 +98,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn concatenator_empty_clips_should_err() {
+    fn concatenator_empty_inputs_should_err() {
         let result = VideoConcatenator::new(Vec::<PathBuf>::new()).build();
         assert!(
             matches!(result, Err(FilterError::CompositionFailed { .. })),
-            "expected CompositionFailed for empty clips, got {result:?}"
+            "expected CompositionFailed for empty inputs, got {result:?}"
         );
     }
 
     #[test]
-    fn concatenator_three_clips_should_build_successfully() {
-        // Build with three nonexistent clips.  Graph construction of individual
+    fn concatenator_three_inputs_should_build_successfully() {
+        // Build with three nonexistent inputs.  Graph construction of individual
         // filter nodes (movie, concat, buffersink) should succeed; failure only
         // at avfilter_graph_config (file not found) is expected.
         //

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -489,24 +489,6 @@ pub enum FilterStep {
         /// Font color as an `FFmpeg` color string, e.g. `"white"` or `"0xFFFFFF"`.
         font_color: String,
     },
-    /// Join two video clips with a cross-dissolve transition.
-    ///
-    /// Compound step — expands in `filter_inner` to:
-    /// ```text
-    /// in0 → trim(end=clip_a_end+dissolve_dur) → setpts → xfade[0]
-    /// in1 → trim(start=max(0, clip_b_start−dissolve_dur)) → setpts → xfade[1]
-    /// ```
-    ///
-    /// Requires two video input slots: slot 0 = clip A, slot 1 = clip B.
-    /// `clip_a_end` and `dissolve_dur` must be > 0.0.
-    JoinWithDissolve {
-        /// Timestamp (seconds) where clip A ends. Must be > 0.0.
-        clip_a_end: f64,
-        /// Timestamp (seconds) where clip B content starts (before the overlap).
-        clip_b_start: f64,
-        /// Cross-dissolve overlap duration in seconds. Must be > 0.0.
-        dissolve_dur: f64,
-    },
     /// Composite a PNG image (watermark / logo) over video with optional opacity.
     ///
     /// This is a compound step: internally it creates a `movie` source, an
@@ -1046,9 +1028,6 @@ impl FilterStep {
             // "asetpts" is checked at build-time (audio counterpart of ResetPts).
             Self::AResetPts => "asetpts",
             Self::ConcatVideo { .. } | Self::ConcatAudio { .. } => "concat",
-            // JoinWithDissolve is a compound step (trim+setpts → xfade ← setpts+trim);
-            // "xfade" is used by validate_filter_steps as the primary filter check.
-            Self::JoinWithDissolve { .. } => "xfade",
             Self::SubtitlesSrt { .. } => "subtitles",
             Self::SubtitlesAss { .. } => "ass",
             // OverlayImage is a compound step (movie → lut → overlay); "overlay"
@@ -1570,14 +1549,6 @@ impl FilterStep {
             Self::AResetPts => "PTS-STARTPTS".to_string(),
             Self::ConcatVideo { n } => format!("n={n}:v=1:a=0"),
             Self::ConcatAudio { n } => format!("n={n}:v=0:a=1"),
-            // args() for JoinWithDissolve is not used by the build loop (which is
-            // bypassed in favour of add_join_with_dissolve_step); provided here for
-            // completeness using the xfade args.
-            Self::JoinWithDissolve {
-                clip_a_end,
-                dissolve_dur,
-                ..
-            } => format!("transition=dissolve:duration={dissolve_dur}:offset={clip_a_end}"),
             Self::CropAnimated {
                 x,
                 y,

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1585,50 +1585,6 @@ fn push_audio_through_concat_audio_should_produce_output() {
     assert_eq!(out.channels(), 2, "channel count should be unchanged");
 }
 
-#[test]
-fn push_two_clips_through_join_with_dissolve_should_produce_output() {
-    let mut graph = match FilterGraph::builder()
-        .join_with_dissolve(4.0, 1.0, 1.0)
-        .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
-    let clip_a = make_yuv420p_frame(64, 64);
-    let clip_b = make_yuv420p_frame(64, 64);
-    // Push clip A to slot 0 first; this initialises the graph.
-    match graph.push_video(0, &clip_a) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    // Push clip B to slot 1.
-    match graph.push_video(1, &clip_b) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    let result = graph.pull_video().expect("pull_video must not fail");
-    let out = result.expect("expected Some(frame) after join_with_dissolve push");
-    assert_eq!(
-        out.width(),
-        64,
-        "output width should match input after join_with_dissolve"
-    );
-    assert_eq!(
-        out.height(),
-        64,
-        "output height should match input after join_with_dissolve"
-    );
-}
-
 // ── Blend: Multiply and Screen ────────────────────────────────────────────────
 
 /// YUV420p frame filled with a solid luma value; U/V neutral at 128.


### PR DESCRIPTION
## Objective
- The P1 re-review surfaced a two-clip, timeline-driven dissolve encoded as a primitive that the initial classification missed. `FilterStep::JoinWithDissolve` (fields `clip_a_end`/`clip_b_start` are timeline positions), its `FilterGraphBuilder::join_with_dissolve` constructor, and their build plumbing are editorial, engine-unused (the engine composes transitions from `Trim` + `XFade` since the compositor purification), and redundant with those primitives. Part of #1326.

## Solution
- Remove `FilterStep::JoinWithDissolve`, `FilterGraphBuilder::join_with_dissolve`, and all their plumbing (the compound-step expansion + dispatch, the `video_input_count` and audio-skip `matches!` arms, the builder validation, and the tests of the removed feature).
- Keep `ClipJoiner` and the video/audio concatenators — they take file paths and need no editing model, so they remain file-level compositing primitives; only de-editorialise the naming (`clips` -> `inputs`, `clip_a`/`clip_b` -> `input_a`/`input_b`, docs/errors).
- Behaviour-preserving: the removed step was never used by the engine; the renames are internal. Verified by the `ff-filter` and `ff-pipeline` test suites and the `avio-examples` harness.

With this, `ff-filter` is model-free across its whole surface — no clip, track, timeline, or edit semantics remain in the primitives.

Closes #1337