### PR TITLE
chore: decouple crate versions from the shared workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 members = ["crates/*", "examples"]
 resolver = "2"
 
+# Per-crate versions are independent (declared in each crate's `[package].version`)
+# as of v0.16.0; only the fields below stay shared.
 [workspace.package]
-version = "0.15.1"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -12,18 +13,18 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.15.1" }
-ff-common   = { path = "crates/ff-common",   version = "0.15.1" }
-ff-format   = { path = "crates/ff-format",   version = "0.15.1" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.15.1" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.15.1" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.15.1" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.15.1" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.15.1" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.15.1" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.15.1" }
-ff-render   = { path = "crates/ff-render",   version = "0.15.1" }
-avio        = { path = "crates/avio",         version = "0.15.1" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.16.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.16.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.16.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.16.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.16.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.16.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.16.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.16.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.16.0" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.16.0" }
+ff-render   = { path = "crates/ff-render",   version = "0.16.0" }
+avio        = { path = "crates/avio",         version = "0.16.0" }
 
 # Error handling
 thiserror = "2.0.17"

--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avio"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Safe, high-level audio/video/image processing for Rust — backend-agnostic multimedia toolkit"

--- a/crates/ff-common/Cargo.toml
+++ b/crates/ff-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-common"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Common types and utilities for FFmpeg-based media processing"

--- a/crates/ff-decode/Cargo.toml
+++ b/crates/ff-decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-decode"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Video and audio decoding - the Rust way"

--- a/crates/ff-encode/Cargo.toml
+++ b/crates/ff-encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-encode"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Video and audio encoding - the Rust way"

--- a/crates/ff-filter/Cargo.toml
+++ b/crates/ff-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-filter"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Video and audio filter graph operations - the Rust way"

--- a/crates/ff-format/Cargo.toml
+++ b/crates/ff-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-format"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Common types for video/audio processing - the Rust way"

--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-pipeline"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Unified decode-filter-encode pipeline for the ff-* crate family"

--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-preview"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Real-time video/audio preview and proxy workflow"

--- a/crates/ff-probe/Cargo.toml
+++ b/crates/ff-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-probe"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Media file metadata extraction - the Rust way"

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-render"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "GPU compositing pipeline for real-time preview (wgpu-based)"

--- a/crates/ff-stream/Cargo.toml
+++ b/crates/ff-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-stream"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "HLS and DASH adaptive streaming output for the ff-* crate family"

--- a/crates/ff-sys/Cargo.toml
+++ b/crates/ff-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-sys"
-version.workspace = true
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Low-level FFmpeg FFI bindings for Rust"


### PR DESCRIPTION
## Objective

- For the v0.16.0 engine/library split, the `ff-*` primitives should version independently so each crate's number reflects its own change cadence, rather than a lockstep bump that churns unchanged crates.

## Solution

- Remove `version` from `[workspace.package]`; declare a literal `version` in each crate's `[package]`. All crates start at 0.16.0 (crates.io versions are monotonic — the published baseline is 0.15.x, so a 0.1.0 reset is impossible; 1.0.0 is deferred to API finalization per the roadmap). From here only changed crates advance.
- Move the `[workspace.dependencies]` internal `path` + `version` requirements to 0.16.0, keeping every crate publishable.
- Manifest-only; no publish happens here (the change-driven release flow is a follow-up, #1369). `cargo check --all-targets` and a leaf `cargo publish --dry-run` (ff-common 0.16.0) pass; internal-dep crates dry-run only once their dependencies are published in dependency order.

Resolves #1368