### PR TITLE
chore(examples): add multitrack, transition, and keyframe harness scenarios

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,9 @@ Each script generates a small synthetic clip by default, so it runs with no setu
 ```bash
 cargo run -p avio-examples --bin single_clip_import
 cargo run -p avio-examples --bin single_clip_export
+cargo run -p avio-examples --bin multitrack_export
+cargo run -p avio-examples --bin transition_export
+cargo run -p avio-examples --bin keyframe_export
 ```
 
 Point a script at a real media file, and keep the temp files for inspection:
@@ -50,9 +53,9 @@ A script prints one line per check and exits non-zero if any check fails.
 | Import a clip (probe + decode) | `single_clip_import` | done |
 | Export a clip (Timeline render) | `single_clip_export` | done |
 | Trim | `single_clip_trim` | TODO |
-| Multi-track composition / PiP + blend | `multitrack_compose` | TODO |
-| Transitions (`XfadeTransition`) | `transitions` | TODO |
-| Keyframe animation (`AnimationTrack`) | `keyframe_animation` | TODO |
+| Multi-track composition / PiP + blend | `multitrack_export` | done |
+| Transitions (`XfadeTransition`) | `transition_export` | done |
+| Keyframe animation (`AnimationTrack`) | `keyframe_export` | done |
 | Per-clip effects (`FilterStep`) | `effect_<name>` | TODO |
 | Preview matches export | `preview_matches_export` | TODO |
 | Audio mix + per-clip volume/fades | `audio_mix` | TODO |

--- a/examples/src/bin/keyframe_export.rs
+++ b/examples/src/bin/keyframe_export.rs
@@ -1,0 +1,79 @@
+//! Verify keyframe animation: place a base clip on V1 and an overlay on V2 whose
+//! opacity is animated 0 -> 1 over the first second via a keyframe track, render,
+//! then re-probe the output.
+//!
+//! This exercises the animation derivation (`Clip::with_opacity_track` /
+//! `AnimationTrack` -> `Timeline::render` -> animated `colorchannelmixer` alpha)
+//! against avio alone.
+//!
+//! ```bash
+//! cargo run -p avio-examples --bin keyframe_export
+//! cargo run -p avio-examples --bin keyframe_export -- --input clip.mp4 --keep
+//! ```
+
+use std::time::Duration;
+
+use avio::{AnimationTrack, Clip, Easing, EncoderConfig, Keyframe, Timeline};
+use avio_examples::{BoxResult, Report, parse_args, resolve_input};
+
+fn main() -> BoxResult<()> {
+    let args = parse_args();
+    let tmp = tempfile::tempdir()?;
+    let input = resolve_input(&args, tmp.path())?;
+
+    let in_info = avio::open(&input)?;
+    let in_video = in_info.video_streams();
+    let Some(v) = in_video.first() else {
+        return Err("input has no video stream".into());
+    };
+    let (canvas_w, canvas_h, fps) = (v.width(), v.height(), v.fps());
+
+    // ── Overlay opacity animated 0 -> 1 over the first second ─────────────────
+    let opacity = AnimationTrack::new()
+        .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+        .push(Keyframe::new(Duration::from_secs(1), 1.0, Easing::Linear));
+
+    let output = tmp.path().join("keyframe.mp4");
+    let timeline = Timeline::builder()
+        .canvas(canvas_w, canvas_h)
+        .frame_rate(fps)
+        .video_track(vec![Clip::new(&input)])
+        .video_track(vec![Clip::new(&input).with_opacity_track(opacity)])
+        .build()?;
+    println!(
+        "rendering keyframed opacity overlay {canvas_w}x{canvas_h} {fps:.2}fps -> {}",
+        output.display()
+    );
+    timeline.render(&output, EncoderConfig::builder().build())?;
+
+    // ── Verify the rendered output ────────────────────────────────────────────
+    let size = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+    let mut report = Report::new("keyframe_export");
+    report.check("output file is non-empty", size > 0);
+
+    match avio::open(&output) {
+        Ok(out_info) => {
+            let out_video = out_info.video_streams();
+            let out_primary = out_video.first();
+            let (out_w, out_h) = out_primary.map_or((0, 0), |v| (v.width(), v.height()));
+            println!(
+                "output: {out_w}x{out_h} dur={:.3}s size={size}B",
+                out_info.duration().as_secs_f64()
+            );
+            report.check("output has a video stream", out_primary.is_some());
+            report.check(
+                "output dims match canvas",
+                out_w == canvas_w && out_h == canvas_h,
+            );
+        }
+        Err(e) => {
+            println!("  (could not re-probe output: {e})");
+            report.check("output is probeable", false);
+        }
+    }
+
+    if args.keep {
+        println!("kept temp dir: {}", tmp.keep().display());
+    }
+    report.finish()
+}

--- a/examples/src/bin/multitrack_export.rs
+++ b/examples/src/bin/multitrack_export.rs
@@ -1,0 +1,72 @@
+//! Verify multitrack composition: place a base clip on V1 and a half-opacity
+//! overlay of the same clip on V2, render the composite, then re-probe the
+//! output and check its dimensions.
+//!
+//! This exercises the multi-layer composition derivation (`Timeline::render` ->
+//! `MultiTrackComposer`) against avio alone through the public facade.
+//!
+//! ```bash
+//! cargo run -p avio-examples --bin multitrack_export
+//! cargo run -p avio-examples --bin multitrack_export -- --input clip.mp4 --keep
+//! ```
+
+use avio::{Clip, EncoderConfig, Timeline};
+use avio_examples::{BoxResult, Report, parse_args, resolve_input};
+
+fn main() -> BoxResult<()> {
+    let args = parse_args();
+    let tmp = tempfile::tempdir()?;
+    let input = resolve_input(&args, tmp.path())?;
+
+    let in_info = avio::open(&input)?;
+    let in_video = in_info.video_streams();
+    let Some(v) = in_video.first() else {
+        return Err("input has no video stream".into());
+    };
+    let (canvas_w, canvas_h, fps) = (v.width(), v.height(), v.fps());
+
+    // ── Build a two-track timeline: V1 base + V2 half-opacity overlay ──────────
+    let output = tmp.path().join("multitrack.mp4");
+    let timeline = Timeline::builder()
+        .canvas(canvas_w, canvas_h)
+        .frame_rate(fps)
+        .video_track(vec![Clip::new(&input)])
+        .video_track(vec![Clip::new(&input).with_opacity(0.5)])
+        .build()?;
+    println!(
+        "rendering 2-track composite {canvas_w}x{canvas_h} {fps:.2}fps -> {}",
+        output.display()
+    );
+    timeline.render(&output, EncoderConfig::builder().build())?;
+
+    // ── Verify the rendered output ────────────────────────────────────────────
+    let size = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+    let mut report = Report::new("multitrack_export");
+    report.check("output file is non-empty", size > 0);
+
+    match avio::open(&output) {
+        Ok(out_info) => {
+            let out_video = out_info.video_streams();
+            let out_primary = out_video.first();
+            let (out_w, out_h) = out_primary.map_or((0, 0), |v| (v.width(), v.height()));
+            println!(
+                "output: {out_w}x{out_h} dur={:.3}s size={size}B",
+                out_info.duration().as_secs_f64()
+            );
+            report.check("output has a video stream", out_primary.is_some());
+            report.check(
+                "composite dims match canvas",
+                out_w == canvas_w && out_h == canvas_h,
+            );
+        }
+        Err(e) => {
+            println!("  (could not re-probe output: {e})");
+            report.check("output is probeable", false);
+        }
+    }
+
+    if args.keep {
+        println!("kept temp dir: {}", tmp.keep().display());
+    }
+    report.finish()
+}

--- a/examples/src/bin/transition_export.rs
+++ b/examples/src/bin/transition_export.rs
@@ -1,0 +1,80 @@
+//! Verify an inter-clip transition: place two clips on V1 with a crossfade from
+//! the first into the second, render, then re-probe the output.
+//!
+//! This exercises the transition derivation (`Clip::with_transition` ->
+//! `Timeline::render` -> `FilterStep::XFade`) against avio alone.
+//!
+//! ```bash
+//! cargo run -p avio-examples --bin transition_export
+//! cargo run -p avio-examples --bin transition_export -- --input clip.mp4 --keep
+//! ```
+
+use std::time::Duration;
+
+use avio::{Clip, EncoderConfig, Timeline, XfadeTransition};
+use avio_examples::{BoxResult, Report, parse_args, resolve_input};
+
+fn main() -> BoxResult<()> {
+    let args = parse_args();
+    let tmp = tempfile::tempdir()?;
+    let input = resolve_input(&args, tmp.path())?;
+
+    let in_info = avio::open(&input)?;
+    let in_video = in_info.video_streams();
+    let Some(v) = in_video.first() else {
+        return Err("input has no video stream".into());
+    };
+    let (canvas_w, canvas_h, fps) = (v.width(), v.height(), v.fps());
+
+    // ── Two 1s clips with a 0.5s crossfade overlap on V1 ──────────────────────
+    let clip_len = Duration::from_secs(1);
+    let xfade = Duration::from_millis(500);
+    let output = tmp.path().join("transition.mp4");
+    let timeline = Timeline::builder()
+        .canvas(canvas_w, canvas_h)
+        .frame_rate(fps)
+        .video_track(vec![
+            Clip::new(&input).trim(Duration::ZERO, clip_len),
+            Clip::new(&input)
+                .trim(Duration::ZERO, clip_len)
+                .offset(clip_len.saturating_sub(xfade))
+                .with_transition(XfadeTransition::Fade, xfade),
+        ])
+        .build()?;
+    println!(
+        "rendering 2-clip xfade {canvas_w}x{canvas_h} {fps:.2}fps -> {}",
+        output.display()
+    );
+    timeline.render(&output, EncoderConfig::builder().build())?;
+
+    // ── Verify the rendered output ────────────────────────────────────────────
+    let size = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+    let mut report = Report::new("transition_export");
+    report.check("output file is non-empty", size > 0);
+
+    match avio::open(&output) {
+        Ok(out_info) => {
+            let out_video = out_info.video_streams();
+            let out_primary = out_video.first();
+            let (out_w, out_h) = out_primary.map_or((0, 0), |v| (v.width(), v.height()));
+            let out_dur = out_info.duration().as_secs_f64();
+            println!("output: {out_w}x{out_h} dur={out_dur:.3}s size={size}B");
+            report.check("output has a video stream", out_primary.is_some());
+            report.check(
+                "output dims match canvas",
+                out_w == canvas_w && out_h == canvas_h,
+            );
+            // Two 1s clips overlapped by 0.5s -> ~1.5s of content.
+            report.check("output has crossfaded duration (> one clip)", out_dur > 1.0);
+        }
+        Err(e) => {
+            println!("  (could not re-probe output: {e})");
+            report.check("output is probeable", false);
+        }
+    }
+
+    if args.keep {
+        println!("kept temp dir: {}", tmp.keep().display());
+    }
+    report.finish()
+}


### PR DESCRIPTION
## Objective

- Final verification and close-out of the engine/primitive separation (#1326): confirm the editing model works end-to-end through avio after the relocation (#1329) and purification (#1330/#1331/#1332/#1337).

## Solution

- Add three self-verifying `avio-examples` bins that exercise the editing model through the `avio` facade only, each rendering a synthetic clip and re-probing the output:
  - `multitrack_export`: base clip on V1 + half-opacity overlay on V2 (multi-layer composition).
  - `transition_export`: two V1 clips with a crossfade (`Clip::with_transition` -> `FilterStep::XFade`).
  - `keyframe_export`: an overlay whose opacity is animated 0 -> 1 via `AnimationTrack` (keyframe derivation).
- Mark the corresponding rows in the `examples/README.md` capability index as done.
- Confirmed `ff-*` are model-free (litmus re-review: no `Timeline`/`Clip` types remain; `AudioTrack`/`VideoLayer` are purified; the `Scene` seam is the approved primitive interface per §4.1).

## Notes

- All five harness bins pass (`single_clip_import`/`export` + the three new ones); `cargo check --all-targets --all-features`, clippy, and fmt are clean.
- The "in progress (#1326)" note in `CLAUDE.md` is cleared in the working copy; `CLAUDE.md` is gitignored (local AI-instructions file), so that edit is not part of this PR. No tracked doc carried an in-progress marker.
- With this, #1326 (relocation + purification) is complete and closeable; #1327 (immutable-model redesign) continues separately.

Closes #1333