### PR TITLE
chore(release): make internal dev-dependencies version-less for order-independent publishing

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -541,11 +541,11 @@ futures = { workspace = true }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
 # Used directly by the relocated editing-model integration tests
 # (tests/timeline_tests.rs, tests/composition_framerate.rs, tests/fixtures/).
-ff-format = { workspace = true }
-ff-probe  = { workspace = true }
-ff-decode = { workspace = true }
-ff-encode = { workspace = true }
-ff-filter = { workspace = true }
+ff-format = { path = "../ff-format" }
+ff-probe  = { path = "../ff-probe" }
+ff-decode = { path = "../ff-decode" }
+ff-encode = { path = "../ff-encode" }
+ff-filter = { path = "../ff-filter" }
 
 [lints]
 workspace = true

--- a/crates/ff-analysis/Cargo.toml
+++ b/crates/ff-analysis/Cargo.toml
@@ -22,8 +22,8 @@ thiserror = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]
-ff-decode = { workspace = true }
-ff-format = { workspace = true }
+ff-decode = { path = "../ff-decode" }
+ff-format = { path = "../ff-format" }
 
 [lints]
 workspace = true

--- a/crates/ff-decode/Cargo.toml
+++ b/crates/ff-decode/Cargo.toml
@@ -25,7 +25,7 @@ futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-ff-format = { workspace = true }
+ff-format = { path = "../ff-format" }
 tokio = { version = "1.50.0", features = ["macros", "rt", "rt-multi-thread"] }
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/crates/ff-encode/Cargo.toml
+++ b/crates/ff-encode/Cargo.toml
@@ -44,7 +44,7 @@ preview-image = []
 
 [dev-dependencies]
 criterion = { workspace = true }
-ff-probe  = { workspace = true }
+ff-probe  = { path = "../ff-probe" }
 tokio = { version = "1.50.0", features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 # Benchmark configuration

--- a/crates/ff-filter/Cargo.toml
+++ b/crates/ff-filter/Cargo.toml
@@ -26,9 +26,9 @@ thiserror  = { workspace = true }
 serde      = { version = "1.0.228", features = ["derive"], optional = true }
 
 [dev-dependencies]
-ff-decode  = { workspace = true }
-ff-encode  = { workspace = true }
-ff-probe   = { workspace = true }
+ff-decode  = { path = "../ff-decode" }
+ff-encode  = { path = "../ff-encode" }
+ff-probe   = { path = "../ff-probe" }
 image      = { workspace = true, features = ["png"] }
 serde_json = "1.0.149"
 

--- a/crates/ff-pipeline/Cargo.toml
+++ b/crates/ff-pipeline/Cargo.toml
@@ -28,7 +28,7 @@ thiserror  = { workspace = true }
 rayon      = { version = "1.11.0", optional = true }
 
 [dev-dependencies]
-ff-probe = { workspace = true }
+ff-probe = { path = "../ff-probe" }
 
 [lints]
 workspace = true

--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -34,7 +34,7 @@ timeline = ["dep:ff-filter"]
 
 [dev-dependencies]
 criterion = { workspace = true }
-ff-probe  = { workspace = true }
+ff-probe  = { path = "../ff-probe" }
 
 [[bench]]
 name    = "preview_bench"

--- a/crates/ff-remux/Cargo.toml
+++ b/crates/ff-remux/Cargo.toml
@@ -21,9 +21,9 @@ thiserror = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]
-ff-encode = { workspace = true }
-ff-format = { workspace = true }
-ff-probe = { workspace = true }
+ff-encode = { path = "../ff-encode" }
+ff-format = { path = "../ff-format" }
+ff-probe = { path = "../ff-probe" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Objective

- release-plz publishes in normal-dependency order, but `cargo publish` also resolves each crate's `[dev-dependencies]` from crates.io. Internal dev-deps declared `{ workspace = true }` carried the shared version, so a crate could be published before an internal dev-dep's new version existed (e.g. `ff-encode` dev-depends on `ff-probe`), failing with `failed to select a version for the requirement ff-probe = "^0.16.0"`. This forced the 0.16.0 publish to be done by hand in dependency order.

## Solution

- Declare each internal `ff-*` dev-dependency path-only (no version) in the `[dev-dependencies]` sections of `ff-decode`, `ff-analysis`, `ff-encode`, `ff-filter`, `ff-remux`, `ff-pipeline`, `ff-preview`, and `avio` (17 entries).
- cargo drops a path-only dev-dependency from the published manifest, so publish order no longer depends on dev-deps (verified: `cargo package -p ff-encode` produces a manifest with no `ff-probe` dev-dep).
- No `[dependencies]` entry changes (normal deps keep their version, already ordered correctly by release-plz); consumers never use dev-deps, and local builds/tests still resolve via the path.

Closes #1410