### PR TITLE
feat(avio): add an Editor with snapshot history for Do/Undo/Redo

### DIFF
--- a/crates/avio/src/editor.rs
+++ b/crates/avio/src/editor.rs
@@ -1,0 +1,189 @@
+//! Undo/redo history over the immutable [`Timeline`] document.
+//!
+//! An [`Editor`] holds a linear history of `Timeline` versions and a cursor into
+//! it. [`Editor::apply`] runs a [`Command`] (via the pure
+//! [`apply`](crate::apply)) and pushes the resulting version;
+//! [`Editor::undo`] / [`Editor::redo`] move the cursor. This is the stateful
+//! Do/Undo/Redo layer on top of the value-based edit API; the model itself stays
+//! immutable.
+//!
+//! History is stored as full snapshots — one `Timeline` clone per edit. This is
+//! simple and correct but grows with the number of edits; structural-sharing /
+//! diff-based history is a later optimisation (#1352).
+
+use crate::edit::{Command, EditError};
+use crate::timeline::Timeline;
+
+/// A stateful editing session: an undo/redo history of [`Timeline`] versions.
+///
+/// The version at the internal cursor is the current one. Applying a [`Command`]
+/// discards any redo tail and pushes a new version; [`undo`](Self::undo) /
+/// [`redo`](Self::redo) move the cursor without dropping versions.
+#[derive(Debug)]
+pub struct Editor {
+    /// Version history; `history[cursor]` is current. Always non-empty.
+    history: Vec<Timeline>,
+    /// Index of the current version within `history`.
+    cursor: usize,
+}
+
+impl Editor {
+    /// Starts an editing session at `initial`.
+    #[must_use]
+    pub fn new(initial: Timeline) -> Self {
+        Self {
+            history: vec![initial],
+            cursor: 0,
+        }
+    }
+
+    /// The current [`Timeline`] version.
+    #[must_use]
+    pub fn current(&self) -> &Timeline {
+        &self.history[self.cursor]
+    }
+
+    /// Applies `command` to the current version and makes the result current.
+    ///
+    /// Any redo history (versions after the cursor) is discarded first. On an
+    /// invalid edit the history is left completely unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`EditError`] from [`apply`](crate::apply) when the command
+    /// cannot be applied; the history is not modified in that case.
+    pub fn apply(&mut self, command: &Command) -> Result<&Timeline, EditError> {
+        // Compute the new version first: if this fails, `?` returns before any
+        // history mutation, so a rejected edit never disturbs undo/redo state.
+        let next = crate::edit::apply(&self.history[self.cursor], command)?;
+        self.history.truncate(self.cursor + 1);
+        self.history.push(next);
+        self.cursor += 1;
+        Ok(&self.history[self.cursor])
+    }
+
+    /// Moves back one version and returns it, or `None` at the start of history.
+    pub fn undo(&mut self) -> Option<&Timeline> {
+        if self.cursor == 0 {
+            return None;
+        }
+        self.cursor -= 1;
+        Some(&self.history[self.cursor])
+    }
+
+    /// Moves forward one version and returns it, or `None` at the end of history.
+    pub fn redo(&mut self) -> Option<&Timeline> {
+        if self.cursor + 1 >= self.history.len() {
+            return None;
+        }
+        self.cursor += 1;
+        Some(&self.history[self.cursor])
+    }
+
+    /// Whether [`undo`](Self::undo) would move to an earlier version.
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        self.cursor > 0
+    }
+
+    /// Whether [`redo`](Self::redo) would move to a later version.
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        self.cursor + 1 < self.history.len()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::Clip;
+
+    fn timeline(fps: f64) -> Timeline {
+        Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(fps)
+            .video_track(vec![Clip::new("a.mp4")])
+            .build()
+            .unwrap()
+    }
+
+    fn set_fps(fps: f64) -> Command {
+        Command::SetFrameRate { fps }
+    }
+
+    #[test]
+    fn editor_new_should_start_with_no_undo_or_redo() {
+        let ed = Editor::new(timeline(30.0));
+        assert!(!ed.can_undo());
+        assert!(!ed.can_redo());
+        assert!((ed.current().frame_rate() - 30.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn editor_apply_should_advance_and_enable_undo() {
+        let mut ed = Editor::new(timeline(30.0));
+        let cur = ed.apply(&set_fps(24.0)).unwrap();
+        assert!((cur.frame_rate() - 24.0).abs() < f64::EPSILON);
+        assert!(ed.can_undo());
+        assert!(!ed.can_redo());
+    }
+
+    #[test]
+    fn editor_undo_should_restore_previous_version() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        let prev = ed.undo().unwrap();
+        assert!((prev.frame_rate() - 30.0).abs() < f64::EPSILON);
+        assert!(!ed.can_undo());
+        assert!(ed.can_redo());
+    }
+
+    #[test]
+    fn editor_redo_should_reapply_the_undone_version() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.undo().unwrap();
+        let next = ed.redo().unwrap();
+        assert!((next.frame_rate() - 24.0).abs() < f64::EPSILON);
+        assert!(!ed.can_redo());
+    }
+
+    #[test]
+    fn editor_undo_at_start_should_return_none() {
+        let mut ed = Editor::new(timeline(30.0));
+        assert!(ed.undo().is_none());
+        assert!((ed.current().frame_rate() - 30.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn editor_redo_at_end_should_return_none() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        assert!(ed.redo().is_none());
+    }
+
+    #[test]
+    fn editor_new_edit_after_undo_should_truncate_redo() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.apply(&set_fps(48.0)).unwrap();
+        ed.undo().unwrap(); // back to the 24.0 version; 48.0 is now the redo tail
+        let cur = ed.apply(&set_fps(60.0)).unwrap(); // must discard the 48.0 redo
+        assert!((cur.frame_rate() - 60.0).abs() < f64::EPSILON);
+        assert!(!ed.can_redo());
+        assert!(ed.redo().is_none());
+    }
+
+    #[test]
+    fn editor_apply_error_should_leave_history_unchanged() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        let err = ed.apply(&set_fps(0.0)).unwrap_err(); // invalid: fps <= 0
+        assert_eq!(err, EditError::InvalidFrameRate(0.0));
+        // History untouched: still one edit deep, no redo, current is the 24.0 version.
+        assert!(ed.can_undo());
+        assert!(!ed.can_redo());
+        assert!((ed.current().frame_rate() - 24.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -305,6 +305,8 @@ mod clip;
 #[cfg(feature = "pipeline")]
 mod edit;
 #[cfg(feature = "pipeline")]
+mod editor;
+#[cfg(feature = "pipeline")]
 mod error;
 #[cfg(feature = "pipeline")]
 mod timeline;
@@ -313,6 +315,8 @@ mod timeline;
 pub use clip::{Clip, VideoEffectRenderer};
 #[cfg(feature = "pipeline")]
 pub use edit::{ClipProperty, Command, EditError, TrackId, TrackKind, apply};
+#[cfg(feature = "pipeline")]
+pub use editor::Editor;
 #[cfg(feature = "pipeline")]
 pub use error::TimelineError;
 #[cfg(feature = "pipeline")]


### PR DESCRIPTION
## Objective

- Build the stateful Do/Undo/Redo layer on top of the value-based edit API (#1348). Second step of #1327 (immutable-model redesign, design: `docs/specs/engine-and-primitives.md` §2.1).

## Solution

- New `avio::Editor`: holds a linear history of `Timeline` versions plus a cursor. `apply` runs a `Command` via the pure `apply` and pushes the new version (discarding any redo tail); `undo`/`redo` move the cursor; `can_undo`/`can_redo`/`current` round out the API.
- A failed edit is computed before any history mutation, so a rejected `Command` never disturbs undo/redo state; current-version indexing is safe by the non-empty-history invariant.
- History is snapshot-based and unbounded (structural sharing is the deferred optimisation #1352), documented on the type.
- Re-exported from `avio`; 8 unit tests including redo truncation, the undo/redo boundaries, and history-unchanged-on-error.

## Notes

- Additive only — the edit API and the model are untouched; behaviour-preserving and always-green.
- `Editor` derives only `Debug` (not `Clone`): cloning would deep-copy the whole history and has no consumer; adding `Clone` later (e.g. for session forking) is a non-breaking change.

Closes #1349