### PR TITLE
feat(avio): typed ClipSource and first-class text/solid clips

### DIFF
--- a/crates/avio/examples/filter/multi_track_compose.rs
+++ b/crates/avio/examples/filter/multi_track_compose.rs
@@ -22,8 +22,8 @@
 use std::{path::PathBuf, process};
 
 use avio::{
-    AnimatedValue, AudioCodec, AudioTrack, ChannelLayout, MultiTrackAudioMixer, MultiTrackComposer,
-    VideoCodec, VideoEncoder, VideoLayer,
+    AnimatedValue, AudioCodec, AudioTrack, ChannelLayout, LayerSource, MultiTrackAudioMixer,
+    MultiTrackComposer, VideoCodec, VideoEncoder, VideoLayer,
 };
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
@@ -89,9 +89,8 @@ fn main() {
 
     let mut video_graph = match MultiTrackComposer::new(args.width, args.height)
         .add_layer(VideoLayer {
-            source: args.base.clone(),
+            source: LayerSource::File(args.base.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -103,9 +102,8 @@ fn main() {
             effects: vec![],
         })
         .add_layer(VideoLayer {
-            source: args.overlay.clone(),
+            source: LayerSource::File(args.overlay.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(f64::from(overlay_x)),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(0.5),

--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -12,10 +12,26 @@ use ff_filter::{
     AnimationTrack, BlendMode, CompositeOp, FilterGraph, FilterStep, RealtimeLayer,
     RealtimeLayerDescriptor, XfadeTransition,
 };
-use ff_format::{PixelFormat, VideoFrame};
+use ff_format::{Color, PixelFormat, TextSpec, VideoFrame};
 
 use crate::error::TimelineError;
 use crate::ids::ClipId;
+
+/// The origin of a clip's frames.
+///
+/// A clip is either backed by a media file on disk or **generated** from a pure
+/// specification. Generated sources (`Text`/`Solid`) synthesize their frames at
+/// render time and carry no file, so they are infinite and require the clip's
+/// [`out_point`](Clip::out_point) to bound their duration.
+#[derive(Debug, Clone)]
+pub enum ClipSource {
+    /// A media file on disk (video, audio, or image), decoded at render time.
+    File(PathBuf),
+    /// A generated text/title layer rendered from a [`TextSpec`].
+    Text(TextSpec),
+    /// A generated solid-color fill.
+    Solid(Color),
+}
 
 /// How a clip's source frame is framed against the project canvas.
 ///
@@ -71,8 +87,8 @@ pub struct Clip {
     /// stamps a real id when the clip is added (via the builder or
     /// [`Command::AddClip`](crate::Command::AddClip)).
     pub id: ClipId,
-    /// Path to the source media file.
-    pub source: PathBuf,
+    /// Where this clip's frames come from: a media file or a generated source.
+    pub source: ClipSource,
     /// Start point within the source file. `None` = beginning of file.
     pub in_point: Option<Duration>,
     /// End point within the source file. `None` = end of file.
@@ -277,9 +293,46 @@ pub struct Clip {
 impl Clip {
     /// Creates a new clip from a source path with no trim points and zero timeline offset.
     pub fn new(source: impl AsRef<Path>) -> Self {
+        Self::from_source(ClipSource::File(source.as_ref().to_path_buf()))
+    }
+
+    /// Creates a new **text/title** clip from a [`TextSpec`], with no trim points
+    /// and zero timeline offset.
+    ///
+    /// A text clip is a generated source: it synthesizes frames at render time and
+    /// has no intrinsic duration, so an [`out_point`](Self::out_point) (e.g. via
+    /// [`trim`](Self::trim)) must bound it before the timeline is rendered.
+    pub fn text(spec: TextSpec) -> Self {
+        Self::from_source(ClipSource::Text(spec))
+    }
+
+    /// Creates a new **solid-color** clip from a [`Color`], with no trim points and
+    /// zero timeline offset.
+    ///
+    /// A solid clip is a generated source: it synthesizes frames at render time and
+    /// has no intrinsic duration, so an [`out_point`](Self::out_point) (e.g. via
+    /// [`trim`](Self::trim)) must bound it before the timeline is rendered.
+    pub fn solid(color: Color) -> Self {
+        Self::from_source(ClipSource::Solid(color))
+    }
+
+    /// Returns the source file path when this clip is backed by a file, or `None`
+    /// for a generated ([`Text`](ClipSource::Text)/[`Solid`](ClipSource::Solid))
+    /// source.
+    #[must_use]
+    pub fn source_path(&self) -> Option<&Path> {
+        match &self.source {
+            ClipSource::File(path) => Some(path.as_path()),
+            ClipSource::Text(_) | ClipSource::Solid(_) => None,
+        }
+    }
+
+    /// Shared constructor: builds a clip with the given source and every other
+    /// field at its default.
+    fn from_source(source: ClipSource) -> Self {
         Self {
             id: ClipId::UNSET,
-            source: source.as_ref().to_path_buf(),
+            source,
             in_point: None,
             out_point: None,
             offset: Duration::ZERO,
@@ -1338,6 +1391,41 @@ mod tests {
         use ff_filter::BlendMode;
         let clip = Clip::new("overlay.mp4").with_blend_mode(BlendMode::Screen);
         assert_eq!(clip.blend_mode, BlendMode::Screen);
+    }
+
+    #[test]
+    fn clip_new_source_should_be_a_file() {
+        let clip = Clip::new("video.mp4");
+        assert!(matches!(clip.source, ClipSource::File(_)));
+        assert_eq!(clip.source_path().and_then(Path::to_str), Some("video.mp4"));
+    }
+
+    #[test]
+    fn clip_text_source_should_be_a_text_variant() {
+        let clip = Clip::text(TextSpec::new("hello"));
+        match &clip.source {
+            ClipSource::Text(spec) => assert_eq!(spec.text, "hello"),
+            other => panic!("expected Text source, got {other:?}"),
+        }
+        assert_eq!(
+            clip.source_path(),
+            None,
+            "generated source has no file path"
+        );
+    }
+
+    #[test]
+    fn clip_solid_source_should_be_a_solid_variant() {
+        let clip = Clip::solid(Color::rgb(10, 20, 30));
+        match &clip.source {
+            ClipSource::Solid(color) => assert_eq!(*color, Color::rgb(10, 20, 30)),
+            other => panic!("expected Solid source, got {other:?}"),
+        }
+        assert_eq!(
+            clip.source_path(),
+            None,
+            "generated source has no file path"
+        );
     }
 
     #[test]

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -15,15 +15,16 @@
 //! #1351 (see `docs/specs/engine-and-primitives.md` §2.1).
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::time::Duration;
 
 use ff_filter::{
-    AnimatedValue, AnimationTrack, AudioTrack, BlendMode, CompositeOp, FilterStep, ProxySource,
-    RealtimeLayerDescriptor, ScaleAlgorithm, VideoLayer,
+    AnimatedValue, AnimationTrack, AudioTrack, BlendMode, CompositeOp, FilterStep, LayerSource,
+    ProxySource, RealtimeLayerDescriptor, ScaleAlgorithm, VideoLayer,
 };
 use ff_format::ChannelLayout;
 
-use crate::clip::{Clip, FitMode};
+use crate::clip::{Clip, ClipSource, FitMode};
 
 /// Resolves a track-level animation: `AnimatedValue::Track` when the map holds a
 /// track for `"{prefix}_{track_idx}_{prop}"`, else `Static(default)`.
@@ -218,11 +219,16 @@ pub(crate) fn video_layer(
         }
     }
 
+    // Pure model→primitive source mapping (no FFmpeg translation here).
+    let source = match &clip.source {
+        ClipSource::File(path) => LayerSource::File(path.clone()),
+        ClipSource::Text(spec) => LayerSource::Text(spec.clone()),
+        ClipSource::Solid(color) => LayerSource::Solid(*color),
+    };
     let transform = video_transform(clip, track_idx, animations);
     VideoLayer {
-        source: clip.source.clone(),
+        source,
         proxy,
-        input_format: None,
         x: transform.x,
         y: transform.y,
         scale_x: transform.scale_x,
@@ -244,8 +250,9 @@ pub(crate) fn video_layer(
 /// omitted because the preview runner realises them from `ScenePlacement` (in/out
 /// points, speed, transition).
 ///
-/// The timeline-level `lavfi_overlay` and a clip's `input_format` are not projected
-/// here (preview drops them today); closing that is C4d, not this backbone.
+/// The timeline-level `lavfi_overlay` and a clip's generated (Text/Solid) source
+/// are not projected here (preview drops them today); closing that is C4d, not this
+/// backbone.
 pub(crate) fn realtime_descriptor(
     clip: &Clip,
     track_idx: usize,
@@ -302,6 +309,12 @@ pub(crate) fn audio_track(
     fade_out_eff_dur: Option<Duration>,
 ) -> AudioTrack {
     let volume = audio_volume(clip, track_idx, animations);
+    // A generated (Text/Solid) clip has no audio and is never placed on an audio
+    // track; an empty path yields no audio, which is the intended no-op.
+    let source_path = clip
+        .source_path()
+        .map(Path::to_path_buf)
+        .unwrap_or_default();
 
     // Timeline trim + placement first, then speed/fade/effect steps, matching
     // the mixer node order (atrim → asetpts=PTS-STARTPTS → adelay).
@@ -356,13 +369,13 @@ pub(crate) fn audio_track(
                 log::warn!(
                     "fade_out ({:.3}s) >= clip duration — skipping fade_out for {}",
                     clip.fade_out.as_secs_f64(),
-                    clip.source.display(),
+                    source_path.display(),
                 );
             }
             None => {
                 log::warn!(
                     "cannot determine clip duration — skipping fade_out for {}",
-                    clip.source.display(),
+                    source_path.display(),
                 );
             }
         }
@@ -371,7 +384,7 @@ pub(crate) fn audio_track(
     effects.extend(clip.audio_effects.iter().cloned());
 
     AudioTrack {
-        source: clip.source.clone(),
+        source: source_path,
         volume,
         pan: track_animation(animations, "audio", track_idx, "pan", 0.0),
         effects,
@@ -392,6 +405,38 @@ mod tests {
     }
 
     // ── video_layer ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn video_layer_file_clip_should_map_to_file_source() {
+        let clip = Clip::new("a.mp4");
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        match layer.source {
+            LayerSource::File(path) => assert_eq!(path.to_str(), Some("a.mp4")),
+            other => panic!("expected File source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn video_layer_text_clip_should_map_to_text_source() {
+        use ff_format::TextSpec;
+        let clip = Clip::text(TextSpec::new("title"));
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        match layer.source {
+            LayerSource::Text(spec) => assert_eq!(spec.text, "title"),
+            other => panic!("expected Text source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn video_layer_solid_clip_should_map_to_solid_source() {
+        use ff_format::Color;
+        let clip = Clip::solid(Color::rgb(1, 2, 3));
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        match layer.source {
+            LayerSource::Solid(color) => assert_eq!(color, Color::rgb(1, 2, 3)),
+            other => panic!("expected Solid source, got {other:?}"),
+        }
+    }
 
     #[test]
     fn video_layer_trim_should_lead_with_trim_and_resetpts() {

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -309,8 +309,9 @@ pub(crate) fn audio_track(
     fade_out_eff_dur: Option<Duration>,
 ) -> AudioTrack {
     let volume = audio_volume(clip, track_idx, animations);
-    // A generated (Text/Solid) clip has no audio and is never placed on an audio
-    // track; an empty path yields no audio, which is the intended no-op.
+    // Generated (Text/Solid) clips carry no audio and are skipped by the render's
+    // audio loop before reaching here, so a File source is expected; the fallback
+    // to an empty path is defensive only.
     let source_path = clip
         .source_path()
         .map(Path::to_path_buf)

--- a/crates/avio/src/edit.rs
+++ b/crates/avio/src/edit.rs
@@ -570,7 +570,10 @@ mod tests {
         .unwrap();
         assert_eq!(out.video_tracks()[0].clips.len(), 2);
         let added = &out.video_tracks()[0].clips[1];
-        assert_eq!(added.source.to_str(), Some("added.mp4"));
+        assert_eq!(
+            added.source_path().and_then(std::path::Path::to_str),
+            Some("added.mp4")
+        );
         assert!(added.id.is_set());
         assert_ne!(added.id, clip_id(&t, 0), "new clip must get a distinct id");
     }
@@ -587,7 +590,9 @@ mod tests {
         .unwrap();
         assert_eq!(out.video_tracks()[0].clips.len(), 1);
         assert_eq!(
-            out.video_tracks()[0].clips[0].source.to_str(),
+            out.video_tracks()[0].clips[0]
+                .source_path()
+                .and_then(std::path::Path::to_str),
             Some("clip1.mp4")
         );
     }
@@ -999,7 +1004,10 @@ mod tests {
         )
         .unwrap();
         let c = &out.video_tracks()[0].clips[0];
-        assert_eq!(c.source.to_str(), Some("patched.mp4"));
+        assert_eq!(
+            c.source_path().and_then(std::path::Path::to_str),
+            Some("patched.mp4")
+        );
         assert!((c.brightness - 0.5).abs() < f32::EPSILON);
         assert_eq!(c.fade_in, Duration::from_secs(1));
         assert!((c.speed - 2.0).abs() < f64::EPSILON);
@@ -1021,7 +1029,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            out.video_tracks()[0].clips[0].source.to_str(),
+            out.video_tracks()[0].clips[0]
+                .source_path()
+                .and_then(std::path::Path::to_str),
             Some("patched.mp4")
         );
     }
@@ -1050,7 +1060,9 @@ mod tests {
         );
         // The original clip is untouched.
         assert_eq!(
-            t.video_tracks()[0].clips[0].source.to_str(),
+            t.video_tracks()[0].clips[0]
+                .source_path()
+                .and_then(std::path::Path::to_str),
             Some("clip0.mp4")
         );
     }
@@ -1089,7 +1101,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            out.audio_tracks()[0].clips[0].source.to_str(),
+            out.audio_tracks()[0].clips[0]
+                .source_path()
+                .and_then(std::path::Path::to_str),
             Some("patched.mp3")
         );
         assert_eq!(out.audio_tracks()[0].clips[0].id, id);
@@ -1442,9 +1456,15 @@ mod tests {
         let clips = &out.video_tracks()[0].clips;
         assert_eq!(clips.len(), 2);
         // `a` (offset 0) stays; `c` (was 8) shifts left by b's footprint (4) to 4.
-        assert_eq!(clips[0].source.to_str(), Some("a.mp4"));
+        assert_eq!(
+            clips[0].source_path().and_then(std::path::Path::to_str),
+            Some("a.mp4")
+        );
         assert_eq!(clips[0].offset, Duration::ZERO);
-        assert_eq!(clips[1].source.to_str(), Some("c.mp4"));
+        assert_eq!(
+            clips[1].source_path().and_then(std::path::Path::to_str),
+            Some("c.mp4")
+        );
         assert_eq!(clips[1].offset, Duration::from_secs(4));
     }
 
@@ -1510,7 +1530,10 @@ mod tests {
         let out = apply(&t, &Command::RippleDelete { clip: a_id }).unwrap();
         let clips = &out.video_tracks()[0].clips;
         assert_eq!(clips.len(), 1);
-        assert_eq!(clips[0].source.to_str(), Some("b.mp4"));
+        assert_eq!(
+            clips[0].source_path().and_then(std::path::Path::to_str),
+            Some("b.mp4")
+        );
         assert_eq!(
             clips[0].offset,
             Duration::from_secs(5),

--- a/crates/avio/src/editor.rs
+++ b/crates/avio/src/editor.rs
@@ -528,12 +528,16 @@ mod tests {
         })
         .unwrap();
         assert_eq!(
-            ed.current().video_tracks()[0].clips[0].source.to_str(),
+            ed.current().video_tracks()[0].clips[0]
+                .source_path()
+                .and_then(std::path::Path::to_str),
             Some("patched.mp4")
         );
         let prev = ed.undo().unwrap();
         assert_eq!(
-            prev.video_tracks()[0].clips[0].source.to_str(),
+            prev.video_tracks()[0].clips[0]
+                .source_path()
+                .and_then(std::path::Path::to_str),
             Some("a.mp4"),
             "undo restores the pre-patch clip"
         );

--- a/crates/avio/src/error.rs
+++ b/crates/avio/src/error.rs
@@ -49,6 +49,15 @@ pub enum TimelineError {
         /// Absolute or relative path that could not be found.
         path: String,
     },
+
+    /// A generated (`Text`/`Solid`) clip was placed on an active track without an
+    /// out-point.
+    ///
+    /// A generated source synthesizes frames indefinitely, so it has no intrinsic
+    /// end; the clip must set an [`out_point`](crate::Clip::out_point) (e.g. via
+    /// [`Clip::trim`](crate::Clip::trim)) to bound its duration before rendering.
+    #[error("generated source clip needs an out_point to bound its duration")]
+    GeneratedSourceNeedsDuration,
 }
 
 #[cfg(test)]

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -302,8 +302,8 @@ pub use ff_filter::{
     AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
     BlendMode, CompositeOp, CrossfadeJoiner, DrawTextOptions, Easing, EqBand, FilterError,
     FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LavfiSource,
-    LensProfile, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer,
-    NoiseType, ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer,
+    LayerSource, LensProfile, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer,
+    MultiTrackComposer, NoiseType, ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer,
     RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, SolidSource, StabilizeOptions, Stabilizer,
     TextSource, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };
@@ -334,7 +334,7 @@ mod timeline;
 mod track;
 
 #[cfg(feature = "pipeline")]
-pub use clip::{Clip, FitMode, VideoEffectRenderer};
+pub use clip::{Clip, ClipSource, FitMode, VideoEffectRenderer};
 #[cfg(feature = "pipeline")]
 pub use edit::{ClipProperty, Command, EditError, apply};
 #[cfg(feature = "pipeline")]

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -83,8 +83,9 @@ pub struct Timeline {
     pub(crate) audio_animations: HashMap<String, AnimationTrack<f64>>,
     /// Optional `lavfi` filtergraph string composited as the topmost video layer.
     ///
-    /// When set, a [`VideoLayer`] with `input_format = Some("lavfi")` is added above
-    /// all regular video tracks. Use `FFmpeg` `drawtext` syntax to render text titles:
+    /// When set, a [`VideoLayer`] whose source is
+    /// [`LayerSource::Lavfi`](ff_filter::LayerSource) is added above all regular
+    /// video tracks. Use `FFmpeg` `drawtext` syntax to render text titles:
     ///
     /// ```text
     /// color=s=1920x1080:c=black@0.0,drawtext=text='Hello':fontsize=48:fontcolor=white
@@ -193,6 +194,8 @@ impl Timeline {
     /// # Errors
     ///
     /// - [`TimelineError::ClipNotFound`] — a clip's source file is missing
+    /// - [`TimelineError::GeneratedSourceNeedsDuration`] — a generated (Text/Solid)
+    ///   clip on an active track has no `out_point` to bound its duration
     /// - [`TimelineError::Cancelled`] — `on_progress` returned `false`
     /// - [`TimelineError::Encode`] — encoder failure
     /// - [`TimelineError::Filter`] — filter graph construction failure
@@ -255,10 +258,22 @@ impl Timeline {
                 continue;
             }
             for clip in &track.clips {
-                if !clip.source.exists() {
-                    return Err(TimelineError::ClipNotFound {
-                        path: clip.source.to_string_lossy().into_owned(),
-                    });
+                match clip.source_path() {
+                    // File source: it must exist on disk.
+                    Some(path) => {
+                        if !path.exists() {
+                            return Err(TimelineError::ClipNotFound {
+                                path: path.to_string_lossy().into_owned(),
+                            });
+                        }
+                    }
+                    // Generated (Text/Solid) source: infinite, so an out_point is
+                    // required to bound its duration.
+                    None => {
+                        if clip.duration().is_none() {
+                            return Err(TimelineError::GeneratedSourceNeedsDuration);
+                        }
+                    }
                 }
             }
         }
@@ -314,23 +329,24 @@ impl Timeline {
                     // When a proxy is set, probe the original source resolution so
                     // the decoded proxy frames can be scaled back up to full size.
                     // If the probe fails the proxy is ignored (original used directly).
-                    let proxy =
-                        clip.proxy.as_ref().and_then(|proxy_path| {
-                            match VideoDecoder::open(&clip.source).build() {
-                                Ok(dec) => Some(ProxySource {
-                                    path: proxy_path.clone(),
-                                    width: dec.width(),
-                                    height: dec.height(),
-                                }),
-                                Err(e) => {
-                                    log::warn!(
-                                        "proxy ignored: cannot probe source {} resolution: {e}",
-                                        clip.source.display()
-                                    );
-                                    None
-                                }
+                    // A proxy is meaningful only for a file source (generated
+                    // sources are rendered at canvas size, nothing to probe).
+                    let proxy = clip.proxy.as_ref().zip(clip.source_path()).and_then(
+                        |(proxy_path, src)| match VideoDecoder::open(src).build() {
+                            Ok(dec) => Some(ProxySource {
+                                path: proxy_path.clone(),
+                                width: dec.width(),
+                                height: dec.height(),
+                            }),
+                            Err(e) => {
+                                log::warn!(
+                                    "proxy ignored: cannot probe source {} resolution: {e}",
+                                    src.display()
+                                );
+                                None
                             }
-                        });
+                        },
+                    );
 
                     // Per-clip editorial interpretation → layer lives in `derive`.
                     composer = composer.add_layer(derive::video_layer(
@@ -347,9 +363,9 @@ impl Timeline {
                     // transition on the same track can compute the correct offset.
                     let end_secs = match clip.duration() {
                         Some(d) => d.as_secs_f64(),
-                        None => VideoDecoder::open(&clip.source)
-                            .build()
-                            .ok()
+                        None => clip
+                            .source_path()
+                            .and_then(|src| VideoDecoder::open(src).build().ok())
                             .map_or(0.0, |d| {
                                 let total = d.duration().as_secs_f64();
                                 match clip.in_point {
@@ -363,11 +379,10 @@ impl Timeline {
             }
             // Lavfi overlay sits above all regular tracks.
             if let Some(ref lavfi_str) = lavfi_overlay {
-                use ff_filter::{BlendMode, CompositeOp};
+                use ff_filter::{BlendMode, CompositeOp, LayerSource};
                 composer = composer.add_layer(VideoLayer {
-                    source: std::path::PathBuf::from(lavfi_str),
+                    source: LayerSource::Lavfi(lavfi_str.clone()),
                     proxy: None,
-                    input_format: Some("lavfi".to_string()),
                     x: AnimatedValue::Static(0.0),
                     y: AnimatedValue::Static(0.0),
                     scale_x: AnimatedValue::Static(1.0),
@@ -398,13 +413,15 @@ impl Timeline {
                     // pure per-clip build lives in `derive`).
                     let fade_out_eff_dur = if clip.fade_out > Duration::ZERO {
                         clip.duration().or_else(|| {
-                            VideoDecoder::open(&clip.source).build().ok().map(|d| {
-                                let total = d.duration();
-                                match clip.in_point {
-                                    Some(ip) => total.saturating_sub(ip),
-                                    None => total,
-                                }
-                            })
+                            clip.source_path()
+                                .and_then(|src| VideoDecoder::open(src).build().ok())
+                                .map(|d| {
+                                    let total = d.duration();
+                                    match clip.in_point {
+                                        Some(ip) => total.saturating_sub(ip),
+                                        None => total,
+                                    }
+                                })
                         })
                     } else {
                         None
@@ -764,22 +781,30 @@ impl TimelineBuilder {
             || self.canvas_height.is_none()
             || self.frame_rate.is_none();
 
+        // Probe the first video clip when it is file-backed. A leading generated
+        // (Text/Solid) clip has no file to probe (`source_path()` is `None`), so
+        // the canvas falls through to the 1920x1080@30 default.
         if need_probe
-            && let Some(first_clip) = self.video_tracks.first().and_then(|t| t.clips.first())
+            && let Some(source) = self
+                .video_tracks
+                .first()
+                .and_then(|t| t.clips.first())
+                .and_then(|c| c.source_path())
         {
-            if !first_clip.source.exists() {
+            if !source.exists() {
                 return Err(TimelineError::ClipNotFound {
-                    path: first_clip.source.to_string_lossy().into_owned(),
+                    path: source.to_string_lossy().into_owned(),
                 });
             }
-            let vdec = VideoDecoder::open(&first_clip.source).build()?;
+            let vdec = VideoDecoder::open(source).build()?;
             let w = self.canvas_width.unwrap_or_else(|| vdec.width());
             let h = self.canvas_height.unwrap_or_else(|| vdec.height());
             let fps = self.frame_rate.unwrap_or_else(|| vdec.frame_rate());
             return Ok((w, h, fps));
         }
 
-        // All values explicit, or no video tracks (audio-only) — fall back for absent values.
+        // All values explicit, no video tracks (audio-only), or a leading
+        // generated clip with no file to probe — fall back for absent values.
         Ok((
             self.canvas_width.unwrap_or(1920),
             self.canvas_height.unwrap_or(1080),
@@ -811,7 +836,12 @@ fn video_placement(
     // actual xfade kind; overlays force no transition (matching the compositor).
     let xfade_kind = if is_base { clip.transition } else { None };
     ff_preview::ScenePlacement {
-        source: clip.source.clone(),
+        // Preview compositing of generated (Text/Solid) sources is deferred; a
+        // non-file clip projects an empty path (the preview runner renders nothing).
+        source: clip
+            .source_path()
+            .map(Path::to_path_buf)
+            .unwrap_or_default(),
         offset: clip.offset,
         in_point: clip.in_point.unwrap_or(Duration::ZERO),
         out_point: clip.out_point,
@@ -846,7 +876,10 @@ fn audio_placement(
     animations: &HashMap<String, AnimationTrack<f64>>,
 ) -> ff_preview::SceneAudioPlacement {
     ff_preview::SceneAudioPlacement {
-        source: clip.source.clone(),
+        source: clip
+            .source_path()
+            .map(Path::to_path_buf)
+            .unwrap_or_default(),
         offset: clip.offset,
         in_point: clip.in_point.unwrap_or(Duration::ZERO),
         out_point: clip.out_point,
@@ -1216,6 +1249,41 @@ mod tests {
     fn timeline_builder_should_err_when_no_tracks() {
         let result = Timeline::builder().build();
         assert!(matches!(result, Err(TimelineError::NoInput)));
+    }
+
+    #[test]
+    fn render_should_reject_generated_clip_without_out_point() {
+        use ff_format::TextSpec;
+        // A Text clip with no out_point is infinite; the render pre-check must
+        // reject it before touching FFmpeg (deterministic on any machine).
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::text(TextSpec::new("no out_point"))])
+            .build()
+            .unwrap();
+        let out = std::env::temp_dir().join("avio_generated_no_outpoint_test.mp4");
+        let result = timeline.render(out, EncoderConfig::builder().build());
+        assert!(matches!(
+            result,
+            Err(TimelineError::GeneratedSourceNeedsDuration)
+        ));
+    }
+
+    #[test]
+    fn build_should_default_canvas_when_first_clip_is_generated() {
+        use ff_format::Color;
+        // A leading generated clip has no file to probe, so the canvas falls
+        // through to the 1920x1080@30 default without any I/O.
+        let timeline = Timeline::builder()
+            .video_track(vec![
+                Clip::solid(Color::rgb(0, 0, 0)).trim(Duration::ZERO, Duration::from_secs(1)),
+            ])
+            .build()
+            .unwrap();
+        assert_eq!(timeline.canvas_width, 1920);
+        assert_eq!(timeline.canvas_height, 1080);
+        assert!((timeline.frame_rate - 30.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -268,9 +268,10 @@ impl Timeline {
                         }
                     }
                     // Generated (Text/Solid) source: infinite, so an out_point is
-                    // required to bound its duration.
+                    // required to bound its duration. Only out_point matters — the
+                    // derive emits `Trim { end }` from it (in_point may be unset).
                     None => {
-                        if clip.duration().is_none() {
+                        if clip.out_point.is_none() {
                             return Err(TimelineError::GeneratedSourceNeedsDuration);
                         }
                     }
@@ -408,6 +409,11 @@ impl Timeline {
                     continue;
                 }
                 for clip in &track.clips {
+                    // Generated (Text/Solid) clips carry no audio; skip them so a
+                    // non-File clip never yields an empty-path audio source.
+                    if clip.source_path().is_none() {
+                        continue;
+                    }
                     // Resolve the effective clip duration only when a fade-out
                     // needs it to compute its start offset (probing is I/O; the
                     // pure per-clip build lives in `derive`).
@@ -1268,6 +1274,30 @@ mod tests {
             result,
             Err(TimelineError::GeneratedSourceNeedsDuration)
         ));
+    }
+
+    #[test]
+    fn render_should_accept_generated_clip_with_out_point_only() {
+        use ff_format::Color;
+        // Only out_point bounds a generated source (in_point may be unset); the
+        // derive emits `Trim { end }` from it. The pre-check must NOT reject this
+        // valid, bounded clip. Deterministic on any machine: whatever the render
+        // outcome, it must not be GeneratedSourceNeedsDuration.
+        let mut clip = Clip::solid(Color::rgb(0, 0, 0));
+        clip.out_point = Some(Duration::from_secs(1));
+        assert!(clip.in_point.is_none());
+        let timeline = Timeline::builder()
+            .canvas(160, 90)
+            .frame_rate(30.0)
+            .video_track(vec![clip])
+            .build()
+            .unwrap();
+        let out = std::env::temp_dir().join("avio_generated_outpoint_only_test.mp4");
+        let result = timeline.render(out, EncoderConfig::builder().build());
+        assert!(
+            !matches!(result, Err(TimelineError::GeneratedSourceNeedsDuration)),
+            "an out_point-only generated clip must not be rejected"
+        );
     }
 
     #[test]

--- a/crates/avio/tests/timeline_tests.rs
+++ b/crates/avio/tests/timeline_tests.rs
@@ -421,3 +421,67 @@ fn timeline_with_volume_animation_should_encode_successfully() {
         "output must have non-zero duration"
     );
 }
+
+/// A timeline built entirely from generated (Solid + Text) clips renders to a
+/// probe-valid file with no source media on disk. Exercises the compositor's
+/// generated-source path (color/drawtext, not the lavfi demuxer — RK-013) end to
+/// end through the engine. Filter/encoder unavailable → skip (RK-002).
+#[test]
+fn timeline_render_generated_clips_should_produce_valid_output() {
+    use ff_format::{Color, TextSpec};
+
+    let out_path = test_output_path("timeline_generated_out.mp4");
+    let _g_out = FileGuard::new(out_path.clone());
+
+    // Generated sources are infinite; trim gives each a 1-second out_point.
+    let solid = Clip::solid(Color::rgb(0, 0, 255)).trim(Duration::ZERO, Duration::from_secs(1));
+    let text = Clip::text(TextSpec::new("title"))
+        .trim(Duration::ZERO, Duration::from_secs(1))
+        .with_opacity(0.8);
+
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![solid])
+        .video_track(vec![text])
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    match timeline.render(&out_path, render_config()) {
+        Ok(()) => {}
+        Err(TimelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+            return;
+        }
+        Err(TimelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+        Err(TimelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+            return;
+        }
+        Err(e) => panic!("unexpected error from Timeline::render: {e}"),
+    }
+
+    let info = match ff_probe::open(&out_path) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping: ff_probe::open failed: {e}");
+            return;
+        }
+    };
+    assert!(
+        info.has_video(),
+        "generated-clip render must contain a video stream"
+    );
+    let video = info.video_stream(0).expect("video stream must be present");
+    assert_eq!(video.width(), W, "output width must match canvas");
+    assert_eq!(video.height(), H, "output height must match canvas");
+}

--- a/crates/ff-filter/src/graph/builder/video/text.rs
+++ b/crates/ff-filter/src/graph/builder/video/text.rs
@@ -182,6 +182,36 @@ mod tests {
     }
 
     #[test]
+    fn filter_step_drawtext_should_escape_colon_in_fontfile() {
+        // A Windows-style drive-letter path must not be read as an option
+        // separator (which would break parsing and allow option injection).
+        let opts = DrawTextOptions {
+            font_file: Some("C:\\Windows\\Fonts\\arial.ttf".to_string()),
+            ..make_drawtext_opts()
+        };
+        let step = FilterStep::DrawText { opts };
+        let args = step.args();
+        assert!(
+            args.contains("fontfile=C\\:/Windows/Fonts/arial.ttf"),
+            "fontfile colon/backslash must be escaped/normalised: {args}"
+        );
+    }
+
+    #[test]
+    fn filter_step_drawtext_should_disable_text_expansion() {
+        // Text is drawn literally; `%{...}` expansion must be off so a user
+        // string cannot inject drawtext expansions.
+        let step = FilterStep::DrawText {
+            opts: make_drawtext_opts(),
+        };
+        let args = step.args();
+        assert!(
+            args.contains("expansion=none"),
+            "drawtext must disable text expansion: {args}"
+        );
+    }
+
+    #[test]
     fn filter_step_drawtext_should_escape_colon_in_text() {
         let opts = DrawTextOptions {
             text: "Time: 12:00".to_string(),

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -22,7 +22,7 @@ use crate::graph::filter_step::FilterStep;
 use crate::graph::graph::FilterGraph;
 use crate::graph::types::{DrawTextOptions, Rgb, ScaleAlgorithm};
 
-use super::multi_track_composer::VideoLayer;
+use super::multi_track_composer::{LayerSource, VideoLayer};
 use super::multi_track_mixer::AudioTrack;
 
 /// Maps a `BlendMode` to the `FFmpeg` `blend` filter `all_mode` name.
@@ -122,51 +122,66 @@ pub(super) unsafe fn build_video_composition(
     for (idx, layer) in layers.iter().enumerate() {
         let is_last = idx == layer_count - 1;
 
-        // ── movie= source ─────────────────────────────────────────────────────
-        let movie_filter = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
-        if movie_filter.is_null() {
-            bail!(graph, "filter not found: movie");
-        }
-        let Ok(movie_name) = CString::new(format!("movie{idx}")) else {
-            bail!(graph, "CString::new failed for movie name");
+        // ── Layer source node ─────────────────────────────────────────────────
+        // File/Lavfi decode through a `movie` source; Text/Solid synthesize their
+        // frames from `color`(+`drawtext`) nodes (RK-013: the lavfi *demuxer* is
+        // absent on dev/CI, so generated layers must not route through it).
+        let mut chain_end = match &layer.source {
+            LayerSource::File(path) => {
+                // Decode from the proxy file when one is set; otherwise the source.
+                let decode_path = match &layer.proxy {
+                    Some(p) => p.path.as_path(),
+                    None => path.as_path(),
+                };
+                let arg = decode_path
+                    .to_string_lossy()
+                    .replace('\\', "/")
+                    .replace(':', "\\:");
+                let Some(ctx) = add_movie(graph, idx, &format!("filename={arg}")) else {
+                    bail!(graph, format!("failed to build movie source layer={idx}"));
+                };
+                log::debug!("video composition layer={idx} movie source");
+                ctx
+            }
+            LayerSource::Lavfi(spec) => {
+                // A lavfi filtergraph string opened via FFmpeg's lavfi demuxer;
+                // escape "\" and ":" for the option parser.
+                let Some(ctx) = add_movie(graph, idx, &lavfi_movie_args(spec)) else {
+                    bail!(graph, format!("failed to build lavfi source layer={idx}"));
+                };
+                log::debug!("video composition layer={idx} lavfi source");
+                ctx
+            }
+            LayerSource::Solid(color) => {
+                let args = super::solid_source::solid_color_args(
+                    *color,
+                    canvas_width,
+                    canvas_height,
+                    frame_rate,
+                );
+                let Some(ctx) = add_color_rgba(graph, &format!("l{idx}"), &args) else {
+                    bail!(graph, format!("failed to build solid source layer={idx}"));
+                };
+                log::debug!("video composition layer={idx} solid source");
+                ctx
+            }
+            LayerSource::Text(spec) => {
+                let color_args =
+                    format!("c=black@0.0:s={canvas_width}x{canvas_height}:r={fps_str}");
+                let Some(base) = add_color_rgba(graph, &format!("l{idx}"), &color_args) else {
+                    bail!(graph, format!("failed to build text base layer={idx}"));
+                };
+                let dt_args = crate::FilterStep::DrawText {
+                    opts: super::text_source::spec_to_drawtext(spec),
+                }
+                .args();
+                let Some(ctx) = add_drawtext(graph, &format!("l{idx}"), base, &dt_args) else {
+                    bail!(graph, format!("failed to build text drawtext layer={idx}"));
+                };
+                log::debug!("video composition layer={idx} text source");
+                ctx
+            }
         };
-        // When input_format is "lavfi", source is a filtergraph string opened via
-        // FFmpeg's lavfi virtual demuxer; escape "\" and ":" for the option parser.
-        // For regular files, normalise Windows backslashes and escape the drive colon.
-        let movie_args_str = if layer.input_format.as_deref() == Some("lavfi") {
-            lavfi_movie_args(&layer.source.to_string_lossy())
-        } else {
-            // Decode from the proxy file when one is set; otherwise the original source.
-            let decode_path = match &layer.proxy {
-                Some(p) => p.path.as_path(),
-                None => layer.source.as_path(),
-            };
-            let path = decode_path
-                .to_string_lossy()
-                .replace('\\', "/")
-                .replace(':', "\\:");
-            format!("filename={path}")
-        };
-        let Ok(movie_args) = CString::new(movie_args_str) else {
-            bail!(graph, "CString::new failed for movie args");
-        };
-        let mut movie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-        let ret = ff_sys::avfilter_graph_create_filter(
-            &raw mut movie_ctx,
-            movie_filter,
-            movie_name.as_ptr(),
-            movie_args.as_ptr(),
-            std::ptr::null_mut(),
-            graph,
-        );
-        if ret < 0 {
-            bail!(
-                graph,
-                format!("failed to create movie filter layer={idx} code={ret}")
-            );
-        }
-        log::debug!("video composition layer={idx} movie source");
-        let mut chain_end = movie_ctx;
 
         // ── Proxy upscale ─────────────────────────────────────────────────────
         // When decoding from a proxy, scale the low-resolution frames up to the
@@ -2533,6 +2548,139 @@ pub(super) unsafe fn build_lavfi_source(lavfi: &str) -> Result<FilterGraph, Filt
     Ok(FilterGraph::from_prebuilt(inner))
 }
 
+// ── Generated-source node helpers (shared by the source graphs and the compositor)
+
+/// Creates a `movie` source node named `movie{idx}` with `movie_args` and
+/// returns it. Returns `None` on any failure; the caller owns and frees the
+/// graph.
+///
+/// # Safety
+///
+/// `graph` must be a valid `AVFilterGraph` the caller owns.
+unsafe fn add_movie(
+    graph: *mut ff_sys::AVFilterGraph,
+    idx: usize,
+    movie_args: &str,
+) -> Option<*mut ff_sys::AVFilterContext> {
+    use std::ffi::CString;
+
+    let movie_filter = ff_sys::avfilter_get_by_name(c"movie".as_ptr());
+    if movie_filter.is_null() {
+        return None;
+    }
+    let movie_name = CString::new(format!("movie{idx}")).ok()?;
+    let args = CString::new(movie_args).ok()?;
+    let mut movie_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    if ff_sys::avfilter_graph_create_filter(
+        &raw mut movie_ctx,
+        movie_filter,
+        movie_name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    ) < 0
+    {
+        return None;
+    }
+    Some(movie_ctx)
+}
+
+/// Creates a `color` source (`<color_args>`) followed by `format=rgba`, links
+/// them, and returns the `format` context. `tag` disambiguates the filter
+/// instance names. Returns `None` on any failure; the caller owns and frees the
+/// graph.
+///
+/// # Safety
+///
+/// `graph` must be a valid `AVFilterGraph` the caller owns.
+unsafe fn add_color_rgba(
+    graph: *mut ff_sys::AVFilterGraph,
+    tag: &str,
+    color_args: &str,
+) -> Option<*mut ff_sys::AVFilterContext> {
+    use std::ffi::CString;
+
+    let color_filter = ff_sys::avfilter_get_by_name(c"color".as_ptr());
+    if color_filter.is_null() {
+        return None;
+    }
+    let color_name = CString::new(format!("color_{tag}")).ok()?;
+    let args = CString::new(color_args).ok()?;
+    let mut color_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    if ff_sys::avfilter_graph_create_filter(
+        &raw mut color_ctx,
+        color_filter,
+        color_name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    ) < 0
+    {
+        return None;
+    }
+
+    let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
+    if fmt_filter.is_null() {
+        return None;
+    }
+    let fmt_name = CString::new(format!("fmt_{tag}")).ok()?;
+    let mut fmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    if ff_sys::avfilter_graph_create_filter(
+        &raw mut fmt_ctx,
+        fmt_filter,
+        fmt_name.as_ptr(),
+        c"pix_fmts=rgba".as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    ) < 0
+    {
+        return None;
+    }
+    if ff_sys::avfilter_link(color_ctx, 0, fmt_ctx, 0) < 0 {
+        return None;
+    }
+    Some(fmt_ctx)
+}
+
+/// Creates a `drawtext` node fed by `prev` and returns it. `dt_args` is the full
+/// drawtext argument string; `tag` disambiguates the name. Returns `None` on
+/// failure; the caller owns and frees the graph.
+///
+/// # Safety
+///
+/// `graph` and `prev` must be valid pointers owned by the same `AVFilterGraph`.
+unsafe fn add_drawtext(
+    graph: *mut ff_sys::AVFilterGraph,
+    tag: &str,
+    prev: *mut ff_sys::AVFilterContext,
+    dt_args: &str,
+) -> Option<*mut ff_sys::AVFilterContext> {
+    use std::ffi::CString;
+
+    let filter = ff_sys::avfilter_get_by_name(c"drawtext".as_ptr());
+    if filter.is_null() {
+        return None;
+    }
+    let name = CString::new(format!("draw_{tag}")).ok()?;
+    let args = CString::new(dt_args).ok()?;
+    let mut ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+    if ff_sys::avfilter_graph_create_filter(
+        &raw mut ctx,
+        filter,
+        name.as_ptr(),
+        args.as_ptr(),
+        std::ptr::null_mut(),
+        graph,
+    ) < 0
+    {
+        return None;
+    }
+    if ff_sys::avfilter_link(prev, 0, ctx, 0) < 0 {
+        return None;
+    }
+    Some(ctx)
+}
+
 // ── Text layer source graph (generated title/caption layer) ───────────────────
 
 /// Builds a source-only graph that renders a text layer onto a transparent canvas:
@@ -2553,8 +2701,6 @@ pub(super) unsafe fn build_text_source(
     height: u32,
     fps: f64,
 ) -> Result<FilterGraph, FilterError> {
-    use std::ffi::CString;
-
     macro_rules! bail {
         ($graph:ident, $reason:expr) => {{
             let mut g = $graph;
@@ -2572,78 +2718,15 @@ pub(super) unsafe fn build_text_source(
         });
     }
 
-    // ── color source (transparent base canvas) ────────────────────────────────
-    let color_filter = ff_sys::avfilter_get_by_name(c"color".as_ptr());
-    if color_filter.is_null() {
-        bail!(graph, "filter not found: color");
-    }
-    let color_args_str = format!("c=black@0.0:s={width}x{height}:r={fps}");
-    let Ok(color_args) = CString::new(color_args_str.as_str()) else {
-        bail!(graph, "CString::new failed for color filter args");
+    // color(transparent) → format=rgba → drawtext (shared node helpers).
+    let color_args = format!("c=black@0.0:s={width}x{height}:r={fps}");
+    let Some(fmt_ctx) = add_color_rgba(graph, "text", &color_args) else {
+        bail!(graph, "failed to build color/format source");
     };
-    let mut color_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-    let ret = ff_sys::avfilter_graph_create_filter(
-        &raw mut color_ctx,
-        color_filter,
-        c"text_base".as_ptr(),
-        color_args.as_ptr(),
-        std::ptr::null_mut(),
-        graph,
-    );
-    if ret < 0 {
-        bail!(graph, format!("failed to create color source code={ret}"));
-    }
-
-    // ── format=rgba (establish the transparent alpha canvas) ──────────────────
-    let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
-    if fmt_filter.is_null() {
-        bail!(graph, "filter not found: format");
-    }
-    let mut fmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-    let ret = ff_sys::avfilter_graph_create_filter(
-        &raw mut fmt_ctx,
-        fmt_filter,
-        c"text_fmt".as_ptr(),
-        c"pix_fmts=rgba".as_ptr(),
-        std::ptr::null_mut(),
-        graph,
-    );
-    if ret < 0 {
-        bail!(graph, format!("failed to create format filter code={ret}"));
-    }
-    let ret = ff_sys::avfilter_link(color_ctx, 0, fmt_ctx, 0);
-    if ret < 0 {
-        bail!(graph, "link failed: color→format");
-    }
-
-    // ── drawtext (reuse the FilterStep arg rendering) ─────────────────────────
-    let drawtext_filter = ff_sys::avfilter_get_by_name(c"drawtext".as_ptr());
-    if drawtext_filter.is_null() {
-        bail!(graph, "filter not found: drawtext");
-    }
-    let dt_args_str = FilterStep::DrawText { opts: opts.clone() }.args();
-    let Ok(dt_args) = CString::new(dt_args_str.as_str()) else {
-        bail!(graph, "CString::new failed for drawtext args");
+    let dt_args = FilterStep::DrawText { opts: opts.clone() }.args();
+    let Some(dt_ctx) = add_drawtext(graph, "text", fmt_ctx, &dt_args) else {
+        bail!(graph, "failed to build drawtext node");
     };
-    let mut dt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-    let ret = ff_sys::avfilter_graph_create_filter(
-        &raw mut dt_ctx,
-        drawtext_filter,
-        c"text_draw".as_ptr(),
-        dt_args.as_ptr(),
-        std::ptr::null_mut(),
-        graph,
-    );
-    if ret < 0 {
-        bail!(
-            graph,
-            format!("failed to create drawtext filter code={ret}")
-        );
-    }
-    let ret = ff_sys::avfilter_link(fmt_ctx, 0, dt_ctx, 0);
-    if ret < 0 {
-        bail!(graph, "link failed: format→drawtext");
-    }
 
     // ── buffersink ────────────────────────────────────────────────────────────
     let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());
@@ -2702,8 +2785,6 @@ pub(super) unsafe fn build_text_source(
 /// Follows the same avfilter ownership rules as [`build_video_composition`]: the
 /// returned graph owns every context it created.
 pub(super) unsafe fn build_solid_source(color_args: &str) -> Result<FilterGraph, FilterError> {
-    use std::ffi::CString;
-
     macro_rules! bail {
         ($graph:ident, $reason:expr) => {{
             let mut g = $graph;
@@ -2721,48 +2802,10 @@ pub(super) unsafe fn build_solid_source(color_args: &str) -> Result<FilterGraph,
         });
     }
 
-    // ── color source ──────────────────────────────────────────────────────────
-    let color_filter = ff_sys::avfilter_get_by_name(c"color".as_ptr());
-    if color_filter.is_null() {
-        bail!(graph, "filter not found: color");
-    }
-    let Ok(args) = CString::new(color_args) else {
-        bail!(graph, "CString::new failed for color filter args");
+    // color(<args>) → format=rgba (shared node helper).
+    let Some(fmt_ctx) = add_color_rgba(graph, "solid", color_args) else {
+        bail!(graph, "failed to build color/format source");
     };
-    let mut color_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-    let ret = ff_sys::avfilter_graph_create_filter(
-        &raw mut color_ctx,
-        color_filter,
-        c"solid_base".as_ptr(),
-        args.as_ptr(),
-        std::ptr::null_mut(),
-        graph,
-    );
-    if ret < 0 {
-        bail!(graph, format!("failed to create color source code={ret}"));
-    }
-
-    // ── format=rgba (preserve the fill's alpha) ───────────────────────────────
-    let fmt_filter = ff_sys::avfilter_get_by_name(c"format".as_ptr());
-    if fmt_filter.is_null() {
-        bail!(graph, "filter not found: format");
-    }
-    let mut fmt_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
-    let ret = ff_sys::avfilter_graph_create_filter(
-        &raw mut fmt_ctx,
-        fmt_filter,
-        c"solid_fmt".as_ptr(),
-        c"pix_fmts=rgba".as_ptr(),
-        std::ptr::null_mut(),
-        graph,
-    );
-    if ret < 0 {
-        bail!(graph, format!("failed to create format filter code={ret}"));
-    }
-    let ret = ff_sys::avfilter_link(color_ctx, 0, fmt_ctx, 0);
-    if ret < 0 {
-        bail!(graph, "link failed: color→format");
-    }
 
     // ── buffersink ────────────────────────────────────────────────────────────
     let sink_filter = ff_sys::avfilter_get_by_name(c"buffersink".as_ptr());

--- a/crates/ff-filter/src/graph/composition/mod.rs
+++ b/crates/ff-filter/src/graph/composition/mod.rs
@@ -20,7 +20,7 @@ mod video_concatenator;
 
 pub use audio_concatenator::AudioConcatenator;
 pub use crossfade_joiner::CrossfadeJoiner;
-pub use multi_track_composer::{MultiTrackComposer, ProxySource, VideoLayer};
+pub use multi_track_composer::{LayerSource, MultiTrackComposer, ProxySource, VideoLayer};
 pub use multi_track_mixer::{AudioTrack, MultiTrackAudioMixer};
 pub use realtime_composer::{
     LavfiSource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,

--- a/crates/ff-filter/src/graph/composition/multi_track_composer.rs
+++ b/crates/ff-filter/src/graph/composition/multi_track_composer.rs
@@ -4,12 +4,34 @@
 
 use std::path::PathBuf;
 
+use ff_format::{Color, TextSpec};
+
 use crate::animation::AnimatedValue;
 use crate::blend::BlendMode;
 use crate::composite::CompositeOp;
 use crate::error::FilterError;
 use crate::graph::graph::FilterGraph;
 use crate::graph::types::Rgb;
+
+// ── LayerSource ───────────────────────────────────────────────────────────────
+
+/// The source of a composited [`VideoLayer`]'s frames.
+///
+/// `File`/`Lavfi` are opened via the `movie` filter (a media file, or a `lavfi`
+/// filtergraph string via the lavfi demuxer). `Text`/`Solid` are **generated**
+/// inline via the `color` filter source (and `drawtext` for text), so they render
+/// without any file or the lavfi demuxer.
+#[derive(Debug, Clone)]
+pub enum LayerSource {
+    /// A media file opened via `movie=filename=<path>`.
+    File(PathBuf),
+    /// A `lavfi` filtergraph string opened via `movie=<str>:format_name=lavfi`.
+    Lavfi(String),
+    /// A generated text/title layer over a transparent canvas.
+    Text(TextSpec),
+    /// A generated solid-color fill.
+    Solid(Color),
+}
 
 // ── ProxySource ───────────────────────────────────────────────────────────────
 
@@ -47,23 +69,16 @@ pub struct ProxySource {
 /// the value at `Duration::ZERO`; per-frame updates are added in issue #363.
 #[derive(Debug, Clone)]
 pub struct VideoLayer {
-    /// Source media file path, or a `lavfi` filtergraph string when
-    /// [`input_format`](Self::input_format) is `Some("lavfi")`.
-    pub source: PathBuf,
+    /// Where this layer's frames come from (a file, a `lavfi` string, or a
+    /// generated text/solid source).
+    pub source: LayerSource,
     /// Optional low-resolution proxy to decode from instead of `source`.
     ///
     /// When `Some`, frames are decoded from the proxy and scaled up to the
     /// original source resolution before trim/effects/compositing, so the
-    /// output is identical in size to a non-proxy render. Ignored when
-    /// [`input_format`](Self::input_format) is `Some("lavfi")`.
+    /// output is identical in size to a non-proxy render. Only meaningful for a
+    /// [`LayerSource::File`] source.
     pub proxy: Option<ProxySource>,
-    /// Optional `FFmpeg` input format name passed to the `movie` filter.
-    ///
-    /// When `Some("lavfi")`, `source` is interpreted as a filtergraph string
-    /// (e.g. `"color=s=1920x1080:c=black@0.0,drawtext=text='Title'"`) and opened
-    /// via `FFmpeg`'s `lavfi` virtual demuxer. When `None` (the default), `source`
-    /// is opened as an ordinary media file.
-    pub input_format: Option<String>,
     /// X offset on the canvas in pixels (top-left origin).
     pub x: AnimatedValue<f64>,
     /// Y offset on the canvas in pixels.
@@ -120,13 +135,12 @@ pub struct VideoLayer {
 /// # Examples
 ///
 /// ```ignore
-/// use ff_filter::{AnimatedValue, MultiTrackComposer, VideoLayer};
+/// use ff_filter::{AnimatedValue, LayerSource, MultiTrackComposer, VideoLayer};
 ///
 /// let mut graph = MultiTrackComposer::new(1920, 1080)
 ///     .add_layer(VideoLayer {
-///         source: "clip.mp4".into(),
+///         source: LayerSource::File("clip.mp4".into()),
 ///         proxy: None,
-///         input_format: None,
 ///         x: AnimatedValue::Static(0.0),
 ///         y: AnimatedValue::Static(0.0),
 ///         scale_x: AnimatedValue::Static(1.0),
@@ -258,9 +272,8 @@ mod tests {
         // width = 0
         let result = MultiTrackComposer::new(0, 1080)
             .add_layer(VideoLayer {
-                source: "clip.mp4".into(),
+                source: LayerSource::File("clip.mp4".into()),
                 proxy: None,
-                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -280,9 +293,8 @@ mod tests {
         // height = 0
         let result = MultiTrackComposer::new(1920, 0)
             .add_layer(VideoLayer {
-                source: "clip.mp4".into(),
+                source: LayerSource::File("clip.mp4".into()),
                 proxy: None,
-                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -310,9 +322,8 @@ mod tests {
         // not found), not because of canvas size.
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
-                source: "nonexistent_640x480.mp4".into(),
+                source: LayerSource::File("nonexistent_640x480.mp4".into()),
                 proxy: None,
-                input_format: None,
                 x: AnimatedValue::Static(100.0),
                 y: AnimatedValue::Static(100.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -349,13 +360,12 @@ mod tests {
         // file) but must NOT fail at "filter not found: scale".
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
-                source: "nonexistent.mp4".into(),
+                source: LayerSource::File("nonexistent.mp4".into()),
                 proxy: Some(ProxySource {
                     path: "nonexistent_proxy_quarter.mp4".into(),
                     width: 1920,
                     height: 1080,
                 }),
-                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -383,9 +393,8 @@ mod tests {
         // "filter not found: setpts".
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
-                source: "nonexistent.mp4".into(),
+                source: LayerSource::File("nonexistent.mp4".into()),
                 proxy: None,
-                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),
@@ -411,9 +420,8 @@ mod tests {
         // A layer whose effects carry no Trim/OffsetPts inserts no `setpts` node.
         let result = MultiTrackComposer::new(1920, 1080)
             .add_layer(VideoLayer {
-                source: "nonexistent.mp4".into(),
+                source: LayerSource::File("nonexistent.mp4".into()),
                 proxy: None,
-                input_format: None,
                 x: AnimatedValue::Static(0.0),
                 y: AnimatedValue::Static(0.0),
                 scale_x: AnimatedValue::Static(1.0),

--- a/crates/ff-filter/src/graph/composition/solid_source.rs
+++ b/crates/ff-filter/src/graph/composition/solid_source.rs
@@ -15,7 +15,7 @@ use crate::graph::graph::FilterGraph;
 ///
 /// `c=#RRGGBB@{alpha}:s={w}x{h}:r={fps}` (lowercase hex, alpha as `a/255`),
 /// mirroring the base-canvas color source in `build_video_composition`.
-fn solid_color_args(color: Color, width: u32, height: u32, fps: f64) -> String {
+pub(super) fn solid_color_args(color: Color, width: u32, height: u32, fps: f64) -> String {
     format!(
         "c=#{:02x}{:02x}{:02x}@{:.3}:s={width}x{height}:r={fps}",
         color.r,

--- a/crates/ff-filter/src/graph/composition/text_source.rs
+++ b/crates/ff-filter/src/graph/composition/text_source.rs
@@ -47,7 +47,7 @@ fn anchor_exprs(anchor: Anchor, offset: (i32, i32)) -> (String, String) {
 }
 
 /// Translates a pure [`TextSpec`] into the FFmpeg-flavoured [`DrawTextOptions`].
-fn spec_to_drawtext(spec: &TextSpec) -> DrawTextOptions {
+pub(super) fn spec_to_drawtext(spec: &TextSpec) -> DrawTextOptions {
     let (x, y) = anchor_exprs(spec.anchor, spec.offset);
     let style = &spec.style;
     DrawTextOptions {

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -1367,13 +1367,23 @@ impl FilterStep {
                     .replace('\'', "\\'");
                 let mut parts = vec![
                     format!("text='{escaped}'"),
+                    // The text is drawn literally; disable `%{...}` expansion so a
+                    // user string cannot inject drawtext expansions (`%{gmtime}`, ...).
+                    "expansion=none".to_string(),
                     format!("x={}", opts.x),
                     format!("y={}", opts.y),
                     format!("fontsize={}", opts.font_size),
                     format!("fontcolor={}@{:.2}", opts.font_color, opts.opacity),
                 ];
                 if let Some(ref ff) = opts.font_file {
-                    parts.push(format!("fontfile={ff}"));
+                    // Escape like a filter path: an unescaped `:` (e.g. a Windows
+                    // drive letter) would be read as an option separator and could
+                    // inject drawtext options (`textfile=`, ...).
+                    let ff_escaped = ff
+                        .replace('\\', "/")
+                        .replace(':', "\\:")
+                        .replace('\'', "\\'");
+                    parts.push(format!("fontfile={ff_escaped}"));
                 }
                 if let Some(ref bc) = opts.box_color {
                     parts.push("box=1".to_string());

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -10,7 +10,7 @@ pub mod types;
 
 pub use builder::FilterGraphBuilder;
 pub use composition::{
-    AudioConcatenator, AudioTrack, CrossfadeJoiner, LavfiSource, MultiTrackAudioMixer,
+    AudioConcatenator, AudioTrack, CrossfadeJoiner, LavfiSource, LayerSource, MultiTrackAudioMixer,
     MultiTrackComposer, ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor,
     SolidSource, TextSource, VideoConcatenator, VideoLayer,
 };

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -51,7 +51,8 @@ pub use error::FilterError;
 pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::{
     AudioConcatenator, AudioTrack, CrossfadeJoiner, DrawTextOptions, EqBand, FilterGraph,
-    FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, MultiTrackAudioMixer, MultiTrackComposer,
-    ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb, ScaleAlgorithm,
-    SolidSource, TextSource, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, LayerSource, MultiTrackAudioMixer,
+    MultiTrackComposer, ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb,
+    ScaleAlgorithm, SolidSource, TextSource, ToneMap, VideoConcatenator, VideoLayer,
+    XfadeTransition, YadifMode,
 };

--- a/crates/ff-filter/tests/animation_integration_test.rs
+++ b/crates/ff-filter/tests/animation_integration_test.rs
@@ -12,7 +12,7 @@ mod fixtures;
 use std::time::Duration;
 
 use ff_filter::{
-    AnimatedValue, MultiTrackComposer, VideoLayer,
+    AnimatedValue, LayerSource, MultiTrackComposer, VideoLayer,
     animation::{AnimationTrack, Easing, Keyframe},
 };
 use fixtures::{FileGuard, make_source_file, test_output_path};
@@ -146,9 +146,8 @@ fn bezier_position_animation_should_match_reference_curve() {
 
     let mut composer = match MultiTrackComposer::new(CANVAS_W, CANVAS_H)
         .add_layer(VideoLayer {
-            source: bg_path.clone(),
+            source: LayerSource::File(bg_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -160,9 +159,8 @@ fn bezier_position_animation_should_match_reference_curve() {
             effects: vec![],
         })
         .add_layer(VideoLayer {
-            source: marker_path.clone(),
+            source: LayerSource::File(marker_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Track(bezier_track),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use ff_encode::{AudioCodec, AudioEncoder, VideoCodec, VideoEncoder};
 use ff_filter::{
-    AnimatedValue, AudioConcatenator, AudioTrack, FilterStep, MultiTrackAudioMixer,
+    AnimatedValue, AudioConcatenator, AudioTrack, FilterStep, LayerSource, MultiTrackAudioMixer,
     MultiTrackComposer, VideoConcatenator, VideoLayer, XfadeTransition,
     animation::{AnimationTrack, Easing, Keyframe},
 };
@@ -81,9 +81,8 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
     // ── Step 2: build MultiTrackComposer with three layers ─────────────────────
     let mut composer = match MultiTrackComposer::new(CANVAS_W, CANVAS_H)
         .add_layer(VideoLayer {
-            source: src1_path.clone(),
+            source: LayerSource::File(src1_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -95,9 +94,8 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             effects: vec![],
         })
         .add_layer(VideoLayer {
-            source: src2_path.clone(),
+            source: LayerSource::File(src2_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(160.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -109,9 +107,8 @@ fn multi_track_composition_should_produce_valid_mp4_output() {
             effects: vec![],
         })
         .add_layer(VideoLayer {
-            source: src3_path.clone(),
+            source: LayerSource::File(src3_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(134.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -551,9 +548,8 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
 
     let mut composer = match MultiTrackComposer::new(W, H)
         .add_layer(VideoLayer {
-            source: bg_path.clone(),
+            source: LayerSource::File(bg_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -565,9 +561,8 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
             effects: vec![],
         })
         .add_layer(VideoLayer {
-            source: layer_path.clone(),
+            source: LayerSource::File(layer_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -816,9 +811,8 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
 
     let mut composer = match MultiTrackComposer::new(W, H)
         .add_layer(VideoLayer {
-            source: src_path.clone(),
+            source: LayerSource::File(src_path.clone()),
             proxy: None,
-            input_format: None,
             x: AnimatedValue::Static(0.0),
             y: AnimatedValue::Static(0.0),
             scale_x: AnimatedValue::Static(1.0),
@@ -867,9 +861,8 @@ fn multi_track_composition_should_produce_yuv420p_frames() {
 #[test]
 fn composite_op_in_layer_should_build_and_produce_frame() {
     let layer = VideoLayer {
-        source: "color=c=white:s=64x64:r=25:d=1".into(),
+        source: LayerSource::Lavfi("color=c=white:s=64x64:r=25:d=1".to_string()),
         proxy: None,
-        input_format: Some("lavfi".to_string()),
         x: AnimatedValue::Static(0.0),
         y: AnimatedValue::Static(0.0),
         scale_x: AnimatedValue::Static(1.0),
@@ -913,9 +906,8 @@ fn composite_op_in_layer_should_build_and_produce_frame() {
 #[test]
 fn composite_op_under_layer_with_opacity_should_build_and_produce_frame() {
     let layer = VideoLayer {
-        source: "color=c=white:s=64x64:r=25:d=1".into(),
+        source: LayerSource::Lavfi("color=c=white:s=64x64:r=25:d=1".to_string()),
         proxy: None,
-        input_format: Some("lavfi".to_string()),
         x: AnimatedValue::Static(0.0),
         y: AnimatedValue::Static(0.0),
         scale_x: AnimatedValue::Static(1.0),
@@ -961,9 +953,8 @@ fn composite_op_under_layer_with_opacity_should_build_and_produce_frame() {
 #[test]
 fn trim_and_offset_effects_should_build_and_produce_frame() {
     let layer = VideoLayer {
-        source: "color=c=white:s=64x64:r=25:d=2".into(),
+        source: LayerSource::Lavfi("color=c=white:s=64x64:r=25:d=2".to_string()),
         proxy: None,
-        input_format: Some("lavfi".to_string()),
         x: AnimatedValue::Static(0.0),
         y: AnimatedValue::Static(0.0),
         scale_x: AnimatedValue::Static(1.0),
@@ -1057,9 +1048,8 @@ fn audio_trim_and_offset_effects_should_build_mix_and_pull() {
 #[test]
 fn xfade_effect_layer_should_build_and_produce_frame() {
     let layer_a = VideoLayer {
-        source: "color=c=red:s=64x64:r=25:d=2".into(),
+        source: LayerSource::Lavfi("color=c=red:s=64x64:r=25:d=2".to_string()),
         proxy: None,
-        input_format: Some("lavfi".to_string()),
         x: AnimatedValue::Static(0.0),
         y: AnimatedValue::Static(0.0),
         scale_x: AnimatedValue::Static(1.0),
@@ -1071,9 +1061,8 @@ fn xfade_effect_layer_should_build_and_produce_frame() {
         effects: vec![],
     };
     let layer_b = VideoLayer {
-        source: "color=c=blue:s=64x64:r=25:d=2".into(),
+        source: LayerSource::Lavfi("color=c=blue:s=64x64:r=25:d=2".to_string()),
         proxy: None,
-        input_format: Some("lavfi".to_string()),
         x: AnimatedValue::Static(0.0),
         y: AnimatedValue::Static(0.0),
         scale_x: AnimatedValue::Static(1.0),
@@ -1105,6 +1094,51 @@ fn xfade_effect_layer_should_build_and_produce_frame() {
             assert_eq!(frame.height(), 64, "xfade must not change frame height");
         }
         Ok(None) => println!("Skipping: xfade graph produced no frame"),
+        Err(e) => println!("Skipping: pull_video failed: {e}"),
+    }
+}
+
+/// A generated Solid layer and a generated Text layer compose in one multi-layer
+/// graph and produce a canvas-sized frame. Generated sources build from the
+/// `color`(+`drawtext`) filter nodes, not the lavfi demuxer (RK-013), so this
+/// verifies the compositor's generated-source path end to end. `build`/`pull`
+/// failure → skip (RK-002).
+#[test]
+fn generated_solid_and_text_layers_should_compose_and_produce_frame() {
+    use ff_format::{Color, TextSpec};
+
+    let base = |source: LayerSource| VideoLayer {
+        source,
+        proxy: None,
+        x: AnimatedValue::Static(0.0),
+        y: AnimatedValue::Static(0.0),
+        scale_x: AnimatedValue::Static(1.0),
+        scale_y: AnimatedValue::Static(1.0),
+        rotation: AnimatedValue::Static(0.0),
+        opacity: AnimatedValue::Static(1.0),
+        blend_mode: ff_filter::BlendMode::Normal,
+        composite_op: ff_filter::CompositeOp::Over,
+        effects: vec![],
+    };
+
+    let mut graph = match MultiTrackComposer::new(128, 64)
+        .frame_rate(25.0)
+        .add_layer(base(LayerSource::Solid(Color::rgb(0, 0, 255))))
+        .add_layer(base(LayerSource::Text(TextSpec::new("hi"))))
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: MultiTrackComposer::build failed: {e}");
+            return;
+        }
+    };
+    match graph.pull_video() {
+        Ok(Some(frame)) => {
+            assert_eq!(frame.width(), 128, "generated layers must fill the canvas");
+            assert_eq!(frame.height(), 64, "generated layers must fill the canvas");
+        }
+        Ok(None) => println!("Skipping: generated composition produced no frame"),
         Err(e) => println!("Skipping: pull_video failed: {e}"),
     }
 }


### PR DESCRIPTION
## Objective

- `Clip.source` is a bare `PathBuf`, so a clip can only be a media file; there is no way to place a text/title or solid-color clip on a timeline.
- The compositor can only source layers from files (or the lavfi demuxer, which is unavailable on many FFmpeg builds), so a generated layer cannot render.

## Solution

- Make the source typed: `ClipSource { File(PathBuf), Text(TextSpec), Solid(Color) }`. `Clip::new` wraps a path into `File`; add `Clip::text` / `Clip::solid` and a file-only `source_path()` accessor.
- Fold `VideoLayer.source` + `input_format` into `LayerSource { File, Lavfi, Text, Solid }`; `build_video_composition` builds inline `color`(+`drawtext`) nodes for generated variants, shared with the `TextSource`/`SolidSource` builders via `add_movie` / `add_color_rgba` / `add_drawtext` helpers.
- Derive maps `ClipSource` to `LayerSource`; timeline probes are file-only, and the canvas falls through to 1920x1080@30 when the first video clip is generated.
- A generated source is infinite, so a Text/Solid clip on an active track requires an out-point; rendering without one fails with the new `TimelineError::GeneratedSourceNeedsDuration`.
- Export path only; preview compositing of generated clips is a follow-up.

Closes #1425