### PR TITLE
fix(ff-encode): free FFmpeg resources on early-return error paths in preview_inner

### DIFF
--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -438,11 +438,12 @@ unsafe fn encode_frame_as_png_inner(
     }
 
     // ── Find and open PNG encoder ─────────────────────────────────────────────
-    let codec = avcodec::find_encoder(AVCodecID_AV_CODEC_ID_PNG).ok_or_else(|| {
-        PreviewImageError::UnsupportedCodec {
+    let Some(codec) = avcodec::find_encoder(AVCodecID_AV_CODEC_ID_PNG) else {
+        avformat_free_context(fmt_ctx);
+        return Err(PreviewImageError::UnsupportedCodec {
             codec: "png".to_string(),
-        }
-    })?;
+        });
+    };
 
     let codec_ctx = match avcodec::alloc_context3(codec) {
         Ok(ctx) => ctx,
@@ -1114,17 +1115,20 @@ unsafe fn encode_gif_unsafe(
 
     // ── Open GIF output ───────────────────────────────────────────────────────
     let mut fmt_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
-    let c_path =
-        CString::new(
-            output
-                .to_str()
-                .ok_or_else(|| PreviewImageError::CannotCreateFile {
-                    path: output.to_path_buf(),
-                })?,
-        )
-        .map_err(|_| PreviewImageError::CannotCreateFile {
+    let Some(path_str) = output.to_str() else {
+        let mut g = graph;
+        avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(PreviewImageError::CannotCreateFile {
             path: output.to_path_buf(),
-        })?;
+        });
+    };
+    let Ok(c_path) = CString::new(path_str) else {
+        let mut g = graph;
+        avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(PreviewImageError::CannotCreateFile {
+            path: output.to_path_buf(),
+        });
+    };
 
     let ret = avformat_alloc_output_context2(
         &mut fmt_ctx,
@@ -1149,11 +1153,14 @@ unsafe fn encode_gif_unsafe(
         });
     }
 
-    let codec = avcodec::find_encoder(AVCodecID_AV_CODEC_ID_GIF).ok_or_else(|| {
-        PreviewImageError::UnsupportedCodec {
+    let Some(codec) = avcodec::find_encoder(AVCodecID_AV_CODEC_ID_GIF) else {
+        avformat_free_context(fmt_ctx);
+        let mut g = graph;
+        avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(PreviewImageError::UnsupportedCodec {
             codec: "gif".to_string(),
-        }
-    })?;
+        });
+    };
 
     let codec_ctx = match avcodec::alloc_context3(codec) {
         Ok(ctx) => ctx,


### PR DESCRIPTION
## Objective

- `preview_inner.rs` (behind the `preview-image` feature) leaked FFmpeg resources on three rare error edges where a `?` early-return skipped the manual `avformat_free_context` / `avfilter_graph_free` that every other failure path in the same function performs.
- Pre-existing; surfaced by the Tier-2 review of #1393.

## Solution

- Root cause: the encoder-lookup / path-conversion steps used `?`, while sibling failures (e.g. `avformat_new_stream` returning null) already freed explicitly. The `?` sites were missed.
- `encode_frame_as_png_inner`: free the allocated `AVFormatContext` when the PNG encoder is absent.
- `encode_gif_unsafe`: free the filter graph on a non-UTF-8 / interior-NUL output path, and free both the `AVFormatContext` and the filter graph when the GIF encoder is absent.
- Each early-return now frees the already-allocated context(s) before returning, matching the surrounding cleanup style and preserving the existing error variants (`UnsupportedCodec` / `CannotCreateFile`). A full scan confirms these were the only leaking sites.

Fixes #1399