### PR TITLE
chore(release): switch to lockstep versioning and a single-tag CHANGELOG release

### DIFF
--- a/.github/scripts/extract-changelog.py
+++ b/.github/scripts/extract-changelog.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Extract one version's section body from CHANGELOG.md for GitHub Release notes.
+
+Usage: extract-changelog.py <version> [changelog_path]
+
+Prints the body between the `## [<version>]` header and the next `## [` header
+(the trailing `---` separator and surrounding blank lines are stripped). Exits
+non-zero if the section is missing or empty, so a release without a curated
+changelog entry fails loudly instead of cutting an empty GitHub Release.
+"""
+
+import re
+import sys
+
+
+def extract(text: str, version: str) -> str | None:
+    """Return the body of the `## [<version>]` section, or None if absent."""
+    pattern = re.compile(
+        r"^##\s*\[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^##\s*\[|\Z)",
+        re.DOTALL | re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if match is None:
+        return None
+    body = match.group(1)
+    # Drop a trailing `---` separator (Keep a Changelog uses it between versions).
+    body = re.sub(r"\n+---\s*\n*\Z", "\n", body)
+    return body.strip("\n")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: extract-changelog.py <version> [changelog_path]\n")
+        return 2
+    version = sys.argv[1]
+    path = sys.argv[2] if len(sys.argv) > 2 else "CHANGELOG.md"
+
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as err:
+        sys.stderr.write(f"error: cannot read {path}: {err}\n")
+        return 1
+
+    body = extract(text, version)
+    if body is None:
+        sys.stderr.write(f"error: no `## [{version}]` section in {path}\n")
+        return 1
+    if not body.strip():
+        sys.stderr.write(f"error: `## [{version}]` section in {path} is empty\n")
+        return 1
+
+    sys.stdout.write(body + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,25 +1,31 @@
 name: Release-plz
 
-# Change-driven, per-crate releases for the workspace (replaces the tag-push
-# release.yml). On every push to `main`:
+# Lockstep release for the workspace: every crate shares `[workspace.package].version`.
+# On every push to `main`:
 #
-#   - `release-plz-pr` opens/updates a "Release PR" that bumps versions and
-#     regenerates per-crate changelogs from conventional commits.
-#   - `release-plz-release` publishes any crate whose Cargo.toml version is not
-#     yet on crates.io (in dependency order), creates per-crate tags
-#     (`<crate>-v<version>`), and cuts GitHub Releases. It is a no-op when there
-#     is nothing new to publish.
+#   - `release-plz-release` publishes any crate whose Cargo.toml version is not yet
+#     on crates.io (in dependency order), then cuts a SINGLE `v<version>` tag and a
+#     SINGLE GitHub Release whose body is the matching section of `CHANGELOG.md`.
+#     It is idempotent: nothing is published once the version is on crates.io, and
+#     the tag/release step is skipped once `v<version>` exists.
+#
+# There is no version-bump PR job: versions and the changelog are curated by hand.
+# To release, merge a PR that bumps `[workspace.package].version` (and the matching
+# internal versions in `[workspace.dependencies]`) and moves the CHANGELOG's
+# `[Unreleased]` section to `[<version>]`.
 #
 # Publishing uses crates.io Trusted Publishing (OIDC) NATIVELY: release-plz performs
 # the token exchange itself, so there is NO long-lived `CARGO_REGISTRY_TOKEN`. Each
 # crate must have a Trusted Publisher configured on crates.io (workflow
-# `release-plz.yml`, environment `crates-io`).
+# `release-plz.yml`, environment `crates-io`). release-plz creates no tags or GitHub
+# Releases itself (`git_tag_enable` / `git_release_enable` are false in release-plz.toml);
+# this workflow owns the single tag + Release.
 #
 # The release job runs in the `crates-io` GitHub environment: it scopes the OIDC
 # token and (if the environment has required reviewers) gates each publish behind
 # manual approval. As a result the release job enters "pending approval" on every
-# push to main; approve it only when a Release PR has been merged and a release is
-# intended.
+# push to main; approve it only when a version-bump PR has been merged and a release
+# is intended.
 #
 # The release-plz action is pinned to a full commit SHA (it holds the OIDC token
 # and contents:write), matching how the other workflows pin third-party actions.
@@ -33,33 +39,6 @@ permissions:
   contents: read
 
 jobs:
-  release-plz-pr:
-    name: Release-plz PR
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'itsakeyfut' }}
-    permissions:
-      contents: write # push the release-plz branch
-      pull-requests: write # open/update the Release PR
-    concurrency:
-      group: release-plz-pr-${{ github.ref }}
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0 # release-plz reads the full git history
-          persist-credentials: false
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: "1.93.0"
-
-      - name: Open/update the Release PR
-        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
-        with:
-          command: release-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
@@ -67,14 +46,14 @@ jobs:
     # Scopes the crates.io OIDC token to this environment (matching each crate's
     # Trusted Publisher config) and gates publishing behind manual approval.
     environment: crates-io
-    # Serialize publishing so two pushes to main cannot run `release` concurrently
-    # (a race could double-publish or clash on tag/GitHub-Release creation).
-    # Never cancel an in-flight publish: it has non-idempotent side effects.
+    # Serialize releasing so two pushes to main cannot run concurrently (a race
+    # could double-publish or clash on tag/GitHub-Release creation). Never cancel
+    # an in-flight publish: it has non-idempotent side effects.
     concurrency:
       group: release-plz-release
       cancel-in-progress: false
     permissions:
-      contents: write # push per-crate tags, create GitHub Releases
+      contents: write # publish crates, create the tag and the GitHub Release
       id-token: write # crates.io Trusted Publishing (OIDC); release-plz exchanges it
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -93,3 +72,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # NO CARGO_REGISTRY_TOKEN: release-plz performs the OIDC exchange itself.
+
+      - name: Read the workspace version
+        id: ver
+        run: |
+          version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "avio") | .version')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cut the single v<version> tag and GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists; skipping."
+            exit 0
+          fi
+          # Fails loudly if the curated CHANGELOG section is missing, so a release
+          # is never cut with empty notes.
+          python3 .github/scripts/extract-changelog.py "${VERSION}" > "${RUNNER_TEMP}/notes.md"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file "${RUNNER_TEMP}/notes.md" \
+            --target "${GITHUB_SHA}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.16.0] - 2026-08-18
+
+This release splits the project into an editing **engine** (`avio`) and a family of **model-free primitive libraries** (the `ff-*` crates). The editing model moves up into `avio`, the primitives are purified so they impose no editing vocabulary, all crates share one version (lockstep), and every crate is prepared for its first standalone crates.io publish. Two new primitive crates are carved out of the existing ones, and a shared error-classification contract is added across the family.
+
+### Added
+
+#### ff-analysis (new crate)
+- Media-analysis suite (scene / silence / black-frame / keyframe detection, histogram and waveform extraction, `BpmResult`, and video scopes) extracted from `ff-decode` into its own crate ([#1391](https://github.com/itsakeyfut/avio/issues/1391))
+
+#### ff-remux (new crate)
+- Stream-copy remuxing (trim, and audio replace / extract / add) without re-encoding, extracted from `ff-encode` ([#1393](https://github.com/itsakeyfut/avio/issues/1393))
+
+#### ff-format
+- `MediaError` trait and `ErrorSeverity` classification (`Fatal` / `Recoverable` / `Other`), implemented by every `ff-*` error type so callers can branch on recoverability generically ([#1392](https://github.com/itsakeyfut/avio/issues/1392))
+
+#### avio
+- The editing model now lives in the engine: an `Editor` with snapshot history for Do/Undo/Redo, and a Command edit API with a pure apply step ([#1327](https://github.com/itsakeyfut/avio/issues/1327))
+
+#### ff-filter
+- Raw-filter escape hatch (`FilterStep::Raw`) for passing an arbitrary filter string
+- Animated rotation via a self-animating expression, supersampled and alpha-premultiplied to remove edge halos
+- `pitch_shift()` extended to +/-24 semitones via an atempo chain
+
+#### ff-preview
+- Render `xfade` transition kinds in preview
+- Converge audio derivation and apply per-clip volume / speed / fades in preview
+- Per-clip volume automation track
+
+#### CI / release
+- Change-driven crates.io publishing via release-plz with Trusted Publishing ([#1369](https://github.com/itsakeyfut/avio/issues/1369)), and a lockstep single-tag release that draws its notes from this changelog ([#1407](https://github.com/itsakeyfut/avio/issues/1407))
+- Publishing-readiness gate validating metadata for all library crates ([#1371](https://github.com/itsakeyfut/avio/issues/1371))
+
+### Changed
+
+- **Engine / primitive split:** the editing model (Timeline / Clip, model-to-scene derivation, edit history) was relocated into `avio`, and the `ff-*` crates were purified into model-free primitives; the boundary is now enforced by dependency direction ([#1326](https://github.com/itsakeyfut/avio/issues/1326))
+- De-editorialized public names on the primitive surface so the primitives impose no editing vocabulary
+
+#### ff-decode
+- `DecodeError` drops the analysis-only `AnalysisFailed` / `BpmDetectionFailed` variants (moved to `ff-analysis`'s `AnalysisError`) and gains `ExtractionFailed` for the frame / thumbnail extractor ([#1391](https://github.com/itsakeyfut/avio/issues/1391))
+
+#### ff-encode
+- `EncodeError` drops `MediaOperationFailed`; remux operations move to `ff-remux`'s `RemuxError`, and the preview-image encoders are gated behind a `preview-image` feature ([#1393](https://github.com/itsakeyfut/avio/issues/1393))
+
+#### ff-filter
+- Extensible public enums are marked `#[non_exhaustive]` so future variants stay non-breaking
+
+### Removed
+
+#### ff-filter
+- Editorial `dissolve` / `join` `FilterStep`s and the timeline / editorial fields on `VideoLayer` / `AudioTrack`, so the primitives no longer carry model concepts
+
+### Fixed
+
+#### ff-encode
+- Free the `AVFormatContext` / filter graph on early-return error paths in the preview-image encoders ([#1399](https://github.com/itsakeyfut/avio/issues/1399))
+
+### Docs
+
+- Published the engine / primitive architecture and coding rules, and reframed the crate READMEs so `avio` reads as an editing engine and the `ff-*` crates as standalone primitive libraries ([#1373](https://github.com/itsakeyfut/avio/issues/1373))
+- Aligned the `ff-render` README with the crate's actual implementation status ([#1394](https://github.com/itsakeyfut/avio/issues/1394))
+
+### Internal
+
+- `MediaError::severity()` classification is now unit-tested per crate ([#1398](https://github.com/itsakeyfut/avio/issues/1398))
+
+---
+
 ## [0.15.1] - 2026-08-07
 
 This release unifies the preview and export compositing paths on a single `RealtimeComposer` and ships the fixes uncovered along the way, plus the `wgpu` 30 upgrade for the GPU renderer.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,13 @@
 members = ["crates/*", "examples"]
 resolver = "2"
 
-# Per-crate versions are independent (declared in each crate's `[package].version`)
-# as of v0.16.0; only the fields below stay shared.
+# Lockstep versioning: every crate shares this one version (crates inherit it via
+# `version.workspace = true`). On a release bump, update `version` here AND the
+# matching `version = "..."` on each internal dependency in `[workspace.dependencies]`
+# below. Per-crate independent versioning is revisited at the Organization /
+# multi-repo migration.
 [workspace.package]
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"

--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avio"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Safe, high-level audio/video/image processing for Rust — backend-agnostic multimedia toolkit"

--- a/crates/ff-analysis/Cargo.toml
+++ b/crates/ff-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-analysis"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Media analysis (scene, silence, BPM, histogram, keyframe, black-frame, scopes) - the Rust way"

--- a/crates/ff-common/Cargo.toml
+++ b/crates/ff-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-common"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Common types and utilities for FFmpeg-based media processing"

--- a/crates/ff-decode/Cargo.toml
+++ b/crates/ff-decode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-decode"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Video and audio decoding - the Rust way"

--- a/crates/ff-encode/Cargo.toml
+++ b/crates/ff-encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-encode"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Video and audio encoding - the Rust way"

--- a/crates/ff-filter/Cargo.toml
+++ b/crates/ff-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-filter"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Video and audio filter graph operations - the Rust way"

--- a/crates/ff-format/Cargo.toml
+++ b/crates/ff-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-format"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Common types for video/audio processing - the Rust way"

--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-pipeline"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Unified decode-filter-encode pipeline for the ff-* crate family"

--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-preview"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Real-time video/audio preview and proxy workflow"

--- a/crates/ff-probe/Cargo.toml
+++ b/crates/ff-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-probe"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Media file metadata extraction - the Rust way"

--- a/crates/ff-remux/Cargo.toml
+++ b/crates/ff-remux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-remux"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Stream-copy remuxing (trim, audio replace/extract/add) over FFmpeg - the Rust way"

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-render"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "GPU compositing pipeline for real-time preview (wgpu-based)"

--- a/crates/ff-stream/Cargo.toml
+++ b/crates/ff-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-stream"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "HLS and DASH adaptive streaming output for the ff-* crate family"

--- a/crates/ff-sys/Cargo.toml
+++ b/crates/ff-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-sys"
-version = "0.16.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Low-level FFmpeg FFI bindings for Rust"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,15 +1,16 @@
 # release-plz configuration: https://release-plz.dev/docs/config
 #
-# Drives change-driven, per-crate releases: versions and per-crate changelogs are
-# derived from conventional commits, and only crates whose version is not yet on
-# crates.io are published (in dependency order). See `.github/workflows/release-plz.yml`.
+# Lockstep versioning: every crate shares `[workspace.package].version`. release-plz
+# is used ONLY to publish to crates.io (in dependency order, via Trusted Publishing);
+# it publishes any crate whose version is not yet on crates.io. The single `v<version>`
+# tag and the single GitHub Release (with the CHANGELOG.md section) are created by
+# `.github/workflows/release-plz.yml`, NOT by release-plz.
 
 [workspace]
-# HOLD: block all releasing/publishing until the 0.16.0 clean-primitive gate
-# (#1395) is complete. With this set, the `release` job is a no-op (it publishes
-# nothing) while CI stays green. Remove this line to enable the 0.16.0 publish
-# once #1395 lands.
-release = false
+# release-plz publishes only; the workflow owns the single tag + GitHub Release.
+# Disabling these prevents per-crate `<crate>-v<version>` tags and per-crate Releases.
+git_tag_enable = false
+git_release_enable = false
 
 # Skip the `cargo publish` verification build. The publish step then never compiles
 # or links FFmpeg, so all uploads finish inside the crates.io OIDC token window.
@@ -21,8 +22,8 @@ publish_no_verify = true
 semver_check = false
 
 # Give the crates.io sparse index time to propagate between dependent publishes
-# (12 crates in dependency order) so a dependent does not fail because its
-# dependency is not yet visible.
+# (14 library crates in dependency order) so a dependent does not fail because
+# its dependency is not yet visible.
 publish_timeout = "10m"
 
 # Non-library workspace members: not published, versioned, tagged, or released.


### PR DESCRIPTION
## Objective

- Per-crate independent versioning is more overhead than value for a single repository; adopt shared (lockstep) workspace versioning and revisit independence at the Organization / multi-repo migration.
- Make a release a single `v<version>` tag with one GitHub Release whose notes come from the curated `CHANGELOG.md`, triggered by merging a version-bump PR to `main`.

## Solution

- Add `version` to `[workspace.package]` and make all 14 crates inherit it via `version.workspace = true`; the internal `[workspace.dependencies]` pins stay in sync (bumped together on release).
- Keep `release-plz` only for the crates.io publish (Trusted Publishing OIDC, dependency order) with `git_tag_enable` / `git_release_enable = false`; drop the `release-pr` job.
- Add workflow steps that create the single `v<version>` tag and one GitHub Release whose body is the `CHANGELOG.md` `[<version>]` section (`extract-changelog.py`, which fails loudly if the section is missing). The step is idempotent (skipped once `v<version>` exists) and the `crates-io` environment approval gate is preserved.
- Record the 0.16.0 release in `CHANGELOG.md`. Supersedes #1406.

Closes #1407