### PR TITLE
feat(ff-filter): text/title layer source primitive

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -217,12 +217,13 @@
 // in from ff-format anyway).
 pub use ff_format::subtitle::{SubtitleError, SubtitleEvent, SubtitleTrack};
 pub use ff_format::{
-    AlphaMode, AudioCodec, AudioFrame, AudioStreamInfo, AudioStreamInfoBuilder, ChannelLayout,
-    ChapterInfo, ChapterInfoBuilder, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer,
-    ContainerInfo, ContainerInfoBuilder, ErrorSeverity, FormatError, FrameError, Hdr10Metadata,
-    MasteringDisplay, MediaError, MediaInfo, MediaInfoBuilder, NetworkOptions, PixelFormat,
-    Rational, SampleFormat, SubtitleCodec, SubtitleStreamInfo, SubtitleStreamInfoBuilder,
-    Timestamp, VideoCodec, VideoFrame, VideoStreamInfo, VideoStreamInfoBuilder,
+    AlphaMode, Anchor, AudioCodec, AudioFrame, AudioStreamInfo, AudioStreamInfoBuilder,
+    ChannelLayout, ChapterInfo, ChapterInfoBuilder, Color, ColorPrimaries, ColorRange, ColorSpace,
+    ColorTransfer, ContainerInfo, ContainerInfoBuilder, ErrorSeverity, FormatError, FrameError,
+    Hdr10Metadata, MasteringDisplay, MediaError, MediaInfo, MediaInfoBuilder, NetworkOptions,
+    PixelFormat, Rational, SampleFormat, SubtitleCodec, SubtitleStreamInfo,
+    SubtitleStreamInfoBuilder, TextSpec, TextStyle, Timestamp, VideoCodec, VideoFrame,
+    VideoStreamInfo, VideoStreamInfoBuilder,
 };
 
 // ── probe feature ─────────────────────────────────────────────────────────────
@@ -303,8 +304,8 @@ pub use ff_filter::{
     FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LavfiSource,
     LensProfile, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer,
     NoiseType, ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer,
-    RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, ToneMap,
-    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, TextSource,
+    ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -20,7 +20,7 @@ use crate::filter_inner::FilterGraphInner;
 use crate::graph::FfmpegToken;
 use crate::graph::filter_step::FilterStep;
 use crate::graph::graph::FilterGraph;
-use crate::graph::types::{Rgb, ScaleAlgorithm};
+use crate::graph::types::{DrawTextOptions, Rgb, ScaleAlgorithm};
 
 use super::multi_track_composer::VideoLayer;
 use super::multi_track_mixer::AudioTrack;
@@ -2530,5 +2530,159 @@ pub(super) unsafe fn build_lavfi_source(lavfi: &str) -> Result<FilterGraph, Filt
     let sink_nn = NonNull::new_unchecked(sink_ctx);
     let inner = FilterGraphInner::with_prebuilt_video_graph(graph_nn, sink_nn);
     log::info!("lavfi source graph built");
+    Ok(FilterGraph::from_prebuilt(inner))
+}
+
+// ── Text layer source graph (generated title/caption layer) ───────────────────
+
+/// Builds a source-only graph that renders a text layer onto a transparent canvas:
+/// `color(c=black@0.0:s=WxH:r=fps) → format=rgba → drawtext → buffersink`.
+///
+/// Unlike [`build_lavfi_source`], this uses the `color` **filter** source (not the
+/// `movie=…:format_name=lavfi` demuxer), so it does not depend on the lavfi
+/// demuxer. The transparent base + `rgba` output make the result composite as an
+/// overlay. Pulled with [`FilterGraph::pull_video`]; no `buffersrc` input.
+///
+/// # Safety
+///
+/// Follows the same avfilter ownership rules as [`build_video_composition`]: the
+/// returned graph owns every context it created.
+pub(super) unsafe fn build_text_source(
+    opts: &DrawTextOptions,
+    width: u32,
+    height: u32,
+    fps: f64,
+) -> Result<FilterGraph, FilterError> {
+    use std::ffi::CString;
+
+    macro_rules! bail {
+        ($graph:ident, $reason:expr) => {{
+            let mut g = $graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::CompositionFailed {
+                reason: format!("{}", $reason),
+            });
+        }};
+    }
+
+    let graph = ff_sys::avfilter_graph_alloc();
+    if graph.is_null() {
+        return Err(FilterError::CompositionFailed {
+            reason: "avfilter_graph_alloc failed".to_string(),
+        });
+    }
+
+    // ── color source (transparent base canvas) ────────────────────────────────
+    let color_filter = ff_sys::avfilter_get_by_name(c"color".as_ptr());
+    if color_filter.is_null() {
+        bail!(graph, "filter not found: color");
+    }
+    let color_args_str = format!("c=black@0.0:s={width}x{height}:r={fps}");
+    let Ok(color_args) = CString::new(color_args_str.as_str()) else {
+        bail!(graph, "CString::new failed for color filter args");
+    };
+    let mut color_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut color_ctx,
+        color_filter,
+        c"text_base".as_ptr(),
+        color_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create color source code={ret}"));
+    }
+
+    // ── format=rgba (establish the transparent alpha canvas) ──────────────────
+    let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if fmt_filter.is_null() {
+        bail!(graph, "filter not found: format");
+    }
+    let mut fmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut fmt_ctx,
+        fmt_filter,
+        c"text_fmt".as_ptr(),
+        c"pix_fmts=rgba".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create format filter code={ret}"));
+    }
+    let ret = ff_sys::avfilter_link(color_ctx, 0, fmt_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: color→format");
+    }
+
+    // ── drawtext (reuse the FilterStep arg rendering) ─────────────────────────
+    let drawtext_filter = ff_sys::avfilter_get_by_name(c"drawtext".as_ptr());
+    if drawtext_filter.is_null() {
+        bail!(graph, "filter not found: drawtext");
+    }
+    let dt_args_str = FilterStep::DrawText { opts: opts.clone() }.args();
+    let Ok(dt_args) = CString::new(dt_args_str.as_str()) else {
+        bail!(graph, "CString::new failed for drawtext args");
+    };
+    let mut dt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut dt_ctx,
+        drawtext_filter,
+        c"text_draw".as_ptr(),
+        dt_args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("failed to create drawtext filter code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(fmt_ctx, 0, dt_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: format→drawtext");
+    }
+
+    // ── buffersink ────────────────────────────────────────────────────────────
+    let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
+    if sink_filter.is_null() {
+        bail!(graph, "filter not found: buffersink");
+    }
+    let mut sink_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sink_ctx,
+        sink_filter,
+        c"text_sink".as_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("failed to create text buffersink code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(dt_ctx, 0, sink_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: drawtext→buffersink");
+    }
+
+    // ── Configure ─────────────────────────────────────────────────────────────
+    let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("text source avfilter_graph_config failed code={ret}")
+        );
+    }
+
+    // SAFETY: ret >= 0 guarantees both pointers are non-null.
+    let graph_nn = NonNull::new_unchecked(graph);
+    let sink_nn = NonNull::new_unchecked(sink_ctx);
+    let inner = FilterGraphInner::with_prebuilt_video_graph(graph_nn, sink_nn);
+    log::info!("text source graph built canvas={width}x{height}");
     Ok(FilterGraph::from_prebuilt(inner))
 }

--- a/crates/ff-filter/src/graph/composition/mod.rs
+++ b/crates/ff-filter/src/graph/composition/mod.rs
@@ -14,6 +14,7 @@ mod crossfade_joiner;
 mod multi_track_composer;
 mod multi_track_mixer;
 mod realtime_composer;
+mod text_source;
 mod video_concatenator;
 
 pub use audio_concatenator::AudioConcatenator;
@@ -23,4 +24,5 @@ pub use multi_track_mixer::{AudioTrack, MultiTrackAudioMixer};
 pub use realtime_composer::{
     LavfiSource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,
 };
+pub use text_source::TextSource;
 pub use video_concatenator::VideoConcatenator;

--- a/crates/ff-filter/src/graph/composition/text_source.rs
+++ b/crates/ff-filter/src/graph/composition/text_source.rs
@@ -1,0 +1,191 @@
+//! Text/title layer source primitive.
+//!
+//! [`TextSource`] renders a pure [`TextSpec`] into a source-only `rgba` frame
+//! stream over `drawtext`, with no timeline/track/clip knowledge. It backs the
+//! engine's first-class text clips.
+
+#![allow(unsafe_code)]
+
+use ff_format::{Anchor, Color, TextSpec, VideoFrame};
+
+use crate::error::FilterError;
+use crate::graph::graph::FilterGraph;
+use crate::graph::types::DrawTextOptions;
+
+/// Formats an RGB color (alpha handled separately) as an `FFmpeg` `0xRRGGBB` token.
+fn color_hex(c: Color) -> String {
+    format!("0x{:02X}{:02X}{:02X}", c.r, c.g, c.b)
+}
+
+/// Maps an [`Anchor`] + pixel offset to `drawtext` `x`/`y` expression strings.
+///
+/// `drawtext` exposes `w`/`h` (canvas) and `text_w`/`text_h` (text box). The
+/// offset is applied only when non-zero, keeping the common (centred) case clean.
+fn anchor_exprs(anchor: Anchor, offset: (i32, i32)) -> (String, String) {
+    let base_x = match anchor {
+        Anchor::TopLeft | Anchor::CenterLeft | Anchor::BottomLeft => "0",
+        Anchor::TopCenter | Anchor::Center | Anchor::BottomCenter => "(w-text_w)/2",
+        Anchor::TopRight | Anchor::CenterRight | Anchor::BottomRight => "w-text_w",
+    };
+    let base_y = match anchor {
+        Anchor::TopLeft | Anchor::TopCenter | Anchor::TopRight => "0",
+        Anchor::CenterLeft | Anchor::Center | Anchor::CenterRight => "(h-text_h)/2",
+        Anchor::BottomLeft | Anchor::BottomCenter | Anchor::BottomRight => "h-text_h",
+    };
+    let (dx, dy) = offset;
+    let x = if dx == 0 {
+        base_x.to_string()
+    } else {
+        format!("({base_x})+({dx})")
+    };
+    let y = if dy == 0 {
+        base_y.to_string()
+    } else {
+        format!("({base_y})+({dy})")
+    };
+    (x, y)
+}
+
+/// Translates a pure [`TextSpec`] into the FFmpeg-flavoured [`DrawTextOptions`].
+fn spec_to_drawtext(spec: &TextSpec) -> DrawTextOptions {
+    let (x, y) = anchor_exprs(spec.anchor, spec.offset);
+    let style = &spec.style;
+    DrawTextOptions {
+        text: spec.text.clone(),
+        x,
+        y,
+        font_size: style.font_size,
+        font_color: color_hex(style.color),
+        opacity: f32::from(style.color.a) / 255.0,
+        font_file: style
+            .font_file
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned()),
+        box_color: style
+            .box_color
+            .map(|bc| format!("{}@{:.3}", color_hex(bc), f32::from(bc.a) / 255.0)),
+        box_border_width: style.box_border_width,
+    }
+}
+
+/// Renders a [`TextSpec`] into a source-only `rgba` frame stream.
+///
+/// The output composites as a transparent overlay (text over a fully transparent
+/// canvas). Frames are produced sequentially via [`pull`](Self::pull); the source
+/// exposes no seek, so a host that seeks rebuilds it. It is model-agnostic: it
+/// takes only a spec plus the target canvas size and frame rate.
+pub struct TextSource {
+    graph: FilterGraph,
+}
+
+impl TextSource {
+    /// Builds a text source for a `width × height` canvas at `fps`.
+    ///
+    /// # Errors
+    ///
+    /// - [`FilterError::InvalidConfig`] when the text is empty.
+    /// - [`FilterError`] when the underlying `FFmpeg` graph cannot be built (e.g.
+    ///   `color` / `drawtext` filters are unavailable).
+    pub fn new(spec: &TextSpec, width: u32, height: u32, fps: f64) -> Result<Self, FilterError> {
+        if spec.text.is_empty() {
+            return Err(FilterError::InvalidConfig {
+                reason: "text must not be empty".to_string(),
+            });
+        }
+        let opts = spec_to_drawtext(spec);
+        // SAFETY: `build_text_source` follows the avfilter ownership rules; the
+        // returned graph owns every context it created.
+        let graph =
+            unsafe { super::composition_inner::build_text_source(&opts, width, height, fps)? };
+        Ok(Self { graph })
+    }
+
+    /// Pulls the next rendered frame (`rgba`), or `None` when none is buffered yet
+    /// or at end-of-stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] on an unexpected `FFmpeg` error.
+    pub fn pull(&mut self) -> Result<Option<VideoFrame>, FilterError> {
+        self.graph.pull_video()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{anchor_exprs, spec_to_drawtext};
+    use ff_format::{Anchor, Color, TextSpec, TextStyle};
+
+    #[test]
+    fn center_anchor_should_map_to_centered_exprs() {
+        let (x, y) = anchor_exprs(Anchor::Center, (0, 0));
+        assert_eq!(x, "(w-text_w)/2");
+        assert_eq!(y, "(h-text_h)/2");
+    }
+
+    #[test]
+    fn corner_anchor_should_map_to_edge_exprs() {
+        let (x, y) = anchor_exprs(Anchor::BottomRight, (0, 0));
+        assert_eq!(x, "w-text_w");
+        assert_eq!(y, "h-text_h");
+        let (x0, y0) = anchor_exprs(Anchor::TopLeft, (0, 0));
+        assert_eq!(x0, "0");
+        assert_eq!(y0, "0");
+    }
+
+    #[test]
+    fn nonzero_offset_should_wrap_base_expr() {
+        let (x, y) = anchor_exprs(Anchor::Center, (10, -20));
+        assert_eq!(x, "((w-text_w)/2)+(10)");
+        assert_eq!(y, "((h-text_h)/2)+(-20)");
+    }
+
+    #[test]
+    fn spec_to_drawtext_should_map_color_and_opacity() {
+        let mut spec = TextSpec::new("Hi");
+        spec.style = TextStyle {
+            color: Color::rgba(255, 0, 0, 128),
+            ..TextStyle::default()
+        };
+        let opts = spec_to_drawtext(&spec);
+        assert_eq!(opts.text, "Hi");
+        assert_eq!(opts.font_color, "0xFF0000");
+        assert!((opts.opacity - 128.0 / 255.0).abs() < 1e-6);
+        assert!(opts.box_color.is_none());
+    }
+
+    #[test]
+    fn spec_to_drawtext_default_should_be_opaque_white() {
+        let spec = TextSpec::new("Hi");
+        let opts = spec_to_drawtext(&spec);
+        assert_eq!(opts.font_color, "0xFFFFFF");
+        assert!((opts.opacity - 1.0).abs() < 1e-6);
+        assert_eq!(opts.font_size, 48);
+        assert!(opts.font_file.is_none());
+    }
+
+    #[test]
+    fn spec_to_drawtext_should_map_font_file() {
+        use std::path::PathBuf;
+        let mut spec = TextSpec::new("Hi");
+        spec.style = TextStyle {
+            font_file: Some(PathBuf::from("/fonts/Roboto.ttf")),
+            ..TextStyle::default()
+        };
+        let opts = spec_to_drawtext(&spec);
+        assert_eq!(opts.font_file.as_deref(), Some("/fonts/Roboto.ttf"));
+    }
+
+    #[test]
+    fn spec_to_drawtext_should_map_box_color_with_alpha() {
+        let mut spec = TextSpec::new("Hi");
+        spec.style = TextStyle {
+            box_color: Some(Color::rgba(0, 0, 0, 255)),
+            box_border_width: 8,
+            ..TextStyle::default()
+        };
+        let opts = spec_to_drawtext(&spec);
+        assert_eq!(opts.box_color.as_deref(), Some("0x000000@1.000"));
+        assert_eq!(opts.box_border_width, 8);
+    }
+}

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -12,7 +12,7 @@ pub use builder::FilterGraphBuilder;
 pub use composition::{
     AudioConcatenator, AudioTrack, CrossfadeJoiner, LavfiSource, MultiTrackAudioMixer,
     MultiTrackComposer, ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,
-    VideoConcatenator, VideoLayer,
+    TextSource, VideoConcatenator, VideoLayer,
 };
 pub use ffmpeg_token::FfmpegToken;
 pub use filter_step::FilterStep;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -53,5 +53,5 @@ pub use graph::{
     AudioConcatenator, AudioTrack, CrossfadeJoiner, DrawTextOptions, EqBand, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, MultiTrackAudioMixer, MultiTrackComposer,
     ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb, ScaleAlgorithm,
-    ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    TextSource, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };

--- a/crates/ff-filter/tests/text_source_tests.rs
+++ b/crates/ff-filter/tests/text_source_tests.rs
@@ -1,0 +1,54 @@
+//! Integration tests for the text/title layer source primitive.
+//!
+//! Probe-gated (RK-002): CI's Linux FFmpeg is built with no filters, so
+//! `color`/`drawtext` may be absent and `TextSource::new` fails → skip. On a
+//! full-FFmpeg machine this renders a real frame.
+
+use ff_filter::{FilterError, TextSource};
+use ff_format::TextSpec;
+
+#[test]
+fn text_source_should_render_frame_at_requested_size() {
+    let spec = TextSpec::new("Title");
+    let mut src = match TextSource::new(&spec, 320, 80, 30.0) {
+        Ok(s) => s,
+        // Filter unavailable (CI's filterless FFmpeg) — the only legitimate skip.
+        Err(e) => {
+            println!("Skipping: TextSource::new failed: {e}");
+            return;
+        }
+    };
+    match src.pull() {
+        Ok(Some(frame)) => {
+            assert_eq!(frame.width(), 320, "text source width must match canvas");
+            assert_eq!(frame.height(), 80, "text source height must match canvas");
+            // The graph built (so `color`/`drawtext` and a font resolved), so the
+            // frame must actually contain drawn text: the background is a fully
+            // transparent black canvas (all-zero rgba bytes), so any non-zero byte
+            // proves pixels were drawn.
+            let plane = frame.plane(0).expect("rgba frame must have plane 0");
+            assert!(
+                plane.iter().any(|&b| b != 0),
+                "rendered text frame must contain drawn (non-transparent) pixels"
+            );
+        }
+        // The graph built, so it must produce a frame; no frame is an anomaly, not
+        // a skip condition.
+        Ok(None) => panic!("text source built but produced no frame"),
+        Err(e) => println!("Skipping: pull failed: {e}"),
+    }
+}
+
+#[test]
+fn text_source_should_reject_empty_text() {
+    // The empty-text guard runs before any FFmpeg call, so this must fail with
+    // `InvalidConfig` everywhere — matching the variant (not just `is_err`) keeps
+    // the test meaningful on the filterless CI, where a missing guard would still
+    // surface as a (different) build error.
+    let spec = TextSpec::new("");
+    match TextSource::new(&spec, 320, 80, 30.0) {
+        Err(FilterError::InvalidConfig { .. }) => {}
+        Err(e) => panic!("expected InvalidConfig for empty text, got a different error: {e}"),
+        Ok(_) => panic!("expected InvalidConfig for empty text, but construction succeeded"),
+    }
+}

--- a/crates/ff-format/src/color.rs
+++ b/crates/ff-format/src/color.rs
@@ -951,3 +951,60 @@ mod tests {
         }
     }
 }
+
+/// An 8-bit-per-channel RGBA color value.
+///
+/// A plain color value (fill / text / box color), independent of any colorimetry
+/// metadata ([`ColorSpace`] et al.). `a` is the alpha channel: `255` = opaque,
+/// `0` = fully transparent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Color {
+    /// Red channel (0–255).
+    pub r: u8,
+    /// Green channel (0–255).
+    pub g: u8,
+    /// Blue channel (0–255).
+    pub b: u8,
+    /// Alpha channel (0 = transparent, 255 = opaque).
+    pub a: u8,
+}
+
+impl Color {
+    /// Opaque white.
+    pub const WHITE: Self = Self::rgb(255, 255, 255);
+    /// Opaque black.
+    pub const BLACK: Self = Self::rgb(0, 0, 0);
+    /// Fully transparent (black with zero alpha).
+    pub const TRANSPARENT: Self = Self::rgba(0, 0, 0, 0);
+
+    /// Creates an opaque color (`a = 255`).
+    #[must_use]
+    pub const fn rgb(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b, a: 255 }
+    }
+
+    /// Creates a color with an explicit alpha channel.
+    #[must_use]
+    pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
+}
+
+#[cfg(test)]
+mod color_value_tests {
+    use super::Color;
+
+    #[test]
+    fn rgb_should_be_opaque() {
+        let c = Color::rgb(10, 20, 30);
+        assert_eq!(c, Color::rgba(10, 20, 30, 255));
+        assert_eq!(c.a, 255);
+    }
+
+    #[test]
+    fn consts_should_have_expected_channels() {
+        assert_eq!(Color::WHITE, Color::rgba(255, 255, 255, 255));
+        assert_eq!(Color::BLACK, Color::rgba(0, 0, 0, 255));
+        assert_eq!(Color::TRANSPARENT.a, 0);
+    }
+}

--- a/crates/ff-format/src/lib.rs
+++ b/crates/ff-format/src/lib.rs
@@ -14,7 +14,8 @@
 //! - `stream` - Stream info ([`VideoStreamInfo`], [`AudioStreamInfo`])
 //! - `container` - Container info ([`ContainerInfo`])
 //! - `media` - Media container info ([`MediaInfo`])
-//! - `color` - Color space definitions ([`ColorSpace`], [`ColorRange`], [`ColorPrimaries`])
+//! - `color` - Color definitions ([`ColorSpace`], [`ColorRange`], [`ColorPrimaries`], [`Color`])
+//! - `text` - Text/title layer spec types ([`TextSpec`], [`TextStyle`], [`Anchor`])
 //! - `hdr` - HDR metadata types ([`Hdr10Metadata`], [`MasteringDisplay`])
 //! - `network` - Network configuration ([`NetworkOptions`])
 //! - `codec` - Codec definitions ([`VideoCodec`], [`AudioCodec`])
@@ -68,12 +69,13 @@ pub mod pixel;
 pub mod sample;
 pub mod stream;
 pub mod subtitle;
+pub mod text;
 pub mod time;
 
 pub use channel::ChannelLayout;
 pub use chapter::{ChapterInfo, ChapterInfoBuilder};
 pub use codec::{AudioCodec, SubtitleCodec, VideoCodec};
-pub use color::{AlphaMode, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer};
+pub use color::{AlphaMode, Color, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer};
 pub use container::{ContainerInfo, ContainerInfoBuilder};
 pub use error::{FormatError, FrameError, SubtitleError};
 pub use ff_common::PooledBuffer;
@@ -88,6 +90,7 @@ pub use stream::{
     AudioStreamInfo, AudioStreamInfoBuilder, SubtitleStreamInfo, SubtitleStreamInfoBuilder,
     VideoStreamInfo, VideoStreamInfoBuilder,
 };
+pub use text::{Anchor, TextSpec, TextStyle};
 pub use time::{Rational, Timestamp};
 
 /// Prelude module for convenient imports.

--- a/crates/ff-format/src/text.rs
+++ b/crates/ff-format/src/text.rs
@@ -1,0 +1,127 @@
+//! Pure text/title layer spec types.
+//!
+//! [`TextSpec`] and [`TextStyle`] describe a text layer's content, position, and
+//! styling as plain values, with **no** `FFmpeg` dependency. A rendering primitive
+//! (in `ff-filter`) translates a [`TextSpec`] into a compositable frame; the model
+//! (in `avio`) uses it for first-class text clips. Neither concern leaks here.
+
+use std::path::PathBuf;
+
+use crate::color::Color;
+
+/// Where a text layer is anchored within its canvas.
+///
+/// The renderer places the text box at the anchor, then applies
+/// [`TextSpec::offset`] as a pixel nudge from it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Anchor {
+    /// Top-left corner.
+    TopLeft,
+    /// Top edge, horizontally centred.
+    TopCenter,
+    /// Top-right corner.
+    TopRight,
+    /// Left edge, vertically centred.
+    CenterLeft,
+    /// Centre of the canvas. The default.
+    #[default]
+    Center,
+    /// Right edge, vertically centred.
+    CenterRight,
+    /// Bottom-left corner.
+    BottomLeft,
+    /// Bottom edge, horizontally centred.
+    BottomCenter,
+    /// Bottom-right corner.
+    BottomRight,
+}
+
+/// Visual styling for a text layer.
+///
+/// Mirrors the typical draw-text options as plain values; opacity is carried by
+/// the alpha channel of [`color`](Self::color) (and [`box_color`](Self::box_color)).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextStyle {
+    /// Font size in points.
+    pub font_size: u32,
+    /// Fill color of the text (alpha = opacity).
+    pub color: Color,
+    /// Optional path to a `TrueType` font file. A default font is used when `None`.
+    pub font_file: Option<PathBuf>,
+    /// Optional background box color behind the text (alpha = box opacity). No box
+    /// when `None`.
+    pub box_color: Option<Color>,
+    /// Background box padding in pixels. Ignored when [`box_color`](Self::box_color)
+    /// is `None`.
+    pub box_border_width: u32,
+}
+
+impl Default for TextStyle {
+    fn default() -> Self {
+        Self {
+            font_size: 48,
+            color: Color::WHITE,
+            font_file: None,
+            box_color: None,
+            box_border_width: 0,
+        }
+    }
+}
+
+/// A text/title layer: the string, its placement, and its styling.
+///
+/// Size-agnostic: the canvas dimensions are supplied by the renderer, so the same
+/// spec can render at any resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextSpec {
+    /// The text to render (UTF-8).
+    pub text: String,
+    /// Where the text is anchored within the canvas.
+    pub anchor: Anchor,
+    /// Pixel offset `(dx, dy)` from the anchor (positive = right / down).
+    pub offset: (i32, i32),
+    /// Visual styling.
+    pub style: TextStyle,
+}
+
+impl TextSpec {
+    /// Creates a centred text spec with default styling.
+    #[must_use]
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            anchor: Anchor::Center,
+            offset: (0, 0),
+            style: TextStyle::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Anchor, TextSpec, TextStyle};
+    use crate::color::Color;
+
+    #[test]
+    fn anchor_default_should_be_center() {
+        assert_eq!(Anchor::default(), Anchor::Center);
+    }
+
+    #[test]
+    fn text_style_default_should_be_white_48() {
+        let s = TextStyle::default();
+        assert_eq!(s.font_size, 48);
+        assert_eq!(s.color, Color::WHITE);
+        assert!(s.font_file.is_none());
+        assert!(s.box_color.is_none());
+    }
+
+    #[test]
+    fn text_spec_new_should_center_with_default_style() {
+        let spec = TextSpec::new("Hello");
+        assert_eq!(spec.text, "Hello");
+        assert_eq!(spec.anchor, Anchor::Center);
+        assert_eq!(spec.offset, (0, 0));
+        assert_eq!(spec.style, TextStyle::default());
+    }
+}


### PR DESCRIPTION
## Objective

- The engine's first-class text clips (#1425) need a model-agnostic primitive that renders a text/title spec into a compositable frame, plus the pure `ff-format` types it consumes. Neither existed.

## Solution

- Add pure, FFmpeg-free `ff-format` types: an RGBA `Color` value, and `TextSpec` / `TextStyle` / `Anchor` describing a text layer's content, placement (an `Anchor` plus a pixel offset), and styling.
- Add `ff-filter` `TextSource`: it builds a source-only `FilterGraph` (transparent `color` source -> `format=rgba` -> `drawtext` -> `buffersink`, pulled via `pull_video`) and translates the pure spec into `drawtext` arguments (`Anchor` + offset to x/y expressions, `Color` to a `0xRRGGBB` token with opacity), reusing the existing `DrawText` argument rendering.
- Use the `color` filter source rather than the lavfi demuxer, so the primitive does not depend on the demuxer. It is model-agnostic: it takes only a spec plus the target canvas size and frame rate.
- Re-export the new types through `ff-filter` and `avio`. The render test is probe-gated (skips when the filters are unavailable), and otherwise asserts the frame dimensions and that pixels were drawn; the translation and type tests are build-independent.
- Unblocks #1425 (text clips consume the types + `TextSource`) and pairs with #1428 (the solid source reuses `Color`).

Closes #1427