### PR TITLE
ci(coverage): add cargo-llvm-cov + Codecov reporting (informational)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,64 @@
+name: Coverage
+
+# Informational code coverage. This workflow is deliberately SEPARATE from ci.yml
+# and is NOT part of ci.yml's required `ci` aggregation gate, so a coverage or
+# Codecov hiccup can never block a merge (see codecov.yml for the policy).
+#
+# It runs on macOS because the Linux CI FFmpeg is built with no individual filters
+# (.github/actions/setup-ffmpeg), so filter/integration tests skip there and would
+# under-report coverage. macOS uses Homebrew's full FFmpeg, so those tests execute.
+
+on:
+  # PR delta is the actionable signal (Codecov comments the change before merge).
+  pull_request:
+    branches: [main]
+  # Weekly main-branch snapshot for the coverage trend. A solo, low-volume repo
+  # does not need a heavy macOS run on every merge, so push[main] is intentionally
+  # omitted in favour of this periodic run (Codecov's base refreshes weekly).
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  # On-demand run.
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR; never cancel scheduled/manual runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  coverage:
+    name: Coverage (macOS, full FFmpeg)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      # Full FFmpeg (all filters), matching the macOS test leg in ci.yml, so
+      # filter/integration tests actually run under instrumentation.
+      - name: Install FFmpeg (macOS)
+        run: brew install ffmpeg pkg-config
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      # Same coverage surface as the test job (`--all --all-features`).
+      - name: Collect coverage
+        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          # Informational only: a Codecov outage must not fail this job.
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A safe, high-level Rust API over FFmpeg: an editing engine on top of a family of
 
 [![Crates.io](https://img.shields.io/crates/v/avio.svg)](https://crates.io/crates/avio)
 [![Docs.rs](https://docs.rs/avio/badge.svg)](https://docs.rs/avio)
+[![Codecov](https://codecov.io/gh/itsakeyfut/avio/branch/main/graph/badge.svg)](https://codecov.io/gh/itsakeyfut/avio)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+
+> Coverage is a **trend and gap indicator, not a single target**. It is measured on macOS (Homebrew full FFmpeg), because the Linux CI FFmpeg has no individual filters, so filter/integration tests skip there. Even on macOS some tests are probe-, hardware-, or feature-gated (e.g. `wgpu`, `gpl`) and skip depending on the runner, so genuinely-tested paths can read as uncovered. Windows is not a coverage target (its CI job only runs `cargo check`, no tests), so `#[cfg(windows)]` branches are a known measurement gap. The check is informational and never blocks a merge.
 
 ## Overview
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,44 @@
+# Codecov configuration for avio.
+#
+# Policy: INFORMATIONAL ONLY. Coverage never blocks a merge. Both the project and
+# patch statuses are `informational`, so they report a delta but always pass, and
+# the coverage workflow (.github/workflows/coverage.yml) is intentionally kept out
+# of ci.yml's required `ci` aggregation gate. This lets a baseline stabilize before
+# anyone considers gating.
+#
+# Environment rationale: coverage is collected on macOS (Homebrew full FFmpeg), NOT
+# on the Linux CI leg. The Linux CI FFmpeg is built with `--disable-everything
+# --enable-avfilter` and no individual filters (.github/actions/setup-ffmpeg), so
+# filter/integration tests skip there and would under-report coverage. Even on
+# macOS the number understates reality: some tests are probe-/hardware-/feature-
+# gated (e.g. wgpu, gpl) and skip depending on the runner. Treat coverage as a
+# TREND and GAP indicator, not a single target to hit.
+#
+# Windows is intentionally NOT a coverage target: the Windows CI job only runs
+# `cargo check` (no FFmpeg, no test suite; building FFmpeg via vcpkg dominates CI
+# time, per ci.yml), so there is nothing executed to measure. `#[cfg(windows)]`
+# code is not compiled on macOS, so it is absent from the report rather than
+# counted as uncovered. It does not lower the number, but its Windows-only
+# branches are a known measurement gap.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true # report only; never blocks a PR
+    patch:
+      default:
+        informational: true # report only; never blocks a PR
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: false
+
+# Excluded from the coverage number so it stays meaningful (non-source or
+# environment-skewed paths).
+ignore:
+  - "examples/**"            # avio-examples: a manual end-to-end harness, not library code
+  - "crates/*/tests/**"      # integration test code itself
+  - "crates/*/fuzz/**"       # fuzz targets (ff-decode/ff-encode/ff-probe)
+  - "**/docsrs_stubs.rs"     # generated docs.rs stub bindings, never linked in a real build


### PR DESCRIPTION
## Objective

- There is no code-coverage measurement in CI. Add one as an informational signal (never blocks a merge) so a baseline can form, while respecting that the Linux CI FFmpeg has no individual filters, so filter/integration tests skip there and would under-report.

## Solution

- Add `.github/workflows/coverage.yml`: a standalone job on `macos-latest` (Homebrew full FFmpeg, so filter/integration tests actually run) that collects `cargo llvm-cov --workspace --all-features` and uploads lcov to Codecov (`codecov/codecov-action@v5`, `fail_ci_if_error: false`).
- Keep it non-blocking three ways: a separate workflow (not in ci.yml's required `ci` aggregation gate), `codecov.yml` marks both project and patch statuses `informational: true`, and the upload does not fail the job.
- Triggers: `pull_request` (the actionable delta), a weekly `schedule` for the main-branch trend, and `workflow_dispatch`; `push[main]` is omitted so a low-volume repo does not run the heavy macOS job on every merge.
- Add `codecov.yml` documenting the informational policy and the environment rationale (macOS vs the stripped Linux leg; Windows is not a target as its CI job only runs `cargo check`), with an ignore list for non-source paths. The README gains a badge and a note that coverage is a trend/gap indicator, not a single target.
- Note: "never blocks a merge" assumes branch protection requires only the `ci` aggregation check (as ci.yml intends); worth confirming the new `Coverage` check is not separately required.

Closes #1315