### PR TITLE
refactor(ff-filter): mark extensible public enums #[non_exhaustive]

### DIFF
--- a/crates/avio/examples/transcode/hw_transcode.rs
+++ b/crates/avio/examples/transcode/hw_transcode.rs
@@ -137,6 +137,7 @@ fn main() {
         HwAccel::Cuda => "CUDA (NVENC)",
         HwAccel::VideoToolbox => "VideoToolbox",
         HwAccel::Vaapi => "VA-API",
+        _ => "hardware",
     });
 
     let codec_label = match video_codec {

--- a/crates/ff-filter/src/animation/easing.rs
+++ b/crates/ff-filter/src/animation/easing.rs
@@ -6,6 +6,8 @@
 ///
 /// Individual easing functions are implemented across issues #352–#357.
 #[derive(Debug, Clone)]
+// Open catalog: more easing curves (Steps, Bounce, …) can be added.
+#[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Easing {
     /// Hold: the value snaps to the next keyframe without interpolation.

--- a/crates/ff-filter/src/blend.rs
+++ b/crates/ff-filter/src/blend.rs
@@ -14,6 +14,8 @@
 /// use [`CompositeOp`](crate::CompositeOp) instead — that is a separate concept
 /// (alpha channel operators, not pixel-value blend modes). Note `BlendMode::Xor`
 /// is the *arithmetic* `xor` blend, distinct from `CompositeOp::Xor`.
+// Open catalog: mirrors `FFmpeg`'s `blend all_mode` set, which can grow.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlendMode {
     // ── Standard modes ────────────────────────────────────────────────────

--- a/crates/ff-filter/src/composite.rs
+++ b/crates/ff-filter/src/composite.rs
@@ -11,6 +11,8 @@
 /// There is no `blend all_mode` token for Porter-Duff compositing, so this type
 /// has no `FfmpegToken` impl; each operator maps to a specific `FFmpeg` construction
 /// (`overlay` or `blend` with a per-channel expression) in the filter graph.
+// Open catalog: the Porter-Duff operator set is added to incrementally.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompositeOp {
     /// Top layer rendered over the bottom (standard alpha compositing).

--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -7,6 +7,8 @@ use crate::graph::FilterGraph;
 use crate::graph::filter_step::FilterStep;
 
 /// Noise type used as the initial spectral model for `afftdn`.
+// Open catalog: `FFmpeg` noise colours (blue, violet, velvet, …) can be added.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NoiseType {
     /// White noise (flat spectrum).

--- a/crates/ff-filter/src/effects/lens_profile.rs
+++ b/crates/ff-filter/src/effects/lens_profile.rs
@@ -7,6 +7,8 @@
 /// correction.
 ///
 /// Use with [`FilterGraph::lens_profile`](crate::FilterGraph::lens_profile).
+// Open catalog: more camera/lens profiles are added over time.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LensProfile {
     /// `GoPro` Hero 9 / 10 / 11 wide-angle mode (heavy barrel distortion).

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -30,6 +30,9 @@ pub(crate) fn escape_filter_path(path: &str) -> String {
 ///
 /// Used by [`crate::FilterGraphBuilder`] to build pipeline filter graphs, and by
 /// [`crate::AudioTrack::effects`] to attach per-track effects in a multi-track mix.
+// Open catalog: new filter steps are added over time (e.g. `Raw`), so downstream
+// matches must carry a `_` arm.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum FilterStep {
     /// Convert video to a suitable pixel format from the given options.

--- a/crates/ff-filter/src/graph/types.rs
+++ b/crates/ff-filter/src/graph/types.rs
@@ -13,6 +13,8 @@
 /// | [`Hable`](Self::Hable) | Filmic, rich contrast | Film / cinematic content |
 /// | [`Reinhard`](Self::Reinhard) | Simple, fast, neutral | Fast previews, general video |
 /// | [`Mobius`](Self::Mobius) | Smooth highlights | Bright outdoor or HDR10 content |
+// Open catalog: `FFmpeg`'s `tonemap` supports more operators than are exposed here.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToneMap {
     /// Hable (Uncharted 2) filmic tone mapping.
@@ -49,6 +51,8 @@ impl ToneMap {
 /// When set on the builder, upload/download filters are inserted automatically
 /// around the filter chain. This is independent of `ff_decode::HardwareAccel`
 /// and is defined here to avoid a hard dependency on `ff-decode`.
+// Open catalog: more hardware backends (QSV, D3D11VA, Vulkan, …) can be added.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HwAccel {
     /// NVIDIA CUDA.
@@ -88,6 +92,8 @@ impl Rgb {
 /// Resampling algorithm for the `scale` filter.
 ///
 /// Used with [`super::FilterGraphBuilder::scale`].
+// Open catalog: `swscale` exposes more flags (neighbor, area, gauss, …) than these.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScaleAlgorithm {
     /// Fast bilinear interpolation (default). Good balance of speed and quality.
@@ -191,6 +197,8 @@ impl XfadeTransition {
 /// A single band for the parametric equalizer.
 ///
 /// Used with [`super::FilterGraphBuilder::equalizer`].
+// Open catalog: more biquad band types (lowpass, highpass, notch, …) can be added.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum EqBand {
     /// Low-shelf EQ: boosts or cuts all frequencies below `freq_hz`.

--- a/crates/ff-pipeline/src/pipeline.rs
+++ b/crates/ff-pipeline/src/pipeline.rs
@@ -303,6 +303,13 @@ pub fn hwaccel_to_hardware_encoder(hw: Option<HwAccel>) -> HardwareEncoder {
         Some(HwAccel::Cuda) => HardwareEncoder::Nvenc,
         Some(HwAccel::VideoToolbox) => HardwareEncoder::VideoToolbox,
         Some(HwAccel::Vaapi) => HardwareEncoder::Vaapi,
+        // `HwAccel` is `#[non_exhaustive]`: a backend without an encoder mapping
+        // falls back to software encoding rather than failing to build. Log it so a
+        // newly-added backend that lacks a mapping is not silently ignored.
+        Some(other) => {
+            log::warn!("unmapped hardware backend, encoding in software backend={other:?}");
+            HardwareEncoder::None
+        }
     }
 }
 


### PR DESCRIPTION
## Objective

- Before the v0.16.0 publish, open the `ff-filter` enums that mirror an evolving external catalog (FFmpeg filters, blend/tonemap/scale sets, hardware backends, …) so future variant additions are non-breaking rather than requiring another breaking release — the strategic pairing for the raw-filter hatch (#1376) and the primitive-expressiveness work (#1379).

## Solution

- Mark `FilterStep`, `BlendMode`, `CompositeOp`, `ToneMap`, `HwAccel`, `ScaleAlgorithm`, `NoiseType`, `LensProfile`, `Easing`, `EqBand` `#[non_exhaustive]` (peers of the already-marked `XfadeTransition`), each with a short rationale comment.
- Leave the closed, complete enums exhaustive, with the reason recorded: `YadifMode` (modes 0-3), `AnimatedValue` (`Static`|`Track`), `Interpolation` (fixed vidstab option), `FilterError`.
- Enum-level `non_exhaustive` keeps downstream variant construction working (verified by the `--all-targets` build); only exhaustive matches need a wildcard arm. The compiler surfaced exactly two, both on `HwAccel`: the encoder-backend mapping in `ff-pipeline` (an unmapped backend now `log::warn`s and falls back to software) and a label mapping in an avio example.
- Behaviour-preserving; `cargo check --all-targets` and `cargo clippy --all -- -D warnings` are clean workspace-wide.

Resolves #1382