### PR TITLE
feat(ff-preview): converge audio derivation and apply volume/speed/fades in preview

### DIFF
--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -200,6 +200,23 @@ pub(crate) fn realtime_descriptor(
     }
 }
 
+/// The 3-way-merged audio volume (dB): a per-clip volume track wins, then a static
+/// non-zero `volume_db`, then the timeline `audio_{idx}_volume` automation. This is
+/// the single interpretation the export [`audio_track`] and the preview audio
+/// projection ([`Timeline::to_scene`](crate::Timeline::to_scene)) share.
+#[allow(clippy::float_cmp)]
+pub(crate) fn audio_volume(
+    clip: &Clip,
+    track_idx: usize,
+    animations: &HashMap<String, AnimationTrack<f64>>,
+) -> AnimatedValue<f64> {
+    match &clip.volume_track {
+        Some(track) => AnimatedValue::Track(track.clone()),
+        None if clip.volume_db != 0.0 => AnimatedValue::Static(clip.volume_db),
+        None => track_animation(animations, "audio", track_idx, "volume", 0.0),
+    }
+}
+
 /// Derives the export [`AudioTrack`] for one clip.
 ///
 /// `fade_out_eff_dur` is the caller-resolved effective clip duration, used only
@@ -210,13 +227,7 @@ pub(crate) fn audio_track(
     animations: &HashMap<String, AnimationTrack<f64>>,
     fade_out_eff_dur: Option<Duration>,
 ) -> AudioTrack {
-    // A per-clip volume track wins over the static volume_db, which overrides
-    // the track-level animation.
-    let volume = match &clip.volume_track {
-        Some(track) => AnimatedValue::Track(track.clone()),
-        None if clip.volume_db != 0.0 => AnimatedValue::Static(clip.volume_db),
-        None => track_animation(animations, "audio", track_idx, "volume", 0.0),
-    };
+    let volume = audio_volume(clip, track_idx, animations);
 
     // Timeline trim + placement first, then speed/fade/effect steps, matching
     // the mixer node order (atrim → asetpts=PTS-STARTPTS → adelay).
@@ -472,6 +483,36 @@ mod tests {
         let clip = Clip::new("a.mp3");
         let track = audio_track(&clip, 0, &anims, None);
         assert!(matches!(track.pan, AnimatedValue::Track(_)));
+    }
+
+    // ── audio_volume (shared 3-way merge) ─────────────────────────────────────
+
+    #[test]
+    fn audio_volume_should_fall_back_to_timeline_animation() {
+        let mut anims = HashMap::new();
+        anims.insert(
+            "audio_0_volume".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, -3.0, Easing::Linear)),
+        );
+        let clip = Clip::new("a.mp3"); // neutral volume_db, no volume_track
+        assert!(matches!(
+            audio_volume(&clip, 0, &anims),
+            AnimatedValue::Track(_)
+        ));
+    }
+
+    #[test]
+    fn audio_volume_static_should_win_over_timeline() {
+        let mut anims = HashMap::new();
+        anims.insert(
+            "audio_0_volume".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, -3.0, Easing::Linear)),
+        );
+        let clip = Clip::new("a.mp3").volume(-6.0);
+        assert!(matches!(
+            audio_volume(&clip, 0, &anims),
+            AnimatedValue::Static(x) if (x + 6.0).abs() < 1e-9
+        ));
     }
 
     // ── realtime_descriptor (single derive → preview) ─────────────────────────

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -672,23 +672,31 @@ fn video_placement(
         layer: crate::derive::realtime_descriptor(clip, track_idx, animations),
         fade_in: clip.fade_in,
         fade_out: clip.fade_out,
-        volume_db: clip.volume_db,
-        volume_track: clip.volume_track.clone(),
+        // V1 clip audio has no dedicated audio-track counterpart in export (which
+        // mixes only `audio_tracks`), so its volume is the per-clip merge only.
+        volume: crate::derive::audio_volume(clip, 0, &HashMap::new()),
     }
 }
 
 /// Projects one audio-only clip into a [`SceneAudioPlacement`](ff_preview::SceneAudioPlacement).
+/// `track_idx` is the audio track index; `animations` the timeline `audio_animations`.
 #[cfg(feature = "preview")]
-fn audio_placement(clip: &Clip) -> ff_preview::SceneAudioPlacement {
+fn audio_placement(
+    clip: &Clip,
+    track_idx: usize,
+    animations: &HashMap<String, AnimationTrack<f64>>,
+) -> ff_preview::SceneAudioPlacement {
     ff_preview::SceneAudioPlacement {
         source: clip.source.clone(),
         timeline_offset: clip.timeline_offset,
         in_point: clip.in_point.unwrap_or(Duration::ZERO),
         out_point: clip.out_point,
+        speed: clip.speed.max(0.01),
         fade_in: clip.fade_in,
         fade_out: clip.fade_out,
-        volume_db: clip.volume_db,
-        volume_track: clip.volume_track.clone(),
+        // The single derive: the volume 3-way merge (incl. the timeline
+        // `audio_{idx}_volume` automation) reaches preview, matching export.
+        volume: crate::derive::audio_volume(clip, track_idx, animations),
     }
 }
 
@@ -720,8 +728,12 @@ impl Timeline {
         let audio_tracks = self
             .audio_tracks()
             .iter()
-            .map(|track| ff_preview::SceneAudioTrack {
-                placements: track.iter().map(audio_placement).collect(),
+            .enumerate()
+            .map(|(track_idx, track)| ff_preview::SceneAudioTrack {
+                placements: track
+                    .iter()
+                    .map(|clip| audio_placement(clip, track_idx, &self.audio_animations))
+                    .collect(),
             })
             .collect();
 
@@ -792,7 +804,7 @@ mod tests {
             Duration::ZERO,
             "clip 0 has no transition"
         );
-        assert!(base.volume_track.is_some());
+        assert!(matches!(base.volume, AnimatedValue::Track(_)));
         assert!(
             matches!(base.layer.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < f64::EPSILON)
         );
@@ -811,7 +823,7 @@ mod tests {
         assert_eq!(audio.source.to_str(), Some("music.mp3"));
         assert_eq!(audio.fade_in, Duration::from_millis(200));
         assert_eq!(audio.fade_out, Duration::from_millis(300));
-        assert!((audio.volume_db - (-6.0)).abs() < f64::EPSILON);
+        assert!(matches!(audio.volume, AnimatedValue::Static(v) if (v + 6.0).abs() < f64::EPSILON));
     }
 
     #[cfg(feature = "preview")]
@@ -864,6 +876,29 @@ mod tests {
             scene.lavfi_overlay.as_deref(),
             Some("color=s=1920x1080:c=black@0.0")
         );
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_carry_audio_speed_and_merged_volume() {
+        use ff_filter::{Easing, Keyframe};
+
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("v.mp4")])
+            .audio_track(vec![Clip::new("a.mp3").with_speed(2.0)]) // neutral volume
+            .audio_animation(
+                "audio_0_volume",
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, -3.0, Easing::Linear)),
+            )
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        let audio = &scene.audio_tracks[0].placements[0];
+        assert!((audio.speed - 2.0).abs() < f64::EPSILON);
+        // The neutral clip volume falls back to the timeline `audio_0_volume` automation.
+        assert!(matches!(audio.volume, AnimatedValue::Track(_)));
     }
 
     #[test]

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -45,7 +45,10 @@ pub use runner::TimelineRunner;
 pub use scene::{Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack};
 
 use audio_resampling::spawn_audio_track_thread;
-use state::{AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer};
+use ff_filter::AnimatedValue;
+use state::{
+    AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer, db_to_linear,
+};
 
 // -- Constants --
 
@@ -186,6 +189,14 @@ impl ScenePlayer {
                 decode_buf.seek(p.in_pt)?;
             }
 
+            // Apply a static V1 audio gain once at open; an animated gain is driven
+            // per-tick by the runner.
+            if let (Some(handle), AnimatedValue::Static(db)) =
+                (&audio_track_handles[i], &clip_list[i].volume)
+                && *db != 0.0
+            {
+                handle.set_volume(db_to_linear(*db));
+            }
             clip_states.push(ClipState {
                 source: p.source.clone(),
                 decode_buf,
@@ -198,7 +209,9 @@ impl ScenePlayer {
                 speed: p.speed,
                 opacity: p.opacity,
                 layer_desc: clip_list[i].layer.clone(),
-                volume_track: clip_list[i].volume_track.clone(),
+                volume: clip_list[i].volume.clone(),
+                fade_in: clip_list[i].fade_in,
+                fade_out: clip_list[i].fade_out,
             });
         }
 
@@ -234,6 +247,11 @@ impl ScenePlayer {
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .add_track();
+                    if let AnimatedValue::Static(db) = &p.volume
+                        && *db != 0.0
+                    {
+                        handle.set_volume(db_to_linear(*db));
+                    }
                     audio_only_tracks.push(AudioOnlyTrack {
                         source: p.source.clone(),
                         timeline_start,
@@ -242,8 +260,9 @@ impl ScenePlayer {
                         fade_in: p.fade_in,
                         fade_out: p.fade_out,
                         clip_dur,
+                        speed: p.speed,
                         handle,
-                        volume_track: p.volume_track.clone(),
+                        volume: p.volume.clone(),
                         cancel: None,
                         thread: None,
                     });
@@ -260,7 +279,9 @@ impl ScenePlayer {
                     speed: p.speed,
                     opacity: p.opacity,
                     layer_desc: p.layer.clone(),
-                    volume_track: p.volume_track.clone(),
+                    volume: p.volume.clone(),
+                    fade_in: p.fade_in,
+                    fade_out: p.fade_out,
                 });
             }
             overlay_layers.push(OverlayLayer {
@@ -295,13 +316,12 @@ impl ScenePlayer {
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .add_track();
-                // Apply per-clip gain (dB → linear). A volume_track (animated) takes
-                // precedence and is driven per-tick by the runner, so only apply the
-                // static gain when no track is present.
-                if p.volume_track.is_none() && p.volume_db != 0.0 {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let linear = 10.0_f64.powf(p.volume_db / 20.0) as f32;
-                    handle.set_volume(linear);
+                // Apply a static gain once at open; an animated gain (a track) is driven
+                // per-tick by the runner.
+                if let AnimatedValue::Static(db) = &p.volume
+                    && *db != 0.0
+                {
+                    handle.set_volume(db_to_linear(*db));
                 }
                 audio_only_tracks.push(AudioOnlyTrack {
                     source: p.source.clone(),
@@ -311,8 +331,9 @@ impl ScenePlayer {
                     fade_in: p.fade_in,
                     fade_out: p.fade_out,
                     clip_dur,
+                    speed: p.speed,
                     handle,
-                    volume_track: p.volume_track.clone(),
+                    volume: p.volume.clone(),
                     cancel: None,
                     thread: None,
                 });

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -24,6 +24,7 @@ use crate::playback::sink::FrameSink;
 use super::audio_resampling::spawn_audio_track_thread;
 use super::state::{
     AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer, TransitionState,
+    db_to_linear,
 };
 use super::timeline_inner;
 
@@ -638,22 +639,19 @@ impl TimelineRunner {
                             // not play this track's buffered audio past clip end.
                             at.handle.clear();
                         }
-                        // Per-clip volume automation: evaluate the dB envelope at the
-                        // timeline PTS and update the mixer track gain each tick.
-                        if should_run && let Some(track) = &at.volume_track {
-                            #[allow(clippy::cast_possible_truncation)]
-                            let linear = 10f32.powf(track.value_at(timeline_pts) as f32 / 20.0);
-                            at.handle.set_volume(linear);
+                        // Per-clip volume automation: an animated gain is evaluated at
+                        // the timeline PTS each tick (a static gain was set at open).
+                        if should_run && let AnimatedValue::Track(track) = &at.volume {
+                            at.handle
+                                .set_volume(db_to_linear(track.value_at(timeline_pts)));
                         }
                     }
 
                     // Primary-track volume automation for the active clip.
                     if let Some(handle) = &self.clips[active].audio_track
-                        && let Some(track) = &self.clips[active].volume_track
+                        && let AnimatedValue::Track(track) = &self.clips[active].volume
                     {
-                        #[allow(clippy::cast_possible_truncation)]
-                        let linear = 10f32.powf(track.value_at(timeline_pts) as f32 / 20.0);
-                        handle.set_volume(linear);
+                        handle.set_volume(db_to_linear(track.value_at(timeline_pts)));
                     }
 
                     // Update shared current_pts and resume anchor.
@@ -1111,19 +1109,25 @@ impl TimelineRunner {
         };
         handle.clear(); // discard stale samples
 
-        let source = self.clips[clip_idx].source.clone();
-        let clip_speed = self.clips[clip_idx].speed;
+        let c = &self.clips[clip_idx];
+        let source = c.source.clone();
+        // V1 clip audio honours its own fades + speed (the A-track path already does).
+        // `clip_dur` must be the SOURCE-time span (the resampler multiplies it by
+        // `1/speed` to get timeline time, as the A-tracks feed `out-in` source span);
+        // the timeline span is `source/speed`, so scale it back by `speed`.
+        let fades = AudioFadeConfig {
+            fade_in: c.fade_in,
+            fade_out: c.fade_out,
+            clip_dur: c
+                .timeline_end
+                .saturating_sub(c.timeline_start)
+                .mul_f64(c.speed),
+            in_point: c.in_point,
+            speed: c.speed,
+        };
         let cancel = Arc::new(AtomicBool::new(false));
-        let thread = spawn_audio_track_thread(
-            source,
-            start_pts,
-            handle,
-            Arc::clone(&cancel),
-            AudioFadeConfig {
-                speed: clip_speed,
-                ..AudioFadeConfig::NONE
-            },
-        );
+        let thread =
+            spawn_audio_track_thread(source, start_pts, handle, Arc::clone(&cancel), fades);
         self.active_audio_cancel = Some(cancel);
         self.active_audio_thread = Some(thread);
     }

--- a/crates/ff-preview/src/timeline/scene.rs
+++ b/crates/ff-preview/src/timeline/scene.rs
@@ -16,7 +16,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use ff_filter::{AnimationTrack, RealtimeLayerDescriptor};
+use ff_filter::{AnimatedValue, RealtimeLayerDescriptor};
 
 // ── Scene ─────────────────────────────────────────────────────────────────────
 
@@ -79,10 +79,9 @@ pub struct ScenePlacement {
     pub fade_in: Duration,
     /// Audio fade-out duration (`Duration::ZERO` = none).
     pub fade_out: Duration,
-    /// Static audio gain in dB.
-    pub volume_db: f64,
-    /// Per-clip volume automation (dB, timeline-global). Overrides the static gain.
-    pub volume_track: Option<AnimationTrack<f64>>,
+    /// Resolved audio gain (dB), static or animated. A static value is applied once at
+    /// open; an animated one is evaluated per tick.
+    pub volume: AnimatedValue<f64>,
 }
 
 // ── SceneAudioTrack ─────────────────────────────────────────────────────────────
@@ -107,12 +106,14 @@ pub struct SceneAudioPlacement {
     pub in_point: Duration,
     /// Source-file PTS at which playback ends (`None` = play to EOF).
     pub out_point: Option<Duration>,
+    /// Playback speed multiplier (`1.0` = normal), clamped to at least `0.01`,
+    /// applied by resampling.
+    pub speed: f64,
     /// Audio fade-in duration (`Duration::ZERO` = none).
     pub fade_in: Duration,
     /// Audio fade-out duration (`Duration::ZERO` = none).
     pub fade_out: Duration,
-    /// Static audio gain in dB.
-    pub volume_db: f64,
-    /// Per-clip volume automation (dB, timeline-global). Overrides the static gain.
-    pub volume_track: Option<AnimationTrack<f64>>,
+    /// Resolved audio gain (dB), static or animated. A static value is applied once at
+    /// open; an animated one is evaluated per tick.
+    pub volume: AnimatedValue<f64>,
 }

--- a/crates/ff-preview/src/timeline/state.rs
+++ b/crates/ff-preview/src/timeline/state.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use ff_filter::{AnimationTrack, LavfiSource, RealtimeLayerDescriptor};
+use ff_filter::{AnimatedValue, LavfiSource, RealtimeLayerDescriptor};
 use ff_format::VideoFrame;
 
 use crate::audio::AudioTrackHandle;
@@ -18,6 +18,12 @@ use crate::playback::SwsRgbaConverter;
 use crate::playback::decode_buffer::DecodeBuffer;
 
 use super::audio_resampling::spawn_audio_track_thread;
+
+/// Converts a gain in dB to a linear amplitude multiplier for the mixer.
+#[allow(clippy::cast_possible_truncation)]
+pub(super) fn db_to_linear(db: f64) -> f32 {
+    10.0_f64.powf(db / 20.0) as f32
+}
 
 // ── ClipState ─────────────────────────────────────────────────────────────────
 
@@ -49,9 +55,13 @@ pub(super) struct ClipState {
     /// opacity/position tracks). The runner realises it into a `RealtimeLayer`
     /// each frame via [`RealtimeLayer::with_dimensions`](ff_filter::RealtimeLayer::with_dimensions).
     pub(super) layer_desc: RealtimeLayerDescriptor,
-    /// Per-clip volume automation (dB, timeline-global). When `Some`, the runner
-    /// updates the primary-track mixer gain each tick.
-    pub(super) volume_track: Option<AnimationTrack<f64>>,
+    /// Audio gain (dB), static or automated (the 3-way-merged value). Applied to the
+    /// primary-track mixer gain: a static value once at open, an animated one per-tick.
+    pub(super) volume: AnimatedValue<f64>,
+    /// Per-clip audio fade-in / fade-out for this clip's own audio (`Duration::ZERO`
+    /// = none). Forwarded to the audio decode thread's fade envelope.
+    pub(super) fade_in: Duration,
+    pub(super) fade_out: Duration,
 }
 
 // ── TransitionState ───────────────────────────────────────────────────────────
@@ -214,10 +224,12 @@ pub(super) struct AudioOnlyTrack {
     pub(super) fade_out: Duration,
     /// Effective clip duration — used to position the fade-out ramp.
     pub(super) clip_dur: Duration,
+    /// Playback speed multiplier (`1.0` = normal), applied by resampling.
+    pub(super) speed: f64,
     pub(super) handle: AudioTrackHandle,
-    /// Per-clip volume automation (dB, timeline-global). When `Some`, the runner
-    /// updates `handle`'s volume each tick; overrides the static one-shot gain.
-    pub(super) volume_track: Option<AnimationTrack<f64>>,
+    /// Audio gain (dB), static or automated (the 3-way-merged value). Applied to
+    /// `handle`: a static value once at open, an animated one per-tick.
+    pub(super) volume: AnimatedValue<f64>,
     pub(super) cancel: Option<Arc<AtomicBool>>,
     pub(super) thread: Option<JoinHandle<()>>,
 }
@@ -241,7 +253,7 @@ impl AudioOnlyTrack {
                 fade_out: self.fade_out,
                 clip_dur: self.clip_dur,
                 in_point: self.in_point,
-                speed: 1.0,
+                speed: self.speed,
             },
         );
         self.cancel = Some(cancel);
@@ -267,6 +279,18 @@ impl Drop for AudioOnlyTrack {
 mod tests {
     use super::*;
     use ff_format::{Rational, Timestamp};
+
+    #[test]
+    fn db_to_linear_should_convert_gain() {
+        // The shared dB→linear conversion used by every audio-gain site.
+        assert!((db_to_linear(0.0) - 1.0).abs() < 1e-6, "0 dB = unity");
+        assert!(
+            (db_to_linear(-6.0) - 0.501_187).abs() < 1e-3,
+            "-6 dB ≈ 0.501"
+        );
+        assert!((db_to_linear(6.0) - 1.995).abs() < 1e-3, "+6 dB ≈ 1.995");
+        assert!(db_to_linear(-120.0) < 1e-5, "very quiet ≈ 0");
+    }
 
     #[test]
     fn lavfi_advance_to_should_surface_due_frames_and_hold_future_ones() {

--- a/docs/specs/engine-and-primitives.md
+++ b/docs/specs/engine-and-primitives.md
@@ -148,6 +148,17 @@ fixed full-frame Normal/`Over`, matching export — on both the present and gap-
 source has no seek, so on a timeline seek the generator is rebuilt from t=0; a static overlay (a drawtext
 title, the dominant case) is exact, while a time-varying lavfi restarts from t=0 after a seek.
 
+**C4e (done):** the audio derivation converged on `avio::derive::audio_volume` (the 3-way volume merge), which
+both the export `audio_track` and the preview `to_scene` audio projection now share; `to_scene` threads
+`audio_animations` (previously unused). Preview audio now applies the merged volume (incl. the timeline
+`audio_{idx}_volume` automation), the audio-only-track `speed` (was hard-coded 1.0), and the V1-clip audio
+fades and static `volume_db` (previously dropped). Note export mixes only the dedicated `audio_tracks` (not
+video-clip audio), so the audio-track placements are the parity target. **Deferred (audio-Q2):** `pan` — a
+no-op in the export mixer today (`build_audio_mix` computes but never applies it) — and `audio_effects` — the
+preview audio path is a hand-rolled decode+resample+mix pipeline with no `FilterStep` executor. Both await a
+per-track preview audio `FilterGraph` executor (the audio analogue of the video executor convergence), which
+would also apply pitch-accurate `atempo` speed and realise pan in both ends.
+
 ## 3. Boundary principle (model vs primitive)
 
 **Litmus:** does this type/function need to know **TIME, TRACK, CLIP, EDIT, or HISTORY** to do


### PR DESCRIPTION
## Objective

- The preview audio pipeline was never routed through `avio::derive`: it dropped the timeline `audio_animations` (the volume 3-way-merge third arm), hard-coded audio-only-track `speed` to `1.0`, and dropped V1 clip audio fades and static `volume_db`. Export honoured these for its dedicated `audio_tracks`.

## Solution

- Extract the shared volume merge into `avio::derive::audio_volume` (per-clip track > static `volume_db` > timeline `audio_{idx}_volume`), consumed by both the export `audio_track` and the preview `to_scene` projection; thread `audio_animations` through `to_scene`.
- Converge the `Scene` audio volume onto a single `volume: AnimatedValue<f64>` and add `speed` to `SceneAudioPlacement`. The runner applies a static gain once at open and an animated gain per tick (fixing the V1 static-`volume_db` drop and the overlay-audio omission), passes the audio-only-track `speed`, and gives V1 clip audio its own fades.
- `pan` is a no-op in the export mixer today and `audio_effects` has no preview executor, so both are deferred to an audio-Q2 follow-up (a per-track preview audio `FilterGraph` executor). Documented in `engine-and-primitives.md` 2.1.

Closes #1359