### PR TITLE
refactor(ff-filter): add RealtimeLayerDescriptor (dimension-free RealtimeLayer)

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -287,9 +287,9 @@ pub use ff_filter::{
     BlendMode, ClipJoiner, CompositeOp, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile, Lerp,
     LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
-    ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer, Rgb, ScaleAlgorithm,
-    StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition,
-    YadifMode,
+    ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb,
+    ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer,
+    XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/graph/composition/mod.rs
+++ b/crates/ff-filter/src/graph/composition/mod.rs
@@ -20,5 +20,5 @@ pub use audio_concatenator::AudioConcatenator;
 pub use clip_joiner::ClipJoiner;
 pub use multi_track_composer::{MultiTrackComposer, ProxySource, VideoLayer};
 pub use multi_track_mixer::{AudioTrack, MultiTrackAudioMixer};
-pub use realtime_composer::{RealtimeComposer, RealtimeLayer};
+pub use realtime_composer::{RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor};
 pub use video_concatenator::VideoConcatenator;

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -65,6 +65,61 @@ pub struct RealtimeLayer {
     pub blend_mode: BlendMode,
 }
 
+// ── RealtimeLayerDescriptor ───────────────────────────────────────────────────
+
+/// The dimension-independent part of a [`RealtimeLayer`]: every field except
+/// `width` / `height` / `pixel_format`, which are only known once a frame has been
+/// decoded.
+///
+/// An engine derives a descriptor from its editing model; a real-time driver
+/// realises it into a [`RealtimeLayer`] at decode time via
+/// [`RealtimeLayer::with_dimensions`].
+#[derive(Debug, Clone)]
+pub struct RealtimeLayerDescriptor {
+    /// See [`RealtimeLayer::effects`].
+    pub effects: Vec<FilterStep>,
+    /// See [`RealtimeLayer::opacity`].
+    pub opacity: f32,
+    /// See [`RealtimeLayer::opacity_track`].
+    pub opacity_track: Option<AnimationTrack<f64>>,
+    /// See [`RealtimeLayer::x`].
+    pub x: f64,
+    /// See [`RealtimeLayer::y`].
+    pub y: f64,
+    /// See [`RealtimeLayer::x_track`].
+    pub x_track: Option<AnimationTrack<f64>>,
+    /// See [`RealtimeLayer::y_track`].
+    pub y_track: Option<AnimationTrack<f64>>,
+    /// See [`RealtimeLayer::blend_mode`].
+    pub blend_mode: BlendMode,
+}
+
+impl RealtimeLayer {
+    /// Build a [`RealtimeLayer`] from a [`RealtimeLayerDescriptor`] plus the frame
+    /// dimensions and pixel format known at decode time.
+    #[must_use]
+    pub fn with_dimensions(
+        descriptor: RealtimeLayerDescriptor,
+        width: u32,
+        height: u32,
+        pixel_format: PixelFormat,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            pixel_format,
+            effects: descriptor.effects,
+            opacity: descriptor.opacity,
+            opacity_track: descriptor.opacity_track,
+            x: descriptor.x,
+            y: descriptor.y,
+            x_track: descriptor.x_track,
+            y_track: descriptor.y_track,
+            blend_mode: descriptor.blend_mode,
+        }
+    }
+}
+
 // ── RealtimeComposer ──────────────────────────────────────────────────────────
 
 /// Composites externally-decoded frames from several layers into one frame,
@@ -146,6 +201,32 @@ impl RealtimeComposer {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn realtime_layer_with_dimensions_should_copy_descriptor_fields() {
+        let descriptor = RealtimeLayerDescriptor {
+            effects: vec![FilterStep::HFlip],
+            opacity: 0.5,
+            opacity_track: Some(AnimationTrack::new()),
+            x: 12.0,
+            y: 34.0,
+            x_track: None,
+            y_track: Some(AnimationTrack::new()),
+            blend_mode: BlendMode::Multiply,
+        };
+        let layer = RealtimeLayer::with_dimensions(descriptor, 640, 360, PixelFormat::Rgba);
+        assert_eq!(layer.width, 640);
+        assert_eq!(layer.height, 360);
+        assert!(matches!(layer.pixel_format, PixelFormat::Rgba));
+        assert_eq!(layer.effects.len(), 1, "effects moved into the layer");
+        assert!((layer.opacity - 0.5).abs() < f32::EPSILON);
+        assert!(layer.opacity_track.is_some());
+        assert!((layer.x - 12.0).abs() < f64::EPSILON);
+        assert!((layer.y - 34.0).abs() < f64::EPSILON);
+        assert!(layer.x_track.is_none());
+        assert!(layer.y_track.is_some());
+        assert!(matches!(layer.blend_mode, BlendMode::Multiply));
+    }
 
     #[test]
     fn empty_layers_should_err() {

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -11,7 +11,8 @@ pub mod types;
 pub use builder::FilterGraphBuilder;
 pub use composition::{
     AudioConcatenator, AudioTrack, ClipJoiner, MultiTrackAudioMixer, MultiTrackComposer,
-    ProxySource, RealtimeComposer, RealtimeLayer, VideoConcatenator, VideoLayer,
+    ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, VideoConcatenator,
+    VideoLayer,
 };
 pub use ffmpeg_token::FfmpegToken;
 pub use filter_step::FilterStep;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -51,6 +51,6 @@ pub use error::FilterError;
 pub use graph::{
     AudioConcatenator, AudioTrack, ClipJoiner, DrawTextOptions, EqBand, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, MultiTrackAudioMixer, MultiTrackComposer, ProxySource,
-    RealtimeComposer, RealtimeLayer, Rgb, ScaleAlgorithm, ToneMap, VideoConcatenator, VideoLayer,
-    XfadeTransition, YadifMode,
+    RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, ToneMap,
+    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };


### PR DESCRIPTION
## Objective

- The preview runner builds a `RealtimeLayer` per tick at decode time, when `width`/`height`/`pixel_format` first become known, so an engine cannot pre-build a full `RealtimeLayer` from its editing model.
- Slice A of the Scene-decouple for #1329: provide a dimension-free layer description the engine can derive and the runner completes.

## Solution

- Add `RealtimeLayerDescriptor` in `ff-filter` = `RealtimeLayer` minus `width`/`height`/`pixel_format` (the eight fields `effects`, `opacity`, `opacity_track`, `x`, `y`, `x_track`, `y_track`, `blend_mode`).
- Add `RealtimeLayer::with_dimensions(descriptor, width, height, pixel_format)` to realise a descriptor into a full layer (moves the fields, no clone).
- Re-export the new type through the usual path up to `avio`.
- Additive only: `RealtimeLayer` construction is unchanged and no callers are touched. Covered by a round-trip unit test plus the existing `RealtimeComposer` tests.
- Named `RealtimeLayerDescriptor` rather than the issue's `RealtimeLayerSpec`, to match the `Descriptor` naming already used for wgpu construction inputs in this workspace.

Closes #1339