### PR TITLE
feat(ff-preview): composite lavfi_overlay in the preview runner

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -285,8 +285,8 @@ pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 pub use ff_filter::{
     AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
     BlendMode, ClipJoiner, CompositeOp, DrawTextOptions, Easing, EqBand, FilterError, FilterGraph,
-    FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LensProfile, Lerp,
-    LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
+    FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LavfiSource, LensProfile,
+    Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType,
     ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb,
     ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap, VideoConcatenator, VideoLayer,
     XfadeTransition, YadifMode,

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -728,6 +728,7 @@ impl Timeline {
         ff_preview::Scene {
             fps: self.frame_rate().max(1.0),
             canvas: self.explicit_canvas(),
+            lavfi_overlay: self.lavfi_overlay.clone(),
             video_tracks,
             audio_tracks,
         }
@@ -846,6 +847,23 @@ mod tests {
         assert!(matches!(overlay.layer.scale_x, AnimatedValue::Track(_)));
         assert!(matches!(overlay.layer.rotation, AnimatedValue::Track(_)));
         assert!(matches!(overlay.layer.opacity, AnimatedValue::Track(_)));
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_carry_lavfi_overlay() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .lavfi_overlay("color=s=1920x1080:c=black@0.0")
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        assert_eq!(
+            scene.lavfi_overlay.as_deref(),
+            Some("color=s=1920x1080:c=black@0.0")
+        );
     }
 
     #[test]

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -134,9 +134,7 @@ pub(super) unsafe fn build_video_composition(
         // FFmpeg's lavfi virtual demuxer; escape "\" and ":" for the option parser.
         // For regular files, normalise Windows backslashes and escape the drive colon.
         let movie_args_str = if layer.input_format.as_deref() == Some("lavfi") {
-            let lavfi_str = layer.source.to_string_lossy();
-            let escaped = lavfi_str.replace('\\', "\\\\").replace(':', "\\:");
-            format!("filename={escaped}:format_name=lavfi")
+            lavfi_movie_args(&layer.source.to_string_lossy())
         } else {
             // Decode from the proxy file when one is set; otherwise the original source.
             let decode_path = match &layer.proxy {
@@ -2399,5 +2397,138 @@ pub(super) unsafe fn build_dissolve_join(
     let sink_nn = NonNull::new_unchecked(sink_ctx);
     let inner = FilterGraphInner::with_prebuilt_video_graph(graph_nn, sink_nn);
     log::info!("dissolve join graph built dissolve_sec={dissolve_sec} xfade_offset={xfade_offset}");
+    Ok(FilterGraph::from_prebuilt(inner))
+}
+
+/// Builds the `movie` filter args for a `lavfi` source string, escaping `\` and `:`
+/// for the option parser. Shared by the export composition (`build_video_composition`)
+/// and the preview [`build_lavfi_source`] so the two stay in sync.
+fn lavfi_movie_args(lavfi: &str) -> String {
+    let escaped = lavfi.replace('\\', "\\\\").replace(':', "\\:");
+    format!("filename={escaped}:format_name=lavfi")
+}
+
+// ── Lavfi source graph (generated overlay for the preview runner) ──────────────
+
+/// Builds a source-only graph that generates frames from a `lavfi` filtergraph
+/// string: `movie=filename=<lavfi>:format_name=lavfi → format=rgba → buffersink`.
+///
+/// Unlike the export composition (which composites the lavfi layer onto a canvas),
+/// this keeps the lavfi's **own alpha** (output `rgba`, no canvas underneath) so the
+/// preview runner can overlay it on the live composite. Pulled with
+/// [`FilterGraph::pull_video`]; it has no `buffersrc` input and no animation entries.
+///
+/// # Safety
+///
+/// Follows the same avfilter ownership rules as [`build_video_composition`]: the
+/// returned graph owns every context it created.
+pub(super) unsafe fn build_lavfi_source(lavfi: &str) -> Result<FilterGraph, FilterError> {
+    use std::ffi::CString;
+
+    macro_rules! bail {
+        ($graph:ident, $reason:expr) => {{
+            let mut g = $graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::CompositionFailed {
+                reason: format!("{}", $reason),
+            });
+        }};
+    }
+
+    let graph = ff_sys::avfilter_graph_alloc();
+    if graph.is_null() {
+        return Err(FilterError::CompositionFailed {
+            reason: "avfilter_graph_alloc failed".to_string(),
+        });
+    }
+
+    // ── movie=filename=<escaped>:format_name=lavfi ────────────────────────────
+    let movie_filter = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
+    if movie_filter.is_null() {
+        bail!(graph, "filter not found: movie");
+    }
+    let Ok(movie_args) = CString::new(lavfi_movie_args(lavfi)) else {
+        bail!(graph, "CString::new failed for lavfi movie args");
+    };
+    let mut movie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut movie_ctx,
+        movie_filter,
+        c"lavfi_movie".as_ptr(),
+        movie_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("failed to create lavfi movie source code={ret}")
+        );
+    }
+
+    // ── format=rgba (preserve the overlay's own alpha) ────────────────────────
+    let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if fmt_filter.is_null() {
+        bail!(graph, "filter not found: format");
+    }
+    let mut fmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut fmt_ctx,
+        fmt_filter,
+        c"lavfi_fmt".as_ptr(),
+        c"pix_fmts=rgba".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("failed to create lavfi format filter code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(movie_ctx, 0, fmt_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: lavfi movie→format");
+    }
+
+    // ── buffersink ────────────────────────────────────────────────────────────
+    let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
+    if sink_filter.is_null() {
+        bail!(graph, "filter not found: buffersink");
+    }
+    let mut sink_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sink_ctx,
+        sink_filter,
+        c"lavfi_sink".as_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("failed to create lavfi buffersink code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(fmt_ctx, 0, sink_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: lavfi format→buffersink");
+    }
+
+    // ── Configure ─────────────────────────────────────────────────────────────
+    let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("lavfi avfilter_graph_config failed code={ret}")
+        );
+    }
+
+    // SAFETY: ret >= 0 guarantees both pointers are non-null.
+    let graph_nn = NonNull::new_unchecked(graph);
+    let sink_nn = NonNull::new_unchecked(sink_ctx);
+    let inner = FilterGraphInner::with_prebuilt_video_graph(graph_nn, sink_nn);
+    log::info!("lavfi source graph built");
     Ok(FilterGraph::from_prebuilt(inner))
 }

--- a/crates/ff-filter/src/graph/composition/mod.rs
+++ b/crates/ff-filter/src/graph/composition/mod.rs
@@ -20,5 +20,7 @@ pub use audio_concatenator::AudioConcatenator;
 pub use clip_joiner::ClipJoiner;
 pub use multi_track_composer::{MultiTrackComposer, ProxySource, VideoLayer};
 pub use multi_track_mixer::{AudioTrack, MultiTrackAudioMixer};
-pub use realtime_composer::{RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor};
+pub use realtime_composer::{
+    LavfiSource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,
+};
 pub use video_concatenator::VideoConcatenator;

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -202,6 +202,46 @@ impl RealtimeComposer {
     }
 }
 
+// ── LavfiSource ────────────────────────────────────────────────────────────────
+
+/// Generates video frames from an `FFmpeg` `lavfi` filtergraph string (e.g.
+/// `color=s=1920x1080:c=black@0.0,drawtext=text='Title'`), so a host such as the
+/// preview runner can feed a timeline-level generated overlay into a
+/// [`RealtimeComposer`] as pushed frames.
+///
+/// The output is `rgba` and preserves the graph's own alpha (no canvas is
+/// composited underneath), matching the export path's topmost lavfi layer. Frames
+/// are produced sequentially via [`pull`](Self::pull); the source exposes no seek,
+/// so a host that seeks rebuilds it from scratch.
+pub struct LavfiSource {
+    graph: FilterGraph,
+}
+
+impl LavfiSource {
+    /// Builds a source from a `lavfi` filtergraph string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] when the underlying `FFmpeg` graph cannot be built
+    /// (e.g. the `movie` / `lavfi` demuxer is unavailable, or the string is invalid).
+    pub fn new(lavfi: &str) -> Result<Self, FilterError> {
+        // SAFETY: `build_lavfi_source` follows the avfilter ownership rules; the
+        // returned graph owns every context it created.
+        let graph = unsafe { super::composition_inner::build_lavfi_source(lavfi)? };
+        Ok(Self { graph })
+    }
+
+    /// Pulls the next generated frame (`rgba`), or `None` when none is buffered yet
+    /// or at end-of-stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] on an unexpected `FFmpeg` error.
+    pub fn pull(&mut self) -> Result<Option<VideoFrame>, FilterError> {
+        self.graph.pull_video()
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -1756,5 +1796,35 @@ mod tests {
             Ok(None) => println!("Skipping: no frame produced"),
             Err(e) => println!("Skipping: {e}"),
         }
+    }
+
+    #[test]
+    fn lavfi_source_should_generate_rgba_frames() {
+        // C4d: a `LavfiSource` generates rgba frames from a filtergraph string. Probe-
+        // gated: CI's Linux FFmpeg has no filters / lavfi demuxer, so skip gracefully.
+        let mut source = match LavfiSource::new("color=c=red:s=16x16:d=1") {
+            Ok(s) => s,
+            Err(e) => {
+                println!("Skipping: {e}");
+                return;
+            }
+        };
+        // The movie/lavfi source may return None before it warms up; try a few pulls.
+        for _ in 0..8 {
+            match source.pull() {
+                Ok(Some(frame)) => {
+                    assert_eq!(frame.format(), PixelFormat::Rgba);
+                    assert_eq!(frame.width(), 16);
+                    assert_eq!(frame.height(), 16);
+                    return;
+                }
+                Ok(None) => continue,
+                Err(e) => {
+                    println!("Skipping: {e}");
+                    return;
+                }
+            }
+        }
+        println!("Skipping: no frame produced");
     }
 }

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -10,9 +10,9 @@ pub mod types;
 
 pub use builder::FilterGraphBuilder;
 pub use composition::{
-    AudioConcatenator, AudioTrack, ClipJoiner, MultiTrackAudioMixer, MultiTrackComposer,
-    ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, VideoConcatenator,
-    VideoLayer,
+    AudioConcatenator, AudioTrack, ClipJoiner, LavfiSource, MultiTrackAudioMixer,
+    MultiTrackComposer, ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,
+    VideoConcatenator, VideoLayer,
 };
 pub use ffmpeg_token::FfmpegToken;
 pub use filter_step::FilterStep;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -50,7 +50,7 @@ pub use effects::{
 pub use error::FilterError;
 pub use graph::{
     AudioConcatenator, AudioTrack, ClipJoiner, DrawTextOptions, EqBand, FilterGraph,
-    FilterGraphBuilder, FilterStep, HwAccel, MultiTrackAudioMixer, MultiTrackComposer, ProxySource,
-    RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, ToneMap,
-    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, MultiTrackAudioMixer, MultiTrackComposer,
+    ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb, ScaleAlgorithm,
+    ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -45,7 +45,7 @@ pub use runner::TimelineRunner;
 pub use scene::{Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack};
 
 use audio_resampling::spawn_audio_track_thread;
-use state::{AudioFadeConfig, AudioOnlyTrack, ClipState, OverlayLayer};
+use state::{AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer};
 
 // -- Constants --
 
@@ -405,6 +405,10 @@ impl ScenePlayer {
             composer: None,
             composer_key: Vec::new(),
             canvas: scene.canvas,
+            lavfi: scene
+                .lavfi_overlay
+                .as_deref()
+                .and_then(LavfiOverlayState::new),
         };
 
         let handle = PlayerHandle::for_timeline(

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use ff_filter::{AnimatedValue, BlendMode, RealtimeComposer, RealtimeLayer};
+use ff_filter::{AnimatedValue, BlendMode, CompositeOp, RealtimeComposer, RealtimeLayer};
 use ff_format::{PixelFormat, Rational, Timestamp, VideoFrame};
 
 use crate::audio::AudioMixer;
@@ -22,7 +22,9 @@ use crate::playback::player::PlayerCommand;
 use crate::playback::sink::FrameSink;
 
 use super::audio_resampling::spawn_audio_track_thread;
-use super::state::{AudioFadeConfig, AudioOnlyTrack, ClipState, OverlayLayer, TransitionState};
+use super::state::{
+    AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer, TransitionState,
+};
 use super::timeline_inner;
 
 // ── TimelineRunner ────────────────────────────────────────────────────────────
@@ -89,6 +91,9 @@ pub struct TimelineRunner {
     /// matches the project's output aspect. `None` composites at the base clip's
     /// own size (legacy behaviour).
     pub(super) canvas: Option<(u32, u32)>,
+    /// Timeline-global generated `lavfi` overlay, composited as the topmost layer
+    /// (above every file overlay). `None` when the timeline set no `lavfi_overlay`.
+    pub(super) lavfi: Option<LavfiOverlayState>,
 }
 
 impl TimelineRunner {
@@ -151,6 +156,14 @@ impl TimelineRunner {
         active
     }
 
+    /// Advances the generated `lavfi` overlay (if any) to the frame due at
+    /// `target_pts`, holding otherwise — see [`LavfiOverlayState::advance_to`].
+    /// Returns the current frame's `(width, height)`, or `None` when there is no
+    /// lavfi overlay / no frame yet.
+    fn sync_lavfi(&mut self, target_pts: Duration) -> Option<(u32, u32)> {
+        self.lavfi.as_mut()?.advance_to(target_pts)
+    }
+
     /// Composites `base_frame` (the bottom layer) with the given overlay layers
     /// through the cached [`RealtimeComposer`], applying each layer's effects and
     /// blend mode. `base_id` identifies the base for cache invalidation — the V1
@@ -186,6 +199,27 @@ impl TimelineRunner {
             ));
             key.push((li + 1, oc.active, ow, oh));
         }
+        // Topmost timeline-global lavfi overlay (generated), when a frame is held.
+        // Fixed full-frame Normal/Over layer, matching export; its transparency comes
+        // from the lavfi content's own alpha. A sentinel layer id keys the cache.
+        let lavfi_dims = self.lavfi.as_ref().and_then(|s| s.dims);
+        if let Some((lw, lh)) = lavfi_dims {
+            specs.push(RealtimeLayer {
+                width: lw,
+                height: lh,
+                pixel_format: PixelFormat::Rgba,
+                effects: Vec::new(),
+                opacity: AnimatedValue::Static(1.0),
+                x: AnimatedValue::Static(0.0),
+                y: AnimatedValue::Static(0.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
+            });
+            key.push((usize::MAX - 1, 0, lw, lh));
+        }
         if self.composer.is_none() || self.composer_key != key {
             self.composer = RealtimeComposer::with_canvas(&specs, self.canvas).ok();
             self.composer_key = if self.composer.is_some() {
@@ -209,6 +243,19 @@ impl TimelineRunner {
                 VideoFrame::from_rgba(ow, oh, self.overlay_layers[li].rgba.clone()).ok()?;
             vf.set_timestamp(ts);
             if composer.push_layer(slot + 1, &vf).is_err() {
+                return None;
+            }
+        }
+        // Push the lavfi overlay last (topmost slot), reading its held rgba from the
+        // disjoint `lavfi` field (as the overlay loop reads `overlay_layers`).
+        if let Some((lw, lh)) = lavfi_dims {
+            let rgba = self
+                .lavfi
+                .as_ref()
+                .map_or_else(Vec::new, |s| s.rgba.clone());
+            let mut vf = VideoFrame::from_rgba(lw, lh, rgba).ok()?;
+            vf.set_timestamp(ts);
+            if composer.push_layer(overlays.len() + 1, &vf).is_err() {
                 return None;
             }
         }
@@ -705,36 +752,40 @@ impl TimelineRunner {
                                 self.gap_buf.resize(n, 0);
                                 self.gap_buf.fill(0);
                                 let gap_overlays = self.sync_overlays(gap_pts);
-                                let gap_composited = if gap_overlays.is_empty() {
-                                    None
-                                } else {
-                                    let base_layer = RealtimeLayer {
-                                        width: gw,
-                                        height: gh,
-                                        pixel_format: PixelFormat::Rgba,
-                                        effects: Vec::new(),
-                                        opacity: AnimatedValue::Static(1.0),
-                                        x: AnimatedValue::Static(0.0),
-                                        y: AnimatedValue::Static(0.0),
-                                        scale_x: AnimatedValue::Static(1.0),
-                                        scale_y: AnimatedValue::Static(1.0),
-                                        rotation: AnimatedValue::Static(0.0),
-                                        blend_mode: BlendMode::Normal,
-                                        composite_op: ff_filter::CompositeOp::Over,
+                                let gap_lavfi = self.sync_lavfi(gap_pts);
+                                // Composite when there is a file overlay OR a lavfi
+                                // overlay to draw over the gap's black base.
+                                let gap_composited =
+                                    if gap_overlays.is_empty() && gap_lavfi.is_none() {
+                                        None
+                                    } else {
+                                        let base_layer = RealtimeLayer {
+                                            width: gw,
+                                            height: gh,
+                                            pixel_format: PixelFormat::Rgba,
+                                            effects: Vec::new(),
+                                            opacity: AnimatedValue::Static(1.0),
+                                            x: AnimatedValue::Static(0.0),
+                                            y: AnimatedValue::Static(0.0),
+                                            scale_x: AnimatedValue::Static(1.0),
+                                            scale_y: AnimatedValue::Static(1.0),
+                                            rotation: AnimatedValue::Static(0.0),
+                                            blend_mode: BlendMode::Normal,
+                                            composite_op: ff_filter::CompositeOp::Over,
+                                        };
+                                        match VideoFrame::from_rgba(gw, gh, self.gap_buf.clone()) {
+                                            Ok(bf) => self.composite_frame(
+                                                base_layer,
+                                                usize::MAX,
+                                                bf,
+                                                gw,
+                                                gh,
+                                                &gap_overlays,
+                                                gap_pts,
+                                            ),
+                                            Err(_) => None,
+                                        }
                                     };
-                                    match VideoFrame::from_rgba(gw, gh, self.gap_buf.clone()) {
-                                        Ok(bf) => self.composite_frame(
-                                            base_layer,
-                                            usize::MAX,
-                                            bf,
-                                            gw,
-                                            gh,
-                                            &gap_overlays,
-                                            gap_pts,
-                                        ),
-                                        Err(_) => None,
-                                    }
-                                };
                                 // Manage audio-only decode threads (A1/A2…).
                                 for at in &mut self.audio_only_tracks {
                                     let should_run =
@@ -877,6 +928,7 @@ impl TimelineRunner {
                         // Update overlays (held-frame, advanced by PTS) and composite
                         // the V1 base with them through the shared compositor.
                         let active_overlays = self.sync_overlays(timeline_pts);
+                        self.sync_lavfi(timeline_pts);
                         let base_layer = RealtimeLayer::with_dimensions(
                             self.clips[active].layer_desc.clone(),
                             w,
@@ -999,6 +1051,13 @@ impl TimelineRunner {
             }
         }
 
+        // The lavfi overlay source exposes no seek — rebuild it so it restarts from
+        // t=0. Static overlays are unaffected; a time-varying lavfi restarts (a
+        // documented limitation).
+        if let Some(st) = &mut self.lavfi {
+            st.rebuild();
+        }
+
         // Stop all audio-only threads; they restart on the next frame tick.
         for at in &mut self.audio_only_tracks {
             at.stop();
@@ -1030,6 +1089,10 @@ impl TimelineRunner {
             .seek_coarse(clip_local_pts)?;
         self.active = clip_idx;
         self.transition = None;
+        // Keep the lavfi overlay consistent with the main seek path (no source seek).
+        if let Some(st) = &mut self.lavfi {
+            st.rebuild();
+        }
         Ok(())
     }
 

--- a/crates/ff-preview/src/timeline/scene.rs
+++ b/crates/ff-preview/src/timeline/scene.rs
@@ -27,6 +27,10 @@ pub struct Scene {
     pub fps: f64,
     /// Explicit output canvas `(width, height)`, or `None` to size from the base track.
     pub canvas: Option<(u32, u32)>,
+    /// Optional timeline-global `lavfi` filtergraph string (e.g.
+    /// `color=s=1920x1080:c=black@0.0,drawtext=text='Title'`) generated and composited
+    /// as the **topmost** video layer, matching the export path. `None` = no overlay.
+    pub lavfi_overlay: Option<String>,
     /// Video tracks, composited bottom-up: index `0` is the V1 base, `1..` are overlays.
     pub video_tracks: Vec<SceneVideoTrack>,
     /// Dedicated audio-only tracks (A1, A2, …).

--- a/crates/ff-preview/src/timeline/state.rs
+++ b/crates/ff-preview/src/timeline/state.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use ff_filter::{AnimationTrack, RealtimeLayerDescriptor};
+use ff_filter::{AnimationTrack, LavfiSource, RealtimeLayerDescriptor};
 use ff_format::VideoFrame;
 
 use crate::audio::AudioTrackHandle;
@@ -81,6 +81,95 @@ pub(super) struct OverlayLayer {
     /// A frame popped ahead of its presentation time, held until `timeline_pts`
     /// reaches it. Decouples decode order from the present rate.
     pub(super) pending: Option<VideoFrame>,
+}
+
+// ── LavfiOverlayState ─────────────────────────────────────────────────────────
+
+/// A timeline-global generated `lavfi` overlay, composited as the topmost layer.
+///
+/// The [`LavfiSource`] produces frames sequentially (no seek); the runner advances
+/// it with the same held-frame model as [`OverlayLayer`] and rebuilds it on seek.
+pub(super) struct LavfiOverlayState {
+    /// The lavfi filtergraph string, kept for rebuild-on-seek.
+    lavfi: String,
+    /// The frame generator (`movie=…:format_name=lavfi → format=rgba`).
+    source: LavfiSource,
+    /// Reuses one buffer across ticks (like [`OverlayLayer::sws`]).
+    sws: SwsRgbaConverter,
+    /// Current held rgba frame data.
+    pub(super) rgba: Vec<u8>,
+    /// Dimensions of the current held frame, or `None` when none is held yet.
+    pub(super) dims: Option<(u32, u32)>,
+    /// A frame popped ahead of its presentation time (held until due).
+    pub(super) pending: Option<VideoFrame>,
+}
+
+impl LavfiOverlayState {
+    /// Builds the generator from a lavfi string, or logs and returns `None` when the
+    /// source cannot be built (e.g. the `movie` / `lavfi` demuxer is unavailable) —
+    /// the overlay is then simply dropped from the preview rather than failing `open`.
+    pub(super) fn new(lavfi: &str) -> Option<Self> {
+        match LavfiSource::new(lavfi) {
+            Ok(source) => Some(Self {
+                lavfi: lavfi.to_string(),
+                source,
+                sws: SwsRgbaConverter::new(),
+                rgba: Vec::new(),
+                dims: None,
+                pending: None,
+            }),
+            Err(e) => {
+                log::warn!("lavfi overlay unavailable, dropped from preview: {e}");
+                None
+            }
+        }
+    }
+
+    /// Advances the generator to the frame due at `target_pts`, holding the current
+    /// frame otherwise (the same held-frame model as [`OverlayLayer`]). The source
+    /// PTS runs monotonically from 0 alongside the timeline. Returns the current
+    /// frame's `(width, height)`, or `None` when no frame is held yet.
+    ///
+    /// Only the newest due frame is converted (not every intermediate one during a
+    /// far-seek catch-up), reusing the `rgba` buffer like the file-overlay path.
+    pub(super) fn advance_to(&mut self, target_pts: Duration) -> Option<(u32, u32)> {
+        let mut latest: Option<VideoFrame> = None;
+        loop {
+            let f = match self.pending.take() {
+                Some(pf) => pf,
+                None => match self.source.pull() {
+                    Ok(Some(f)) => f,
+                    _ => break,
+                },
+            };
+            if f.timestamp().as_duration() > target_pts {
+                // Not due yet — hold it for a later present.
+                self.pending = Some(f);
+                break;
+            }
+            latest = Some(f);
+        }
+        if let Some(f) = latest
+            && self.sws.convert(&f, &mut self.rgba)
+        {
+            self.dims = Some((f.width(), f.height()));
+        }
+        self.dims
+    }
+
+    /// Rebuilds the source from t=0 (the source has no seek) and clears held state.
+    /// On failure the overlay keeps its previous source and is logged.
+    pub(super) fn rebuild(&mut self) {
+        match LavfiSource::new(&self.lavfi) {
+            Ok(source) => {
+                self.source = source;
+                self.pending = None;
+                self.rgba.clear();
+                self.dims = None;
+            }
+            Err(e) => log::warn!("lavfi overlay seek rebuild failed: {e}"),
+        }
+    }
 }
 
 // ── AudioFadeConfig ───────────────────────────────────────────────────────────
@@ -170,5 +259,40 @@ impl AudioOnlyTrack {
 impl Drop for AudioOnlyTrack {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use ff_format::{Rational, Timestamp};
+
+    #[test]
+    fn lavfi_advance_to_should_surface_due_frames_and_hold_future_ones() {
+        // Probe-gated: needs the `movie` filter to build the source (absent on CI's
+        // Linux FFmpeg). The lavfi demuxer is also absent here, so `source.pull()`
+        // yields nothing and the seeded `pending` frames drive the held-frame logic
+        // deterministically.
+        let Some(mut st) = LavfiOverlayState::new("color=c=red:s=8x8:d=1") else {
+            println!("Skipping: movie/lavfi filter unavailable");
+            return;
+        };
+        let stamped = |w: u32, h: u32, secs: u64| {
+            let mut f = VideoFrame::from_rgba(w, h, vec![200u8; (w * h * 4) as usize]).unwrap();
+            f.set_timestamp(Timestamp::from_duration(
+                Duration::from_secs(secs),
+                Rational::new(1, 1_000_000),
+            ));
+            f
+        };
+        // A frame due at t=0 is surfaced (dims set, buffer converted).
+        st.pending = Some(stamped(8, 8, 0));
+        assert_eq!(st.advance_to(Duration::ZERO), Some((8, 8)));
+        assert!(!st.rgba.is_empty(), "the due frame was converted into rgba");
+        // A far-future frame is held, not surfaced; dims stay the last shown 8x8.
+        st.pending = Some(stamped(4, 4, 10));
+        assert_eq!(st.advance_to(Duration::from_secs(1)), Some((8, 8)));
+        assert!(st.pending.is_some(), "the future frame is held for later");
     }
 }

--- a/docs/specs/engine-and-primitives.md
+++ b/docs/specs/engine-and-primitives.md
@@ -140,6 +140,14 @@ expr-operator attenuation only becomes visible once the Q2 colour-space reconcil
 are alpha-composited and match export today. As with export, animated opacity/position on a non-`Over` layer
 is not tracked (the static t=0 value is used).
 
+**C4d (done):** preview composites the timeline-level `lavfi_overlay` (gap 4 closed). A new `ff_filter`
+primitive `LavfiSource` builds a source-only `movie=…:format_name=lavfi → format=rgba` graph (keeping the
+overlay's own alpha), carried into the `Scene` as a top-level `lavfi_overlay: Option<String>`. The runner
+generates a frame per tick (held-frame model, same as file overlays) and pushes it as the topmost layer —
+fixed full-frame Normal/`Over`, matching export — on both the present and gap-fill paths. **Limitation:** the
+source has no seek, so on a timeline seek the generator is rebuilt from t=0; a static overlay (a drawtext
+title, the dominant case) is exact, while a time-varying lavfi restarts from t=0 after a seek.
+
 ## 3. Boundary principle (model vs primitive)
 
 **Litmus:** does this type/function need to know **TIME, TRACK, CLIP, EDIT, or HISTORY** to do


### PR DESCRIPTION
## Objective

- A Timeline's `lavfi_overlay` (an FFmpeg lavfi filtergraph like `color=...,drawtext=...`, composited as the topmost video layer) was honoured by export but dropped by the preview path (`to_scene`).

## Solution

- Add a model-agnostic `ff_filter::LavfiSource` primitive: a source-only `movie=...:format_name=lavfi -> format=rgba` graph that keeps the overlay's own alpha (unlike the export path, which composites onto a canvas).
- Carry the string into the `Scene` as a top-level `lavfi_overlay`, and have the runner generate a frame per tick with the same held-frame model as file overlays (`LavfiOverlayState::advance_to`), pushing it as the topmost fixed Normal/Over layer on both the present and gap-fill paths. On seek the source is rebuilt from t=0 (it exposes no seek).
- The generator reuses one rgba buffer via `SwsRgbaConverter` and converts only the newest due frame (not every intermediate frame during a far-seek catch-up); the lavfi movie-args escaping is shared with the export path via one helper.
- Limitation: a static overlay (a drawtext title, the dominant case) is exact; a time-varying lavfi restarts from t=0 after a seek. The lavfi virtual demuxer is absent on the dev machine and CI Linux FFmpeg, so real compositing is verified only on a full FFmpeg build (the same as the existing export lavfi tests); the runner held-frame logic has a probe-gated deterministic unit test.

Closes #1358