### PR TITLE
refactor(error): add a shared MediaError classification across the ff-* crates

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -218,10 +218,10 @@ pub use ff_format::subtitle::{SubtitleError, SubtitleEvent, SubtitleTrack};
 pub use ff_format::{
     AlphaMode, AudioCodec, AudioFrame, AudioStreamInfo, AudioStreamInfoBuilder, ChannelLayout,
     ChapterInfo, ChapterInfoBuilder, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer,
-    ContainerInfo, ContainerInfoBuilder, FormatError, FrameError, Hdr10Metadata, MasteringDisplay,
-    MediaInfo, MediaInfoBuilder, NetworkOptions, PixelFormat, Rational, SampleFormat,
-    SubtitleCodec, SubtitleStreamInfo, SubtitleStreamInfoBuilder, Timestamp, VideoCodec,
-    VideoFrame, VideoStreamInfo, VideoStreamInfoBuilder,
+    ContainerInfo, ContainerInfoBuilder, ErrorSeverity, FormatError, FrameError, Hdr10Metadata,
+    MasteringDisplay, MediaError, MediaInfo, MediaInfoBuilder, NetworkOptions, PixelFormat,
+    Rational, SampleFormat, SubtitleCodec, SubtitleStreamInfo, SubtitleStreamInfoBuilder,
+    Timestamp, VideoCodec, VideoFrame, VideoStreamInfo, VideoStreamInfoBuilder,
 };
 
 // ── probe feature ─────────────────────────────────────────────────────────────

--- a/crates/ff-decode/src/error.rs
+++ b/crates/ff-decode/src/error.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use ff_format::{ErrorSeverity, MediaError};
 use thiserror::Error;
 
 use crate::HardwareAccel;
@@ -366,94 +367,17 @@ impl DecodeError {
             message: message.into(),
         }
     }
+}
 
-    /// Returns `true` if this error is recoverable.
-    ///
-    /// Recoverable errors are those where the operation that raised the error
-    /// can be retried (or the decoder can transparently reconnect) without
-    /// rebuilding the decoder from scratch.
-    ///
-    /// | Variant | Recoverable |
-    /// |---|---|
-    /// | [`DecodingFailed`](Self::DecodingFailed) | ✓ — corrupt frame; skip and continue |
-    /// | [`SeekFailed`](Self::SeekFailed) | ✓ — retry at a different position |
-    /// | [`NetworkTimeout`](Self::NetworkTimeout) | ✓ — transient; reconnect |
-    /// | [`StreamInterrupted`](Self::StreamInterrupted) | ✓ — transient; reconnect |
-    /// | all others | ✗ |
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ff_decode::DecodeError;
-    /// use std::time::Duration;
-    ///
-    /// // Decoding failures are recoverable
-    /// assert!(DecodeError::decoding_failed("test").is_recoverable());
-    ///
-    /// // Seek failures are recoverable
-    /// assert!(DecodeError::seek_failed(Duration::from_secs(1), "test").is_recoverable());
-    ///
-    /// ```
-    #[must_use]
-    pub fn is_recoverable(&self) -> bool {
+impl MediaError for DecodeError {
+    /// Recoverable errors are retryable without rebuilding the decoder (a corrupt
+    /// frame, a transient network fault); fatal errors mean it must be discarded.
+    fn severity(&self) -> ErrorSeverity {
         match self {
             Self::DecodingFailed { .. }
             | Self::SeekFailed { .. }
             | Self::NetworkTimeout { .. }
-            | Self::StreamInterrupted { .. } => true,
-            Self::FileNotFound { .. }
-            | Self::NoVideoStream { .. }
-            | Self::NoAudioStream { .. }
-            | Self::UnsupportedCodec { .. }
-            | Self::DecoderUnavailable { .. }
-            | Self::HwAccelUnavailable { .. }
-            | Self::InvalidOutputDimensions { .. }
-            | Self::ConnectionFailed { .. }
-            | Self::Io(_)
-            | Self::Ffmpeg { .. }
-            | Self::SeekNotSupported
-            | Self::UnsupportedResolution { .. }
-            | Self::StreamCorrupted { .. }
-            | Self::NoFrameAtTimestamp { .. }
-            | Self::AnalysisFailed { .. }
-            | Self::BpmDetectionFailed { .. } => false,
-        }
-    }
-
-    /// Returns `true` if this error is fatal.
-    ///
-    /// Fatal errors indicate that the decoder cannot continue operating and
-    /// must be discarded; re-opening or reconfiguring is required.
-    ///
-    /// | Variant | Fatal |
-    /// |---|---|
-    /// | [`FileNotFound`](Self::FileNotFound) | ✓ |
-    /// | [`NoVideoStream`](Self::NoVideoStream) | ✓ |
-    /// | [`NoAudioStream`](Self::NoAudioStream) | ✓ |
-    /// | [`UnsupportedCodec`](Self::UnsupportedCodec) | ✓ |
-    /// | [`DecoderUnavailable`](Self::DecoderUnavailable) | ✓ |
-    /// | [`HwAccelUnavailable`](Self::HwAccelUnavailable) | ✓ — must reconfigure without HW |
-    /// | [`InvalidOutputDimensions`](Self::InvalidOutputDimensions) | ✓ — bad config |
-    /// | [`ConnectionFailed`](Self::ConnectionFailed) | ✓ — host unreachable |
-    /// | [`Io`](Self::Io) | ✓ — I/O failure |
-    /// | all others | ✗ |
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ff_decode::DecodeError;
-    /// use std::path::PathBuf;
-    ///
-    /// // File not found is fatal
-    /// assert!(DecodeError::FileNotFound { path: PathBuf::new() }.is_fatal());
-    ///
-    /// // Unsupported codec is fatal
-    /// assert!(DecodeError::UnsupportedCodec { codec: "test".to_string() }.is_fatal());
-    ///
-    /// ```
-    #[must_use]
-    pub fn is_fatal(&self) -> bool {
-        match self {
+            | Self::StreamInterrupted { .. } => ErrorSeverity::Recoverable,
             Self::FileNotFound { .. }
             | Self::NoVideoStream { .. }
             | Self::NoAudioStream { .. }
@@ -465,15 +389,11 @@ impl DecodeError {
             | Self::Io(_)
             | Self::StreamCorrupted { .. }
             | Self::AnalysisFailed { .. }
-            | Self::BpmDetectionFailed { .. } => true,
-            Self::DecodingFailed { .. }
-            | Self::SeekFailed { .. }
-            | Self::NetworkTimeout { .. }
-            | Self::StreamInterrupted { .. }
-            | Self::Ffmpeg { .. }
+            | Self::BpmDetectionFailed { .. } => ErrorSeverity::Fatal,
+            Self::Ffmpeg { .. }
             | Self::SeekNotSupported
             | Self::UnsupportedResolution { .. }
-            | Self::NoFrameAtTimestamp { .. } => false,
+            | Self::NoFrameAtTimestamp { .. } => ErrorSeverity::Other,
         }
     }
 }

--- a/crates/ff-decode/src/error.rs
+++ b/crates/ff-decode/src/error.rs
@@ -259,7 +259,7 @@ impl DecodeError {
     /// # Examples
     ///
     /// ```
-    /// use ff_decode::DecodeError;
+    /// use ff_decode::{DecodeError, MediaError};
     ///
     /// let error = DecodeError::decoding_failed("Corrupted frame data");
     /// assert!(error.to_string().contains("Corrupted frame data"));
@@ -283,7 +283,7 @@ impl DecodeError {
     /// # Examples
     ///
     /// ```
-    /// use ff_decode::DecodeError;
+    /// use ff_decode::{DecodeError, MediaError};
     /// use std::time::Duration;
     ///
     /// let error = DecodeError::decoding_failed_at(
@@ -311,7 +311,7 @@ impl DecodeError {
     /// # Examples
     ///
     /// ```
-    /// use ff_decode::DecodeError;
+    /// use ff_decode::{DecodeError, MediaError};
     /// use std::time::Duration;
     ///
     /// let error = DecodeError::seek_failed(

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -124,6 +124,7 @@ pub use error::DecodeError;
 pub use extract::{FrameExtractor, ThumbnailSelector};
 pub use ff_common::{FramePool, PooledBuffer};
 pub use ff_format::ContainerInfo;
+pub use ff_format::{ErrorSeverity, MediaError};
 pub use image::{ImageDecoder, ImageDecoderBuilder};
 pub use scope::{Histogram, RgbParade, ScopeAnalyzer};
 pub use shared::{HardwareAccel, SeekMode};

--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for encoding operations.
 
+use ff_format::{ErrorSeverity, MediaError};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -174,6 +175,32 @@ impl EncodeError {
         EncodeError::Ffmpeg {
             code: errnum,
             message: ff_sys::av_error_string(errnum),
+        }
+    }
+}
+
+impl MediaError for EncodeError {
+    fn severity(&self) -> ErrorSeverity {
+        match self {
+            Self::Ffmpeg { .. } | Self::Cancelled => ErrorSeverity::Other,
+            Self::CannotCreateFile { .. }
+            | Self::UnsupportedCodec { .. }
+            | Self::NoSuitableEncoder { .. }
+            | Self::EncodingFailed { .. }
+            | Self::InvalidConfig { .. }
+            | Self::HwEncoderUnavailable { .. }
+            | Self::EncoderUnavailable { .. }
+            | Self::MuxingFailed { .. }
+            | Self::Io(_)
+            | Self::InvalidOption { .. }
+            | Self::UnsupportedContainerCodecCombination { .. }
+            | Self::InvalidDimensions { .. }
+            | Self::InvalidBitrate { .. }
+            | Self::InvalidChannelCount { .. }
+            | Self::InvalidSampleRate { .. }
+            | Self::WorkerPanicked
+            | Self::MediaOperationFailed { .. }
+            | Self::PresetConstraintViolation { .. } => ErrorSeverity::Fatal,
         }
     }
 }

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -209,6 +209,7 @@ pub use audio::{
     Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
 };
 pub use error::EncodeError;
+pub use ff_format::{ErrorSeverity, MediaError};
 pub use image::{ImageEncoder, ImageEncoderBuilder};
 pub use media_ops::{AudioAdder, AudioExtractor, AudioReplacement};
 pub use preset::{AudioEncoderConfig, ExportPreset, VideoEncoderConfig};

--- a/crates/ff-filter/src/error.rs
+++ b/crates/ff-filter/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for filter graph operations.
 
+use ff_format::{ErrorSeverity, MediaError};
 use thiserror::Error;
 
 /// Errors that can occur during filter graph construction and processing.
@@ -71,6 +72,21 @@ pub enum FilterError {
         /// Name of the filter or capability that requires GPL.
         feature: &'static str,
     },
+}
+
+impl MediaError for FilterError {
+    fn severity(&self) -> ErrorSeverity {
+        match self {
+            Self::Ffmpeg { .. } | Self::ProcessFailed | Self::InvalidInput { .. } => {
+                ErrorSeverity::Other
+            }
+            Self::BuildFailed
+            | Self::InvalidConfig { .. }
+            | Self::CompositionFailed { .. }
+            | Self::AnalysisFailed { .. }
+            | Self::GplRequired { .. } => ErrorSeverity::Fatal,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -48,6 +48,7 @@ pub use effects::{
     AnalyzeOptions, Interpolation, LensProfile, NoiseType, StabilizeOptions, Stabilizer,
 };
 pub use error::FilterError;
+pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::{
     AudioConcatenator, AudioTrack, CrossfadeJoiner, DrawTextOptions, EqBand, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, MultiTrackAudioMixer, MultiTrackComposer,

--- a/crates/ff-format/src/lib.rs
+++ b/crates/ff-format/src/lib.rs
@@ -62,6 +62,7 @@ pub mod error;
 pub mod frame;
 pub mod hdr;
 pub mod media;
+pub mod media_error;
 pub mod network;
 pub mod pixel;
 pub mod sample;
@@ -79,6 +80,7 @@ pub use ff_common::PooledBuffer;
 pub use frame::{AudioFrame, VideoFrame};
 pub use hdr::{Hdr10Metadata, MasteringDisplay};
 pub use media::{MediaInfo, MediaInfoBuilder};
+pub use media_error::{ErrorSeverity, MediaError};
 pub use network::NetworkOptions;
 pub use pixel::PixelFormat;
 pub use sample::SampleFormat;
@@ -98,8 +100,9 @@ pub use time::{Rational, Timestamp};
 pub mod prelude {
     pub use crate::{
         AudioCodec, AudioFrame, AudioStreamInfo, ChannelLayout, ChapterInfo, ColorPrimaries,
-        ColorRange, ColorSpace, FormatError, FrameError, MediaInfo, NetworkOptions, PixelFormat,
-        PooledBuffer, Rational, SampleFormat, Timestamp, VideoCodec, VideoFrame, VideoStreamInfo,
+        ColorRange, ColorSpace, ErrorSeverity, FormatError, FrameError, MediaError, MediaInfo,
+        NetworkOptions, PixelFormat, PooledBuffer, Rational, SampleFormat, Timestamp, VideoCodec,
+        VideoFrame, VideoStreamInfo,
     };
 }
 

--- a/crates/ff-format/src/media_error.rs
+++ b/crates/ff-format/src/media_error.rs
@@ -1,0 +1,97 @@
+//! Shared error classification for the `ff-*` crate family.
+//!
+//! Every `ff-*` error type implements [`MediaError`], which classifies an error
+//! by [`ErrorSeverity`] so a caller can branch on recoverability generically,
+//! without matching each crate's variants. This lives in `ff-format` (the lowest
+//! shared, `FFmpeg`-free type crate) and adds no `FFmpeg` dependency.
+
+/// Severity class of a media error: whether the failing operation can be retried
+/// without rebuilding the component that raised it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorSeverity {
+    /// The component cannot continue; it must be discarded or reconfigured
+    /// (e.g. a missing file, an unsupported codec, an I/O failure).
+    Fatal,
+    /// Transient: the failing operation can be retried, or the stream reconnected,
+    /// without rebuilding (e.g. a corrupt frame, a network timeout).
+    Recoverable,
+    /// Neither strictly fatal nor retryable: a one-off condition the caller can
+    /// handle in context (e.g. a raw `FFmpeg` error, no frame at a timestamp).
+    Other,
+}
+
+/// Shared classification for the `ff-*` crate error types.
+///
+/// Implement [`severity`](MediaError::severity) on each error type; the boolean
+/// helpers are derived from it. This lets downstream code branch on recoverability
+/// generically:
+///
+/// ```
+/// use ff_format::{FormatError, MediaError, ErrorSeverity};
+///
+/// let err = FormatError::invalid_pixel_format("nope");
+/// assert_eq!(err.severity(), ErrorSeverity::Other);
+/// assert!(!err.is_recoverable());
+/// assert!(!err.is_fatal());
+/// ```
+pub trait MediaError {
+    /// Classifies this error.
+    fn severity(&self) -> ErrorSeverity;
+
+    /// Returns `true` if the failing operation can be retried without rebuilding.
+    fn is_recoverable(&self) -> bool {
+        matches!(self.severity(), ErrorSeverity::Recoverable)
+    }
+
+    /// Returns `true` if the component must be discarded or reconfigured.
+    fn is_fatal(&self) -> bool {
+        matches!(self.severity(), ErrorSeverity::Fatal)
+    }
+}
+
+impl MediaError for crate::FormatError {
+    fn severity(&self) -> ErrorSeverity {
+        // Format errors are validation / conversion failures on caller-provided
+        // data: not retryable, but a one-off input problem rather than a component
+        // that must be torn down.
+        ErrorSeverity::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_should_drive_is_recoverable_and_is_fatal() {
+        struct Fatal;
+        struct Recoverable;
+        struct Other;
+        impl MediaError for Fatal {
+            fn severity(&self) -> ErrorSeverity {
+                ErrorSeverity::Fatal
+            }
+        }
+        impl MediaError for Recoverable {
+            fn severity(&self) -> ErrorSeverity {
+                ErrorSeverity::Recoverable
+            }
+        }
+        impl MediaError for Other {
+            fn severity(&self) -> ErrorSeverity {
+                ErrorSeverity::Other
+            }
+        }
+
+        assert!(Fatal.is_fatal() && !Fatal.is_recoverable());
+        assert!(Recoverable.is_recoverable() && !Recoverable.is_fatal());
+        assert!(!Other.is_fatal() && !Other.is_recoverable());
+    }
+
+    #[test]
+    fn format_error_severity_should_be_other() {
+        let err = crate::FormatError::invalid_pixel_format("x");
+        assert_eq!(err.severity(), ErrorSeverity::Other);
+    }
+}

--- a/crates/ff-pipeline/src/error.rs
+++ b/crates/ff-pipeline/src/error.rs
@@ -3,6 +3,8 @@
 //! This module provides [`PipelineError`], which covers all failure modes that
 //! can arise when building or running a [`Pipeline`](crate::Pipeline).
 
+use ff_format::{ErrorSeverity, MediaError};
+
 /// Errors that can occur while building or running a pipeline.
 ///
 /// # Error Categories
@@ -77,6 +79,20 @@ pub enum PipelineError {
     /// decodable frame exists at that point.
     #[error("no frame available at the requested position")]
     FrameNotAvailable,
+}
+
+impl MediaError for PipelineError {
+    fn severity(&self) -> ErrorSeverity {
+        match self {
+            Self::Decode(e) => e.severity(),
+            Self::Filter(e) => e.severity(),
+            Self::Encode(e) => e.severity(),
+            Self::Cancelled | Self::FrameNotAvailable => ErrorSeverity::Other,
+            Self::NoInput | Self::NoOutput | Self::SecondaryInputWithoutFilter | Self::Io(_) => {
+                ErrorSeverity::Fatal
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ff-pipeline/src/lib.rs
+++ b/crates/ff-pipeline/src/lib.rs
@@ -62,6 +62,7 @@ pub mod video_pipeline;
 pub use audio_pipeline::AudioPipeline;
 pub use encoder_config::{EncoderConfig, EncoderConfigBuilder};
 pub use error::PipelineError;
+pub use ff_format::{ErrorSeverity, MediaError};
 pub use pipeline::{Pipeline, PipelineBuilder};
 pub use progress::{Progress, ProgressCallback};
 pub use thumbnail::ThumbnailPipeline;

--- a/crates/ff-preview/src/error.rs
+++ b/crates/ff-preview/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use ff_format::{ErrorSeverity, MediaError};
 use thiserror::Error;
 
 /// Errors that can occur during preview and proxy operations.
@@ -66,4 +67,20 @@ pub enum PreviewError {
         /// The requested presentation timestamp that fell outside all clips.
         pts: std::time::Duration,
     },
+}
+
+impl MediaError for PreviewError {
+    fn severity(&self) -> ErrorSeverity {
+        match self {
+            Self::Decode(e) => e.severity(),
+            Self::Probe(e) => e.severity(),
+            #[cfg(feature = "proxy")]
+            Self::Pipeline(e) => e.severity(),
+            Self::SeekFailed { .. } => ErrorSeverity::Recoverable,
+            Self::Ffmpeg { .. } | Self::SeekOutOfRange { .. } => ErrorSeverity::Other,
+            Self::FileNotFound { .. } | Self::NoVideoStream { .. } | Self::Io(_) => {
+                ErrorSeverity::Fatal
+            }
+        }
+    }
 }

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -42,6 +42,7 @@ pub use audio::{AudioMixer, AudioTrackHandle};
 pub use error::PreviewError;
 pub use event::PlayerEvent;
 pub use ff_decode::HardwareAccel;
+pub use ff_format::{ErrorSeverity, MediaError};
 pub use playback::{
     DecodeBuffer, DecodeBufferBuilder, FrameResult, FrameSink, PlaybackClock, PlayerCommand,
     PlayerHandle, PlayerRunner, PreviewPlayer, RgbaFrame, RgbaSink, SeekEvent,

--- a/crates/ff-probe/src/error.rs
+++ b/crates/ff-probe/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for media probing.
 
+use ff_format::{ErrorSeverity, MediaError};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -50,6 +51,19 @@ pub enum ProbeError {
         /// Human-readable error message from `av_strerror` or an internal description.
         message: String,
     },
+}
+
+impl MediaError for ProbeError {
+    fn severity(&self) -> ErrorSeverity {
+        match self {
+            Self::Ffmpeg { .. } => ErrorSeverity::Other,
+            Self::FileNotFound { .. }
+            | Self::CannotOpen { .. }
+            | Self::InvalidMedia { .. }
+            | Self::NoStreams { .. }
+            | Self::Io(_) => ErrorSeverity::Fatal,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ff-probe/src/lib.rs
+++ b/crates/ff-probe/src/lib.rs
@@ -138,6 +138,7 @@ pub use ff_format::{
 };
 
 pub use error::ProbeError;
+pub use ff_format::{ErrorSeverity, MediaError};
 
 // Re-export the open function at the crate level
 pub use probe::open;

--- a/crates/ff-render/src/error.rs
+++ b/crates/ff-render/src/error.rs
@@ -1,3 +1,5 @@
+use ff_format::{ErrorSeverity, MediaError};
+
 #[derive(Debug, thiserror::Error)]
 pub enum RenderError {
     #[error("GPU device creation failed: {message}")]
@@ -30,4 +32,19 @@ pub enum RenderError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+impl MediaError for RenderError {
+    fn severity(&self) -> ErrorSeverity {
+        match self {
+            Self::Ffmpeg { .. } | Self::UnsupportedFormat { .. } => ErrorSeverity::Other,
+            Self::DeviceCreation { .. }
+            | Self::ShaderCompile { .. }
+            | Self::TextureCreation { .. }
+            | Self::Composite { .. }
+            | Self::LutLoad { .. }
+            | Self::GpuTimeout { .. }
+            | Self::Io(_) => ErrorSeverity::Fatal,
+        }
+    }
 }

--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -71,6 +71,7 @@ pub mod context;
 #[cfg(feature = "wgpu")]
 pub use compositor::{Compositor, FrameLayer, LayerTransform};
 pub use error::RenderError;
+pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,

--- a/crates/ff-stream/src/error.rs
+++ b/crates/ff-stream/src/error.rs
@@ -4,6 +4,8 @@
 //! possible errors that can occur during HLS / DASH output and ABR ladder
 //! generation.
 
+use ff_format::{ErrorSeverity, MediaError};
+
 /// Errors that can occur during streaming output operations.
 ///
 /// This enum covers all error conditions that may arise when configuring,
@@ -93,6 +95,19 @@ pub enum StreamError {
         /// Human-readable description of the `FFmpeg` error.
         message: String,
     },
+}
+
+impl MediaError for StreamError {
+    fn severity(&self) -> ErrorSeverity {
+        match self {
+            Self::Encode(e) => e.severity(),
+            Self::Ffmpeg { .. } | Self::FanoutFailure { .. } => ErrorSeverity::Other,
+            Self::InvalidConfig { .. }
+            | Self::UnsupportedCodec { .. }
+            | Self::ProtocolUnavailable { .. }
+            | Self::Io(_) => ErrorSeverity::Fatal,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ff-stream/src/lib.rs
+++ b/crates/ff-stream/src/lib.rs
@@ -99,6 +99,7 @@ pub use abr::{AbrLadder, Rendition};
 pub use dash::DashOutput;
 pub use error::StreamError;
 pub use fanout::FanoutOutput;
+pub use ff_format::{ErrorSeverity, MediaError};
 pub use hls::{HlsOutput, HlsSegmentFormat};
 pub use live_abr::{AbrRendition, LiveAbrFormat, LiveAbrLadder};
 pub use live_dash::LiveDashOutput;

--- a/docs/rules/error-handling.md
+++ b/docs/rules/error-handling.md
@@ -51,6 +51,34 @@ pub enum DecodeError {
 }
 ```
 
+Keep this variant shape (`Ffmpeg { code, message }`) so callers can pattern-match the fields
+directly without an extra nested type.
+
+---
+
+## Classifying errors (recoverable vs fatal)
+
+Every `ff-*` error type implements `ff_format::MediaError`, which classifies an error by
+`severity() -> ErrorSeverity` (`Fatal` / `Recoverable` / `Other`) and derives `is_recoverable()` /
+`is_fatal()` from it. This lets a caller branch on recoverability generically, without matching each
+crate's variants:
+
+```rust
+use ff_format::MediaError;
+
+if let Err(e) = decoder.decode_one() {
+    if e.is_recoverable() { /* skip the frame / reconnect */ } else { return Err(e); }
+}
+```
+
+- `Recoverable`: the failing operation can be retried without rebuilding (a corrupt frame, a
+  transient network fault).
+- `Fatal`: the component must be discarded and reconfigured (missing file, unsupported codec, I/O).
+- `Other`: neither of the above; a one-off condition handled in context.
+
+Wrapper error types (`PipelineError`, `PreviewError`, `StreamError`, …) **delegate** `severity()` to
+the inner error of their `#[from]` variants.
+
 ---
 
 ## Nesting errors


### PR DESCRIPTION
## Objective

- Each `ff-*` crate classifies errors differently (only `DecodeError` had `is_recoverable()` / `is_fatal()`), so a user combining several primitives has to learn a different error idiom per crate.

## Solution

- Add `MediaError` (`severity()` + derived `is_recoverable()` / `is_fatal()`) and `ErrorSeverity` (`Fatal` / `Recoverable` / `Other`, `#[non_exhaustive]`) to `ff-format`; no FFmpeg dependency and no `unsafe`.
- Implement `MediaError` for all nine `ff-*` error types. Wrapper variants (`Decode` / `Filter` / `Encode` / `Probe` / `Pipeline`) delegate to the inner error's severity; the `Ffmpeg` variant is `Other`.
- Replace `DecodeError`'s bespoke inherent `is_recoverable()` / `is_fatal()` with a `severity()` that reproduces the previous classification exactly; the existing assertions now exercise it through the trait.
- Re-export `MediaError` / `ErrorSeverity` from each crate root and from `avio`, and document the convention in `docs/rules/error-handling.md`.
- The `Ffmpeg { code, message }` struct variants are left unchanged, so callers still pattern-match the fields directly.

Closes #1392