### PR TITLE
test(error): assert MediaError severity() classification per crate

### DIFF
--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -195,6 +195,8 @@ impl MediaError for EncodeError {
 
 #[cfg(test)]
 mod tests {
+    use ff_format::MediaError;
+
     use super::EncodeError;
 
     #[test]
@@ -305,5 +307,17 @@ mod tests {
             msg.contains("[8000, 384000]"),
             "expected '[8000, 384000]' in '{msg}'"
         );
+    }
+
+    #[test]
+    fn encode_io_should_be_fatal() {
+        let e: EncodeError = std::io::Error::other("x").into();
+        assert!(e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn encode_cancelled_should_be_other() {
+        let e = EncodeError::Cancelled;
+        assert!(!e.is_fatal() && !e.is_recoverable());
     }
 }

--- a/crates/ff-filter/src/error.rs
+++ b/crates/ff-filter/src/error.rs
@@ -91,6 +91,8 @@ impl MediaError for FilterError {
 
 #[cfg(test)]
 mod tests {
+    use ff_format::MediaError;
+
     use super::FilterError;
     use std::error::Error;
 
@@ -167,5 +169,17 @@ mod tests {
             code: 0,
             message: String::new(),
         });
+    }
+
+    #[test]
+    fn filter_build_failed_should_be_fatal() {
+        let e = FilterError::BuildFailed;
+        assert!(e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn filter_process_failed_should_be_other() {
+        let e = FilterError::ProcessFailed;
+        assert!(!e.is_fatal() && !e.is_recoverable());
     }
 }

--- a/crates/ff-pipeline/src/error.rs
+++ b/crates/ff-pipeline/src/error.rs
@@ -99,6 +99,8 @@ impl MediaError for PipelineError {
 mod tests {
     use std::error::Error;
 
+    use ff_format::MediaError;
+
     use super::PipelineError;
 
     // --- Display messages: unit variants ---
@@ -215,5 +217,24 @@ mod tests {
         let inner = std::io::Error::new(std::io::ErrorKind::Other, "some error");
         let err: PipelineError = inner.into();
         assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn pipeline_io_should_be_fatal() {
+        let e: PipelineError = std::io::Error::other("x").into();
+        assert!(e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn pipeline_cancelled_should_be_other() {
+        let e = PipelineError::Cancelled;
+        assert!(!e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn pipeline_decode_should_delegate_recoverable() {
+        // A recoverable inner DecodeError must remain recoverable through the wrapper.
+        let e = PipelineError::Decode(ff_decode::DecodeError::decoding_failed("x"));
+        assert!(e.is_recoverable() && !e.is_fatal());
     }
 }

--- a/crates/ff-preview/src/error.rs
+++ b/crates/ff-preview/src/error.rs
@@ -84,3 +84,30 @@ impl MediaError for PreviewError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_io_should_be_fatal() {
+        let e: PreviewError = std::io::Error::other("x").into();
+        assert!(e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn preview_seek_failed_should_be_recoverable() {
+        let e = PreviewError::SeekFailed {
+            target: std::time::Duration::from_secs(1),
+            reason: "x".into(),
+        };
+        assert!(e.is_recoverable() && !e.is_fatal());
+    }
+
+    #[test]
+    fn preview_decode_should_delegate_recoverable() {
+        // A recoverable inner DecodeError must remain recoverable through the wrapper.
+        let e = PreviewError::Decode(ff_decode::DecodeError::decoding_failed("x"));
+        assert!(e.is_recoverable() && !e.is_fatal());
+    }
+}

--- a/crates/ff-probe/src/error.rs
+++ b/crates/ff-probe/src/error.rs
@@ -129,4 +129,19 @@ mod tests {
         let err: ProbeError = io_err.into();
         assert!(matches!(err, ProbeError::Io(_)));
     }
+
+    #[test]
+    fn probe_io_should_be_fatal() {
+        let e: ProbeError = std::io::Error::other("x").into();
+        assert!(e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn probe_ffmpeg_should_be_other() {
+        let e = ProbeError::Ffmpeg {
+            code: -22,
+            message: "x".into(),
+        };
+        assert!(!e.is_fatal() && !e.is_recoverable());
+    }
 }

--- a/crates/ff-render/src/error.rs
+++ b/crates/ff-render/src/error.rs
@@ -48,3 +48,23 @@ impl MediaError for RenderError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_io_should_be_fatal() {
+        let e: RenderError = std::io::Error::other("x").into();
+        assert!(e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn render_ffmpeg_should_be_other() {
+        let e = RenderError::Ffmpeg {
+            code: -22,
+            message: "x".into(),
+        };
+        assert!(!e.is_fatal() && !e.is_recoverable());
+    }
+}

--- a/crates/ff-stream/src/error.rs
+++ b/crates/ff-stream/src/error.rs
@@ -185,4 +185,26 @@ mod tests {
         assert!(msg.contains("Cannot open codec"), "got: {msg}");
         assert!(msg.contains("code=-22"), "got: {msg}");
     }
+
+    #[test]
+    fn stream_io_should_be_fatal() {
+        let e: StreamError = std::io::Error::other("x").into();
+        assert!(e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn stream_ffmpeg_should_be_other() {
+        let e = StreamError::Ffmpeg {
+            code: -22,
+            message: "x".into(),
+        };
+        assert!(!e.is_fatal() && !e.is_recoverable());
+    }
+
+    #[test]
+    fn stream_encode_should_delegate_other() {
+        // A wrapped EncodeError::Cancelled (Other) must classify as Other, not Fatal.
+        let e = StreamError::Encode(ff_encode::EncodeError::Cancelled);
+        assert!(!e.is_fatal() && !e.is_recoverable());
+    }
 }


### PR DESCRIPTION
## Objective

- `MediaError` (added in #1392) was only classification-tested for `DecodeError`. For the other crates the `severity()` match is compiler-checked for completeness, but the specific `Fatal` / `Recoverable` / `Other` choices were unpinned, so a future mis-edit could pass silently.

## Solution

- Add pure unit tests to `ff-probe`, `ff-encode`, `ff-filter`, `ff-pipeline`, `ff-stream`, `ff-preview`, and `ff-render`, each asserting a representative `severity()` result via the trait's `is_fatal()` / `is_recoverable()` (`Other` = neither).
- The wrapper crates (`ff-pipeline` / `ff-stream` / `ff-preview`) include a delegation test that feeds a non-fatal inner error (`DecodeError::decoding_failed` → Recoverable, `EncodeError::Cancelled` → Other) and checks the inner classification shows through.
- `ff-preview` / `ff-render` gain a new `#[cfg(test)]` module; `ff-encode` / `ff-filter` / `ff-pipeline` import `MediaError` explicitly in their test module (their existing tests use a specific `use super::Type` rather than a glob, so the trait was not in scope).

Resolves #1398