### PR TITLE
feat(ff-filter): render composite_op in the preview compositor

### DIFF
--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -547,4 +547,12 @@ mod tests {
         let d = realtime_descriptor(&clip, 0, &anims);
         assert!(matches!(d.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
+
+    #[test]
+    fn realtime_descriptor_should_carry_composite_op() {
+        let mut clip = Clip::new("a.mp4");
+        clip.composite_op = CompositeOp::Under;
+        let d = realtime_descriptor(&clip, 0, &no_anim());
+        assert!(matches!(d.composite_op, CompositeOp::Under));
+    }
 }

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -1500,10 +1500,11 @@ pub(super) unsafe fn add_blend_under_step(
 
 // ── Blend expression-based compound step ────────────────────────────────────
 
-/// Insert a Porter-Duff expression-based blend step (In, Out).
+/// Insert a Porter-Duff expression-based blend step (In / Out / Atop / Xor).
 ///
-/// Chains `top_steps` on `top_src_ctx`, then creates
-/// `blend=all_expr=<expr>` and links both inputs.
+/// Chains `top_steps` on `top_src_ctx`, then creates `blend=all_expr=<expr>` and
+/// links both inputs. `opacity` is forwarded via `all_opacity` when it differs
+/// from `1.0` (attenuating the operator, matching the export path).
 ///
 /// ```text
 /// [in1]top_steps...[top_processed]
@@ -1520,6 +1521,7 @@ pub(super) unsafe fn add_blend_expr_step(
     top_src_ctx: *mut ff_sys::AVFilterContext,
     top_steps: &[FilterStep],
     expr: &str,
+    opacity: f32,
     index: usize,
 ) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
     use std::ffi::CString;
@@ -1563,7 +1565,14 @@ pub(super) unsafe fn add_blend_expr_step(
     }
     let blend_name =
         CString::new(format!("blend_expr{index}")).map_err(|_| FilterError::BuildFailed)?;
-    let blend_args_str = format!("all_expr={expr}");
+    // Opacity is forwarded via `all_opacity` (matching the export path and the
+    // photographic blend branch); omitted at 1.0 so the default stays byte-identical.
+    // `:.6` matches the export inline formatting (`composition_inner.rs`).
+    let blend_args_str = if (opacity - 1.0).abs() < f32::EPSILON {
+        format!("all_expr={expr}")
+    } else {
+        format!("all_expr={expr}:all_opacity={opacity:.6}")
+    };
     let blend_args = CString::new(blend_args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
     let mut blend_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
     let ret = ff_sys::avfilter_graph_create_filter(
@@ -1616,7 +1625,8 @@ pub(super) unsafe fn add_blend_expr_step(
 // ── Composite compound step ───────────────────────────────────────────────────
 /// Builds a Porter-Duff composite step from a [`CompositeOp`], dispatching to the
 /// shared blend construction helpers (`overlay` for `Over`/`Under`, `blend` with
-/// a per-channel expression for the rest). Consumed by [`FilterStep::Composite`].
+/// a per-channel expression for the rest). Consumed by [`FilterStep::Composite`]
+/// and by the realtime compositor (`build_realtime_composition`).
 ///
 /// # Safety
 ///
@@ -1624,7 +1634,7 @@ pub(super) unsafe fn add_blend_expr_step(
 /// same `AVFilterGraph`.
 // One more argument (`op`) than the 7-arg blend helpers it forwards to.
 #[allow(clippy::too_many_arguments)]
-pub(super) unsafe fn add_composite_step(
+pub(crate) unsafe fn add_composite_step(
     graph: *mut ff_sys::AVFilterGraph,
     bottom_ctx: *mut ff_sys::AVFilterContext,
     top_src_ctx: *mut ff_sys::AVFilterContext,
@@ -1637,7 +1647,15 @@ pub(super) unsafe fn add_composite_step(
     // `blend_all_expr` is `Some` for In/Out/Atop/Xor (built via `blend all_expr`),
     // `None` for Over/Under (built via the `overlay` filter).
     match op.blend_all_expr() {
-        Some(expr) => add_blend_expr_step(graph, bottom_ctx, top_src_ctx, top_steps, expr, index),
+        Some(expr) => add_blend_expr_step(
+            graph,
+            bottom_ctx,
+            top_src_ctx,
+            top_steps,
+            expr,
+            opacity,
+            index,
+        ),
         None => match op {
             CompositeOp::Under => add_blend_under_step(
                 graph,

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -20,7 +20,8 @@ mod push_pull;
 pub(crate) use build::add_and_link_step;
 pub(crate) use build::add_asetrate_resample_chain;
 pub(crate) use build::{
-    NormalBlendParams, add_blend_normal_step, add_blend_photographic_step, video_buffersrc_args,
+    NormalBlendParams, add_blend_normal_step, add_blend_photographic_step, add_composite_step,
+    video_buffersrc_args,
 };
 pub(crate) use convert::pixel_format_to_av;
 

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1152,7 +1152,28 @@ pub(super) unsafe fn build_realtime_composition(
             });
         }
         top_steps.extend(layer.effects.iter().cloned());
-        acc = if layer.blend_mode == BlendMode::Normal {
+        acc = if layer.composite_op != CompositeOp::Over {
+            // Porter-Duff (Under/In/Out/Atop/Xor) via the same shared construction the
+            // export path and `FilterStep::Composite` use. The colour `blend_mode` is
+            // not additionally applied, and opacity is the static clamped value —
+            // animated opacity/position on a non-Over layer is intentionally not
+            // tracked, matching export.
+            #[allow(clippy::cast_possible_truncation)]
+            let opacity = layer.opacity.value_at(Duration::ZERO).clamp(0.0, 1.0) as f32;
+            match crate::filter_inner::add_composite_step(
+                graph,
+                acc,
+                top_src.as_ptr(),
+                &top_steps,
+                layer.composite_op,
+                opacity,
+                ff_format::AlphaMode::Straight,
+                idx,
+            ) {
+                Ok(c) => c,
+                Err(e) => bail!(graph, format!("composite failed layer={idx}: {e:?}")),
+            }
+        } else if layer.blend_mode == BlendMode::Normal {
             // Lower the engine's `AnimatedValue` opacity/position to the existing
             // blend parameters (static value, or a track wired for `send_command`).
             #[allow(clippy::cast_possible_truncation)]

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -1647,4 +1647,114 @@ mod tests {
             Err(e) => println!("Skipping: {e}"),
         }
     }
+
+    #[test]
+    fn overlay_composite_under_should_render_base_over_overlay() {
+        // C4b: `CompositeOp::Under` swaps the compositing so the base renders over the
+        // overlay. An opaque red base over an opaque blue overlay must stay red — the
+        // opposite of the default `Over` (which would show the blue overlay on top).
+        // Probe-gated (CI's Linux FFmpeg has no filters).
+        if RealtimeComposer::new(&[base_8x8()]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+        let mut overlay = base_8x8();
+        overlay.composite_op = CompositeOp::Under;
+        let mut composer = RealtimeComposer::new(&[base_8x8(), overlay])
+            .expect("composite Under must build once FFmpeg filters exist");
+        let red = VideoFrame::from_rgba(8, 8, [255u8, 0, 0, 255].repeat(64)).unwrap();
+        let blue = VideoFrame::from_rgba(8, 8, [0u8, 0, 255, 255].repeat(64)).unwrap();
+        if composer.push_layer(0, &red).is_err() || composer.push_layer(1, &blue).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => {
+                let rgba = out.to_rgba().expect("rgba");
+                assert!(
+                    rgba[0] > 100 && rgba[2] < 100,
+                    "Under should keep the red base on top of the blue overlay: {:?}",
+                    &rgba[0..4]
+                );
+            }
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
+    fn overlay_composite_expr_ops_should_build_and_pull() {
+        // C4b: the expression-based Porter-Duff operators (In/Out/Atop/Xor) must build
+        // the `blend all_expr` node in the realtime compositor and pull an rgba frame.
+        // Probe-gated.
+        if RealtimeComposer::new(&[base_8x8()]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+        for op in [
+            CompositeOp::In,
+            CompositeOp::Out,
+            CompositeOp::Atop,
+            CompositeOp::Xor,
+        ] {
+            let mut overlay = base_8x8();
+            overlay.composite_op = op;
+            // The no-effect probe above guarantees the base filter set; `blend` may
+            // still be absent on a partial host, so degrade gracefully (RK-002).
+            let mut composer = match RealtimeComposer::new(&[base_8x8(), overlay]) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("Skipping {op:?}: {e}");
+                    continue;
+                }
+            };
+            let bf = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+            let tf = VideoFrame::from_rgba(8, 8, vec![180u8; 8 * 8 * 4]).unwrap();
+            if composer.push_layer(0, &bf).is_err() || composer.push_layer(1, &tf).is_err() {
+                println!("Skipping {op:?}: push failed (FFmpeg unavailable?)");
+                continue;
+            }
+            match composer.pull() {
+                Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+                Ok(None) => println!("Skipping {op:?}: no frame produced"),
+                Err(e) => println!("Skipping {op:?}: {e}"),
+            }
+        }
+    }
+
+    #[test]
+    fn overlay_composite_expr_op_with_opacity_should_build_and_pull() {
+        // C4b: an expr operator (`In`) with opacity < 1.0 exercises the `all_opacity`
+        // branch of `add_blend_expr_step` — this asserts FFmpeg accepts the
+        // `all_expr=…:all_opacity=0.500000` argument (validated at push, RK-001) and the
+        // graph pulls an rgba frame. Note: on the realtime rgba inputs `blend`'s
+        // `all_opacity` currently has no visible effect (it is planar-oriented, which is
+        // why export normalises to yuv420p); real attenuation for the channel-math
+        // operators lands with the Q2 colour-space reconciliation. Probe-gated.
+        if RealtimeComposer::new(&[base_8x8()]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+        let mut overlay = base_8x8();
+        overlay.composite_op = CompositeOp::In;
+        overlay.opacity = AnimatedValue::Static(0.5);
+        let mut composer = match RealtimeComposer::new(&[base_8x8(), overlay]) {
+            Ok(c) => c,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        let bf = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+        let tf = VideoFrame::from_rgba(8, 8, vec![180u8; 8 * 8 * 4]).unwrap();
+        if composer.push_layer(0, &bf).is_err() || composer.push_layer(1, &tf).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable? / bad all_opacity arg)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
 }

--- a/docs/specs/engine-and-primitives.md
+++ b/docs/specs/engine-and-primitives.md
@@ -126,6 +126,20 @@ exact pixel-parity (the realtime `rgba`/base-size output vs export's `color`-can
 overlay force-scale) and base-track (V1) scale/rotation — both entangled with canvas semantics — are left
 to a C4 canvas-reconciliation follow-up.
 
+**C4b (done):** preview renders `composite_op` (gap 1 closed). `build_realtime_composition` now dispatches
+non-`Over` overlays through the shared `add_composite_step` — the same Porter-Duff *construction* the export
+path and `FilterStep::Composite` use (`overlay` swap for `Under`, `blend all_expr` for In/Out/Atop/Xor), and
+`add_blend_expr_step` forwards opacity via `all_opacity` to match export's construction. `eof_action` stays
+export-only (the realtime buffersrc inputs are finite, not the infinite `color` canvas). Two effects fall
+under the Q2 pixel-parity deferral, both rooted in the realtime graph compositing in **rgba** while export
+normalises the `blend` inputs to **yuv420p**: (a) the channel-math operators (In/Out/Atop/Xor — like the
+photographic blend modes, which already have this property) apply the *same operator* but evaluate it in a
+different colour space, so exact pixels differ; and (b) `blend`'s `all_opacity` is planar-oriented, so on the
+rgba inputs it is currently a no-op — the `all_opacity` arg is emitted for construction parity but the
+expr-operator attenuation only becomes visible once the Q2 colour-space reconciliation lands. `Under`/`Over`
+are alpha-composited and match export today. As with export, animated opacity/position on a non-`Over` layer
+is not tracked (the static t=0 value is used).
+
 ## 3. Boundary principle (model vs primitive)
 
 **Litmus:** does this type/function need to know **TIME, TRACK, CLIP, EDIT, or HISTORY** to do


### PR DESCRIPTION
## Objective

- Preview (`build_realtime_composition`) composited every overlay as `Over`, ignoring the `composite_op` that C4a had already threaded into `RealtimeLayer` / the derive. So preview dropped the Porter-Duff operators (Under/In/Out/Atop/Xor) that export renders.

## Solution

- Wire the existing shared `add_composite_step` (previously only for `FilterStep::Composite`) into `build_realtime_composition`, dispatching non-`Over` overlays to it before the blend-mode branch (mirroring export's precedence): `Under` via the swapped `overlay`, In/Out/Atop/Xor via `blend all_expr`, `Over` via the normal overlay.
- Give `add_blend_expr_step` an `all_opacity` pass so the expression operators forward opacity as export's construction does (the default 1.0 stays byte-identical; only the shared `FilterStep::Composite` expr path gains attenuation when opacity < 1.0).
- `Under`/`Over` are alpha-composited and match export. The channel-math operators, like the photographic blend modes, evaluate in the realtime `rgba` space vs export's `yuv420p`, and `blend`'s `all_opacity` is a no-op on rgba, so their exact pixels and opacity attenuation await the Q2 colour-space reconciliation (documented in `engine-and-primitives.md` 2.1).

Closes #1357