### PR TITLE
feat(ff-filter): solid/color source primitive

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -304,8 +304,8 @@ pub use ff_filter::{
     FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LavfiSource,
     LensProfile, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer,
     NoiseType, ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer,
-    RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, StabilizeOptions, Stabilizer, TextSource,
-    ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, SolidSource, StabilizeOptions, Stabilizer,
+    TextSource, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };
 
 // ── pipeline feature ──────────────────────────────────────────────────────────

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -2686,3 +2686,122 @@ pub(super) unsafe fn build_text_source(
     log::info!("text source graph built canvas={width}x{height}");
     Ok(FilterGraph::from_prebuilt(inner))
 }
+
+// ── Solid color source graph (generated fill layer) ───────────────────────────
+
+/// Builds a source-only graph that generates a solid color layer:
+/// `color(<color_args>) → format=rgba → buffersink`. `color_args` is the full
+/// `color` filter argument string (`c=…:s=…:r=…`), built by the caller.
+///
+/// A strict subset of [`build_text_source`] (no `drawtext`). Uses the `color`
+/// filter source, not the lavfi demuxer. Pulled with [`FilterGraph::pull_video`];
+/// no `buffersrc` input.
+///
+/// # Safety
+///
+/// Follows the same avfilter ownership rules as [`build_video_composition`]: the
+/// returned graph owns every context it created.
+pub(super) unsafe fn build_solid_source(color_args: &str) -> Result<FilterGraph, FilterError> {
+    use std::ffi::CString;
+
+    macro_rules! bail {
+        ($graph:ident, $reason:expr) => {{
+            let mut g = $graph;
+            ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(FilterError::CompositionFailed {
+                reason: format!("{}", $reason),
+            });
+        }};
+    }
+
+    let graph = ff_sys::avfilter_graph_alloc();
+    if graph.is_null() {
+        return Err(FilterError::CompositionFailed {
+            reason: "avfilter_graph_alloc failed".to_string(),
+        });
+    }
+
+    // ── color source ──────────────────────────────────────────────────────────
+    let color_filter = ff_sys::avfilter_get_by_name(c"color".as_ptr());
+    if color_filter.is_null() {
+        bail!(graph, "filter not found: color");
+    }
+    let Ok(args) = CString::new(color_args) else {
+        bail!(graph, "CString::new failed for color filter args");
+    };
+    let mut color_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut color_ctx,
+        color_filter,
+        c"solid_base".as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create color source code={ret}"));
+    }
+
+    // ── format=rgba (preserve the fill's alpha) ───────────────────────────────
+    let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if fmt_filter.is_null() {
+        bail!(graph, "filter not found: format");
+    }
+    let mut fmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut fmt_ctx,
+        fmt_filter,
+        c"solid_fmt".as_ptr(),
+        c"pix_fmts=rgba".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(graph, format!("failed to create format filter code={ret}"));
+    }
+    let ret = ff_sys::avfilter_link(color_ctx, 0, fmt_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: color→format");
+    }
+
+    // ── buffersink ────────────────────────────────────────────────────────────
+    let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
+    if sink_filter.is_null() {
+        bail!(graph, "filter not found: buffersink");
+    }
+    let mut sink_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    let ret = ff_sys::avfilter_graph_create_filter(
+        &raw mut sink_ctx,
+        sink_filter,
+        c"solid_sink".as_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        graph,
+    );
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("failed to create solid buffersink code={ret}")
+        );
+    }
+    let ret = ff_sys::avfilter_link(fmt_ctx, 0, sink_ctx, 0);
+    if ret < 0 {
+        bail!(graph, "link failed: format→buffersink");
+    }
+
+    // ── Configure ─────────────────────────────────────────────────────────────
+    let ret = ff_sys::avfilter_graph_config(graph, std::ptr::null_mut());
+    if ret < 0 {
+        bail!(
+            graph,
+            format!("solid source avfilter_graph_config failed code={ret}")
+        );
+    }
+
+    // SAFETY: ret >= 0 guarantees both pointers are non-null.
+    let graph_nn = NonNull::new_unchecked(graph);
+    let sink_nn = NonNull::new_unchecked(sink_ctx);
+    let inner = FilterGraphInner::with_prebuilt_video_graph(graph_nn, sink_nn);
+    log::info!("solid source graph built args={color_args}");
+    Ok(FilterGraph::from_prebuilt(inner))
+}

--- a/crates/ff-filter/src/graph/composition/mod.rs
+++ b/crates/ff-filter/src/graph/composition/mod.rs
@@ -14,6 +14,7 @@ mod crossfade_joiner;
 mod multi_track_composer;
 mod multi_track_mixer;
 mod realtime_composer;
+mod solid_source;
 mod text_source;
 mod video_concatenator;
 
@@ -24,5 +25,6 @@ pub use multi_track_mixer::{AudioTrack, MultiTrackAudioMixer};
 pub use realtime_composer::{
     LavfiSource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,
 };
+pub use solid_source::SolidSource;
 pub use text_source::TextSource;
 pub use video_concatenator::VideoConcatenator;

--- a/crates/ff-filter/src/graph/composition/solid_source.rs
+++ b/crates/ff-filter/src/graph/composition/solid_source.rs
@@ -1,0 +1,80 @@
+//! Solid-color layer source primitive.
+//!
+//! [`SolidSource`] generates a solid-color `rgba` frame stream from a [`Color`]
+//! plus a canvas size and frame rate, with no timeline/track/clip knowledge. It
+//! backs the engine's solid color clips.
+
+#![allow(unsafe_code)]
+
+use ff_format::{Color, VideoFrame};
+
+use crate::error::FilterError;
+use crate::graph::graph::FilterGraph;
+
+/// Builds the `color` filter argument string for a solid fill.
+///
+/// `c=#RRGGBB@{alpha}:s={w}x{h}:r={fps}` (lowercase hex, alpha as `a/255`),
+/// mirroring the base-canvas color source in `build_video_composition`.
+fn solid_color_args(color: Color, width: u32, height: u32, fps: f64) -> String {
+    format!(
+        "c=#{:02x}{:02x}{:02x}@{:.3}:s={width}x{height}:r={fps}",
+        color.r,
+        color.g,
+        color.b,
+        f32::from(color.a) / 255.0,
+    )
+}
+
+/// Generates a solid-color `rgba` frame stream.
+///
+/// Frames are produced sequentially via [`pull`](Self::pull); the source exposes
+/// no seek, so a host that seeks rebuilds it. It is model-agnostic: it takes only
+/// a color plus the target canvas size and frame rate (a clip's duration is the
+/// consumer's concern, not the source's).
+pub struct SolidSource {
+    graph: FilterGraph,
+}
+
+impl SolidSource {
+    /// Builds a solid-color source for a `width × height` canvas at `fps`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] when the underlying `FFmpeg` graph cannot be built
+    /// (e.g. the `color` filter is unavailable).
+    pub fn new(color: Color, width: u32, height: u32, fps: f64) -> Result<Self, FilterError> {
+        let args = solid_color_args(color, width, height, fps);
+        // SAFETY: `build_solid_source` follows the avfilter ownership rules; the
+        // returned graph owns every context it created.
+        let graph = unsafe { super::composition_inner::build_solid_source(&args)? };
+        Ok(Self { graph })
+    }
+
+    /// Pulls the next generated frame (`rgba`), or `None` when none is buffered yet
+    /// or at end-of-stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] on an unexpected `FFmpeg` error.
+    pub fn pull(&mut self) -> Result<Option<VideoFrame>, FilterError> {
+        self.graph.pull_video()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::solid_color_args;
+    use ff_format::Color;
+
+    #[test]
+    fn opaque_red_should_map_to_color_args() {
+        let args = solid_color_args(Color::rgb(255, 0, 0), 320, 80, 30.0);
+        assert_eq!(args, "c=#ff0000@1.000:s=320x80:r=30");
+    }
+
+    #[test]
+    fn alpha_should_map_to_fraction() {
+        let args = solid_color_args(Color::rgba(0, 128, 255, 128), 16, 16, 25.0);
+        assert_eq!(args, "c=#0080ff@0.502:s=16x16:r=25");
+    }
+}

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -12,7 +12,7 @@ pub use builder::FilterGraphBuilder;
 pub use composition::{
     AudioConcatenator, AudioTrack, CrossfadeJoiner, LavfiSource, MultiTrackAudioMixer,
     MultiTrackComposer, ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,
-    TextSource, VideoConcatenator, VideoLayer,
+    SolidSource, TextSource, VideoConcatenator, VideoLayer,
 };
 pub use ffmpeg_token::FfmpegToken;
 pub use filter_step::FilterStep;

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -53,5 +53,5 @@ pub use graph::{
     AudioConcatenator, AudioTrack, CrossfadeJoiner, DrawTextOptions, EqBand, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, MultiTrackAudioMixer, MultiTrackComposer,
     ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb, ScaleAlgorithm,
-    TextSource, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    SolidSource, TextSource, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };

--- a/crates/ff-filter/tests/solid_source_tests.rs
+++ b/crates/ff-filter/tests/solid_source_tests.rs
@@ -1,0 +1,39 @@
+//! Integration tests for the solid/color layer source primitive.
+//!
+//! Probe-gated (RK-002): CI's Linux FFmpeg is built with no filters, so the
+//! `color` filter may be absent and `SolidSource::new` fails → skip. On a
+//! full-FFmpeg machine this renders a real frame.
+
+use ff_filter::SolidSource;
+use ff_format::Color;
+
+#[test]
+fn solid_source_should_render_filled_frame_at_requested_size() {
+    let mut src = match SolidSource::new(Color::rgb(255, 0, 0), 320, 80, 30.0) {
+        Ok(s) => s,
+        // Filter unavailable (CI's filterless FFmpeg) — the only legitimate skip.
+        Err(e) => {
+            println!("Skipping: SolidSource::new failed: {e}");
+            return;
+        }
+    };
+    match src.pull() {
+        Ok(Some(frame)) => {
+            assert_eq!(frame.width(), 320, "solid source width must match canvas");
+            assert_eq!(frame.height(), 80, "solid source height must match canvas");
+            // rgba: the requested red fill must reach the frame. Sample the centre
+            // pixel (row 40, col 160 → byte offset within plane 0).
+            let plane = frame.plane(0).expect("rgba frame must have plane 0");
+            let stride = plane.len() / 80; // bytes per row (>= width*4, may be padded)
+            let px = 40 * stride + 160 * 4;
+            let (r, g, b) = (plane[px], plane[px + 1], plane[px + 2]);
+            assert!(
+                r > 200 && g < 60 && b < 60,
+                "centre pixel must be the red fill, got rgb=({r},{g},{b})"
+            );
+        }
+        // The graph built, so it must produce a frame; no frame is an anomaly.
+        Ok(None) => panic!("solid source built but produced no frame"),
+        Err(e) => println!("Skipping: pull failed: {e}"),
+    }
+}


### PR DESCRIPTION
## Objective

- The engine's `ClipSource::Solid` (#1425) needs a model-agnostic primitive that generates a solid-color compositable frame, pairing with the text source (#1427).

## Solution

- Add `ff-filter` `SolidSource`: it builds a source-only `FilterGraph` (a `color` filter source at the requested size and frame rate -> `format=rgba` -> `buffersink`, pulled via `pull_video`), from a pure, unit-tested helper that formats the `color` filter arguments from an `ff_format::Color` plus the canvas size.
- The graph construction is a strict subset of the text source (no `drawtext`), and uses the `color` filter source rather than the lavfi demuxer, so it does not depend on the demuxer. It is model-agnostic: it takes only a color plus the target canvas size and frame rate.
- Re-export `SolidSource` through `ff-filter` and `avio`; reuse the `ff_format::Color` value type from #1427.
- The render test is probe-gated (skips when the `color` filter is unavailable), and otherwise asserts the frame dimensions and that the requested fill color reached the centre pixel; the argument-formatting test is build-independent.
- With #1427 (text source), this unblocks #1425 (`ClipSource::{File, Text, Solid}`).

Closes #1428