### PR TITLE
chore(ci): fix release-plz publish mismatch and hold the 0.16.0 release

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,6 +5,12 @@
 # crates.io are published (in dependency order). See `.github/workflows/release-plz.yml`.
 
 [workspace]
+# HOLD: block all releasing/publishing until the 0.16.0 clean-primitive gate
+# (#1395) is complete. With this set, the `release` job is a no-op (it publishes
+# nothing) while CI stays green. Remove this line to enable the 0.16.0 publish
+# once #1395 lands.
+release = false
+
 # Skip the `cargo publish` verification build. The publish step then never compiles
 # or links FFmpeg, so all uploads finish inside the crates.io OIDC token window.
 publish_no_verify = true
@@ -19,10 +25,13 @@ semver_check = false
 # dependency is not yet visible.
 publish_timeout = "10m"
 
-# Non-library workspace members: not versioned, tagged, or released. Cargo's
-# `publish = false` is also honored automatically; this makes the intent explicit.
+# Non-library workspace members: not published, versioned, tagged, or released.
+# `publish = false` must be set here to match the crate's own `publish = false`
+# in Cargo.toml (release-plz validates that the two agree); `release = false`
+# additionally skips versioning/tagging/changelog for it.
 # (The `tools` and `fuzz` crates are separate workspaces, so they are outside
 # release-plz's set already.)
 [[package]]
 name = "avio-examples"
+publish = false
 release = false


### PR DESCRIPTION
## Objective

- The release-plz `release` job fails config validation: `avio-examples` has `publish = false` in Cargo.toml, but its release-plz package entry left `publish` at the default `true`. release-plz requires the two to agree, so the release job errors before publishing anything (nothing was published to crates.io).
- Keep the 0.16.0 publish held until the clean-primitive gate (#1395) is complete.

## Solution

- Add `publish = false` to the `avio-examples` release-plz package entry so it matches the crate's Cargo.toml, clearing the validation error (CI back to green).
- Add `release = false` at the `[workspace]` level so the `release` job is a no-op (publishes nothing) while the gate is open. Removing that single line later re-enables the 0.16.0 publish.

Refs #1369, #1395