### PR TITLE
feat(avio): host-adoptable Editor (amend / group / seat) and Command::Batch

### DIFF
--- a/crates/avio/src/edit.rs
+++ b/crates/avio/src/edit.rs
@@ -107,6 +107,13 @@ pub enum Command {
         /// Frames per second.
         fps: f64,
     },
+    /// Apply several commands as one atomic edit (and, through [`Editor`](crate::Editor),
+    /// one undo step).
+    ///
+    /// The sub-commands are applied in order to the same timeline. If any one
+    /// fails, the whole batch is rejected and the timeline is left unchanged. An
+    /// empty batch is a no-op, and batches may nest.
+    Batch(Vec<Command>),
 }
 
 /// An edit that could not be applied to a [`Timeline`].
@@ -142,7 +149,9 @@ pub enum EditError {
 /// This is a pure function: `timeline` is not modified (it is borrowed
 /// immutably), no I/O is performed, and no source is re-probed — an edit carries
 /// the already-resolved canvas/fps. Invalid edits (an unknown track/clip id, zero
-/// canvas, non-positive fps) return an [`EditError`] and change nothing.
+/// canvas, non-positive fps) return an [`EditError`] and change nothing. A
+/// [`Command::Batch`] applies its sub-commands atomically: if any one fails, none
+/// take effect.
 ///
 /// # Errors
 ///
@@ -223,6 +232,14 @@ pub fn apply(timeline: &Timeline, command: &Command) -> Result<Timeline, EditErr
                 return Err(EditError::InvalidFrameRate(*fps));
             }
             next.frame_rate = *fps;
+        }
+        Command::Batch(commands) => {
+            // Apply each sub-command to the accumulating timeline. On failure `?`
+            // returns and `next` is dropped, so the input timeline is unchanged
+            // (the batch is atomic). The id counters carry forward through `next`.
+            for command in commands {
+                next = apply(&next, command)?;
+            }
         }
     }
     Ok(next)
@@ -663,5 +680,92 @@ mod tests {
                 height: 720
             }
         );
+    }
+
+    #[test]
+    fn apply_batch_should_apply_all_sub_commands() {
+        let t = timeline_with(1);
+        let out = apply(
+            &t,
+            &Command::Batch(vec![
+                Command::AddClip {
+                    track: track0(&t),
+                    clip: Box::new(Clip::new("a.mp4")),
+                },
+                Command::SetFrameRate { fps: 24.0 },
+            ]),
+        )
+        .unwrap();
+        assert_eq!(out.video_tracks()[0].clips.len(), 2);
+        assert!((out.frame_rate() - 24.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn apply_batch_should_be_atomic_on_failure() {
+        let t = timeline_with(1);
+        let err = apply(
+            &t,
+            &Command::Batch(vec![
+                Command::AddClip {
+                    track: track0(&t),
+                    clip: Box::new(Clip::new("a.mp4")),
+                },
+                // Fails: unknown clip id. The whole batch must be rejected.
+                Command::RemoveClip {
+                    clip: ClipId::UNSET,
+                },
+                Command::SetFrameRate { fps: 24.0 },
+            ]),
+        )
+        .unwrap_err();
+        assert_eq!(err, EditError::ClipNotFound { id: ClipId::UNSET });
+        // apply returned Err, so the caller keeps the original timeline unchanged.
+        assert_eq!(t.video_tracks()[0].clips.len(), 1);
+        assert!((t.frame_rate() - 30.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn apply_empty_batch_should_be_a_no_op() {
+        let t = timeline_with(1);
+        let out = apply(&t, &Command::Batch(vec![])).unwrap();
+        assert_eq!(out.video_tracks()[0].clips.len(), 1);
+        assert!((out.frame_rate() - 30.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn apply_nested_batch_should_apply() {
+        let t = timeline_with(1);
+        let out = apply(
+            &t,
+            &Command::Batch(vec![Command::Batch(vec![Command::AddClip {
+                track: track0(&t),
+                clip: Box::new(Clip::new("a.mp4")),
+            }])]),
+        )
+        .unwrap();
+        assert_eq!(out.video_tracks()[0].clips.len(), 2);
+    }
+
+    #[test]
+    fn apply_batch_of_two_add_clip_should_mint_distinct_ids() {
+        let t = timeline_with(1);
+        let out = apply(
+            &t,
+            &Command::Batch(vec![
+                Command::AddClip {
+                    track: track0(&t),
+                    clip: Box::new(Clip::new("a.mp4")),
+                },
+                Command::AddClip {
+                    track: track0(&t),
+                    clip: Box::new(Clip::new("b.mp4")),
+                },
+            ]),
+        )
+        .unwrap();
+        let clips = &out.video_tracks()[0].clips;
+        assert_eq!(clips.len(), 3);
+        assert_ne!(clips[1].id, clips[2].id, "batch must mint distinct ids");
+        assert!(clips[1].id.is_set() && clips[2].id.is_set());
     }
 }

--- a/crates/avio/src/editor.rs
+++ b/crates/avio/src/editor.rs
@@ -23,9 +23,14 @@ use crate::timeline::Timeline;
 
 /// A stateful editing session: an undo/redo history of [`Timeline`] versions.
 ///
-/// The version at the internal cursor is the current one. Applying a [`Command`]
+/// The version at the internal cursor is the current one. [`apply`](Self::apply)
 /// discards any redo tail and pushes a new version; [`undo`](Self::undo) /
 /// [`redo`](Self::redo) move the cursor without dropping versions.
+///
+/// For a real host: [`amend`](Self::amend) / [`replace_current`](Self::replace_current)
+/// update the current version in place **without** adding an undo step, and
+/// [`begin_group`](Self::begin_group) … [`commit_group`](Self::commit_group)
+/// coalesce a gesture's many edits into a single undo step.
 #[derive(Debug)]
 pub struct Editor {
     /// Version history; `history[cursor]` is current. Always non-empty.
@@ -36,10 +41,24 @@ pub struct Editor {
     /// See the module docs.
     next_clip_id: u64,
     next_track_id: u64,
+    /// An in-progress coalesced gesture, or `None`. See [`Editor::begin_group`].
+    group: Option<Group>,
+}
+
+/// An in-progress coalesced gesture: edits fold into `working` until commit.
+#[derive(Debug)]
+struct Group {
+    /// The evolving version, seeded from the current version at `begin_group`.
+    working: Timeline,
+    /// Whether any edit changed `working` (so `commit_group` knows to push a step).
+    dirty: bool,
 }
 
 impl Editor {
     /// Starts an editing session at `initial`.
+    ///
+    /// This also seats an externally built or mutated [`Timeline`] as the current
+    /// version: the session's id high-water starts from `initial`'s counters.
     #[must_use]
     pub fn new(initial: Timeline) -> Self {
         let next_clip_id = initial.next_clip_id;
@@ -49,72 +68,155 @@ impl Editor {
             cursor: 0,
             next_clip_id,
             next_track_id,
+            group: None,
         }
     }
 
-    /// The current [`Timeline`] version.
+    /// The current [`Timeline`] version. While a group is active this is the
+    /// gesture's in-progress version.
     #[must_use]
     pub fn current(&self) -> &Timeline {
-        &self.history[self.cursor]
+        match &self.group {
+            Some(g) => &g.working,
+            None => &self.history[self.cursor],
+        }
     }
 
-    /// Applies `command` to the current version and makes the result current.
+    /// Applies `command` to the current version, seating the session id high-water
+    /// first (so an edit after `undo` never re-mints a discarded id) and raising
+    /// it from the result. Returns the new version. Does not touch history.
+    fn edit_current(&mut self, command: &Command) -> Result<Timeline, EditError> {
+        let mut seed = self.current().clone();
+        seed.next_clip_id = self.next_clip_id;
+        seed.next_track_id = self.next_track_id;
+        let next = crate::edit::apply(&seed, command)?;
+        self.next_clip_id = next.next_clip_id;
+        self.next_track_id = next.next_track_id;
+        Ok(next)
+    }
+
+    /// Applies `command` and makes the result current.
     ///
-    /// Any redo history (versions after the cursor) is discarded first. On an
-    /// invalid edit the history is left completely unchanged.
+    /// Outside a group this pushes a new undo step (discarding any redo tail);
+    /// inside a group it folds into the gesture's in-progress version instead. On
+    /// an invalid edit nothing changes.
     ///
     /// # Errors
     ///
     /// Returns the [`EditError`] from [`apply`](crate::apply) when the command
-    /// cannot be applied; the history is not modified in that case.
+    /// cannot be applied; no state is modified in that case.
     pub fn apply(&mut self, command: &Command) -> Result<&Timeline, EditError> {
-        // Seat the session high-water counters onto the current version before
-        // applying, so an edit after an `undo` (which restored an older snapshot,
-        // and with it that snapshot's smaller counters) never re-mints an id a
-        // truncated branch already handed out.
-        let mut current = self.history[self.cursor].clone();
-        current.next_clip_id = self.next_clip_id;
-        current.next_track_id = self.next_track_id;
-
         // Compute the new version first: if this fails, `?` returns before any
-        // history mutation, so a rejected edit never disturbs undo/redo state.
-        let next = crate::edit::apply(&current, command)?;
-        self.next_clip_id = next.next_clip_id;
-        self.next_track_id = next.next_track_id;
-        self.history.truncate(self.cursor + 1);
-        self.history.push(next);
-        self.cursor += 1;
-        Ok(&self.history[self.cursor])
+        // state mutation, so a rejected edit never disturbs the history or group.
+        let next = self.edit_current(command)?;
+        if let Some(g) = &mut self.group {
+            g.working = next;
+            g.dirty = true;
+        } else {
+            self.history.truncate(self.cursor + 1);
+            self.history.push(next);
+            self.cursor += 1;
+        }
+        Ok(self.current())
     }
 
-    /// Moves back one version and returns it, or `None` at the start of history.
+    /// Applies `command` to the current version **in place**, without adding an
+    /// undo step (for live drags / in-place refinement of the current version).
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`EditError`] from [`apply`](crate::apply); nothing changes then.
+    pub fn amend(&mut self, command: &Command) -> Result<&Timeline, EditError> {
+        let next = self.edit_current(command)?;
+        self.replace_current(next);
+        Ok(self.current())
+    }
+
+    /// Seats `timeline` as the current version **in place**, without adding an undo
+    /// step. Outside a group this replaces the current version and drops the redo
+    /// tail; inside a group it replaces the gesture's in-progress version. The id
+    /// high-water is raised to cover `timeline` (never rewound).
+    pub fn replace_current(&mut self, timeline: Timeline) {
+        self.next_clip_id = self.next_clip_id.max(timeline.next_clip_id);
+        self.next_track_id = self.next_track_id.max(timeline.next_track_id);
+        if let Some(g) = &mut self.group {
+            g.working = timeline;
+            g.dirty = true;
+        } else {
+            self.history.truncate(self.cursor + 1);
+            self.history[self.cursor] = timeline;
+        }
+    }
+
+    /// Begins coalescing subsequent edits into a single undo step.
+    ///
+    /// Until [`commit_group`](Self::commit_group) or [`cancel_group`](Self::cancel_group),
+    /// [`apply`](Self::apply) folds into the gesture's in-progress version instead
+    /// of pushing steps, and [`undo`](Self::undo) / [`redo`](Self::redo) are
+    /// disabled. Groups do not nest: calling this while a group is active is a
+    /// no-op.
+    pub fn begin_group(&mut self) {
+        if self.group.is_none() {
+            self.group = Some(Group {
+                // Equivalent to `history[cursor]` under this guard, but reads as
+                // "seed from the current version" and cannot be confused with the
+                // in-group case.
+                working: self.current().clone(),
+                dirty: false,
+            });
+        }
+    }
+
+    /// Ends the current group, pushing its accumulated edits as **one** undo step.
+    /// A group with no edits produces no step. A no-op if no group is active.
+    pub fn commit_group(&mut self) {
+        if let Some(g) = self.group.take()
+            && g.dirty
+        {
+            self.history.truncate(self.cursor + 1);
+            self.history.push(g.working);
+            self.cursor += 1;
+        }
+    }
+
+    /// Discards the current group and its in-progress edits, leaving the history
+    /// unchanged. A no-op if no group is active.
+    pub fn cancel_group(&mut self) {
+        self.group = None;
+    }
+
+    /// Moves back one version and returns it, or `None` at the start of history or
+    /// while a group is active (commit or cancel the group first).
     pub fn undo(&mut self) -> Option<&Timeline> {
-        if self.cursor == 0 {
+        if self.group.is_some() || self.cursor == 0 {
             return None;
         }
         self.cursor -= 1;
         Some(&self.history[self.cursor])
     }
 
-    /// Moves forward one version and returns it, or `None` at the end of history.
+    /// Moves forward one version and returns it, or `None` at the end of history or
+    /// while a group is active.
     pub fn redo(&mut self) -> Option<&Timeline> {
-        if self.cursor + 1 >= self.history.len() {
+        if self.group.is_some() || self.cursor + 1 >= self.history.len() {
             return None;
         }
         self.cursor += 1;
         Some(&self.history[self.cursor])
     }
 
-    /// Whether [`undo`](Self::undo) would move to an earlier version.
+    /// Whether [`undo`](Self::undo) would move to an earlier version (never while a
+    /// group is active).
     #[must_use]
     pub fn can_undo(&self) -> bool {
-        self.cursor > 0
+        self.group.is_none() && self.cursor > 0
     }
 
-    /// Whether [`redo`](Self::redo) would move to a later version.
+    /// Whether [`redo`](Self::redo) would move to a later version (never while a
+    /// group is active).
     #[must_use]
     pub fn can_redo(&self) -> bool {
-        self.cursor + 1 < self.history.len()
+        self.group.is_none() && self.cursor + 1 < self.history.len()
     }
 }
 
@@ -255,5 +357,162 @@ mod tests {
             first, second,
             "an id used by a discarded branch must not be reused"
         );
+    }
+
+    #[test]
+    fn editor_apply_batch_should_be_one_undo_step() {
+        let mut ed = Editor::new(timeline(30.0));
+        let track = ed.current().video_tracks()[0].id;
+        ed.apply(&Command::Batch(vec![
+            Command::AddClip {
+                track,
+                clip: Box::new(Clip::new("a.mp4")),
+            },
+            Command::AddClip {
+                track,
+                clip: Box::new(Clip::new("b.mp4")),
+            },
+        ]))
+        .unwrap();
+        assert_eq!(ed.current().video_tracks()[0].clips.len(), 3);
+        // One undo removes the whole batch.
+        let prev = ed.undo().unwrap();
+        assert_eq!(prev.video_tracks()[0].clips.len(), 1);
+    }
+
+    #[test]
+    fn editor_group_should_coalesce_to_one_undo_step() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.begin_group();
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.apply(&set_fps(48.0)).unwrap();
+        assert!(
+            (ed.current().frame_rate() - 48.0).abs() < f64::EPSILON,
+            "the working version reflects grouped edits live"
+        );
+        ed.commit_group();
+        assert!((ed.current().frame_rate() - 48.0).abs() < f64::EPSILON);
+        // One undo step: undo restores the pre-gesture version (30), not 24.
+        let prev = ed.undo().unwrap();
+        assert!((prev.frame_rate() - 30.0).abs() < f64::EPSILON);
+        assert!(!ed.can_undo());
+    }
+
+    #[test]
+    fn editor_empty_group_should_add_no_step() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.begin_group();
+        ed.commit_group(); // no edits in the group
+        assert!(!ed.can_redo());
+        // Only the single real edit remains: one undo returns to 30.
+        let prev = ed.undo().unwrap();
+        assert!((prev.frame_rate() - 30.0).abs() < f64::EPSILON);
+        assert!(!ed.can_undo());
+    }
+
+    #[test]
+    fn editor_cancel_group_should_discard_edits() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.begin_group();
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.cancel_group();
+        assert!(
+            (ed.current().frame_rate() - 30.0).abs() < f64::EPSILON,
+            "cancel reverts to the pre-group version"
+        );
+        assert!(!ed.can_undo(), "cancel added no step");
+    }
+
+    #[test]
+    fn editor_undo_redo_should_be_disabled_during_a_group() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.begin_group();
+        ed.apply(&set_fps(48.0)).unwrap();
+        assert!(!ed.can_undo());
+        assert!(ed.undo().is_none());
+        assert!(ed.redo().is_none());
+        ed.commit_group();
+        // After commit, undo works again and restores the pre-gesture version.
+        assert!(ed.can_undo());
+        let prev = ed.undo().unwrap();
+        assert!((prev.frame_rate() - 24.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn editor_amend_should_update_current_without_growing_history() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap(); // step 1
+        ed.amend(&set_fps(48.0)).unwrap(); // in place: no new step
+        assert!((ed.current().frame_rate() - 48.0).abs() < f64::EPSILON);
+        assert!(ed.can_undo());
+        assert!(!ed.can_redo());
+        // One undo goes past the amended value to the pre-step-1 version (30).
+        let prev = ed.undo().unwrap();
+        assert!((prev.frame_rate() - 30.0).abs() < f64::EPSILON);
+        assert!(!ed.can_undo());
+    }
+
+    #[test]
+    fn editor_replace_current_should_seat_value_and_drop_redo() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.apply(&set_fps(48.0)).unwrap();
+        ed.undo().unwrap(); // back to 24, redo tail = [48]
+        assert!(ed.can_redo());
+        ed.replace_current(timeline(60.0));
+        assert!((ed.current().frame_rate() - 60.0).abs() < f64::EPSILON);
+        assert!(!ed.can_redo(), "seating a value drops the redo tail");
+    }
+
+    #[test]
+    fn editor_group_should_keep_ids_monotonic() {
+        let mut ed = Editor::new(timeline(30.0));
+        let track = ed.current().video_tracks()[0].id;
+        ed.begin_group();
+        ed.apply(&Command::AddClip {
+            track,
+            clip: Box::new(Clip::new("a.mp4")),
+        })
+        .unwrap();
+        ed.apply(&Command::AddClip {
+            track,
+            clip: Box::new(Clip::new("b.mp4")),
+        })
+        .unwrap();
+        ed.commit_group();
+        let clips = &ed.current().video_tracks()[0].clips;
+        assert_eq!(clips.len(), 3);
+        assert_ne!(clips[1].id, clips[2].id);
+    }
+
+    #[test]
+    fn editor_amend_during_group_should_fold_into_the_gesture() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.begin_group();
+        ed.apply(&set_fps(24.0)).unwrap();
+        ed.amend(&set_fps(48.0)).unwrap(); // folds into the working version, not a step
+        assert!((ed.current().frame_rate() - 48.0).abs() < f64::EPSILON);
+        ed.commit_group();
+        // Still one undo step: undo restores the pre-gesture version.
+        let prev = ed.undo().unwrap();
+        assert!((prev.frame_rate() - 30.0).abs() < f64::EPSILON);
+        assert!(!ed.can_undo());
+    }
+
+    #[test]
+    fn editor_nested_begin_group_should_not_restart_the_gesture() {
+        let mut ed = Editor::new(timeline(30.0));
+        ed.begin_group();
+        ed.apply(&set_fps(24.0)).unwrap(); // working now at 24
+        ed.begin_group(); // no-op: must not reseed working from history (still 30)
+        assert!(
+            (ed.current().frame_rate() - 24.0).abs() < f64::EPSILON,
+            "a second begin_group must not discard in-progress edits"
+        );
+        ed.commit_group();
+        let prev = ed.undo().unwrap();
+        assert!((prev.frame_rate() - 30.0).abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
## Objective

- `avio::Editor` could not be adopted by a real editor host: every edit pushed exactly one undo step (a drag gesture floods the history), there was no in-place amend, and no atomic multi-command edit (#1414 B6 + B3).

## Solution

- Add `Command::Batch(Vec<Command>)`, applied atomically: `apply` folds it over its sub-commands, so any failure leaves the timeline unchanged, and through `Editor` it is one undo step. Empty batches are no-ops; batches nest.
- `Editor` gains `amend` / `replace_current` (update the current version in place, without a new undo step) and `begin_group` / `commit_group` / `cancel_group` (coalesce a gesture's edits into one undo step); `undo`/`redo` are disabled while a group is active.
- The id high-water is seated before each edit, so grouped and amended edits keep ADR-0001's never-reused guarantee across undo.
- The "seat an external Timeline" requirement is met by the existing `Editor::new(Timeline)`, so no redundant `from_timeline` constructor is added.

Closes #1417