### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Line-ending normalization.
+#
+# Rust / Cargo projects use LF. Enforce LF in the repository AND in the working
+# tree so Windows checkouts do not churn line endings and git stops emitting the
+# "LF will be replaced by CRLF" warnings caused by `core.autocrlf=true`.
+* text=auto eol=lf
+
+# Binary assets — never apply line-ending conversion (belt-and-suspenders over
+# git's own binary detection). Note: `.cube` / `.3dl` LUTs are TEXT and are left
+# to the rule above.
+*.mp4 binary
+*.png binary
+*.bin binary


### PR DESCRIPTION
## Objective

- The repo has no `.gitattributes` and runs with `core.autocrlf=true` on Windows, so git emits a `LF will be replaced by CRLF` warning for every file it touches and could churn line endings on checkout.

## Solution

- Add `.gitattributes` pinning all text files to LF (`text=auto eol=lf`), matching the already-LF repository content, and mark binary assets (`mp4`/`png`/`bin`) explicitly. `.cube`/`.3dl` LUTs are text and left to the LF rule.
- A `git add --renormalize .` staged nothing beyond `.gitattributes`, confirming the tracked content is already LF (this only enforces it going forward and silences the warnings).