### PR TITLE
chore(ff-sys): isolate bindgen behind mod raw and lint the safe wrappers

### DIFF
--- a/crates/ff-sys/build.rs
+++ b/crates/ff-sys/build.rs
@@ -42,6 +42,13 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    // Declare the custom cfgs this build script may emit. Without this, the
+    // `unexpected_cfgs` lint fires on the hand-written wrapper modules now that
+    // the crate no longer carries a blanket `#![allow(warnings)]`.
+    println!("cargo::rustc-check-cfg=cfg(docsrs)");
+    println!("cargo::rustc-check-cfg=cfg(ffmpeg8)");
+    println!("cargo::rustc-check-cfg=cfg(ffmpeg_buffersrc_flag_u32)");
+
     // docs.rs does not have FFmpeg installed.  Emit empty bindings so that the
     // crate compiles; docsrs_stubs.rs (included by lib.rs) provides stub types.
     if env::var("DOCS_RS").is_ok() {

--- a/crates/ff-sys/src/avcodec.rs
+++ b/crates/ff-sys/src/avcodec.rs
@@ -12,7 +12,6 @@
 //! - Calling functions in the correct order (e.g., alloc before open, open before send/receive)
 
 use std::os::raw::c_int;
-use std::ptr;
 
 use crate::{
     AVCodec, AVCodecContext, AVCodecID, AVCodecParameters, AVDictionary, AVFrame, AVPacket,
@@ -53,7 +52,10 @@ use crate::{
 pub unsafe fn find_decoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
     ensure_initialized();
 
-    let codec = ffi_avcodec_find_decoder(codec_id);
+    // SAFETY: `ffi_avcodec_find_decoder` is a pure table lookup that takes a codec
+    // ID by value and dereferences no caller pointer; it always returns either a
+    // valid static codec pointer or null.
+    let codec = unsafe { ffi_avcodec_find_decoder(codec_id) };
     if codec.is_null() { None } else { Some(codec) }
 }
 
@@ -79,7 +81,10 @@ pub unsafe fn find_decoder_by_name(name: *const i8) -> Option<*const AVCodec> {
         return None;
     }
 
-    let codec = ffi_avcodec_find_decoder_by_name(name);
+    // SAFETY: `name` was null-checked just above, so it is non-null here; the caller
+    // guarantees it is a valid null-terminated C string. The call reads only that
+    // string and returns a valid static codec pointer or null.
+    let codec = unsafe { ffi_avcodec_find_decoder_by_name(name) };
     if codec.is_null() { None } else { Some(codec) }
 }
 
@@ -101,7 +106,10 @@ pub unsafe fn find_decoder_by_name(name: *const i8) -> Option<*const AVCodec> {
 pub unsafe fn find_encoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
     ensure_initialized();
 
-    let codec = ffi_avcodec_find_encoder(codec_id);
+    // SAFETY: `ffi_avcodec_find_encoder` is a pure table lookup that takes a codec
+    // ID by value and dereferences no caller pointer; it always returns either a
+    // valid static codec pointer or null.
+    let codec = unsafe { ffi_avcodec_find_encoder(codec_id) };
     if codec.is_null() { None } else { Some(codec) }
 }
 
@@ -127,7 +135,10 @@ pub unsafe fn find_encoder_by_name(name: *const i8) -> Option<*const AVCodec> {
         return None;
     }
 
-    let codec = ffi_avcodec_find_encoder_by_name(name);
+    // SAFETY: `name` was null-checked just above, so it is non-null here; the caller
+    // guarantees it is a valid null-terminated C string. The call reads only that
+    // string and returns a valid static codec pointer or null.
+    let codec = unsafe { ffi_avcodec_find_encoder_by_name(name) };
     if codec.is_null() { None } else { Some(codec) }
 }
 
@@ -152,7 +163,10 @@ pub unsafe fn find_encoder_by_name(name: *const i8) -> Option<*const AVCodec> {
 pub unsafe fn alloc_context3(codec: *const AVCodec) -> Result<*mut AVCodecContext, c_int> {
     ensure_initialized();
 
-    let ctx = ffi_avcodec_alloc_context3(codec);
+    // SAFETY: `codec` is either null (allowed, yields a generic context) or a valid
+    // codec pointer as guaranteed by the caller; the call only reads it and returns
+    // a freshly allocated context or null on allocation failure.
+    let ctx = unsafe { ffi_avcodec_alloc_context3(codec) };
     if ctx.is_null() {
         Err(crate::error_codes::ENOMEM)
     } else {
@@ -178,8 +192,14 @@ pub unsafe fn alloc_context3(codec: *const AVCodec) -> Result<*mut AVCodecContex
 /// - `ctx` being null
 /// - `*ctx` being null
 pub unsafe fn free_context(ctx: *mut *mut AVCodecContext) {
-    if !ctx.is_null() && !(*ctx).is_null() {
-        ffi_avcodec_free_context(ctx);
+    // SAFETY: `ctx` is checked for null before it is dereferenced (short-circuit),
+    // and `*ctx` is checked for null before being freed. The caller guarantees any
+    // non-null `*ctx` was allocated by `alloc_context3` and is not used afterwards;
+    // FFmpeg frees it and writes null back into `*ctx`.
+    unsafe {
+        if !ctx.is_null() && !(*ctx).is_null() {
+            ffi_avcodec_free_context(ctx);
+        }
     }
 }
 
@@ -210,7 +230,10 @@ pub unsafe fn parameters_from_context(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avcodec_parameters_from_context(par, ctx);
+    // SAFETY: both pointers were null-checked above, so they are non-null; the caller
+    // guarantees `par` points to a valid destination and `ctx` to a valid, opened
+    // codec context. The call only reads `ctx` and writes into `par`.
+    let ret = unsafe { ffi_avcodec_parameters_from_context(par, ctx) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -244,7 +267,10 @@ pub unsafe fn parameters_to_context(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avcodec_parameters_to_context(ctx, par);
+    // SAFETY: both pointers were null-checked above, so they are non-null; the caller
+    // guarantees `ctx` is an allocated but not-yet-opened context and `par` is valid
+    // codec parameters. The call reads `par` and writes into `ctx`.
+    let ret = unsafe { ffi_avcodec_parameters_to_context(ctx, par) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -286,7 +312,10 @@ pub unsafe fn open2(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avcodec_open2(ctx, codec, options);
+    // SAFETY: `ctx` was null-checked above, so it is non-null; the caller guarantees
+    // it is an allocated, not-yet-opened context and that `codec`/`options` are
+    // either null or valid. FFmpeg initialises the context in place.
+    let ret = unsafe { ffi_avcodec_open2(ctx, codec, options) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -324,7 +353,10 @@ pub unsafe fn send_packet(ctx: *mut AVCodecContext, pkt: *const AVPacket) -> Res
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avcodec_send_packet(ctx, pkt);
+    // SAFETY: `ctx` was null-checked above, so it is non-null; the caller guarantees
+    // it is a valid, open decoder context and that `pkt` is either null (flush) or a
+    // valid packet. FFmpeg reads the packet and mutates the decoder's internal state.
+    let ret = unsafe { ffi_avcodec_send_packet(ctx, pkt) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -358,7 +390,10 @@ pub unsafe fn receive_frame(ctx: *mut AVCodecContext, frame: *mut AVFrame) -> Re
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avcodec_receive_frame(ctx, frame);
+    // SAFETY: both pointers were null-checked above, so they are non-null; the caller
+    // guarantees `ctx` is a valid, open decoder context and `frame` is an allocated
+    // frame. FFmpeg reads the decoder state and writes the decoded frame into `frame`.
+    let ret = unsafe { ffi_avcodec_receive_frame(ctx, frame) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -396,7 +431,10 @@ pub unsafe fn send_frame(ctx: *mut AVCodecContext, frame: *const AVFrame) -> Res
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avcodec_send_frame(ctx, frame);
+    // SAFETY: `ctx` was null-checked above, so it is non-null; the caller guarantees
+    // it is a valid, open encoder context and that `frame` is either null (flush) or a
+    // valid frame. FFmpeg reads the frame and mutates the encoder's internal state.
+    let ret = unsafe { ffi_avcodec_send_frame(ctx, frame) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -430,7 +468,10 @@ pub unsafe fn receive_packet(ctx: *mut AVCodecContext, pkt: *mut AVPacket) -> Re
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avcodec_receive_packet(ctx, pkt);
+    // SAFETY: both pointers were null-checked above, so they are non-null; the caller
+    // guarantees `ctx` is a valid, open encoder context and `pkt` is an allocated
+    // packet. FFmpeg reads the encoder state and writes the encoded packet into `pkt`.
+    let ret = unsafe { ffi_avcodec_receive_packet(ctx, pkt) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -458,8 +499,12 @@ pub unsafe fn receive_packet(ctx: *mut AVCodecContext, pkt: *mut AVPacket) -> Re
 /// This function does not return an error code as FFmpeg's `avcodec_flush_buffers()`
 /// returns void.
 pub unsafe fn flush_buffers(ctx: *mut AVCodecContext) {
-    if !ctx.is_null() {
-        ffi_avcodec_flush_buffers(ctx);
+    // SAFETY: `ctx` is null-checked before use; when non-null the caller guarantees it
+    // is a valid, open codec context. FFmpeg only resets the context's internal state.
+    unsafe {
+        if !ctx.is_null() {
+            ffi_avcodec_flush_buffers(ctx);
+        }
     }
 }
 
@@ -515,6 +560,7 @@ mod tests {
     use super::*;
     use crate::AVCodecID_AV_CODEC_ID_H264;
     use std::ffi::CString;
+    use std::ptr;
 
     #[test]
     fn test_find_decoder_h264() {

--- a/crates/ff-sys/src/avformat.rs
+++ b/crates/ff-sys/src/avformat.rs
@@ -148,7 +148,10 @@ pub unsafe fn open_input(path: &Path) -> Result<*mut AVFormatContext, c_int> {
     let mut ctx: *mut AVFormatContext = ptr::null_mut();
 
     // Open input file
-    let ret = ffi_avformat_open_input(&mut ctx, c_path.as_ptr(), ptr::null(), ptr::null_mut());
+    // SAFETY: `c_path` is a valid NUL-terminated C string whose binding outlives
+    //         this call; `ctx` is a valid out-pointer initialised to null.
+    let ret =
+        unsafe { ffi_avformat_open_input(&mut ctx, c_path.as_ptr(), ptr::null(), ptr::null_mut()) };
 
     if ret < 0 {
         return Err(ret);
@@ -292,26 +295,38 @@ pub unsafe fn open_input_image_sequence(
     // passing null falls back to FFmpeg's auto-detection from file extension.
     // SAFETY: string literal has no null bytes
     let image2_name = CString::new("image2").unwrap();
-    let input_fmt = crate::av_find_input_format(image2_name.as_ptr());
+    // SAFETY: `image2_name` is a valid C string whose binding outlives the call.
+    let input_fmt = unsafe { crate::av_find_input_format(image2_name.as_ptr()) };
 
     // Build options dictionary: framerate=<n>
     let mut opts: *mut crate::AVDictionary = ptr::null_mut();
     // SAFETY: string literals have no null bytes
     let framerate_key = CString::new("framerate").unwrap();
     let framerate_str = CString::new(framerate.to_string()).unwrap();
-    crate::av_dict_set(
-        ptr::addr_of_mut!(opts),
-        framerate_key.as_ptr(),
-        framerate_str.as_ptr(),
-        0,
-    );
+    // SAFETY: `opts` is a valid dictionary out-pointer initialised to null; the
+    //         key/value C string bindings outlive the call and are not retained
+    //         by FFmpeg after it returns.
+    unsafe {
+        crate::av_dict_set(
+            ptr::addr_of_mut!(opts),
+            framerate_key.as_ptr(),
+            framerate_str.as_ptr(),
+            0,
+        );
+    }
 
     let mut ctx: *mut AVFormatContext = ptr::null_mut();
-    let ret = ffi_avformat_open_input(&mut ctx, c_path.as_ptr(), input_fmt, &mut opts);
+    // SAFETY: `c_path` is a valid C string whose binding outlives the call;
+    //         `input_fmt` is null or a valid demuxer; `opts` and `ctx` are valid
+    //         out-pointers.
+    let ret = unsafe { ffi_avformat_open_input(&mut ctx, c_path.as_ptr(), input_fmt, &mut opts) };
 
     // Free any options that FFmpeg did not consume.
     if !opts.is_null() {
-        crate::av_dict_free(ptr::addr_of_mut!(opts));
+        // SAFETY: `opts` is non-null (checked) and was allocated by `av_dict_set`.
+        unsafe {
+            crate::av_dict_free(ptr::addr_of_mut!(opts));
+        }
     }
 
     if ret < 0 {
@@ -341,8 +356,14 @@ pub unsafe fn open_input_image_sequence(
 /// - `ctx` being null
 /// - `*ctx` being null
 pub unsafe fn close_input(ctx: *mut *mut AVFormatContext) {
-    if !ctx.is_null() && !(*ctx).is_null() {
-        ffi_avformat_close_input(ctx);
+    // SAFETY: The caller guarantees `ctx` is either null or a valid pointer to a
+    //         context pointer allocated by `open_input`. Dereferencing `ctx` is
+    //         guarded by the null check, and `avformat_close_input` tolerates a
+    //         null `*ctx`.
+    unsafe {
+        if !ctx.is_null() && !(*ctx).is_null() {
+            ffi_avformat_close_input(ctx);
+        }
     }
 }
 
@@ -371,7 +392,8 @@ pub unsafe fn find_stream_info(ctx: *mut AVFormatContext) -> Result<(), c_int> {
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avformat_find_stream_info(ctx, ptr::null_mut());
+    // SAFETY: `ctx` is non-null (checked) and a valid context from `open_input`.
+    let ret = unsafe { ffi_avformat_find_stream_info(ctx, ptr::null_mut()) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -406,7 +428,8 @@ pub unsafe fn seek_frame(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_av_seek_frame(ctx, stream_index, timestamp, flags);
+    // SAFETY: `ctx` is non-null (checked) and a valid context from `open_input`.
+    let ret = unsafe { ffi_av_seek_frame(ctx, stream_index, timestamp, flags) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -448,7 +471,8 @@ pub unsafe fn seek_file(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_avformat_seek_file(ctx, stream_index, min_ts, ts, max_ts, flags);
+    // SAFETY: `ctx` is non-null (checked) and a valid context from `open_input`.
+    let ret = unsafe { ffi_avformat_seek_file(ctx, stream_index, min_ts, ts, max_ts, flags) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -483,7 +507,9 @@ pub unsafe fn read_frame(ctx: *mut AVFormatContext, pkt: *mut AVPacket) -> Resul
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_av_read_frame(ctx, pkt);
+    // SAFETY: `ctx` and `pkt` are non-null (checked); `ctx` is a valid context
+    //         from `open_input` and `pkt` is an allocated, initialised packet.
+    let ret = unsafe { ffi_av_read_frame(ctx, pkt) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -516,7 +542,9 @@ pub unsafe fn write_frame(ctx: *mut AVFormatContext, pkt: *mut AVPacket) -> Resu
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_av_write_frame(ctx, pkt);
+    // SAFETY: `ctx` and `pkt` are non-null (checked); `ctx` is a valid output
+    //         format context and `pkt` holds valid encoded data.
+    let ret = unsafe { ffi_av_write_frame(ctx, pkt) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -579,7 +607,9 @@ pub unsafe fn open_output(path: &Path, flags: c_int) -> Result<*mut AVIOContext,
     let mut pb: *mut AVIOContext = ptr::null_mut();
 
     // Open output file
-    let ret = avio_open(&mut pb, c_path.as_ptr(), flags);
+    // SAFETY: `c_path` is a valid C string whose binding outlives the call; `pb`
+    //         is a valid out-pointer initialised to null.
+    let ret = unsafe { avio_open(&mut pb, c_path.as_ptr(), flags) };
 
     if ret < 0 {
         return Err(ret);
@@ -622,8 +652,13 @@ pub unsafe fn open_output(path: &Path, flags: c_int) -> Result<*mut AVIOContext,
 /// }
 /// ```
 pub unsafe fn close_output(pb: *mut *mut AVIOContext) {
-    if !pb.is_null() && !(*pb).is_null() {
-        avio_closep(pb);
+    // SAFETY: The caller guarantees `pb` is either null or a valid pointer to an
+    //         AVIOContext pointer from `open_output`. Dereferencing `pb` is
+    //         guarded by the null check, and `avio_closep` tolerates a null `*pb`.
+    unsafe {
+        if !pb.is_null() && !(*pb).is_null() {
+            avio_closep(pb);
+        }
     }
 }
 

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -15,26 +15,28 @@
 //! - `ff-encode` - Encoding and export
 //! - `ff-filter` - Filters and effects
 
-// Suppress warnings from auto-generated bindgen code
-#![allow(warnings)]
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(dead_code)]
-#![allow(clippy::all)]
-#![allow(clippy::pedantic)]
-#![allow(clippy::useless_transmute)]
-#![allow(clippy::unnecessary_cast)]
-#![allow(clippy::transmute_int_to_bool)]
+// The hand-written wrapper modules below are held to the normal lint set plus
+// `unsafe_op_in_unsafe_fn`; only the auto-generated bindings opt out of it, inside
+// `mod raw`.
+#![deny(unsafe_op_in_unsafe_fn)]
 
-// On docs.rs (DOCS_RS=1) the build script emits an empty bindings.rs and sets
-// cfg(docsrs).  We include the hand-written stubs instead so that all dependent
-// crates compile without any changes of their own.
-#[cfg(not(docsrs))]
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+// Auto-generated bindgen output is isolated behind this module so its blanket
+// lint allow does not silence the hand-written wrapper modules. On docs.rs
+// (DOCS_RS=1) the build script emits an empty bindings.rs and sets cfg(docsrs);
+// we include the hand-written stubs instead so dependent crates compile unchanged.
+// `pub use raw::*` keeps every bindgen symbol available at the crate root, so
+// downstream `ff_sys::<name>` references are unaffected.
+mod raw {
+    #![allow(warnings)]
+    #![allow(unsafe_op_in_unsafe_fn)]
 
-#[cfg(docsrs)]
-include!("docsrs_stubs.rs");
+    #[cfg(not(docsrs))]
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+    #[cfg(docsrs)]
+    include!("docsrs_stubs.rs");
+}
+pub use raw::*;
 
 // ── Wrapper modules (real bindings only) ─────────────────────────────────────
 #[cfg(not(docsrs))]

--- a/crates/ff-sys/src/swresample/audio_fifo.rs
+++ b/crates/ff-sys/src/swresample/audio_fifo.rs
@@ -25,7 +25,7 @@ pub unsafe fn alloc(
     nb_samples: c_int,
 ) -> Result<*mut AVAudioFifo, c_int> {
     // SAFETY: caller guarantees parameters are valid
-    let fifo = crate::av_audio_fifo_alloc(sample_fmt, channels, nb_samples);
+    let fifo = unsafe { crate::av_audio_fifo_alloc(sample_fmt, channels, nb_samples) };
     if fifo.is_null() { Err(-1) } else { Ok(fifo) }
 }
 
@@ -36,7 +36,7 @@ pub unsafe fn alloc(
 /// `fifo` must be a valid non-null pointer returned by [`alloc`].
 pub unsafe fn free(fifo: *mut AVAudioFifo) {
     // SAFETY: caller guarantees fifo is valid
-    crate::av_audio_fifo_free(fifo);
+    unsafe { crate::av_audio_fifo_free(fifo) };
 }
 
 /// Write `nb_samples` samples from `data` into the FIFO.
@@ -56,7 +56,7 @@ pub unsafe fn write(
     nb_samples: c_int,
 ) -> Result<c_int, c_int> {
     // SAFETY: caller guarantees all pointers are valid
-    let ret = crate::av_audio_fifo_write(fifo, data, nb_samples);
+    let ret = unsafe { crate::av_audio_fifo_write(fifo, data, nb_samples) };
     if ret < 0 { Err(ret) } else { Ok(ret) }
 }
 
@@ -79,7 +79,7 @@ pub unsafe fn read(
     nb_samples: c_int,
 ) -> Result<c_int, c_int> {
     // SAFETY: caller guarantees all pointers are valid
-    let ret = crate::av_audio_fifo_read(fifo, data, nb_samples);
+    let ret = unsafe { crate::av_audio_fifo_read(fifo, data, nb_samples) };
     if ret < 0 { Err(ret) } else { Ok(ret) }
 }
 
@@ -90,5 +90,5 @@ pub unsafe fn read(
 /// `fifo` must be a valid non-null pointer.
 pub unsafe fn size(fifo: *mut AVAudioFifo) -> c_int {
     // SAFETY: caller guarantees fifo is valid
-    crate::av_audio_fifo_size(fifo)
+    unsafe { crate::av_audio_fifo_size(fifo) }
 }

--- a/crates/ff-sys/src/swresample/channel_layout.rs
+++ b/crates/ff-sys/src/swresample/channel_layout.rs
@@ -18,7 +18,9 @@ use crate::{
 /// - If `ch_layout` is null, this function is a no-op (silently ignored).
 pub unsafe fn set_default(ch_layout: *mut AVChannelLayout, nb_channels: i32) {
     if !ch_layout.is_null() {
-        av_channel_layout_default(ch_layout, nb_channels);
+        // SAFETY: `ch_layout` is non-null (checked above) and points to storage
+        // the caller guarantees is valid to initialize.
+        unsafe { av_channel_layout_default(ch_layout, nb_channels) };
     }
 }
 
@@ -34,7 +36,9 @@ pub unsafe fn set_default(ch_layout: *mut AVChannelLayout, nb_channels: i32) {
 /// - If `ch_layout` is null, this function is a no-op (silently ignored).
 pub unsafe fn uninit(ch_layout: *mut AVChannelLayout) {
     if !ch_layout.is_null() {
-        av_channel_layout_uninit(ch_layout);
+        // SAFETY: `ch_layout` is non-null (checked above) and points to a valid
+        // channel layout to uninitialize.
+        unsafe { av_channel_layout_uninit(ch_layout) };
     }
 }
 
@@ -57,7 +61,9 @@ pub unsafe fn copy(dst: *mut AVChannelLayout, src: *const AVChannelLayout) -> Re
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = av_channel_layout_copy(dst, src);
+    // SAFETY: `dst` and `src` are both non-null (checked above) and point to
+    // valid channel layouts.
+    let ret = unsafe { av_channel_layout_copy(dst, src) };
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
 
@@ -80,7 +86,9 @@ pub unsafe fn is_equal(chl: *const AVChannelLayout, chl1: *const AVChannelLayout
         return false;
     }
 
-    av_channel_layout_compare(chl, chl1) == 0
+    // SAFETY: `chl` and `chl1` are both non-null (checked above) and point to
+    // valid channel layouts.
+    unsafe { av_channel_layout_compare(chl, chl1) == 0 }
 }
 
 /// Create a mono channel layout.
@@ -90,6 +98,7 @@ pub unsafe fn is_equal(chl: *const AVChannelLayout, chl1: *const AVChannelLayout
 /// Returns a mono (1 channel) layout.
 pub fn mono() -> AVChannelLayout {
     let mut layout = AVChannelLayout::default();
+    // SAFETY: `&mut layout` points to a valid, stack-allocated channel layout.
     unsafe {
         av_channel_layout_default(&mut layout, 1);
     }
@@ -103,6 +112,7 @@ pub fn mono() -> AVChannelLayout {
 /// Returns a stereo (2 channel) layout.
 pub fn stereo() -> AVChannelLayout {
     let mut layout = AVChannelLayout::default();
+    // SAFETY: `&mut layout` points to a valid, stack-allocated channel layout.
     unsafe {
         av_channel_layout_default(&mut layout, 2);
     }
@@ -122,6 +132,7 @@ pub fn stereo() -> AVChannelLayout {
 /// Returns a channel layout with the default configuration for `nb_channels`.
 pub fn with_channels(nb_channels: i32) -> AVChannelLayout {
     let mut layout = AVChannelLayout::default();
+    // SAFETY: `&mut layout` points to a valid, stack-allocated channel layout.
     unsafe {
         av_channel_layout_default(&mut layout, nb_channels);
     }

--- a/crates/ff-sys/src/swresample/context.rs
+++ b/crates/ff-sys/src/swresample/context.rs
@@ -24,7 +24,9 @@ use crate::{
 pub unsafe fn alloc() -> Result<*mut SwrContext, c_int> {
     ensure_initialized();
 
-    let ctx = ffi_swr_alloc();
+    // SAFETY: swr_alloc takes no arguments and allocates a fresh context;
+    // FFmpeg has been initialized above.
+    let ctx = unsafe { ffi_swr_alloc() };
     if ctx.is_null() {
         Err(crate::error_codes::ENOMEM)
     } else {
@@ -77,17 +79,22 @@ pub unsafe fn alloc_set_opts2(
 
     let mut ctx: *mut SwrContext = std::ptr::null_mut();
 
-    let ret = ffi_swr_alloc_set_opts2(
-        &mut ctx,
-        out_ch_layout,
-        out_sample_fmt,
-        out_sample_rate,
-        in_ch_layout,
-        in_sample_fmt,
-        in_sample_rate,
-        0,                    // log_offset
-        std::ptr::null_mut(), // log_ctx
-    );
+    // SAFETY: `&mut ctx` is a valid out-pointer; `out_ch_layout` and
+    // `in_ch_layout` are non-null (checked above) and remain valid for the
+    // duration of this call; the sample rates are positive (checked above).
+    let ret = unsafe {
+        ffi_swr_alloc_set_opts2(
+            &mut ctx,
+            out_ch_layout,
+            out_sample_fmt,
+            out_sample_rate,
+            in_ch_layout,
+            in_sample_fmt,
+            in_sample_rate,
+            0,                    // log_offset
+            std::ptr::null_mut(), // log_ctx
+        )
+    };
 
     if ret < 0 {
         Err(ret)
@@ -126,7 +133,9 @@ pub unsafe fn init(ctx: *mut SwrContext) -> Result<(), c_int> {
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_swr_init(ctx);
+    // SAFETY: `ctx` is non-null (checked above) and points to a context
+    // allocated and configured by the caller.
+    let ret = unsafe { ffi_swr_init(ctx) };
 
     if ret < 0 { Err(ret) } else { Ok(()) }
 }
@@ -149,7 +158,8 @@ pub unsafe fn is_initialized(ctx: *const SwrContext) -> bool {
         return false;
     }
 
-    ffi_swr_is_initialized(ctx.cast_mut()) != 0
+    // SAFETY: `ctx` is non-null (checked above) and points to a valid context.
+    unsafe { ffi_swr_is_initialized(ctx.cast_mut()) != 0 }
 }
 
 /// Free a resampling context.
@@ -170,8 +180,13 @@ pub unsafe fn is_initialized(ctx: *const SwrContext) -> bool {
 /// - `ctx` being null
 /// - `*ctx` being null
 pub unsafe fn free(ctx: *mut *mut SwrContext) {
-    if !ctx.is_null() && !(*ctx).is_null() {
-        ffi_swr_free(ctx);
+    // SAFETY: `ctx` is checked non-null before `*ctx` is dereferenced (via
+    // short-circuit `&&`); `*ctx` is either null or a context allocated by
+    // `alloc`/`alloc_set_opts2`, which swr_free frees and sets to null.
+    unsafe {
+        if !ctx.is_null() && !(*ctx).is_null() {
+            ffi_swr_free(ctx);
+        }
     }
 }
 

--- a/crates/ff-sys/src/swresample/convert.rs
+++ b/crates/ff-sys/src/swresample/convert.rs
@@ -58,7 +58,10 @@ pub unsafe fn convert(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_swr_convert(ctx, out, out_count, in_, in_count);
+    // SAFETY: `ctx` is non-null (checked above) and initialized per the caller
+    // contract; `out`/`in_` and their counts describe buffers valid for the
+    // context's configured formats (or null with a zero count when flushing).
+    let ret = unsafe { ffi_swr_convert(ctx, out, out_count, in_, in_count) };
 
     if ret < 0 { Err(ret) } else { Ok(ret) }
 }
@@ -85,7 +88,8 @@ pub unsafe fn get_delay(ctx: *mut SwrContext, base: i64) -> i64 {
         return 0;
     }
 
-    ffi_swr_get_delay(ctx, base)
+    // SAFETY: `ctx` is non-null (checked above) and points to a valid context.
+    unsafe { ffi_swr_get_delay(ctx, base) }
 }
 
 /// Calculate the required output buffer size for a given input size.
@@ -119,6 +123,11 @@ pub fn estimate_output_samples(out_sample_rate: i32, in_sample_rate: i32, in_sam
 
 #[cfg(test)]
 mod tests {
+    // Test-only scaffolding calls the raw wrapper fns directly; keep the terse
+    // pre-2024 style here. The library's safe layer is held to
+    // `unsafe_op_in_unsafe_fn` at the crate root.
+    #![allow(unsafe_op_in_unsafe_fn)]
+
     use super::*;
     use crate::swresample::{alloc_set_opts2, channel_layout, free, init, sample_format};
 
@@ -211,8 +220,8 @@ mod tests {
             let in_ptr = in_data.as_ptr() as *const u8;
             let in_ptrs: [*const u8; 1] = [in_ptr];
 
-            let mut out_ptr_left = out_left.as_mut_ptr() as *mut u8;
-            let mut out_ptr_right = out_right.as_mut_ptr() as *mut u8;
+            let out_ptr_left = out_left.as_mut_ptr() as *mut u8;
+            let out_ptr_right = out_right.as_mut_ptr() as *mut u8;
             let mut out_ptrs: [*mut u8; 2] = [out_ptr_left, out_ptr_right];
 
             let result = convert(
@@ -282,7 +291,7 @@ mod tests {
             let in_ptr = in_data.as_ptr() as *const u8;
             let in_ptrs: [*const u8; 1] = [in_ptr];
 
-            let mut out_ptr = out_data.as_mut_ptr() as *mut u8;
+            let out_ptr = out_data.as_mut_ptr() as *mut u8;
             let mut out_ptrs: [*mut u8; 1] = [out_ptr];
 
             let result = convert(
@@ -422,7 +431,7 @@ mod tests {
                 let in_ptr = in_data.as_ptr() as *const u8;
                 let in_ptrs: [*const u8; 1] = [in_ptr];
 
-                let mut out_ptr = out_data.as_mut_ptr() as *mut u8;
+                let out_ptr = out_data.as_mut_ptr() as *mut u8;
                 let mut out_ptrs: [*mut u8; 1] = [out_ptr];
 
                 let result = convert(
@@ -471,7 +480,7 @@ mod tests {
             let in_ptr = in_data.as_ptr() as *const u8;
             let in_ptrs: [*const u8; 1] = [in_ptr];
 
-            let mut out_ptr = out_data.as_mut_ptr() as *mut u8;
+            let out_ptr = out_data.as_mut_ptr() as *mut u8;
             let mut out_ptrs: [*mut u8; 1] = [out_ptr];
 
             convert(

--- a/crates/ff-sys/src/swresample/mod.rs
+++ b/crates/ff-sys/src/swresample/mod.rs
@@ -23,6 +23,11 @@ pub use convert::{convert, estimate_output_samples, get_delay};
 
 #[cfg(test)]
 mod tests {
+    // Test-only scaffolding drives a raw FFmpeg decode pipeline directly, so the
+    // helper `unsafe fn`s keep the terse pre-2024 style. The library's safe layer
+    // is held to `unsafe_op_in_unsafe_fn` at the crate root.
+    #![allow(unsafe_op_in_unsafe_fn)]
+
     use super::*;
 
     // ========================================================================
@@ -179,6 +184,9 @@ mod tests {
 
     impl Drop for AudioDecoder {
         fn drop(&mut self) {
+            // SAFETY: each pointer is null-checked before it is freed and is owned
+            //         solely by this decoder; FFmpeg frees each and writes null back,
+            //         so no double free is possible.
             unsafe {
                 if !self.packet.is_null() {
                     crate::av_packet_free(&mut self.packet);
@@ -358,7 +366,7 @@ mod tests {
                 // Stage 1: Convert to S16
                 let mid_count = estimate_output_samples(44100, in_sample_rate, nb_samples);
                 let mut mid_data: Vec<i16> = vec![0; mid_count as usize * 2];
-                let mut mid_ptr = mid_data.as_mut_ptr() as *mut u8;
+                let mid_ptr = mid_data.as_mut_ptr() as *mut u8;
                 let mut mid_ptrs: [*mut u8; 1] = [mid_ptr];
 
                 let mid_result = convert(
@@ -459,7 +467,7 @@ mod tests {
                 // Convert to mono
                 let mono_count = nb_samples + 256;
                 let mut mono_data: Vec<f32> = vec![0.0; mono_count as usize];
-                let mut mono_ptr = mono_data.as_mut_ptr() as *mut u8;
+                let mono_ptr = mono_data.as_mut_ptr() as *mut u8;
                 let mut mono_ptrs: [*mut u8; 1] = [mono_ptr];
 
                 let mono_result = convert(

--- a/crates/ff-sys/src/swresample/sample_format.rs
+++ b/crates/ff-sys/src/swresample/sample_format.rs
@@ -38,6 +38,8 @@ pub const DBLP: AVSampleFormat = AVSampleFormat_AV_SAMPLE_FMT_DBLP;
 ///
 /// Returns the number of bytes per sample, or a negative value for invalid formats.
 pub fn bytes_per_sample(sample_fmt: AVSampleFormat) -> i32 {
+    // SAFETY: av_get_bytes_per_sample reads only the enum value passed by
+    // value and dereferences no pointers.
     unsafe { ffi_av_get_bytes_per_sample(sample_fmt) }
 }
 
@@ -54,6 +56,8 @@ pub fn bytes_per_sample(sample_fmt: AVSampleFormat) -> i32 {
 ///
 /// Returns `true` if the format is planar, `false` if packed.
 pub fn is_planar(sample_fmt: AVSampleFormat) -> bool {
+    // SAFETY: av_sample_fmt_is_planar reads only the enum value passed by
+    // value and dereferences no pointers.
     unsafe { ffi_av_sample_fmt_is_planar(sample_fmt) != 0 }
 }
 

--- a/crates/ff-sys/src/swscale.rs
+++ b/crates/ff-sys/src/swscale.rs
@@ -196,18 +196,24 @@ pub unsafe fn get_context(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ctx = ffi_sws_getContext(
-        src_w,
-        src_h,
-        src_fmt,
-        dst_w,
-        dst_h,
-        dst_fmt,
-        flags,
-        std::ptr::null_mut(), // srcFilter
-        std::ptr::null_mut(), // dstFilter
-        std::ptr::null(),     // param
-    );
+    // SAFETY: `ensure_initialized` has run and the dimensions are validated as
+    // positive above. The srcFilter/dstFilter/param arguments are null, which
+    // `sws_getContext` accepts. The returned pointer is checked for null before
+    // it is handed back to the caller.
+    let ctx = unsafe {
+        ffi_sws_getContext(
+            src_w,
+            src_h,
+            src_fmt,
+            dst_w,
+            dst_h,
+            dst_fmt,
+            flags,
+            std::ptr::null_mut(), // srcFilter
+            std::ptr::null_mut(), // dstFilter
+            std::ptr::null(),     // param
+        )
+    };
 
     if ctx.is_null() {
         Err(crate::error_codes::ENOMEM)
@@ -232,7 +238,11 @@ pub unsafe fn get_context(
 /// This function safely handles a null pointer.
 pub unsafe fn free_context(ctx: *mut SwsContext) {
     if !ctx.is_null() {
-        ffi_sws_freeContext(ctx);
+        // SAFETY: `ctx` is non-null here and, per this function's contract, was
+        // allocated by `get_context` and has not been freed already.
+        unsafe {
+            ffi_sws_freeContext(ctx);
+        }
     }
 }
 
@@ -305,15 +315,21 @@ pub unsafe fn scale(
         return Err(crate::error_codes::EINVAL);
     }
 
-    let ret = ffi_sws_scale(
-        ctx,
-        src,
-        src_stride,
-        src_slice_y,
-        src_slice_h,
-        dst,
-        dst_stride,
-    );
+    // SAFETY: `ctx`, `src`, `dst`, and the two stride arrays are all non-null
+    // (checked above). Per the safety contract the plane and stride arrays are
+    // valid and sized for the formats and dimensions the context was created
+    // for, so `sws_scale` reads and writes only within those buffers.
+    let ret = unsafe {
+        ffi_sws_scale(
+            ctx,
+            src,
+            src_stride,
+            src_slice_y,
+            src_slice_h,
+            dst,
+            dst_stride,
+        )
+    };
 
     if ret < 0 { Err(ret) } else { Ok(ret) }
 }
@@ -331,9 +347,17 @@ pub unsafe fn scale(
 /// # Returns
 ///
 /// Returns `true` if the format can be used as a source format for scaling.
+///
+/// # Safety
+///
+/// This function dereferences no caller-provided pointers; it is `unsafe` only
+/// because it calls into the FFmpeg C API. `pix_fmt` must be a valid
+/// `AVPixelFormat` value.
 pub unsafe fn is_supported_input(pix_fmt: AVPixelFormat) -> bool {
     ensure_initialized();
-    ffi_sws_isSupportedInput(pix_fmt) != 0
+    // SAFETY: the query takes a plain pixel-format enum by value and reads no
+    // memory through pointers; the library is initialized above.
+    unsafe { ffi_sws_isSupportedInput(pix_fmt) != 0 }
 }
 
 /// Check if a pixel format is supported as output.
@@ -345,9 +369,17 @@ pub unsafe fn is_supported_input(pix_fmt: AVPixelFormat) -> bool {
 /// # Returns
 ///
 /// Returns `true` if the format can be used as a destination format for scaling.
+///
+/// # Safety
+///
+/// This function dereferences no caller-provided pointers; it is `unsafe` only
+/// because it calls into the FFmpeg C API. `pix_fmt` must be a valid
+/// `AVPixelFormat` value.
 pub unsafe fn is_supported_output(pix_fmt: AVPixelFormat) -> bool {
     ensure_initialized();
-    ffi_sws_isSupportedOutput(pix_fmt) != 0
+    // SAFETY: the query takes a plain pixel-format enum by value and reads no
+    // memory through pointers; the library is initialized above.
+    unsafe { ffi_sws_isSupportedOutput(pix_fmt) != 0 }
 }
 
 /// Check if endianness conversion is supported for a pixel format.
@@ -359,9 +391,17 @@ pub unsafe fn is_supported_output(pix_fmt: AVPixelFormat) -> bool {
 /// # Returns
 ///
 /// Returns `true` if endianness conversion is supported for the format.
+///
+/// # Safety
+///
+/// This function dereferences no caller-provided pointers; it is `unsafe` only
+/// because it calls into the FFmpeg C API. `pix_fmt` must be a valid
+/// `AVPixelFormat` value.
 pub unsafe fn is_supported_endianness_conversion(pix_fmt: AVPixelFormat) -> bool {
     ensure_initialized();
-    ffi_sws_isSupportedEndiannessConversion(pix_fmt) != 0
+    // SAFETY: the query takes a plain pixel-format enum by value and reads no
+    // memory through pointers; the library is initialized above.
+    unsafe { ffi_sws_isSupportedEndiannessConversion(pix_fmt) != 0 }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Objective

- The crate-wide `#![allow(warnings)]` for the bindgen output also silenced every lint in the hand-written wrapper modules, so the safe layer ran without explicit unsafe blocks, SAFETY comments, or safety docs.
- Establish the lint foundation the ff-sys RAII wrappers build on (ADR-0003, tracked in #1473).

## Solution

- Move the bindgen include behind a private `mod raw` that keeps the blanket allow, and re-export it with `pub use raw::*` so the public surface is unchanged (downstream `ff_sys::<name>` references are unaffected).
- Compile the hand-written wrapper modules under the normal lint set plus `#![deny(unsafe_op_in_unsafe_fn)]`.
- Wrap each of the 47 `pub unsafe fn`'s FFmpeg calls in an explicit unsafe block with a `// SAFETY:` comment and add a `# Safety` doc section to each.
- Declare the custom cfgs (`docsrs`, `ffmpeg8`, `ffmpeg_buffersrc_flag_u32`) via `cargo::rustc-check-cfg`; scope `unsafe_op_in_unsafe_fn` back to allow inside the test-only raw FFI scaffolding; tidy an unused test import and a few needless `mut`s.
- Behaviour is unchanged.

Closes #1475