### PR TITLE
feat(avio): timeline-level master audio effect chain on render

### DIFF
--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -12,8 +12,8 @@ use std::time::{Duration, Instant};
 use ff_decode::VideoDecoder;
 use ff_encode::VideoEncoder;
 use ff_filter::{
-    AnimatedValue, AnimationTrack, MultiTrackAudioMixer, MultiTrackComposer, ProxySource,
-    VideoLayer,
+    AnimatedValue, AnimationTrack, FilterGraph, FilterStep, MultiTrackAudioMixer,
+    MultiTrackComposer, ProxySource, VideoLayer,
 };
 use ff_format::ChannelLayout;
 
@@ -90,6 +90,14 @@ pub struct Timeline {
     /// color=s=1920x1080:c=black@0.0,drawtext=text='Hello':fontsize=48:fontcolor=white
     /// ```
     pub(crate) lavfi_overlay: Option<String>,
+    /// Timeline-level (master bus) audio effect chain applied to the final mix on
+    /// render. Empty by default (no processing).
+    ///
+    /// Applied after the multi-track mix, so it operates on the whole program's
+    /// audio — the natural place for loudness normalization
+    /// ([`FilterStep::LoudnessNormalize`]). Per-track (pre-mix) effects are a
+    /// separate feature (see issue #1446).
+    pub(crate) audio_filter: Vec<FilterStep>,
 }
 
 impl Timeline {
@@ -223,6 +231,7 @@ impl Timeline {
             video_animations,
             audio_animations,
             lavfi_overlay,
+            audio_filter,
         } = self;
 
         let nv = video_tracks.len();
@@ -411,6 +420,21 @@ impl Timeline {
             audio_graph = Some(mixer.build().map_err(TimelineError::Filter)?);
         }
 
+        // Timeline-level (master bus) audio effect chain, applied post-mix. Built
+        // only when there is audio to process. A two-pass step (`LoudnessNormalize`)
+        // works here because a builder-made `FilterGraph` carries the `steps` its
+        // push/pull path keys off — unlike the source-only mixer graph, where it
+        // would be inert.
+        let master_audio = if audio_graph.is_some() && !audio_filter.is_empty() {
+            let mut builder = FilterGraph::builder();
+            for step in &audio_filter {
+                builder = builder.add_step(step.clone());
+            }
+            Some(builder.build().map_err(TimelineError::Filter)?)
+        } else {
+            None
+        };
+
         // 5. Build encoder.
         let hw = hwaccel_to_hardware_encoder(config.hardware);
         let mut enc_builder = VideoEncoder::create(output)
@@ -454,20 +478,43 @@ impl Timeline {
             }
         }
 
-        // 7. Drain audio graph → encoder.
+        // 7. Drain audio graph → (optional master bus) → encoder.
         //    tick() advances the audio animation clock by the actual duration
         //    of each chunk so PTS stays sample-accurate.
         if let Some(mut agraph) = audio_graph {
-            let mut audio_pts = Duration::ZERO;
-            loop {
-                agraph.tick(audio_pts);
-                match agraph.pull_audio().map_err(TimelineError::Filter)? {
-                    Some(frame) => {
-                        let chunk_dur = frame.duration();
-                        encoder.push_audio(&frame).map_err(TimelineError::Encode)?;
-                        audio_pts += chunk_dur;
+            if let Some(mut master) = master_audio {
+                // Route the mix through the master effect chain. A two-pass step
+                // (loudness normalization) buffers every frame, so feed the whole
+                // mix, flush to signal EOF, then drain the processed output.
+                let mut audio_pts = Duration::ZERO;
+                loop {
+                    agraph.tick(audio_pts);
+                    match agraph.pull_audio().map_err(TimelineError::Filter)? {
+                        Some(frame) => {
+                            audio_pts += frame.duration();
+                            master
+                                .push_audio(0, &frame)
+                                .map_err(TimelineError::Filter)?;
+                        }
+                        None => break,
                     }
-                    None => break,
+                }
+                master.flush_audio();
+                while let Some(frame) = master.pull_audio().map_err(TimelineError::Filter)? {
+                    encoder.push_audio(&frame).map_err(TimelineError::Encode)?;
+                }
+            } else {
+                let mut audio_pts = Duration::ZERO;
+                loop {
+                    agraph.tick(audio_pts);
+                    match agraph.pull_audio().map_err(TimelineError::Filter)? {
+                        Some(frame) => {
+                            let chunk_dur = frame.duration();
+                            encoder.push_audio(&frame).map_err(TimelineError::Encode)?;
+                            audio_pts += chunk_dur;
+                        }
+                        None => break,
+                    }
                 }
             }
         }
@@ -496,6 +543,8 @@ pub struct TimelineBuilder {
     audio_animations: HashMap<String, AnimationTrack<f64>>,
     /// See [`TimelineBuilder::lavfi_overlay`].
     lavfi_overlay: Option<String>,
+    /// See [`TimelineBuilder::audio_filter`].
+    audio_filter: Vec<FilterStep>,
 }
 
 impl Default for TimelineBuilder {
@@ -516,6 +565,7 @@ impl TimelineBuilder {
             video_animations: HashMap::new(),
             audio_animations: HashMap::new(),
             lavfi_overlay: None,
+            audio_filter: Vec::new(),
         }
     }
 
@@ -632,6 +682,22 @@ impl TimelineBuilder {
         }
     }
 
+    /// Sets a timeline-level (master bus) audio effect chain applied to the final
+    /// mix on render.
+    ///
+    /// The steps run in order on the whole program's mixed audio, after the
+    /// multi-track mix and before the encoder — the natural place for loudness
+    /// normalization ([`FilterStep::LoudnessNormalize`]). When not set (the
+    /// default, an empty chain) the audio path is unchanged. Per-track (pre-mix)
+    /// effects are a separate feature (see issue #1446).
+    #[must_use]
+    pub fn audio_filter(self, steps: Vec<FilterStep>) -> Self {
+        Self {
+            audio_filter: steps,
+            ..self
+        }
+    }
+
     /// Builds the [`Timeline`].
     ///
     /// # Errors
@@ -676,6 +742,7 @@ impl TimelineBuilder {
             video_animations: self.video_animations,
             audio_animations: self.audio_animations,
             lavfi_overlay: self.lavfi_overlay,
+            audio_filter: self.audio_filter,
         })
     }
 
@@ -988,6 +1055,33 @@ mod tests {
             scene.lavfi_overlay.as_deref(),
             Some("color=s=1920x1080:c=black@0.0")
         );
+    }
+
+    #[test]
+    fn timeline_default_audio_filter_should_be_empty() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .build()
+            .unwrap();
+        assert!(timeline.audio_filter.is_empty());
+    }
+
+    #[test]
+    fn timeline_builder_audio_filter_should_set_chain() {
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .audio_filter(vec![FilterStep::Volume(-6.0)])
+            .build()
+            .unwrap();
+        assert_eq!(timeline.audio_filter.len(), 1);
+        assert!(matches!(
+            timeline.audio_filter[0],
+            FilterStep::Volume(v) if (v - (-6.0)).abs() < 1e-9
+        ));
     }
 
     #[cfg(feature = "preview")]

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -483,9 +483,12 @@ impl Timeline {
         //    of each chunk so PTS stays sample-accurate.
         if let Some(mut agraph) = audio_graph {
             if let Some(mut master) = master_audio {
-                // Route the mix through the master effect chain. A two-pass step
-                // (loudness normalization) buffers every frame, so feed the whole
-                // mix, flush to signal EOF, then drain the processed output.
+                // Route the mix through the master effect chain, interleaving pulls
+                // so a plain-node chain streams (low memory) rather than buffering
+                // the whole program. A two-pass step (loudness normalization) buffers
+                // internally and emits nothing until `flush_audio` signals EOF, so
+                // the interleaved pull naturally degrades to buffer-all for it; the
+                // trailing flush + drain then emits the processed output.
                 let mut audio_pts = Duration::ZERO;
                 loop {
                     agraph.tick(audio_pts);
@@ -495,6 +498,11 @@ impl Timeline {
                             master
                                 .push_audio(0, &frame)
                                 .map_err(TimelineError::Filter)?;
+                            while let Some(out) =
+                                master.pull_audio().map_err(TimelineError::Filter)?
+                            {
+                                encoder.push_audio(&out).map_err(TimelineError::Encode)?;
+                            }
                         }
                         None => break,
                     }

--- a/crates/avio/tests/timeline_tests.rs
+++ b/crates/avio/tests/timeline_tests.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use avio::{Clip, EncoderConfig, Timeline, TimelineError};
 use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
+use ff_filter::FilterStep;
 use ff_filter::animation::{AnimationTrack, Easing};
 use fixtures::{FileGuard, make_source_file, test_output_path};
 
@@ -128,6 +129,68 @@ fn timeline_render_should_produce_ffprobe_valid_output() {
         video.height(),
         H,
         "output video height must match canvas height"
+    );
+}
+
+/// A timeline-level (master bus) audio effect chain must be applied on render
+/// (issue #1424 — "no longer inert"). A wiring/format bug in the post-mix master
+/// graph would fail push/pull/flush here. `Volume` is a plain node: the synthetic
+/// source audio is silent, so a two-pass loudnorm would be a degenerate input;
+/// `LoudnessNormalize`'s measured correctness lives in ff-filter's tests.
+#[test]
+fn timeline_audio_filter_should_render_through_master_chain() {
+    let src_path = test_output_path("timeline_audiofilter_src.mp4");
+    let out_path = test_output_path("timeline_audiofilter_out.mp4");
+    let _g_src = FileGuard::new(src_path.clone());
+    let _g_out = FileGuard::new(out_path.clone());
+
+    if make_source_file(&src_path, W, H, FPS, FRAME_COUNT, 76, 84, 255).is_none() {
+        return;
+    }
+
+    let clip = Clip::new(&src_path);
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![clip.clone()])
+        .audio_track(vec![clip])
+        .audio_filter(vec![FilterStep::Volume(-6.0)])
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    match timeline.render(&out_path, render_config()) {
+        Ok(()) => {}
+        Err(TimelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+            return;
+        }
+        Err(TimelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+        Err(TimelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+            return;
+        }
+        Err(e) => panic!("unexpected error from Timeline::render: {e}"),
+    }
+
+    let info = match ff_probe::open(&out_path) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping: ff_probe::open failed: {e}");
+            return;
+        }
+    };
+    assert!(
+        info.has_audio(),
+        "rendered output with a master audio filter must contain an audio stream"
     );
 }
 


### PR DESCRIPTION
## Objective

- A timeline-level audio effect chain (e.g. EBU R128 loudness normalization) had no way to be applied on render — the audio path was inert at that level.

## Solution

- Add `Timeline.audio_filter: Vec<FilterStep>` with a `TimelineBuilder::audio_filter` builder (mirroring `lavfi_overlay`). It runs on the whole program's mixed audio, after the multi-track mix and before the encoder.
- On render, when the chain is non-empty and there is audio, route the mixed output through a second single-input `FilterGraph` carrying the chain: pull each mixed frame, push it into the master graph, flush to signal EOF, then drain the processed output to the encoder. When the chain is empty the audio path is byte-for-byte unchanged.
- The second graph is required rather than inserting nodes into `MultiTrackAudioMixer`: that graph is source-only with no recorded `steps`, so the two-pass `LoudnessNormalize` (buffer, measure with `ebur128`, re-apply) that lives in `push_audio`/`pull_audio` would be inert inside it. A builder-made graph carries the `steps` its two-pass path keys off, so loudness normalization works. This is a deliberate deviation from the issue's "applied by `MultiTrackAudioMixer`" wording; the observable outcome is the same.
- Scope: timeline (master bus) level. Track-level (pre-mix) effects have the same two-pass limitation and are tracked in #1446.

Closes #1424