### PR TITLE
refactor(avio): single derive for the video layer (preview == export)

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -378,16 +378,11 @@ impl Clip {
     /// [`RealtimeLayer::with_dimensions`].
     #[must_use]
     pub fn realtime_layer_descriptor(&self) -> RealtimeLayerDescriptor {
-        RealtimeLayerDescriptor {
-            effects: self.video_effect_chain(),
-            opacity: self.opacity,
-            opacity_track: self.opacity_track.clone(),
-            x: self.x,
-            y: self.y,
-            x_track: self.x_track.clone(),
-            y_track: self.y_track.clone(),
-            blend_mode: self.blend_mode,
-        }
+        // One code path: the per-clip descriptor is the shared derive with no
+        // timeline-level animations (track index 0, empty map) — so a per-clip
+        // keyframe or static value still applies, and the shape matches the export
+        // `VideoLayer`.
+        crate::derive::realtime_descriptor(self, 0, &std::collections::HashMap::new())
     }
 
     /// Attaches an audio [`FilterStep`] to this clip and returns the updated clip.
@@ -1179,7 +1174,9 @@ mod tests {
         assert_eq!(layer.width, 640);
         assert_eq!(layer.height, 480);
         assert_eq!(layer.pixel_format, PixelFormat::Yuv420p);
-        assert!((layer.opacity - 0.5).abs() < 1e-6);
+        assert!(
+            matches!(layer.opacity, ff_filter::AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-6)
+        );
         assert_eq!(layer.blend_mode, BlendMode::Screen);
         // The layer's effects are exactly `video_effect_chain()` (Eq + Hue).
         assert!(matches!(

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -17,7 +17,10 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use ff_filter::{AnimatedValue, AnimationTrack, AudioTrack, FilterStep, ProxySource, VideoLayer};
+use ff_filter::{
+    AnimatedValue, AnimationTrack, AudioTrack, BlendMode, CompositeOp, FilterStep, ProxySource,
+    RealtimeLayerDescriptor, VideoLayer,
+};
 use ff_format::ChannelLayout;
 
 use crate::clip::Clip;
@@ -36,6 +39,65 @@ fn track_animation(
         .map_or(AnimatedValue::Static(default), |t| {
             AnimatedValue::Track(t.clone())
         })
+}
+
+/// The per-clip video transform shared by the export [`VideoLayer`] and the
+/// preview [`RealtimeLayerDescriptor`]: the 3-way-merged opacity/position, the
+/// scale/rotation, and the blend/composite operators. This is the single
+/// interpretation both executors consume; only the temporal steps (trim/offset/
+/// speed) and the cross-fade differ between the two paths.
+struct VideoTransform {
+    opacity: AnimatedValue<f64>,
+    x: AnimatedValue<f64>,
+    y: AnimatedValue<f64>,
+    scale_x: AnimatedValue<f64>,
+    scale_y: AnimatedValue<f64>,
+    rotation: AnimatedValue<f64>,
+    blend_mode: BlendMode,
+    composite_op: CompositeOp,
+}
+
+/// Computes the shared [`VideoTransform`]: a per-clip keyframe track wins, then a
+/// static non-neutral value, then any timeline track-level animation.
+fn video_transform(
+    clip: &Clip,
+    track_idx: usize,
+    animations: &HashMap<String, AnimationTrack<f64>>,
+) -> VideoTransform {
+    #[allow(clippy::float_cmp)]
+    let opacity = if let Some(track) = &clip.opacity_track {
+        AnimatedValue::Track(track.clone())
+    } else if clip.opacity != 1.0 {
+        AnimatedValue::Static(f64::from(clip.opacity))
+    } else {
+        track_animation(animations, "video", track_idx, "opacity", 1.0)
+    };
+    #[allow(clippy::float_cmp)]
+    let x = if let Some(track) = &clip.x_track {
+        AnimatedValue::Track(track.clone())
+    } else if clip.x != 0.0 {
+        AnimatedValue::Static(clip.x)
+    } else {
+        track_animation(animations, "video", track_idx, "x", 0.0)
+    };
+    #[allow(clippy::float_cmp)]
+    let y = if let Some(track) = &clip.y_track {
+        AnimatedValue::Track(track.clone())
+    } else if clip.y != 0.0 {
+        AnimatedValue::Static(clip.y)
+    } else {
+        track_animation(animations, "video", track_idx, "y", 0.0)
+    };
+    VideoTransform {
+        opacity,
+        x,
+        y,
+        scale_x: track_animation(animations, "video", track_idx, "scale_x", 1.0),
+        scale_y: track_animation(animations, "video", track_idx, "scale_y", 1.0),
+        rotation: track_animation(animations, "video", track_idx, "rotation", 0.0),
+        blend_mode: clip.blend_mode,
+        composite_op: clip.composite_op,
+    }
 }
 
 /// Derives the export [`VideoLayer`] for one clip.
@@ -93,46 +155,48 @@ pub(crate) fn video_layer(
         }
     }
 
-    // Per-clip opacity/position: an explicit keyframe track wins, then a static
-    // non-neutral value, then any track-level animation.
-    #[allow(clippy::float_cmp)]
-    let opacity = if let Some(track) = &clip.opacity_track {
-        AnimatedValue::Track(track.clone())
-    } else if clip.opacity != 1.0 {
-        AnimatedValue::Static(f64::from(clip.opacity))
-    } else {
-        track_animation(animations, "video", track_idx, "opacity", 1.0)
-    };
-    #[allow(clippy::float_cmp)]
-    let x = if let Some(track) = &clip.x_track {
-        AnimatedValue::Track(track.clone())
-    } else if clip.x != 0.0 {
-        AnimatedValue::Static(clip.x)
-    } else {
-        track_animation(animations, "video", track_idx, "x", 0.0)
-    };
-    #[allow(clippy::float_cmp)]
-    let y = if let Some(track) = &clip.y_track {
-        AnimatedValue::Track(track.clone())
-    } else if clip.y != 0.0 {
-        AnimatedValue::Static(clip.y)
-    } else {
-        track_animation(animations, "video", track_idx, "y", 0.0)
-    };
-
+    let transform = video_transform(clip, track_idx, animations);
     VideoLayer {
         source: clip.source.clone(),
         proxy,
         input_format: None,
-        x,
-        y,
-        scale_x: track_animation(animations, "video", track_idx, "scale_x", 1.0),
-        scale_y: track_animation(animations, "video", track_idx, "scale_y", 1.0),
-        rotation: track_animation(animations, "video", track_idx, "rotation", 0.0),
-        opacity,
-        blend_mode: clip.blend_mode,
-        composite_op: clip.composite_op,
+        x: transform.x,
+        y: transform.y,
+        scale_x: transform.scale_x,
+        scale_y: transform.scale_y,
+        rotation: transform.rotation,
+        opacity: transform.opacity,
+        blend_mode: transform.blend_mode,
+        composite_op: transform.composite_op,
         effects: layer_effects,
+    }
+}
+
+/// Derives the preview [`RealtimeLayerDescriptor`] for one clip.
+///
+/// Uses the same [`VideoTransform`] as [`video_layer`] (so both paths share one
+/// interpretation), but carries only the per-clip effect chain: the temporal
+/// steps (trim/offset/speed) and the cross-fade are omitted because the preview
+/// runner realises them from `ScenePlacement` (in/out points, speed, transition).
+///
+/// The timeline-level `lavfi_overlay` and a clip's `input_format` are not projected
+/// here (preview drops them today); closing that is C4d, not this backbone.
+pub(crate) fn realtime_descriptor(
+    clip: &Clip,
+    track_idx: usize,
+    animations: &HashMap<String, AnimationTrack<f64>>,
+) -> RealtimeLayerDescriptor {
+    let transform = video_transform(clip, track_idx, animations);
+    RealtimeLayerDescriptor {
+        effects: clip.video_effect_chain(),
+        opacity: transform.opacity,
+        x: transform.x,
+        y: transform.y,
+        scale_x: transform.scale_x,
+        scale_y: transform.scale_y,
+        rotation: transform.rotation,
+        blend_mode: transform.blend_mode,
+        composite_op: transform.composite_op,
     }
 }
 
@@ -408,5 +472,79 @@ mod tests {
         let clip = Clip::new("a.mp3");
         let track = audio_track(&clip, 0, &anims, None);
         assert!(matches!(track.pan, AnimatedValue::Track(_)));
+    }
+
+    // ── realtime_descriptor (single derive → preview) ─────────────────────────
+
+    #[test]
+    fn realtime_descriptor_should_carry_no_temporal_or_xfade_steps() {
+        // The preview runner realises trim/offset/speed/xfade from `ScenePlacement`;
+        // the descriptor must carry only the per-clip effect chain.
+        let clip = Clip::new("a.mp4")
+            .trim(Duration::from_secs(1), Duration::from_secs(3))
+            .offset(Duration::from_secs(2))
+            .with_speed(2.0)
+            .with_transition(XfadeTransition::Fade, Duration::from_millis(500));
+        let d = realtime_descriptor(&clip, 0, &no_anim());
+        assert!(!d.effects.iter().any(|s| matches!(
+            s,
+            FilterStep::Trim { .. }
+                | FilterStep::ResetPts
+                | FilterStep::OffsetPts { .. }
+                | FilterStep::Speed { .. }
+                | FilterStep::XFade { .. }
+        )));
+    }
+
+    #[test]
+    fn realtime_descriptor_should_carry_effect_chain() {
+        let mut clip = Clip::new("a.mp4");
+        clip.brightness = 0.5; // forces an Eq step in `video_effect_chain`
+        let d = realtime_descriptor(&clip, 0, &no_anim());
+        assert!(d.effects.iter().any(|s| matches!(s, FilterStep::Eq { .. })));
+    }
+
+    #[test]
+    fn realtime_descriptor_should_pick_up_timeline_scale_and_rotation() {
+        let mut anims = HashMap::new();
+        anims.insert(
+            "video_1_scale_x".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+        );
+        anims.insert(
+            "video_1_rotation".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 90.0, Easing::Linear)),
+        );
+        let clip = Clip::new("a.mp4");
+        let d = realtime_descriptor(&clip, 1, &anims);
+        assert!(matches!(d.scale_x, AnimatedValue::Track(_)));
+        assert!(matches!(d.rotation, AnimatedValue::Track(_)));
+        assert!(matches!(d.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+    }
+
+    #[test]
+    fn realtime_descriptor_opacity_should_fall_back_to_timeline_animation() {
+        // A neutral per-clip opacity (1.0) falls through to the timeline track.
+        let mut anims = HashMap::new();
+        anims.insert(
+            "video_0_opacity".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 1.0, Easing::Linear)),
+        );
+        let clip = Clip::new("a.mp4");
+        let d = realtime_descriptor(&clip, 0, &anims);
+        assert!(matches!(d.opacity, AnimatedValue::Track(_)));
+    }
+
+    #[test]
+    fn realtime_descriptor_static_opacity_should_win_over_timeline() {
+        // A per-clip static non-neutral opacity wins the 3-way merge.
+        let mut anims = HashMap::new();
+        anims.insert(
+            "video_0_opacity".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.2, Easing::Linear)),
+        );
+        let clip = Clip::new("a.mp4").with_opacity(0.5);
+        let d = realtime_descriptor(&clip, 0, &anims);
+        assert!(matches!(d.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
 }

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -647,7 +647,12 @@ impl TimelineBuilder {
 /// `is_base` selects the V1 base track, where a crossfade transition contributes a
 /// `transition_dur`; overlays force zero (matching the compositor).
 #[cfg(feature = "preview")]
-fn video_placement(clip: &Clip, is_base: bool) -> ff_preview::ScenePlacement {
+fn video_placement(
+    clip: &Clip,
+    track_idx: usize,
+    is_base: bool,
+    animations: &HashMap<String, AnimationTrack<f64>>,
+) -> ff_preview::ScenePlacement {
     let transition_dur = if is_base && clip.transition.is_some() {
         clip.transition_duration
     } else {
@@ -661,7 +666,10 @@ fn video_placement(clip: &Clip, is_base: bool) -> ff_preview::ScenePlacement {
         speed: clip.speed.max(0.01),
         transition_dur,
         opacity: clip.opacity.clamp(0.0, 1.0),
-        layer: clip.realtime_layer_descriptor(),
+        // The single derive: preview and export build their video layers from the
+        // same `avio::derive`, so the timeline-level animations (scale/rotation and
+        // the opacity/x/y track-level fallbacks) reach the preview too.
+        layer: crate::derive::realtime_descriptor(clip, track_idx, animations),
         fade_in: clip.fade_in,
         fade_out: clip.fade_out,
         volume_db: clip.volume_db,
@@ -702,7 +710,9 @@ impl Timeline {
             .map(|(track_idx, track)| ff_preview::SceneVideoTrack {
                 placements: track
                     .iter()
-                    .map(|clip| video_placement(clip, track_idx == 0))
+                    .map(|clip| {
+                        video_placement(clip, track_idx, track_idx == 0, &self.video_animations)
+                    })
                     .collect(),
             })
             .collect();
@@ -782,7 +792,9 @@ mod tests {
             "clip 0 has no transition"
         );
         assert!(base.volume_track.is_some());
-        assert!((base.layer.opacity - 0.5).abs() < f32::EPSILON);
+        assert!(
+            matches!(base.layer.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < f64::EPSILON)
+        );
 
         let base1 = &scene.video_tracks[0].placements[1];
         assert_eq!(base1.transition_dur, Duration::from_millis(750));
@@ -799,6 +811,41 @@ mod tests {
         assert_eq!(audio.fade_in, Duration::from_millis(200));
         assert_eq!(audio.fade_out, Duration::from_millis(300));
         assert!((audio.volume_db - (-6.0)).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_route_timeline_animations_into_the_preview_layer() {
+        use ff_filter::{AnimatedValue, Easing, Keyframe};
+
+        // Track 1 (overlay) gets timeline scale_x + rotation animations, and an opacity
+        // animation the neutral clip should fall back to (the 3-way merge). The single
+        // derive must route all three into the preview placement's layer.
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("base.mp4")])
+            .video_track(vec![Clip::new("overlay.mp4")])
+            .video_animation(
+                "video_1_scale_x",
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+            )
+            .video_animation(
+                "video_1_rotation",
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 45.0, Easing::Linear)),
+            )
+            .video_animation(
+                "video_1_opacity",
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 1.0, Easing::Linear)),
+            )
+            .build()
+            .unwrap();
+
+        let scene = timeline.to_scene();
+        let overlay = &scene.video_tracks[1].placements[0];
+        assert!(matches!(overlay.layer.scale_x, AnimatedValue::Track(_)));
+        assert!(matches!(overlay.layer.rotation, AnimatedValue::Track(_)));
+        assert!(matches!(overlay.layer.opacity, AnimatedValue::Track(_)));
     }
 
     #[test]

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1119,22 +1119,64 @@ pub(super) unsafe fn build_realtime_composition(
         let Some(top_src) = src_ctxs[idx] else {
             bail!(graph, format!("missing buffersrc for layer={idx}"));
         };
-        // Scale the top layer to the canvas size first, then apply its effects.
-        let mut top_steps: Vec<FilterStep> = Vec::with_capacity(layer.effects.len() + 1);
+        // Scale the top layer to the canvas size first, then apply the engine-derived
+        // static transform (scale multiplier + rotation, evaluated at t=0 to match the
+        // export path — animated scale/rotate are not honoured on either side), then
+        // its per-clip effects.
+        let mut top_steps: Vec<FilterStep> = Vec::with_capacity(layer.effects.len() + 3);
         top_steps.push(FilterStep::Scale {
             width: canvas_w,
             height: canvas_h,
             algorithm: ScaleAlgorithm::Fast,
         });
+        let sx = layer.scale_x.value_at(Duration::ZERO);
+        let sy = layer.scale_y.value_at(Duration::ZERO);
+        if (sx - 1.0).abs() > f64::EPSILON || (sy - 1.0).abs() > f64::EPSILON {
+            // Force-scaled to the canvas above, so the multiplier maps to
+            // `canvas * scale` — the same target dimensions the export path uses.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let sw = ((f64::from(canvas_w) * sx).round() as u32).max(1);
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let sh = ((f64::from(canvas_h) * sy).round() as u32).max(1);
+            top_steps.push(FilterStep::Scale {
+                width: sw,
+                height: sh,
+                algorithm: ScaleAlgorithm::Bicubic,
+            });
+        }
+        let rotation_deg = layer.rotation.value_at(Duration::ZERO);
+        if rotation_deg.abs() > f64::EPSILON {
+            top_steps.push(FilterStep::RotateAnimated {
+                angle: AnimatedValue::Static(rotation_deg),
+                fill_color: "black".to_string(),
+            });
+        }
         top_steps.extend(layer.effects.iter().cloned());
         acc = if layer.blend_mode == BlendMode::Normal {
+            // Lower the engine's `AnimatedValue` opacity/position to the existing
+            // blend parameters (static value, or a track wired for `send_command`).
+            #[allow(clippy::cast_possible_truncation)]
+            let (opacity, opacity_track) = match &layer.opacity {
+                // Clamp the static value to [0,1] before it reaches the blend args,
+                // matching the export path (`build_video_composition`).
+                AnimatedValue::Static(v) => ((*v).clamp(0.0, 1.0) as f32, None),
+                AnimatedValue::Track(t) => (1.0, Some(t)),
+            };
+            let (x, x_track) = match &layer.x {
+                AnimatedValue::Static(v) => (*v, None),
+                AnimatedValue::Track(t) => (0.0, Some(t)),
+            };
+            let (y, y_track) = match &layer.y {
+                AnimatedValue::Static(v) => (*v, None),
+                AnimatedValue::Track(t) => (0.0, Some(t)),
+            };
             let params = crate::filter_inner::NormalBlendParams {
-                opacity: layer.opacity,
-                opacity_track: layer.opacity_track.as_ref(),
-                x: layer.x,
-                y: layer.y,
-                x_track: layer.x_track.as_ref(),
-                y_track: layer.y_track.as_ref(),
+                opacity,
+                opacity_track,
+                x,
+                y,
+                x_track,
+                y_track,
                 alpha: ff_format::AlphaMode::Straight,
             };
             match crate::filter_inner::add_blend_normal_step(
@@ -1151,13 +1193,16 @@ pub(super) unsafe fn build_realtime_composition(
             }
         } else {
             let mode_name = blend_mode_to_ffmpeg(layer.blend_mode);
+            // Clamp to [0,1] before `all_opacity`, matching the export path.
+            #[allow(clippy::cast_possible_truncation)]
+            let opacity = layer.opacity.value_at(Duration::ZERO).clamp(0.0, 1.0) as f32;
             match crate::filter_inner::add_blend_photographic_step(
                 graph,
                 acc,
                 top_src.as_ptr(),
                 &top_steps,
                 mode_name,
-                layer.opacity,
+                opacity,
                 idx,
             ) {
                 Ok(c) => c,

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -12,8 +12,9 @@
 
 use ff_format::{PixelFormat, VideoFrame};
 
-use crate::animation::AnimationTrack;
+use crate::animation::AnimatedValue;
 use crate::blend::BlendMode;
+use crate::composite::CompositeOp;
 use crate::error::FilterError;
 use crate::graph::filter_step::FilterStep;
 use crate::graph::graph::FilterGraph;
@@ -38,31 +39,32 @@ pub struct RealtimeLayer {
     /// Per-clip video effect chain applied to this layer before compositing
     /// (the same `FilterStep`s as `Clip::video_effect_chain` / the export path).
     pub effects: Vec<FilterStep>,
-    /// Opacity in `[0.0, 1.0]`. Applied when this layer is blended onto the layer
-    /// below it (no effect on the base layer 0 — apply base opacity host-side).
-    pub opacity: f32,
-    /// Optional keyframe track animating this layer's opacity (Normal blend only).
-    ///
-    /// When `Some`, the `colorchannelmixer` alpha node is always created (even at
-    /// initial opacity `1.0`) and registered for per-frame `send_command`, so a host
-    /// that pushes frames stamped with the composite's timeline PTS gets an animated
-    /// alpha. `None` keeps the static [`opacity`](Self::opacity). No effect on the
-    /// base layer 0 (apply animated base opacity host-side).
-    pub opacity_track: Option<AnimationTrack<f64>>,
-    /// Static overlay position (pixels) on the canvas. Maps to the `overlay` filter's
-    /// `x`/`y` (Normal blend only). Default `(0.0, 0.0)`. No effect on the base layer 0.
-    pub x: f64,
-    /// See [`x`](Self::x).
-    pub y: f64,
-    /// Optional keyframe tracks animating the overlay X / Y position (Normal blend).
-    /// When `Some`, the `overlay` node is created with `:eval=frame` and registered for
-    /// per-frame `send_command`. `None` keeps the static [`x`](Self::x)/[`y`](Self::y).
-    pub x_track: Option<AnimationTrack<f64>>,
-    /// See [`x_track`](Self::x_track).
-    pub y_track: Option<AnimationTrack<f64>>,
+    /// Opacity in `[0.0, 1.0]`, static or animated. Applied via `colorchannelmixer`
+    /// alpha when this layer is blended onto the layer below (Normal blend only). An
+    /// [`AnimatedValue::Track`] registers the node for per-frame `send_command`. No
+    /// effect on the base layer 0 (apply base opacity host-side).
+    pub opacity: AnimatedValue<f64>,
+    /// Overlay X position (pixels) on the canvas, static or animated. Maps to the
+    /// `overlay` filter's `x` (Normal blend only); a [`AnimatedValue::Track`] uses
+    /// `:eval=frame` + per-frame `send_command`. No effect on the base layer 0.
+    pub x: AnimatedValue<f64>,
+    /// Overlay Y position; see [`x`](Self::x).
+    pub y: AnimatedValue<f64>,
+    /// Horizontal scale multiplier, evaluated statically at t=0 (matching the export
+    /// path). `1.0` = unscaled. Applied to overlay layers before their effects.
+    pub scale_x: AnimatedValue<f64>,
+    /// Vertical scale multiplier; see [`scale_x`](Self::scale_x).
+    pub scale_y: AnimatedValue<f64>,
+    /// Rotation in degrees, evaluated statically at t=0 (matching the export path).
+    /// `0.0` = no rotation. Applied to overlay layers before their effects.
+    pub rotation: AnimatedValue<f64>,
     /// How this layer blends with the layer below. [`BlendMode::Normal`] uses
     /// `overlay`; other modes use `blend=all_mode=<token>`.
     pub blend_mode: BlendMode,
+    /// Porter-Duff composite operator. Carried for representation parity with the
+    /// export [`VideoLayer`](super::VideoLayer); the realtime builder renders `Over`
+    /// today (the other operators land in C4b).
+    pub composite_op: CompositeOp,
 }
 
 // ── RealtimeLayerDescriptor ───────────────────────────────────────────────────
@@ -79,19 +81,21 @@ pub struct RealtimeLayerDescriptor {
     /// See [`RealtimeLayer::effects`].
     pub effects: Vec<FilterStep>,
     /// See [`RealtimeLayer::opacity`].
-    pub opacity: f32,
-    /// See [`RealtimeLayer::opacity_track`].
-    pub opacity_track: Option<AnimationTrack<f64>>,
+    pub opacity: AnimatedValue<f64>,
     /// See [`RealtimeLayer::x`].
-    pub x: f64,
+    pub x: AnimatedValue<f64>,
     /// See [`RealtimeLayer::y`].
-    pub y: f64,
-    /// See [`RealtimeLayer::x_track`].
-    pub x_track: Option<AnimationTrack<f64>>,
-    /// See [`RealtimeLayer::y_track`].
-    pub y_track: Option<AnimationTrack<f64>>,
+    pub y: AnimatedValue<f64>,
+    /// See [`RealtimeLayer::scale_x`].
+    pub scale_x: AnimatedValue<f64>,
+    /// See [`RealtimeLayer::scale_y`].
+    pub scale_y: AnimatedValue<f64>,
+    /// See [`RealtimeLayer::rotation`].
+    pub rotation: AnimatedValue<f64>,
     /// See [`RealtimeLayer::blend_mode`].
     pub blend_mode: BlendMode,
+    /// See [`RealtimeLayer::composite_op`].
+    pub composite_op: CompositeOp,
 }
 
 impl RealtimeLayer {
@@ -110,12 +114,13 @@ impl RealtimeLayer {
             pixel_format,
             effects: descriptor.effects,
             opacity: descriptor.opacity,
-            opacity_track: descriptor.opacity_track,
             x: descriptor.x,
             y: descriptor.y,
-            x_track: descriptor.x_track,
-            y_track: descriptor.y_track,
+            scale_x: descriptor.scale_x,
+            scale_y: descriptor.scale_y,
+            rotation: descriptor.rotation,
             blend_mode: descriptor.blend_mode,
+            composite_op: descriptor.composite_op,
         }
     }
 }
@@ -206,26 +211,34 @@ mod tests {
     fn realtime_layer_with_dimensions_should_copy_descriptor_fields() {
         let descriptor = RealtimeLayerDescriptor {
             effects: vec![FilterStep::HFlip],
-            opacity: 0.5,
-            opacity_track: Some(AnimationTrack::new()),
-            x: 12.0,
-            y: 34.0,
-            x_track: None,
-            y_track: Some(AnimationTrack::new()),
+            opacity: AnimatedValue::Track(crate::animation::AnimationTrack::new()),
+            x: AnimatedValue::Static(12.0),
+            y: AnimatedValue::Static(34.0),
+            scale_x: AnimatedValue::Static(2.0),
+            scale_y: AnimatedValue::Static(3.0),
+            rotation: AnimatedValue::Static(45.0),
             blend_mode: BlendMode::Multiply,
+            composite_op: CompositeOp::Under,
         };
         let layer = RealtimeLayer::with_dimensions(descriptor, 640, 360, PixelFormat::Rgba);
         assert_eq!(layer.width, 640);
         assert_eq!(layer.height, 360);
         assert!(matches!(layer.pixel_format, PixelFormat::Rgba));
         assert_eq!(layer.effects.len(), 1, "effects moved into the layer");
-        assert!((layer.opacity - 0.5).abs() < f32::EPSILON);
-        assert!(layer.opacity_track.is_some());
-        assert!((layer.x - 12.0).abs() < f64::EPSILON);
-        assert!((layer.y - 34.0).abs() < f64::EPSILON);
-        assert!(layer.x_track.is_none());
-        assert!(layer.y_track.is_some());
+        assert!(matches!(layer.opacity, AnimatedValue::Track(_)));
+        assert!(matches!(layer.x, AnimatedValue::Static(v) if (v - 12.0).abs() < f64::EPSILON));
+        assert!(matches!(layer.y, AnimatedValue::Static(v) if (v - 34.0).abs() < f64::EPSILON));
+        assert!(
+            matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 2.0).abs() < f64::EPSILON)
+        );
+        assert!(
+            matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 3.0).abs() < f64::EPSILON)
+        );
+        assert!(
+            matches!(layer.rotation, AnimatedValue::Static(v) if (v - 45.0).abs() < f64::EPSILON)
+        );
         assert!(matches!(layer.blend_mode, BlendMode::Multiply));
+        assert!(matches!(layer.composite_op, CompositeOp::Under));
     }
 
     #[test]
@@ -252,13 +265,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -274,13 +288,14 @@ mod tests {
                 radius: 4.0,
                 intensity: 0.5,
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[layer])
             .expect("Glow compound step must dispatch and build once FFmpeg filters exist");
@@ -305,13 +320,14 @@ mod tests {
             height: 360,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::with_canvas(&[base], Some((1080, 1920))) {
             Ok(c) => c,
@@ -361,13 +377,14 @@ mod tests {
                     height: 1920,
                 },
             ],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
             Ok(c) => c,
@@ -408,13 +425,14 @@ mod tests {
                 height: 1920,
                 color: "black".to_string(),
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
             Ok(c) => c,
@@ -446,13 +464,14 @@ mod tests {
             height: 4,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: op,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(f64::from(op)),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[layer(1.0), layer(0.5)]) {
             Ok(c) => c,
@@ -488,26 +507,28 @@ mod tests {
             height: 4,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let top = RealtimeLayer {
             width: 8,
             height: 6,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Screen,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[base, top]) {
             Ok(c) => c,
@@ -555,13 +576,14 @@ mod tests {
                     algorithm: crate::graph::types::ScaleAlgorithm::Bilinear,
                 },
             ],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
             Ok(c) => c,
@@ -625,13 +647,14 @@ mod tests {
                 width: 4,
                 height: 6,
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
             Ok(c) => c,
@@ -683,13 +706,14 @@ mod tests {
                 path: srt.to_string_lossy().into_owned(),
                 force_style: Some("Fontsize=24,PrimaryColour=&H00FFFFFF&,Alignment=2".to_owned()),
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[base]) {
             Ok(c) => c,
@@ -726,13 +750,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -746,13 +771,14 @@ mod tests {
                 vertices: vec![(0.2, 0.1), (0.9, 0.5), (0.3, 0.9)],
                 invert: false,
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[base])
             .expect("polygon-matte geq must build once FFmpeg filters exist");
@@ -783,13 +809,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -805,13 +832,14 @@ mod tests {
                 softness: 0.1,
                 invert: true,
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[base])
             .expect("inverted lumakey must build once FFmpeg filters exist");
@@ -843,13 +871,14 @@ mod tests {
             height: 4,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -864,26 +893,28 @@ mod tests {
             height: 4,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let top = RealtimeLayer {
             width: 4,
             height: 4,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: Some(track),
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Track(track),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[base, top])
             .expect("animated-opacity composite must build once FFmpeg filters exist");
@@ -932,13 +963,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -953,26 +985,28 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let top = RealtimeLayer {
             width: 8,
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 8.0,
-            y: 0.0,
-            x_track: Some(x_track),
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Track(x_track),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[base, top])
             .expect("animated-position composite must build once FFmpeg filters exist");
@@ -1020,13 +1054,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -1046,13 +1081,14 @@ mod tests {
                 width: AnimatedValue::Static(4.0),
                 height: AnimatedValue::Static(8.0),
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[base])
             .expect("animated-crop base must build once FFmpeg filters exist");
@@ -1108,13 +1144,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -1133,13 +1170,14 @@ mod tests {
                 height: AnimatedValue::Static(8.0),
                 algorithm: ScaleAlgorithm::Bilinear,
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[base])
             .expect("animated-scale base must build once FFmpeg filters exist");
@@ -1181,13 +1219,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -1205,13 +1244,14 @@ mod tests {
                 angle: AnimatedValue::Track(angle),
                 fill_color: "black".to_string(),
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = RealtimeComposer::new(&[base])
             .expect("animated-rotate base must build once FFmpeg filters exist");
@@ -1266,13 +1306,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -1284,13 +1325,14 @@ mod tests {
             height: 8,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let top = RealtimeLayer {
             width: 8,
@@ -1300,13 +1342,14 @@ mod tests {
                 angle: AnimatedValue::Static(45.0),
                 fill_color: "none".to_string(),
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::new(&[base, top]) {
             Ok(c) => c,
@@ -1355,13 +1398,14 @@ mod tests {
             height: 360,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -1372,13 +1416,14 @@ mod tests {
             height: 360,
             pixel_format: PixelFormat::Rgba,
             effects,
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let base = mk(vec![]);
         let top = mk(vec![FilterStep::RotateAnimated {
@@ -1434,13 +1479,14 @@ mod tests {
             height: 16,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         if RealtimeComposer::new(&[probe]).is_err() {
             println!("Skipping: FFmpeg filters unavailable");
@@ -1452,13 +1498,14 @@ mod tests {
             height: 16,
             pixel_format: PixelFormat::Rgba,
             effects: vec![],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         // Overlay is 32×24 (≠ base 16×16) → real force-scale to canvas before rotate.
         let top = RealtimeLayer {
@@ -1469,13 +1516,14 @@ mod tests {
                 angle: AnimatedValue::Static(45.0),
                 fill_color: "none".to_string(),
             }],
-            opacity: 1.0,
-            opacity_track: None,
-            x: 0.0,
-            y: 0.0,
-            x_track: None,
-            y_track: None,
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
         };
         let mut composer = match RealtimeComposer::with_canvas(&[base, top], Some((16, 16))) {
             Ok(c) => c,
@@ -1504,6 +1552,97 @@ mod tests {
                     &rgba[0..4]
                 );
             }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    fn base_8x8() -> RealtimeLayer {
+        RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        }
+    }
+
+    #[test]
+    fn overlay_static_scale_should_shrink_the_overlay_and_reveal_base() {
+        // C4a: an overlay descriptor with a static `scale_x`/`scale_y` (the merged
+        // timeline transform) must build the scale node so the overlay shrinks —
+        // otherwise it would cover the whole canvas. A blue overlay at scale 0.5 over
+        // a red base covers only the top-left 4×4 quadrant, so the top-left pixel is
+        // blue but the bottom-right pixel reveals the red base. Probe-gated (CI's Linux
+        // FFmpeg has no filters), and pull is required to actually observe the effect.
+        if RealtimeComposer::new(&[base_8x8()]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+        let mut overlay = base_8x8();
+        overlay.scale_x = AnimatedValue::Static(0.5);
+        overlay.scale_y = AnimatedValue::Static(0.5);
+        let mut composer = RealtimeComposer::new(&[base_8x8(), overlay])
+            .expect("overlay scale must build once FFmpeg filters exist");
+        let red = VideoFrame::from_rgba(8, 8, [255u8, 0, 0, 255].repeat(64)).unwrap();
+        let blue = VideoFrame::from_rgba(8, 8, [0u8, 0, 255, 255].repeat(64)).unwrap();
+        if composer.push_layer(0, &red).is_err() || composer.push_layer(1, &blue).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                assert_eq!(out.width(), 8);
+                assert_eq!(out.height(), 8);
+                let rgba = out.to_rgba().expect("rgba");
+                // Top-left: the shrunk blue overlay sits here.
+                assert!(
+                    rgba[2] > 100 && rgba[0] < 100,
+                    "top-left should show the blue overlay: {:?}",
+                    &rgba[0..4]
+                );
+                // Bottom-right (row 7, col 7): outside the 4×4 overlay → red base. If
+                // the scale node were dropped, the overlay would cover this too (blue).
+                let br = (7 * 8 + 7) * 4;
+                assert!(
+                    rgba[br] > 100 && rgba[br + 2] < 100,
+                    "bottom-right should reveal the red base (overlay shrunk): {:?}",
+                    &rgba[br..br + 4]
+                );
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
+    fn overlay_static_rotation_should_build_and_pull() {
+        // C4a: a static `rotation` field must build the rotate node in the realtime
+        // compositor (the field path, distinct from a per-clip `RotateAnimated` effect)
+        // and pull an rgba frame. Probe-gated.
+        if RealtimeComposer::new(&[base_8x8()]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+        let mut overlay = base_8x8();
+        overlay.rotation = AnimatedValue::Static(45.0);
+        let mut composer = RealtimeComposer::new(&[base_8x8(), overlay])
+            .expect("overlay rotate must build once FFmpeg filters exist");
+        let bf = VideoFrame::from_rgba(8, 8, vec![80u8; 8 * 8 * 4]).unwrap();
+        let tf = VideoFrame::from_rgba(8, 8, vec![160u8; 8 * 8 * 4]).unwrap();
+        if composer.push_layer(0, &bf).is_err() || composer.push_layer(1, &tf).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
             Ok(None) => println!("Skipping: no frame produced"),
             Err(e) => println!("Skipping: {e}"),
         }

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use ff_filter::{BlendMode, RealtimeComposer, RealtimeLayer};
+use ff_filter::{AnimatedValue, BlendMode, RealtimeComposer, RealtimeLayer};
 use ff_format::{PixelFormat, Rational, Timestamp, VideoFrame};
 
 use crate::audio::AudioMixer;
@@ -713,13 +713,14 @@ impl TimelineRunner {
                                         height: gh,
                                         pixel_format: PixelFormat::Rgba,
                                         effects: Vec::new(),
-                                        opacity: 1.0,
-                                        opacity_track: None,
-                                        x: 0.0,
-                                        y: 0.0,
-                                        x_track: None,
-                                        y_track: None,
+                                        opacity: AnimatedValue::Static(1.0),
+                                        x: AnimatedValue::Static(0.0),
+                                        y: AnimatedValue::Static(0.0),
+                                        scale_x: AnimatedValue::Static(1.0),
+                                        scale_y: AnimatedValue::Static(1.0),
+                                        rotation: AnimatedValue::Static(0.0),
                                         blend_mode: BlendMode::Normal,
+                                        composite_op: ff_filter::CompositeOp::Over,
                                     };
                                     match VideoFrame::from_rgba(gw, gh, self.gap_buf.clone()) {
                                         Ok(bf) => self.composite_frame(
@@ -832,14 +833,16 @@ impl TimelineRunner {
 
                     if a_ok {
                         // V1 per-clip opacity: pre-multiply toward black (producer-side;
-                        // the composer ignores base-layer opacity). An opacity track is
-                        // evaluated at the timeline PTS (tracks are timeline-global), so
-                        // base-layer opacity animates too.
-                        let v1_op = match self.clips[active].layer_desc.opacity_track.as_ref() {
+                        // the composer ignores base-layer opacity). The merged opacity is
+                        // an `AnimatedValue`; a track is evaluated at the timeline PTS
+                        // (tracks are timeline-global), so base-layer opacity animates too.
+                        let v1_op = match &self.clips[active].layer_desc.opacity {
                             // Value is clamped to [0.0, 1.0], so the f32 narrowing is safe.
                             #[allow(clippy::cast_possible_truncation)]
-                            Some(track) => track.value_at(timeline_pts).clamp(0.0, 1.0) as f32,
-                            None => self.clips[active].opacity,
+                            AnimatedValue::Track(track) => {
+                                track.value_at(timeline_pts).clamp(0.0, 1.0) as f32
+                            }
+                            AnimatedValue::Static(_) => self.clips[active].opacity,
                         };
                         if (v1_op - 1.0).abs() > 1e-6 {
                             for chunk in self.rgba_a.chunks_exact_mut(4) {

--- a/docs/specs/engine-and-primitives.md
+++ b/docs/specs/engine-and-primitives.md
@@ -82,6 +82,15 @@ Confirmed design (user-approved):
 + executor convergence (its own design sub-cycle); **C5** structural-sharing history (memory, if
 needed). C1/C2 are the immediate, high-value, low-risk work; C3–C5 follow.
 
+**C4 decomposition (scope B — full visual parity):** C4 is an epic. Both compositors are FFmpeg
+libavfilter graphs that already share the same lower-level builders, so "same executor" means the same
+per-frame overlay/blend graph. Scope B closes the nine gaps below so preview is visually identical to
+export while keeping the two executors (full per-frame-export unification, retiring `MultiTrackComposer`,
+is out of scope). Children: **C4a** single `derive` backbone + video representation convergence (gaps 2, 3);
+**C4b** `composite_op` in the preview executor (gap 1); **C4c** transition/xfade-kind parity (gap 8, last,
+own sub-cycle); **C4d** `lavfi_overlay` in preview (gap 4); **C4e** audio derivation + preview parity
+(gaps 5, 6, 7). Sequence: C4a → {C4b, C4d, C4e} → C4c.
+
 #### C4 gap-list — where preview (`to_scene`) diverges from export (`render`) today
 
 A field-by-field mapping (during C3) showed the two derivations diverge not just in *encoding* but in
@@ -105,6 +114,17 @@ The one extraction genuinely shared today is `Clip::video_effect_chain()` (eq + 
 consumed by export directly and by preview via `Clip::realtime_layer_descriptor`. **C3** extracted the
 export per-clip interpretation into the pure `avio::derive` module (`video_layer` / `audio_track`) so it
 has one testable home; **C4** makes preview derive from the same core, closing the gaps above.
+
+**C4a (done):** both paths now build their video layer from one core. `avio::derive::video_transform`
+computes the merged opacity/x/y/scale/rotation + blend + composite once; `video_layer` (export) and
+`realtime_descriptor` (preview) both consume it, and `to_scene` routes through the latter. The
+`RealtimeLayerDescriptor` converged to the `VideoLayer` shape (`AnimatedValue<f64>` opacity/x/y +
+`scale_x`/`scale_y`/`rotation` + `composite_op`), and `build_realtime_composition` consumes the new
+fields (rendering scale/rotation as static-at-t=0 nodes, matching export; `composite_op` is carried but
+still rendered as `Over` until C4b). This closes gaps 2 and 3 for preview overlays. **Deferred (Q2):**
+exact pixel-parity (the realtime `rgba`/base-size output vs export's `color`-canvas/`yuv420p`, and the
+overlay force-scale) and base-track (V1) scale/rotation — both entangled with canvas semantics — are left
+to a C4 canvas-reconciliation follow-up.
 
 ## 3. Boundary principle (model vs primitive)
 


### PR DESCRIPTION
## Objective

- Preview (`Timeline::to_scene`) built its video layer from `Clip::realtime_layer_descriptor`, which never saw the timeline `video_animations` map, so it silently dropped the timeline-level scale/rotation and the opacity/x/y track-level fallbacks and 3-way merge that export honours.
- Export and preview interpreted each clip through different code, so there was no single `derive` feeding both.

## Solution

- Extract the shared per-clip transform into `avio::derive::video_transform`; both the export `VideoLayer` and the new preview `realtime_descriptor` consume it, so both paths derive from one core.
- Converge `RealtimeLayerDescriptor` / `RealtimeLayer` to the `VideoLayer` shape (`AnimatedValue` opacity/x/y plus `scale_x`/`scale_y`/`rotation` and `composite_op`); teach `build_realtime_composition` to render overlay scale/rotation as static-at-t=0 nodes mirroring export, and clamp opacity to `[0,1]` before the blend args to match export. `composite_op` is carried but still rendered as `Over` until C4b.
- Closes the scale/rotation and timeline-animation gaps for preview overlays. Exact pixel parity (canvas/format, overlay force-scale) and base-track scale/rotation are entangled with canvas semantics and deferred to a later C4 follow-up (documented in `engine-and-primitives.md` 2.1).

Closes #1356