### PR TITLE
feat(avio): per-clip fit/fill framing mode against the canvas

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -17,6 +17,34 @@ use ff_format::{PixelFormat, VideoFrame};
 use crate::error::TimelineError;
 use crate::ids::ClipId;
 
+/// How a clip's source frame is framed against the project canvas.
+///
+/// The derive maps the mode to canvas-relative framing filters (crop / scale /
+/// pad) using only the canvas dimensions — the source size is resolved at render
+/// time by `FFmpeg` expressions, so the model stays pure.
+///
+/// # Interaction with per-clip transforms
+///
+/// A non-[`None`](Self::None) `fit` is the clip's sizing control against the
+/// canvas. The compositor applies the per-clip [`scale`](Clip::scale) /
+/// [`x`](Clip::x) / [`y`](Clip::y) transforms *before* the framing step, so
+/// combining a non-default `scale` with a non-`None` `fit` double-transforms —
+/// leave `scale` at `1.0` when `fit` is set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FitMode {
+    /// Scale to *cover* the canvas (preserving aspect), cropping the overflow.
+    Fill,
+    /// Scale to *contain* within the canvas (preserving aspect), letterboxing or
+    /// pillarboxing the remainder with black bars.
+    Fit,
+    /// Stretch to exactly fill the canvas, ignoring the source aspect ratio.
+    Stretch,
+    /// Leave the source at its native size (no framing step); the existing
+    /// per-clip transforms and position apply unchanged. The default.
+    #[default]
+    None,
+}
+
 /// A single media clip on a timeline.
 ///
 /// `Clip` is a plain Rust value type — it holds no `FFmpeg` context. All fields
@@ -162,6 +190,9 @@ pub struct Clip {
     /// (degrees) over time (timeline-global time). Takes precedence over the static
     /// [`rotation`](Self::rotation). Default `None`.
     pub rotation_track: Option<AnimationTrack<f64>>,
+    /// How this clip's source frame is framed against the project canvas.
+    /// Default: [`FitMode::None`] (native size, existing transforms apply).
+    pub fit: FitMode,
     /// Blend mode for compositing this clip over the layer(s) below it.
     /// Default: [`BlendMode::Normal`] (standard alpha-over composite).
     ///
@@ -257,6 +288,7 @@ impl Clip {
             scale_track: None,
             rotation: 0.0,
             rotation_track: None,
+            fit: FitMode::None,
             blend_mode: BlendMode::Normal,
             composite_op: CompositeOp::Over,
             speed: 1.0,
@@ -413,7 +445,10 @@ impl Clip {
         // timeline-level animations (track index 0, empty map) — so a per-clip
         // keyframe or static value still applies, and the shape matches the export
         // `VideoLayer`.
-        crate::derive::realtime_descriptor(self, 0, &std::collections::HashMap::new())
+        // No timeline canvas here, so `fit` is not applied (the derive skips the
+        // framing step for a zero canvas); a canvas-aware descriptor comes from
+        // `Timeline::to_scene`.
+        crate::derive::realtime_descriptor(self, 0, &std::collections::HashMap::new(), 0, 0)
     }
 
     /// Attaches an audio [`FilterStep`] to this clip and returns the updated clip.
@@ -763,6 +798,13 @@ impl Clip {
             rotation_track: Some(track),
             ..self
         }
+    }
+
+    /// Sets how this clip's source frame is framed against the project canvas
+    /// (cover, contain, stretch, or native) and returns the updated clip.
+    #[must_use]
+    pub fn with_fit(self, fit: FitMode) -> Self {
+        Self { fit, ..self }
     }
 
     /// Sets the blend mode for compositing this clip over the layer below and returns
@@ -1154,6 +1196,18 @@ mod tests {
         let clip = Clip::new("pip.mp4").with_rotation_track(track);
         let stored = clip.rotation_track.expect("rotation track stored");
         assert!((stored.value_at(Duration::from_secs(1)) - 45.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clip_new_should_default_fit_none() {
+        let clip = Clip::new("a.mp4");
+        assert_eq!(clip.fit, FitMode::None);
+    }
+
+    #[test]
+    fn clip_with_fit_should_set_fit() {
+        let clip = Clip::new("a.mp4").with_fit(FitMode::Fill);
+        assert_eq!(clip.fit, FitMode::Fill);
     }
 
     #[test]

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -19,11 +19,11 @@ use std::time::Duration;
 
 use ff_filter::{
     AnimatedValue, AnimationTrack, AudioTrack, BlendMode, CompositeOp, FilterStep, ProxySource,
-    RealtimeLayerDescriptor, VideoLayer,
+    RealtimeLayerDescriptor, ScaleAlgorithm, VideoLayer,
 };
 use ff_format::ChannelLayout;
 
-use crate::clip::Clip;
+use crate::clip::{Clip, FitMode};
 
 /// Resolves a track-level animation: `AnimatedValue::Track` when the map holds a
 /// track for `"{prefix}_{track_idx}_{prop}"`, else `Static(default)`.
@@ -127,15 +127,46 @@ fn video_transform(
     }
 }
 
+/// Maps a clip's [`FitMode`] to the canvas-relative framing [`FilterStep`], or
+/// `None` for [`FitMode::None`] (native size, no framing). Shared by the export
+/// [`video_layer`] and preview [`realtime_descriptor`] paths so both frame a clip
+/// against the canvas identically. `cw`/`ch` are the project canvas dimensions.
+fn fit_step(clip: &Clip, cw: u32, ch: u32) -> Option<FilterStep> {
+    if cw == 0 || ch == 0 {
+        return None; // no canvas to frame against
+    }
+    match clip.fit {
+        FitMode::None => None,
+        FitMode::Stretch => Some(FilterStep::Scale {
+            width: cw,
+            height: ch,
+            algorithm: ScaleAlgorithm::Bilinear,
+        }),
+        FitMode::Fit => Some(FilterStep::FitToAspect {
+            width: cw,
+            height: ch,
+            color: "black".to_string(),
+        }),
+        FitMode::Fill => Some(FilterStep::FillToAspect {
+            width: cw,
+            height: ch,
+        }),
+    }
+}
+
 /// Derives the export [`VideoLayer`] for one clip.
 ///
-/// `prev_end` is the preceding clip's end-seconds on this track (for the
-/// cross-fade offset); `None` marks the track's first clip — a transition on it
-/// is ignored with a warning. `proxy` is the caller-probed proxy source.
+/// `canvas_width`/`canvas_height` are the project canvas dimensions (for the
+/// [`fit`](Clip::fit) framing step). `prev_end` is the preceding clip's
+/// end-seconds on this track (for the cross-fade offset); `None` marks the
+/// track's first clip — a transition on it is ignored with a warning. `proxy` is
+/// the caller-probed proxy source.
 pub(crate) fn video_layer(
     clip: &Clip,
     track_idx: usize,
     animations: &HashMap<String, AnimationTrack<f64>>,
+    canvas_width: u32,
+    canvas_height: u32,
     prev_end: Option<f64>,
     proxy: Option<ProxySource>,
 ) -> VideoLayer {
@@ -157,6 +188,11 @@ pub(crate) fn video_layer(
     }
     if (clip.speed - 1.0).abs() > 1e-9 {
         layer_effects.push(FilterStep::Speed { factor: clip.speed });
+    }
+    // Frame the source to the project canvas (cover/contain/stretch) before the
+    // colour/effect chain; `FitMode::None` emits nothing (native size).
+    if let Some(step) = fit_step(clip, canvas_width, canvas_height) {
+        layer_effects.push(step);
     }
     // Colour-correction (eq) + caller-attached per-clip video effects, shared
     // with the preview path via `Clip::video_effect_chain`.
@@ -202,9 +238,11 @@ pub(crate) fn video_layer(
 /// Derives the preview [`RealtimeLayerDescriptor`] for one clip.
 ///
 /// Uses the same [`VideoTransform`] as [`video_layer`] (so both paths share one
-/// interpretation), but carries only the per-clip effect chain: the temporal
-/// steps (trim/offset/speed) and the cross-fade are omitted because the preview
-/// runner realises them from `ScenePlacement` (in/out points, speed, transition).
+/// interpretation) and the same canvas [`fit`](Clip::fit) framing step
+/// (`canvas_width`/`canvas_height`), but otherwise carries only the per-clip
+/// effect chain: the temporal steps (trim/offset/speed) and the cross-fade are
+/// omitted because the preview runner realises them from `ScenePlacement` (in/out
+/// points, speed, transition).
 ///
 /// The timeline-level `lavfi_overlay` and a clip's `input_format` are not projected
 /// here (preview drops them today); closing that is C4d, not this backbone.
@@ -212,10 +250,19 @@ pub(crate) fn realtime_descriptor(
     clip: &Clip,
     track_idx: usize,
     animations: &HashMap<String, AnimationTrack<f64>>,
+    canvas_width: u32,
+    canvas_height: u32,
 ) -> RealtimeLayerDescriptor {
     let transform = video_transform(clip, track_idx, animations);
+    // Frame to the canvas (same step as the export path) before the colour chain,
+    // so preview and export share one framing interpretation.
+    let mut effects = Vec::new();
+    if let Some(step) = fit_step(clip, canvas_width, canvas_height) {
+        effects.push(step);
+    }
+    effects.extend(clip.video_effect_chain());
     RealtimeLayerDescriptor {
-        effects: clip.video_effect_chain(),
+        effects,
         opacity: transform.opacity,
         x: transform.x,
         y: transform.y,
@@ -336,7 +383,7 @@ mod tests {
     #[test]
     fn video_layer_trim_should_lead_with_trim_and_resetpts() {
         let clip = Clip::new("a.mp4").trim(Duration::from_secs(1), Duration::from_secs(3));
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(
             layer.effects[0],
             FilterStep::Trim {
@@ -350,7 +397,7 @@ mod tests {
     #[test]
     fn video_layer_offset_should_emit_offsetpts() {
         let clip = Clip::new("a.mp4").offset(Duration::from_secs(2));
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(layer.effects.iter().any(
             |s| matches!(s, FilterStep::OffsetPts { seconds } if (seconds - 2.0).abs() < 1e-9)
         ));
@@ -359,7 +406,7 @@ mod tests {
     #[test]
     fn video_layer_speed_should_emit_speed() {
         let clip = Clip::new("a.mp4").with_speed(2.0);
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(
             layer
                 .effects
@@ -372,7 +419,7 @@ mod tests {
     fn video_layer_transition_with_prev_end_should_emit_xfade() {
         let clip =
             Clip::new("b.mp4").with_transition(XfadeTransition::Fade, Duration::from_millis(500));
-        let layer = video_layer(&clip, 0, &no_anim(), Some(4.0), None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, Some(4.0), None);
         // offset = (prev_end 4.0 - dur 0.5).max(0) = 3.5
         assert!(layer.effects.iter().any(|s| matches!(
             s,
@@ -385,7 +432,7 @@ mod tests {
     fn video_layer_transition_on_first_clip_should_emit_no_xfade() {
         let clip =
             Clip::new("a.mp4").with_transition(XfadeTransition::Fade, Duration::from_millis(500));
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(
             !layer
                 .effects
@@ -399,14 +446,14 @@ mod tests {
         let mut clip = Clip::new("a.mp4").with_opacity(0.5);
         clip.opacity_track =
             Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear)));
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(layer.opacity, AnimatedValue::Track(_)));
     }
 
     #[test]
     fn video_layer_static_opacity_should_be_animatedvalue_static() {
         let clip = Clip::new("a.mp4").with_opacity(0.5);
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(layer.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
 
@@ -418,7 +465,7 @@ mod tests {
             AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 1.0, Easing::Linear)),
         );
         let clip = Clip::new("a.mp4"); // opacity defaults to 1.0 (neutral)
-        let layer = video_layer(&clip, 0, &anims, None, None);
+        let layer = video_layer(&clip, 0, &anims, 1920, 1080, None, None);
         assert!(matches!(layer.opacity, AnimatedValue::Track(_)));
     }
 
@@ -428,7 +475,7 @@ mod tests {
         let mut clip = Clip::new("a.mp4");
         clip.blend_mode = BlendMode::Multiply;
         clip.composite_op = CompositeOp::Under;
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(layer.blend_mode, BlendMode::Multiply));
         assert!(matches!(layer.composite_op, CompositeOp::Under));
     }
@@ -441,7 +488,7 @@ mod tests {
             .with_speed(2.0)
             .with_transition(XfadeTransition::Fade, Duration::from_millis(500));
         clip.brightness = 0.5; // makes `video_effect_chain` emit a trailing Eq step
-        let layer = video_layer(&clip, 0, &no_anim(), Some(10.0), None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, Some(10.0), None);
         let e = &layer.effects;
         assert!(matches!(e[0], FilterStep::Trim { .. }));
         assert!(matches!(e[1], FilterStep::ResetPts));
@@ -449,6 +496,106 @@ mod tests {
         assert!(matches!(e[3], FilterStep::Speed { .. }));
         assert!(matches!(e[4], FilterStep::Eq { .. }));
         assert!(matches!(e[5], FilterStep::XFade { .. }));
+    }
+
+    // ── fit / fill framing (#1422) ──────────────────────────────────────────
+
+    #[test]
+    fn video_layer_fit_none_should_emit_no_framing_step() {
+        let clip = Clip::new("a.mp4"); // fit defaults to None
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        assert!(!layer.effects.iter().any(|s| matches!(
+            s,
+            FilterStep::FillToAspect { .. }
+                | FilterStep::FitToAspect { .. }
+                | FilterStep::Scale { .. }
+        )));
+    }
+
+    #[test]
+    fn video_layer_fit_fill_should_emit_fill_to_aspect() {
+        let clip = Clip::new("a.mp4").with_fit(FitMode::Fill);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        assert!(layer.effects.iter().any(|s| matches!(
+            s,
+            FilterStep::FillToAspect {
+                width: 1920,
+                height: 1080
+            }
+        )));
+    }
+
+    #[test]
+    fn video_layer_fit_fit_should_emit_fit_to_aspect_black() {
+        let clip = Clip::new("a.mp4").with_fit(FitMode::Fit);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        assert!(layer.effects.iter().any(|s| matches!(
+            s,
+            FilterStep::FitToAspect { width: 1920, height: 1080, color } if color == "black"
+        )));
+    }
+
+    #[test]
+    fn video_layer_fit_stretch_should_emit_scale_to_canvas() {
+        let clip = Clip::new("a.mp4").with_fit(FitMode::Stretch);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        assert!(layer.effects.iter().any(|s| matches!(
+            s,
+            FilterStep::Scale {
+                width: 1920,
+                height: 1080,
+                algorithm: ScaleAlgorithm::Bilinear
+            }
+        )));
+    }
+
+    #[test]
+    fn video_layer_fit_should_sit_after_speed_and_before_effect_chain() {
+        let mut clip = Clip::new("a.mp4").with_speed(2.0).with_fit(FitMode::Fill);
+        clip.brightness = 0.5; // trailing Eq via `video_effect_chain`
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        let e = &layer.effects;
+        assert!(matches!(e[0], FilterStep::Speed { .. }));
+        assert!(matches!(e[1], FilterStep::FillToAspect { .. }));
+        assert!(matches!(e[2], FilterStep::Eq { .. }));
+    }
+
+    #[test]
+    fn realtime_descriptor_fit_fill_should_share_step_with_export() {
+        // export == preview parity: both emit the same framing step.
+        let clip = Clip::new("a.mp4").with_fit(FitMode::Fill);
+        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        assert!(matches!(
+            d.effects.first(),
+            Some(FilterStep::FillToAspect {
+                width: 1920,
+                height: 1080
+            })
+        ));
+    }
+
+    #[test]
+    fn realtime_descriptor_fit_none_should_emit_no_framing_step() {
+        let clip = Clip::new("a.mp4"); // fit defaults to None
+        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        assert!(!d.effects.iter().any(|s| matches!(
+            s,
+            FilterStep::FillToAspect { .. }
+                | FilterStep::FitToAspect { .. }
+                | FilterStep::Scale { .. }
+        )));
+    }
+
+    #[test]
+    fn fit_step_should_be_skipped_when_canvas_is_zero() {
+        // The canvas-less `Clip::realtime_layer_descriptor` passes 0×0.
+        let clip = Clip::new("a.mp4").with_fit(FitMode::Fill);
+        let d = realtime_descriptor(&clip, 0, &no_anim(), 0, 0);
+        assert!(
+            !d.effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::FillToAspect { .. }))
+        );
     }
 
     // ── audio_track ─────────────────────────────────────────────────────────
@@ -553,7 +700,7 @@ mod tests {
             .offset(Duration::from_secs(2))
             .with_speed(2.0)
             .with_transition(XfadeTransition::Fade, Duration::from_millis(500));
-        let d = realtime_descriptor(&clip, 0, &no_anim());
+        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
         assert!(!d.effects.iter().any(|s| matches!(
             s,
             FilterStep::Trim { .. }
@@ -568,7 +715,7 @@ mod tests {
     fn realtime_descriptor_should_carry_effect_chain() {
         let mut clip = Clip::new("a.mp4");
         clip.brightness = 0.5; // forces an Eq step in `video_effect_chain`
-        let d = realtime_descriptor(&clip, 0, &no_anim());
+        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
         assert!(d.effects.iter().any(|s| matches!(s, FilterStep::Eq { .. })));
     }
 
@@ -584,7 +731,7 @@ mod tests {
             AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 90.0, Easing::Linear)),
         );
         let clip = Clip::new("a.mp4");
-        let d = realtime_descriptor(&clip, 1, &anims);
+        let d = realtime_descriptor(&clip, 1, &anims, 1920, 1080);
         assert!(matches!(d.scale_x, AnimatedValue::Track(_)));
         assert!(matches!(d.rotation, AnimatedValue::Track(_)));
         assert!(matches!(d.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
@@ -599,7 +746,7 @@ mod tests {
             AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 1.0, Easing::Linear)),
         );
         let clip = Clip::new("a.mp4");
-        let d = realtime_descriptor(&clip, 0, &anims);
+        let d = realtime_descriptor(&clip, 0, &anims, 1920, 1080);
         assert!(matches!(d.opacity, AnimatedValue::Track(_)));
     }
 
@@ -612,7 +759,7 @@ mod tests {
             AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.2, Easing::Linear)),
         );
         let clip = Clip::new("a.mp4").with_opacity(0.5);
-        let d = realtime_descriptor(&clip, 0, &anims);
+        let d = realtime_descriptor(&clip, 0, &anims, 1920, 1080);
         assert!(matches!(d.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
 
@@ -620,7 +767,7 @@ mod tests {
     fn realtime_descriptor_should_carry_composite_op() {
         let mut clip = Clip::new("a.mp4");
         clip.composite_op = CompositeOp::Under;
-        let d = realtime_descriptor(&clip, 0, &no_anim());
+        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
         assert!(matches!(d.composite_op, CompositeOp::Under));
     }
 
@@ -629,7 +776,7 @@ mod tests {
     #[test]
     fn video_layer_static_scale_should_drive_both_axes() {
         let clip = Clip::new("a.mp4").with_scale(0.5);
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
         assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
@@ -639,7 +786,7 @@ mod tests {
         let mut clip = Clip::new("a.mp4");
         clip.scale_track =
             Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 2.0, Easing::Linear)));
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(layer.scale_x, AnimatedValue::Track(_)));
         assert!(matches!(layer.scale_y, AnimatedValue::Track(_)));
     }
@@ -652,7 +799,7 @@ mod tests {
             AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
         );
         let clip = Clip::new("a.mp4"); // scale defaults to 1.0 (neutral)
-        let layer = video_layer(&clip, 0, &anims, None, None);
+        let layer = video_layer(&clip, 0, &anims, 1920, 1080, None, None);
         assert!(matches!(layer.scale_x, AnimatedValue::Track(_)));
         // scale_y has no timeline animation -> the default static 1.0.
         assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
@@ -668,7 +815,7 @@ mod tests {
         // A per-clip static non-neutral scale wins the 3-way merge over the
         // timeline `scale_x` animation.
         let clip = Clip::new("a.mp4").with_scale(0.5);
-        let layer = video_layer(&clip, 0, &anims, None, None);
+        let layer = video_layer(&clip, 0, &anims, 1920, 1080, None, None);
         assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
         assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
@@ -676,7 +823,7 @@ mod tests {
     #[test]
     fn video_layer_static_rotation_should_be_static() {
         let clip = Clip::new("a.mp4").with_rotation(30.0);
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(layer.rotation, AnimatedValue::Static(v) if (v - 30.0).abs() < 1e-9));
     }
 
@@ -685,7 +832,7 @@ mod tests {
         let mut clip = Clip::new("a.mp4");
         clip.rotation_track =
             Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 90.0, Easing::Linear)));
-        let layer = video_layer(&clip, 0, &no_anim(), None, None);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
         assert!(matches!(layer.rotation, AnimatedValue::Track(_)));
     }
 
@@ -694,7 +841,7 @@ mod tests {
         // Preview uses the same `video_transform`, so per-clip scale/rotation reach
         // preview identically to export.
         let clip = Clip::new("a.mp4").with_scale(0.5).with_rotation(45.0);
-        let d = realtime_descriptor(&clip, 0, &no_anim());
+        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
         assert!(matches!(d.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
         assert!(matches!(d.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
         assert!(matches!(d.rotation, AnimatedValue::Static(v) if (v - 45.0).abs() < 1e-9));

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -333,7 +333,7 @@ mod timeline;
 mod track;
 
 #[cfg(feature = "pipeline")]
-pub use clip::{Clip, VideoEffectRenderer};
+pub use clip::{Clip, FitMode, VideoEffectRenderer};
 #[cfg(feature = "pipeline")]
 pub use edit::{ClipProperty, Command, EditError, apply};
 #[cfg(feature = "pipeline")]

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -328,6 +328,8 @@ impl Timeline {
                         clip,
                         track_idx,
                         &video_animations,
+                        canvas_width,
+                        canvas_height,
                         prev_end,
                         proxy,
                     ));
@@ -722,6 +724,8 @@ fn video_placement(
     track_idx: usize,
     is_base: bool,
     animations: &HashMap<String, AnimationTrack<f64>>,
+    canvas_width: u32,
+    canvas_height: u32,
 ) -> ff_preview::ScenePlacement {
     let xfade_dur = if is_base && clip.transition.is_some() {
         clip.transition_duration
@@ -743,7 +747,13 @@ fn video_placement(
         // The single derive: preview and export build their video layers from the
         // same `avio::derive`, so the timeline-level animations (scale/rotation and
         // the opacity/x/y track-level fallbacks) reach the preview too.
-        layer: crate::derive::realtime_descriptor(clip, track_idx, animations),
+        layer: crate::derive::realtime_descriptor(
+            clip,
+            track_idx,
+            animations,
+            canvas_width,
+            canvas_height,
+        ),
         fade_in: clip.fade_in,
         fade_out: clip.fade_out,
         // V1 clip audio has no dedicated audio-track counterpart in export (which
@@ -799,7 +809,14 @@ impl Timeline {
                         .clips
                         .iter()
                         .map(|clip| {
-                            video_placement(clip, track_idx, track_idx == 0, &self.video_animations)
+                            video_placement(
+                                clip,
+                                track_idx,
+                                track_idx == 0,
+                                &self.video_animations,
+                                self.canvas_width,
+                                self.canvas_height,
+                            )
                         })
                         .collect()
                 } else {

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -152,6 +152,9 @@ pub(crate) unsafe fn add_and_link_step(
             height,
             color,
         } => return add_fit_to_aspect_step(graph, prev_ctx, *width, *height, color, index),
+        FilterStep::FillToAspect { width, height } => {
+            return add_fill_to_aspect_step(graph, prev_ctx, *width, *height, index);
+        }
         FilterStep::LumaKey {
             threshold,
             tolerance,
@@ -488,6 +491,102 @@ pub(super) unsafe fn add_fit_to_aspect_step(
     }
 
     add_fit_to_aspect_pad(graph, scale_ctx, width, height, color, index)
+}
+
+/// Add a `crop` filter that centre-crops the covered frame to the target
+/// `width × height` canvas, completing the scale-then-crop compound step for
+/// [`FilterStep::FillToAspect`]. `crop` auto-centres when `x`/`y` are omitted
+/// (defaulting to `(in_w-out_w)/2` / `(in_h-out_h)/2`).
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same
+/// `AVFilterGraph`.
+pub(super) unsafe fn add_fill_to_aspect_crop(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    width: u32,
+    height: u32,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let crop_filter = ff_sys::avfilter_get_by_name(c"crop".as_ptr());
+    if crop_filter.is_null() {
+        log::warn!("filter not found name=crop (fill_to_aspect)");
+        return Err(FilterError::BuildFailed);
+    }
+
+    let name =
+        std::ffi::CString::new(format!("fillcrop{index}")).map_err(|_| FilterError::BuildFailed)?;
+    let args_str = format!("w={width}:h={height}");
+    let args = std::ffi::CString::new(args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+
+    let mut ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut ctx,
+        crop_filter,
+        name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=crop args={args_str}");
+        return Err(FilterError::BuildFailed);
+    }
+    log::debug!("filter added name=crop args={args_str} index={index}");
+
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+    Ok(ctx)
+}
+
+/// Build the full [`FilterStep::FillToAspect`] compound: a `scale`
+/// (`force_original_aspect_ratio=increase`, preserving the source aspect so the
+/// frame *covers* the canvas) followed by a centre-[`crop`](add_fill_to_aspect_crop)
+/// onto the `width × height` canvas. The cover counterpart to
+/// [`add_fit_to_aspect_step`].
+///
+/// # Safety
+///
+/// `graph` and `prev_ctx` must be valid pointers owned by the same `AVFilterGraph`.
+pub(super) unsafe fn add_fill_to_aspect_step(
+    graph: *mut ff_sys::AVFilterGraph,
+    prev_ctx: *mut ff_sys::AVFilterContext,
+    width: u32,
+    height: u32,
+    index: usize,
+) -> Result<*mut ff_sys::AVFilterContext, FilterError> {
+    let scale_filter = ff_sys::avfilter_get_by_name(c"scale".as_ptr());
+    if scale_filter.is_null() {
+        log::warn!("filter not found name=scale (fill_to_aspect)");
+        return Err(FilterError::BuildFailed);
+    }
+    let name = std::ffi::CString::new(format!("fillscale{index}"))
+        .map_err(|_| FilterError::BuildFailed)?;
+    let args_str = format!("w={width}:h={height}:force_original_aspect_ratio=increase");
+    let args = std::ffi::CString::new(args_str.as_str()).map_err(|_| FilterError::BuildFailed)?;
+
+    let mut scale_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut scale_ctx,
+        scale_filter,
+        name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        log::warn!("filter creation failed name=scale args={args_str}");
+        return Err(FilterError::BuildFailed);
+    }
+    let ret = ff_sys::avfilter_link(prev_ctx, 0, scale_ctx, 0);
+    if ret < 0 {
+        return Err(FilterError::BuildFailed);
+    }
+
+    add_fill_to_aspect_crop(graph, scale_ctx, width, height, index)
 }
 
 // ── Speed (atempo chain) ──────────────────────────────────────────────────────

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -650,6 +650,13 @@ impl FilterGraphBuilder {
                     reason: "fit_to_aspect width and height must be > 0".to_string(),
                 });
             }
+            if let FilterStep::FillToAspect { width, height } = step
+                && (*width == 0 || *height == 0)
+            {
+                return Err(FilterError::InvalidConfig {
+                    reason: "fill_to_aspect width and height must be > 0".to_string(),
+                });
+            }
             if let FilterStep::GBlur { sigma } = step
                 && *sigma < 0.0
             {

--- a/crates/ff-filter/src/graph/builder/video/geometry.rs
+++ b/crates/ff-filter/src/graph/builder/video/geometry.rs
@@ -271,6 +271,24 @@ impl FilterGraphBuilder {
         });
         self
     }
+
+    /// Scale the source frame to *cover* `width × height` while preserving its
+    /// aspect ratio, then centre-crop the overflow onto a `width × height` canvas
+    /// (no bars). The cover counterpart to [`fit_to_aspect`](Self::fit_to_aspect).
+    ///
+    /// Sources with a different aspect ratio than the target are scaled up until
+    /// both dimensions cover the canvas, then the excess is cropped equally from
+    /// both sides (centred).
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if
+    /// `width` or `height` is zero.
+    #[must_use]
+    pub fn fill_to_aspect(mut self, width: u32, height: u32) -> Self {
+        self.steps.push(FilterStep::FillToAspect { width, height });
+        self
+    }
 }
 
 #[cfg(test)]
@@ -501,6 +519,39 @@ mod tests {
     #[test]
     fn builder_pad_with_zero_height_should_return_invalid_config() {
         let result = FilterGraph::builder().pad(1920, 0, -1, -1, "black").build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for height=0, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_fill_to_aspect_with_valid_params_should_succeed() {
+        let result = FilterGraph::builder().fill_to_aspect(1920, 1080).build();
+        assert!(
+            result.is_ok(),
+            "fill_to_aspect with valid params must build successfully, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_fill_to_aspect_with_zero_width_should_return_invalid_config() {
+        let result = FilterGraph::builder().fill_to_aspect(0, 1080).build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for width=0, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("fill_to_aspect width and height must be > 0"),
+                "reason should mention fill_to_aspect dimensions: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_fill_to_aspect_with_zero_height_should_return_invalid_config() {
+        let result = FilterGraph::builder().fill_to_aspect(1920, 0).build();
         assert!(
             matches!(result, Err(FilterError::InvalidConfig { .. })),
             "expected InvalidConfig for height=0, got {result:?}"

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -216,6 +216,18 @@ pub enum FilterStep {
         /// Fill color for the bars (any `FFmpeg` color string, e.g. `"black"`).
         color: String,
     },
+    /// Scale (preserving aspect ratio) to *cover* the target dimensions, then
+    /// centre-crop the overflow (no bars).
+    ///
+    /// Implemented as a `scale` filter with `force_original_aspect_ratio=increase`
+    /// followed by a `crop` filter that centres the scaled frame on the canvas.
+    /// The counterpart to [`FitToAspect`](Self::FitToAspect) (cover vs contain).
+    FillToAspect {
+        /// Target canvas width in pixels.
+        width: u32,
+        /// Target canvas height in pixels.
+        height: u32,
+    },
     /// Gaussian blur with configurable radius.
     ///
     /// `sigma` is the blur radius. Valid range: 0.0 – 10.0 (values near 0.0 are
@@ -1032,6 +1044,10 @@ impl FilterStep {
             // build time.  The pad filter is inserted by filter_inner at graph
             // construction time.
             Self::FitToAspect { .. } => "scale",
+            // FillToAspect is scale (cover) + crop; "scale" is validated at build
+            // time.  The crop filter is inserted by filter_inner at graph
+            // construction time.
+            Self::FillToAspect { .. } => "scale",
             Self::GBlur { .. } => "gblur",
             Self::Unsharp { .. } => "unsharp",
             Self::Hqdn3d { .. } => "hqdn3d",
@@ -1518,6 +1534,13 @@ impl FilterStep {
                 // target canvas.
                 format!("w={width}:h={height}:force_original_aspect_ratio=decrease")
             }
+            Self::FillToAspect { width, height } => {
+                // Scale to cover the target dimensions, preserving the source
+                // aspect ratio.  The accompanying crop filter (inserted by
+                // filter_inner after this scale filter) centres the result on the
+                // target canvas.
+                format!("w={width}:h={height}:force_original_aspect_ratio=increase")
+            }
             Self::Pad {
                 width,
                 height,
@@ -1904,6 +1927,27 @@ mod tests {
             args: "reds=0.1 0 0".to_string(),
         };
         assert_eq!(step.filter_name(), "selectivecolor");
+    }
+
+    #[test]
+    fn fill_to_aspect_args_should_cover_with_increase() {
+        let step = FilterStep::FillToAspect {
+            width: 1920,
+            height: 1080,
+        };
+        assert_eq!(
+            step.args(),
+            "w=1920:h=1080:force_original_aspect_ratio=increase"
+        );
+    }
+
+    #[test]
+    fn fill_to_aspect_filter_name_should_be_scale() {
+        let step = FilterStep::FillToAspect {
+            width: 1920,
+            height: 1080,
+        };
+        assert_eq!(step.filter_name(), "scale");
     }
 
     #[test]

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1052,6 +1052,52 @@ fn push_4x3_frame_through_fit_to_aspect_16x9_should_return_target_dimensions() {
 }
 
 #[test]
+fn push_4x3_frame_through_fill_to_aspect_16x9_should_cover_and_crop_to_target() {
+    // 64×48 is 4:3; covering 128×72 (16:9) should crop the vertical overflow.
+    // Scale factor = max(128/64, 72/48) = max(2.0, 1.5) = 2.0
+    // Scaled: 64×2.0=128, 48×2.0=96 → centre-crop to 128×72 (12px removed top/bottom).
+    let mut graph = match FilterGraph::builder().fill_to_aspect(128, 72).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    };
+    let frame = make_yuv420p_frame(64, 48);
+    match graph.push_video(0, &frame) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("Skipping: {e}");
+            return;
+        }
+    }
+    let result = graph.pull_video().expect("pull_video must not fail");
+    let out = result.expect("expected Some(frame) after fill_to_aspect push");
+    assert_eq!(
+        out.width(),
+        128,
+        "width should match target after fill_to_aspect"
+    );
+    assert_eq!(
+        out.height(),
+        72,
+        "height should exactly match target (overflow cropped) after fill_to_aspect"
+    );
+    // Cover, not letterbox/pillarbox: the 4:3 source into 16:9 would pillarbox
+    // under Fit (black bars at the left/right edges, so x=0 is a bar). Fill scales
+    // up to cover and crops, so the top-left pixel is source content (grey Y≈128),
+    // not a bar. This separates cover+crop from contain+pad at the pixel level
+    // (dimensions alone are identical for both modes).
+    if let Some(y_plane) = out.plane(0) {
+        assert!(
+            y_plane[0] > 64,
+            "top-left pixel should be source content, not a letterbox/pillarbox bar; got Y={}",
+            y_plane[0]
+        );
+    }
+}
+
+#[test]
 fn push_wide_frame_through_fit_to_aspect_should_produce_letterbox() {
     // 128×54 is ~2.37:1; fitting into 128×72 (16:9) should produce letterbox bars.
     // Scale factor = min(128/128, 72/54) = min(1.0, 1.33) = 1.0 (no scale needed)


### PR DESCRIPTION
## Objective

- A clip whose source resolution or aspect differs from the project canvas has to be framed into it (cover, contain, stretch, or native), which previously meant hand-building Crop/Scale/Pad filter chains.

## Solution

- Add `FitMode { Fill, Fit, Stretch, None }` and `Clip.fit` (default `None`) in `avio`; the derive maps the mode to a canvas-relative framing `FilterStep` via a shared helper used by both the export and preview paths, so they frame a clip identically.
- Emit the framing step after the temporal steps and before the colour/effect chain; `None` emits nothing (native size, existing transforms unchanged). Thread the canvas dimensions into the derive; a zero canvas (the canvas-less `Clip::realtime_layer_descriptor`) skips framing.
- Add `FilterStep::FillToAspect` in `ff-filter` (scale with `force_original_aspect_ratio=increase` + centred crop) as the cover counterpart to the existing `FitToAspect` (contain + pad); crop auto-centres, so the derive never needs the source size. `Stretch` maps to `Scale`, `Fit` to `FitToAspect`.
- Cover vs contain is verified by a probe-gated push test asserting exact canvas dimensions plus a top-left pixel check from a different-aspect source, and by build-independent derive/args unit tests.
- Note the boundary: framing is orthogonal to the per-clip `scale` transform (applied before the effect chain), so `fit` is the sizing control when set and pixel-exact preview framing through the preview compositor's own conform is out of scope.

Closes #1422