### PR TITLE
docs(roadmap): redefine v0.16.0 as the engine/library split milestone

### DIFF
--- a/docs/roadmap/v0-16-0/ROADMAP.md
+++ b/docs/roadmap/v0-16-0/ROADMAP.md
@@ -1,50 +1,50 @@
-# v0.16.0 — 音MAD Support (Pitch Shift & BPM Detection)
+# v0.16.0 — Engine / Library Split: Independent Publishing
 
-**Goal**: Extend audio processing capabilities to cover the key primitives required for Oto-MAD production on Niconico Douga: a wider pitch-shift range for mapping voice clips to musical notes across two octaves, and a BPM/beat detector that returns per-beat timestamps suitable for direct placement of clips on a `Timeline`.
+**Goal**: Present `avio` as an editing **engine** and the `ff-*` family as standalone, independently-versioned **primitive libraries**. The engine/primitive boundary is already clean (the model relocation and purification of #1326/#1327 landed, and preview == export via the C4 epic). This milestone makes that separation visible to downstream users: each `ff-*` crate is publishable and consumable on its own, versions diverge to reflect each crate's own change cadence, and the project moves to a GitHub organization.
 
-**Prerequisite**: v0.15.0 complete.
+**Prerequisite**: v0.15.x complete — the editing model lives only in `avio`, the `ff-*` crates are model-agnostic primitives, and the single `derive(model, t) -> Scene` feeds both preview and export.
 
-**Crates in scope**: `ff-filter`, `ff-decode`, `avio`
+**Crates in scope**: workspace-wide (every crate's manifest; CI; release automation; docs). No source refactoring of the boundary is required — it is already clean.
+
+**Also included in this cut** (already merged since v0.15.1, additive; not the headline theme):
+- Preview == export visual parity — the C4 epic (single `derive`, `composite_op` / `lavfi_overlay` / audio / xfade-kind parity in preview).
+- **音MAD support** (Pitch Shift ±24 semitones & BPM Detection) — a minor feature; see `oto-mad.md`.
 
 ---
 
 ## Requirements
 
-### Pitch Shift — ±24 Semitone Range
+### Independent per-crate versioning
 
-- `FilterGraph::pitch_shift(semitones)` accepts values in `[-24.0, 24.0]` (±2 octaves).
-- Pitch shifting is performed without changing playback duration (pitch-only, not tape-speed).
-- The implementation chains multiple `atempo` filter instances when the compensation factor falls outside the single-instance range `[0.5, 2.0]`, reusing the same `add_atempo_chain` helper used by `TimeStretch`.
-- Values outside `[-24.0, 24.0]` return `Err(FilterError::Ffmpeg { .. })`.
-- Audio quality is comparable to the existing ±12 semitone range (WSOLA via `atempo`).
+- Each crate carries its own `version` in `[package]`, decoupled from a single shared workspace version. Versions may diverge so that each number reflects only that crate's own changes (the tokio / `http` model, not the bevy / wgpu lockstep model).
+- Foundational primitives (`ff-format`, `ff-common`) can reach and hold a stable version independent of higher-churn crates (`ff-filter`, `ff-preview`, `ff-render`): a change in one crate never forces a version bump in an unchanged crate.
+- Internal dependencies are expressed as both a `path` and a `version` requirement, so every crate is publishable to crates.io and a consumer of a single `ff-*` crate receives an honest SemVer contract for that crate alone.
+- Versions never regress below what is already published on crates.io (the 0.15.1 baseline is monotonic); independent version lines begin at or above that baseline (not reset to 0.1.0).
 
-### BPM Detection and Beat Timestamps
+**Rationale (why independent, not lockstep)**: the purpose of the split is that the `ff-*` crates are pure, independently-usable FFmpeg primitives with genuinely different stability guarantees and audiences. Lockstep would pin the stable foundations to the churn of the volatile engine crates — `ff-format` could never reach and hold 1.0 while `ff-filter` iterates at 0.x (the trap that keeps bevy and futures family-wide at 0.x). Independent versioning is the honest expression of "these are separate libraries."
 
-- A `BpmDetector` struct detects the tempo and per-beat timestamps from an audio file.
-- The public API follows the consuming-builder pattern used by `SilenceDetector`:
+### Automated, change-driven releases
 
-  ```rust
-  BpmDetector::new("track.mp3")
-      .bpm_range(60.0, 200.0)
-      .run()  →  Result<BpmResult, DecodeError>
-  ```
+- Releases are driven by `release-plz`: it derives per-crate version bumps and changelog entries from conventional commits, creates per-crate tags (e.g. `ff-filter-v0.3.0`), and updates dependent crates' internal version requirements automatically.
+- The publish flow tolerates unchanged crates: a release publishes only the crates whose version advanced, and does not abort when an unchanged crate's version already exists on the registry (the current all-crates loop under `set -euo pipefail` would abort here).
+- Publishing continues to use crates.io Trusted Publishing / OIDC (no long-lived tokens); local `cargo publish` remains blocked by design.
+- Each crate has its own changelog, replacing the single-version `CHANGELOG.md` assumption.
 
-- `BpmResult` contains:
-  - `bpm: f64` — detected tempo in beats per minute
-  - `beats: Vec<Duration>` — timestamp of each detected beat from the start of the file
-  - `confidence: f32` — detection confidence in `[0.0, 1.0]`; values below `0.4` indicate ambiguous rhythm
+### Per-crate publishing readiness
 
-- The algorithm is pure Rust (no additional C dependencies):
-  1. Decode the audio file to mono f32 PCM at 22 050 Hz via the existing FFmpeg decode path
-  2. Detect onsets using **spectral flux** (half-wave rectified frame-energy derivative with adaptive threshold)
-  3. Estimate BPM via **normalized autocorrelation** of the onset envelope, searching within `[bpm_min, bpm_max]`
-  4. Generate beat timestamps by stepping forward from the first onset at the estimated interval, snapping to nearby onset peaks
+- Every library crate publishes with complete metadata (`description`, `license`, `repository`, `readme`, `keywords`, `categories`). This is already satisfied for all 12 crates; the milestone verifies it as a release gate rather than adding it.
+- Non-library members (`avio-examples`, `tools/gen-test-assets`, the `fuzz` crates) remain excluded from publishing (`publish = false`).
+- Each primitive crate's public surface and docs read as a standalone library: no dangling references to the editing model from a primitive crate. The stale `scene_adapter` / `avio::TimelinePlayer` doc references in `ff-preview` are reconciled, and any model-flavoured vocabulary on the primitive public surface is reviewed.
 
-- If the pure-Rust implementation does not meet the ±2 BPM accuracy threshold established by the integration tests, the algorithm internals (`detect_onsets`, `estimate_bpm`) are replaced with `aubio` C library bindings. The public API (`BpmDetector` / `BpmResult`) remains unchanged.
+### GitHub organization migration
 
-- `BpmDetector` and `BpmResult` are re-exported from `avio` under the `decode` feature flag.
+- The repository moves to a GitHub organization. The `repository` slug in crate metadata, `CODEOWNERS`, and `.github/*` references point to the org.
+- Each crate's crates.io Trusted Publisher is re-pointed to the org (this configuration lives on crates.io, performed by the maintainer).
+- Historical changelog links and cross-repo references rely on GitHub's transfer redirects rather than being rewritten.
 
-- Primary use case: map detected beat timestamps to `Clip::timeline_offset` values for beat-synchronized video cutting.
+### Documentation — the "engine + primitives" story
+
+- `avio` is documented as the editing engine; the `ff-*` family is documented as independently-usable FFmpeg primitive libraries, with guidance on consuming a single primitive crate without the engine.
 
 ---
 
@@ -52,21 +52,34 @@
 
 | Topic | Decision |
 |---|---|
-| Pitch shift range | ±24 semitones (2 octaves); covers typical Oto-MAD note range without needing external quality libraries |
-| Pitch shift implementation | Extend existing `asetrate` + `add_atempo_chain` path; no rubberband dependency |
-| BPM algorithm | Pure Rust spectral flux + autocorrelation; no C dependency beyond FFmpeg |
-| BPM fallback | If accuracy < ±2 BPM on reference track, migrate internals to aubio (API unchanged) |
-| BPM output granularity | `bpm` + `Vec<Duration>` beats + `confidence`; beat array enables direct `Timeline` placement |
-| Analysis sample rate | 22 050 Hz mono f32; sufficient for onset detection, reduces memory and CPU vs 44 100 Hz |
+| Versioning model | Independent per-crate (tokio / `http`), not lockstep — `ff-*` are standalone products with divergent cadences; a stable `ff-format` must be able to reach and hold 1.0 while `ff-filter` iterates at 0.x |
+| Release tooling | `release-plz` — per-crate tags, per-crate changelogs, dependent-crate version bumps, all derived from conventional commits |
+| Initial versions | Start from the 0.15.1 baseline (crates.io versions are monotonic); do not reset to 0.1.0 |
+| pitch/BPM (Oto-MAD) | Included as a **minor feature** of this release (already implemented; see `oto-mad.md`); additive, not the headline theme |
+| Release numbering | One 0.16.0 cut carries the accumulated code (engine-separation, C4 preview==export, Oto-MAD) and introduces independent versioning + org migration; no separate 0.15.2 is cut |
+| Boundary purification | None required — #1326 / #1327 already landed; only cosmetic doc reconciliation remains |
+| Org migration | Repo transfer + metadata/CI slug updates + crates.io Trusted Publisher re-pointing; changelog history and cross-repo links left to GitHub redirects |
 
 ---
 
 ## Definition of Done
 
-- `pitch_shift(24.0)` and `pitch_shift(-24.0)` succeed; `pitch_shift(24.5)` returns `Err`
-- Integration test: `pitch_shift(+24.0)` on a 220 Hz sine wave produces output frequency within ±5% of 880 Hz
-- `BpmDetector` returns BPM within ±2 on a reference 120 BPM click-track fixture
-- `BpmDetector::run()` returns `Err(DecodeError::BpmDetectionFailed { .. })` for a missing file
-- `avio::BpmDetector` and `avio::BpmResult` are accessible under the `decode` feature flag
-- `cargo clippy --workspace -- -D warnings` clean
-- `cargo test --workspace` passes
+- Each crate declares an independent `[package].version`; the shared `[workspace.package].version` is removed, and every `[workspace.dependencies]` internal dependency keeps a matching `version` requirement.
+- `release-plz` (or equivalent) produces per-crate version bumps, changelogs, and tags from commits; a dry-run release publishes only changed crates and does not abort on unchanged ones.
+- All 12 library crates publish to crates.io with complete metadata; `avio-examples`, `tools`, and `fuzz` crates are excluded.
+- Primitive crates' public docs contain no references to the editing model; the `ff-preview` scene / `TimelinePlayer` doc references are reconciled.
+- The repository lives under the GitHub organization; the crate `repository` slug, `CODEOWNERS`, `.github/*`, and each crate's crates.io Trusted Publisher point to the org.
+- `cargo clippy --workspace --all-features -- -D warnings` clean; `cargo test --workspace` passes (CI full sweep).
+
+---
+
+## Candidate child issues
+
+These decompose the requirements into implementable units (to be filed):
+
+1. **Decouple crate versions** — move `version` from `[workspace.package]` into each `[package]`; keep `[workspace.dependencies]` `path` + `version` requirements in sync. (Highest release-risk; do first.)
+2. **Adopt `release-plz`** — replace the all-crates publish loop in `release.yml` with per-crate, change-driven releases (tolerant of already-published crates); per-crate changelog convention.
+3. **Cosmetic doc reconciliation** — refresh the stale `scene_adapter` / `avio::TimelinePlayer` references and review primitive-surface vocabulary (`ff-preview` `Scene` fields).
+4. **Publishing readiness gate** — a CI/dry-run check that every library crate is publishable (metadata + `--dry-run` per crate) and non-library members stay excluded.
+5. **Org migration** — repository transfer; update `repository` slug, `CODEOWNERS`, `.github/*`; re-point crates.io Trusted Publishers. (Partly maintainer-performed outside the repo.)
+6. **Engine + primitives documentation** — README/story updates positioning `avio` as engine and `ff-*` as standalone libraries.

--- a/docs/roadmap/v0-16-0/oto-mad.md
+++ b/docs/roadmap/v0-16-0/oto-mad.md
@@ -1,0 +1,76 @@
+# v0.16.0 (minor feature) — 音MAD Support (Pitch Shift & BPM Detection)
+
+> This is a **minor feature** included in the v0.16.0 release. The release's headline theme is
+> the engine / library split (see `ROADMAP.md`); this feature is additive and already implemented,
+> and ships as part of the same cut.
+
+**Goal**: Extend audio processing capabilities to cover the key primitives required for Oto-MAD production on Niconico Douga: a wider pitch-shift range for mapping voice clips to musical notes across two octaves, and a BPM/beat detector that returns per-beat timestamps suitable for direct placement of clips on a `Timeline`.
+
+**Prerequisite**: v0.15.0 complete.
+
+**Crates in scope**: `ff-filter`, `ff-decode`, `avio`
+
+---
+
+## Requirements
+
+### Pitch Shift — ±24 Semitone Range
+
+- `FilterGraph::pitch_shift(semitones)` accepts values in `[-24.0, 24.0]` (±2 octaves).
+- Pitch shifting is performed without changing playback duration (pitch-only, not tape-speed).
+- The implementation chains multiple `atempo` filter instances when the compensation factor falls outside the single-instance range `[0.5, 2.0]`, reusing the same `add_atempo_chain` helper used by `TimeStretch`.
+- Values outside `[-24.0, 24.0]` return `Err(FilterError::Ffmpeg { .. })`.
+- Audio quality is comparable to the existing ±12 semitone range (WSOLA via `atempo`).
+
+### BPM Detection and Beat Timestamps
+
+- A `BpmDetector` struct detects the tempo and per-beat timestamps from an audio file.
+- The public API follows the consuming-builder pattern used by `SilenceDetector`:
+
+  ```rust
+  BpmDetector::new("track.mp3")
+      .bpm_range(60.0, 200.0)
+      .run()  →  Result<BpmResult, DecodeError>
+  ```
+
+- `BpmResult` contains:
+  - `bpm: f64` — detected tempo in beats per minute
+  - `beats: Vec<Duration>` — timestamp of each detected beat from the start of the file
+  - `confidence: f32` — detection confidence in `[0.0, 1.0]`; values below `0.4` indicate ambiguous rhythm
+
+- The algorithm is pure Rust (no additional C dependencies):
+  1. Decode the audio file to mono f32 PCM at 22 050 Hz via the existing FFmpeg decode path
+  2. Detect onsets using **spectral flux** (half-wave rectified frame-energy derivative with adaptive threshold)
+  3. Estimate BPM via **normalized autocorrelation** of the onset envelope, searching within `[bpm_min, bpm_max]`
+  4. Generate beat timestamps by stepping forward from the first onset at the estimated interval, snapping to nearby onset peaks
+
+- If the pure-Rust implementation does not meet the ±2 BPM accuracy threshold established by the integration tests, the algorithm internals (`detect_onsets`, `estimate_bpm`) are replaced with `aubio` C library bindings. The public API (`BpmDetector` / `BpmResult`) remains unchanged.
+
+- `BpmDetector` and `BpmResult` are re-exported from `avio` under the `decode` feature flag.
+
+- Primary use case: map detected beat timestamps to `Clip::timeline_offset` values for beat-synchronized video cutting.
+
+---
+
+## Design Decisions
+
+| Topic | Decision |
+|---|---|
+| Pitch shift range | ±24 semitones (2 octaves); covers typical Oto-MAD note range without needing external quality libraries |
+| Pitch shift implementation | Extend existing `asetrate` + `add_atempo_chain` path; no rubberband dependency |
+| BPM algorithm | Pure Rust spectral flux + autocorrelation; no C dependency beyond FFmpeg |
+| BPM fallback | If accuracy < ±2 BPM on reference track, migrate internals to aubio (API unchanged) |
+| BPM output granularity | `bpm` + `Vec<Duration>` beats + `confidence`; beat array enables direct `Timeline` placement |
+| Analysis sample rate | 22 050 Hz mono f32; sufficient for onset detection, reduces memory and CPU vs 44 100 Hz |
+
+---
+
+## Definition of Done
+
+- `pitch_shift(24.0)` and `pitch_shift(-24.0)` succeed; `pitch_shift(24.5)` returns `Err`
+- Integration test: `pitch_shift(+24.0)` on a 220 Hz sine wave produces output frequency within ±5% of 880 Hz
+- `BpmDetector` returns BPM within ±2 on a reference 120 BPM click-track fixture
+- `BpmDetector::run()` returns `Err(DecodeError::BpmDetectionFailed { .. })` for a missing file
+- `avio::BpmDetector` and `avio::BpmResult` are accessible under the `decode` feature flag
+- `cargo clippy --workspace -- -D warnings` clean
+- `cargo test --workspace` passes


### PR DESCRIPTION
## Objective

- The v0.16.0 roadmap described the Oto-MAD (pitch shift + BPM) feature, but that work is already implemented and — together with the model purification and the C4 preview==export epic — merged and unreleased.
- The engine/primitive code boundary is now clean, so v0.16.0 should headline the publishing side of the split: avio as an editing engine, the ff-* family as standalone independently-versioned libraries, plus a move to a GitHub organization.

## Solution

- Rewrite `docs/roadmap/v0-16-0/ROADMAP.md` as the engine/library split milestone: independent per-crate versioning (the tokio/http model, with rationale for why not lockstep), release-plz-driven change-based releases, per-crate publishing readiness, org migration, and engine+primitives documentation.
- Record the requirements as capabilities plus Design Decisions, Definition of Done, and candidate child issues.
- Relocate the Oto-MAD roadmap to `docs/roadmap/v0-16-0/oto-mad.md` as a documented minor feature of the same 0.16.0 cut; no separate 0.15.2 is cut.

Part of #1327