### PR TITLE
feat(avio): serde persistence of the editing document

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -27,7 +27,7 @@ tokio         = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio", "ff-p
 gpl      = ["ff-encode/gpl"]
 hwaccel  = ["ff-encode/hwaccel"]
 srt      = ["ff-decode/srt", "ff-stream/srt"]
-serde    = ["ff-filter/serde"]
+serde    = ["pipeline", "dep:serde", "ff-filter/serde", "ff-format/serde"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -48,6 +48,11 @@ ff-preview  = { workspace = true, optional = true }
 ff-render   = { workspace = true, optional = true }
 thiserror   = { workspace = true, optional = true }
 log         = { workspace = true, optional = true }
+serde       = { version = "1.0.228", features = ["derive"], optional = true }
+
+[[test]]
+name = "serde_persistence"
+required-features = ["serde"]
 
 [[test]]
 name = "timeline_tests"
@@ -546,6 +551,7 @@ ff-probe  = { path = "../ff-probe" }
 ff-decode = { path = "../ff-decode" }
 ff-encode = { path = "../ff-encode" }
 ff-filter = { path = "../ff-filter" }
+serde_json = "1.0.149"
 
 [lints]
 workspace = true

--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -24,6 +24,7 @@ use crate::ids::ClipId;
 /// render time and carry no file, so they are infinite and require the clip's
 /// [`out_point`](Clip::out_point) to bound their duration.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ClipSource {
     /// A media file on disk (video, audio, or image), decoded at render time.
     File(PathBuf),
@@ -47,6 +48,7 @@ pub enum ClipSource {
 /// combining a non-default `scale` with a non-`None` `fit` double-transforms —
 /// leave `scale` at `1.0` when `fit` is set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FitMode {
     /// Scale to *cover* the canvas (preserving aspect), cropping the overflow.
     Fill,
@@ -80,6 +82,7 @@ pub enum FitMode {
 /// assert_eq!(clip.duration(), Some(Duration::from_secs(8)));
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Clip {
     /// Stable identity within a [`Timeline`](crate::Timeline).
     ///
@@ -280,6 +283,10 @@ pub struct Clip {
     /// colour-correction steps, allowing callers to attach any video
     /// [`FilterStep`] (e.g. `Lut3d`, `Curves`, `ChromaKey`, `GBlur`) to a
     /// single clip. An empty vec (the default) is a no-op.
+    ///
+    /// Not persisted by the `serde` feature yet: `FilterStep` is not serializable,
+    /// so this field is skipped and deserializes to an empty vec (see #1426).
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub video_effects: Vec<FilterStep>,
     /// Ordered per-clip audio filter steps applied to the clip's audio track.
     ///
@@ -287,6 +294,9 @@ pub struct Clip {
     /// allowing callers to attach any audio [`FilterStep`] (e.g. `ACompressor`,
     /// `ParametricEq`, `NoiseReduce`) to a single clip. An empty vec (the
     /// default) is a no-op.
+    ///
+    /// Not persisted by the `serde` feature yet (see [`video_effects`](Self::video_effects)).
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub audio_effects: Vec<FilterStep>,
 }
 

--- a/crates/avio/src/ids.rs
+++ b/crates/avio/src/ids.rs
@@ -23,6 +23,7 @@
 /// Assigned by the document (see the module docs); [`Clip::new`](crate::Clip::new)
 /// leaves it [`UNSET`](ClipId::UNSET) until the clip is placed in a timeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClipId(u64);
 
 impl ClipId {
@@ -50,6 +51,7 @@ impl ClipId {
 /// **both** the video and audio track lists (they share one counter), so a
 /// `TrackId` identifies a track without also naming its [`TrackKind`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrackId(u64);
 
 impl TrackId {
@@ -70,6 +72,7 @@ impl TrackId {
 
 /// Which track list a [`TrackId`] refers to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TrackKind {
     /// A video track ([`Timeline::video_tracks`](crate::Timeline::video_tracks)).
     Video,

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -53,6 +53,7 @@ use ff_pipeline::pipeline::hwaccel_to_hardware_encoder;
 /// assert!(result.is_ok());
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Timeline {
     pub(crate) canvas_width: u32,
     pub(crate) canvas_height: u32,
@@ -98,6 +99,10 @@ pub struct Timeline {
     /// audio — the natural place for loudness normalization
     /// ([`FilterStep::LoudnessNormalize`]). Per-track (pre-mix) effects are a
     /// separate feature (see issue #1446).
+    ///
+    /// Not persisted by the `serde` feature yet: `FilterStep` is not serializable,
+    /// so this field is skipped and deserializes to an empty vec (see #1426).
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) audio_filter: Vec<FilterStep>,
 }
 

--- a/crates/avio/src/track.rs
+++ b/crates/avio/src/track.rs
@@ -23,6 +23,7 @@ use crate::ids::TrackId;
 // clearest model.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Track {
     /// Stable identity, assigned by the document (`TrackId::UNSET` until placed).
     pub id: TrackId,

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -1,0 +1,157 @@
+//! Integration tests for serde persistence of the editing document (#1426).
+//!
+//! Gated behind the `serde` feature (which implies `pipeline`). The round-trip
+//! check compares parsed `serde_json::Value`s rather than raw JSON strings so it
+//! is insensitive to `HashMap` key ordering (map keys normalise through the
+//! `Value` representation).
+
+// Built only under the `serde` feature (declared via `[[test]] required-features`).
+#![allow(clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use avio::{
+    AnimationTrack, BlendMode, Clip, ClipSource, Command, Easing, Keyframe, Timeline,
+    XfadeTransition, apply,
+};
+use ff_filter::FilterStep;
+use ff_format::{Color, TextSpec};
+
+/// Builds a representative multi-track document exercising File/Text/Solid clips,
+/// trims, offsets, a transition, blend mode, a clip-level animation track, and a
+/// timeline-level animation map.
+fn sample_timeline() -> Timeline {
+    Timeline::builder()
+        .canvas(1920, 1080)
+        .frame_rate(30.0)
+        .video_track(vec![
+            Clip::new("intro.mp4")
+                .trim(Duration::from_secs(1), Duration::from_secs(3))
+                .offset(Duration::from_millis(500))
+                .with_opacity(0.5)
+                .with_volume_track(AnimationTrack::new().push(Keyframe::new(
+                    Duration::ZERO,
+                    1.0,
+                    Easing::Linear,
+                ))),
+            Clip::new("main.mp4")
+                .with_transition(XfadeTransition::Fade, Duration::from_millis(750))
+                .with_blend_mode(BlendMode::Screen),
+        ])
+        .video_track(vec![
+            Clip::text(TextSpec::new("Title")).trim(Duration::ZERO, Duration::from_secs(2)),
+            Clip::solid(Color::rgb(255, 0, 0)).trim(Duration::ZERO, Duration::from_secs(1)),
+        ])
+        .audio_track(vec![
+            Clip::new("music.mp3")
+                .with_fade_in(Duration::from_millis(200))
+                .volume(-6.0),
+        ])
+        .video_animation(
+            "video_1_scale_x",
+            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+        )
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn timeline_should_round_trip_through_serde() {
+    let original = sample_timeline();
+
+    let json = serde_json::to_string(&original).unwrap();
+    let back: Timeline = serde_json::from_str(&json).unwrap();
+    let json2 = serde_json::to_string(&back).unwrap();
+
+    // Compare as parsed Values so HashMap key ordering does not matter.
+    let v1: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let v2: serde_json::Value = serde_json::from_str(&json2).unwrap();
+    assert_eq!(v1, v2, "document must round-trip through serde");
+
+    // Structural + id-preservation checks on the deserialized document.
+    assert_eq!(back.canvas_width(), 1920);
+    assert_eq!(back.canvas_height(), 1080);
+    assert!((back.frame_rate() - 30.0).abs() < f64::EPSILON);
+    assert_eq!(back.video_tracks().len(), 2);
+    assert_eq!(back.audio_tracks().len(), 1);
+
+    let orig_v0 = &original.video_tracks()[0];
+    let back_v0 = &back.video_tracks()[0];
+    assert_eq!(back_v0.id, orig_v0.id, "track id must be preserved");
+    assert_eq!(
+        back_v0.clips[0].id, orig_v0.clips[0].id,
+        "clip id must be preserved"
+    );
+    assert_eq!(
+        back_v0.clips[1].transition,
+        Some(XfadeTransition::Fade),
+        "transition must survive the round-trip"
+    );
+    assert_eq!(back_v0.clips[1].blend_mode, BlendMode::Screen);
+
+    // The id-allocation counters (`next_clip_id`/`next_track_id`) are serialized, so
+    // a clip added after a round-trip gets a fresh, non-colliding id — the counter
+    // did not reset to 1 on deserialize.
+    let existing: Vec<_> = back
+        .video_tracks()
+        .iter()
+        .flat_map(|t| t.clips.iter().map(|c| c.id))
+        .collect();
+    let grown = apply(
+        &back,
+        &Command::AddClip {
+            track: back_v0.id,
+            clip: Box::new(Clip::new("added.mp4")),
+        },
+    )
+    .unwrap();
+    let new_id = grown.video_tracks()[0].clips.last().unwrap().id;
+    assert!(
+        !existing.contains(&new_id),
+        "a clip added after load must get a fresh id (allocation counter preserved)"
+    );
+}
+
+#[test]
+fn clip_source_should_round_trip_each_variant() {
+    // File
+    let file = Clip::new("clip.mp4");
+    let file_back: Clip = serde_json::from_str(&serde_json::to_string(&file).unwrap()).unwrap();
+    assert!(matches!(file_back.source, ClipSource::File(ref p) if p.to_str() == Some("clip.mp4")));
+
+    // Text (carries a ff-format TextSpec)
+    let text = Clip::text(TextSpec::new("hello"));
+    let text_back: Clip = serde_json::from_str(&serde_json::to_string(&text).unwrap()).unwrap();
+    match text_back.source {
+        ClipSource::Text(spec) => assert_eq!(spec.text, "hello"),
+        other => panic!("expected Text, got {other:?}"),
+    }
+
+    // Solid (carries a ff-format Color)
+    let solid = Clip::solid(Color::rgb(10, 20, 30));
+    let solid_back: Clip = serde_json::from_str(&serde_json::to_string(&solid).unwrap()).unwrap();
+    match solid_back.source {
+        ClipSource::Solid(c) => assert_eq!(c, Color::rgb(10, 20, 30)),
+        other => panic!("expected Solid, got {other:?}"),
+    }
+}
+
+#[test]
+fn clip_effects_should_be_omitted_from_serialization() {
+    // FilterStep is not serializable yet, so video_effects/audio_effects are
+    // skipped: they never appear in the JSON and deserialize to an empty vec.
+    let clip = Clip::new("v.mp4").with_video_effect(FilterStep::Hue { degrees: 30.0 });
+    assert_eq!(clip.video_effects.len(), 1);
+
+    let json = serde_json::to_string(&clip).unwrap();
+    assert!(
+        !json.contains("video_effects"),
+        "skipped field must not be serialized: {json}"
+    );
+
+    let back: Clip = serde_json::from_str(&json).unwrap();
+    assert!(
+        back.video_effects.is_empty(),
+        "skipped field must deserialize to an empty vec"
+    );
+}

--- a/crates/ff-filter/src/blend.rs
+++ b/crates/ff-filter/src/blend.rs
@@ -17,6 +17,7 @@
 // Open catalog: mirrors `FFmpeg`'s `blend all_mode` set, which can grow.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlendMode {
     // ── Standard modes ────────────────────────────────────────────────────
     /// Standard alpha-over composite (`top * opacity + bottom * (1 − opacity)`).

--- a/crates/ff-filter/src/composite.rs
+++ b/crates/ff-filter/src/composite.rs
@@ -14,6 +14,7 @@
 // Open catalog: the Porter-Duff operator set is added to incrementally.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CompositeOp {
     /// Top layer rendered over the bottom (standard alpha compositing).
     ///

--- a/crates/ff-filter/src/graph/types.rs
+++ b/crates/ff-filter/src/graph/types.rs
@@ -140,6 +140,7 @@ pub enum YadifMode {
 /// Used with [`super::FilterGraphBuilder::xfade`].
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum XfadeTransition {
     /// Blend frames (cross-dissolve).
     Dissolve,

--- a/crates/ff-format/Cargo.toml
+++ b/crates/ff-format/Cargo.toml
@@ -14,10 +14,14 @@ categories = ["multimedia::video", "multimedia::audio"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+serde = ["dep:serde"]
+
 [dependencies]
 ff-common = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
+serde = { version = "1.0.228", features = ["derive"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/ff-format/src/color.rs
+++ b/crates/ff-format/src/color.rs
@@ -958,6 +958,7 @@ mod tests {
 /// metadata ([`ColorSpace`] et al.). `a` is the alpha channel: `255` = opaque,
 /// `0` = fully transparent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     /// Red channel (0–255).
     pub r: u8,

--- a/crates/ff-format/src/text.rs
+++ b/crates/ff-format/src/text.rs
@@ -14,6 +14,7 @@ use crate::color::Color;
 /// The renderer places the text box at the anchor, then applies
 /// [`TextSpec::offset`] as a pixel nudge from it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Anchor {
     /// Top-left corner.
     TopLeft,
@@ -41,6 +42,7 @@ pub enum Anchor {
 /// Mirrors the typical draw-text options as plain values; opacity is carried by
 /// the alpha channel of [`color`](Self::color) (and [`box_color`](Self::box_color)).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextStyle {
     /// Font size in points.
     pub font_size: u32,
@@ -73,6 +75,7 @@ impl Default for TextStyle {
 /// Size-agnostic: the canvas dimensions are supplied by the renderer, so the same
 /// spec can render at any resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TextSpec {
     /// The text to render (UTF-8).
     pub text: String,


### PR DESCRIPTION
## Objective

- The editing document (`Timeline` / `Track` / `Clip` / `ClipSource` and the animation types) cannot be saved or loaded; there is no serialization for project save/load.

## Solution

- Add an optional `serde` feature that derives `Serialize`/`Deserialize` on the editing model (`Timeline`, `Track`, `Clip`, `ClipSource`, `ClipId`, `TrackId`, `TrackKind`, `FitMode`). All derives are behind `#[cfg_attr(feature = "serde", ...)]`; the default build pulls in no serde.
- Add a `serde` feature to `ff-format` (Color / TextSpec / Anchor / TextStyle) and derive serde on `ff-filter`'s `XfadeTransition` / `BlendMode` / `CompositeOp`. `avio`'s `serde` feature enables both and implies `pipeline` (where the editing model lives).
- Skip per-clip and timeline effect chains (`Vec<FilterStep>`) for now: `FilterStep` is not serializable yet, so those fields deserialize to an empty vec. Persisting them is a follow-up.
- Add a round-trip integration test over a multi-track document that compares parsed JSON values (insensitive to `HashMap` key order) and asserts ids and the id-allocation counters survive.

Closes #1426