### PR TITLE
docs(ff-preview): reconcile stale editing-model references on the primitive surface

### DIFF
--- a/crates/ff-preview/src/playback/player_handle.rs
+++ b/crates/ff-preview/src/playback/player_handle.rs
@@ -37,7 +37,7 @@ pub struct PlayerHandle {
     /// Mirrors the runner's stopped state; updated immediately by `stop`.
     pub(crate) stopped: Arc<AtomicBool>,
     pub(crate) duration_millis: u64,
-    /// Multi-track mixer — present when the runner was created by `TimelinePlayer`.
+    /// Multi-track mixer — present when the runner was created by `ScenePlayer`.
     pub(crate) audio_mixer: Option<Arc<Mutex<AudioMixer>>>,
 }
 
@@ -164,7 +164,7 @@ impl PlayerHandle {
         if n == 0 {
             return Vec::new();
         }
-        // Mixer path — used when the handle was created by TimelinePlayer.
+        // Mixer path — used when the handle was created by ScenePlayer.
         // The timeline clock is System-based so samples_consumed is not advanced here.
         if let Some(mixer) = &self.audio_mixer {
             return mixer
@@ -222,7 +222,7 @@ impl PlayerHandle {
             }
             return Vec::new();
         }
-        // Mixer path (TimelinePlayer) — System clock, no samples_consumed tracking.
+        // Mixer path (ScenePlayer) — System clock, no samples_consumed tracking.
         if let Some(mixer) = &self.audio_mixer {
             return mixer
                 .lock()

--- a/crates/ff-preview/src/timeline/mod.rs
+++ b/crates/ff-preview/src/timeline/mod.rs
@@ -64,8 +64,7 @@ const CHANNEL_CAP: usize = 64;
 /// mixed into the stereo output from [`PlayerHandle::pop_audio_samples`].
 ///
 /// This player is model-agnostic: an engine derives the [`Scene`] from its
-/// editing model (for example `avio::TimelinePlayer` from a `Timeline`) and
-/// hands it here.
+/// editing model and hands it here.
 pub struct ScenePlayer;
 
 impl ScenePlayer {

--- a/crates/ff-preview/src/timeline/runner.rs
+++ b/crates/ff-preview/src/timeline/runner.rs
@@ -2,7 +2,7 @@
 //!
 //! [`TimelineRunner`] owns the per-track decode buffers and the audio mixer,
 //! and drives frame presentation. Construct it via
-//! [`TimelinePlayer::open`](super::TimelinePlayer::open).
+//! [`ScenePlayer::open`](super::ScenePlayer::open).
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};

--- a/crates/ff-preview/src/timeline/scene.rs
+++ b/crates/ff-preview/src/timeline/scene.rs
@@ -5,13 +5,9 @@
 //! model's primitivised fields (paths, durations, opacity, blend, animation
 //! tracks), never the editing model itself. Resolving a `Scene` against the
 //! media — probing for duration, audio presence, and frame size — happens in
-//! [`TimelinePlayer::open_scene`](super::TimelinePlayer::open_scene), exactly as
-//! it did when the runner consumed `Timeline`/`Clip` directly. So a `Scene`
-//! re-derived on every edit needs no re-probe and behaviour is preserved.
-//!
-//! Temporarily, `ff-preview` also derives a `Scene` from a `Timeline` (see
-//! `scene_adapter`); that adapter moves to `avio` in the model relocation
-//! (#1329, slice C), after which `Scene` is the only input the runner accepts.
+//! [`ScenePlayer::open`](super::ScenePlayer::open), so a `Scene` re-derived on
+//! every edit needs no re-probe and behaviour is preserved. An engine derives a
+//! `Scene` from its own editing model; `Scene` is the only input the runner accepts.
 
 use std::path::PathBuf;
 use std::time::Duration;


### PR DESCRIPTION
## Objective

- Publishing `ff-*` as standalone libraries means their public docs should not name the editing model. Several ff-preview rustdoc comments still referenced `TimelinePlayer`, the pre-rename name of `ScenePlayer`.
- Two of those references were intra-doc links to a non-existent `super::TimelinePlayer` that `cargo doc` could not resolve; the scene.rs module doc also described a `scene_adapter` / `Timeline -> Scene` migration that has since completed and moved to `avio`.

## Solution

- Point the broken links at `ScenePlayer::open` (scene.rs, runner.rs).
- Drop the stale `scene_adapter` migration paragraph and the `Timeline`/`Clip` historical clause from the scene.rs module doc; neutralise the `avio::TimelinePlayer` example in the `ScenePlayer` doc.
- Rename the remaining `TimelinePlayer` references in `player_handle.rs` to `ScenePlayer`, so the primitive crate's public docs no longer name the editing model.
- Doc-comment only; `cargo doc`, clippy, and fmt clean. `Scene`/`ScenePlacement` vocabulary de-editorialization is a breaking rename handled separately (#1375).

Closes #1370