### PR TITLE
docs(adr): introduce Architecture Decision Records and record the id scheme

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,6 +13,7 @@ If you're unsure where to start, feel free to open an issue and ask.
 - [Issue Labels](#issue-labels)
 - [Reporting Bugs](#reporting-bugs)
 - [Feature Requests](#feature-requests)
+- [Architecture Decision Records (ADR)](#architecture-decision-records-adr)
 - [Pull Requests](#pull-requests)
 - [Commit Messages](#commit-messages)
 - [Code Style](#code-style)
@@ -122,6 +123,24 @@ Open an issue describing:
 
 For changes that touch multiple crates or the public API surface, please discuss in an issue
 before starting implementation.
+
+---
+
+## Architecture Decision Records (ADR)
+
+Significant design and architecture decisions are recorded as ADRs in
+[`docs/adr/`](../docs/adr/) using the [MADR 4.0](https://adr.github.io/madr/) format. Please write one
+when:
+
+- two or more implementations are possible and you are choosing between them,
+- the choice shapes the editing model or crosses crate boundaries, or
+- you are reversing an earlier decision (add a new record and mark the old one `superseded by ADR-NNNN`).
+
+To add one, copy [`docs/adr/adr-template.md`](../docs/adr/adr-template.md), number it consecutively,
+fill in the **Confirmation** section (which test fails if the decision is violated), and add a row to
+the index in [`docs/adr/README.md`](../docs/adr/README.md). Keep the rationale in the ADR; the specs
+and per-crate design docs state the outcome and link to it. Naming, formatting, and single-call-site
+changes do not need an ADR.
 
 ---
 

--- a/docs/adr/0001-clip-and-track-identity.md
+++ b/docs/adr/0001-clip-and-track-identity.md
@@ -1,0 +1,140 @@
+---
+status: accepted
+date: 2026-08-19
+decision-makers: itsakeyfut
+---
+
+# Address clips and tracks by a document-scoped, monotonic `u64` id
+
+## Context and Problem Statement
+
+`avio` is the editing engine, and #1414 established that its model must be usable
+as a host's single editing document. The model addressed clips and tracks
+**positionally**: `Timeline` stored `Vec<Vec<Clip>>` and a `Command` carried
+`(TrackId{kind, index}, clip_index)`. Any insert, remove, or reorder invalidates
+an in-flight edit, the document cannot be serialized as a stable reference, and a
+host cannot key its UI state (selection, thumbnails) to a clip across edits.
+
+#1416 introduces a stable identity for clips and tracks. This record decides how
+those ids are represented and assigned. The codebase already relies on this
+decision (it is implemented in #1416), so the record is `accepted`, not
+`proposed`.
+
+## Decision Drivers
+
+* Ids must be stable across insert, remove, reorder, and undo/redo. This is the
+  whole point of the change.
+* The model is immutable and declarative: `apply` clones the document, and
+  `Editor` stores full `Timeline` snapshots. The scheme must fit that.
+* Clip and track order is semantically meaningful (track 0 is the bottom layer;
+  clip order within a track drives transitions), so storage stays ordered.
+* Ids must be deterministic and serializable for project save/load (#1426).
+* Prefer the minimal scheme the current scale needs. Editing is paced by user
+  gestures over tens to hundreds of objects, not a per-frame hot path.
+
+## Considered Options
+
+* A **monotonic per-document `u64` counter**; `Clip`/`Track` carry an id;
+  resolution is a linear scan.
+* A **generational-index arena** (the `slotmap` crate): `SlotMap<Key, Clip>` plus
+  a per-track `Vec<Key>` to keep order.
+* A **UUID/GUID** per object.
+* **Positional addressing** (the status quo).
+
+## Decision Outcome
+
+Chosen option: a **monotonic per-document `u64` counter** held in the `Timeline`
+(`next_clip_id` / `next_track_id`). `ClipId(u64)` and `TrackId(u64)` are opaque
+newtypes; `Clip::new` leaves `ClipId::UNSET` until the clip is placed; the
+document stamps a fresh id at `build()`, `Command::AddClip`, and
+`Command::AddTrack`; ids are never reused; commands resolve an id by linear scan.
+
+This matches how in-memory NLE models commonly represent identity: compact,
+deterministic, and trivially serializable. Because ids are never reused, a command
+naming a removed clip resolves to no track and returns an `EditError`, giving the
+same stale-reference safety a generational index provides, without a second data
+structure or a generation counter. It preserves the ordered-`Vec` storage the
+derivation already depends on, and fits the immutable/full-snapshot model (undo
+and redo restore whole documents, so ids come back intact).
+
+UUIDs are what interchange and asset boundaries need (FCPXML string ids, AAF
+MobIDs); that layer is deferred to the backlog. A `slotmap` arena or a persistent
+ordered map pays off at larger scale, or when structural-sharing history (#1352)
+lands; neither is needed now.
+
+### Confirmation
+
+Unit tests in `crates/avio/src/edit.rs` fail if the scheme is violated:
+
+* `build_should_assign_set_and_unique_ids` - ids are set and unique after build.
+* `apply_add_clip_should_append_with_fresh_id`,
+  `apply_add_track_should_append_empty_track_with_fresh_id` - added objects get a
+  fresh, distinct id.
+* `apply_should_preserve_clip_ids_across_an_unrelated_edit` - ids are stable
+  across an unrelated edit.
+* `apply_unknown_clip_should_err`, `apply_unknown_track_should_err` - an absent
+  or removed id resolves to an `EditError` (the stale-reference safety).
+
+The monotonic, never-reused property is a code invariant: the counters only
+increment, in `Timeline::build` and `apply`. Serialization determinism will be
+confirmed by the serde round-trip test in #1426.
+
+### Consequences
+
+* Good, because ids survive edits and undo/redo, are deterministic and
+  serde-ready, and add minimal code over the existing ordered `Vec`s.
+* Good, because resolution is `O(n)` but editing is gesture-paced, so it is not a
+  hot path.
+* Bad, because ids are unique only within one document; cross-document copy/paste
+  needs remapping (acceptable until interchange exists).
+* Bad, because each command does a linear scan; if a profile ever shows it matters
+  at scale, an index map is a localized fix.
+* What would reverse this: adding cross-project copy/paste or interchange (move to
+  UUIDs), or structural-sharing history and large-scale random-access editing
+  making the scan or the ordered-`Vec` clone costly (move to `slotmap` or a
+  persistent ordered map). A reversal is a new record that supersedes this one.
+
+## Pros and Cons of the Options
+
+### Monotonic per-document `u64` counter (chosen)
+
+* Good, because it is compact, deterministic, and serde-trivial.
+* Good, because it fits the immutable/snapshot model and the ordered storage.
+* Good, because never-reused ids give stale-reference safety with no extra
+  machinery.
+* Bad, because it is document-scoped only, and resolution is `O(n)`.
+
+### Generational-index arena (`slotmap`)
+
+* Good, because resolution is `O(1)` and it detects stale keys via the generation.
+* Good, because storage is decoupled from order.
+* Bad, because it is unordered, so it still needs a parallel `Vec<Key>` for layer
+  and sequence order.
+* Bad, because a mutable arena fits poorly with the immutable/snapshot model and
+  the future persistent-sharing direction (#1352), and the generation is redundant
+  when ids are never reused.
+
+### UUID/GUID
+
+* Good, because it is globally unique and safe across documents; it is what
+  interchange formats use.
+* Bad, because it is 128-bit and not human-friendly, and is not needed until
+  cross-document or interchange work exists.
+
+### Positional addressing (status quo)
+
+* Good, because there is no id field and storage is simplest.
+* Bad, because it is invalidated by insert/remove/reorder, is not a stable
+  serializable reference, and cannot key host UI state. This is the defect #1414
+  recorded.
+
+## More Information
+
+* Requirement catalog: #1414 (A7 stable identity, A8 serde). Implemented in #1416.
+* Design of record: `docs/specs/engine-and-primitives.md`;
+  `docs/roadmap/v0-17-0/ROADMAP.md`.
+* Code: `crates/avio/src/ids.rs` (`ClipId`/`TrackId`), `track.rs` (`Track`),
+  `timeline.rs` (counters and `build` stamping), `edit.rs` (id-addressed commands
+  and `apply`).
+* Industry references: FCPXML element ids, AAF MobID (SMPTE UMID), and the
+  `slotmap` crate (generational index).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,58 @@
+# Architecture Decision Records
+
+A design decision's rationale lives here and nowhere else. `docs/specs/**` and the
+per-crate `docs/crates/*/design.md` state the *outcome* and link to the record;
+they do not repeat the reasoning.
+
+These records are written in **English** (like `docs/rules/`), because they
+constrain implementation and are read by both contributors and tooling.
+
+Format: [MADR 4.0](https://adr.github.io/madr/), the de facto Markdown ADR
+standard. Copy [`adr-template.md`](./adr-template.md) to start one.
+
+## Index
+
+| # | Decision | Status | Confirmed by |
+|---|---|---|---|
+| [0001](./0001-clip-and-track-identity.md) | Address clips and tracks by a document-scoped, monotonic `u64` id | accepted | unit tests in `crates/avio/src/edit.rs` (id set/unique, stability, not-found) |
+
+**By status** - accepted: 0001 · proposed: none · superseded: none
+
+Records are numbered consecutively from `0001`.
+
+## Where each kind of writing belongs
+
+| Location | Holds | Does not hold |
+|---|---|---|
+| `docs/specs/**` | what the design is (architecture of record) | why it was chosen; links here instead |
+| `docs/crates/*/design.md` | per-crate design and the FFmpeg call order | why a cross-cutting decision was made |
+| `docs/adr/**` | why a decision was chosen, when, and what would reverse it | type or signature detail; links to the specs |
+| `docs/rules/**` | what to do while implementing | how a decision was reached |
+| `docs/roadmap/**` | what to build next (capabilities) | how a decision was reached |
+
+## When to write one
+
+* Two or more implementations are possible and one is chosen, especially when the
+  choice is cross-crate or shapes the editing model.
+* An existing decision is reversed: write a new record, mark the old one
+  `superseded by ADR-NNNN`, and note what changed.
+* You are about to write "undecided" into a spec: open one as `proposed`.
+
+**Not worth an ADR:** naming, formatting, or anything affecting a single call site.
+
+## Conventions
+
+* Filename `NNNN-short-slug.md`, numbers consecutive.
+* MADR statuses: `proposed`, `accepted`, `rejected`, `deprecated`,
+  `superseded by ADR-NNNN`.
+* Every record fills in **Confirmation**: which test or guard fails if the
+  decision is violated. If nothing would fail, say so. A decision that looks
+  enforced and is not is worse than one that is honestly unenforced.
+* A `proposed` status while the codebase already relies on the decision is itself
+  a defect; say so in *Context and Problem Statement*.
+* Keep the status in sync between an ADR's front matter and its row in this index.
+
+## More Information
+
+* [MADR 4.0](https://adr.github.io/madr/) - the template this follows.
+* [`adr-template.md`](./adr-template.md) - copy this to start a new record.

--- a/docs/adr/adr-template.md
+++ b/docs/adr/adr-template.md
@@ -1,0 +1,53 @@
+---
+status: "proposed | accepted | rejected | deprecated | superseded by ADR-NNNN"
+date: YYYY-MM-DD
+decision-makers: who decided
+---
+
+# Short title, in the form "do X because Y" or "X is Z"
+
+## Context and Problem Statement
+
+What is the problem, and why does it need deciding now? Two or three sentences.
+If something already depends on the answer while this record is still `proposed`,
+say so here.
+
+## Decision Drivers
+
+* the constraints that actually narrow the choice
+
+## Considered Options
+
+* option 1
+* option 2
+
+## Decision Outcome
+
+Chosen option: "option 1", because ...
+
+### Confirmation
+
+Which test, fixture, or guard fails if this decision is violated? If nothing would
+fail, say so.
+
+### Consequences
+
+* Good, because ...
+* Bad, because ...
+* What would reverse this: ...
+
+## Pros and Cons of the Options
+
+### option 1
+
+* Good, because ...
+* Bad, because ...
+
+### option 2
+
+* Good, because ...
+* Bad, because ...
+
+## More Information
+
+Links to the specs, code, issues, and measurements this rests on.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -14,5 +14,7 @@ This directory collects the conventions to follow when writing code across the a
 | [gpu.md](./gpu.md) | wgpu resource lifecycle, bytemuck, color (`ff-render`) |
 | [wgsl.md](./wgsl.md) | Shader naming, struct alignment, bindings (`ff-render`) |
 
-Design specs live in [`../specs/`](../specs/). Internal review-knowledge and process docs live in
-`docs/dev/`.
+Design specs live in [`../specs/`](../specs/), and the rationale behind significant design and
+architecture decisions in [`../adr/`](../adr/) (Architecture Decision Records; see
+[when to write one](../adr/README.md#when-to-write-one)). Internal review-knowledge and process docs
+live in `docs/dev/`.


### PR DESCRIPTION
## Objective

- Establish a single, consistent home for the rationale behind significant design and architecture decisions, so committers record them going forward instead of scattering reasoning across specs and review notes.
- Capture the first such decision: how clips and tracks are identified in the editing model.

## Solution

- Add `docs/adr/` (MADR 4.0, English) with a template and an index README.
- Add **ADR-0001**: address clips and tracks by a document-scoped, monotonic `u64` id, with the considered alternatives (slotmap arena, UUIDs, positional addressing), the confirmation tests, and what would reverse the decision.
- Document the practice for contributors in `.github/CONTRIBUTING.md` and the `docs/rules/` index: the rationale lives in the ADR; the specs and per-crate design docs state the outcome and link to it.