### PR TITLE
feat(ff-preview): render xfade transition kinds in preview

### DIFF
--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -658,6 +658,9 @@ fn video_placement(
     } else {
         Duration::ZERO
     };
+    // Carry the transition kind (not just its duration) so preview renders the
+    // actual xfade kind; overlays force no transition (matching the compositor).
+    let transition_kind = if is_base { clip.transition } else { None };
     ff_preview::ScenePlacement {
         source: clip.source.clone(),
         timeline_offset: clip.timeline_offset,
@@ -665,6 +668,7 @@ fn video_placement(
         out_point: clip.out_point,
         speed: clip.speed.max(0.01),
         transition_dur,
+        transition_kind,
         opacity: clip.opacity.clamp(0.0, 1.0),
         // The single derive: preview and export build their video layers from the
         // same `avio::derive`, so the timeline-level animations (scale/rotation and
@@ -804,6 +808,7 @@ mod tests {
             Duration::ZERO,
             "clip 0 has no transition"
         );
+        assert_eq!(base.transition_kind, None, "clip 0 has no transition kind");
         assert!(matches!(base.volume, AnimatedValue::Track(_)));
         assert!(
             matches!(base.layer.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < f64::EPSILON)
@@ -811,12 +816,21 @@ mod tests {
 
         let base1 = &scene.video_tracks[0].placements[1];
         assert_eq!(base1.transition_dur, Duration::from_millis(750));
+        assert_eq!(
+            base1.transition_kind,
+            Some(XfadeTransition::Fade),
+            "base track carries the xfade kind"
+        );
 
         let overlay = &scene.video_tracks[1].placements[0];
         assert_eq!(
             overlay.transition_dur,
             Duration::ZERO,
             "overlay transitions must project as zero"
+        );
+        assert_eq!(
+            overlay.transition_kind, None,
+            "overlay transition kind is forced off"
         );
 
         let audio = &scene.audio_tracks[0].placements[0];

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -45,7 +45,7 @@ pub use runner::TimelineRunner;
 pub use scene::{Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack};
 
 use audio_resampling::spawn_audio_track_thread;
-use ff_filter::AnimatedValue;
+use ff_filter::{AnimatedValue, XfadeTransition};
 use state::{
     AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer, db_to_linear,
 };
@@ -91,6 +91,7 @@ impl ScenePlayer {
             timeline_offset: Duration,
             out_point: Option<Duration>,
             transition_dur: Duration,
+            transition_kind: Option<XfadeTransition>,
             has_audio: bool,
             /// Video frame dimensions — used to pre-populate `last_frame_w/h` so the
             /// gap-fill loop can synthesise black frames before the first real frame.
@@ -147,6 +148,7 @@ impl ScenePlayer {
                 timeline_offset: p.timeline_offset,
                 out_point: p.out_point,
                 transition_dur: p.transition_dur,
+                transition_kind: p.transition_kind,
                 has_audio,
                 video_w,
                 video_h,
@@ -205,6 +207,7 @@ impl ScenePlayer {
                 in_point: p.in_pt,
                 out_point: p.out_point,
                 transition_dur: p.transition_dur,
+                transition_kind: p.transition_kind,
                 audio_track: audio_track_handles[i].clone(),
                 speed: p.speed,
                 opacity: p.opacity,
@@ -275,6 +278,7 @@ impl ScenePlayer {
                     in_point: in_pt,
                     out_point: p.out_point,
                     transition_dur: Duration::ZERO,
+                    transition_kind: None,
                     audio_track: None,
                     speed: p.speed,
                     opacity: p.opacity,

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -9,7 +9,9 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use ff_filter::{AnimatedValue, BlendMode, CompositeOp, RealtimeComposer, RealtimeLayer};
+use ff_filter::{
+    AnimatedValue, BlendMode, CompositeOp, RealtimeComposer, RealtimeLayer, XfadeTransition,
+};
 use ff_format::{PixelFormat, Rational, Timestamp, VideoFrame};
 
 use crate::audio::AudioMixer;
@@ -672,6 +674,7 @@ impl TimelineRunner {
                                     next_idx: active + 1,
                                     start: next.timeline_start,
                                     duration: next.transition_dur,
+                                    kind: next.transition_kind.unwrap_or(XfadeTransition::Fade),
                                 });
                             } else {
                                 // Jumped past the entire transition zone.
@@ -873,10 +876,17 @@ impl TimelineRunner {
 
                     // Copy transition fields to avoid holding a borrow while
                     // calling `pop_frame` on the next clip.
-                    let (in_trans, next_idx, trans_start, trans_dur) = match &self.transition {
-                        Some(tp) => (true, tp.next_idx, tp.start, tp.duration),
-                        None => (false, 0, Duration::ZERO, Duration::ZERO),
-                    };
+                    let (in_trans, next_idx, trans_start, trans_dur, trans_kind) =
+                        match &self.transition {
+                            Some(tp) => (true, tp.next_idx, tp.start, tp.duration, tp.kind),
+                            None => (
+                                false,
+                                0,
+                                Duration::ZERO,
+                                Duration::ZERO,
+                                XfadeTransition::Fade,
+                            ),
+                        };
 
                     let a_ok = self.sws_a.convert(&frame, &mut self.rgba_a);
 
@@ -914,10 +924,13 @@ impl TimelineRunner {
                             let alpha = (timeline_pts.saturating_sub(trans_start).as_secs_f32()
                                 / trans_dur.as_secs_f32())
                             .clamp(0.0, 1.0);
-                            timeline_inner::blend_rgba(
+                            timeline_inner::apply_xfade(
+                                trans_kind,
                                 &self.rgba_a,
                                 &self.rgba_b,
                                 alpha,
+                                w,
+                                h,
                                 &mut self.blend_buf,
                             );
                             std::mem::swap(&mut self.rgba_a, &mut self.blend_buf);

--- a/crates/ff-preview/src/timeline/runner_layout.rs
+++ b/crates/ff-preview/src/timeline/runner_layout.rs
@@ -78,6 +78,7 @@ impl TimelineRunner {
             self.clips[i].out_point = p.out_point;
             self.clips[i].speed = new_speed;
             self.clips[i].transition_dur = p.transition_dur;
+            self.clips[i].transition_kind = p.transition_kind;
         }
 
         // ── Update overlay layers (V2+) ────────────────────────────────────────

--- a/crates/ff-preview/src/timeline/scene.rs
+++ b/crates/ff-preview/src/timeline/scene.rs
@@ -16,7 +16,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use ff_filter::{AnimatedValue, RealtimeLayerDescriptor};
+use ff_filter::{AnimatedValue, RealtimeLayerDescriptor, XfadeTransition};
 
 // ── Scene ─────────────────────────────────────────────────────────────────────
 
@@ -69,6 +69,10 @@ pub struct ScenePlacement {
     /// Crossfade duration from the previous placement into this one. Meaningful on
     /// the V1 base track only; `Duration::ZERO` = hard cut.
     pub transition_dur: Duration,
+    /// The `xfade` transition kind for this crossfade (V1 base track only). `None`
+    /// when there is no transition; the runner defaults to `Fade` if a duration is
+    /// set without a kind.
+    pub transition_kind: Option<XfadeTransition>,
     /// Per-clip opacity in `[0.0, 1.0]`.
     pub opacity: f32,
     /// The dimension-free compositing description (effects, blend, position, and the

--- a/crates/ff-preview/src/timeline/state.rs
+++ b/crates/ff-preview/src/timeline/state.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use ff_filter::{AnimatedValue, LavfiSource, RealtimeLayerDescriptor};
+use ff_filter::{AnimatedValue, LavfiSource, RealtimeLayerDescriptor, XfadeTransition};
 use ff_format::VideoFrame;
 
 use crate::audio::AudioTrackHandle;
@@ -42,6 +42,8 @@ pub(super) struct ClipState {
     /// Duration of the crossfade from the previous clip into this one.
     /// `Duration::ZERO` = hard cut.
     pub(super) transition_dur: Duration,
+    /// The `xfade` transition kind for that crossfade (`None` = default `Fade`).
+    pub(super) transition_kind: Option<XfadeTransition>,
     /// Audio track handle — `None` if the clip has no audio stream.
     pub(super) audio_track: Option<AudioTrackHandle>,
     /// Playback speed multiplier from `Clip::speed` (`1.0` = normal).
@@ -73,6 +75,8 @@ pub(super) struct TransitionState {
     pub(super) start: Duration,
     /// Duration of the transition.
     pub(super) duration: Duration,
+    /// The `xfade` kind to render for this transition.
+    pub(super) kind: XfadeTransition,
 }
 
 // ── OverlayLayer ──────────────────────────────────────────────────────────────

--- a/crates/ff-preview/src/timeline/timeline_inner.rs
+++ b/crates/ff-preview/src/timeline/timeline_inner.rs
@@ -2,6 +2,109 @@
 
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_precision_loss)]
+// `a`/`b` (frames), `w`/`h` (dims), `x`/`y` (coords) are the natural names here.
+#![allow(clippy::many_single_char_names)]
+
+use ff_filter::XfadeTransition;
+
+/// Blends the outgoing frame `a` and incoming frame `b` (packed RGBA, `w*h*4`) at
+/// transition progress `alpha` (`0` = all A, `1` = all B) using the `xfade` `kind`.
+///
+/// `wipe*`, `slide*`, and `dissolve` are rendered host-side here. `fade` and the
+/// geometric / mosaic kinds (`fadegrays`, `circleopen`, `circleclose`, `pixelize`)
+/// fall through to the linear cross-dissolve — exact fidelity for those is deferred
+/// to the GPU compositing work (#1365). Falls back to the linear blend when the
+/// buffers are mismatched or their length is not `w*h*4`.
+pub(super) fn apply_xfade(
+    kind: XfadeTransition,
+    a: &[u8],
+    b: &[u8],
+    alpha: f32,
+    w: u32,
+    h: u32,
+    dst: &mut Vec<u8>,
+) {
+    let expected = (w as usize) * (h as usize) * 4;
+    if a.len() != b.len() || a.len() != expected {
+        blend_rgba(a, b, alpha, dst);
+        return;
+    }
+    let p = alpha.clamp(0.0, 1.0);
+    let (wf, hf) = (w as f32, h as f32);
+    match kind {
+        XfadeTransition::WipeRight => wipe(a, b, w, h, dst, |x, _| (x as f32) < p * wf),
+        XfadeTransition::WipeLeft => wipe(a, b, w, h, dst, |x, _| (x as f32) >= (1.0 - p) * wf),
+        XfadeTransition::WipeDown => wipe(a, b, w, h, dst, |_, y| (y as f32) < p * hf),
+        XfadeTransition::WipeUp => wipe(a, b, w, h, dst, |_, y| (y as f32) >= (1.0 - p) * hf),
+        XfadeTransition::SlideLeft => slide(a, b, w, h, dst, (p * wf) as i64, 0),
+        XfadeTransition::SlideRight => slide(a, b, w, h, dst, -((p * wf) as i64), 0),
+        XfadeTransition::SlideUp => slide(a, b, w, h, dst, 0, (p * hf) as i64),
+        XfadeTransition::SlideDown => slide(a, b, w, h, dst, 0, -((p * hf) as i64)),
+        XfadeTransition::Dissolve => dissolve(a, b, w, h, dst, p),
+        // `Fade` and the deferred geometric/mosaic kinds (plus any future variant of
+        // this `#[non_exhaustive]` enum) render as the linear cross-dissolve.
+        _ => blend_rgba(a, b, alpha, dst),
+    }
+}
+
+/// Per-pixel hard-edge pick between `a` and `b` (wipes).
+fn wipe(a: &[u8], b: &[u8], w: u32, h: u32, dst: &mut Vec<u8>, is_b: impl Fn(u32, u32) -> bool) {
+    dst.resize(a.len(), 0);
+    for y in 0..h {
+        for x in 0..w {
+            let i = ((y * w + x) * 4) as usize;
+            let src = if is_b(x, y) { b } else { a };
+            dst[i..i + 4].copy_from_slice(&src[i..i + 4]);
+        }
+    }
+}
+
+/// Slide: the outgoing frame `a` translates by `(dx, dy)`; where it leaves the frame
+/// the incoming frame `b` has slid into view from the opposite edge.
+fn slide(a: &[u8], b: &[u8], w: u32, h: u32, dst: &mut Vec<u8>, dx: i64, dy: i64) {
+    dst.resize(a.len(), 0);
+    let (wi, hi) = (i64::from(w), i64::from(h));
+    for y in 0..hi {
+        for x in 0..wi {
+            let (sx, sy) = (x + dx, y + dy);
+            let (src, ux, uy) = if (0..wi).contains(&sx) && (0..hi).contains(&sy) {
+                (a, sx, sy)
+            } else {
+                (b, sx.rem_euclid(wi), sy.rem_euclid(hi))
+            };
+            let di = ((y * wi + x) * 4) as usize;
+            let si = ((uy * wi + ux) * 4) as usize;
+            dst[di..di + 4].copy_from_slice(&src[si..si + 4]);
+        }
+    }
+}
+
+/// Dissolve: reveal `b` per-pixel once progress passes a deterministic per-pixel
+/// threshold (a plausible noise dissolve, not `FFmpeg`'s exact PRNG).
+fn dissolve(a: &[u8], b: &[u8], w: u32, h: u32, dst: &mut Vec<u8>, p: f32) {
+    dst.resize(a.len(), 0);
+    for y in 0..h {
+        for x in 0..w {
+            let i = ((y * w + x) * 4) as usize;
+            let src = if p > hash01(x, y) { b } else { a };
+            dst[i..i + 4].copy_from_slice(&src[i..i + 4]);
+        }
+    }
+}
+
+/// A cheap deterministic per-pixel hash in `[0.0, 1.0)`.
+fn hash01(x: u32, y: u32) -> f32 {
+    let mut h = x
+        .wrapping_mul(374_761_393)
+        .wrapping_add(y.wrapping_mul(668_265_263));
+    h = (h ^ (h >> 13)).wrapping_mul(1_274_126_177);
+    h ^= h >> 16;
+    // Top 24 bits over 2^24: max = (2^24 - 1) / 2^24 = 1 - 2^-24, exactly
+    // representable in f32 and strictly < 1.0, so `dissolve`'s `p > hash01`
+    // reveals every pixel at p = 1.0 (the all-B boundary holds exactly).
+    (h >> 8) as f32 / (1u32 << 24) as f32
+}
 
 /// Blend two packed-RGBA buffers: `dst[i] = (1 − alpha) · a[i] + alpha · b[i]`.
 ///
@@ -62,5 +165,143 @@ mod tests {
         let mut dst = Vec::new();
         blend_rgba(&a, &b, 0.5, &mut dst);
         assert_eq!(dst, a);
+    }
+
+    // ── apply_xfade (kind-aware transition blend) ─────────────────────────────
+
+    // A 4x1 packed-RGBA frame filled with one colour.
+    fn frame(color: [u8; 4]) -> Vec<u8> {
+        color.repeat(4)
+    }
+    const RED: [u8; 4] = [255, 0, 0, 255];
+    const BLUE: [u8; 4] = [0, 0, 255, 255];
+
+    #[test]
+    fn apply_xfade_fade_should_match_linear_blend() {
+        let (a, b) = (frame(RED), frame(BLUE));
+        let (mut x, mut y) = (Vec::new(), Vec::new());
+        apply_xfade(XfadeTransition::Fade, &a, &b, 0.5, 4, 1, &mut x);
+        blend_rgba(&a, &b, 0.5, &mut y);
+        assert_eq!(x, y, "Fade == linear blend");
+    }
+
+    #[test]
+    fn apply_xfade_wiperight_half_should_fill_b_from_the_left() {
+        let (a, b) = (frame(RED), frame(BLUE));
+        let mut dst = Vec::new();
+        apply_xfade(XfadeTransition::WipeRight, &a, &b, 0.5, 4, 1, &mut dst);
+        // edge = 2.0 → cols 0,1 = B (blue), cols 2,3 = A (red).
+        assert_eq!(&dst[0..4], &BLUE);
+        assert_eq!(&dst[4..8], &BLUE);
+        assert_eq!(&dst[8..12], &RED);
+        assert_eq!(&dst[12..16], &RED);
+    }
+
+    #[test]
+    fn apply_xfade_wipeleft_half_should_fill_b_from_the_right() {
+        let (a, b) = (frame(RED), frame(BLUE));
+        let mut dst = Vec::new();
+        apply_xfade(XfadeTransition::WipeLeft, &a, &b, 0.5, 4, 1, &mut dst);
+        // edge = 2.0 → cols 0,1 = A, cols 2,3 = B.
+        assert_eq!(&dst[0..4], &RED);
+        assert_eq!(&dst[8..12], &BLUE);
+    }
+
+    #[test]
+    fn apply_xfade_boundaries_should_be_all_a_or_all_b() {
+        let (a, b) = (frame(RED), frame(BLUE));
+        for kind in [
+            XfadeTransition::WipeRight,
+            XfadeTransition::WipeLeft,
+            XfadeTransition::WipeUp,
+            XfadeTransition::WipeDown,
+            XfadeTransition::SlideLeft,
+            XfadeTransition::SlideRight,
+            XfadeTransition::SlideUp,
+            XfadeTransition::SlideDown,
+            XfadeTransition::Dissolve,
+        ] {
+            let mut dst = Vec::new();
+            apply_xfade(kind, &a, &b, 0.0, 4, 1, &mut dst);
+            assert_eq!(dst, a, "{kind:?} at progress 0 = all A");
+            apply_xfade(kind, &a, &b, 1.0, 4, 1, &mut dst);
+            assert_eq!(dst, b, "{kind:?} at progress 1 = all B");
+        }
+    }
+
+    // A `w`x`h` packed-RGBA frame where pixel (x, y) is a distinct colour, so a
+    // test can tell which source and which coordinate a destination pixel came
+    // from. Encodes `x` in R and `y` in G.
+    fn tagged(w: u32, h: u32, base_b: u8) -> Vec<u8> {
+        let mut v = Vec::with_capacity((w * h * 4) as usize);
+        for y in 0..h {
+            for x in 0..w {
+                v.extend_from_slice(&[x as u8, y as u8, base_b, 255]);
+            }
+        }
+        v
+    }
+
+    #[test]
+    fn apply_xfade_wipedown_half_should_fill_b_from_the_top_rows() {
+        // 2x4 frame (h=4): a vertical wipe must split by *row*, not column.
+        let (a, b) = (tagged(2, 4, 0), tagged(2, 4, 99));
+        let mut dst = Vec::new();
+        apply_xfade(XfadeTransition::WipeDown, &a, &b, 0.5, 2, 4, &mut dst);
+        // edge = 2.0 → rows 0,1 = B (base_b 99), rows 2,3 = A (base_b 0).
+        let px = |x: u32, y: u32| {
+            let i = ((y * 2 + x) * 4) as usize;
+            dst[i + 2] // the base-B channel identifies the source frame
+        };
+        assert_eq!(px(0, 0), 99, "row 0 = B");
+        assert_eq!(px(1, 1), 99, "row 1 = B");
+        assert_eq!(px(0, 2), 0, "row 2 = A");
+        assert_eq!(px(1, 3), 0, "row 3 = A");
+    }
+
+    #[test]
+    fn apply_xfade_slideleft_mid_should_shift_a_left_and_slide_b_in_from_the_right() {
+        // 4x1: SlideLeft translates A left by p*w; B fills from the right edge.
+        let (a, b) = (tagged(4, 1, 0), tagged(4, 1, 99));
+        let mut dst = Vec::new();
+        apply_xfade(XfadeTransition::SlideLeft, &a, &b, 0.5, 4, 1, &mut dst);
+        // dx = 2. dst[x] = A[x+2] for x+2 < 4, else B[(x+2) mod 4].
+        let src = |x: usize| dst[x * 4 + 2]; // base-B channel: 0 = A, 99 = B
+        let col = |x: usize| dst[x * 4]; // R channel = source x-coordinate
+        assert_eq!(src(0), 0, "col 0 from A");
+        assert_eq!(col(0), 2, "col 0 = A[2] (shifted left by 2)");
+        assert_eq!(src(1), 0, "col 1 from A");
+        assert_eq!(col(1), 3, "col 1 = A[3]");
+        assert_eq!(src(2), 99, "col 2 from B (slid in)");
+        assert_eq!(src(3), 99, "col 3 from B (slid in)");
+    }
+
+    #[test]
+    fn apply_xfade_dissolve_mid_should_mix_a_and_b() {
+        // A larger frame so the per-pixel hash yields both A and B at p=0.5.
+        let (a, b) = (tagged(16, 16, 0), tagged(16, 16, 99));
+        let mut dst = Vec::new();
+        apply_xfade(XfadeTransition::Dissolve, &a, &b, 0.5, 16, 16, &mut dst);
+        let has_a = dst.chunks_exact(4).any(|p| p[2] == 0);
+        let has_b = dst.chunks_exact(4).any(|p| p[2] == 99);
+        assert!(has_a && has_b, "mid-progress dissolve mixes both A and B");
+    }
+
+    #[test]
+    fn apply_xfade_deferred_kind_should_fall_back_to_fade() {
+        let (a, b) = (frame(RED), frame(BLUE));
+        let (mut x, mut y) = (Vec::new(), Vec::new());
+        apply_xfade(XfadeTransition::Pixelize, &a, &b, 0.3, 4, 1, &mut x);
+        blend_rgba(&a, &b, 0.3, &mut y);
+        assert_eq!(x, y, "deferred kinds render as the linear fade");
+    }
+
+    #[test]
+    fn apply_xfade_mismatched_buffers_should_fall_back_to_linear() {
+        let a = frame(RED);
+        let b = vec![9u8, 9];
+        let mut dst = Vec::new();
+        apply_xfade(XfadeTransition::WipeRight, &a, &b, 0.5, 4, 1, &mut dst);
+        assert_eq!(dst, a, "mismatched → linear fallback copies A");
     }
 }

--- a/docs/specs/engine-and-primitives.md
+++ b/docs/specs/engine-and-primitives.md
@@ -159,6 +159,18 @@ preview audio path is a hand-rolled decode+resample+mix pipeline with no `Filter
 per-track preview audio `FilterGraph` executor (the audio analogue of the video executor convergence), which
 would also apply pitch-accurate `atempo` speed and realise pan in both ends.
 
+**C4c (done, completes C4):** preview renders the export xfade *kind* (gap 8 closed). Previously every
+transition rendered as a single host-side linear crossfade (`blend_rgba`); the kind was collapsed to a bool
+in `video_placement`. The derived `Scene` now carries `transition_kind: Option<XfadeTransition>` (base track
+only; overlays force `None`, matching the compositor), threaded into the runner's `TransitionState`. At each
+transition frame the runner already holds both frames (`rgba_a`, `rgba_b`), a scalar progress, and `w`/`h`
+host-side, so a new pure `ff_preview::timeline_inner::apply_xfade` dispatches on the kind over packed RGBA:
+`fade`, `wipe{left,right,up,down}`, `slide{left,right,up,down}`, and `dissolve` render with real fidelity and
+are covered by deterministic unit tests (no FFmpeg, no probe-gating). Preview transitions are CPU, as
+export's `xfade` is CPU. **Deferred:** the geometric/mosaic kinds (`fadegrays`, `circleopen`, `circleclose`,
+`pixelize`) fall back to the linear fade; exact fidelity for those and GPU-default compositing (export +
+preview) are tracked in #1365.
+
 ## 3. Boundary principle (model vs primitive)
 
 **Litmus:** does this type/function need to know **TIME, TRACK, CLIP, EDIT, or HISTORY** to do


### PR DESCRIPTION
## Objective

- Preview approximated every crossfade with a single host-side linear blend, so wipe/slide/dissolve all rendered as a plain dissolve while export honoured the FFmpeg `xfade` kind.
- The transition kind was collapsed to a bool in the model-to-scene derivation and never reached the runner. This is the last preview/export parity gap of the C4 visual-parity epic.

## Solution

- Carry the transition kind (`Option<XfadeTransition>`) through the derived `Scene` (V1 base track only; overlays force `None` to match the compositor) and into the runner's transition state.
- Add a pure `timeline_inner::apply_xfade` that dispatches on the kind over the RGBA frames the runner already holds: `fade`, `wipe{left,right,up,down}`, `slide{left,right,up,down}`, and `dissolve` render host-side with real fidelity.
- Defer the geometric/mosaic kinds (`fadegrays`, `circleopen`, `circleclose`, `pixelize`) to a linear-fade fallback, documented as exact-fidelity-deferred to the GPU compositing work (#1365).
- Bound `dissolve`'s per-pixel hash strictly to `[0, 1)` so the all-B boundary at progress 1 holds exactly.
- Add deterministic unit tests covering the kinds across both axes, mid-progress slide content, and the dissolve mix (no FFmpeg dependency).

Closes #1360