### PR TITLE
ci: rename the release workflow to release.yml to match crates.io Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ name: Release-plz
 # Publishing uses crates.io Trusted Publishing (OIDC) NATIVELY: release-plz performs
 # the token exchange itself, so there is NO long-lived `CARGO_REGISTRY_TOKEN`. Each
 # crate must have a Trusted Publisher configured on crates.io (workflow
-# `release-plz.yml`, environment `crates-io`). release-plz creates no tags or GitHub
+# `release.yml`, environment `crates-io`). release-plz creates no tags or GitHub
 # Releases itself (`git_tag_enable` / `git_release_enable` are false in release-plz.toml);
 # this workflow owns the single tag + Release.
 #

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,7 +4,7 @@
 # is used ONLY to publish to crates.io (in dependency order, via Trusted Publishing);
 # it publishes any crate whose version is not yet on crates.io. The single `v<version>`
 # tag and the single GitHub Release (with the CHANGELOG.md section) are created by
-# `.github/workflows/release-plz.yml`, NOT by release-plz.
+# `.github/workflows/release.yml`, NOT by release-plz.
 
 [workspace]
 # release-plz publishes only; the workflow owns the single tag + GitHub Release.


### PR DESCRIPTION
## Objective

- The first 0.16.0 publish failed: `Trusted Publishing config for repository itsakeyfut/avio does not match the workflow filename release-plz.yml in the JWT. Expected workflow filenames: release.yml`.
- crates.io matches the OIDC token's workflow claim (the workflow filename) against each crate's Trusted Publisher config, and the existing crates were configured for `release.yml` while #1369 had renamed the workflow to `release-plz.yml`.

## Solution

- Rename `.github/workflows/release-plz.yml` back to `.github/workflows/release.yml` so the JWT workflow claim matches the existing Trusted Publisher configs (the workflow's display name and the `release-plz.toml` config filename are unchanged).
- After merge, only the two new crates (`ff-analysis`, `ff-remux`) still need a Trusted Publisher registered on crates.io, with workflow `release.yml` and environment `crates-io`; then re-approve the release job (it is idempotent and resumes the unpublished crates).