### PR TITLE
chore(ff-encode,ff-remux): retire the crate-wide clippy-allow blocks

### DIFF
--- a/crates/ff-encode/src/audio/async_encoder.rs
+++ b/crates/ff-encode/src/audio/async_encoder.rs
@@ -62,7 +62,7 @@ impl AsyncAudioEncoder {
     ///
     /// Consumes the builder, validates the configuration, opens the output
     /// file, and starts the worker thread. The worker runs the synchronous
-    /// FFmpeg encode loop in the background.
+    /// `FFmpeg` encode loop in the background.
     ///
     /// # Errors
     ///

--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -131,7 +131,7 @@ impl AudioEncoderBuilder {
     }
 }
 
-/// Encodes audio frames to a file using FFmpeg.
+/// Encodes audio frames to a file using `FFmpeg`.
 ///
 /// # Construction
 ///
@@ -278,7 +278,7 @@ impl AudioEncoder {
         })
     }
 
-    /// Returns the name of the FFmpeg encoder actually used (e.g. `"aac"`, `"libopus"`).
+    /// Returns the name of the `FFmpeg` encoder actually used (e.g. `"aac"`, `"libopus"`).
     #[must_use]
     pub fn actual_codec(&self) -> &str {
         self.inner

--- a/crates/ff-encode/src/audio/codec_options.rs
+++ b/crates/ff-encode/src/audio/codec_options.rs
@@ -55,7 +55,7 @@ pub enum OpusApplication {
     /// Optimised for general audio (music, speech mix). Default.
     #[default]
     Audio,
-    /// Optimised for VoIP / speech clarity at low bitrates.
+    /// Optimised for `VoIP` / speech clarity at low bitrates.
     Voip,
     /// Minimum latency mode — disables lookahead.
     LowDelay,
@@ -79,7 +79,7 @@ pub struct AacOptions {
     /// AAC encoding profile.
     ///
     /// `He` and `Hev2` typically require `libfdk_aac` (non-free). The built-in
-    /// FFmpeg `aac` encoder may not support them — the failure is logged as a
+    /// `FFmpeg` `aac` encoder may not support them — the failure is logged as a
     /// warning and encoding continues with the encoder's default profile.
     pub profile: AacProfile,
     /// VBR quality mode (1–5). `Some(q)` enables VBR; `None` uses CBR.

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -6,9 +6,15 @@
 // Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
-// FFmpeg C API frequently requires raw pointer casting
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use crate::audio::codec_options::{AudioCodecOptions, Mp3Quality};
 use crate::{AudioCodec, EncodeError};
@@ -87,7 +93,7 @@ impl AudioEncoderInner {
 
             let mut format_ctx: *mut AVFormatContext = ptr::null_mut();
             let ret = avformat_alloc_output_context2(
-                &mut format_ctx,
+                &raw mut format_ctx,
                 ptr::null_mut(),
                 ptr::null(),
                 c_path.as_ptr(),
@@ -119,14 +125,15 @@ impl AudioEncoderInner {
             encoder.init_audio_encoder(config)?;
 
             // Open output file
-            match ff_sys::avformat::open_output(&config.path, ff_sys::avformat::avio_flags::WRITE) {
-                Ok(pb) => (*format_ctx).pb = pb,
-                Err(_) => {
-                    encoder.cleanup();
-                    return Err(EncodeError::CannotCreateFile {
-                        path: config.path.clone(),
-                    });
-                }
+            if let Ok(pb) =
+                ff_sys::avformat::open_output(&config.path, ff_sys::avformat::avio_flags::WRITE)
+            {
+                (*format_ctx).pb = pb;
+            } else {
+                encoder.cleanup();
+                return Err(EncodeError::CannotCreateFile {
+                    path: config.path.clone(),
+                });
             }
 
             // Write file header
@@ -150,7 +157,7 @@ impl AudioEncoderInner {
     ) -> Result<(), EncodeError> {
         // Select encoder based on codec and availability
         let encoder_name = self.select_audio_encoder(config.codec)?;
-        self.actual_codec = encoder_name.clone();
+        self.actual_codec.clone_from(&encoder_name);
 
         let c_encoder_name =
             CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
@@ -176,7 +183,7 @@ impl AudioEncoderInner {
 
         // Set channel layout using FFmpeg 7.x API
         swresample::channel_layout::set_default(
-            &mut (*codec_ctx).ch_layout,
+            &raw mut (*codec_ctx).ch_layout,
             config.channels as i32,
         );
 
@@ -254,7 +261,7 @@ impl AudioEncoderInner {
         // Create stream
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
-            avcodec::free_context(&mut codec_ctx as *mut *mut _);
+            avcodec::free_context(&raw mut codec_ctx);
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "Cannot create stream".to_string(),
@@ -473,7 +480,7 @@ impl AudioEncoderInner {
 
                 let convert_result = self.convert_audio_frame(frame, av_frame);
                 if let Err(e) = convert_result {
-                    av_frame_free(&mut av_frame as *mut *mut _);
+                    av_frame_free(&raw mut av_frame);
                     return Err(e);
                 }
 
@@ -487,7 +494,7 @@ impl AudioEncoderInner {
                     nb_samples,
                 );
 
-                av_frame_free(&mut av_frame as *mut *mut _);
+                av_frame_free(&raw mut av_frame);
 
                 write_result.map_err(|e| EncodeError::Ffmpeg {
                     code: e,
@@ -514,7 +521,7 @@ impl AudioEncoderInner {
 
                 let convert_result = self.convert_audio_frame(frame, av_frame);
                 if let Err(e) = convert_result {
-                    av_frame_free(&mut av_frame as *mut *mut _);
+                    av_frame_free(&raw mut av_frame);
                     return Err(e);
                 }
 
@@ -522,7 +529,7 @@ impl AudioEncoderInner {
 
                 let send_result = avcodec::send_frame(codec_ctx, av_frame);
                 if let Err(e) = send_result {
-                    av_frame_free(&mut av_frame as *mut *mut _);
+                    av_frame_free(&raw mut av_frame);
                     return Err(EncodeError::Ffmpeg {
                         code: e,
                         message: format!(
@@ -533,7 +540,7 @@ impl AudioEncoderInner {
                 }
 
                 let receive_result = self.receive_packets();
-                av_frame_free(&mut av_frame as *mut *mut _);
+                av_frame_free(&raw mut av_frame);
                 receive_result?;
 
                 self.sample_count += frame.samples() as u64;
@@ -569,16 +576,17 @@ impl AudioEncoderInner {
         (*av_frame).nb_samples = frame_size;
         (*av_frame).pts = self.sample_count as i64;
 
-        if let Err(e) =
-            swresample::channel_layout::copy(&mut (*av_frame).ch_layout, &(*codec_ctx).ch_layout)
-        {
-            av_frame_free(&mut av_frame as *mut *mut _);
+        if let Err(e) = swresample::channel_layout::copy(
+            &raw mut (*av_frame).ch_layout,
+            &raw const (*codec_ctx).ch_layout,
+        ) {
+            av_frame_free(&raw mut av_frame);
             return Err(EncodeError::from_ffmpeg_error(e));
         }
 
         let ret = ff_sys::av_frame_get_buffer(av_frame, 0);
         if ret < 0 {
-            av_frame_free(&mut av_frame as *mut *mut _);
+            av_frame_free(&raw mut av_frame);
             return Err(EncodeError::Ffmpeg {
                 code: ret,
                 message: format!(
@@ -610,7 +618,7 @@ impl AudioEncoderInner {
             (*av_frame).data.as_ptr().cast::<*mut c_void>(),
             frame_size,
         ) {
-            av_frame_free(&mut av_frame as *mut *mut _);
+            av_frame_free(&raw mut av_frame);
             return Err(EncodeError::Ffmpeg {
                 code: e,
                 message: format!(
@@ -622,7 +630,7 @@ impl AudioEncoderInner {
         // nb_samples stays as frame_size: the encoder always receives a full frame.
 
         let send_result = avcodec::send_frame(codec_ctx, av_frame);
-        av_frame_free(&mut av_frame as *mut *mut _);
+        av_frame_free(&raw mut av_frame);
 
         send_result.map_err(|e| EncodeError::Ffmpeg {
             code: e,
@@ -654,13 +662,13 @@ impl AudioEncoderInner {
         let src_format = sample_format_to_av(src.format());
         let src_ch_layout = {
             let mut layout = AVChannelLayout::default();
-            swresample::channel_layout::set_default(&mut layout, src.channels() as i32);
+            swresample::channel_layout::set_default(&raw mut layout, src.channels() as i32);
             layout
         };
 
         let needs_resampling = src_sample_rate != target_sample_rate
             || src_format != target_format
-            || !swresample::channel_layout::is_equal(&src_ch_layout, target_ch_layout);
+            || !swresample::channel_layout::is_equal(&raw const src_ch_layout, target_ch_layout);
 
         if needs_resampling {
             // Initialize resampler if needed
@@ -669,7 +677,7 @@ impl AudioEncoderInner {
                     target_ch_layout,
                     target_format,
                     target_sample_rate,
-                    &src_ch_layout,
+                    &raw const src_ch_layout,
                     src_format,
                     src_sample_rate,
                 )
@@ -697,7 +705,7 @@ impl AudioEncoderInner {
             (*dst).nb_samples = out_samples;
 
             // Copy target channel layout
-            swresample::channel_layout::copy(&mut (*dst).ch_layout, target_ch_layout)
+            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, target_ch_layout)
                 .map_err(EncodeError::from_ffmpeg_error)?;
 
             // Allocate frame buffer
@@ -739,7 +747,7 @@ impl AudioEncoderInner {
             (*dst).nb_samples = src.samples() as i32;
 
             // Copy channel layout
-            swresample::channel_layout::copy(&mut (*dst).ch_layout, &src_ch_layout)
+            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, &raw const src_ch_layout)
                 .map_err(EncodeError::from_ffmpeg_error)?;
 
             // Allocate frame buffer
@@ -799,7 +807,7 @@ impl AudioEncoderInner {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&mut packet as *mut *mut _);
+                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e,
                         message: format!(
@@ -817,7 +825,7 @@ impl AudioEncoderInner {
             let write_ret = av_interleaved_write_frame(self.format_ctx, packet);
             if write_ret < 0 {
                 av_packet_unref(packet);
-                av_packet_free(&mut packet as *mut *mut _);
+                av_packet_free(&raw mut packet);
                 return Err(EncodeError::MuxingFailed {
                     reason: ff_sys::av_error_string(write_ret),
                 });
@@ -828,7 +836,7 @@ impl AudioEncoderInner {
             av_packet_unref(packet);
         }
 
-        av_packet_free(&mut packet as *mut *mut _);
+        av_packet_free(&raw mut packet);
         Ok(())
     }
 
@@ -876,18 +884,18 @@ impl AudioEncoderInner {
 
         // Free audio codec context
         if let Some(mut ctx) = self.codec_ctx.take() {
-            avcodec::free_context(&mut ctx as *mut *mut _);
+            avcodec::free_context(&raw mut ctx);
         }
 
         // Free resampling context
         if let Some(mut ctx) = self.swr_ctx.take() {
-            swresample::free(&mut ctx as *mut *mut _);
+            swresample::free(&raw mut ctx);
         }
 
         // Close output file
         if !self.format_ctx.is_null() {
             if !(*self.format_ctx).pb.is_null() {
-                ff_sys::avformat::close_output(&mut (*self.format_ctx).pb);
+                ff_sys::avformat::close_output(&raw mut (*self.format_ctx).pb);
             }
             avformat_free_context(self.format_ctx);
             self.format_ctx = ptr::null_mut();

--- a/crates/ff-encode/src/audio/mod.rs
+++ b/crates/ff-encode/src/audio/mod.rs
@@ -1,6 +1,6 @@
 //! Audio encoding implementation.
 //!
-//! This module provides audio encoding functionality with an FFmpeg backend.
+//! This module provides audio encoding functionality with an `FFmpeg` backend.
 //! The implementation is split into public API ([`builder`]) and internal
 //! implementation details ([`encoder_inner`]).
 

--- a/crates/ff-encode/src/error.rs
+++ b/crates/ff-encode/src/error.rs
@@ -58,7 +58,7 @@ pub enum EncodeError {
     EncoderUnavailable {
         /// Requested codec name (e.g. `"h265/hevc"`).
         codec: String,
-        /// Human-readable guidance (e.g. how to build FFmpeg with this encoder).
+        /// Human-readable guidance (e.g. how to build `FFmpeg` with this encoder).
         hint: String,
     },
 
@@ -144,7 +144,7 @@ pub enum EncodeError {
     ///
     /// Returned by [`ExportPreset::validate()`](crate::ExportPreset::validate)
     /// when the preset's configuration conflicts with a platform rule (e.g.
-    /// fps > 60 for a YouTube preset).
+    /// fps > 60 for a `YouTube` preset).
     #[error("preset constraint violated: preset={preset} reason={reason}")]
     PresetConstraintViolation {
         /// Name of the preset that failed validation.
@@ -155,7 +155,7 @@ pub enum EncodeError {
 }
 
 impl EncodeError {
-    /// Create an error from an FFmpeg error code.
+    /// Create an error from an `FFmpeg` error code.
     ///
     /// This is more type-safe than implementing `From<i32>` globally,
     /// as it makes the conversion explicit and prevents accidental

--- a/crates/ff-encode/src/image/builder.rs
+++ b/crates/ff-encode/src/image/builder.rs
@@ -69,7 +69,7 @@ impl ImageEncoderBuilder {
     ///
     /// If not set, a codec-native default is used (e.g. `YUVJ420P` for JPEG,
     /// `RGB24` for PNG). Setting an incompatible format may cause encoding to
-    /// fail with an FFmpeg error.
+    /// fail with an `FFmpeg` error.
     #[must_use]
     pub fn pixel_format(mut self, fmt: PixelFormat) -> Self {
         self.pixel_format = Some(fmt);
@@ -154,7 +154,7 @@ impl ImageEncoder {
     ///
     /// # Errors
     ///
-    /// Returns an error if the FFmpeg encoder is unavailable, the output file
+    /// Returns an error if the `FFmpeg` encoder is unavailable, the output file
     /// cannot be created, or encoding fails.
     pub fn encode(self, frame: &VideoFrame) -> Result<(), EncodeError> {
         let opts = encoder_inner::ImageEncodeOptions {

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -14,8 +14,15 @@
 // Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use std::ffi::CString;
 use std::path::Path;
@@ -137,14 +144,14 @@ impl ImageEncoderInner {
 
         let mut ret = if let Some(fmt) = explicit_fmt {
             avformat_alloc_output_context2(
-                &mut inner.format_ctx,
+                &raw mut inner.format_ctx,
                 ptr::null_mut(),
                 fmt,
                 c_path.as_ptr(),
             )
         } else {
             avformat_alloc_output_context2(
-                &mut inner.format_ctx,
+                &raw mut inner.format_ctx,
                 ptr::null_mut(),
                 ptr::null(),
                 c_path.as_ptr(),
@@ -155,7 +162,7 @@ impl ImageEncoderInner {
         // failed (e.g. on a minimal FFmpeg build that omits the dedicated muxer).
         if ret < 0 || inner.format_ctx.is_null() {
             ret = avformat_alloc_output_context2(
-                &mut inner.format_ctx,
+                &raw mut inner.format_ctx,
                 ptr::null_mut(),
                 ptr::null(),
                 c_path.as_ptr(),
@@ -365,7 +372,7 @@ impl ImageEncoderInner {
         // ── Finalise file ─────────────────────────────────────────────────────
         av_write_trailer(self.format_ctx);
         // SAFETY: format_ctx and pb are non-null at this point.
-        avformat::close_output(&mut (*self.format_ctx).pb);
+        avformat::close_output(&raw mut (*self.format_ctx).pb);
 
         Ok(())
     }
@@ -413,11 +420,11 @@ impl Drop for ImageEncoderInner {
         unsafe {
             if !self.dst_frame.is_null() {
                 // SAFETY: dst_frame is non-null and owned by this struct.
-                av_frame_free(&mut self.dst_frame);
+                av_frame_free(&raw mut self.dst_frame);
             }
             if !self.packet.is_null() {
                 // SAFETY: packet is non-null and owned by this struct.
-                av_packet_free(&mut self.packet);
+                av_packet_free(&raw mut self.packet);
             }
             if let Some(sws) = self.sws_ctx.take() {
                 // SAFETY: sws is a valid SwsContext that hasn't been freed yet.
@@ -426,7 +433,7 @@ impl Drop for ImageEncoderInner {
             if !self.codec_ctx.is_null() {
                 // SAFETY: codec_ctx is non-null and owned by this struct.
                 // avcodec_free_context sets the pointer to null after freeing.
-                avcodec::free_context(&mut self.codec_ctx);
+                avcodec::free_context(&raw mut self.codec_ctx);
             }
             if !self.format_ctx.is_null() {
                 // SAFETY: format_ctx is non-null and owned by this struct.
@@ -434,7 +441,7 @@ impl Drop for ImageEncoderInner {
                 // to null by avio_closep, so this check prevents a double-close
                 // when encode_frame already closed it on success).
                 if !(*self.format_ctx).pb.is_null() {
-                    avformat::close_output(&mut (*self.format_ctx).pb);
+                    avformat::close_output(&raw mut (*self.format_ctx).pb);
                 }
                 avformat_free_context(self.format_ctx);
                 self.format_ctx = ptr::null_mut();

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -2,29 +2,10 @@
 //!
 //! Video and audio encoding - the Rust way.
 
-// FFmpeg binding requires unsafe code for C API calls
+// FFmpeg's C API is called through `unsafe`; the FFI is isolated in the
+// `*_inner` modules, which carry their own scoped clippy allows for the
+// FFmpeg-boundary lints (casts, pointer idioms).
 #![allow(unsafe_code)]
-// Raw pointer operations are necessary for FFmpeg C API
-#![allow(clippy::borrow_as_ptr)]
-#![allow(clippy::ptr_as_ptr)]
-#![allow(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_safety_doc)]
-// Casting between C and Rust types
-#![allow(clippy::cast_possible_wrap)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::cast_sign_loss)]
-// C string literals
-#![allow(clippy::manual_c_str_literals)]
-// Code structure warnings
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::single_match_else)]
-#![allow(clippy::inefficient_to_string)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
-#![allow(clippy::doc_markdown)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::assigning_clones)]
-#![allow(clippy::unused_self)]
-#![allow(clippy::unnecessary_safety_comment)]
 //!
 //! This crate provides video and audio encoding functionality for timeline export.
 //! It supports automatic codec selection with LGPL compliance, hardware acceleration,
@@ -156,11 +137,11 @@
 //! When H.264/H.265 encoding is requested, the encoder automatically selects codecs in this priority:
 //!
 //! 1. **Hardware encoders** (LGPL-compatible, no licensing fees):
-//!    - NVIDIA NVENC (h264_nvenc, hevc_nvenc)
-//!    - Intel Quick Sync Video (h264_qsv, hevc_qsv)
-//!    - AMD AMF/VCE (h264_amf, hevc_amf)
-//!    - Apple VideoToolbox (h264_videotoolbox, hevc_videotoolbox)
-//!    - VA-API (h264_vaapi, hevc_vaapi) - Linux
+//!    - NVIDIA NVENC (`h264_nvenc`, `hevc_nvenc`)
+//!    - Intel Quick Sync Video (`h264_qsv`, `hevc_qsv`)
+//!    - AMD AMF/VCE (`h264_amf`, `hevc_amf`)
+//!    - Apple `VideoToolbox` (`h264_videotoolbox`, `hevc_videotoolbox`)
+//!    - VA-API (`h264_vaapi`, `hevc_vaapi`) - Linux
 //!
 //! 2. **Fallback to royalty-free codecs**:
 //!    - For H.264 request → VP9 (libvpx-vp9)

--- a/crates/ff-encode/src/preset/mod.rs
+++ b/crates/ff-encode/src/preset/mod.rs
@@ -56,7 +56,7 @@ pub struct AudioEncoderConfig {
     pub sample_rate: u32,
     /// Number of audio channels (1 = mono, 2 = stereo).
     pub channels: u32,
-    /// Audio bitrate in bits per second (e.g. 192_000 = 192 kbps).
+    /// Audio bitrate in bits per second (e.g. `192_000` = 192 kbps).
     pub bitrate: u64,
 }
 
@@ -93,13 +93,13 @@ pub struct ExportPreset {
 impl ExportPreset {
     // ── Predefined presets ────────────────────────────────────────────────────
 
-    /// YouTube 1080p preset: H.264, CRF 18, 1920×1080, 30 fps, AAC 192 kbps.
+    /// `YouTube` 1080p preset: H.264, CRF 18, 1920×1080, 30 fps, AAC 192 kbps.
     #[must_use]
     pub fn youtube_1080p() -> Self {
         presets::youtube_1080p()
     }
 
-    /// YouTube 4K preset: H.265, CRF 20, 3840×2160, 30 fps, AAC 256 kbps.
+    /// `YouTube` 4K preset: H.265, CRF 20, 3840×2160, 30 fps, AAC 256 kbps.
     #[must_use]
     pub fn youtube_4k() -> Self {
         presets::youtube_4k()
@@ -158,7 +158,7 @@ impl ExportPreset {
     /// # Errors
     ///
     /// Returns [`EncodeError::PresetConstraintViolation`] when a platform rule
-    /// is violated (e.g. fps > 60 on a YouTube preset, or wrong aspect ratio
+    /// is violated (e.g. fps > 60 on a `YouTube` preset, or wrong aspect ratio
     /// on an Instagram preset).
     pub fn validate(&self) -> Result<(), EncodeError> {
         validation::validate_preset(self)

--- a/crates/ff-encode/src/preset/presets.rs
+++ b/crates/ff-encode/src/preset/presets.rs
@@ -3,7 +3,7 @@
 use super::{AudioEncoderConfig, ExportPreset, VideoEncoderConfig};
 use crate::{AudioCodec, BitrateMode, VideoCodec};
 
-/// YouTube 1080p preset: H.264 CRF 18, 1920×1080, 30 fps, AAC 192 kbps.
+/// `YouTube` 1080p preset: H.264 CRF 18, 1920×1080, 30 fps, AAC 192 kbps.
 pub(super) fn youtube_1080p() -> ExportPreset {
     ExportPreset {
         name: "youtube_1080p".to_string(),
@@ -25,7 +25,7 @@ pub(super) fn youtube_1080p() -> ExportPreset {
     }
 }
 
-/// YouTube 4K preset: H.265 CRF 20, 3840×2160, 30 fps, AAC 256 kbps.
+/// `YouTube` 4K preset: H.265 CRF 20, 3840×2160, 30 fps, AAC 256 kbps.
 pub(super) fn youtube_4k() -> ExportPreset {
     ExportPreset {
         name: "youtube_4k".to_string(),

--- a/crates/ff-encode/src/preview/mod.rs
+++ b/crates/ff-encode/src/preview/mod.rs
@@ -4,7 +4,7 @@
 //! into a single PNG image suitable for video-player scrub-bar hover previews.
 //!
 //! [`GifPreview`] generates an animated GIF from a configurable time range
-//! using FFmpeg's two-pass `palettegen` + `paletteuse` approach.
+//! using `FFmpeg`'s two-pass `palettegen` + `paletteuse` approach.
 
 mod error;
 mod preview_inner;
@@ -105,7 +105,7 @@ impl SpriteSheet {
     ///
     /// - [`PreviewImageError::OperationFailed`] — `cols` or `rows` is zero,
     ///   `frame_width` or `frame_height` is zero, or `output` path is not set.
-    /// - [`PreviewImageError::Ffmpeg`] — any FFmpeg filter graph or encoding call fails.
+    /// - [`PreviewImageError::Ffmpeg`] — any `FFmpeg` filter graph or encoding call fails.
     pub fn run(self) -> Result<(), PreviewImageError> {
         if self.cols == 0 || self.rows == 0 {
             return Err(PreviewImageError::OperationFailed {
@@ -135,7 +135,7 @@ impl SpriteSheet {
 
 /// Generates an animated GIF preview from a configurable time range.
 ///
-/// Uses FFmpeg's two-pass `palettegen` + `paletteuse` approach for
+/// Uses `FFmpeg`'s two-pass `palettegen` + `paletteuse` approach for
 /// high-quality colour fidelity within GIF's 256-colour limit.
 ///
 /// # Examples
@@ -222,7 +222,7 @@ impl GifPreview {
     ///
     /// - [`PreviewImageError::OperationFailed`] — output path not set, output
     ///   extension is not `.gif`, `fps` ≤ 0, or `width` is zero.
-    /// - [`PreviewImageError::Ffmpeg`] — any FFmpeg filter graph or encoding call fails.
+    /// - [`PreviewImageError::Ffmpeg`] — any `FFmpeg` filter graph or encoding call fails.
     pub fn run(self) -> Result<(), PreviewImageError> {
         if self.output.as_os_str().is_empty() {
             return Err(PreviewImageError::OperationFailed {

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -8,6 +8,15 @@
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string literals,
+// and FFI-wrapper ergonomics concentrate in this unsafe module.
+#![allow(clippy::ptr_as_ptr)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use std::ffi::CString;
 use std::path::Path;
@@ -36,14 +45,14 @@ unsafe fn probe_video_duration_secs(path: &Path) -> Result<f64, PreviewImageErro
 
     if let Err(e) = avformat::find_stream_info(fmt_ctx) {
         let mut p = fmt_ctx;
-        avformat::close_input(&mut p);
+        avformat::close_input(&raw mut p);
         return Err(PreviewImageError::from_ffmpeg_error(e));
     }
 
     // SAFETY: fmt_ctx is non-null (open_input succeeded).
     let duration_av = (*fmt_ctx).duration;
     let mut p = fmt_ctx;
-    avformat::close_input(&mut p);
+    avformat::close_input(&raw mut p);
 
     if duration_av <= 0 {
         return Err(PreviewImageError::OperationFailed {
@@ -418,7 +427,7 @@ unsafe fn encode_frame_as_png_inner(
     // accepts the APNG (animated PNG) codec — not the plain PNG codec — and
     // would fail at avformat_write_header.
     let ret = avformat_alloc_output_context2(
-        &mut fmt_ctx,
+        &raw mut fmt_ctx,
         ptr::null_mut(),
         c"image2".as_ptr(),
         c_path.as_ptr(),
@@ -479,7 +488,7 @@ unsafe fn encode_frame_as_png_inner(
         Ok(ctx) => ctx,
         Err(e) => {
             let mut cc = codec_ctx;
-            avcodec::free_context(&mut cc);
+            avcodec::free_context(&raw mut cc);
             avformat_free_context(fmt_ctx);
             return Err(PreviewImageError::from_ffmpeg_error(e));
         }
@@ -488,9 +497,9 @@ unsafe fn encode_frame_as_png_inner(
 
     let ret = avformat_write_header(fmt_ctx, ptr::null_mut());
     if ret < 0 {
-        avformat::close_output(&mut (*fmt_ctx).pb);
+        avformat::close_output(&raw mut (*fmt_ctx).pb);
         let mut cc = codec_ctx;
-        avcodec::free_context(&mut cc);
+        avcodec::free_context(&raw mut cc);
         avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::from_ffmpeg_error(ret));
     }
@@ -499,9 +508,9 @@ unsafe fn encode_frame_as_png_inner(
     let packet = av_packet_alloc();
     if packet.is_null() {
         av_write_trailer(fmt_ctx);
-        avformat::close_output(&mut (*fmt_ctx).pb);
+        avformat::close_output(&raw mut (*fmt_ctx).pb);
         let mut cc = codec_ctx;
-        avcodec::free_context(&mut cc);
+        avcodec::free_context(&raw mut cc);
         avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::Ffmpeg {
             code: 0,
@@ -522,7 +531,7 @@ unsafe fn encode_frame_as_png_inner(
     })();
 
     av_write_trailer(fmt_ctx);
-    avformat::close_output(&mut (*fmt_ctx).pb);
+    avformat::close_output(&raw mut (*fmt_ctx).pb);
     av_packet_free(&mut { packet });
     avcodec::free_context(&mut { codec_ctx });
     avformat_free_context(fmt_ctx);
@@ -1131,7 +1140,7 @@ unsafe fn encode_gif_unsafe(
     };
 
     let ret = avformat_alloc_output_context2(
-        &mut fmt_ctx,
+        &raw mut fmt_ctx,
         ptr::null_mut(),
         c"gif".as_ptr(),
         c_path.as_ptr(),
@@ -1258,7 +1267,7 @@ unsafe fn encode_gif_unsafe(
 
     let ret = avformat_write_header(fmt_ctx, ptr::null_mut());
     if ret < 0 {
-        avformat::close_output(&mut (*fmt_ctx).pb);
+        avformat::close_output(&raw mut (*fmt_ctx).pb);
         let mut f = first_frame;
         av_frame_free(std::ptr::addr_of_mut!(f));
         avcodec::free_context(&mut { codec_ctx });
@@ -1271,7 +1280,7 @@ unsafe fn encode_gif_unsafe(
     let packet = av_packet_alloc();
     if packet.is_null() {
         av_write_trailer(fmt_ctx);
-        avformat::close_output(&mut (*fmt_ctx).pb);
+        avformat::close_output(&raw mut (*fmt_ctx).pb);
         let mut f = first_frame;
         av_frame_free(std::ptr::addr_of_mut!(f));
         avcodec::free_context(&mut { codec_ctx });
@@ -1325,7 +1334,7 @@ unsafe fn encode_gif_unsafe(
     })();
 
     av_write_trailer(fmt_ctx);
-    avformat::close_output(&mut (*fmt_ctx).pb);
+    avformat::close_output(&raw mut (*fmt_ctx).pb);
     av_packet_free(&mut { packet });
     let mut f = first_frame;
     av_frame_free(std::ptr::addr_of_mut!(f));

--- a/crates/ff-encode/src/shared/hardware.rs
+++ b/crates/ff-encode/src/shared/hardware.rs
@@ -37,7 +37,7 @@ pub enum HardwareEncoder {
 impl HardwareEncoder {
     /// Get the list of concrete hardware encoder backends available on this system.
     ///
-    /// Returns only actual hardware backends (NVENC, QSV, AMF, VideoToolbox,
+    /// Returns only actual hardware backends (NVENC, QSV, AMF, `VideoToolbox`,
     /// VA-API). The control variants [`Auto`](Self::Auto) and [`None`](Self::None)
     /// are intentionally excluded — they are configuration options, not hardware
     /// backends.
@@ -89,7 +89,7 @@ impl HardwareEncoder {
 
     /// Check if this hardware encoder is available.
     ///
-    /// Queries FFmpeg to determine if the hardware encoder is available
+    /// Queries `FFmpeg` to determine if the hardware encoder is available
     /// on the current system. This checks for both H.264 and H.265 support.
     ///
     /// # Examples
@@ -124,7 +124,7 @@ impl HardwareEncoder {
 ///
 /// # Arguments
 ///
-/// * `name` - The encoder name to check (e.g., "h264_nvenc", "hevc_qsv")
+/// * `name` - The encoder name to check (e.g., "`h264_nvenc`", "`hevc_qsv`")
 ///
 /// # Returns
 ///

--- a/crates/ff-encode/src/shared/progress.rs
+++ b/crates/ff-encode/src/shared/progress.rs
@@ -52,7 +52,7 @@ impl EncodeProgress {
     }
 }
 
-/// EncodeProgress callback trait for monitoring encoding progress.
+/// `EncodeProgress` callback trait for monitoring encoding progress.
 ///
 /// Implement this trait to receive real-time encoding progress updates
 /// and optionally support encoding cancellation.
@@ -109,7 +109,7 @@ pub trait EncodeProgressCallback: Send {
     }
 }
 
-/// Implement EncodeProgressCallback for closures.
+/// Implement `EncodeProgressCallback` for closures.
 ///
 /// This allows using simple closures as progress callbacks without
 /// needing to define a custom struct implementing the trait.

--- a/crates/ff-encode/src/video/async_encoder.rs
+++ b/crates/ff-encode/src/video/async_encoder.rs
@@ -62,7 +62,7 @@ impl AsyncVideoEncoder {
     ///
     /// Consumes the builder, validates the configuration, opens the output
     /// file, and starts the worker thread. The worker runs the synchronous
-    /// FFmpeg encode loop in the background.
+    /// `FFmpeg` encode loop in the background.
     ///
     /// # Errors
     ///

--- a/crates/ff-encode/src/video/builder/color.rs
+++ b/crates/ff-encode/src/video/builder/color.rs
@@ -33,7 +33,7 @@ impl VideoEncoderBuilder {
 
     /// Override the color space (matrix coefficients) written to the codec context.
     ///
-    /// When omitted the encoder uses the FFmpeg default. HDR10 metadata, if set
+    /// When omitted the encoder uses the `FFmpeg` default. HDR10 metadata, if set
     /// via [`hdr10_metadata()`](Self::hdr10_metadata), automatically selects
     /// BT.2020 NCL — this setter takes priority over that automatic choice.
     #[must_use]
@@ -44,7 +44,7 @@ impl VideoEncoderBuilder {
 
     /// Override the color transfer characteristic (gamma curve) written to the codec context.
     ///
-    /// When omitted the encoder uses the FFmpeg default. HDR10 metadata
+    /// When omitted the encoder uses the `FFmpeg` default. HDR10 metadata
     /// automatically selects PQ (SMPTE ST 2084) — this setter takes priority.
     /// Use [`ColorTransfer::Hlg`](ff_format::ColorTransfer::Hlg) for HLG broadcast HDR.
     #[must_use]
@@ -55,7 +55,7 @@ impl VideoEncoderBuilder {
 
     /// Override the color primaries written to the codec context.
     ///
-    /// When omitted the encoder uses the FFmpeg default. HDR10 metadata
+    /// When omitted the encoder uses the `FFmpeg` default. HDR10 metadata
     /// automatically selects BT.2020 — this setter takes priority.
     #[must_use]
     pub fn color_primaries(mut self, cp: ff_format::ColorPrimaries) -> Self {

--- a/crates/ff-encode/src/video/builder/mod.rs
+++ b/crates/ff-encode/src/video/builder/mod.rs
@@ -151,7 +151,7 @@ impl VideoEncoderBuilder {
 
     /// Apply container-specific codec defaults before validation.
     ///
-    /// For WebM paths/containers, default to VP9 + Opus when the caller has
+    /// For `WebM` paths/containers, default to VP9 + Opus when the caller has
     /// not explicitly chosen a codec.
     fn apply_container_defaults(mut self) -> Self {
         let is_webm = self
@@ -545,7 +545,7 @@ impl VideoEncoderBuilder {
     }
 }
 
-/// Encodes video (and optionally audio) frames to a file using FFmpeg.
+/// Encodes video (and optionally audio) frames to a file using `FFmpeg`.
 ///
 /// # Construction
 ///
@@ -584,7 +584,7 @@ impl VideoEncoder {
             video_fps: builder.video_fps,
             video_codec: builder.video_codec,
             video_bitrate_mode: builder.video_bitrate_mode,
-            preset: preset_to_string(&builder.preset),
+            preset: preset_to_string(builder.preset),
             hardware_encoder: builder.hardware_encoder,
             audio_sample_rate: builder.audio_sample_rate,
             audio_channels: builder.audio_channels,
@@ -624,7 +624,7 @@ impl VideoEncoder {
         })
     }
 
-    /// Returns the name of the FFmpeg encoder actually used (e.g. `"h264_nvenc"`, `"libx264"`).
+    /// Returns the name of the `FFmpeg` encoder actually used (e.g. `"h264_nvenc"`, `"libx264"`).
     #[must_use]
     pub fn actual_video_codec(&self) -> &str {
         self.inner
@@ -632,7 +632,7 @@ impl VideoEncoder {
             .map_or("", |inner| inner.actual_video_codec.as_str())
     }
 
-    /// Returns the name of the FFmpeg audio encoder actually used.
+    /// Returns the name of the `FFmpeg` audio encoder actually used.
     #[must_use]
     pub fn actual_audio_codec(&self) -> &str {
         self.inner
@@ -769,6 +769,10 @@ impl VideoEncoder {
             0.0
         };
         #[allow(clippy::cast_precision_loss)]
+        // Bitrate is a non-negative bits-per-second rate; the f64→u64 fallback
+        // (used only when the integer division would divide by zero) cannot wrap
+        // or lose a sign in practice.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let current_bitrate = if !elapsed.is_zero() {
             let elapsed_secs = elapsed.as_secs();
             match (bytes_written * 8).checked_div(elapsed_secs) {

--- a/crates/ff-encode/src/video/codec_options/dnxhd.rs
+++ b/crates/ff-encode/src/video/codec_options/dnxhd.rs
@@ -1,9 +1,9 @@
-//! Avid DNxHD / DNxHR per-codec encoding options.
+//! Avid `DNxHD` / `DNxHR` per-codec encoding options.
 
-/// DNxHD / DNxHR encoding variant.
+/// `DNxHD` / `DNxHR` encoding variant.
 ///
-/// Legacy DNxHD variants (`Dnxhd*`) are constrained to 1920×1080 or 1280×720
-/// and require a fixed bitrate. DNxHR variants (`Dnxhr*`) work at any resolution.
+/// Legacy `DNxHD` variants (`Dnxhd*`) are constrained to 1920×1080 or 1280×720
+/// and require a fixed bitrate. `DNxHR` variants (`Dnxhr*`) work at any resolution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DnxhdVariant {
     // ── DNxHD (legacy fixed-bitrate, 1920×1080 or 1280×720 only) ─────────────
@@ -57,9 +57,9 @@ impl DnxhdVariant {
         }
     }
 
-    /// For legacy DNxHD variants, returns the required fixed bitrate in bps.
+    /// For legacy `DNxHD` variants, returns the required fixed bitrate in bps.
     ///
-    /// DNxHR variants return `None` — the encoder selects the bitrate automatically.
+    /// `DNxHR` variants return `None` — the encoder selects the bitrate automatically.
     pub(in crate::video) fn fixed_bitrate_bps(self) -> Option<i64> {
         match self {
             Self::Dnxhd115 => Some(115_000_000),
@@ -69,7 +69,7 @@ impl DnxhdVariant {
         }
     }
 
-    /// Returns `true` for legacy DNxHD variants that require 1920×1080 or 1280×720.
+    /// Returns `true` for legacy `DNxHD` variants that require 1920×1080 or 1280×720.
     pub(in crate::video) fn is_dnxhd(self) -> bool {
         matches!(
             self,
@@ -78,9 +78,9 @@ impl DnxhdVariant {
     }
 }
 
-/// Avid DNxHD / DNxHR per-codec options.
+/// Avid `DNxHD` / `DNxHR` per-codec options.
 ///
-/// Output should use a `.mxf` or `.mov` container. Legacy DNxHD variants
+/// Output should use a `.mxf` or `.mov` container. Legacy `DNxHD` variants
 /// (`Dnxhd*`) are validated in `build()` to require 1920×1080 or 1280×720.
 #[derive(Debug, Clone, Default)]
 pub struct DnxhdOptions {

--- a/crates/ff-encode/src/video/codec_options/h265.rs
+++ b/crates/ff-encode/src/video/codec_options/h265.rs
@@ -15,11 +15,11 @@ pub struct H265Options {
     ///
     /// `None` leaves the encoder default. Invalid or unsupported values are logged as a
     /// warning and skipped — `build()` never fails due to an unsupported preset.
-    /// Hardware HEVC encoders (hevc_nvenc, etc.) ignore this option.
+    /// Hardware HEVC encoders (`hevc_nvenc`, etc.) ignore this option.
     pub preset: Option<String>,
     /// Raw x265-params string passed verbatim to libx265 (e.g. `"ctu=32:ref=4"`).
     ///
-    /// **Note**: H.265 encoding requires an FFmpeg build with `--enable-libx265`.
+    /// **Note**: H.265 encoding requires an `FFmpeg` build with `--enable-libx265`.
     ///
     /// An invalid parameter string is logged as a warning and skipped. It never causes
     /// `build()` to return an error.

--- a/crates/ff-encode/src/video/codec_options/mod.rs
+++ b/crates/ff-encode/src/video/codec_options/mod.rs
@@ -42,9 +42,9 @@ pub enum VideoCodecOptions {
     Av1Svt(SvtAv1Options),
     /// VP9 encoding options (reserved for a future issue).
     Vp9(Vp9Options),
-    /// Apple ProRes encoding options (reserved for a future issue).
+    /// Apple `ProRes` encoding options (reserved for a future issue).
     ProRes(ProResOptions),
-    /// Avid DNxHD / DNxHR encoding options (reserved for a future issue).
+    /// Avid `DNxHD` / `DNxHR` encoding options (reserved for a future issue).
     Dnxhd(DnxhdOptions),
 }
 

--- a/crates/ff-encode/src/video/codec_options/prores.rs
+++ b/crates/ff-encode/src/video/codec_options/prores.rs
@@ -1,6 +1,6 @@
-//! Apple ProRes per-codec encoding options.
+//! Apple `ProRes` per-codec encoding options.
 
-/// Apple ProRes encoding profile.
+/// Apple `ProRes` encoding profile.
 ///
 /// Controls quality and chroma sampling. 422 profiles use `yuv422p10le`;
 /// 4444 profiles use `yuva444p10le`.
@@ -40,15 +40,15 @@ impl ProResProfile {
     }
 }
 
-/// Apple ProRes per-codec options.
+/// Apple `ProRes` per-codec options.
 ///
-/// Requires an FFmpeg build with `prores_ks` encoder support. Output should
+/// Requires an `FFmpeg` build with `prores_ks` encoder support. Output should
 /// use a `.mov` container.
 #[derive(Debug, Clone)]
 pub struct ProResOptions {
-    /// ProRes encoding profile controlling quality and chroma sampling.
+    /// `ProRes` encoding profile controlling quality and chroma sampling.
     pub profile: ProResProfile,
-    /// Optional 4-byte FourCC vendor tag embedded in the stream.
+    /// Optional 4-byte `FourCC` vendor tag embedded in the stream.
     ///
     /// Set to `Some([b'a', b'p', b'p', b'l'])` to mimic Apple encoders.
     /// `None` leaves the encoder default.

--- a/crates/ff-encode/src/video/codec_options/svt_av1.rs
+++ b/crates/ff-encode/src/video/codec_options/svt_av1.rs
@@ -2,9 +2,9 @@
 
 /// SVT-AV1 (libsvtav1) per-codec options.
 ///
-/// **Note**: Requires an FFmpeg build with `--enable-libsvtav1` (LGPL).
+/// **Note**: Requires an `FFmpeg` build with `--enable-libsvtav1` (LGPL).
 /// `build()` returns [`EncodeError::EncoderUnavailable`](crate::EncodeError::EncoderUnavailable)
-/// when libsvtav1 is absent from the FFmpeg build.
+/// when libsvtav1 is absent from the `FFmpeg` build.
 #[derive(Debug, Clone)]
 pub struct SvtAv1Options {
     /// Encoder preset: 0 = best quality / slowest, 13 = fastest / lowest quality.

--- a/crates/ff-encode/src/video/encoder_inner/color.rs
+++ b/crates/ff-encode/src/video/encoder_inner/color.rs
@@ -1,7 +1,14 @@
 //! Color format conversion helpers.
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use super::AVPixelFormat;
 

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -1,7 +1,14 @@
 //! Format context, stream, and subtitle initialization helpers.
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use super::color::{
     color_primaries_to_av, color_space_to_av, color_transfer_to_av, from_av_pixel_format,
@@ -38,7 +45,7 @@ impl VideoEncoderInner {
             // SAFETY: format_ctx is valid and non-null. c_key/c_value are valid
             // CStrings covering this call. av_dict_set copies both strings.
             let ret = ff_sys::av_dict_set(
-                &mut (*format_ctx).metadata,
+                &raw mut (*format_ctx).metadata,
                 c_key.as_ptr(),
                 c_value.as_ptr(),
                 0,
@@ -141,7 +148,7 @@ impl VideoEncoderInner {
                 };
                 // SAFETY: chap->metadata is null; av_dict_set allocates and copies.
                 let ret = ff_sys::av_dict_set(
-                    &mut (*chap).metadata,
+                    &raw mut (*chap).metadata,
                     b"title\0".as_ptr() as *const _,
                     c_title.as_ptr(),
                     0,
@@ -166,6 +173,10 @@ impl VideoEncoderInner {
     /// When `two_pass` is `true` the codec context is opened with
     /// `AV_CODEC_FLAG_PASS1` and stored in `pass1_codec_ctx`; in single-pass
     /// mode it is stored in `video_codec_ctx` as usual.
+    // The encoder parameters (dimensions, fps, codec, bitrate mode, options,
+    // two-pass) map one-to-one onto FFmpeg's `AVCodecContext` fields; grouping
+    // them into a struct would only shuffle the same values across the FFI call.
+    #[allow(clippy::too_many_arguments)]
     pub(super) unsafe fn init_video_encoder(
         &mut self,
         width: u32,
@@ -185,7 +196,7 @@ impl VideoEncoderInner {
         use crate::BitrateMode;
         // Select encoder based on codec and availability
         let encoder_name = self.select_video_encoder(codec, hardware_encoder)?;
-        self.actual_video_codec = encoder_name.clone();
+        self.actual_video_codec.clone_from(&encoder_name);
 
         let c_encoder_name =
             CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
@@ -330,7 +341,7 @@ impl VideoEncoderInner {
         // Create stream
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
-            avcodec::free_context(&mut codec_ctx as *mut *mut _);
+            avcodec::free_context(&raw mut codec_ctx);
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "Cannot create stream".to_string(),
@@ -374,7 +385,7 @@ impl VideoEncoderInner {
     ) -> Result<(), EncodeError> {
         // Select encoder based on codec and availability
         let encoder_name = self.select_audio_encoder(codec)?;
-        self.actual_audio_codec = encoder_name.clone();
+        self.actual_audio_codec.clone_from(&encoder_name);
 
         let c_encoder_name =
             CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
@@ -399,7 +410,7 @@ impl VideoEncoderInner {
         (*codec_ctx).sample_rate = sample_rate as i32;
 
         // Set channel layout using FFmpeg 7.x API
-        swresample::channel_layout::set_default(&mut (*codec_ctx).ch_layout, channels as i32);
+        swresample::channel_layout::set_default(&raw mut (*codec_ctx).ch_layout, channels as i32);
 
         // Use the first sample format the codec actually declares; fall back to
         // FLTP only when the codec exposes no preference.  FLTP is NOT valid for
@@ -447,7 +458,7 @@ impl VideoEncoderInner {
         // Create stream
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
-            avcodec::free_context(&mut codec_ctx as *mut *mut _);
+            avcodec::free_context(&raw mut codec_ctx);
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "Cannot create stream".to_string(),
@@ -578,13 +589,13 @@ impl VideoEncoderInner {
             };
             // SAFETY: out_stream->metadata pointer is valid (initialized by avformat_new_stream).
             ff_sys::av_dict_set(
-                &mut (*out_stream).metadata,
+                &raw mut (*out_stream).metadata,
                 b"filename\0".as_ptr() as *const i8,
                 c_filename.as_ptr(),
                 0,
             );
             ff_sys::av_dict_set(
-                &mut (*out_stream).metadata,
+                &raw mut (*out_stream).metadata,
                 b"mimetype\0".as_ptr() as *const i8,
                 c_mime.as_ptr(),
                 0,
@@ -633,7 +644,7 @@ impl VideoEncoderInner {
                 ff_sys::av_error_string(e)
             );
             let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&mut src_ctx_ptr);
+            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
@@ -644,7 +655,7 @@ impl VideoEncoderInner {
                  index={source_stream_index} nb_streams={nb_streams}"
             );
             let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&mut src_ctx_ptr);
+            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
@@ -657,7 +668,7 @@ impl VideoEncoderInner {
                  is not a subtitle stream"
             );
             let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&mut src_ctx_ptr);
+            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
@@ -668,7 +679,7 @@ impl VideoEncoderInner {
         if out_stream.is_null() {
             log::warn!("subtitle_passthrough: avformat_new_stream failed");
             let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&mut src_ctx_ptr);
+            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
@@ -680,7 +691,7 @@ impl VideoEncoderInner {
                 ff_sys::av_error_string(ret)
             );
             let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&mut src_ctx_ptr);
+            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
@@ -688,7 +699,7 @@ impl VideoEncoderInner {
         (*(*out_stream).codecpar).codec_tag = 0;
 
         let mut src_ctx_ptr = src_ctx;
-        ff_sys::avformat::close_input(&mut src_ctx_ptr);
+        ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
 
         self.subtitle_passthrough = Some((
             source_path.to_string(),
@@ -739,7 +750,7 @@ impl VideoEncoderInner {
                 ff_sys::av_error_string(e)
             );
             let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&mut src_ctx_ptr);
+            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return Ok(());
         }
 
@@ -754,7 +765,7 @@ impl VideoEncoderInner {
         let pkt = av_packet_alloc();
         if pkt.is_null() {
             let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&mut src_ctx_ptr);
+            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "subtitle_passthrough: av_packet_alloc failed".to_string(),
@@ -804,9 +815,9 @@ impl VideoEncoderInner {
             av_packet_unref(pkt);
         }
 
-        av_packet_free(&mut (pkt as *mut _) as *mut *mut _);
+        av_packet_free(std::ptr::from_mut::<*mut _>(&mut (pkt as *mut _)));
         let mut src_ctx_ptr = src_ctx;
-        ff_sys::avformat::close_input(&mut src_ctx_ptr);
+        ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
 
         Ok(())
     }
@@ -818,19 +829,19 @@ impl VideoEncoderInner {
         // Null it out BEFORE avcodec_free_context so FFmpeg does not call av_free on it.
         if let Some(mut ctx) = self.video_codec_ctx.take() {
             (*ctx).stats_in = ptr::null_mut();
-            avcodec::free_context(&mut ctx as *mut *mut _);
+            avcodec::free_context(&raw mut ctx);
         }
         // Drop the owned CString now that the codec context no longer references it.
         self.stats_in_cstr = None;
 
         // Free pass-1 codec context (only set in two-pass mode).
         if let Some(mut ctx) = self.pass1_codec_ctx.take() {
-            avcodec::free_context(&mut ctx as *mut *mut _);
+            avcodec::free_context(&raw mut ctx);
         }
 
         // Free audio codec context
         if let Some(mut ctx) = self.audio_codec_ctx.take() {
-            avcodec::free_context(&mut ctx as *mut *mut _);
+            avcodec::free_context(&raw mut ctx);
         }
 
         // Free scaling context
@@ -840,7 +851,7 @@ impl VideoEncoderInner {
 
         // Free resampling context
         if let Some(mut ctx) = self.swr_ctx.take() {
-            swresample::free(&mut ctx as *mut *mut _);
+            swresample::free(&raw mut ctx);
         }
 
         // Free audio FIFO
@@ -851,7 +862,7 @@ impl VideoEncoderInner {
         // Close output file
         if !self.format_ctx.is_null() {
             if !(*self.format_ctx).pb.is_null() {
-                ff_sys::avformat::close_output(&mut (*self.format_ctx).pb);
+                ff_sys::avformat::close_output(&raw mut (*self.format_ctx).pb);
             }
             avformat_free_context(self.format_ctx);
             self.format_ctx = ptr::null_mut();

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -1,7 +1,14 @@
 //! Frame conversion and packet reception helpers.
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use super::color::{pixel_format_to_av, sample_format_to_av};
 use super::{
@@ -49,7 +56,7 @@ impl VideoEncoderInner {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&mut packet as *mut *mut _);
+                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e,
                         message: format!(
@@ -61,7 +68,7 @@ impl VideoEncoderInner {
             }
         }
 
-        av_packet_free(&mut packet as *mut *mut _);
+        av_packet_free(&raw mut packet);
         Ok(())
     }
 
@@ -343,7 +350,7 @@ impl VideoEncoderInner {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&mut packet as *mut *mut _);
+                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e,
                         message: format!("Error receiving packet: {}", ff_sys::av_error_string(e)),
@@ -366,7 +373,7 @@ impl VideoEncoderInner {
             let write_ret = av_interleaved_write_frame(self.format_ctx, packet);
             if write_ret < 0 {
                 av_packet_unref(packet);
-                av_packet_free(&mut packet as *mut *mut _);
+                av_packet_free(&raw mut packet);
                 return Err(EncodeError::MuxingFailed {
                     reason: ff_sys::av_error_string(write_ret),
                 });
@@ -377,7 +384,7 @@ impl VideoEncoderInner {
             av_packet_unref(packet);
         }
 
-        av_packet_free(&mut packet as *mut *mut _);
+        av_packet_free(&raw mut packet);
         Ok(())
     }
 
@@ -402,13 +409,13 @@ impl VideoEncoderInner {
         let src_format = sample_format_to_av(src.format());
         let src_ch_layout = {
             let mut layout = AVChannelLayout::default();
-            swresample::channel_layout::set_default(&mut layout, src.channels() as i32);
+            swresample::channel_layout::set_default(&raw mut layout, src.channels() as i32);
             layout
         };
 
         let needs_resampling = src_sample_rate != target_sample_rate
             || src_format != target_format
-            || !swresample::channel_layout::is_equal(&src_ch_layout, target_ch_layout);
+            || !swresample::channel_layout::is_equal(&raw const src_ch_layout, target_ch_layout);
 
         if needs_resampling {
             // Initialize resampler if needed
@@ -417,7 +424,7 @@ impl VideoEncoderInner {
                     target_ch_layout,
                     target_format,
                     target_sample_rate,
-                    &src_ch_layout,
+                    &raw const src_ch_layout,
                     src_format,
                     src_sample_rate,
                 )
@@ -445,7 +452,7 @@ impl VideoEncoderInner {
             (*dst).nb_samples = out_samples;
 
             // Copy target channel layout
-            swresample::channel_layout::copy(&mut (*dst).ch_layout, target_ch_layout)
+            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, target_ch_layout)
                 .map_err(EncodeError::from_ffmpeg_error)?;
 
             // Allocate frame buffer
@@ -487,7 +494,7 @@ impl VideoEncoderInner {
             (*dst).nb_samples = src.samples() as i32;
 
             // Copy channel layout
-            swresample::channel_layout::copy(&mut (*dst).ch_layout, &src_ch_layout)
+            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, &raw const src_ch_layout)
                 .map_err(EncodeError::from_ffmpeg_error)?;
 
             // Allocate frame buffer
@@ -549,7 +556,7 @@ impl VideoEncoderInner {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&mut packet as *mut *mut _);
+                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e,
                         message: format!(
@@ -567,7 +574,7 @@ impl VideoEncoderInner {
             let write_ret = av_interleaved_write_frame(self.format_ctx, packet);
             if write_ret < 0 {
                 av_packet_unref(packet);
-                av_packet_free(&mut packet as *mut *mut _);
+                av_packet_free(&raw mut packet);
                 return Err(EncodeError::MuxingFailed {
                     reason: ff_sys::av_error_string(write_ret),
                 });
@@ -578,7 +585,7 @@ impl VideoEncoderInner {
             av_packet_unref(packet);
         }
 
-        av_packet_free(&mut packet as *mut *mut _);
+        av_packet_free(&raw mut packet);
         Ok(())
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner/hdr.rs
+++ b/crates/ff-encode/src/video/encoder_inner/hdr.rs
@@ -1,7 +1,14 @@
 //! HDR10 side-data helpers.
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use super::{
     AVPacket, AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -5,9 +5,15 @@
 
 // Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
 #![allow(unsafe_op_in_unsafe_fn)]
-// FFmpeg C API frequently requires raw pointer casting
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 mod color;
 mod context;
@@ -178,7 +184,7 @@ impl VideoEncoderInner {
 
             let mut format_ctx: *mut AVFormatContext = ptr::null_mut();
             let ret = avformat_alloc_output_context2(
-                &mut format_ctx,
+                &raw mut format_ctx,
                 ptr::null_mut(),
                 if is_image_sequence {
                     b"image2\0".as_ptr() as *const i8
@@ -278,17 +284,16 @@ impl VideoEncoderInner {
             // manages I/O internally (AVFMT_NOFILE) — skip avio_open in that case.
             if !config.two_pass {
                 if !is_image_sequence {
-                    match ff_sys::avformat::open_output(
+                    if let Ok(pb) = ff_sys::avformat::open_output(
                         &config.path,
                         ff_sys::avformat::avio_flags::WRITE,
                     ) {
-                        Ok(pb) => (*format_ctx).pb = pb,
-                        Err(_) => {
-                            encoder.cleanup();
-                            return Err(EncodeError::CannotCreateFile {
-                                path: config.path.clone(),
-                            });
-                        }
+                        (*format_ctx).pb = pb;
+                    } else {
+                        encoder.cleanup();
+                        return Err(EncodeError::CannotCreateFile {
+                            path: config.path.clone(),
+                        });
                     }
                 }
 
@@ -336,7 +341,7 @@ impl VideoEncoderInner {
 
                 let convert_result = self.convert_video_frame(frame, av_frame, pass1_ctx);
                 if let Err(e) = convert_result {
-                    av_frame_free(&mut av_frame as *mut *mut _);
+                    av_frame_free(&raw mut av_frame);
                     return Err(e);
                 }
 
@@ -375,7 +380,7 @@ impl VideoEncoderInner {
                 (*av_frame).pts = self.frame_count as i64 * 1000;
                 let send_result = avcodec::send_frame(pass1_ctx, av_frame);
                 if let Err(e) = send_result {
-                    av_frame_free(&mut av_frame as *mut *mut _);
+                    av_frame_free(&raw mut av_frame);
                     return Err(EncodeError::Ffmpeg {
                         code: e,
                         message: format!(
@@ -386,7 +391,7 @@ impl VideoEncoderInner {
                 }
 
                 let drain_result = self.drain_pass1_packets(pass1_ctx);
-                av_frame_free(&mut av_frame as *mut *mut _);
+                av_frame_free(&raw mut av_frame);
                 drain_result?;
 
                 self.frame_count += 1;
@@ -412,7 +417,7 @@ impl VideoEncoderInner {
             // Convert VideoFrame to AVFrame
             let convert_result = self.convert_video_frame(frame, av_frame, codec_ctx);
             if let Err(e) = convert_result {
-                av_frame_free(&mut av_frame as *mut *mut _);
+                av_frame_free(&raw mut av_frame);
                 return Err(e);
             }
 
@@ -423,7 +428,7 @@ impl VideoEncoderInner {
             // Send frame to encoder
             let send_result = avcodec::send_frame(codec_ctx, av_frame);
             if let Err(e) = send_result {
-                av_frame_free(&mut av_frame as *mut *mut _);
+                av_frame_free(&raw mut av_frame);
                 return Err(EncodeError::Ffmpeg {
                     code: e,
                     message: format!("Failed to send frame: {}", ff_sys::av_error_string(e)),
@@ -434,7 +439,7 @@ impl VideoEncoderInner {
             let receive_result = self.receive_packets();
 
             // Always cleanup the frame
-            av_frame_free(&mut av_frame as *mut *mut _);
+            av_frame_free(&raw mut av_frame);
 
             // Check if receiving packets failed
             receive_result?;
@@ -472,7 +477,7 @@ impl VideoEncoderInner {
                 });
             }
             if let Err(e) = self.convert_audio_frame(frame, av_frame) {
-                av_frame_free(&mut av_frame as *mut *mut _);
+                av_frame_free(&raw mut av_frame);
                 return Err(e);
             }
 
@@ -480,7 +485,7 @@ impl VideoEncoderInner {
             if frame_size <= 0 || self.audio_fifo.is_none() {
                 (*av_frame).pts = self.audio_sample_count as i64;
                 let send_result = avcodec::send_frame(codec_ctx, av_frame);
-                av_frame_free(&mut av_frame as *mut *mut _);
+                av_frame_free(&raw mut av_frame);
                 if let Err(e) = send_result {
                     return Err(EncodeError::Ffmpeg {
                         code: e,
@@ -507,7 +512,7 @@ impl VideoEncoderInner {
                 (*av_frame).data.as_ptr() as *const *mut _,
                 nb_samples,
             );
-            av_frame_free(&mut av_frame as *mut *mut _);
+            av_frame_free(&raw mut av_frame);
             write_result.map_err(EncodeError::from_ffmpeg_error)?;
 
             // Drain full frame_size chunks.
@@ -523,14 +528,14 @@ impl VideoEncoderInner {
                 (*out_frame).format = (*codec_ctx).sample_fmt;
                 (*out_frame).sample_rate = (*codec_ctx).sample_rate;
                 swresample::channel_layout::copy(
-                    &mut (*out_frame).ch_layout,
-                    &(*codec_ctx).ch_layout,
+                    &raw mut (*out_frame).ch_layout,
+                    &raw const (*codec_ctx).ch_layout,
                 )
                 .map_err(EncodeError::from_ffmpeg_error)?;
 
                 let ret = ff_sys::av_frame_get_buffer(out_frame, 0);
                 if ret < 0 {
-                    av_frame_free(&mut out_frame as *mut *mut _);
+                    av_frame_free(&raw mut out_frame);
                     return Err(EncodeError::Ffmpeg {
                         code: ret,
                         message: format!(
@@ -545,13 +550,13 @@ impl VideoEncoderInner {
                     (*out_frame).data.as_mut_ptr().cast(),
                     frame_size,
                 ) {
-                    av_frame_free(&mut out_frame as *mut *mut _);
+                    av_frame_free(&raw mut out_frame);
                     return Err(EncodeError::from_ffmpeg_error(e));
                 }
 
                 (*out_frame).pts = self.audio_sample_count as i64;
                 let send_result = avcodec::send_frame(codec_ctx, out_frame);
-                av_frame_free(&mut out_frame as *mut *mut _);
+                av_frame_free(&raw mut out_frame);
                 if let Err(e) = send_result {
                     return Err(EncodeError::Ffmpeg {
                         code: e,
@@ -598,8 +603,8 @@ impl VideoEncoderInner {
                         (*out_frame).format = (*codec_ctx).sample_fmt;
                         (*out_frame).sample_rate = (*codec_ctx).sample_rate;
                         let _ = swresample::channel_layout::copy(
-                            &mut (*out_frame).ch_layout,
-                            &(*codec_ctx).ch_layout,
+                            &raw mut (*out_frame).ch_layout,
+                            &raw const (*codec_ctx).ch_layout,
                         );
                         if ff_sys::av_frame_get_buffer(out_frame, 0) == 0 {
                             let _ = ff_sys::swresample::audio_fifo::read(
@@ -612,7 +617,7 @@ impl VideoEncoderInner {
                             let _ = self.receive_audio_packets();
                             self.audio_sample_count += remaining as u64;
                         }
-                        av_frame_free(&mut out_frame as *mut *mut _);
+                        av_frame_free(&raw mut out_frame);
                     }
                 }
             }

--- a/crates/ff-encode/src/video/encoder_inner/options.rs
+++ b/crates/ff-encode/src/video/encoder_inner/options.rs
@@ -1,7 +1,14 @@
 //! Codec option application and encoder selection helpers.
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use super::{
     AVCodecContext, AVCodecID, AVCodecID_AV_CODEC_ID_AAC, AVCodecID_AV_CODEC_ID_AC3,
@@ -36,7 +43,7 @@ pub(super) fn codec_to_id(codec: VideoCodec) -> AVCodecID {
     }
 }
 
-pub fn preset_to_string(preset: &crate::Preset) -> String {
+pub fn preset_to_string(preset: crate::Preset) -> String {
     match preset {
         crate::Preset::Ultrafast => "ultrafast",
         crate::Preset::Faster => "faster",

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -1,7 +1,14 @@
 //! Two-pass encoding helpers.
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: casts at the C ABI, pointer idioms, C-string
+// literals, and FFI-wrapper ergonomics concentrate in this unsafe module.
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::manual_c_str_literals)]
+#![allow(clippy::unused_self)]
 
 use super::color::{
     color_primaries_to_av, color_space_to_av, color_transfer_to_av, pixel_format_to_av,
@@ -88,7 +95,7 @@ impl VideoEncoderInner {
 
         // ── Step 3: Free pass-1 codec context ───────────────────────────────
         // SAFETY: pass1_ctx is no longer needed; we own it exclusively.
-        avcodec::free_context(&mut pass1_ctx as *mut *mut _);
+        avcodec::free_context(&raw mut pass1_ctx);
         self.pass1_codec_ctx = None;
 
         // ── Step 4: Set up pass-2 codec context ─────────────────────────────
@@ -379,7 +386,7 @@ impl VideoEncoderInner {
         // Allocate the frame buffer.
         let ret = ff_sys::av_frame_get_buffer(av_frame, 0);
         if ret < 0 {
-            av_frame_free(&mut av_frame as *mut *mut _);
+            av_frame_free(&raw mut av_frame);
             return Err(EncodeError::Ffmpeg {
                 code: ret,
                 message: format!(
@@ -426,7 +433,7 @@ impl VideoEncoderInner {
         // Send to pass-2 encoder.
         let send_result = avcodec::send_frame(codec_ctx, av_frame);
         if let Err(e) = send_result {
-            av_frame_free(&mut av_frame as *mut *mut _);
+            av_frame_free(&raw mut av_frame);
             return Err(EncodeError::Ffmpeg {
                 code: e,
                 message: format!(
@@ -437,7 +444,7 @@ impl VideoEncoderInner {
         }
 
         let receive_result = self.receive_packets();
-        av_frame_free(&mut av_frame as *mut *mut _);
+        av_frame_free(&raw mut av_frame);
         receive_result?;
 
         self.frame_count += 1;

--- a/crates/ff-encode/src/video/mod.rs
+++ b/crates/ff-encode/src/video/mod.rs
@@ -1,6 +1,6 @@
 //! Video encoding implementation.
 //!
-//! This module provides video encoding functionality with an FFmpeg backend.
+//! This module provides video encoding functionality with an `FFmpeg` backend.
 //! The implementation is split into public API ([`builder`]) and internal
 //! implementation details ([`encoder_inner`]).
 

--- a/crates/ff-remux/src/lib.rs
+++ b/crates/ff-remux/src/lib.rs
@@ -1,34 +1,20 @@
 //! # ff-remux
 //!
-//! Stream-copy remuxing over FFmpeg: trim a clip, and replace / extract / add an
+//! Stream-copy remuxing over `FFmpeg`: trim a clip, and replace / extract / add an
 //! audio stream, all **without re-encoding** (a bitstream copy through
 //! libavformat's demuxer and muxer).
 //!
-//! This is a distinct FFmpeg area from encoding (`ff-encode` wraps libavcodec);
+//! This is a distinct `FFmpeg` area from encoding (`ff-encode` wraps libavcodec);
 //! `ff-remux` wraps libavformat stream copy. Use it on its own, or combine it with
 //! the other `ff-*` crates. Errors are typed and contextual ([`RemuxError`]).
 //!
 //! Part of the [`avio`](https://github.com/itsakeyfut/avio) crate family; each
 //! crate is versioned independently.
 
+// FFmpeg's C API is called through `unsafe`; the FFI is isolated in the
+// `*_inner` modules, which carry their own scoped clippy allows for the
+// FFmpeg-boundary lints (casts, pointer idioms).
 #![allow(unsafe_code)]
-#![allow(clippy::borrow_as_ptr)]
-#![allow(clippy::ptr_as_ptr)]
-#![allow(clippy::ref_as_ptr)]
-#![allow(clippy::unnecessary_safety_doc)]
-#![allow(clippy::cast_possible_wrap)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::cast_sign_loss)]
-#![allow(clippy::manual_c_str_literals)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::single_match_else)]
-#![allow(clippy::inefficient_to_string)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
-#![allow(clippy::doc_markdown)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::assigning_clones)]
-#![allow(clippy::unused_self)]
-#![allow(clippy::unnecessary_safety_comment)]
 
 mod error;
 mod media_ops;

--- a/crates/ff-remux/src/media_ops/media_inner.rs
+++ b/crates/ff-remux/src/media_ops/media_inner.rs
@@ -2,6 +2,12 @@
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: intentional narrowing/sign casts at the C ABI and
+// acronym-heavy FFmpeg doc terms concentrate in this isolated FFI module.
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::doc_markdown)]
 
 use std::path::Path;
 
@@ -38,7 +44,7 @@ unsafe fn run_audio_replacement_unsafe(
     // SAFETY: vid_ctx is non-null (open_input succeeded).
     if let Err(e) = ff_sys::avformat::find_stream_info(vid_ctx) {
         let mut p = vid_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::from_ffmpeg_error(e));
     }
 
@@ -55,7 +61,7 @@ unsafe fn run_audio_replacement_unsafe(
     }
     let Some(video_stream_idx) = video_stream_idx else {
         let mut p = vid_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::OperationFailed {
             reason: format!(
                 "no video stream found in video input path={}",
@@ -70,7 +76,7 @@ unsafe fn run_audio_replacement_unsafe(
         Ok(ctx) => ctx,
         Err(e) => {
             let mut p = vid_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             return Err(RemuxError::from_ffmpeg_error(e));
         }
     };
@@ -79,9 +85,9 @@ unsafe fn run_audio_replacement_unsafe(
     // SAFETY: aud_ctx is non-null (open_input succeeded).
     if let Err(e) = ff_sys::avformat::find_stream_info(aud_ctx) {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::from_ffmpeg_error(e));
     }
 
@@ -98,9 +104,9 @@ unsafe fn run_audio_replacement_unsafe(
     }
     let Some(audio_stream_idx) = audio_stream_idx else {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::OperationFailed {
             reason: format!(
                 "no audio stream found in audio input path={}",
@@ -112,9 +118,9 @@ unsafe fn run_audio_replacement_unsafe(
     // ── Step 7: allocate output context ──────────────────────────────────────
     let Some(output_str) = output.to_str() else {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path is not valid UTF-8".to_string(),
@@ -122,9 +128,9 @@ unsafe fn run_audio_replacement_unsafe(
     };
     let Ok(c_output) = std::ffi::CString::new(output_str) else {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path contains null bytes".to_string(),
@@ -134,16 +140,16 @@ unsafe fn run_audio_replacement_unsafe(
     let mut out_ctx: *mut ff_sys::AVFormatContext = std::ptr::null_mut();
     // SAFETY: c_output is a valid null-terminated C string.
     let ret = ff_sys::avformat_alloc_output_context2(
-        &mut out_ctx,
+        &raw mut out_ctx,
         std::ptr::null_mut(),
         std::ptr::null(),
         c_output.as_ptr(),
     );
     if ret < 0 || out_ctx.is_null() {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
 
@@ -154,9 +160,9 @@ unsafe fn run_audio_replacement_unsafe(
     let vid_out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
     if vid_out_stream.is_null() {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::Ffmpeg {
             code: 0,
@@ -168,9 +174,9 @@ unsafe fn run_audio_replacement_unsafe(
         ff_sys::avcodec_parameters_copy((*vid_out_stream).codecpar, (*vid_in_stream).codecpar);
     if ret < 0 {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
@@ -184,9 +190,9 @@ unsafe fn run_audio_replacement_unsafe(
     let aud_out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
     if aud_out_stream.is_null() {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::Ffmpeg {
             code: 0,
@@ -198,9 +204,9 @@ unsafe fn run_audio_replacement_unsafe(
         ff_sys::avcodec_parameters_copy((*aud_out_stream).codecpar, (*aud_in_stream).codecpar);
     if ret < 0 {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
@@ -213,9 +219,9 @@ unsafe fn run_audio_replacement_unsafe(
         Ok(pb) => pb,
         Err(e) => {
             let mut pv = vid_ctx;
-            ff_sys::avformat::close_input(&mut pv);
+            ff_sys::avformat::close_input(&raw mut pv);
             let mut pa = aud_ctx;
-            ff_sys::avformat::close_input(&mut pa);
+            ff_sys::avformat::close_input(&raw mut pa);
             ff_sys::avformat_free_context(out_ctx);
             return Err(RemuxError::from_ffmpeg_error(e));
         }
@@ -231,9 +237,9 @@ unsafe fn run_audio_replacement_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
 
@@ -257,9 +263,9 @@ unsafe fn run_audio_replacement_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "av_packet_alloc failed".to_string(),
@@ -343,7 +349,7 @@ unsafe fn run_audio_replacement_unsafe(
 
     // SAFETY: pkt was allocated by av_packet_alloc above and is still valid.
     let mut pkt_ptr = pkt;
-    ff_sys::av_packet_free(&mut pkt_ptr);
+    ff_sys::av_packet_free(&raw mut pkt_ptr);
 
     // ── Step 14: write trailer ────────────────────────────────────────────────
     // SAFETY: out_ctx is valid; write_header was called successfully.
@@ -356,9 +362,9 @@ unsafe fn run_audio_replacement_unsafe(
     ff_sys::avformat_free_context(out_ctx);
     // SAFETY: vid_ctx and aud_ctx are non-null (open_input succeeded).
     let mut pv = vid_ctx;
-    ff_sys::avformat::close_input(&mut pv);
+    ff_sys::avformat::close_input(&raw mut pv);
     let mut pa = aud_ctx;
-    ff_sys::avformat::close_input(&mut pa);
+    ff_sys::avformat::close_input(&raw mut pa);
 
     log::info!("audio replaced output={}", output.display());
 
@@ -402,7 +408,7 @@ unsafe fn run_audio_extraction_unsafe(
     // SAFETY: in_ctx is non-null (open_input succeeded).
     if let Err(e) = ff_sys::avformat::find_stream_info(in_ctx) {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::from_ffmpeg_error(e));
     }
 
@@ -413,7 +419,7 @@ unsafe fn run_audio_extraction_unsafe(
         // Validate that the requested index is actually an audio stream.
         if idx >= nb_streams {
             let mut p = in_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             return Err(RemuxError::OperationFailed {
                 reason: format!("stream index {idx} out of range (input has {nb_streams} streams)"),
             });
@@ -421,7 +427,7 @@ unsafe fn run_audio_extraction_unsafe(
         let stream = *(*in_ctx).streams.add(idx);
         if (*(*stream).codecpar).codec_type != ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO {
             let mut p = in_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             return Err(RemuxError::OperationFailed {
                 reason: format!("stream index {idx} is not an audio stream"),
             });
@@ -437,22 +443,21 @@ unsafe fn run_audio_extraction_unsafe(
                 break;
             }
         }
-        match found {
-            Some(idx) => idx,
-            None => {
-                let mut p = in_ctx;
-                ff_sys::avformat::close_input(&mut p);
-                return Err(RemuxError::OperationFailed {
-                    reason: format!("no audio stream found in input path={}", input.display()),
-                });
-            }
+        if let Some(idx) = found {
+            idx
+        } else {
+            let mut p = in_ctx;
+            ff_sys::avformat::close_input(&raw mut p);
+            return Err(RemuxError::OperationFailed {
+                reason: format!("no audio stream found in input path={}", input.display()),
+            });
         }
     };
 
     // ── Step 4: allocate output context ──────────────────────────────────────
     let Some(output_str) = output.to_str() else {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path is not valid UTF-8".to_string(),
@@ -460,7 +465,7 @@ unsafe fn run_audio_extraction_unsafe(
     };
     let Ok(c_output) = std::ffi::CString::new(output_str) else {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path contains null bytes".to_string(),
@@ -470,14 +475,14 @@ unsafe fn run_audio_extraction_unsafe(
     let mut out_ctx: *mut ff_sys::AVFormatContext = std::ptr::null_mut();
     // SAFETY: c_output is a valid null-terminated C string; format is auto-detected from ext.
     let ret = ff_sys::avformat_alloc_output_context2(
-        &mut out_ctx,
+        &raw mut out_ctx,
         std::ptr::null_mut(),
         std::ptr::null(),
         c_output.as_ptr(),
     );
     if ret < 0 || out_ctx.is_null() {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
 
@@ -488,7 +493,7 @@ unsafe fn run_audio_extraction_unsafe(
     let out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
     if out_stream.is_null() {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::Ffmpeg {
             code: 0,
@@ -499,7 +504,7 @@ unsafe fn run_audio_extraction_unsafe(
     let ret = ff_sys::avcodec_parameters_copy((*out_stream).codecpar, (*in_stream).codecpar);
     if ret < 0 {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
@@ -512,7 +517,7 @@ unsafe fn run_audio_extraction_unsafe(
         Ok(pb) => pb,
         Err(e) => {
             let mut p = in_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             ff_sys::avformat_free_context(out_ctx);
             return Err(RemuxError::from_ffmpeg_error(e));
         }
@@ -531,7 +536,7 @@ unsafe fn run_audio_extraction_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::OperationFailed {
             reason: format!(
                 "codec incompatible with output container: {}",
@@ -559,7 +564,7 @@ unsafe fn run_audio_extraction_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "av_packet_alloc failed".to_string(),
@@ -603,7 +608,7 @@ unsafe fn run_audio_extraction_unsafe(
 
     // SAFETY: pkt was allocated by av_packet_alloc above and is still valid.
     let mut pkt_ptr = pkt;
-    ff_sys::av_packet_free(&mut pkt_ptr);
+    ff_sys::av_packet_free(&raw mut pkt_ptr);
 
     // ── Step 10: write trailer ────────────────────────────────────────────────
     // SAFETY: out_ctx is valid; write_header was called successfully.
@@ -616,7 +621,7 @@ unsafe fn run_audio_extraction_unsafe(
     ff_sys::avformat_free_context(out_ctx);
     // SAFETY: in_ctx is non-null (open_input succeeded).
     let mut p = in_ctx;
-    ff_sys::avformat::close_input(&mut p);
+    ff_sys::avformat::close_input(&raw mut p);
 
     log::info!(
         "audio extracted output={} stream_index={audio_stream_idx}",
@@ -667,7 +672,7 @@ unsafe fn run_audio_addition_unsafe(
     // SAFETY: vid_ctx is non-null (open_input succeeded).
     if let Err(e) = ff_sys::avformat::find_stream_info(vid_ctx) {
         let mut p = vid_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::from_ffmpeg_error(e));
     }
 
@@ -684,7 +689,7 @@ unsafe fn run_audio_addition_unsafe(
     }
     let Some(video_stream_idx) = video_stream_idx else {
         let mut p = vid_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::OperationFailed {
             reason: format!(
                 "no video stream found in video input path={}",
@@ -699,7 +704,7 @@ unsafe fn run_audio_addition_unsafe(
         Ok(ctx) => ctx,
         Err(e) => {
             let mut p = vid_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             return Err(RemuxError::from_ffmpeg_error(e));
         }
     };
@@ -708,9 +713,9 @@ unsafe fn run_audio_addition_unsafe(
     // SAFETY: aud_ctx is non-null (open_input succeeded).
     if let Err(e) = ff_sys::avformat::find_stream_info(aud_ctx) {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::from_ffmpeg_error(e));
     }
 
@@ -727,9 +732,9 @@ unsafe fn run_audio_addition_unsafe(
     }
     let Some(audio_stream_idx) = audio_stream_idx else {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::OperationFailed {
             reason: format!(
                 "no audio stream found in audio input path={}",
@@ -751,9 +756,9 @@ unsafe fn run_audio_addition_unsafe(
     // ── Step 8: allocate output context ──────────────────────────────────────
     let Some(output_str) = output.to_str() else {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path is not valid UTF-8".to_string(),
@@ -761,9 +766,9 @@ unsafe fn run_audio_addition_unsafe(
     };
     let Ok(c_output) = std::ffi::CString::new(output_str) else {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path contains null bytes".to_string(),
@@ -773,16 +778,16 @@ unsafe fn run_audio_addition_unsafe(
     let mut out_ctx: *mut ff_sys::AVFormatContext = std::ptr::null_mut();
     // SAFETY: c_output is a valid null-terminated C string.
     let ret = ff_sys::avformat_alloc_output_context2(
-        &mut out_ctx,
+        &raw mut out_ctx,
         std::ptr::null_mut(),
         std::ptr::null(),
         c_output.as_ptr(),
     );
     if ret < 0 || out_ctx.is_null() {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
 
@@ -793,9 +798,9 @@ unsafe fn run_audio_addition_unsafe(
     let vid_out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
     if vid_out_stream.is_null() {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::Ffmpeg {
             code: 0,
@@ -807,9 +812,9 @@ unsafe fn run_audio_addition_unsafe(
         ff_sys::avcodec_parameters_copy((*vid_out_stream).codecpar, (*vid_in_stream).codecpar);
     if ret < 0 {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
@@ -823,9 +828,9 @@ unsafe fn run_audio_addition_unsafe(
     let aud_out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
     if aud_out_stream.is_null() {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::Ffmpeg {
             code: 0,
@@ -837,9 +842,9 @@ unsafe fn run_audio_addition_unsafe(
         ff_sys::avcodec_parameters_copy((*aud_out_stream).codecpar, (*aud_in_stream).codecpar);
     if ret < 0 {
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
@@ -852,9 +857,9 @@ unsafe fn run_audio_addition_unsafe(
         Ok(pb) => pb,
         Err(e) => {
             let mut pv = vid_ctx;
-            ff_sys::avformat::close_input(&mut pv);
+            ff_sys::avformat::close_input(&raw mut pv);
             let mut pa = aud_ctx;
-            ff_sys::avformat::close_input(&mut pa);
+            ff_sys::avformat::close_input(&raw mut pa);
             ff_sys::avformat_free_context(out_ctx);
             return Err(RemuxError::from_ffmpeg_error(e));
         }
@@ -870,9 +875,9 @@ unsafe fn run_audio_addition_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
 
@@ -904,9 +909,9 @@ unsafe fn run_audio_addition_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut pv = vid_ctx;
-        ff_sys::avformat::close_input(&mut pv);
+        ff_sys::avformat::close_input(&raw mut pv);
         let mut pa = aud_ctx;
-        ff_sys::avformat::close_input(&mut pa);
+        ff_sys::avformat::close_input(&raw mut pa);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "av_packet_alloc failed".to_string(),
@@ -1014,7 +1019,7 @@ unsafe fn run_audio_addition_unsafe(
 
     // SAFETY: pkt was allocated by av_packet_alloc above and is still valid.
     let mut pkt_ptr = pkt;
-    ff_sys::av_packet_free(&mut pkt_ptr);
+    ff_sys::av_packet_free(&raw mut pkt_ptr);
 
     // ── Step 15: write trailer ────────────────────────────────────────────────
     // SAFETY: out_ctx is valid; write_header was called successfully.
@@ -1027,9 +1032,9 @@ unsafe fn run_audio_addition_unsafe(
     ff_sys::avformat_free_context(out_ctx);
     // SAFETY: vid_ctx and aud_ctx are non-null (open_input succeeded).
     let mut pv = vid_ctx;
-    ff_sys::avformat::close_input(&mut pv);
+    ff_sys::avformat::close_input(&raw mut pv);
     let mut pa = aud_ctx;
-    ff_sys::avformat::close_input(&mut pa);
+    ff_sys::avformat::close_input(&raw mut pa);
 
     log::info!(
         "audio added output={} loop_audio={loop_audio}",

--- a/crates/ff-remux/src/media_ops/mod.rs
+++ b/crates/ff-remux/src/media_ops/mod.rs
@@ -52,7 +52,7 @@ impl AudioReplacement {
     ///
     /// - [`RemuxError::OperationFailed`] if `video_input` has no video
     ///   stream or `audio_input` has no audio stream.
-    /// - [`RemuxError::Ffmpeg`] if any FFmpeg API call fails.
+    /// - [`RemuxError::Ffmpeg`] if any `FFmpeg` API call fails.
     pub fn run(self) -> Result<(), RemuxError> {
         log::debug!(
             "audio replacement start video_input={} audio_input={} output={}",
@@ -117,7 +117,7 @@ impl AudioExtractor {
     /// - [`RemuxError::OperationFailed`] if no audio stream is found,
     ///   the requested stream index is invalid or not audio, or the codec is
     ///   incompatible with the output container.
-    /// - [`RemuxError::Ffmpeg`] if any FFmpeg API call fails.
+    /// - [`RemuxError::Ffmpeg`] if any `FFmpeg` API call fails.
     pub fn run(self) -> Result<(), RemuxError> {
         log::debug!(
             "audio extraction start input={} output={} stream_index={:?}",
@@ -192,7 +192,7 @@ impl AudioAdder {
     ///
     /// - [`RemuxError::OperationFailed`] if `video_input` has no video
     ///   stream or `audio_input` has no audio stream.
-    /// - [`RemuxError::Ffmpeg`] if any FFmpeg API call fails.
+    /// - [`RemuxError::Ffmpeg`] if any `FFmpeg` API call fails.
     pub fn run(self) -> Result<(), RemuxError> {
         log::debug!(
             "audio addition start video_input={} audio_input={} output={} loop_audio={}",

--- a/crates/ff-remux/src/trim/trim_inner.rs
+++ b/crates/ff-remux/src/trim/trim_inner.rs
@@ -2,7 +2,13 @@
 
 #![allow(unsafe_code)]
 #![allow(unsafe_op_in_unsafe_fn)]
+// FFmpeg-boundary lints: intentional narrowing/sign casts at the C ABI and
+// acronym-heavy FFmpeg doc terms concentrate in this isolated FFI module.
 #![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::doc_markdown)]
 
 use std::path::Path;
 
@@ -43,14 +49,14 @@ unsafe fn run_trim_unsafe(
     // SAFETY: in_ctx is non-null (open_input succeeded).
     if let Err(e) = ff_sys::avformat::find_stream_info(in_ctx) {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::from_ffmpeg_error(e));
     }
 
     // ── Step 3: allocate output context ──────────────────────────────────────
     let Some(output_str) = output.to_str() else {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path is not valid UTF-8".to_string(),
@@ -58,7 +64,7 @@ unsafe fn run_trim_unsafe(
     };
     let Ok(c_output) = std::ffi::CString::new(output_str) else {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "output path contains null bytes".to_string(),
@@ -68,14 +74,14 @@ unsafe fn run_trim_unsafe(
     let mut out_ctx: *mut ff_sys::AVFormatContext = std::ptr::null_mut();
     // SAFETY: c_output is a valid null-terminated C string.
     let ret = ff_sys::avformat_alloc_output_context2(
-        &mut out_ctx,
+        &raw mut out_ctx,
         std::ptr::null_mut(),
         std::ptr::null(),
         c_output.as_ptr(),
     );
     if ret < 0 || out_ctx.is_null() {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
 
@@ -89,7 +95,7 @@ unsafe fn run_trim_unsafe(
         let out_stream = ff_sys::avformat_new_stream(out_ctx, std::ptr::null());
         if out_stream.is_null() {
             let mut p = in_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             ff_sys::avformat_free_context(out_ctx);
             return Err(RemuxError::Ffmpeg {
                 code: 0,
@@ -101,7 +107,7 @@ unsafe fn run_trim_unsafe(
         let ret = ff_sys::avcodec_parameters_copy((*out_stream).codecpar, (*in_stream).codecpar);
         if ret < 0 {
             let mut p = in_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             ff_sys::avformat_free_context(out_ctx);
             return Err(RemuxError::from_ffmpeg_error(ret));
         }
@@ -114,7 +120,7 @@ unsafe fn run_trim_unsafe(
     // SAFETY: in_ctx is valid; seeking to AV_TIME_BASE-scaled timestamp.
     if let Err(e) = ff_sys::avformat::seek_file(in_ctx, -1, i64::MIN, start_ts, start_ts, 0) {
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         ff_sys::avformat_free_context(out_ctx);
         return Err(RemuxError::from_ffmpeg_error(e));
     }
@@ -125,7 +131,7 @@ unsafe fn run_trim_unsafe(
         Ok(pb) => pb,
         Err(e) => {
             let mut p = in_ctx;
-            ff_sys::avformat::close_input(&mut p);
+            ff_sys::avformat::close_input(&raw mut p);
             ff_sys::avformat_free_context(out_ctx);
             return Err(RemuxError::from_ffmpeg_error(e));
         }
@@ -141,7 +147,7 @@ unsafe fn run_trim_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::from_ffmpeg_error(ret));
     }
 
@@ -155,7 +161,7 @@ unsafe fn run_trim_unsafe(
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut p = in_ctx;
-        ff_sys::avformat::close_input(&mut p);
+        ff_sys::avformat::close_input(&raw mut p);
         return Err(RemuxError::Ffmpeg {
             code: 0,
             message: "av_packet_alloc failed".to_string(),
@@ -219,7 +225,7 @@ unsafe fn run_trim_unsafe(
 
     // SAFETY: pkt was allocated by av_packet_alloc above and is still valid.
     let mut pkt_ptr = pkt;
-    ff_sys::av_packet_free(&mut pkt_ptr);
+    ff_sys::av_packet_free(&raw mut pkt_ptr);
 
     // ── Step 9: write trailer ─────────────────────────────────────────────────
     // SAFETY: out_ctx is valid; write_header was called successfully.
@@ -232,7 +238,7 @@ unsafe fn run_trim_unsafe(
     ff_sys::avformat_free_context(out_ctx);
     // SAFETY: in_ctx is non-null (open_input succeeded).
     let mut in_ctx_ptr = in_ctx;
-    ff_sys::avformat::close_input(&mut in_ctx_ptr);
+    ff_sys::avformat::close_input(&raw mut in_ctx_ptr);
 
     log::debug!("stream copy trim complete");
 

--- a/crates/ff-remux/src/trim/trimmer.rs
+++ b/crates/ff-remux/src/trim/trimmer.rs
@@ -55,7 +55,7 @@ impl StreamCopyTrimmer {
     /// # Errors
     ///
     /// - [`RemuxError::InvalidConfig`] if `start_sec >= end_sec`.
-    /// - [`RemuxError::Ffmpeg`] if any FFmpeg API call fails.
+    /// - [`RemuxError::Ffmpeg`] if any `FFmpeg` API call fails.
     pub fn run(self) -> Result<(), RemuxError> {
         if self.start_sec >= self.end_sec {
             return Err(RemuxError::InvalidConfig {
@@ -130,7 +130,7 @@ impl StreamCopyTrim {
     /// # Errors
     ///
     /// - [`RemuxError::OperationFailed`] if `start >= end`.
-    /// - [`RemuxError::Ffmpeg`] if any FFmpeg API call fails.
+    /// - [`RemuxError::Ffmpeg`] if any `FFmpeg` API call fails.
     pub fn run(self) -> Result<(), RemuxError> {
         if self.start >= self.end {
             return Err(RemuxError::OperationFailed {


### PR DESCRIPTION
## Objective

- The ~18-line crate-wide `#![allow(clippy::...)]` blocks in ff-encode and ff-remux suppressed lints (`cast_possible_truncation`, `needless_pass_by_value`, `borrow_as_ptr`, and more) across the two largest FFI crates, lowering the lint signal there.

## Solution

- Remove both crate-wide clippy-allow blocks, adopting the scheme the other FFI crates (ff-decode, ff-filter) already use.
- Fix the mechanically improvable lints crate-wide: pointer casts become `&raw const` / `&raw mut`, manual nul-terminated byte strings become `c"..."` literals, an assign-then-clone becomes `clone_from`, and a `Copy`-by-ref parameter is taken by value.
- Scope the genuinely FFmpeg-boundary lints (C-ABI casts, pointer idioms, acronym-heavy doc terms, C-string literals) to per-module allows on the isolated `*_inner` modules, plus two justified per-item allows (a many-argument FFI init, a bitrate cast).
- No crate-wide clippy-allow block remains; `cargo clippy -p ff-encode -p ff-remux --all-features -- -D warnings` is clean. Behavior is unchanged (existing tests pass).

Closes #1430