### PR TITLE
feat(avio): first-class timeline markers

### DIFF
--- a/crates/avio/src/edit.rs
+++ b/crates/avio/src/edit.rs
@@ -18,7 +18,8 @@ use ff_filter::BlendMode;
 use thiserror::Error;
 
 use crate::clip::Clip;
-use crate::ids::{ClipId, TrackId, TrackKind};
+use crate::ids::{ClipId, MarkerId, TrackId, TrackKind};
+use crate::marker::Marker;
 use crate::timeline::Timeline;
 use crate::track::Track;
 
@@ -167,6 +168,27 @@ pub enum Command {
         /// Track to remove.
         track: TrackId,
     },
+    /// Add an editorial [`Marker`] to the timeline.
+    ///
+    /// The marker is assigned a fresh [`MarkerId`] by the document; any id already
+    /// on the incoming marker is ignored. Markers are metadata only and do not
+    /// affect render or preview.
+    AddMarker {
+        /// Marker to add (its id is replaced with a fresh one).
+        marker: Marker,
+    },
+    /// Remove the marker with id `marker`.
+    RemoveMarker {
+        /// Marker to remove.
+        marker: MarkerId,
+    },
+    /// Set the timeline position (`pts`) of the marker with id `marker`.
+    MoveMarker {
+        /// Marker to move.
+        marker: MarkerId,
+        /// New timeline position.
+        pts: Duration,
+    },
     /// Set the output canvas dimensions (marks the canvas explicit).
     SetCanvas {
         /// Canvas width in pixels (must be non-zero).
@@ -202,6 +224,13 @@ pub enum EditError {
     ClipNotFound {
         /// The id that resolved to no clip.
         id: ClipId,
+    },
+    /// A [`Command::RemoveMarker`] / [`Command::MoveMarker`] named a marker id that
+    /// is present in no marker.
+    #[error("no marker with id {id:?}")]
+    MarkerNotFound {
+        /// The id that resolved to no marker.
+        id: MarkerId,
     },
     /// A [`Command::SetClip`] value carries an id that names a different clip.
     #[error("clip id mismatch: expected {expected:?}, value has {found:?}")]
@@ -394,6 +423,27 @@ pub fn apply(timeline: &Timeline, command: &Command) -> Result<Timeline, EditErr
             if !remove_track(&mut next, *track) {
                 return Err(EditError::TrackNotFound { id: *track });
             }
+        }
+        Command::AddMarker { marker } => {
+            let mut marker = marker.clone();
+            marker.id = MarkerId::from_raw(next.next_marker_id);
+            next.markers.push(marker);
+            next.next_marker_id += 1;
+        }
+        Command::RemoveMarker { marker } => {
+            let before = next.markers.len();
+            next.markers.retain(|m| m.id != *marker);
+            if next.markers.len() == before {
+                return Err(EditError::MarkerNotFound { id: *marker });
+            }
+        }
+        Command::MoveMarker { marker, pts } => {
+            let m = next
+                .markers
+                .iter_mut()
+                .find(|m| m.id == *marker)
+                .ok_or(EditError::MarkerNotFound { id: *marker })?;
+            m.pts = *pts;
         }
         Command::SetCanvas { width, height } => {
             if *width == 0 || *height == 0 {
@@ -1830,5 +1880,138 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, EditError::ClipNotFound { id: ClipId::UNSET });
+    }
+
+    // ── markers ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_add_marker_should_append_with_fresh_id() {
+        let t = timeline_with(1);
+        let out = apply(
+            &t,
+            &Command::AddMarker {
+                marker: Marker::new(Duration::from_secs(2)).with_name("intro"),
+            },
+        )
+        .unwrap();
+        assert_eq!(out.markers().len(), 1);
+        let m = &out.markers()[0];
+        assert!(m.id.is_set(), "an added marker gets a set id");
+        assert_eq!(m.pts, Duration::from_secs(2));
+        assert_eq!(m.name.as_deref(), Some("intro"));
+    }
+
+    #[test]
+    fn apply_add_marker_should_stamp_fresh_id_over_incoming() {
+        let t = timeline_with(1);
+        let mut incoming = Marker::new(Duration::ZERO);
+        incoming.id = MarkerId::from_raw(999);
+        let out = apply(&t, &Command::AddMarker { marker: incoming }).unwrap();
+        assert_ne!(
+            out.markers()[0].id,
+            MarkerId::from_raw(999),
+            "the incoming id is replaced with a fresh one"
+        );
+        assert!(out.markers()[0].id.is_set());
+    }
+
+    #[test]
+    fn apply_add_marker_should_assign_distinct_ids() {
+        let t = timeline_with(1);
+        let t = apply(
+            &t,
+            &Command::AddMarker {
+                marker: Marker::new(Duration::from_secs(1)),
+            },
+        )
+        .unwrap();
+        let t = apply(
+            &t,
+            &Command::AddMarker {
+                marker: Marker::new(Duration::from_secs(2)),
+            },
+        )
+        .unwrap();
+        assert_ne!(
+            t.markers()[0].id,
+            t.markers()[1].id,
+            "each marker gets a distinct id"
+        );
+    }
+
+    #[test]
+    fn apply_remove_marker_should_drop_it_by_id() {
+        let t = timeline_with(1);
+        let t = apply(
+            &t,
+            &Command::AddMarker {
+                marker: Marker::new(Duration::from_secs(1)),
+            },
+        )
+        .unwrap();
+        let id = t.markers()[0].id;
+        let out = apply(&t, &Command::RemoveMarker { marker: id }).unwrap();
+        assert!(out.markers().is_empty());
+    }
+
+    #[test]
+    fn apply_remove_marker_missing_should_err() {
+        let t = timeline_with(1);
+        let missing = MarkerId::from_raw(9999);
+        let err = apply(&t, &Command::RemoveMarker { marker: missing }).unwrap_err();
+        assert_eq!(err, EditError::MarkerNotFound { id: missing });
+    }
+
+    #[test]
+    fn apply_move_marker_should_set_pts() {
+        let t = timeline_with(1);
+        let t = apply(
+            &t,
+            &Command::AddMarker {
+                marker: Marker::new(Duration::from_secs(1)),
+            },
+        )
+        .unwrap();
+        let id = t.markers()[0].id;
+        let out = apply(
+            &t,
+            &Command::MoveMarker {
+                marker: id,
+                pts: Duration::from_secs(5),
+            },
+        )
+        .unwrap();
+        assert_eq!(out.markers()[0].pts, Duration::from_secs(5));
+        assert_eq!(out.markers()[0].id, id, "the marker id is unchanged");
+    }
+
+    #[test]
+    fn apply_move_marker_missing_should_err() {
+        let t = timeline_with(1);
+        let missing = MarkerId::from_raw(9999);
+        let err = apply(
+            &t,
+            &Command::MoveMarker {
+                marker: missing,
+                pts: Duration::from_secs(1),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, EditError::MarkerNotFound { id: missing });
+    }
+
+    #[test]
+    fn apply_add_marker_should_not_change_clips() {
+        let t = timeline_with(2);
+        let before: Vec<_> = t.video_tracks()[0].clips.iter().map(|c| c.id).collect();
+        let out = apply(
+            &t,
+            &Command::AddMarker {
+                marker: Marker::new(Duration::ZERO),
+            },
+        )
+        .unwrap();
+        let after: Vec<_> = out.video_tracks()[0].clips.iter().map(|c| c.id).collect();
+        assert_eq!(before, after, "adding a marker does not touch clips");
     }
 }

--- a/crates/avio/src/editor.rs
+++ b/crates/avio/src/editor.rs
@@ -267,6 +267,26 @@ mod tests {
     }
 
     #[test]
+    fn editor_undo_redo_should_round_trip_an_added_marker() {
+        use crate::Marker;
+        use std::time::Duration;
+
+        let mut ed = Editor::new(timeline(30.0));
+        let after = ed
+            .apply(&Command::AddMarker {
+                marker: Marker::new(Duration::from_secs(1)),
+            })
+            .unwrap();
+        assert_eq!(after.markers().len(), 1);
+
+        let undone = ed.undo().unwrap();
+        assert!(undone.markers().is_empty(), "undo removes the added marker");
+
+        let redone = ed.redo().unwrap();
+        assert_eq!(redone.markers().len(), 1, "redo restores the marker");
+    }
+
+    #[test]
     fn editor_redo_should_reapply_the_undone_version() {
         let mut ed = Editor::new(timeline(30.0));
         ed.apply(&set_fps(24.0)).unwrap();

--- a/crates/avio/src/ids.rs
+++ b/crates/avio/src/ids.rs
@@ -70,6 +70,31 @@ impl TrackId {
     }
 }
 
+/// Stable identity of a [`Marker`](crate::Marker) within a [`Timeline`](crate::Timeline).
+///
+/// Assigned by the document (see the module docs); a marker built by the caller is
+/// [`UNSET`](MarkerId::UNSET) until it is added via
+/// [`Command::AddMarker`](crate::Command::AddMarker).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MarkerId(u64);
+
+impl MarkerId {
+    /// The id of a marker that has not yet been added to a document.
+    pub const UNSET: MarkerId = MarkerId(0);
+
+    /// Whether this id has been assigned by a document (i.e. is not [`UNSET`](Self::UNSET)).
+    #[must_use]
+    pub fn is_set(self) -> bool {
+        self.0 != 0
+    }
+
+    /// Mints an id from a raw counter value. Crate-internal (see `ClipId::from_raw`).
+    pub(crate) fn from_raw(value: u64) -> Self {
+        MarkerId(value)
+    }
+}
+
 /// Which track list a [`TrackId`] refers to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -329,6 +329,8 @@ mod error;
 #[cfg(feature = "pipeline")]
 mod ids;
 #[cfg(feature = "pipeline")]
+mod marker;
+#[cfg(feature = "pipeline")]
 mod timeline;
 #[cfg(feature = "pipeline")]
 mod track;
@@ -344,7 +346,9 @@ pub use editor::Editor;
 #[cfg(feature = "pipeline")]
 pub use error::TimelineError;
 #[cfg(feature = "pipeline")]
-pub use ids::{ClipId, TrackId, TrackKind};
+pub use ids::{ClipId, MarkerId, TrackId, TrackKind};
+#[cfg(feature = "pipeline")]
+pub use marker::Marker;
 #[cfg(feature = "pipeline")]
 pub use timeline::{Timeline, TimelineBuilder};
 #[cfg(feature = "pipeline")]

--- a/crates/avio/src/marker.rs
+++ b/crates/avio/src/marker.rs
@@ -1,0 +1,74 @@
+//! Editorial timeline markers.
+//!
+//! A [`Marker`] is a labelled point on the timeline (for navigation, notes, or
+//! chapter authoring). Markers are metadata only: they never affect derivation,
+//! render, or preview. They are added, moved, and removed through the undoable
+//! [`Command`](crate::Command) path and addressed by a stable
+//! [`MarkerId`](crate::MarkerId).
+
+use std::time::Duration;
+
+use ff_format::Color;
+
+use crate::ids::MarkerId;
+
+/// A labelled point on the timeline.
+///
+/// All fields are public so callers can inspect them; a marker's [`id`](Self::id)
+/// is assigned by the document when it is added (any id on an incoming marker is
+/// replaced with a fresh one).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Marker {
+    /// Stable identity within a [`Timeline`](crate::Timeline).
+    ///
+    /// [`MarkerId::UNSET`] until the marker is added to a document.
+    pub id: MarkerId,
+    /// Position on the timeline (presentation timestamp from the start of the
+    /// composition).
+    pub pts: Duration,
+    /// Optional human-readable label. `None` = an unnamed marker.
+    pub name: Option<String>,
+    /// Optional marker colour (for a host's UI). `None` = the host default.
+    pub color: Option<Color>,
+    /// Optional free-form note. `None` = no comment.
+    pub comment: Option<String>,
+}
+
+impl Marker {
+    /// Creates a new, unnamed marker at `pts` with no colour or comment.
+    ///
+    /// Its [`id`](Self::id) is [`MarkerId::UNSET`] until it is added to a document
+    /// via [`Command::AddMarker`](crate::Command::AddMarker).
+    #[must_use]
+    pub fn new(pts: Duration) -> Self {
+        Self {
+            id: MarkerId::UNSET,
+            pts,
+            name: None,
+            color: None,
+            comment: None,
+        }
+    }
+
+    /// Sets the marker's label and returns the updated marker.
+    #[must_use]
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Sets the marker's colour and returns the updated marker.
+    #[must_use]
+    pub fn with_color(mut self, color: Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    /// Sets the marker's comment and returns the updated marker.
+    #[must_use]
+    pub fn with_comment(mut self, comment: impl Into<String>) -> Self {
+        self.comment = Some(comment.into());
+        self
+    }
+}

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -21,6 +21,7 @@ use crate::clip::Clip;
 use crate::derive;
 use crate::error::TimelineError;
 use crate::ids::{ClipId, TrackId};
+use crate::marker::Marker;
 use crate::track::Track;
 use ff_pipeline::EncoderConfig;
 use ff_pipeline::Progress;
@@ -70,6 +71,11 @@ pub struct Timeline {
     pub(crate) next_clip_id: u64,
     /// Next [`TrackId`](crate::TrackId) value to hand out (see `next_clip_id`).
     pub(crate) next_track_id: u64,
+    /// Next [`MarkerId`](crate::MarkerId) value to hand out (see `next_clip_id`).
+    pub(crate) next_marker_id: u64,
+    /// Editorial markers on the timeline. Metadata only — they do not affect
+    /// derivation, render, or preview. Addressed by [`MarkerId`](crate::MarkerId).
+    pub(crate) markers: Vec<Marker>,
     /// Animation tracks for video layer properties.
     ///
     /// Key format: `"video_{track_index}_{property}"`, e.g. `"video_0_opacity"`.
@@ -147,6 +153,11 @@ impl Timeline {
     /// Returns a slice of all audio tracks.
     pub fn audio_tracks(&self) -> &[Track] {
         &self.audio_tracks
+    }
+
+    /// Returns the timeline's editorial markers.
+    pub fn markers(&self) -> &[Marker] {
+        &self.markers
     }
 
     /// Renders the timeline to an output file.
@@ -236,6 +247,8 @@ impl Timeline {
             audio_tracks,
             next_clip_id: _,
             next_track_id: _,
+            next_marker_id: _,
+            markers: _,
             video_animations,
             audio_animations,
             lavfi_overlay,
@@ -775,6 +788,8 @@ impl TimelineBuilder {
             audio_tracks,
             next_clip_id,
             next_track_id,
+            next_marker_id: 1,
+            markers: Vec::new(),
             video_animations: self.video_animations,
             audio_animations: self.audio_animations,
             lavfi_overlay: self.lavfi_overlay,

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -11,7 +11,7 @@
 use std::time::Duration;
 
 use avio::{
-    AnimationTrack, BlendMode, Clip, ClipSource, Command, Easing, Keyframe, Timeline,
+    AnimationTrack, BlendMode, Clip, ClipSource, Command, Easing, Keyframe, Marker, Timeline,
     XfadeTransition, apply,
 };
 use ff_filter::FilterStep;
@@ -154,4 +154,50 @@ fn clip_effects_should_be_omitted_from_serialization() {
         back.video_effects.is_empty(),
         "skipped field must deserialize to an empty vec"
     );
+}
+
+#[test]
+fn markers_should_round_trip_through_serde() {
+    let base = Timeline::builder()
+        .canvas(1920, 1080)
+        .frame_rate(30.0)
+        .video_track(vec![Clip::new("a.mp4")])
+        .build()
+        .unwrap();
+    let with_markers = apply(
+        &base,
+        &Command::AddMarker {
+            marker: Marker::new(Duration::from_secs(2))
+                .with_name("chapter 1")
+                .with_color(Color::rgb(255, 0, 0)),
+        },
+    )
+    .unwrap();
+    let with_markers = apply(
+        &with_markers,
+        &Command::AddMarker {
+            marker: Marker::new(Duration::from_secs(5)).with_comment("note"),
+        },
+    )
+    .unwrap();
+
+    let json = serde_json::to_string(&with_markers).unwrap();
+    let back: Timeline = serde_json::from_str(&json).unwrap();
+
+    // Value comparison is insensitive to HashMap key ordering.
+    let v1: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let v2: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&back).unwrap()).unwrap();
+    assert_eq!(v1, v2, "markers must round-trip through serde");
+
+    assert_eq!(back.markers().len(), 2, "both markers survive");
+    assert_eq!(back.markers()[0].name.as_deref(), Some("chapter 1"));
+    assert_eq!(back.markers()[0].pts, Duration::from_secs(2));
+    assert_eq!(back.markers()[0].color, Some(Color::rgb(255, 0, 0)));
+    assert_eq!(
+        back.markers()[0].id,
+        with_markers.markers()[0].id,
+        "marker id is preserved"
+    );
+    assert_eq!(back.markers()[1].comment.as_deref(), Some("note"));
 }


### PR DESCRIPTION
## Objective

- A host adopting `avio::Timeline` has no first-class editorial markers (labelled points for navigation, notes, chapter authoring) and must keep them in a sidecar.

## Solution

- Add a `Marker` (`pts`, optional `name`/`color`/`comment`) with a stable `MarkerId`, allocated like `ClipId`/`TrackId` from a document counter (`next_marker_id`).
- Edit markers through the undoable command path: `AddMarker` (stamps a fresh id), `RemoveMarker`, `MoveMarker`, addressed by `MarkerId`; a missing id yields the new `EditError::MarkerNotFound`. Markers are metadata only — `render`/`derive`/preview ignore them.
- Serialize markers and the id counter under the `serde` feature so a saved document round-trips its markers (ids preserved). Covered by unit tests for the three commands, an Editor undo/redo round-trip, and a serde round-trip.

Closes #1455