### PR TITLE
feat(avio): per-clip scale and rotation as first-class animatable fields

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -143,6 +143,25 @@ pub struct Clip {
     pub x_track: Option<AnimationTrack<f64>>,
     /// See [`x_track`](Self::x_track).
     pub y_track: Option<AnimationTrack<f64>>,
+    /// Uniform scale factor applied to this clip's layer (`1.0` = original size).
+    ///
+    /// Drives both the horizontal and vertical scale of the clip's
+    /// [`VideoLayer`](ff_filter::VideoLayer). Default `1.0`. Superseded by
+    /// [`scale_track`](Self::scale_track) when a track is set.
+    pub scale: f64,
+    /// Optional keyframe track animating this clip's [`scale`](Self::scale) over time
+    /// (timeline-global time). Drives both scale axes; takes precedence over the
+    /// static [`scale`](Self::scale). Default `None`.
+    pub scale_track: Option<AnimationTrack<f64>>,
+    /// Rotation of this clip's layer in **degrees**, clockwise (`0.0` = none).
+    ///
+    /// Default `0.0`. Superseded by [`rotation_track`](Self::rotation_track) when a
+    /// track is set.
+    pub rotation: f64,
+    /// Optional keyframe track animating this clip's [`rotation`](Self::rotation)
+    /// (degrees) over time (timeline-global time). Takes precedence over the static
+    /// [`rotation`](Self::rotation). Default `None`.
+    pub rotation_track: Option<AnimationTrack<f64>>,
     /// Blend mode for compositing this clip over the layer(s) below it.
     /// Default: [`BlendMode::Normal`] (standard alpha-over composite).
     ///
@@ -234,6 +253,10 @@ impl Clip {
             y: 0.0,
             x_track: None,
             y_track: None,
+            scale: 1.0,
+            scale_track: None,
+            rotation: 0.0,
+            rotation_track: None,
             blend_mode: BlendMode::Normal,
             composite_op: CompositeOp::Over,
             speed: 1.0,
@@ -690,6 +713,58 @@ impl Clip {
         }
     }
 
+    /// Sets the uniform [`scale`](Self::scale) factor (`1.0` = original size).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use avio::Clip;
+    ///
+    /// let clip = Clip::new("pip.mp4").with_scale(0.5);
+    /// assert_eq!(clip.scale, 0.5);
+    /// ```
+    #[must_use]
+    pub fn with_scale(self, scale: f64) -> Self {
+        Self { scale, ..self }
+    }
+
+    /// Animates this clip's [`scale`](Self::scale) with a keyframe track
+    /// (timeline-global time). Drives both scale axes; takes precedence over the
+    /// static [`with_scale`](Self::with_scale) value.
+    #[must_use]
+    pub fn with_scale_track(self, track: AnimationTrack<f64>) -> Self {
+        Self {
+            scale_track: Some(track),
+            ..self
+        }
+    }
+
+    /// Sets the static [`rotation`](Self::rotation) in degrees (clockwise).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use avio::Clip;
+    ///
+    /// let clip = Clip::new("pip.mp4").with_rotation(45.0);
+    /// assert_eq!(clip.rotation, 45.0);
+    /// ```
+    #[must_use]
+    pub fn with_rotation(self, rotation: f64) -> Self {
+        Self { rotation, ..self }
+    }
+
+    /// Animates this clip's [`rotation`](Self::rotation) (degrees) with a keyframe
+    /// track (timeline-global time). Takes precedence over the static
+    /// [`with_rotation`](Self::with_rotation) value.
+    #[must_use]
+    pub fn with_rotation_track(self, track: AnimationTrack<f64>) -> Self {
+        Self {
+            rotation_track: Some(track),
+            ..self
+        }
+    }
+
     /// Sets the blend mode for compositing this clip over the layer below and returns
     /// the updated clip.
     ///
@@ -1028,6 +1103,57 @@ mod tests {
         let stored = clip.x_track.expect("x track stored");
         // Midpoint of a 0→640 linear sweep is 320.
         assert!((stored.value_at(Duration::from_secs(1)) - 320.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clip_new_should_default_scale_and_rotation() {
+        let clip = Clip::new("video.mp4");
+        assert!((clip.scale - 1.0).abs() < f64::EPSILON);
+        assert!((clip.rotation - 0.0).abs() < f64::EPSILON);
+        assert!(clip.scale_track.is_none() && clip.rotation_track.is_none());
+    }
+
+    #[test]
+    fn clip_with_scale_should_set_scale() {
+        let clip = Clip::new("pip.mp4").with_scale(0.5);
+        assert!((clip.scale - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn clip_with_rotation_should_set_rotation() {
+        let clip = Clip::new("pip.mp4").with_rotation(45.0);
+        assert!((clip.rotation - 45.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn clip_with_scale_track_should_store_track() {
+        use ff_filter::{AnimationTrack, Easing};
+        let track = AnimationTrack::fade(
+            1.0,
+            2.0,
+            Duration::ZERO,
+            Duration::from_secs(2),
+            Easing::Linear,
+        );
+        let clip = Clip::new("pip.mp4").with_scale_track(track);
+        let stored = clip.scale_track.expect("scale track stored");
+        // Midpoint of a 1→2 linear ramp is 1.5.
+        assert!((stored.value_at(Duration::from_secs(1)) - 1.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clip_with_rotation_track_should_store_track() {
+        use ff_filter::{AnimationTrack, Easing};
+        let track = AnimationTrack::fade(
+            0.0,
+            90.0,
+            Duration::ZERO,
+            Duration::from_secs(2),
+            Easing::Linear,
+        );
+        let clip = Clip::new("pip.mp4").with_rotation_track(track);
+        let stored = clip.rotation_track.expect("rotation track stored");
+        assert!((stored.value_at(Duration::from_secs(1)) - 45.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -88,13 +88,40 @@ fn video_transform(
     } else {
         track_animation(animations, "video", track_idx, "y", 0.0)
     };
+    // The uniform per-clip `scale` drives both axes; a per-clip track wins, then a
+    // static non-neutral value, then the per-axis timeline animation (kept
+    // independent for `scale_x` vs `scale_y` in the fallback).
+    #[allow(clippy::float_cmp)]
+    let scale_x = if let Some(track) = &clip.scale_track {
+        AnimatedValue::Track(track.clone())
+    } else if clip.scale != 1.0 {
+        AnimatedValue::Static(clip.scale)
+    } else {
+        track_animation(animations, "video", track_idx, "scale_x", 1.0)
+    };
+    #[allow(clippy::float_cmp)]
+    let scale_y = if let Some(track) = &clip.scale_track {
+        AnimatedValue::Track(track.clone())
+    } else if clip.scale != 1.0 {
+        AnimatedValue::Static(clip.scale)
+    } else {
+        track_animation(animations, "video", track_idx, "scale_y", 1.0)
+    };
+    #[allow(clippy::float_cmp)]
+    let rotation = if let Some(track) = &clip.rotation_track {
+        AnimatedValue::Track(track.clone())
+    } else if clip.rotation != 0.0 {
+        AnimatedValue::Static(clip.rotation)
+    } else {
+        track_animation(animations, "video", track_idx, "rotation", 0.0)
+    };
     VideoTransform {
         opacity,
         x,
         y,
-        scale_x: track_animation(animations, "video", track_idx, "scale_x", 1.0),
-        scale_y: track_animation(animations, "video", track_idx, "scale_y", 1.0),
-        rotation: track_animation(animations, "video", track_idx, "rotation", 0.0),
+        scale_x,
+        scale_y,
+        rotation,
         blend_mode: clip.blend_mode,
         composite_op: clip.composite_op,
     }
@@ -595,5 +622,81 @@ mod tests {
         clip.composite_op = CompositeOp::Under;
         let d = realtime_descriptor(&clip, 0, &no_anim());
         assert!(matches!(d.composite_op, CompositeOp::Under));
+    }
+
+    // ── per-clip scale / rotation (3-way merge) ───────────────────────────────
+
+    #[test]
+    fn video_layer_static_scale_should_drive_both_axes() {
+        let clip = Clip::new("a.mp4").with_scale(0.5);
+        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
+        assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
+    }
+
+    #[test]
+    fn video_layer_scale_track_should_win_on_both_axes() {
+        let mut clip = Clip::new("a.mp4");
+        clip.scale_track =
+            Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 2.0, Easing::Linear)));
+        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        assert!(matches!(layer.scale_x, AnimatedValue::Track(_)));
+        assert!(matches!(layer.scale_y, AnimatedValue::Track(_)));
+    }
+
+    #[test]
+    fn video_layer_neutral_scale_should_fall_back_to_timeline_animation() {
+        let mut anims = HashMap::new();
+        anims.insert(
+            "video_0_scale_x".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+        );
+        let clip = Clip::new("a.mp4"); // scale defaults to 1.0 (neutral)
+        let layer = video_layer(&clip, 0, &anims, None, None);
+        assert!(matches!(layer.scale_x, AnimatedValue::Track(_)));
+        // scale_y has no timeline animation -> the default static 1.0.
+        assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+    }
+
+    #[test]
+    fn video_layer_static_scale_should_win_over_timeline_animation() {
+        let mut anims = HashMap::new();
+        anims.insert(
+            "video_0_scale_x".to_string(),
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.25, Easing::Linear)),
+        );
+        // A per-clip static non-neutral scale wins the 3-way merge over the
+        // timeline `scale_x` animation.
+        let clip = Clip::new("a.mp4").with_scale(0.5);
+        let layer = video_layer(&clip, 0, &anims, None, None);
+        assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
+        assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
+    }
+
+    #[test]
+    fn video_layer_static_rotation_should_be_static() {
+        let clip = Clip::new("a.mp4").with_rotation(30.0);
+        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        assert!(matches!(layer.rotation, AnimatedValue::Static(v) if (v - 30.0).abs() < 1e-9));
+    }
+
+    #[test]
+    fn video_layer_rotation_track_should_win() {
+        let mut clip = Clip::new("a.mp4");
+        clip.rotation_track =
+            Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 90.0, Easing::Linear)));
+        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        assert!(matches!(layer.rotation, AnimatedValue::Track(_)));
+    }
+
+    #[test]
+    fn realtime_descriptor_should_share_scale_and_rotation_with_export() {
+        // Preview uses the same `video_transform`, so per-clip scale/rotation reach
+        // preview identically to export.
+        let clip = Clip::new("a.mp4").with_scale(0.5).with_rotation(45.0);
+        let d = realtime_descriptor(&clip, 0, &no_anim());
+        assert!(matches!(d.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
+        assert!(matches!(d.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
+        assert!(matches!(d.rotation, AnimatedValue::Static(v) if (v - 45.0).abs() < 1e-9));
     }
 }


### PR DESCRIPTION
## Objective

- `Clip` had per-clip opacity, position, and volume (with keyframe tracks) but no per-clip scale/rotation; those existed only as `FilterStep`s or per-track timeline animations, so a host could not scale/rotate a single clip declaratively (#1414 A3).

## Solution

- `Clip` gains `scale` / `scale_track` and `rotation` / `rotation_track` (with `with_scale` / `with_scale_track` / `with_rotation` / `with_rotation_track`), mirroring `opacity` / `opacity_track`. `scale` is uniform and drives both axes; `rotation` is in degrees.
- `derive.rs::video_transform` composes them with the same 3-way merge as opacity/x/y (per-clip keyframe track wins, then a static non-neutral value, then the existing per-track timeline animation). Export and preview share this single derivation, and the existing timeline scale/rotation fallback is preserved.

Scope: this is model/derive parity. The compositor still evaluates scale/rotation at `t=0` (static) in both export and preview, so a keyframe track does not yet animate them per-frame — per-frame compositor animation of scale/rotation is separate ff-filter work.

Closes #1421