### PR TITLE
chore: satisfy new clippy 1.98 lints across ff-* crates

### DIFF
--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -329,9 +329,9 @@ unsafe fn encode_frame_as_png(
     // PNG encoder only accepts: rgb24, rgba, rgb48be, rgba64be, pal8, gray, …
     // Filter outputs (tile, palettegen) typically emit yuv420p or bgra.
     // We unconditionally convert to rgb24 to avoid EINVAL from avcodec_open2.
-    let converted_frame: *mut ff_sys::AVFrame;
+
     let needs_conversion = src_pix_fmt != AVPixelFormat_AV_PIX_FMT_RGB24;
-    if needs_conversion {
+    let converted_frame: *mut ff_sys::AVFrame = if needs_conversion {
         let cf = av_frame_alloc();
         if cf.is_null() {
             return Err(PreviewImageError::Ffmpeg {
@@ -379,10 +379,10 @@ unsafe fn encode_frame_as_png(
             av_frame_free(std::ptr::addr_of_mut!(f));
             return Err(PreviewImageError::from_ffmpeg_error(e));
         }
-        converted_frame = cf;
+        cf
     } else {
-        converted_frame = frame;
-    }
+        frame
+    };
 
     let encode_result = encode_frame_as_png_inner(converted_frame, output, width, height);
 

--- a/crates/ff-format/src/frame/audio/samples.rs
+++ b/crates/ff-format/src/frame/audio/samples.rs
@@ -117,7 +117,9 @@ impl AudioFrame {
             SampleFormat::F64 => {
                 let bytes = self.data();
                 bytes
-                    .chunks_exact(8)
+                    .as_chunks::<8>()
+                    .0
+                    .iter()
                     .map(|b| {
                         f64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]) as f32
                     })
@@ -128,7 +130,7 @@ impl AudioFrame {
                 let ch_count = self.channels as usize;
                 for ch in 0..ch_count {
                     if let Some(bytes) = self.channel(ch) {
-                        for (i, b) in bytes.chunks_exact(8).enumerate() {
+                        for (i, b) in bytes.as_chunks::<8>().0.iter().enumerate() {
                             out[i * ch_count + ch] = f64::from_le_bytes([
                                 b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
                             ]) as f32;
@@ -140,7 +142,9 @@ impl AudioFrame {
             SampleFormat::I16 => {
                 let bytes = self.data();
                 bytes
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|b| f32::from(i16::from_le_bytes([b[0], b[1]])) / f32::from(i16::MAX))
                     .collect()
             }
@@ -149,7 +153,7 @@ impl AudioFrame {
                 let ch_count = self.channels as usize;
                 for ch in 0..ch_count {
                     if let Some(bytes) = self.channel(ch) {
-                        for (i, b) in bytes.chunks_exact(2).enumerate() {
+                        for (i, b) in bytes.as_chunks::<2>().0.iter().enumerate() {
                             out[i * ch_count + ch] =
                                 f32::from(i16::from_le_bytes([b[0], b[1]])) / f32::from(i16::MAX);
                         }
@@ -160,7 +164,9 @@ impl AudioFrame {
             SampleFormat::I32 => {
                 let bytes = self.data();
                 bytes
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]) as f32 / i32::MAX as f32)
                     .collect()
             }
@@ -169,7 +175,7 @@ impl AudioFrame {
                 let ch_count = self.channels as usize;
                 for ch in 0..ch_count {
                     if let Some(bytes) = self.channel(ch) {
-                        for (i, b) in bytes.chunks_exact(4).enumerate() {
+                        for (i, b) in bytes.as_chunks::<4>().0.iter().enumerate() {
                             out[i * ch_count + ch] = i32::from_le_bytes([b[0], b[1], b[2], b[3]])
                                 as f32
                                 / i32::MAX as f32;
@@ -250,7 +256,9 @@ impl AudioFrame {
             SampleFormat::F32 => {
                 let bytes = self.data();
                 bytes
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|b| {
                         let s = f32::from_le_bytes([b[0], b[1], b[2], b[3]]);
                         (s.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16
@@ -262,7 +270,7 @@ impl AudioFrame {
                 let ch_count = self.channels as usize;
                 for ch in 0..ch_count {
                     if let Some(bytes) = self.channel(ch) {
-                        for (i, b) in bytes.chunks_exact(4).enumerate() {
+                        for (i, b) in bytes.as_chunks::<4>().0.iter().enumerate() {
                             let s = f32::from_le_bytes([b[0], b[1], b[2], b[3]]);
                             out[i * ch_count + ch] =
                                 (s.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
@@ -274,7 +282,9 @@ impl AudioFrame {
             SampleFormat::F64 => {
                 let bytes = self.data();
                 bytes
-                    .chunks_exact(8)
+                    .as_chunks::<8>()
+                    .0
+                    .iter()
                     .map(|b| {
                         let s =
                             f64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]);
@@ -287,7 +297,7 @@ impl AudioFrame {
                 let ch_count = self.channels as usize;
                 for ch in 0..ch_count {
                     if let Some(bytes) = self.channel(ch) {
-                        for (i, b) in bytes.chunks_exact(8).enumerate() {
+                        for (i, b) in bytes.as_chunks::<8>().0.iter().enumerate() {
                             let s = f64::from_le_bytes([
                                 b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
                             ]);
@@ -301,7 +311,9 @@ impl AudioFrame {
             SampleFormat::I32 => {
                 let bytes = self.data();
                 bytes
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|b| (i32::from_le_bytes([b[0], b[1], b[2], b[3]]) >> 16) as i16)
                     .collect()
             }
@@ -310,7 +322,7 @@ impl AudioFrame {
                 let ch_count = self.channels as usize;
                 for ch in 0..ch_count {
                     if let Some(bytes) = self.channel(ch) {
-                        for (i, b) in bytes.chunks_exact(4).enumerate() {
+                        for (i, b) in bytes.as_chunks::<4>().0.iter().enumerate() {
                             out[i * ch_count + ch] =
                                 (i32::from_le_bytes([b[0], b[1], b[2], b[3]]) >> 16) as i16;
                         }

--- a/crates/ff-preview/src/scene/audio_resampling.rs
+++ b/crates/ff-preview/src/scene/audio_resampling.rs
@@ -122,14 +122,14 @@ pub(super) fn spawn_audio_track_thread(
                         // For speed > 1.0: fewer output samples (fast motion, pitch up).
                         // For speed < 1.0: more output samples (slow motion, pitch down).
                         // This is a simple preview-quality resample; no pitch correction.
-                        let samples: &[f32];
+
                         let resampled: Vec<f32>;
-                        if apply_speed {
+                        let samples: &[f32] = if apply_speed {
                             resampled = resample_linear(raw, speed, &mut speed_phase);
-                            samples = &resampled;
+                            &resampled
                         } else {
-                            samples = raw;
-                        }
+                            raw
+                        };
 
                         if apply_fades {
                             let mut buf: Vec<f32> = samples.to_vec();

--- a/crates/ff-preview/src/scene/runner.rs
+++ b/crates/ff-preview/src/scene/runner.rs
@@ -902,7 +902,7 @@ impl SceneRunner {
                             AnimatedValue::Static(_) => self.clips[active].opacity,
                         };
                         if (v1_op - 1.0).abs() > 1e-6 {
-                            for chunk in self.rgba_a.chunks_exact_mut(4) {
+                            for chunk in self.rgba_a.as_chunks_mut::<4>().0 {
                                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                                 {
                                     chunk[0] = (f32::from(chunk[0]) * v1_op).round() as u8;

--- a/crates/ff-render/src/nodes/color_grade.rs
+++ b/crates/ff-render/src/nodes/color_grade.rs
@@ -65,7 +65,7 @@ impl Default for ColorGradeNode {
 impl RenderNodeCpu for ColorGradeNode {
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
-        for pixel in rgba.chunks_exact_mut(4) {
+        for pixel in rgba.as_chunks_mut::<4>().0 {
             let r = f32::from(pixel[0]) / 255.0;
             let g = f32::from(pixel[1]) / 255.0;
             let b = f32::from(pixel[2]) / 255.0;

--- a/crates/ff-render/src/nodes/composite/blend_math.rs
+++ b/crates/ff-render/src/nodes/composite/blend_math.rs
@@ -6,7 +6,7 @@ use super::blend_mode::BlendMode;
 fn rgb_to_hsl(r: f32, g: f32, b: f32) -> [f32; 3] {
     let max_c = r.max(g).max(b);
     let min_c = r.min(g).min(b);
-    let l = (max_c + min_c) * 0.5;
+    let l = max_c.midpoint(min_c);
     if (max_c - min_c).abs() < 1e-6 {
         return [0.0, 0.0, l];
     }

--- a/crates/ff-render/src/nodes/composite/blend_mode.rs
+++ b/crates/ff-render/src/nodes/composite/blend_mode.rs
@@ -117,8 +117,10 @@ impl RenderNodeCpu for BlendModeNode {
             return;
         }
         for (base, ov) in rgba
-            .chunks_exact_mut(4)
-            .zip(self.overlay_rgba.chunks_exact(4))
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(self.overlay_rgba.as_chunks::<4>().0.iter())
         {
             let br = f32::from(base[0]) / 255.0;
             let bg = f32::from(base[1]) / 255.0;

--- a/crates/ff-render/src/nodes/composite/chroma_key.rs
+++ b/crates/ff-render/src/nodes/composite/chroma_key.rs
@@ -70,7 +70,7 @@ fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
 impl RenderNodeCpu for ChromaKeyNode {
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
-        for pixel in rgba.chunks_exact_mut(4) {
+        for pixel in rgba.as_chunks_mut::<4>().0 {
             let r = f32::from(pixel[0]) / 255.0;
             let g = f32::from(pixel[1]) / 255.0;
             let b = f32::from(pixel[2]) / 255.0;

--- a/crates/ff-render/src/nodes/composite/masks.rs
+++ b/crates/ff-render/src/nodes/composite/masks.rs
@@ -138,7 +138,12 @@ impl RenderNodeCpu for ShapeMaskNode {
         if self.mask_rgba.len() != rgba.len() {
             return;
         }
-        for (base, mask) in rgba.chunks_exact_mut(4).zip(self.mask_rgba.chunks_exact(4)) {
+        for (base, mask) in rgba
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(self.mask_rgba.as_chunks::<4>().0.iter())
+        {
             let keep = if mask[3] > 1 { 1.0_f32 } else { 0.0_f32 };
             let a = f32::from(base[3]) / 255.0;
             base[3] = ((a * keep).clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
@@ -220,7 +225,12 @@ impl RenderNodeCpu for LumaMaskNode {
         if self.mask_rgba.len() != rgba.len() {
             return;
         }
-        for (base, mask) in rgba.chunks_exact_mut(4).zip(self.mask_rgba.chunks_exact(4)) {
+        for (base, mask) in rgba
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(self.mask_rgba.as_chunks::<4>().0.iter())
+        {
             let mr = f32::from(mask[0]) / 255.0;
             let mg = f32::from(mask[1]) / 255.0;
             let mb = f32::from(mask[2]) / 255.0;
@@ -307,8 +317,10 @@ impl RenderNodeCpu for AlphaMatteNode {
             return;
         }
         for (fg, bg) in rgba
-            .chunks_exact_mut(4)
-            .zip(self.background_rgba.chunks_exact(4))
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(self.background_rgba.as_chunks::<4>().0.iter())
         {
             let fa = f32::from(fg[3]) / 255.0;
             let ba = f32::from(bg[3]) / 255.0;

--- a/crates/ff-render/src/nodes/overlay.rs
+++ b/crates/ff-render/src/nodes/overlay.rs
@@ -59,8 +59,10 @@ impl RenderNodeCpu for OverlayNode {
             return;
         }
         for (base, ov) in rgba
-            .chunks_exact_mut(4)
-            .zip(self.overlay_rgba.chunks_exact(4))
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(self.overlay_rgba.as_chunks::<4>().0.iter())
         {
             let ov_a = f32::from(ov[3]) / 255.0;
             let base_a = f32::from(base[3]) / 255.0;


### PR DESCRIPTION
## Objective

- Rust stable advanced to 1.98, whose clippy adds `chunks_exact_to_as_chunks`, `needless_late_init`, and `manual_midpoint`. The workspace denies warnings, so CI on `main` started failing on these lints even though the files were unchanged (the PR runs earlier had passed on stable 1.97, which lacked the lints).

## Solution

- Const-size chunking now uses `as_chunks::<N>()` / `as_chunks_mut::<N>()` (fixed-size array views, no per-element bounds check) across ff-format sample conversion and the ff-render / ff-preview pixel loops.
- An HSL lightness average uses `f32::midpoint`; two late-initialized locals are initialized directly.
- All APIs are stable well before 1.98; behavior is unchanged (existing tests pass). Verified clean with `cargo +1.98.0 clippy --all --all-features -- -D warnings` (the exact CI command).