### PR TITLE
refactor(avio): stable ClipId/TrackId and a first-class Track model

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -15,6 +15,7 @@ use ff_filter::{
 use ff_format::{PixelFormat, VideoFrame};
 
 use crate::error::TimelineError;
+use crate::ids::ClipId;
 
 /// A single media clip on a timeline.
 ///
@@ -36,6 +37,12 @@ use crate::error::TimelineError;
 /// ```
 #[derive(Debug, Clone)]
 pub struct Clip {
+    /// Stable identity within a [`Timeline`](crate::Timeline).
+    ///
+    /// [`ClipId::UNSET`] until the clip is placed in a document; the timeline
+    /// stamps a real id when the clip is added (via the builder or
+    /// [`Command::AddClip`](crate::Command::AddClip)).
+    pub id: ClipId,
     /// Path to the source media file.
     pub source: PathBuf,
     /// Start point within the source file. `None` = beginning of file.
@@ -206,6 +213,7 @@ impl Clip {
     /// Creates a new clip from a source path with no trim points and zero timeline offset.
     pub fn new(source: impl AsRef<Path>) -> Self {
         Self {
+            id: ClipId::UNSET,
             source: source.as_ref().to_path_buf(),
             in_point: None,
             out_point: None,

--- a/crates/avio/src/edit.rs
+++ b/crates/avio/src/edit.rs
@@ -6,6 +6,11 @@
 //! this is the foundation for Do/Undo/Redo (the `Editor` history is added in a
 //! follow-up). This edit layer is part of the engine; the `ff-*` primitives
 //! never see it.
+//!
+//! Clips and tracks are addressed by their stable [`ClipId`] / [`TrackId`], not
+//! by position, so an edit stays valid when the timeline changes around it.
+//! Resolution is a linear scan over the document's tracks; a command naming an
+//! id that is present in no track returns an [`EditError`] and changes nothing.
 
 use std::time::Duration;
 
@@ -13,45 +18,9 @@ use ff_filter::BlendMode;
 use thiserror::Error;
 
 use crate::clip::Clip;
+use crate::ids::{ClipId, TrackId, TrackKind};
 use crate::timeline::Timeline;
-
-/// Which track list a [`TrackId`] refers to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TrackKind {
-    /// A video track (`Timeline::video_tracks`).
-    Video,
-    /// An audio track (`Timeline::audio_tracks`).
-    Audio,
-}
-
-/// Addresses a single track within a [`Timeline`] by kind and position.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TrackId {
-    /// Whether this is a video or audio track.
-    pub kind: TrackKind,
-    /// Zero-based index into the track list of that kind.
-    pub index: usize,
-}
-
-impl TrackId {
-    /// The video track at `index`.
-    #[must_use]
-    pub fn video(index: usize) -> Self {
-        Self {
-            kind: TrackKind::Video,
-            index,
-        }
-    }
-
-    /// The audio track at `index`.
-    #[must_use]
-    pub fn audio(index: usize) -> Self {
-        Self {
-            kind: TrackKind::Audio,
-            index,
-        }
-    }
-}
+use crate::track::Track;
 
 /// A per-clip property that [`Command::SetClipProperty`] can set.
 #[derive(Debug, Clone, PartialEq)]
@@ -76,58 +45,52 @@ pub enum ClipProperty {
 /// A single, value-based edit to a [`Timeline`]. Apply it with [`apply`].
 #[derive(Debug, Clone)]
 pub enum Command {
-    /// Append `clip` to the end of `track`.
+    /// Append `clip` to the end of the track with id `track`.
     ///
-    /// The clip is boxed so `Command` stays small (it is stored in the edit
-    /// history); every other variant is a few machine words.
+    /// The clip is assigned a fresh [`ClipId`] by the document; any id already on
+    /// the incoming clip is ignored. The clip is boxed so `Command` stays small
+    /// (it is stored in the edit history); every other variant is a few machine
+    /// words.
     AddClip {
-        /// Target track.
+        /// Target track id.
         track: TrackId,
-        /// Clip to append.
+        /// Clip to append (its id is replaced with a fresh one).
         clip: Box<Clip>,
     },
-    /// Remove the clip at `index` from `track`.
+    /// Remove the clip with id `clip`.
     RemoveClip {
-        /// Target track.
-        track: TrackId,
-        /// Zero-based clip index.
-        index: usize,
+        /// Clip to remove.
+        clip: ClipId,
     },
-    /// Set the timeline offset of the clip at `index` on `track`.
+    /// Set the timeline offset of the clip with id `clip`.
     MoveClip {
-        /// Target track.
-        track: TrackId,
-        /// Zero-based clip index.
-        index: usize,
+        /// Clip to move.
+        clip: ClipId,
         /// New timeline offset.
         offset: Duration,
     },
-    /// Set the source in/out points of the clip at `index` on `track`.
+    /// Set the source in/out points of the clip with id `clip`.
     TrimClip {
-        /// Target track.
-        track: TrackId,
-        /// Zero-based clip index.
-        index: usize,
+        /// Clip to trim.
+        clip: ClipId,
         /// New source in-point (`None` = start of file).
         in_point: Option<Duration>,
         /// New source out-point (`None` = end of file).
         out_point: Option<Duration>,
     },
-    /// Set a property of the clip at `index` on `track`.
+    /// Set a property of the clip with id `clip`.
     SetClipProperty {
-        /// Target track.
-        track: TrackId,
-        /// Zero-based clip index.
-        index: usize,
+        /// Clip to modify.
+        clip: ClipId,
         /// The property to set.
         property: ClipProperty,
     },
-    /// Append a new, empty track of `kind`.
+    /// Append a new, empty track of `kind` (assigned a fresh [`TrackId`]).
     AddTrack {
         /// Kind of track to append.
         kind: TrackKind,
     },
-    /// Remove `track` and all of its clips.
+    /// Remove the track with id `track` and all of its clips.
     RemoveTrack {
         /// Track to remove.
         track: TrackId,
@@ -149,23 +112,17 @@ pub enum Command {
 /// An edit that could not be applied to a [`Timeline`].
 #[derive(Debug, Error, PartialEq)]
 pub enum EditError {
-    /// The addressed track does not exist.
-    #[error("{kind:?} track index {index} out of range (len {len})")]
-    TrackOutOfRange {
-        /// Track kind addressed.
-        kind: TrackKind,
-        /// Requested index.
-        index: usize,
-        /// Number of tracks of that kind.
-        len: usize,
+    /// No track with the given id exists in the document.
+    #[error("no track with id {id:?}")]
+    TrackNotFound {
+        /// The id that resolved to no track.
+        id: TrackId,
     },
-    /// The addressed clip does not exist in its track.
-    #[error("clip index {index} out of range (len {len})")]
-    ClipOutOfRange {
-        /// Requested index.
-        index: usize,
-        /// Number of clips in the track.
-        len: usize,
+    /// No clip with the given id exists in the document.
+    #[error("no clip with id {id:?}")]
+    ClipNotFound {
+        /// The id that resolved to no clip.
+        id: ClipId,
     },
     /// Canvas dimensions must be non-zero.
     #[error("invalid canvas: {width}x{height}")]
@@ -184,66 +141,71 @@ pub enum EditError {
 ///
 /// This is a pure function: `timeline` is not modified (it is borrowed
 /// immutably), no I/O is performed, and no source is re-probed — an edit carries
-/// the already-resolved canvas/fps. Invalid edits (out-of-range track/clip index,
-/// zero canvas, non-positive fps) return an [`EditError`] and change nothing.
+/// the already-resolved canvas/fps. Invalid edits (an unknown track/clip id, zero
+/// canvas, non-positive fps) return an [`EditError`] and change nothing.
 ///
 /// # Errors
 ///
-/// Returns [`EditError`] when the target track or clip index is out of range, or
-/// a [`Command::SetCanvas`] / [`Command::SetFrameRate`] value is invalid.
+/// Returns [`EditError`] when the target track or clip id is not present, or a
+/// [`Command::SetCanvas`] / [`Command::SetFrameRate`] value is invalid.
 pub fn apply(timeline: &Timeline, command: &Command) -> Result<Timeline, EditError> {
     let mut next = timeline.clone();
     match command {
         Command::AddClip { track, clip } => {
-            track_mut(&mut next, *track)?.push((**clip).clone());
+            // Read the id before borrowing the track so the counter bump below
+            // does not conflict with the mutable track borrow.
+            let id = ClipId::from_raw(next.next_clip_id);
+            let mut new_clip = (**clip).clone();
+            new_clip.id = id;
+            let tr =
+                find_track_mut(&mut next, *track).ok_or(EditError::TrackNotFound { id: *track })?;
+            tr.clips.push(new_clip);
+            next.next_clip_id += 1;
         }
-        Command::RemoveClip { track, index } => {
-            let clips = track_mut(&mut next, *track)?;
-            check_clip(clips, *index)?;
-            clips.remove(*index);
+        Command::RemoveClip { clip } => {
+            if !remove_clip(&mut next, *clip) {
+                return Err(EditError::ClipNotFound { id: *clip });
+            }
         }
-        Command::MoveClip {
-            track,
-            index,
-            offset,
-        } => {
-            clip_mut(&mut next, *track, *index)?.offset = *offset;
+        Command::MoveClip { clip, offset } => {
+            find_clip_mut(&mut next, *clip)
+                .ok_or(EditError::ClipNotFound { id: *clip })?
+                .offset = *offset;
         }
         Command::TrimClip {
-            track,
-            index,
+            clip,
             in_point,
             out_point,
         } => {
-            let clip = clip_mut(&mut next, *track, *index)?;
-            clip.in_point = *in_point;
-            clip.out_point = *out_point;
+            let c = find_clip_mut(&mut next, *clip).ok_or(EditError::ClipNotFound { id: *clip })?;
+            c.in_point = *in_point;
+            c.out_point = *out_point;
         }
-        Command::SetClipProperty {
-            track,
-            index,
-            property,
-        } => {
-            let clip = clip_mut(&mut next, *track, *index)?;
+        Command::SetClipProperty { clip, property } => {
+            let c = find_clip_mut(&mut next, *clip).ok_or(EditError::ClipNotFound { id: *clip })?;
             match property {
                 // Match `Clip::with_opacity`, which clamps to the documented range.
-                ClipProperty::Opacity(v) => clip.opacity = v.clamp(0.0, 1.0),
-                ClipProperty::Speed(v) => clip.speed = *v,
-                ClipProperty::BlendMode(v) => clip.blend_mode = *v,
-                ClipProperty::VolumeDb(v) => clip.volume_db = *v,
+                ClipProperty::Opacity(v) => c.opacity = v.clamp(0.0, 1.0),
+                ClipProperty::Speed(v) => c.speed = *v,
+                ClipProperty::BlendMode(v) => c.blend_mode = *v,
+                ClipProperty::VolumeDb(v) => c.volume_db = *v,
                 ClipProperty::Position { x, y } => {
-                    clip.x = *x;
-                    clip.y = *y;
+                    c.x = *x;
+                    c.y = *y;
                 }
             }
         }
         Command::AddTrack { kind } => {
-            tracks_mut(&mut next, *kind).push(Vec::new());
+            let id = TrackId::from_raw(next.next_track_id);
+            let mut tr = Track::new(Vec::new());
+            tr.id = id;
+            tracks_mut(&mut next, *kind).push(tr);
+            next.next_track_id += 1;
         }
         Command::RemoveTrack { track } => {
-            let tracks = tracks_mut(&mut next, track.kind);
-            check_track(tracks, track.kind, track.index)?;
-            tracks.remove(track.index);
+            if !remove_track(&mut next, *track) {
+                return Err(EditError::TrackNotFound { id: *track });
+            }
         }
         Command::SetCanvas { width, height } => {
             if *width == 0 || *height == 0 {
@@ -266,44 +228,64 @@ pub fn apply(timeline: &Timeline, command: &Command) -> Result<Timeline, EditErr
     Ok(next)
 }
 
-fn tracks_mut(timeline: &mut Timeline, kind: TrackKind) -> &mut Vec<Vec<Clip>> {
+fn tracks_mut(timeline: &mut Timeline, kind: TrackKind) -> &mut Vec<Track> {
     match kind {
         TrackKind::Video => &mut timeline.video_tracks,
         TrackKind::Audio => &mut timeline.audio_tracks,
     }
 }
 
-fn check_track(tracks: &[Vec<Clip>], kind: TrackKind, index: usize) -> Result<(), EditError> {
-    if index >= tracks.len() {
-        return Err(EditError::TrackOutOfRange {
-            kind,
-            index,
-            len: tracks.len(),
-        });
+/// Finds the track with `id` in either list (video then audio).
+fn find_track_mut(timeline: &mut Timeline, id: TrackId) -> Option<&mut Track> {
+    if let Some(tr) = timeline.video_tracks.iter_mut().find(|tr| tr.id == id) {
+        return Some(tr);
     }
-    Ok(())
+    timeline.audio_tracks.iter_mut().find(|tr| tr.id == id)
 }
 
-fn check_clip(clips: &[Clip], index: usize) -> Result<(), EditError> {
-    if index >= clips.len() {
-        return Err(EditError::ClipOutOfRange {
-            index,
-            len: clips.len(),
-        });
+/// Finds the clip with `id` anywhere in the document (video then audio tracks).
+fn find_clip_mut(timeline: &mut Timeline, id: ClipId) -> Option<&mut Clip> {
+    for tr in &mut timeline.video_tracks {
+        if let Some(c) = tr.clips.iter_mut().find(|c| c.id == id) {
+            return Some(c);
+        }
     }
-    Ok(())
+    for tr in &mut timeline.audio_tracks {
+        if let Some(c) = tr.clips.iter_mut().find(|c| c.id == id) {
+            return Some(c);
+        }
+    }
+    None
 }
 
-fn track_mut(timeline: &mut Timeline, id: TrackId) -> Result<&mut Vec<Clip>, EditError> {
-    let tracks = tracks_mut(timeline, id.kind);
-    check_track(tracks, id.kind, id.index)?;
-    Ok(&mut tracks[id.index])
+/// Removes the clip with `id` from whichever track holds it. Returns whether a
+/// clip was removed.
+fn remove_clip(timeline: &mut Timeline, id: ClipId) -> bool {
+    for tr in timeline
+        .video_tracks
+        .iter_mut()
+        .chain(timeline.audio_tracks.iter_mut())
+    {
+        if let Some(pos) = tr.clips.iter().position(|c| c.id == id) {
+            tr.clips.remove(pos);
+            return true;
+        }
+    }
+    false
 }
 
-fn clip_mut(timeline: &mut Timeline, id: TrackId, index: usize) -> Result<&mut Clip, EditError> {
-    let clips = track_mut(timeline, id)?;
-    check_clip(clips, index)?;
-    Ok(&mut clips[index])
+/// Removes the track with `id` from whichever list holds it. Returns whether a
+/// track was removed.
+fn remove_track(timeline: &mut Timeline, id: TrackId) -> bool {
+    if let Some(pos) = timeline.video_tracks.iter().position(|tr| tr.id == id) {
+        timeline.video_tracks.remove(pos);
+        return true;
+    }
+    if let Some(pos) = timeline.audio_tracks.iter().position(|tr| tr.id == id) {
+        timeline.audio_tracks.remove(pos);
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -323,34 +305,63 @@ mod tests {
             .unwrap()
     }
 
+    /// The id of the first video track.
+    fn track0(t: &Timeline) -> TrackId {
+        t.video_tracks()[0].id
+    }
+
+    /// The id of clip `i` on the first video track.
+    fn clip_id(t: &Timeline, i: usize) -> ClipId {
+        t.video_tracks()[0].clips[i].id
+    }
+
     #[test]
-    fn apply_add_clip_should_append_to_track() {
+    fn build_should_assign_set_and_unique_ids() {
+        let t = timeline_with(3);
+        let track = &t.video_tracks()[0];
+        assert!(track.id.is_set());
+        let ids: Vec<ClipId> = track.clips.iter().map(|c| c.id).collect();
+        assert!(ids.iter().all(|id| id.is_set()));
+        // Unique.
+        let mut sorted = ids.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "clip ids must be unique");
+    }
+
+    #[test]
+    fn apply_add_clip_should_append_with_fresh_id() {
         let t = timeline_with(1);
         let out = apply(
             &t,
             &Command::AddClip {
-                track: TrackId::video(0),
+                track: track0(&t),
                 clip: Box::new(Clip::new("added.mp4")),
             },
         )
         .unwrap();
-        assert_eq!(out.video_tracks()[0].len(), 2);
-        assert_eq!(out.video_tracks()[0][1].source.to_str(), Some("added.mp4"));
+        assert_eq!(out.video_tracks()[0].clips.len(), 2);
+        let added = &out.video_tracks()[0].clips[1];
+        assert_eq!(added.source.to_str(), Some("added.mp4"));
+        assert!(added.id.is_set());
+        assert_ne!(added.id, clip_id(&t, 0), "new clip must get a distinct id");
     }
 
     #[test]
-    fn apply_remove_clip_should_drop_it() {
+    fn apply_remove_clip_should_drop_it_by_id() {
         let t = timeline_with(2);
         let out = apply(
             &t,
             &Command::RemoveClip {
-                track: TrackId::video(0),
-                index: 0,
+                clip: clip_id(&t, 0),
             },
         )
         .unwrap();
-        assert_eq!(out.video_tracks()[0].len(), 1);
-        assert_eq!(out.video_tracks()[0][0].source.to_str(), Some("clip1.mp4"));
+        assert_eq!(out.video_tracks()[0].clips.len(), 1);
+        assert_eq!(
+            out.video_tracks()[0].clips[0].source.to_str(),
+            Some("clip1.mp4")
+        );
     }
 
     #[test]
@@ -359,13 +370,15 @@ mod tests {
         let out = apply(
             &t,
             &Command::MoveClip {
-                track: TrackId::video(0),
-                index: 0,
+                clip: clip_id(&t, 0),
                 offset: Duration::from_secs(3),
             },
         )
         .unwrap();
-        assert_eq!(out.video_tracks()[0][0].offset, Duration::from_secs(3));
+        assert_eq!(
+            out.video_tracks()[0].clips[0].offset,
+            Duration::from_secs(3)
+        );
     }
 
     #[test]
@@ -374,19 +387,18 @@ mod tests {
         let out = apply(
             &t,
             &Command::TrimClip {
-                track: TrackId::video(0),
-                index: 0,
+                clip: clip_id(&t, 0),
                 in_point: Some(Duration::from_secs(1)),
                 out_point: Some(Duration::from_secs(4)),
             },
         )
         .unwrap();
         assert_eq!(
-            out.video_tracks()[0][0].in_point,
+            out.video_tracks()[0].clips[0].in_point,
             Some(Duration::from_secs(1))
         );
         assert_eq!(
-            out.video_tracks()[0][0].out_point,
+            out.video_tracks()[0].clips[0].out_point,
             Some(Duration::from_secs(4))
         );
     }
@@ -397,13 +409,12 @@ mod tests {
         let out = apply(
             &t,
             &Command::SetClipProperty {
-                track: TrackId::video(0),
-                index: 0,
+                clip: clip_id(&t, 0),
                 property: ClipProperty::Opacity(0.25),
             },
         )
         .unwrap();
-        assert!((out.video_tracks()[0][0].opacity - 0.25).abs() < f32::EPSILON);
+        assert!((out.video_tracks()[0].clips[0].opacity - 0.25).abs() < f32::EPSILON);
     }
 
     #[test]
@@ -412,17 +423,16 @@ mod tests {
         let out = apply(
             &t,
             &Command::SetClipProperty {
-                track: TrackId::video(0),
-                index: 0,
+                clip: clip_id(&t, 0),
                 property: ClipProperty::Opacity(2.0),
             },
         )
         .unwrap();
-        assert!((out.video_tracks()[0][0].opacity - 1.0).abs() < f32::EPSILON);
+        assert!((out.video_tracks()[0].clips[0].opacity - 1.0).abs() < f32::EPSILON);
     }
 
     #[test]
-    fn apply_add_track_should_append_empty_track() {
+    fn apply_add_track_should_append_empty_track_with_fresh_id() {
         let t = timeline_with(1);
         let out = apply(
             &t,
@@ -432,11 +442,14 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out.video_tracks().len(), 2);
-        assert!(out.video_tracks()[1].is_empty());
+        let added = &out.video_tracks()[1];
+        assert!(added.clips.is_empty());
+        assert!(added.id.is_set());
+        assert_ne!(added.id, track0(&t), "new track must get a distinct id");
     }
 
     #[test]
-    fn apply_remove_track_should_drop_it() {
+    fn apply_remove_track_should_drop_it_by_id() {
         let t = apply(
             &timeline_with(1),
             &Command::AddTrack {
@@ -444,14 +457,21 @@ mod tests {
             },
         )
         .unwrap();
-        let out = apply(
-            &t,
-            &Command::RemoveTrack {
-                track: TrackId::video(1),
-            },
-        )
-        .unwrap();
+        let second = t.video_tracks()[1].id;
+        let out = apply(&t, &Command::RemoveTrack { track: second }).unwrap();
         assert_eq!(out.video_tracks().len(), 1);
+    }
+
+    #[test]
+    fn apply_should_preserve_clip_ids_across_an_unrelated_edit() {
+        let t = timeline_with(2);
+        let ids_before: Vec<ClipId> = t.video_tracks()[0].clips.iter().map(|c| c.id).collect();
+        let out = apply(&t, &Command::SetFrameRate { fps: 24.0 }).unwrap();
+        let ids_after: Vec<ClipId> = out.video_tracks()[0].clips.iter().map(|c| c.id).collect();
+        assert_eq!(
+            ids_before, ids_after,
+            "unrelated edit must not renumber clips"
+        );
     }
 
     #[test]
@@ -480,55 +500,137 @@ mod tests {
     #[test]
     fn apply_should_not_mutate_the_input() {
         let t = timeline_with(1);
-        let before = t.video_tracks()[0].len();
+        let before = t.video_tracks()[0].clips.len();
         let _ = apply(
             &t,
             &Command::AddClip {
-                track: TrackId::video(0),
+                track: track0(&t),
                 clip: Box::new(Clip::new("x.mp4")),
             },
         )
         .unwrap();
         assert_eq!(
-            t.video_tracks()[0].len(),
+            t.video_tracks()[0].clips.len(),
             before,
             "input timeline must be unchanged"
         );
     }
 
     #[test]
-    fn apply_out_of_range_track_should_err() {
+    fn apply_unknown_track_should_err() {
         let t = timeline_with(1);
+        // UNSET is never assigned to a placed track, so it is always absent.
         let err = apply(
             &t,
             &Command::AddClip {
-                track: TrackId::video(5),
+                track: TrackId::UNSET,
                 clip: Box::new(Clip::new("x.mp4")),
             },
         )
         .unwrap_err();
+        assert_eq!(err, EditError::TrackNotFound { id: TrackId::UNSET });
+    }
+
+    #[test]
+    fn apply_unknown_clip_should_err() {
+        let t = timeline_with(1);
+        let err = apply(
+            &t,
+            &Command::RemoveClip {
+                clip: ClipId::UNSET,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, EditError::ClipNotFound { id: ClipId::UNSET });
+    }
+
+    #[test]
+    fn apply_add_clip_repeated_should_mint_distinct_never_reused_ids() {
+        let t = timeline_with(1);
+        let a = apply(
+            &t,
+            &Command::AddClip {
+                track: track0(&t),
+                clip: Box::new(Clip::new("a.mp4")),
+            },
+        )
+        .unwrap();
+        let id_a = a.video_tracks()[0].clips[1].id;
+        // Remove it, then add again along the same linear history: the removed id
+        // must not be reused (the counter never rewinds within a chain).
+        let b = apply(&a, &Command::RemoveClip { clip: id_a }).unwrap();
+        let c = apply(
+            &b,
+            &Command::AddClip {
+                track: track0(&b),
+                clip: Box::new(Clip::new("b.mp4")),
+            },
+        )
+        .unwrap();
+        let id_c = c.video_tracks()[0].clips[1].id;
+        assert_ne!(
+            id_a, id_c,
+            "a removed id must not be reused along a linear history"
+        );
+    }
+
+    #[test]
+    fn apply_remove_unknown_track_should_err() {
+        let t = timeline_with(1);
+        let err = apply(&t, &Command::RemoveTrack { track: TrackId::UNSET }).unwrap_err();
         assert_eq!(
             err,
-            EditError::TrackOutOfRange {
-                kind: TrackKind::Video,
-                index: 5,
-                len: 1,
+            EditError::TrackNotFound {
+                id: TrackId::UNSET
             }
         );
     }
 
     #[test]
-    fn apply_out_of_range_clip_index_should_err() {
+    fn apply_move_unknown_clip_should_err() {
         let t = timeline_with(1);
         let err = apply(
             &t,
-            &Command::RemoveClip {
-                track: TrackId::video(0),
-                index: 9,
+            &Command::MoveClip {
+                clip: ClipId::UNSET,
+                offset: Duration::from_secs(1),
             },
         )
         .unwrap_err();
-        assert_eq!(err, EditError::ClipOutOfRange { index: 9, len: 1 });
+        assert_eq!(err, EditError::ClipNotFound { id: ClipId::UNSET });
+    }
+
+    #[test]
+    fn build_should_assign_unique_ids_across_all_tracks() {
+        let t = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("v0.mp4"), Clip::new("v1.mp4")])
+            .video_track(vec![Clip::new("v2.mp4")])
+            .audio_track(vec![Clip::new("a0.mp3")])
+            .build()
+            .unwrap();
+        let mut track_ids: Vec<TrackId> = t
+            .video_tracks()
+            .iter()
+            .chain(t.audio_tracks().iter())
+            .map(|tr| tr.id)
+            .collect();
+        let n_tracks = track_ids.len();
+        track_ids.sort();
+        track_ids.dedup();
+        assert_eq!(track_ids.len(), n_tracks, "track ids unique across video+audio");
+
+        let mut clip_ids: Vec<ClipId> = t
+            .video_tracks()
+            .iter()
+            .chain(t.audio_tracks().iter())
+            .flat_map(|tr| tr.clips.iter().map(|c| c.id))
+            .collect();
+        let n_clips = clip_ids.len();
+        clip_ids.sort();
+        clip_ids.dedup();
+        assert_eq!(clip_ids.len(), n_clips, "clip ids unique across all tracks");
     }
 
     #[test]

--- a/crates/avio/src/edit.rs
+++ b/crates/avio/src/edit.rs
@@ -577,13 +577,14 @@ mod tests {
     #[test]
     fn apply_remove_unknown_track_should_err() {
         let t = timeline_with(1);
-        let err = apply(&t, &Command::RemoveTrack { track: TrackId::UNSET }).unwrap_err();
-        assert_eq!(
-            err,
-            EditError::TrackNotFound {
-                id: TrackId::UNSET
-            }
-        );
+        let err = apply(
+            &t,
+            &Command::RemoveTrack {
+                track: TrackId::UNSET,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, EditError::TrackNotFound { id: TrackId::UNSET });
     }
 
     #[test]
@@ -619,7 +620,11 @@ mod tests {
         let n_tracks = track_ids.len();
         track_ids.sort();
         track_ids.dedup();
-        assert_eq!(track_ids.len(), n_tracks, "track ids unique across video+audio");
+        assert_eq!(
+            track_ids.len(),
+            n_tracks,
+            "track ids unique across video+audio"
+        );
 
         let mut clip_ids: Vec<ClipId> = t
             .video_tracks()

--- a/crates/avio/src/editor.rs
+++ b/crates/avio/src/editor.rs
@@ -10,6 +10,11 @@
 //! History is stored as full snapshots — one `Timeline` clone per edit. This is
 //! simple and correct but grows with the number of edits; structural-sharing /
 //! diff-based history is a later optimisation (#1352).
+//!
+//! The id counters live here, outside the snapshotted `Timeline`, as a session
+//! high-water mark: an `undo` restores an older snapshot (and its older
+//! counters), so seating the high-water before each edit keeps a later
+//! `AddClip` / `AddTrack` from re-minting an id a discarded branch already used.
 
 use crate::edit::{Command, EditError};
 use crate::timeline::Timeline;
@@ -25,15 +30,23 @@ pub struct Editor {
     history: Vec<Timeline>,
     /// Index of the current version within `history`.
     cursor: usize,
+    /// Session high-water for the next clip/track id, never rewound by `undo`.
+    /// See the module docs.
+    next_clip_id: u64,
+    next_track_id: u64,
 }
 
 impl Editor {
     /// Starts an editing session at `initial`.
     #[must_use]
     pub fn new(initial: Timeline) -> Self {
+        let next_clip_id = initial.next_clip_id;
+        let next_track_id = initial.next_track_id;
         Self {
             history: vec![initial],
             cursor: 0,
+            next_clip_id,
+            next_track_id,
         }
     }
 
@@ -53,9 +66,19 @@ impl Editor {
     /// Returns the [`EditError`] from [`apply`](crate::apply) when the command
     /// cannot be applied; the history is not modified in that case.
     pub fn apply(&mut self, command: &Command) -> Result<&Timeline, EditError> {
+        // Seat the session high-water counters onto the current version before
+        // applying, so an edit after an `undo` (which restored an older snapshot,
+        // and with it that snapshot's smaller counters) never re-mints an id a
+        // truncated branch already handed out.
+        let mut current = self.history[self.cursor].clone();
+        current.next_clip_id = self.next_clip_id;
+        current.next_track_id = self.next_track_id;
+
         // Compute the new version first: if this fails, `?` returns before any
         // history mutation, so a rejected edit never disturbs undo/redo state.
-        let next = crate::edit::apply(&self.history[self.cursor], command)?;
+        let next = crate::edit::apply(&current, command)?;
+        self.next_clip_id = next.next_clip_id;
+        self.next_track_id = next.next_track_id;
         self.history.truncate(self.cursor + 1);
         self.history.push(next);
         self.cursor += 1;
@@ -185,5 +208,50 @@ mod tests {
         assert!(ed.can_undo());
         assert!(!ed.can_redo());
         assert!((ed.current().frame_rate() - 24.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn editor_should_preserve_clip_id_across_undo_redo() {
+        let mut ed = Editor::new(timeline(30.0));
+        let track = ed.current().video_tracks()[0].id;
+        ed.apply(&Command::AddClip {
+            track,
+            clip: Box::new(Clip::new("x.mp4")),
+        })
+        .unwrap();
+        let id = ed.current().video_tracks()[0].clips[1].id;
+        ed.undo().unwrap();
+        let after = ed.redo().unwrap();
+        assert_eq!(
+            after.video_tracks()[0].clips[1].id,
+            id,
+            "undo/redo must not renumber the clip"
+        );
+    }
+
+    #[test]
+    fn editor_should_not_reuse_ids_across_undo() {
+        let mut ed = Editor::new(timeline(30.0));
+        let track = ed.current().video_tracks()[0].id;
+        ed.apply(&Command::AddClip {
+            track,
+            clip: Box::new(Clip::new("a.mp4")),
+        })
+        .unwrap();
+        let first = ed.current().video_tracks()[0].clips[1].id;
+        // Discard that edit; without the session high-water the counter would
+        // rewind and the next AddClip would re-mint `first` for a different clip.
+        ed.undo().unwrap();
+        let after = ed
+            .apply(&Command::AddClip {
+                track,
+                clip: Box::new(Clip::new("b.mp4")),
+            })
+            .unwrap();
+        let second = after.video_tracks()[0].clips[1].id;
+        assert_ne!(
+            first, second,
+            "an id used by a discarded branch must not be reused"
+        );
     }
 }

--- a/crates/avio/src/editor.rs
+++ b/crates/avio/src/editor.rs
@@ -15,6 +15,8 @@
 //! high-water mark: an `undo` restores an older snapshot (and its older
 //! counters), so seating the high-water before each edit keeps a later
 //! `AddClip` / `AddTrack` from re-minting an id a discarded branch already used.
+//! This is what makes the "never reused" guarantee of ADR-0001
+//! (`docs/adr/0001-clip-and-track-identity.md`) hold across undo.
 
 use crate::edit::{Command, EditError};
 use crate::timeline::Timeline;

--- a/crates/avio/src/ids.rs
+++ b/crates/avio/src/ids.rs
@@ -13,6 +13,10 @@
 //! Cross-document uniqueness (copy/paste between projects) and interchange would
 //! want UUIDs; that is deferred to the interchange work. `serde` derives arrive
 //! with the persistence work (#1426).
+//!
+//! The decision, and the alternatives weighed (a `slotmap` arena, UUIDs, or
+//! positional addressing), are recorded in ADR-0001
+//! (`docs/adr/0001-clip-and-track-identity.md`).
 
 /// Stable identity of a [`Clip`](crate::Clip) within a [`Timeline`](crate::Timeline).
 ///

--- a/crates/avio/src/ids.rs
+++ b/crates/avio/src/ids.rs
@@ -1,0 +1,74 @@
+//! Stable identity for the editing document.
+//!
+//! Every [`Clip`](crate::Clip) and [`Track`](crate::Track) carries an id that is
+//! stable across edits, undo/redo, insertion, removal, and reorder. Ids are
+//! **document-scoped monotonic `u64`s**: a [`Timeline`](crate::Timeline) holds a
+//! pair of counters and stamps a fresh id whenever a clip or track is added, and
+//! ids are **never reused**. That makes a command addressing a removed clip fail
+//! (the id is in no track) instead of silently aliasing a different clip — the
+//! same stale-reference safety a generational index gives, without the machinery.
+//! The [`Editor`](crate::Editor) carries the counters as a session high-water so
+//! that an `undo` cannot cause a later edit to re-mint a discarded id.
+//!
+//! Cross-document uniqueness (copy/paste between projects) and interchange would
+//! want UUIDs; that is deferred to the interchange work. `serde` derives arrive
+//! with the persistence work (#1426).
+
+/// Stable identity of a [`Clip`](crate::Clip) within a [`Timeline`](crate::Timeline).
+///
+/// Assigned by the document (see the module docs); [`Clip::new`](crate::Clip::new)
+/// leaves it [`UNSET`](ClipId::UNSET) until the clip is placed in a timeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ClipId(u64);
+
+impl ClipId {
+    /// The id of a clip that has not yet been placed in a document.
+    pub const UNSET: ClipId = ClipId(0);
+
+    /// Whether this id has been assigned by a document (i.e. is not [`UNSET`](Self::UNSET)).
+    #[must_use]
+    pub fn is_set(self) -> bool {
+        self.0 != 0
+    }
+
+    /// Mints an id from a raw counter value. Crate-internal: only the document
+    /// (`Timeline::build` and `apply`) mints ids, so callers cannot forge one.
+    /// The public `id` fields remain writable, but `build`/`apply` re-stamp ids,
+    /// so the document's uniqueness invariant holds regardless.
+    pub(crate) fn from_raw(value: u64) -> Self {
+        ClipId(value)
+    }
+}
+
+/// Stable identity of a [`Track`](crate::Track) within a [`Timeline`](crate::Timeline).
+///
+/// Assigned by the document (see the module docs). Track ids are unique across
+/// **both** the video and audio track lists (they share one counter), so a
+/// `TrackId` identifies a track without also naming its [`TrackKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TrackId(u64);
+
+impl TrackId {
+    /// The id of a track that has not yet been placed in a document.
+    pub const UNSET: TrackId = TrackId(0);
+
+    /// Whether this id has been assigned by a document (i.e. is not [`UNSET`](Self::UNSET)).
+    #[must_use]
+    pub fn is_set(self) -> bool {
+        self.0 != 0
+    }
+
+    /// Mints an id from a raw counter value. Crate-internal (see `ClipId::from_raw`).
+    pub(crate) fn from_raw(value: u64) -> Self {
+        TrackId(value)
+    }
+}
+
+/// Which track list a [`TrackId`] refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackKind {
+    /// A video track ([`Timeline::video_tracks`](crate::Timeline::video_tracks)).
+    Video,
+    /// An audio track ([`Timeline::audio_tracks`](crate::Timeline::audio_tracks)).
+    Audio,
+}

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -326,18 +326,26 @@ mod editor;
 #[cfg(feature = "pipeline")]
 mod error;
 #[cfg(feature = "pipeline")]
+mod ids;
+#[cfg(feature = "pipeline")]
 mod timeline;
+#[cfg(feature = "pipeline")]
+mod track;
 
 #[cfg(feature = "pipeline")]
 pub use clip::{Clip, VideoEffectRenderer};
 #[cfg(feature = "pipeline")]
-pub use edit::{ClipProperty, Command, EditError, TrackId, TrackKind, apply};
+pub use edit::{ClipProperty, Command, EditError, apply};
 #[cfg(feature = "pipeline")]
 pub use editor::Editor;
 #[cfg(feature = "pipeline")]
 pub use error::TimelineError;
 #[cfg(feature = "pipeline")]
+pub use ids::{ClipId, TrackId, TrackKind};
+#[cfg(feature = "pipeline")]
 pub use timeline::{Timeline, TimelineBuilder};
+#[cfg(feature = "pipeline")]
+pub use track::Track;
 
 #[cfg(feature = "pipeline")]
 pub use ff_pipeline::{

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -20,6 +20,8 @@ use ff_format::ChannelLayout;
 use crate::clip::Clip;
 use crate::derive;
 use crate::error::TimelineError;
+use crate::ids::{ClipId, TrackId};
+use crate::track::Track;
 use ff_pipeline::EncoderConfig;
 use ff_pipeline::Progress;
 use ff_pipeline::pipeline::hwaccel_to_hardware_encoder;
@@ -59,9 +61,14 @@ pub struct Timeline {
     /// as the real-time preview know a deliberate output aspect was requested.
     pub(crate) canvas_explicit: bool,
     pub(crate) frame_rate: f64,
-    /// `video_tracks[track_idx][clip_idx]`; track 0 = bottom layer.
-    pub(crate) video_tracks: Vec<Vec<Clip>>,
-    pub(crate) audio_tracks: Vec<Vec<Clip>>,
+    /// `video_tracks[track_idx].clips[clip_idx]`; track 0 = bottom layer.
+    pub(crate) video_tracks: Vec<Track>,
+    pub(crate) audio_tracks: Vec<Track>,
+    /// Next [`ClipId`](crate::ClipId) value to hand out. Monotonic, never reused;
+    /// stamped onto clips as they are added. `1` for a fresh document (`0` = unset).
+    pub(crate) next_clip_id: u64,
+    /// Next [`TrackId`](crate::TrackId) value to hand out (see `next_clip_id`).
+    pub(crate) next_track_id: u64,
     /// Animation tracks for video layer properties.
     ///
     /// Key format: `"video_{track_index}_{property}"`, e.g. `"video_0_opacity"`.
@@ -119,12 +126,12 @@ impl Timeline {
     }
 
     /// Returns a slice of all video tracks.
-    pub fn video_tracks(&self) -> &[Vec<Clip>] {
+    pub fn video_tracks(&self) -> &[Track] {
         &self.video_tracks
     }
 
     /// Returns a slice of all audio tracks.
-    pub fn audio_tracks(&self) -> &[Vec<Clip>] {
+    pub fn audio_tracks(&self) -> &[Track] {
         &self.audio_tracks
     }
 
@@ -199,7 +206,7 @@ impl Timeline {
         let total_frames: Option<u64> = self
             .video_tracks
             .iter()
-            .flat_map(|track| track.iter())
+            .flat_map(|track| track.clips.iter())
             .map(Clip::duration)
             .try_fold(Duration::ZERO, |acc, dur| dur.map(|d| acc + d))
             .map(|total_dur| (total_dur.as_secs_f64() * self.frame_rate).round().max(0.0) as u64);
@@ -211,6 +218,8 @@ impl Timeline {
             frame_rate,
             video_tracks,
             audio_tracks,
+            next_clip_id: _,
+            next_track_id: _,
             video_animations,
             audio_animations,
             lavfi_overlay,
@@ -219,9 +228,24 @@ impl Timeline {
         let nv = video_tracks.len();
         let na = audio_tracks.len();
 
-        // 1. Pre-check: all clip sources must exist on disk.
-        for track in video_tracks.iter().chain(audio_tracks.iter()) {
-            for clip in track {
+        // Solo is scoped per media list; a track is active unless disabled, muted,
+        // or shadowed by a solo elsewhere in its list. Computed once here and
+        // reused by the pre-check and both derivation loops.
+        let any_video_solo = video_tracks.iter().any(|t| t.solo);
+        let any_audio_solo = audio_tracks.iter().any(|t| t.solo);
+
+        // 1. Pre-check: sources of active tracks must exist on disk. Inactive
+        //    tracks contribute nothing to the render, so an offline source on a
+        //    disabled/muted/soloed-out track must not fail the whole export.
+        for (track, any_solo) in video_tracks
+            .iter()
+            .map(|t| (t, any_video_solo))
+            .chain(audio_tracks.iter().map(|t| (t, any_audio_solo)))
+        {
+            if !track.is_active(any_solo) {
+                continue;
+            }
+            for clip in &track.clips {
                 if !clip.source.exists() {
                     return Err(TimelineError::ClipNotFound {
                         path: clip.source.to_string_lossy().into_owned(),
@@ -267,8 +291,14 @@ impl Timeline {
             // relative to the audio for non-30fps timelines.
             let mut composer =
                 MultiTrackComposer::new(canvas_width, canvas_height).frame_rate(frame_rate);
+            // Inactive tracks (disabled, muted, or shadowed by a solo elsewhere in
+            // this list) contribute no layers. The enumerate index is preserved so
+            // the timeline animation keys (`video_{idx}_*`) still line up.
             for (track_idx, track) in video_tracks.iter().enumerate() {
-                for (clip_idx, clip) in track.iter().enumerate() {
+                if !track.is_active(any_video_solo) {
+                    continue;
+                }
+                for (clip_idx, clip) in track.clips.iter().enumerate() {
                     let prev_end =
                         (clip_idx > 0).then(|| *prev_end_by_track.get(&track_idx).unwrap_or(&0.0));
 
@@ -346,8 +376,12 @@ impl Timeline {
         let mut audio_graph = None;
         if !audio_tracks.is_empty() {
             let mut mixer = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo);
+            // Honor mute/solo/enabled: an inactive audio track is silent.
             for (track_idx, track) in audio_tracks.iter().enumerate() {
-                for clip in track {
+                if !track.is_active(any_audio_solo) {
+                    continue;
+                }
+                for clip in &track.clips {
                     // Resolve the effective clip duration only when a fade-out
                     // needs it to compute its start offset (probing is I/O; the
                     // pure per-clip build lives in `derive`).
@@ -454,8 +488,8 @@ pub struct TimelineBuilder {
     canvas_width: Option<u32>,
     canvas_height: Option<u32>,
     frame_rate: Option<f64>,
-    video_tracks: Vec<Vec<Clip>>,
-    audio_tracks: Vec<Vec<Clip>>,
+    video_tracks: Vec<Track>,
+    audio_tracks: Vec<Track>,
     video_animations: HashMap<String, AnimationTrack<f64>>,
     audio_animations: HashMap<String, AnimationTrack<f64>>,
     /// See [`TimelineBuilder::lavfi_overlay`].
@@ -502,22 +536,38 @@ impl TimelineBuilder {
         }
     }
 
-    /// Appends a video track. Track 0 (first call) is the bottom layer.
+    /// Appends a video track holding `clips` (default flags, no name). Track 0
+    /// (first call) is the bottom layer.
+    ///
+    /// Use [`video_track_with`](Self::video_track_with) to append a track with a
+    /// name or mute/solo/enabled/lock flags set.
     #[must_use]
     pub fn video_track(self, clips: Vec<Clip>) -> Self {
+        self.video_track_with(Track::new(clips))
+    }
+
+    /// Appends a preconfigured video [`Track`] (name, mute/solo/enabled/lock).
+    #[must_use]
+    pub fn video_track_with(self, track: Track) -> Self {
         let mut video_tracks = self.video_tracks;
-        video_tracks.push(clips);
+        video_tracks.push(track);
         Self {
             video_tracks,
             ..self
         }
     }
 
-    /// Appends an audio track.
+    /// Appends an audio track holding `clips` (default flags, no name).
     #[must_use]
     pub fn audio_track(self, clips: Vec<Clip>) -> Self {
+        self.audio_track_with(Track::new(clips))
+    }
+
+    /// Appends a preconfigured audio [`Track`] (name, mute/solo/enabled/lock).
+    #[must_use]
+    pub fn audio_track_with(self, track: Track) -> Self {
         let mut audio_tracks = self.audio_tracks;
-        audio_tracks.push(clips);
+        audio_tracks.push(track);
         Self {
             audio_tracks,
             ..self
@@ -596,13 +646,31 @@ impl TimelineBuilder {
         let canvas_explicit = self.canvas_width.is_some() && self.canvas_height.is_some();
         let (canvas_width, canvas_height, frame_rate) = self.resolve_canvas_and_fps()?;
 
+        // Stamp stable ids from monotonic counters (0 = unset; ids start at 1),
+        // video tracks first. The final counter values are stored so later edits
+        // (`AddClip` / `AddTrack`) keep minting fresh, never-reused ids.
+        let mut next_track_id: u64 = 1;
+        let mut next_clip_id: u64 = 1;
+        let mut video_tracks = self.video_tracks;
+        let mut audio_tracks = self.audio_tracks;
+        for track in video_tracks.iter_mut().chain(audio_tracks.iter_mut()) {
+            track.id = TrackId::from_raw(next_track_id);
+            next_track_id += 1;
+            for clip in &mut track.clips {
+                clip.id = ClipId::from_raw(next_clip_id);
+                next_clip_id += 1;
+            }
+        }
+
         Ok(Timeline {
             canvas_width,
             canvas_height,
             canvas_explicit,
             frame_rate,
-            video_tracks: self.video_tracks,
-            audio_tracks: self.audio_tracks,
+            video_tracks,
+            audio_tracks,
+            next_clip_id,
+            next_track_id,
             video_animations: self.video_animations,
             audio_animations: self.audio_animations,
             lavfi_overlay: self.lavfi_overlay,
@@ -619,7 +687,9 @@ impl TimelineBuilder {
             || self.canvas_height.is_none()
             || self.frame_rate.is_none();
 
-        if need_probe && let Some(first_clip) = self.video_tracks.first().and_then(|t| t.first()) {
+        if need_probe
+            && let Some(first_clip) = self.video_tracks.first().and_then(|t| t.clips.first())
+        {
             if !first_clip.source.exists() {
                 return Err(TimelineError::ClipNotFound {
                     path: first_clip.source.to_string_lossy().into_owned(),
@@ -715,29 +785,44 @@ impl Timeline {
     /// are overlays (transitions forced off, matching the compositor).
     #[must_use]
     pub fn to_scene(&self) -> ff_preview::Scene {
+        // Inactive tracks (disabled, muted, or shadowed by a solo elsewhere in the
+        // list) project no placements, but keep their slot so the base-track
+        // (index 0) rule and the `video_{idx}_*` animation keys stay aligned.
+        let any_video_solo = self.video_tracks.iter().any(|t| t.solo);
         let video_tracks = self
-            .video_tracks()
+            .video_tracks
             .iter()
             .enumerate()
             .map(|(track_idx, track)| ff_preview::SceneVideoTrack {
-                placements: track
-                    .iter()
-                    .map(|clip| {
-                        video_placement(clip, track_idx, track_idx == 0, &self.video_animations)
-                    })
-                    .collect(),
+                placements: if track.is_active(any_video_solo) {
+                    track
+                        .clips
+                        .iter()
+                        .map(|clip| {
+                            video_placement(clip, track_idx, track_idx == 0, &self.video_animations)
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                },
             })
             .collect();
 
+        let any_audio_solo = self.audio_tracks.iter().any(|t| t.solo);
         let audio_tracks = self
-            .audio_tracks()
+            .audio_tracks
             .iter()
             .enumerate()
             .map(|(track_idx, track)| ff_preview::SceneAudioTrack {
-                placements: track
-                    .iter()
-                    .map(|clip| audio_placement(clip, track_idx, &self.audio_animations))
-                    .collect(),
+                placements: if track.is_active(any_audio_solo) {
+                    track
+                        .clips
+                        .iter()
+                        .map(|clip| audio_placement(clip, track_idx, &self.audio_animations))
+                        .collect()
+                } else {
+                    Vec::new()
+                },
             })
             .collect();
 
@@ -909,6 +994,103 @@ mod tests {
         assert!((audio.speed - 2.0).abs() < f64::EPSILON);
         // The neutral clip volume falls back to the timeline `audio_0_volume` automation.
         assert!(matches!(audio.volume, AnimatedValue::Track(_)));
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_drop_disabled_video_track_placements() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track_with(Track::new(vec![Clip::new("base.mp4")]).enabled(false))
+            .video_track(vec![Clip::new("overlay.mp4")])
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        assert_eq!(scene.video_tracks.len(), 2, "track slots are preserved");
+        assert!(
+            scene.video_tracks[0].placements.is_empty(),
+            "a disabled track projects no placements"
+        );
+        assert_eq!(scene.video_tracks[1].placements.len(), 1);
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_drop_muted_video_track_placements() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track_with(Track::new(vec![Clip::new("base.mp4")]).muted(true))
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        assert!(scene.video_tracks[0].placements.is_empty());
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_solo_should_keep_only_soloed_video_tracks() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("base.mp4")]) // not soloed
+            .video_track_with(Track::new(vec![Clip::new("overlay.mp4")]).soloed(true))
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        assert!(
+            scene.video_tracks[0].placements.is_empty(),
+            "a non-soloed track is shadowed when another is soloed"
+        );
+        assert_eq!(scene.video_tracks[1].placements.len(), 1);
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_drop_muted_audio_track_placements() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("v.mp4")])
+            .audio_track_with(Track::new(vec![Clip::new("a.mp3")]).muted(true))
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        assert!(scene.audio_tracks[0].placements.is_empty());
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_drop_disabled_audio_track_placements() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("v.mp4")])
+            .audio_track_with(Track::new(vec![Clip::new("a.mp3")]).enabled(false))
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        assert!(scene.audio_tracks[0].placements.is_empty());
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_solo_should_keep_only_soloed_audio_tracks() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("v.mp4")])
+            .audio_track(vec![Clip::new("a.mp3")]) // not soloed
+            .audio_track_with(Track::new(vec![Clip::new("b.mp3")]).soloed(true))
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        assert!(
+            scene.audio_tracks[0].placements.is_empty(),
+            "a non-soloed audio track is shadowed when another is soloed"
+        );
+        assert_eq!(scene.audio_tracks[1].placements.len(), 1);
     }
 
     #[test]

--- a/crates/avio/src/track.rs
+++ b/crates/avio/src/track.rs
@@ -1,0 +1,126 @@
+//! A first-class track in the editing document.
+//!
+//! A [`Track`] is an ordered list of [`Clip`]s plus its editorial state: a stable
+//! [`TrackId`], a name, and the `mute` / `solo` / `enabled` / `lock` flags. It
+//! replaces the bare `Vec<Clip>` lane the [`Timeline`](crate::Timeline) used to
+//! store, so a host can name a track, mute/solo it, and address it by id.
+//!
+//! `mute` / `solo` / `enabled` decide whether a track contributes to the derived
+//! output (see [`Track::is_active`]); `lock` and `name` are authoring metadata the
+//! derivation ignores.
+
+use crate::clip::Clip;
+use crate::ids::TrackId;
+
+/// An ordered list of [`Clip`]s and its editorial state.
+///
+/// Construct one with [`Track::new`] (or via
+/// [`TimelineBuilder::video_track`](crate::TimelineBuilder::video_track)); the
+/// [`Timeline`](crate::Timeline) assigns the [`id`](Track::id) when the track is
+/// placed in the document.
+// The four flags (mute/solo/enabled/lock) are independent, orthogonal editorial
+// states every NLE track carries — not a state machine — so a bool each is the
+// clearest model.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
+pub struct Track {
+    /// Stable identity, assigned by the document (`TrackId::UNSET` until placed).
+    pub id: TrackId,
+    /// Human-readable track name (may be empty).
+    pub name: String,
+    /// When `true`, the track contributes nothing to the output (see `Track::is_active`).
+    pub mute: bool,
+    /// When any track in the same list is soloed, only soloed tracks contribute.
+    pub solo: bool,
+    /// When `false`, the track is disabled and contributes nothing.
+    pub enabled: bool,
+    /// Authoring flag protecting the track from edits; ignored by the derivation.
+    pub lock: bool,
+    /// The clips on this track, in order (index 0 first on the timeline).
+    pub clips: Vec<Clip>,
+}
+
+impl Track {
+    /// Creates an enabled, unnamed track holding `clips`, with its id unset.
+    ///
+    /// The [`Timeline`](crate::Timeline) stamps a real [`TrackId`] when the track
+    /// is placed in the document.
+    #[must_use]
+    pub fn new(clips: Vec<Clip>) -> Self {
+        Self {
+            id: TrackId::UNSET,
+            name: String::new(),
+            mute: false,
+            solo: false,
+            enabled: true,
+            lock: false,
+            clips,
+        }
+    }
+
+    /// Sets the track name.
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Sets the `mute` flag.
+    #[must_use]
+    pub fn muted(mut self, mute: bool) -> Self {
+        self.mute = mute;
+        self
+    }
+
+    /// Sets the `solo` flag.
+    #[must_use]
+    pub fn soloed(mut self, solo: bool) -> Self {
+        self.solo = solo;
+        self
+    }
+
+    /// Sets the `enabled` flag.
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Sets the `lock` flag.
+    #[must_use]
+    pub fn locked(mut self, lock: bool) -> Self {
+        self.lock = lock;
+        self
+    }
+
+    /// Whether this track contributes to the derived output.
+    ///
+    /// A track is active when it is `enabled`, not `mute`d, and — if any track in
+    /// its list is soloed (`any_solo_in_list`) — is itself `solo`. `any_solo_in_list`
+    /// must be computed over the track's own media list (video or audio), since
+    /// solo is scoped per list.
+    pub(crate) fn is_active(&self, any_solo_in_list: bool) -> bool {
+        self.enabled && !self.mute && (!any_solo_in_list || self.solo)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_active_should_reflect_enabled_mute_solo() {
+        // Default (enabled, not muted, no solo in the list) -> active.
+        assert!(Track::new(vec![]).is_active(false));
+        // Disabled -> inactive.
+        assert!(!Track::new(vec![]).enabled(false).is_active(false));
+        // Muted -> inactive.
+        assert!(!Track::new(vec![]).muted(true).is_active(false));
+        // Another track in the list is soloed, this one is not -> shadowed.
+        assert!(!Track::new(vec![]).is_active(true));
+        // Soloed while a solo is present -> active.
+        assert!(Track::new(vec![]).soloed(true).is_active(true));
+        // Soloed but disabled -> still inactive (enabled/mute win over solo).
+        assert!(!Track::new(vec![]).soloed(true).enabled(false).is_active(true));
+    }
+}

--- a/crates/avio/src/track.rs
+++ b/crates/avio/src/track.rs
@@ -121,6 +121,11 @@ mod tests {
         // Soloed while a solo is present -> active.
         assert!(Track::new(vec![]).soloed(true).is_active(true));
         // Soloed but disabled -> still inactive (enabled/mute win over solo).
-        assert!(!Track::new(vec![]).soloed(true).enabled(false).is_active(true));
+        assert!(
+            !Track::new(vec![])
+                .soloed(true)
+                .enabled(false)
+                .is_active(true)
+        );
     }
 }


### PR DESCRIPTION
## Objective

- The editing model addressed clips and tracks positionally (`Vec<Vec<Clip>>` + `(TrackId{kind,index}, index)`), so any insert/remove/reorder invalidated in-flight edits and the document could not serve as a stable, host-adoptable reference (the gap #1414 recorded).
- Foundation for the v0.17.0 editing-model work: the id-dependent follow-ups (usable Editor, SetClip, split/cross-track/ripple, ClipSource) build on this.

## Solution

- Add opaque, monotonic `ClipId`/`TrackId` (document-scoped, never reused) and a first-class `Track` (name, mute/solo/enabled/lock). `Timeline` stores `Vec<Track>` with id counters stamped at `build` and on `AddClip`/`AddTrack`.
- Make every edit command and `apply` id-addressed, with `TrackNotFound`/`ClipNotFound`.
- Honor mute/solo/enabled in both the export render and the preview `to_scene` derivation; inactive tracks contribute nothing.
- Keep the id counters in `Editor` as a session high-water so `undo` cannot rewind them and cause id reuse.
- Out of scope (deferred): timeline animations stay keyed by track index; `serde` persistence is #1426.

Closes #1416