### PR TITLE
refactor(ff-preview): introduce Scene and decouple the runner from Timeline/Clip

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -342,7 +342,10 @@ pub use ff_preview::HardwareAccel;
 // `ff-pipeline`.  The `pipeline` feature in avio enables `ff-preview?/timeline`
 // (see Cargo.toml), which gates these types inside `ff-preview`.
 #[cfg(all(feature = "preview", feature = "pipeline"))]
-pub use ff_preview::{TimelinePlayer, TimelineRunner};
+pub use ff_preview::{
+    Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack, TimelinePlayer,
+    TimelineRunner,
+};
 
 #[cfg(all(feature = "preview", feature = "tokio"))]
 pub use ff_preview::AsyncPreviewPlayer;

--- a/crates/ff-pipeline/src/clip.rs
+++ b/crates/ff-pipeline/src/clip.rs
@@ -9,7 +9,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use ff_filter::{
-    AnimationTrack, BlendMode, CompositeOp, FilterGraph, FilterStep, RealtimeLayer, XfadeTransition,
+    AnimationTrack, BlendMode, CompositeOp, FilterGraph, FilterStep, RealtimeLayer,
+    RealtimeLayerDescriptor, XfadeTransition,
 };
 use ff_format::{PixelFormat, VideoFrame};
 
@@ -360,10 +361,24 @@ impl Clip {
         height: u32,
         pixel_format: PixelFormat,
     ) -> RealtimeLayer {
-        RealtimeLayer {
+        RealtimeLayer::with_dimensions(
+            self.realtime_layer_descriptor(),
             width,
             height,
             pixel_format,
+        )
+    }
+
+    /// Builds the dimension-free [`RealtimeLayerDescriptor`] for this clip — the
+    /// [`realtime_layer`](Self::realtime_layer) fields except `width`/`height`/
+    /// `pixel_format`, which are known only once a frame has been decoded.
+    ///
+    /// An engine derives this from the model ahead of decode; the real-time
+    /// preview runner completes it per frame via
+    /// [`RealtimeLayer::with_dimensions`].
+    #[must_use]
+    pub fn realtime_layer_descriptor(&self) -> RealtimeLayerDescriptor {
+        RealtimeLayerDescriptor {
             effects: self.video_effect_chain(),
             opacity: self.opacity,
             opacity_track: self.opacity_track.clone(),

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -54,4 +54,7 @@ pub use playback::AsyncPreviewPlayer;
 pub use proxy::{ProxyGenerator, ProxyJob, ProxyResolution};
 
 #[cfg(feature = "timeline")]
-pub use timeline::{TimelinePlayer, TimelineRunner};
+pub use timeline::{
+    Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack, TimelinePlayer,
+    TimelineRunner,
+};

--- a/crates/ff-preview/src/playback/player.rs
+++ b/crates/ff-preview/src/playback/player.rs
@@ -12,9 +12,9 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use ff_decode::HardwareAccel;
 #[cfg(feature = "timeline")]
-use ff_pipeline::timeline::Timeline;
+use crate::timeline::Scene;
+use ff_decode::HardwareAccel;
 
 use super::decode_buffer::DecodeBuffer;
 use super::master_clock::MasterClock;
@@ -57,7 +57,7 @@ pub enum PlayerCommand {
     /// in place and seeks to the last known media PTS so the next frame is
     /// spatially correct after the layout change.
     #[cfg(feature = "timeline")]
-    UpdateLayout(Box<Timeline>),
+    UpdateLayout(Box<Scene>),
 }
 
 // ── PreviewPlayer (thin builder) ──────────────────────────────────────────────

--- a/crates/ff-preview/src/playback/player_handle.rs
+++ b/crates/ff-preview/src/playback/player_handle.rs
@@ -1,7 +1,7 @@
 //! Shared, cloneable control handle for a running [`PlayerRunner`](super::player_runner::PlayerRunner).
 
 #[cfg(feature = "timeline")]
-use ff_pipeline::timeline::Timeline;
+use crate::timeline::Scene;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
@@ -88,7 +88,7 @@ impl PlayerHandle {
         let _ = self.cmd_tx.try_send(PlayerCommand::SetAvOffset(ms));
     }
 
-    /// Replace the running timeline's clip layout in place.
+    /// Replace the running timeline's clip layout in place from a new [`Scene`].
     ///
     /// Sends a [`PlayerCommand::UpdateLayout`] to `TimelineRunner`. The runner
     /// updates `timeline_start` / `timeline_end` / `in_point` / `out_point` for
@@ -102,10 +102,10 @@ impl PlayerHandle {
     /// No-op when called on a [`PlayerRunner`](super::player_runner::PlayerRunner)-backed
     /// handle (single-track player). Only `TimelineRunner` handles this command.
     #[cfg(feature = "timeline")]
-    pub fn update_timeline(&self, timeline: Timeline) {
+    pub fn update_scene(&self, scene: Scene) {
         let _ = self
             .cmd_tx
-            .try_send(PlayerCommand::UpdateLayout(Box::new(timeline)));
+            .try_send(PlayerCommand::UpdateLayout(Box::new(scene)));
     }
 
     /// PTS of the most recently presented frame.

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -23,6 +23,8 @@
 mod audio_resampling;
 mod runner;
 mod runner_layout;
+mod scene;
+mod scene_adapter;
 mod state;
 mod timeline_inner;
 
@@ -31,7 +33,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
-use ff_pipeline::Clip;
 use ff_pipeline::timeline::Timeline;
 
 use crate::audio::{AudioMixer, AudioTrackHandle};
@@ -43,6 +44,7 @@ use crate::playback::master_clock::MasterClock;
 use crate::playback::player_handle::PlayerHandle;
 
 pub use runner::TimelineRunner;
+pub use scene::{Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack};
 
 use audio_resampling::spawn_audio_track_thread;
 use state::{AudioFadeConfig, AudioOnlyTrack, ClipState, OverlayLayer};
@@ -98,8 +100,26 @@ impl TimelinePlayer {
     /// - `timeline` has no video tracks or the primary track is empty,
     /// - a clip source file cannot be found or opened,
     /// - a clip cannot be probed for duration.
-    #[allow(clippy::too_many_lines)]
     pub fn open(timeline: &Timeline) -> Result<(TimelineRunner, PlayerHandle), PreviewError> {
+        Self::open_scene(&Scene::from_timeline(timeline))
+    }
+
+    /// Open a [`Scene`] for real-time preview playback.
+    ///
+    /// The `Scene` carries the primitivised editing model; this resolves it
+    /// against the media (probing each placement's source for duration, audio
+    /// availability, and frame size), opens a [`DecodeBuffer`] per V1 clip and
+    /// seeks it to `in_point`, and builds the audio mixer and tracks. This is the
+    /// media-resolution step that [`open`](Self::open) used to inline.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PreviewError`] when:
+    /// - the scene has no video tracks or the base track is empty,
+    /// - a placement source file cannot be found or opened,
+    /// - a placement cannot be probed for duration.
+    #[allow(clippy::too_many_lines)]
+    pub fn open_scene(scene: &Scene) -> Result<(TimelineRunner, PlayerHandle), PreviewError> {
         struct ProbeResult {
             source: PathBuf,
             in_pt: Duration,
@@ -114,45 +134,39 @@ impl TimelinePlayer {
             video_h: u32,
             speed: f64,
             opacity: f32,
-            clip: Clip,
         }
 
-        let tracks = timeline.video_tracks();
-        if tracks.is_empty() || tracks[0].is_empty() {
+        let v_tracks = &scene.video_tracks;
+        if v_tracks.is_empty() || v_tracks[0].placements.is_empty() {
             return Err(PreviewError::Ffmpeg {
                 code: 0,
                 message: "timeline has no video clips in the primary track".into(),
             });
         }
 
-        let fps = timeline.frame_rate().max(1.0);
-        let clip_list = &tracks[0];
+        let fps = scene.fps.max(1.0);
+        let clip_list = &v_tracks[0].placements;
 
         // ── Phase 1: probe all clips ──────────────────────────────────────────
 
         let mut probes: Vec<ProbeResult> = Vec::with_capacity(clip_list.len());
         let mut has_any_audio = false;
 
-        for clip in clip_list {
-            let in_pt = clip.in_point.unwrap_or(Duration::ZERO);
-            let info = ff_probe::open(&clip.source)?;
-            let speed = clip.speed.max(0.01);
+        for p in clip_list {
+            let in_pt = p.in_point;
+            let info = ff_probe::open(&p.source)?;
+            let speed = p.speed;
 
-            let unscaled_dur = match (clip.in_point, clip.out_point) {
-                (Some(ip), Some(op)) => op.saturating_sub(ip),
-                (None, Some(op)) => op,
-                _ => info.duration().saturating_sub(in_pt),
-            };
+            // `in_point` is pre-resolved (defaulted to zero) in the Scene, so this
+            // equals the old `match (in_point, out_point)` for all four cases.
+            let unscaled_dur = p.out_point.map_or_else(
+                || info.duration().saturating_sub(in_pt),
+                |op| op.saturating_sub(in_pt),
+            );
             let clip_dur = if (speed - 1.0).abs() < 1e-9 {
                 unscaled_dur
             } else {
                 unscaled_dur.div_f64(speed)
-            };
-
-            let transition_dur = if clip.transition.is_some() {
-                clip.transition_duration
-            } else {
-                Duration::ZERO
             };
 
             let has_audio = info.has_audio();
@@ -163,18 +177,17 @@ impl TimelinePlayer {
                 .map_or((0, 0), |v| (v.width(), v.height()));
 
             probes.push(ProbeResult {
-                source: clip.source.clone(),
+                source: p.source.clone(),
                 in_pt,
                 clip_dur,
-                timeline_offset: clip.timeline_offset,
-                out_point: clip.out_point,
-                transition_dur,
+                timeline_offset: p.timeline_offset,
+                out_point: p.out_point,
+                transition_dur: p.transition_dur,
                 has_audio,
                 video_w,
                 video_h,
                 speed,
-                opacity: clip.opacity.clamp(0.0, 1.0),
-                clip: clip.clone(),
+                opacity: p.opacity,
             });
         }
 
@@ -223,7 +236,8 @@ impl TimelinePlayer {
                 audio_track: audio_track_handles[i].clone(),
                 speed: p.speed,
                 opacity: p.opacity,
-                clip: p.clip.clone(),
+                layer_desc: clip_list[i].layer.clone(),
+                volume_track: clip_list[i].volume_track.clone(),
             });
         }
 
@@ -234,22 +248,21 @@ impl TimelinePlayer {
         let mut audio_only_tracks: Vec<AudioOnlyTrack> = Vec::new();
 
         let mut overlay_layers: Vec<OverlayLayer> = Vec::new();
-        for v_track in timeline.video_tracks().iter().skip(1) {
-            if v_track.is_empty() {
+        for layer in v_tracks.iter().skip(1) {
+            if layer.placements.is_empty() {
                 continue;
             }
             let mut layer_clips: Vec<ClipState> = Vec::new();
-            for clip in v_track {
-                let in_pt = clip.in_point.unwrap_or(Duration::ZERO);
-                let info = ff_probe::open(&clip.source)?;
-                let clip_dur = match (clip.in_point, clip.out_point) {
-                    (Some(ip), Some(op)) => op.saturating_sub(ip),
-                    (None, Some(op)) => op,
-                    _ => info.duration().saturating_sub(in_pt),
-                };
-                let timeline_start = clip.timeline_offset;
+            for p in &layer.placements {
+                let in_pt = p.in_point;
+                let info = ff_probe::open(&p.source)?;
+                let clip_dur = p.out_point.map_or_else(
+                    || info.duration().saturating_sub(in_pt),
+                    |op| op.saturating_sub(in_pt),
+                );
+                let timeline_start = p.timeline_offset;
                 let timeline_end = timeline_start + clip_dur;
-                let mut decode_buf = DecodeBuffer::open(&clip.source).build()?;
+                let mut decode_buf = DecodeBuffer::open(&p.source).build()?;
                 if in_pt > Duration::ZERO {
                     decode_buf.seek(in_pt)?;
                 }
@@ -261,31 +274,32 @@ impl TimelinePlayer {
                         .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .add_track();
                     audio_only_tracks.push(AudioOnlyTrack {
-                        source: clip.source.clone(),
+                        source: p.source.clone(),
                         timeline_start,
                         timeline_end,
                         in_point: in_pt,
-                        fade_in: clip.fade_in,
-                        fade_out: clip.fade_out,
+                        fade_in: p.fade_in,
+                        fade_out: p.fade_out,
                         clip_dur,
                         handle,
-                        volume_track: clip.volume_track.clone(),
+                        volume_track: p.volume_track.clone(),
                         cancel: None,
                         thread: None,
                     });
                 }
                 layer_clips.push(ClipState {
-                    source: clip.source.clone(),
+                    source: p.source.clone(),
                     decode_buf,
                     timeline_start,
                     timeline_end,
                     in_point: in_pt,
-                    out_point: clip.out_point,
+                    out_point: p.out_point,
                     transition_dur: Duration::ZERO,
                     audio_track: None,
-                    speed: clip.speed.max(0.01),
-                    opacity: clip.opacity.clamp(0.0, 1.0),
-                    clip: clip.clone(),
+                    speed: p.speed,
+                    opacity: p.opacity,
+                    layer_desc: p.layer.clone(),
+                    volume_track: p.volume_track.clone(),
                 });
             }
             overlay_layers.push(OverlayLayer {
@@ -300,19 +314,18 @@ impl TimelinePlayer {
 
         // ── Phase 5: build audio-only tracks (A1, A2, …) ─────────────────────
 
-        for a_track in timeline.audio_tracks() {
-            for clip in a_track {
-                let in_pt = clip.in_point.unwrap_or(Duration::ZERO);
-                let info = ff_probe::open(&clip.source)?;
+        for track in &scene.audio_tracks {
+            for p in &track.placements {
+                let in_pt = p.in_point;
+                let info = ff_probe::open(&p.source)?;
                 if !info.has_audio() {
                     continue;
                 }
-                let clip_dur = match (clip.in_point, clip.out_point) {
-                    (Some(ip), Some(op)) => op.saturating_sub(ip),
-                    (None, Some(op)) => op,
-                    _ => info.duration().saturating_sub(in_pt),
-                };
-                let timeline_start = clip.timeline_offset;
+                let clip_dur = p.out_point.map_or_else(
+                    || info.duration().saturating_sub(in_pt),
+                    |op| op.saturating_sub(in_pt),
+                );
+                let timeline_start = p.timeline_offset;
                 let timeline_end = timeline_start + clip_dur;
                 // Lazily create the mixer if no V1 clip had audio.
                 let mixer_ref =
@@ -324,21 +337,21 @@ impl TimelinePlayer {
                 // Apply per-clip gain (dB → linear). A volume_track (animated) takes
                 // precedence and is driven per-tick by the runner, so only apply the
                 // static gain when no track is present.
-                if clip.volume_track.is_none() && clip.volume_db != 0.0 {
+                if p.volume_track.is_none() && p.volume_db != 0.0 {
                     #[allow(clippy::cast_possible_truncation)]
-                    let linear = 10.0_f64.powf(clip.volume_db / 20.0) as f32;
+                    let linear = 10.0_f64.powf(p.volume_db / 20.0) as f32;
                     handle.set_volume(linear);
                 }
                 audio_only_tracks.push(AudioOnlyTrack {
-                    source: clip.source.clone(),
+                    source: p.source.clone(),
                     timeline_start,
                     timeline_end,
                     in_point: in_pt,
-                    fade_in: clip.fade_in,
-                    fade_out: clip.fade_out,
+                    fade_in: p.fade_in,
+                    fade_out: p.fade_out,
                     clip_dur,
                     handle,
-                    volume_track: clip.volume_track.clone(),
+                    volume_track: p.volume_track.clone(),
                     cancel: None,
                     thread: None,
                 });
@@ -430,7 +443,7 @@ impl TimelinePlayer {
             active_audio_thread: initial_audio_thread,
             composer: None,
             composer_key: Vec::new(),
-            canvas: timeline.explicit_canvas(),
+            canvas: scene.canvas,
         };
 
         let handle = PlayerHandle::for_timeline(

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -178,11 +178,12 @@ impl TimelineRunner {
         let mut key: Vec<(usize, usize, u32, u32)> = vec![(0, base_id, base_w, base_h)];
         for &(li, ow, oh) in overlays {
             let oc = &self.overlay_layers[li];
-            specs.push(
-                oc.clips[oc.active]
-                    .clip
-                    .realtime_layer(ow, oh, PixelFormat::Rgba),
-            );
+            specs.push(RealtimeLayer::with_dimensions(
+                oc.clips[oc.active].layer_desc.clone(),
+                ow,
+                oh,
+                PixelFormat::Rgba,
+            ));
             key.push((li + 1, oc.active, ow, oh));
         }
         if self.composer.is_none() || self.composer_key != key {
@@ -314,8 +315,8 @@ impl TimelineRunner {
                         }
                     }
                     PlayerCommand::SetAvOffset(_) => {} // audio timing is system-clock driven
-                    PlayerCommand::UpdateLayout(timeline) => {
-                        if let Err(e) = self.update_layout_in_place(&timeline, self.resume_pts) {
+                    PlayerCommand::UpdateLayout(scene) => {
+                        if let Err(e) = self.update_layout_in_place(&scene, self.resume_pts) {
                             log::warn!("timeline layout update ignored: {e}");
                         }
                     }
@@ -601,7 +602,7 @@ impl TimelineRunner {
 
                     // Primary-track volume automation for the active clip.
                     if let Some(handle) = &self.clips[active].audio_track
-                        && let Some(track) = &self.clips[active].clip.volume_track
+                        && let Some(track) = &self.clips[active].volume_track
                     {
                         #[allow(clippy::cast_possible_truncation)]
                         let linear = 10f32.powf(track.value_at(timeline_pts) as f32 / 20.0);
@@ -834,7 +835,7 @@ impl TimelineRunner {
                         // the composer ignores base-layer opacity). An opacity track is
                         // evaluated at the timeline PTS (tracks are timeline-global), so
                         // base-layer opacity animates too.
-                        let v1_op = match self.clips[active].clip.opacity_track.as_ref() {
+                        let v1_op = match self.clips[active].layer_desc.opacity_track.as_ref() {
                             // Value is clamped to [0.0, 1.0], so the f32 narrowing is safe.
                             #[allow(clippy::cast_possible_truncation)]
                             Some(track) => track.value_at(timeline_pts).clamp(0.0, 1.0) as f32,
@@ -873,10 +874,12 @@ impl TimelineRunner {
                         // Update overlays (held-frame, advanced by PTS) and composite
                         // the V1 base with them through the shared compositor.
                         let active_overlays = self.sync_overlays(timeline_pts);
-                        let base_layer =
-                            self.clips[active]
-                                .clip
-                                .realtime_layer(w, h, PixelFormat::Rgba);
+                        let base_layer = RealtimeLayer::with_dimensions(
+                            self.clips[active].layer_desc.clone(),
+                            w,
+                            h,
+                            PixelFormat::Rgba,
+                        );
                         let composited = match VideoFrame::from_rgba(w, h, self.rgba_a.clone()) {
                             Ok(bf) => self.composite_frame(
                                 base_layer,

--- a/crates/ff-preview/src/timeline/runner_layout.rs
+++ b/crates/ff-preview/src/timeline/runner_layout.rs
@@ -7,10 +7,11 @@ use std::time::Duration;
 use crate::error::PreviewError;
 
 use super::runner::TimelineRunner;
+use super::scene::Scene;
 
 impl TimelineRunner {
-    /// Update clip positions in place from a new `Timeline` without stopping
-    /// the runner or replacing audio infrastructure.
+    /// Update clip positions in place from a new [`Scene`] without stopping the
+    /// runner or replacing audio infrastructure.
     ///
     /// Only the position metadata (`timeline_start`, `timeline_end`,
     /// `in_point`, `out_point`, `transition_dur`) of existing `ClipState` and
@@ -18,19 +19,19 @@ impl TimelineRunner {
     /// `AudioTrackHandle`s are reused unchanged; only the decode positions are
     /// updated by calling `seek_timeline(resume_pts)` at the end.
     ///
-    /// Returns an error when the new timeline is structurally incompatible with
-    /// the running runner (different V1 clip count or different source paths).
-    /// In that case the runner's state is untouched.
+    /// Returns an error when the new scene is structurally incompatible with the
+    /// running runner (different V1 clip count or different source paths). In
+    /// that case the runner's state is untouched.
     #[allow(clippy::too_many_lines)]
     pub(super) fn update_layout_in_place(
         &mut self,
-        timeline: &ff_pipeline::timeline::Timeline,
+        scene: &Scene,
         resume_pts: Duration,
     ) -> Result<(), PreviewError> {
-        let v_tracks = timeline.video_tracks();
+        let v_tracks = &scene.video_tracks;
 
         // ── Validate V1 ────────────────────────────────────────────────────────
-        let new_v1_len = v_tracks.first().map_or(0, Vec::len);
+        let new_v1_len = v_tracks.first().map_or(0, |t| t.placements.len());
         if new_v1_len != self.clips.len() {
             return Err(PreviewError::Ffmpeg {
                 code: -1,
@@ -40,47 +41,43 @@ impl TimelineRunner {
                 ),
             });
         }
-        for (i, clip) in v_tracks[0].iter().enumerate() {
-            if clip.source != self.clips[i].source {
+        for (i, p) in v_tracks[0].placements.iter().enumerate() {
+            if p.source != self.clips[i].source {
                 return Err(PreviewError::Ffmpeg {
                     code: -1,
                     message: format!(
                         "V1 clip[{i}] source mismatch: runner={} timeline={}",
                         self.clips[i].source.display(),
-                        clip.source.display(),
+                        p.source.display(),
                     ),
                 });
             }
         }
 
         // ── Update V1 clip positions ───────────────────────────────────────────
-        for (i, clip) in v_tracks[0].iter().enumerate() {
-            let new_speed = clip.speed.max(0.01);
+        for (i, p) in v_tracks[0].placements.iter().enumerate() {
+            let new_speed = p.speed;
             let old_scaled_dur = self.clips[i]
                 .timeline_end
                 .saturating_sub(self.clips[i].timeline_start);
             // Recover unscaled (source) duration from the stored scaled duration and old speed.
             let old_unscaled = old_scaled_dur.mul_f64(self.clips[i].speed);
-            let new_unscaled = match (clip.in_point, clip.out_point) {
-                (Some(ip), Some(op)) => op.saturating_sub(ip),
-                (None, Some(op)) => op,
-                _ => old_unscaled,
-            };
+            // `in_point` is pre-resolved in the Scene, so this equals the old
+            // `match (in_point, out_point)` (the `_` arm reused `old_unscaled`).
+            let new_unscaled = p
+                .out_point
+                .map_or(old_unscaled, |op| op.saturating_sub(p.in_point));
             let new_dur = if (new_speed - 1.0).abs() < 1e-9 {
                 new_unscaled
             } else {
                 new_unscaled.div_f64(new_speed)
             };
-            self.clips[i].timeline_start = clip.timeline_offset;
-            self.clips[i].timeline_end = clip.timeline_offset + new_dur;
-            self.clips[i].in_point = clip.in_point.unwrap_or(Duration::ZERO);
-            self.clips[i].out_point = clip.out_point;
+            self.clips[i].timeline_start = p.timeline_offset;
+            self.clips[i].timeline_end = p.timeline_offset + new_dur;
+            self.clips[i].in_point = p.in_point;
+            self.clips[i].out_point = p.out_point;
             self.clips[i].speed = new_speed;
-            self.clips[i].transition_dur = if clip.transition.is_some() {
-                clip.transition_duration
-            } else {
-                Duration::ZERO
-            };
+            self.clips[i].transition_dur = p.transition_dur;
         }
 
         // ── Update overlay layers (V2+) ────────────────────────────────────────
@@ -88,40 +85,32 @@ impl TimelineRunner {
         if new_overlay_count == self.overlay_layers.len() {
             for (layer_i, v_track) in v_tracks.iter().skip(1).enumerate() {
                 let layer = &mut self.overlay_layers[layer_i];
-                if v_track.len() == layer.clips.len() {
-                    for (j, clip) in v_track.iter().enumerate() {
+                if v_track.placements.len() == layer.clips.len() {
+                    for (j, p) in v_track.placements.iter().enumerate() {
                         let old_dur = layer.clips[j]
                             .timeline_end
                             .saturating_sub(layer.clips[j].timeline_start);
-                        let new_dur = match (clip.in_point, clip.out_point) {
-                            (Some(ip), Some(op)) => op.saturating_sub(ip),
-                            (None, Some(op)) => op,
-                            _ => old_dur,
-                        };
-                        layer.clips[j].timeline_start = clip.timeline_offset;
-                        layer.clips[j].timeline_end = clip.timeline_offset + new_dur;
-                        layer.clips[j].in_point = clip.in_point.unwrap_or(Duration::ZERO);
-                        layer.clips[j].out_point = clip.out_point;
+                        let new_dur = p
+                            .out_point
+                            .map_or(old_dur, |op| op.saturating_sub(p.in_point));
+                        layer.clips[j].timeline_start = p.timeline_offset;
+                        layer.clips[j].timeline_end = p.timeline_offset + new_dur;
+                        layer.clips[j].in_point = p.in_point;
+                        layer.clips[j].out_point = p.out_point;
                     }
                 }
             }
         }
 
         // ── Update audio-only tracks (A1+) ─────────────────────────────────────
-        // Collect new (timeline_start, in_point, out_point) from the timeline's
-        // audio tracks, matched positionally. Mismatched counts are skipped
-        // rather than returning an error because audio tracks are optional.
-        let new_a_positions: Vec<(Duration, Duration, Option<Duration>)> = timeline
-            .audio_tracks()
+        // Collect new (timeline_start, in_point, out_point) from the scene's audio
+        // tracks, matched positionally. Mismatched counts are skipped rather than
+        // returning an error because audio tracks are optional.
+        let new_a_positions: Vec<(Duration, Duration, Option<Duration>)> = scene
+            .audio_tracks
             .iter()
-            .flat_map(|track| track.iter())
-            .map(|clip| {
-                (
-                    clip.timeline_offset,
-                    clip.in_point.unwrap_or(Duration::ZERO),
-                    clip.out_point,
-                )
-            })
+            .flat_map(|track| track.placements.iter())
+            .map(|p| (p.timeline_offset, p.in_point, p.out_point))
             .collect();
 
         if new_a_positions.len() == self.audio_only_tracks.len() {

--- a/crates/ff-preview/src/timeline/scene.rs
+++ b/crates/ff-preview/src/timeline/scene.rs
@@ -1,0 +1,114 @@
+//! Model-agnostic description of a timeline for the real-time preview runner.
+//!
+//! A [`Scene`] is the primitive seam between an editing engine and
+//! [`TimelineRunner`](super::runner::TimelineRunner): it carries only the
+//! model's primitivised fields (paths, durations, opacity, blend, animation
+//! tracks), never the editing model itself. Resolving a `Scene` against the
+//! media — probing for duration, audio presence, and frame size — happens in
+//! [`TimelinePlayer::open_scene`](super::TimelinePlayer::open_scene), exactly as
+//! it did when the runner consumed `Timeline`/`Clip` directly. So a `Scene`
+//! re-derived on every edit needs no re-probe and behaviour is preserved.
+//!
+//! Temporarily, `ff-preview` also derives a `Scene` from a `Timeline` (see
+//! `scene_adapter`); that adapter moves to `avio` in the model relocation
+//! (#1329, slice C), after which `Scene` is the only input the runner accepts.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ff_filter::{AnimationTrack, RealtimeLayerDescriptor};
+
+// ── Scene ─────────────────────────────────────────────────────────────────────
+
+/// A whole timeline's worth of playback work, described without the editing model.
+#[derive(Debug, Clone)]
+pub struct Scene {
+    /// Presentation frame rate. Clamped to at least `1.0` by the runner.
+    pub fps: f64,
+    /// Explicit output canvas `(width, height)`, or `None` to size from the base track.
+    pub canvas: Option<(u32, u32)>,
+    /// Video tracks, composited bottom-up: index `0` is the V1 base, `1..` are overlays.
+    pub video_tracks: Vec<SceneVideoTrack>,
+    /// Dedicated audio-only tracks (A1, A2, …).
+    pub audio_tracks: Vec<SceneAudioTrack>,
+}
+
+// ── SceneVideoTrack ─────────────────────────────────────────────────────────────
+
+/// One video track: an ordered list of clip placements along the timeline. The
+/// track's index in [`Scene::video_tracks`] is its compositing order (`0` = base).
+#[derive(Debug, Clone)]
+pub struct SceneVideoTrack {
+    /// Placements in timeline order.
+    pub placements: Vec<ScenePlacement>,
+}
+
+// ── ScenePlacement ──────────────────────────────────────────────────────────────
+
+/// One video clip placed on the timeline.
+///
+/// Fields are pre-resolved model projections (e.g. `in_point` defaulted, `speed`
+/// clamped, `transition_dur` computed); media-dependent resolution (the effective
+/// clip duration when `out_point` is `None`) is done by the runner at open time.
+#[derive(Debug, Clone)]
+pub struct ScenePlacement {
+    /// Source media path.
+    pub source: PathBuf,
+    /// Global timeline position where this placement starts.
+    pub timeline_offset: Duration,
+    /// Source-file PTS at which playback starts (`Clip::in_point`, defaulted to zero).
+    pub in_point: Duration,
+    /// Source-file PTS at which playback ends (`None` = play to EOF).
+    pub out_point: Option<Duration>,
+    /// Playback speed multiplier (`1.0` = normal), clamped to at least `0.01`.
+    pub speed: f64,
+    /// Crossfade duration from the previous placement into this one. Meaningful on
+    /// the V1 base track only; `Duration::ZERO` = hard cut.
+    pub transition_dur: Duration,
+    /// Per-clip opacity in `[0.0, 1.0]`.
+    pub opacity: f32,
+    /// The dimension-free compositing description (effects, blend, position, and the
+    /// opacity/position animation tracks). The runner realises it per frame via
+    /// [`RealtimeLayer::with_dimensions`](ff_filter::RealtimeLayer::with_dimensions).
+    pub layer: RealtimeLayerDescriptor,
+    /// Audio fade-in duration (`Duration::ZERO` = none).
+    pub fade_in: Duration,
+    /// Audio fade-out duration (`Duration::ZERO` = none).
+    pub fade_out: Duration,
+    /// Static audio gain in dB.
+    pub volume_db: f64,
+    /// Per-clip volume automation (dB, timeline-global). Overrides the static gain.
+    pub volume_track: Option<AnimationTrack<f64>>,
+}
+
+// ── SceneAudioTrack ─────────────────────────────────────────────────────────────
+
+/// One dedicated audio-only track (A1, A2, …).
+#[derive(Debug, Clone)]
+pub struct SceneAudioTrack {
+    /// Placements in timeline order.
+    pub placements: Vec<SceneAudioPlacement>,
+}
+
+// ── SceneAudioPlacement ─────────────────────────────────────────────────────────
+
+/// One audio-only clip placed on the timeline.
+#[derive(Debug, Clone)]
+pub struct SceneAudioPlacement {
+    /// Source media path.
+    pub source: PathBuf,
+    /// Global timeline position where this placement starts.
+    pub timeline_offset: Duration,
+    /// Source-file PTS at which playback starts (defaulted to zero).
+    pub in_point: Duration,
+    /// Source-file PTS at which playback ends (`None` = play to EOF).
+    pub out_point: Option<Duration>,
+    /// Audio fade-in duration (`Duration::ZERO` = none).
+    pub fade_in: Duration,
+    /// Audio fade-out duration (`Duration::ZERO` = none).
+    pub fade_out: Duration,
+    /// Static audio gain in dB.
+    pub volume_db: f64,
+    /// Per-clip volume automation (dB, timeline-global). Overrides the static gain.
+    pub volume_track: Option<AnimationTrack<f64>>,
+}

--- a/crates/ff-preview/src/timeline/scene_adapter.rs
+++ b/crates/ff-preview/src/timeline/scene_adapter.rs
@@ -1,0 +1,173 @@
+//! Temporary `Timeline -> Scene` projection.
+//!
+//! This adapter lets `ff-preview` keep accepting a `ff_pipeline::Timeline` while
+//! its runner consumes the primitive [`Scene`]. It is a **pure model
+//! projection**: it reads the timeline's tracks and each clip's fields, does no
+//! probing or I/O, and resolves nothing that needs the media (durations are
+//! resolved later, in [`TimelinePlayer::open_scene`](super::TimelinePlayer::open_scene)).
+//!
+//! It moves to `avio` with the editing model in the relocation (#1329, slice C);
+//! after that, `ff-preview` no longer depends on the model and this file is
+//! deleted.
+
+use std::time::Duration;
+
+use ff_pipeline::Clip;
+use ff_pipeline::timeline::Timeline;
+
+use super::scene::{Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack};
+
+impl Scene {
+    /// Projects a [`Timeline`] into a primitive [`Scene`] (no probing, no I/O).
+    ///
+    /// Video track `0` is the V1 base (crossfade transitions apply); tracks `1..`
+    /// are overlays (transitions forced off, matching the compositor).
+    pub(crate) fn from_timeline(timeline: &Timeline) -> Self {
+        let video_tracks = timeline
+            .video_tracks()
+            .iter()
+            .enumerate()
+            .map(|(track_idx, track)| SceneVideoTrack {
+                placements: track
+                    .iter()
+                    .map(|clip| video_placement(clip, track_idx == 0))
+                    .collect(),
+            })
+            .collect();
+
+        let audio_tracks = timeline
+            .audio_tracks()
+            .iter()
+            .map(|track| SceneAudioTrack {
+                placements: track.iter().map(audio_placement).collect(),
+            })
+            .collect();
+
+        Self {
+            fps: timeline.frame_rate().max(1.0),
+            canvas: timeline.explicit_canvas(),
+            video_tracks,
+            audio_tracks,
+        }
+    }
+}
+
+/// Projects one video clip. `is_base` selects the V1 base track, where a
+/// crossfade transition contributes a `transition_dur`; overlays force zero.
+fn video_placement(clip: &Clip, is_base: bool) -> ScenePlacement {
+    let transition_dur = if is_base && clip.transition.is_some() {
+        clip.transition_duration
+    } else {
+        Duration::ZERO
+    };
+    ScenePlacement {
+        source: clip.source.clone(),
+        timeline_offset: clip.timeline_offset,
+        in_point: clip.in_point.unwrap_or(Duration::ZERO),
+        out_point: clip.out_point,
+        speed: clip.speed.max(0.01),
+        transition_dur,
+        opacity: clip.opacity.clamp(0.0, 1.0),
+        layer: clip.realtime_layer_descriptor(),
+        fade_in: clip.fade_in,
+        fade_out: clip.fade_out,
+        volume_db: clip.volume_db,
+        volume_track: clip.volume_track.clone(),
+    }
+}
+
+/// Projects one audio-only clip.
+fn audio_placement(clip: &Clip) -> SceneAudioPlacement {
+    SceneAudioPlacement {
+        source: clip.source.clone(),
+        timeline_offset: clip.timeline_offset,
+        in_point: clip.in_point.unwrap_or(Duration::ZERO),
+        out_point: clip.out_point,
+        fade_in: clip.fade_in,
+        fade_out: clip.fade_out,
+        volume_db: clip.volume_db,
+        volume_track: clip.volume_track.clone(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use ff_filter::{AnimationTrack, XfadeTransition};
+
+    use super::*;
+
+    #[test]
+    fn scene_from_timeline_should_project_clip_fields() {
+        let timeline = Timeline::builder()
+            // Explicit canvas + fps so build() does not probe the fake sources.
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![
+                Clip::new("a.mp4")
+                    .trim(Duration::from_secs(1), Duration::from_secs(3))
+                    .offset(Duration::from_millis(500))
+                    .with_opacity(0.5)
+                    .with_speed(2.0)
+                    .with_volume_track(AnimationTrack::new()),
+                Clip::new("b.mp4")
+                    .with_transition(XfadeTransition::Fade, Duration::from_millis(750)),
+            ])
+            .video_track(vec![
+                // Overlay: a transition here must be projected as zero.
+                Clip::new("overlay.mp4")
+                    .with_transition(XfadeTransition::Fade, Duration::from_millis(400)),
+            ])
+            .audio_track(vec![
+                Clip::new("music.mp3")
+                    .with_fade_in(Duration::from_millis(200))
+                    .with_fade_out(Duration::from_millis(300))
+                    .volume(-6.0),
+            ])
+            .build()
+            .unwrap();
+
+        let scene = Scene::from_timeline(&timeline);
+
+        assert!((scene.fps - 30.0).abs() < f64::EPSILON);
+        assert_eq!(scene.canvas, Some((1920, 1080)));
+        assert_eq!(scene.video_tracks.len(), 2);
+        assert_eq!(scene.audio_tracks.len(), 1);
+
+        // ── V1 base, clip 0: resolved projections ──
+        let base = &scene.video_tracks[0].placements[0];
+        assert_eq!(base.source.to_str(), Some("a.mp4"));
+        assert_eq!(base.timeline_offset, Duration::from_millis(500));
+        assert_eq!(base.in_point, Duration::from_secs(1));
+        assert_eq!(base.out_point, Some(Duration::from_secs(3)));
+        assert!((base.speed - 2.0).abs() < f64::EPSILON);
+        assert!((base.opacity - 0.5).abs() < f32::EPSILON);
+        assert_eq!(
+            base.transition_dur,
+            Duration::ZERO,
+            "clip 0 has no transition"
+        );
+        assert!(base.volume_track.is_some());
+        // The descriptor carries the same opacity the clip declared.
+        assert!((base.layer.opacity - 0.5).abs() < f32::EPSILON);
+
+        // ── V1 base, clip 1: transition duration is projected ──
+        let base1 = &scene.video_tracks[0].placements[1];
+        assert_eq!(base1.transition_dur, Duration::from_millis(750));
+
+        // ── Overlay: transition forced to zero ──
+        let overlay = &scene.video_tracks[1].placements[0];
+        assert_eq!(
+            overlay.transition_dur,
+            Duration::ZERO,
+            "overlay transitions must project as zero"
+        );
+
+        // ── Audio-only placement ──
+        let audio = &scene.audio_tracks[0].placements[0];
+        assert_eq!(audio.source.to_str(), Some("music.mp3"));
+        assert_eq!(audio.fade_in, Duration::from_millis(200));
+        assert_eq!(audio.fade_out, Duration::from_millis(300));
+        assert!((audio.volume_db - (-6.0)).abs() < f64::EPSILON);
+    }
+}

--- a/crates/ff-preview/src/timeline/state.rs
+++ b/crates/ff-preview/src/timeline/state.rs
@@ -10,9 +10,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use ff_filter::AnimationTrack;
+use ff_filter::{AnimationTrack, RealtimeLayerDescriptor};
 use ff_format::VideoFrame;
-use ff_pipeline::Clip;
 
 use crate::audio::AudioTrackHandle;
 use crate::playback::SwsRgbaConverter;
@@ -44,11 +43,15 @@ pub(super) struct ClipState {
     pub(super) speed: f64,
     /// Per-clip opacity for overlay compositing (`1.0` = fully opaque).
     /// V1 base opacity is pre-multiplied host-side; overlay opacity is applied by
-    /// the composer via [`Clip::realtime_layer`].
+    /// the composer via the layer descriptor.
     pub(super) opacity: f32,
-    /// The source clip — provides the per-clip effect chain and blend mode for
-    /// the real-time compositor via [`Clip::realtime_layer`].
-    pub(super) clip: Clip,
+    /// Dimension-free compositing description (per-clip effect chain, blend mode,
+    /// opacity/position tracks). The runner realises it into a `RealtimeLayer`
+    /// each frame via [`RealtimeLayer::with_dimensions`](ff_filter::RealtimeLayer::with_dimensions).
+    pub(super) layer_desc: RealtimeLayerDescriptor,
+    /// Per-clip volume automation (dB, timeline-global). When `Some`, the runner
+    /// updates the primary-track mixer gain each tick.
+    pub(super) volume_track: Option<AnimationTrack<f64>>,
 }
 
 // ── TransitionState ───────────────────────────────────────────────────────────

--- a/docs/specs/engine-and-primitives.md
+++ b/docs/specs/engine-and-primitives.md
@@ -101,8 +101,8 @@ to `avio`. This avoids exposing `ff-preview` internals (`MasterClock`, `SwsRgbaC
 **Scene types (defined in `ff-preview`, primitive; `avio` constructs them from `Timeline`/`Clip`):**
 
 ```
-Scene { fps, canvas: Option<(u32,u32)>, video_layers: Vec<SceneVideoLayer>, audio_tracks: Vec<SceneAudioTrack> }
-SceneVideoLayer { placements: Vec<ScenePlacement> }        // layer 0 = V1 base, 1.. = overlays
+Scene { fps, canvas: Option<(u32,u32)>, video_tracks: Vec<SceneVideoTrack>, audio_tracks: Vec<SceneAudioTrack> }
+SceneVideoTrack { placements: Vec<ScenePlacement> }        // track 0 = V1 base, 1.. = overlays (index = composite order)
 ScenePlacement  { source: PathBuf, timeline_offset: Duration, in_point: Duration,
                   out_point: Option<Duration>, speed: f64, transition_dur: Duration (V1 only),
                   opacity: f32, layer: RealtimeLayerDescriptor,


### PR DESCRIPTION
## Objective

- `TimelineRunner`/`TimelinePlayer` consumed `ff_pipeline::Timeline`/`Clip` directly (a whole `Clip` was cloned into every `ClipState` and read each tick), coupling `ff-preview` to the editing model.
- Slice B of the Scene-decouple for #1329: have the runner consume a model-agnostic primitive instead, without moving the runner (which would force `MasterClock`/`SwsRgbaConverter`/`PlayerHandle::for_timeline` public).

## Solution

- Define a primitive `Scene` in `ff-preview` (`Scene`, `SceneVideoTrack`, `ScenePlacement`, `SceneAudioTrack`, `SceneAudioPlacement`). It is a projection of the model: primitives only (paths, durations, opacity, blend, animation tracks, and the dimension-free `RealtimeLayerDescriptor`). Media resolution (probing for duration / audio / frame size) stays in the runner's open path, so a Scene re-derived on every edit needs no re-probe and behaviour is preserved.
- `ClipState` holds a `RealtimeLayerDescriptor` + volume track instead of a `Clip`; the per-tick path builds the layer via `RealtimeLayer::with_dimensions`.
- Split `open` into `open_scene(&Scene)` plus a temporary `Timeline -> Scene` adapter behind the `timeline` feature; `PlayerCommand::UpdateLayout` and `PlayerHandle::update_scene` carry a `Scene`.
- Add `Clip::realtime_layer_descriptor` in `ff-pipeline`; `realtime_layer` now delegates to it.
- Name both scene units `...Track` (video and audio), matching timeline conventions; `layer` is reserved for the per-frame `RealtimeLayer`.
- Behaviour-preserving: verified by the runner integration tests (run with `--ignored` against the media asset), the duration-math equivalence, and the `avio-examples` harness.

## Notes

- The temporary `open(&Timeline)` / `from_timeline` adapter keeps a `Timeline` mention behind the `timeline` feature. Full removal of `ff-preview`'s model dependency lands in the model relocation (slice C), so this references rather than closes the issue.

Refs #1340 #1329 #1326