### PR TITLE
feat(ff-filter): add a raw-filter escape hatch (FilterStep::Raw)

### DIFF
--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -68,6 +68,23 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Append an arbitrary `FFmpeg` avfilter as an effect step on the current
+    /// stream — the escape hatch for filters not covered by the typed builder
+    /// methods.
+    ///
+    /// `filter` is the avfilter name (e.g. `"selectivecolor"`) and `args` its
+    /// option string (empty for none). The filter name is checked for existence
+    /// at [`build`](Self::build); the `args` are validated by `FFmpeg` on the
+    /// first push. Equivalent to
+    /// `add_step(FilterStep::Raw { filter, args })`.
+    #[must_use]
+    pub fn raw_filter(self, filter: impl Into<String>, args: impl Into<String>) -> Self {
+        self.add_step(FilterStep::Raw {
+            filter: filter.into(),
+            args: args.into(),
+        })
+    }
+
     /// Enable hardware-accelerated filtering.
     ///
     /// When set, `hwupload` and `hwdownload` filters are inserted around the

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -352,6 +352,64 @@ mod tests {
     }
 
     #[test]
+    fn base_layer_with_raw_effect_should_build() {
+        // #1376: `FilterStep::Raw` (the arbitrary-avfilter escape hatch) must work as a
+        // per-layer effect through the realtime (preview) compositor's `add_and_link_step`
+        // dispatch, exactly like the typed steps — this is the composer-path coverage for
+        // the raw hatch. `hflip` (one-in / one-out, no args) is the raw filter. Probe-gate
+        // as above: CI's Linux FFmpeg has no filters, so a no-effect base layer fails to
+        // build there — skip; where filters exist, the raw `hflip` layer must build.
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let layer = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::Raw {
+                filter: "hflip".to_string(),
+                args: String::new(),
+            }],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        let mut composer = RealtimeComposer::new(&[layer])
+            .expect("raw `hflip` effect must dispatch and build once FFmpeg filters exist");
+        let frame = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn with_canvas_letterboxes_output_to_canvas_size() {
         // A 640×360 (16:9) base composited onto a 1080×1920 (9:16) canvas must
         // produce a 1080×1920 frame (letterboxed), not the base's own size.

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -932,6 +932,28 @@ pub enum FilterStep {
         /// When `true`, the mask is inverted: outside is opaque, inside is transparent.
         invert: bool,
     },
+
+    /// Apply an arbitrary `FFmpeg` avfilter to the current stream — the escape
+    /// hatch for filters not covered by the typed builder methods.
+    ///
+    /// `filter` is the avfilter name (e.g. `"selectivecolor"`, `"pseudocolor"`)
+    /// and `args` its option string (e.g. `"reds=…:blues=…"`; empty when the
+    /// filter takes no options). It is emitted as a single node `filter=args`
+    /// and linked in chain order like any other step, so it accepts one input
+    /// and produces one output.
+    ///
+    /// The filter name is checked for existence when the graph is built
+    /// ([`build`](FilterGraphBuilder::build)); the `args` are validated by
+    /// `FFmpeg` on the first [`push_video`](crate::FilterGraph::push_video) /
+    /// [`push_audio`](crate::FilterGraph::push_audio), exactly as for the typed
+    /// steps. Prefer the typed builder methods where they exist; use this for
+    /// filters they do not cover.
+    Raw {
+        /// The avfilter name (e.g. `"selectivecolor"`).
+        filter: String,
+        /// The avfilter option string (e.g. `"reds=…"`); empty for none.
+        args: String,
+    },
 }
 
 /// Convert a color temperature in Kelvin to linear RGB multipliers using
@@ -962,8 +984,11 @@ fn kelvin_to_rgb(temp_k: u32) -> (f64, f64, f64) {
 
 impl FilterStep {
     /// Returns the libavfilter filter name for this step.
-    pub(crate) fn filter_name(&self) -> &'static str {
+    pub(crate) fn filter_name(&self) -> &str {
         match self {
+            // Escape hatch: the runtime filter name is borrowed from `self`.
+            // (The `&'static str` literals below coerce to the borrowed `&str`.)
+            Self::Raw { filter, .. } => filter,
             Self::Format { .. } => "format",
             Self::SetParams { .. } => "setparams",
             Self::Trim { .. } => "trim",
@@ -1097,6 +1122,8 @@ impl FilterStep {
     /// Returns the `args` string passed to `avfilter_graph_create_filter`.
     pub(crate) fn args(&self) -> String {
         match self {
+            // Escape hatch: the option string is passed through verbatim.
+            Self::Raw { args, .. } => args.clone(),
             Self::Format {
                 pix_fmts,
                 color_spaces,
@@ -1865,6 +1892,34 @@ mod tests {
             color_trc: None,
         };
         assert_eq!(step.filter_name(), "setparams");
+    }
+
+    #[test]
+    fn raw_filter_name_should_be_the_given_filter() {
+        let step = FilterStep::Raw {
+            filter: "selectivecolor".to_string(),
+            args: "reds=0.1 0 0".to_string(),
+        };
+        assert_eq!(step.filter_name(), "selectivecolor");
+    }
+
+    #[test]
+    fn raw_args_should_pass_through_verbatim() {
+        let step = FilterStep::Raw {
+            filter: "selectivecolor".to_string(),
+            args: "reds=0.1 0 0:blues=0 0 0.2".to_string(),
+        };
+        assert_eq!(step.args(), "reds=0.1 0 0:blues=0 0 0.2");
+    }
+
+    #[test]
+    fn raw_with_empty_args_should_render_empty_args() {
+        let step = FilterStep::Raw {
+            filter: "hflip".to_string(),
+            args: String::new(),
+        };
+        assert_eq!(step.filter_name(), "hflip");
+        assert_eq!(step.args(), "");
     }
 
     #[test]

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -106,6 +106,31 @@ fn format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
 }
 
 #[test]
+fn raw_filter_should_apply_an_arbitrary_avfilter() {
+    // #1376: `raw_filter` is the escape hatch for avfilters not covered by the typed
+    // builder methods. `hflip` (one-in / one-out, no args) exercises the whole path:
+    // `FilterStep::Raw` -> generic `add_and_link_step` -> a real avfilter node. CI's
+    // Linux FFmpeg is built with no filters, so a push failure means `hflip` is
+    // unavailable (skip), not that the escape hatch is broken. `build()` always
+    // succeeds because `validate_filter_steps` defers the registration check to push.
+    let frame = make_yuv420p_frame(64, 64);
+    let mut graph = FilterGraph::builder()
+        .raw_filter("hflip", "")
+        .build()
+        .expect("non-empty raw-filter graph must build");
+    if graph.push_video(0, &frame).is_err() {
+        eprintln!("skipping: `hflip` filter not available in this FFmpeg build");
+        return;
+    }
+    let out = graph
+        .pull_video()
+        .expect("pull_video must not fail")
+        .expect("expected Some(frame) after hflip push");
+    assert_eq!(out.width(), 64, "hflip must not change frame width");
+    assert_eq!(out.height(), 64, "hflip must not change frame height");
+}
+
+#[test]
 fn setparams_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg() {
     // #1227: `setparams` args (colorspace=/range=/color_primaries=/color_trc=) are built from
     // `FfmpegToken`. The graph is built lazily on the first `push_video`, so the push — not


### PR DESCRIPTION
## Objective

- The `FilterStep` effect set is a closed enum with no way to apply an arbitrary FFmpeg avfilter to already-decoded frames (arbitrary lavfi was reachable only as a whole-layer source), so any editor built on the `ff-*` primitives was capped at the curated set — surfaced by the editor-buildability audit (#1379).

## Solution

- Add `FilterStep::Raw { filter, args }` and `FilterGraphBuilder::raw_filter`, emitted as a single `filter=args` node and linked in chain order.
- Reuse the existing plumbing: `filter_name()` now returns `&str` (borrowing the runtime name for `Raw`; the `&'static str` literals coerce unchanged), so the generic `add_and_link_step` path and `validate_filter_steps` handle `Raw` with no change. The filter name is checked for existence at build; the args are validated by FFmpeg on the first push.
- Works in the single-source builder and as a layer effect in the realtime/export composers (all drive the same dispatch). Tests: deterministic name/args unit tests, plus probe-gated integration tests exercising a raw filter through the single-source builder and the realtime composer.
- Note: adding a variant to the non-`#[non_exhaustive]` `FilterStep` is a breaking change for external exhaustive matches (in-repo builds unaffected; `avio` uses `matches!`). Marking the extensible enums `#[non_exhaustive]` is tracked separately (#1382).

Closes #1376