### PR TITLE
feat(avio): track-level (pre-mix) audio effect chain

### DIFF
--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -15,7 +15,7 @@ use ff_filter::{
     AnimatedValue, AnimationTrack, FilterGraph, FilterStep, MultiTrackAudioMixer,
     MultiTrackComposer, ProxySource, VideoLayer,
 };
-use ff_format::ChannelLayout;
+use ff_format::{AudioFrame, ChannelLayout};
 
 use crate::clip::Clip;
 use crate::derive;
@@ -418,8 +418,21 @@ impl Timeline {
         }
 
         // 4. Build audio mix graph.
+        //
+        //    Two paths share step 7's drain:
+        //    * Fast path (no active audio track carries a pre-mix effect chain):
+        //      a single source-only mixer over every active clip, streamed to the
+        //      encoder (low memory) — the historical behaviour.
+        //    * Per-track path (some active track has `audio_effects`): each track
+        //      is sub-mixed and run through its own push/pull graph before the
+        //      master mix, so a two-pass step (loudness normalization) there
+        //      actually fires. Built in step 7 from `audio_tracks`.
+        let has_audio = audio_tracks.iter().any(|t| t.is_active(any_audio_solo));
+        let has_track_effects = audio_tracks
+            .iter()
+            .any(|t| t.is_active(any_audio_solo) && !t.audio_effects.is_empty());
         let mut audio_graph = None;
-        if !audio_tracks.is_empty() {
+        if has_audio && !has_track_effects {
             let mut mixer = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo);
             // Honor mute/solo/enabled: an inactive audio track is silent.
             for (track_idx, track) in audio_tracks.iter().enumerate() {
@@ -432,29 +445,11 @@ impl Timeline {
                     if clip.source_path().is_none() {
                         continue;
                     }
-                    // Resolve the effective clip duration only when a fade-out
-                    // needs it to compute its start offset (probing is I/O; the
-                    // pure per-clip build lives in `derive`).
-                    let fade_out_eff_dur = if clip.fade_out > Duration::ZERO {
-                        clip.duration().or_else(|| {
-                            clip.source_path()
-                                .and_then(|src| VideoDecoder::open(src).build().ok())
-                                .map(|d| {
-                                    let total = d.duration();
-                                    match clip.in_point {
-                                        Some(ip) => total.saturating_sub(ip),
-                                        None => total,
-                                    }
-                                })
-                        })
-                    } else {
-                        None
-                    };
                     mixer = mixer.add_track(derive::audio_track(
                         clip,
                         track_idx,
                         &audio_animations,
-                        fade_out_eff_dur,
+                        audio_fade_out_eff_dur(clip),
                     ));
                 }
             }
@@ -462,11 +457,11 @@ impl Timeline {
         }
 
         // Timeline-level (master bus) audio effect chain, applied post-mix. Built
-        // only when there is audio to process. A two-pass step (`LoudnessNormalize`)
-        // works here because a builder-made `FilterGraph` carries the `steps` its
-        // push/pull path keys off — unlike the source-only mixer graph, where it
-        // would be inert.
-        let master_audio = if audio_graph.is_some() && !audio_filter.is_empty() {
+        // whenever there is audio to process (both paths route their mixed output
+        // through it). A two-pass step (`LoudnessNormalize`) works here because a
+        // builder-made `FilterGraph` carries the `steps` its push/pull path keys
+        // off — unlike the source-only mixer graph, where it would be inert.
+        let master_audio = if has_audio && !audio_filter.is_empty() {
             let mut builder = FilterGraph::builder();
             for step in &audio_filter {
                 builder = builder.add_step(step.clone());
@@ -483,7 +478,7 @@ impl Timeline {
             .video_codec(config.video_codec)
             .bitrate_mode(config.bitrate_mode)
             .hardware_encoder(hw);
-        if audio_graph.is_some() {
+        if has_audio {
             enc_builder = enc_builder.audio(48_000, 2).audio_codec(config.audio_codec);
         }
         let mut encoder = enc_builder.build().map_err(TimelineError::Encode)?;
@@ -566,6 +561,28 @@ impl Timeline {
                     }
                 }
             }
+        } else if has_track_effects {
+            // Per-track path: each track's audio is sub-mixed and run through its
+            // own push/pull effect graph (so a two-pass step fires), then summed.
+            let mixed = mix_tracks_with_effects(&audio_tracks, any_audio_solo, &audio_animations)?;
+            // Consume `mixed` by value so each frame drops right after it is pushed
+            // downstream, freeing the mix buffer as we go (the master bus keeps its
+            // own copy for a two-pass step, so holding `mixed` too would double it).
+            if let Some(mut master) = master_audio {
+                for frame in mixed {
+                    master
+                        .push_audio(0, &frame)
+                        .map_err(TimelineError::Filter)?;
+                }
+                master.flush_audio();
+                while let Some(frame) = master.pull_audio().map_err(TimelineError::Filter)? {
+                    encoder.push_audio(&frame).map_err(TimelineError::Encode)?;
+                }
+            } else {
+                for frame in mixed {
+                    encoder.push_audio(&frame).map_err(TimelineError::Encode)?;
+                }
+            }
         }
 
         // 8. Flush encoder.
@@ -577,6 +594,146 @@ impl Timeline {
         );
         Ok(())
     }
+}
+
+/// Resolves a clip's effective duration for a fade-out start offset, probing the
+/// source only when a fade-out actually needs it. `None` = no fade-out, or the
+/// duration could not be determined.
+fn audio_fade_out_eff_dur(clip: &Clip) -> Option<Duration> {
+    if clip.fade_out == Duration::ZERO {
+        return None;
+    }
+    clip.duration().or_else(|| {
+        clip.source_path()
+            .and_then(|src| VideoDecoder::open(src).build().ok())
+            .map(|d| {
+                let total = d.duration();
+                match clip.in_point {
+                    Some(ip) => total.saturating_sub(ip),
+                    None => total,
+                }
+            })
+    })
+}
+
+/// Pulls a source-only audio graph to end-of-stream into a frame buffer, ticking
+/// the animation clock by each chunk's duration so any volume automation stays
+/// sample-accurate.
+fn drain_source_audio(graph: &mut FilterGraph) -> Result<Vec<AudioFrame>, TimelineError> {
+    let mut out = Vec::new();
+    let mut pts = Duration::ZERO;
+    loop {
+        graph.tick(pts);
+        match graph.pull_audio().map_err(TimelineError::Filter)? {
+            Some(frame) => {
+                pts += frame.duration();
+                out.push(frame);
+            }
+            None => break,
+        }
+    }
+    Ok(out)
+}
+
+/// The per-track (pre-mix) audio path: sub-mix each active track's clips, run the
+/// track's [`audio_effects`](Track::audio_effects) chain through its own push/pull
+/// [`FilterGraph`] (so a two-pass step such as loudness normalization fires), then
+/// sum the processed tracks with an additive `amix`. Returns the mixed program
+/// audio (before the timeline master bus).
+fn mix_tracks_with_effects(
+    audio_tracks: &[Track],
+    any_audio_solo: bool,
+    audio_animations: &HashMap<String, AnimationTrack<f64>>,
+) -> Result<Vec<AudioFrame>, TimelineError> {
+    let mut track_buffers: Vec<Vec<AudioFrame>> = Vec::new();
+    for (track_idx, track) in audio_tracks.iter().enumerate() {
+        if !track.is_active(any_audio_solo) {
+            continue;
+        }
+        // Sub-mix this track's audio-bearing clips (generated clips carry no audio).
+        let mut sub = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo);
+        let mut has_clip = false;
+        for clip in &track.clips {
+            if clip.source_path().is_none() {
+                continue;
+            }
+            sub = sub.add_track(derive::audio_track(
+                clip,
+                track_idx,
+                audio_animations,
+                audio_fade_out_eff_dur(clip),
+            ));
+            has_clip = true;
+        }
+        if !has_clip {
+            continue;
+        }
+        let mut sub_graph = sub.build().map_err(TimelineError::Filter)?;
+
+        // No effect chain: the track's contribution is the raw sub-mix. Otherwise
+        // route the sub-mix through the track's push/pull effect graph.
+        let processed = if track.audio_effects.is_empty() {
+            drain_source_audio(&mut sub_graph)?
+        } else {
+            let mut fx_builder = FilterGraph::builder();
+            for step in &track.audio_effects {
+                fx_builder = fx_builder.add_step(step.clone());
+            }
+            let mut fx = fx_builder.build().map_err(TimelineError::Filter)?;
+            let mut pts = Duration::ZERO;
+            loop {
+                sub_graph.tick(pts);
+                match sub_graph.pull_audio().map_err(TimelineError::Filter)? {
+                    Some(frame) => {
+                        pts += frame.duration();
+                        fx.push_audio(0, &frame).map_err(TimelineError::Filter)?;
+                    }
+                    None => break,
+                }
+            }
+            fx.flush_audio();
+            let mut out = Vec::new();
+            while let Some(frame) = fx.pull_audio().map_err(TimelineError::Filter)? {
+                out.push(frame);
+            }
+            out
+        };
+        if !processed.is_empty() {
+            track_buffers.push(processed);
+        }
+    }
+
+    // Sum the processed tracks. One (or zero) track needs no mix; several are
+    // combined with an additive `amix`, pushed slot-by-slot in frame-index
+    // lockstep so the inputs stay aligned and no input reaches EOF early.
+    Ok(match track_buffers.len() {
+        0 => Vec::new(),
+        1 => track_buffers.into_iter().next().unwrap_or_default(),
+        n => {
+            let mut amix = FilterGraph::builder()
+                .amix(n)
+                .build()
+                .map_err(TimelineError::Filter)?;
+            let max_len = track_buffers.iter().map(Vec::len).max().unwrap_or(0);
+            let mut mixed = Vec::new();
+            for i in 0..max_len {
+                for (slot, buf) in track_buffers.iter().enumerate() {
+                    if let Some(frame) = buf.get(i) {
+                        amix.push_audio(slot, frame)
+                            .map_err(TimelineError::Filter)?;
+                    }
+                }
+                while let Some(frame) = amix.pull_audio().map_err(TimelineError::Filter)? {
+                    mixed.push(frame);
+                }
+            }
+            amix.flush_audio();
+            while let Some(frame) = amix.pull_audio().map_err(TimelineError::Filter)? {
+                mixed.push(frame);
+            }
+            mixed
+        }
+    })
 }
 
 /// Builder for [`Timeline`].

--- a/crates/avio/src/track.rs
+++ b/crates/avio/src/track.rs
@@ -9,6 +9,8 @@
 //! output (see [`Track::is_active`]); `lock` and `name` are authoring metadata the
 //! derivation ignores.
 
+use ff_filter::FilterStep;
+
 use crate::clip::Clip;
 use crate::ids::TrackId;
 
@@ -39,6 +41,20 @@ pub struct Track {
     pub lock: bool,
     /// The clips on this track, in order (index 0 first on the timeline).
     pub clips: Vec<Clip>,
+    /// Ordered per-track (pre-mix) audio effect chain applied to this track's
+    /// mixed contribution before it enters the timeline mix, on render.
+    ///
+    /// Its natural use is a two-pass effect such as loudness normalization
+    /// ([`FilterStep::LoudnessNormalize`]) or a compressor
+    /// ([`FilterStep::ACompressor`]) that should act on the whole track rather
+    /// than one clip. An empty chain (the default) is a no-op and leaves the
+    /// audio path unchanged. Ignored for video tracks (they carry no audio).
+    ///
+    /// Not persisted by the `serde` feature yet: `FilterStep` is not
+    /// serializable, so this field is skipped and deserializes to an empty vec
+    /// (mirroring [`Clip::audio_effects`](crate::Clip::audio_effects)).
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub audio_effects: Vec<FilterStep>,
 }
 
 impl Track {
@@ -56,6 +72,7 @@ impl Track {
             enabled: true,
             lock: false,
             clips,
+            audio_effects: Vec::new(),
         }
     }
 
@@ -94,6 +111,14 @@ impl Track {
         self
     }
 
+    /// Sets the per-track (pre-mix) audio effect chain (see
+    /// [`audio_effects`](Self::audio_effects)).
+    #[must_use]
+    pub fn audio_effects(mut self, steps: Vec<FilterStep>) -> Self {
+        self.audio_effects = steps;
+        self
+    }
+
     /// Whether this track contributes to the derived output.
     ///
     /// A track is active when it is `enabled`, not `mute`d, and — if any track in
@@ -128,5 +153,20 @@ mod tests {
                 .enabled(false)
                 .is_active(true)
         );
+    }
+
+    #[test]
+    fn new_track_should_have_empty_audio_effects() {
+        assert!(Track::new(vec![]).audio_effects.is_empty());
+    }
+
+    #[test]
+    fn audio_effects_builder_should_set_chain() {
+        let track = Track::new(vec![]).audio_effects(vec![FilterStep::Volume(-6.0)]);
+        assert_eq!(track.audio_effects.len(), 1);
+        assert!(matches!(
+            track.audio_effects[0],
+            FilterStep::Volume(v) if (v - (-6.0)).abs() < 1e-9
+        ));
     }
 }

--- a/crates/avio/tests/timeline_tests.rs
+++ b/crates/avio/tests/timeline_tests.rs
@@ -9,7 +9,7 @@ mod fixtures;
 
 use std::time::Duration;
 
-use avio::{Clip, EncoderConfig, Timeline, TimelineError};
+use avio::{Clip, EncoderConfig, Timeline, TimelineError, Track};
 use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
 use ff_filter::FilterStep;
 use ff_filter::animation::{AnimationTrack, Easing};
@@ -191,6 +191,198 @@ fn timeline_audio_filter_should_render_through_master_chain() {
     assert!(
         info.has_audio(),
         "rendered output with a master audio filter must contain an audio stream"
+    );
+}
+
+/// A per-track (pre-mix) two-pass audio effect must be applied on render (issue
+/// #1446 — "no longer inert"). `LoudnessNormalize` is a two-pass step: it is inert
+/// inside the source-only mixer, so this exercises the per-track push/pull graph.
+/// A wiring/format bug there would fail push/pull/flush; measured loudness
+/// correctness lives in ff-filter's tests (the synthetic source audio is silent).
+#[test]
+fn timeline_track_audio_effect_should_render_through_per_track_chain() {
+    let src_path = test_output_path("timeline_trackfx_src.mp4");
+    let out_path = test_output_path("timeline_trackfx_out.mp4");
+    let _g_src = FileGuard::new(src_path.clone());
+    let _g_out = FileGuard::new(out_path.clone());
+
+    if make_source_file(&src_path, W, H, FPS, FRAME_COUNT, 76, 84, 255).is_none() {
+        return;
+    }
+
+    let clip = Clip::new(&src_path);
+    let audio = Track::new(vec![clip.clone()]).audio_effects(vec![FilterStep::LoudnessNormalize {
+        target_lufs: -14.0,
+        true_peak_db: -1.0,
+        lra: 7.0,
+    }]);
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![clip])
+        .audio_track_with(audio)
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    match timeline.render(&out_path, render_config()) {
+        Ok(()) => {}
+        Err(TimelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+            return;
+        }
+        Err(TimelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+        Err(TimelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+            return;
+        }
+        Err(e) => panic!("unexpected error from Timeline::render: {e}"),
+    }
+
+    let info = match ff_probe::open(&out_path) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping: ff_probe::open failed: {e}");
+            return;
+        }
+    };
+    assert!(
+        info.has_audio(),
+        "rendered output with a per-track audio effect must contain an audio stream"
+    );
+}
+
+/// Two audio tracks, one carrying a per-track effect, must sum through the
+/// additive master `amix` (issue #1446). This exercises the full per-track path:
+/// per-track sub-mix, a single track's push/pull effect graph, and the master mix
+/// over both processed tracks.
+#[test]
+fn timeline_two_tracks_one_with_effect_should_render_mixed_audio() {
+    let src_path = test_output_path("timeline_trackmix_src.mp4");
+    let out_path = test_output_path("timeline_trackmix_out.mp4");
+    let _g_src = FileGuard::new(src_path.clone());
+    let _g_out = FileGuard::new(out_path.clone());
+
+    if make_source_file(&src_path, W, H, FPS, FRAME_COUNT, 76, 84, 255).is_none() {
+        return;
+    }
+
+    let clip = Clip::new(&src_path);
+    let fx_track = Track::new(vec![clip.clone()]).audio_effects(vec![FilterStep::Volume(-6.0)]);
+    let plain_track = Track::new(vec![clip.clone()]);
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![clip])
+        .audio_track_with(fx_track)
+        .audio_track_with(plain_track)
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    match timeline.render(&out_path, render_config()) {
+        Ok(()) => {}
+        Err(TimelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+            return;
+        }
+        Err(TimelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+        Err(TimelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+            return;
+        }
+        Err(e) => panic!("unexpected error from Timeline::render: {e}"),
+    }
+
+    let info = match ff_probe::open(&out_path) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping: ff_probe::open failed: {e}");
+            return;
+        }
+    };
+    assert!(
+        info.has_audio(),
+        "mixed output over two tracks (one with an effect) must contain an audio stream"
+    );
+}
+
+/// A per-track effect chain and the timeline master bus (`audio_filter`) together
+/// must render (issue #1446). This traverses the per-track drain branch's
+/// `Some(master)` path — the track's push/pull effect graph output is routed
+/// through the master bus before the encoder — which the other #1446 tests (no
+/// `audio_filter`) never exercise.
+#[test]
+fn timeline_track_effect_with_master_bus_should_render() {
+    let src_path = test_output_path("timeline_trackfxbus_src.mp4");
+    let out_path = test_output_path("timeline_trackfxbus_out.mp4");
+    let _g_src = FileGuard::new(src_path.clone());
+    let _g_out = FileGuard::new(out_path.clone());
+
+    if make_source_file(&src_path, W, H, FPS, FRAME_COUNT, 76, 84, 255).is_none() {
+        return;
+    }
+
+    let clip = Clip::new(&src_path);
+    let fx_track = Track::new(vec![clip.clone()]).audio_effects(vec![FilterStep::Volume(-3.0)]);
+    let timeline = match Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(FPS)
+        .video_track(vec![clip])
+        .audio_track_with(fx_track)
+        .audio_filter(vec![FilterStep::Volume(-6.0)])
+        .build()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            println!("Skipping: Timeline::builder().build() failed: {e}");
+            return;
+        }
+    };
+
+    match timeline.render(&out_path, render_config()) {
+        Ok(()) => {}
+        Err(TimelineError::Filter(e)) => {
+            println!("Skipping: filter graph construction failed: {e}");
+            return;
+        }
+        Err(TimelineError::Encode(e)) => {
+            println!("Skipping: encoder unavailable: {e}");
+            return;
+        }
+        Err(TimelineError::Decode(e)) => {
+            println!("Skipping: decoder unavailable: {e}");
+            return;
+        }
+        Err(e) => panic!("unexpected error from Timeline::render: {e}"),
+    }
+
+    let info = match ff_probe::open(&out_path) {
+        Ok(i) => i,
+        Err(e) => {
+            println!("Skipping: ff_probe::open failed: {e}");
+            return;
+        }
+    };
+    assert!(
+        info.has_audio(),
+        "output with a per-track effect and a master bus must contain an audio stream"
     );
 }
 

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -3058,6 +3058,22 @@ impl FilterGraphInner {
                     }
                 }
             }
+
+            // Amix consumes n input pads; like ConcatAudio, `add_and_link_step`
+            // wires only pad 0 (prev_ctx), so link src_ctxs[1..n-1] to pads
+            // 1..n-1 or `avfilter_graph_config` fails on the unconnected pads.
+            if let FilterStep::Amix(n) = step {
+                for slot in 1..*n {
+                    if let Some(Some(extra_src)) = src_ctxs.get(slot) {
+                        let ret =
+                            ff_sys::avfilter_link(extra_src.as_ptr(), 0, prev_ctx, slot as u32);
+                        if ret < 0 {
+                            return Err(FilterError::BuildFailed);
+                        }
+                        log::debug!("filter linked extra_input=in{slot} to amix pad={slot}");
+                    }
+                }
+            }
         }
 
         // Link last filter to sink.

--- a/crates/ff-filter/src/graph/builder/audio.rs
+++ b/crates/ff-filter/src/graph/builder/audio.rs
@@ -182,7 +182,8 @@ impl FilterGraphBuilder {
         self
     }
 
-    /// Mix `inputs` audio streams together.
+    /// Mix `inputs` audio streams together (additive: the inputs are summed, not
+    /// averaged; push each stream to its slot `0..inputs`).
     #[must_use]
     pub fn amix(mut self, inputs: usize) -> Self {
         self.steps.push(FilterStep::Amix(inputs));
@@ -227,7 +228,7 @@ mod tests {
     fn filter_step_amix_should_produce_correct_args() {
         let step = FilterStep::Amix(3);
         assert_eq!(step.filter_name(), "amix");
-        assert_eq!(step.args(), "inputs=3");
+        assert_eq!(step.args(), "inputs=3:normalize=0");
     }
 
     #[test]

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -105,7 +105,8 @@ pub enum FilterStep {
     ToneMap(ToneMap),
     /// Adjust audio volume (in dB; negative = quieter).
     Volume(f64),
-    /// Mix `n` audio inputs together.
+    /// Mix `n` audio inputs together (additive: the inputs are summed, not
+    /// averaged, via `normalize=0`).
     Amix(usize),
     /// Multi-band parametric equalizer (low-shelf, high-shelf, or peak bands).
     ///
@@ -1242,7 +1243,10 @@ impl FilterStep {
             }
             Self::ToneMap(algorithm) => format!("tonemap={}", algorithm.as_str()),
             Self::Volume(db) => format!("volume={db}dB"),
-            Self::Amix(inputs) => format!("inputs={inputs}"),
+            // `normalize=0` sums the inputs (additive) instead of averaging by the
+            // active-input count, matching the multi-track mixer's convention so a
+            // mix has the same level however it is built.
+            Self::Amix(inputs) => format!("inputs={inputs}:normalize=0"),
             // args() for ParametricEq is not used by the build loop (which is
             // bypassed in favour of add_parametric_eq_chain); provided here for
             // completeness using the first band's args.

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -569,30 +569,38 @@ fn push_video_through_tone_map_should_return_frame() {
 
 #[test]
 fn push_audio_through_amix_should_return_mixed_frame() {
-    let mut graph = match FilterGraph::builder().amix(2).build() {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
+    // amix needs its extra input pads (1..n) linked in `build_audio_graph`, not
+    // just pad 0. A regression that drops that linking leaves pads 1..n
+    // unconnected, so `avfilter_graph_config` fails at the first push. Probe a
+    // trivial single-input audio graph first: if that push fails, audio filters
+    // are unavailable (CI's FFmpeg has none) → skip. If it succeeds, filters are
+    // present, so the amix multi-input graph MUST configure and mix — a failure
+    // there is a real bug, not an environment gap, so assert rather than skip.
     let frame = make_audio_frame();
+    {
+        let mut probe = FilterGraph::builder()
+            .volume(0.0)
+            .build()
+            .expect("non-empty volume graph must build");
+        if probe.push_audio(0, &frame).is_err() {
+            println!("skipping: audio filters not available in this FFmpeg build");
+            return;
+        }
+    }
+    // Filters are available → the amix multi-input graph must work.
+    let mut graph = FilterGraph::builder()
+        .amix(2)
+        .build()
+        .expect("non-empty amix graph must build");
     // Push to slot 0 — this also initialises the audio graph.
-    match graph.push_audio(0, &frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    // Push to slot 1 so amix has data on both inputs and can produce output.
-    match graph.push_audio(1, &frame) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
+    graph
+        .push_audio(0, &frame)
+        .expect("amix pad 0 push must succeed when filters are available");
+    // Push to slot 1 so amix has data on both inputs and can produce output; this
+    // fails if the extra input pad was left unconnected (the #1446 regression).
+    graph
+        .push_audio(1, &frame)
+        .expect("amix pad 1 must be linked (extra-input regression guard)");
     let result = graph.pull_audio().expect("pull_audio must not fail");
     let out = result.expect("expected Some(frame) after amix push to both slots");
     assert_eq!(out.sample_rate(), 48000, "sample rate should be unchanged");


### PR DESCRIPTION
## Objective

- A per-track audio effect (e.g. loudness normalization or a compressor) could not act on one track's mixed contribution before the timeline mix: a two-pass effect placed there was inert, because the source-only multi-track mixer graph has no push/pull driver for it.

## Solution

- Add `Track.audio_effects: Vec<FilterStep>` with a `Track::audio_effects` builder (mirrors `Clip`'s effect fields; skipped by serde as `FilterStep` is not serializable).
- On render, when any active audio track carries a chain, switch to a per-track path: sub-mix each track, route it through its own push/pull `FilterGraph` (so a two-pass step such as loudness normalization fires), then sum the tracks with an additive `amix` before the timeline master bus. When no track carries a chain the original streamed single-mixer path is unchanged.
- Unify `FilterStep::Amix` to `inputs=n:normalize=0` (additive sum, not averaging) so a mix has the same level however it is built, matching the multi-track mixer's existing convention.
- Link `amix`'s extra input pads in `build_audio_graph` (only `ConcatAudio` did before) so a multi-input push/pull `amix` graph configures instead of failing on unconnected pads.

Closes #1446