### PR TITLE
feat(ff-sys): add RAII CodecContext and migrate ff-decode

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -38,9 +38,7 @@ use ff_sys::{
 use super::resample_inner;
 
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{
-    AvCodecContextGuard, AvFormatContextGuard, AvFrameGuard, AvPacketGuard,
-};
+use crate::shared::guards_inner::{AvFormatContextGuard, AvFrameGuard, AvPacketGuard};
 
 /// Internal decoder state holding FFmpeg contexts.
 ///
@@ -50,7 +48,7 @@ pub(crate) struct AudioDecoderInner {
     /// Format context for reading the media file
     format_ctx: *mut AVFormatContext,
     /// Codec context for decoding audio frames
-    codec_ctx: *mut AVCodecContext,
+    codec_ctx: ff_sys::CodecContext,
     /// Audio stream index in the format context
     stream_index: i32,
     /// Target output sample format (if conversion is needed)
@@ -179,42 +177,52 @@ impl AudioDecoderInner {
             })?
         };
 
-        // Allocate codec context (with RAII guard)
-        // SAFETY: codec pointer is valid, AvCodecContextGuard ensures cleanup
-        let codec_ctx_guard = unsafe { AvCodecContextGuard::new(codec)? };
-        let codec_ctx = codec_ctx_guard.as_ptr();
+        // Allocate codec context (freed on drop by CodecContext).
+        // SAFETY: codec pointer is valid.
+        let mut codec_ctx =
+            unsafe { ff_sys::CodecContext::new(codec) }.map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate codec context: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         // Copy codec parameters from stream to context
-        // SAFETY: format_ctx and codec_ctx are valid, stream_index is valid
+        // SAFETY: format_ctx is valid, stream_index is valid; codec_ctx is owned
         unsafe {
             let stream = (*format_ctx).streams.add(stream_index as usize);
             let codecpar = (*(*stream)).codecpar;
-            ff_sys::avcodec::parameters_to_context(codec_ctx, codecpar).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
+            codec_ctx
+                .parameters_to_context(codecpar)
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: e.code(),
                     message: format!(
                         "Failed to copy codec parameters: {}",
-                        ff_sys::av_error_string(e)
+                        ff_sys::av_error_string(e.code())
                     ),
-                }
-            })?;
+                })?;
         }
 
         // Open the codec
-        // SAFETY: codec_ctx and codec are valid
+        // SAFETY: codec is valid; codec_ctx is owned
         unsafe {
-            ff_sys::avcodec::open2(codec_ctx, codec, ptr::null_mut()).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
-                    message: format!("Failed to open codec: {}", ff_sys::av_error_string(e)),
-                }
-            })?;
+            codec_ctx
+                .open(codec, ptr::null_mut())
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: e.code(),
+                    message: format!(
+                        "Failed to open codec: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
+                })?;
         }
 
         // Extract stream information
         // SAFETY: All pointers are valid
-        let stream_info =
-            unsafe { Self::extract_stream_info(format_ctx, stream_index as i32, codec_ctx)? };
+        let stream_info = unsafe {
+            Self::extract_stream_info(format_ctx, stream_index as i32, codec_ctx.as_mut_ptr())?
+        };
 
         // Extract container information
         // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
@@ -229,7 +237,7 @@ impl AudioDecoderInner {
         Ok((
             Self {
                 format_ctx: format_ctx_guard.into_raw(),
-                codec_ctx: codec_ctx_guard.into_raw(),
+                codec_ctx,
                 stream_index: stream_index as i32,
                 output_format,
                 output_sample_rate,
@@ -467,88 +475,93 @@ impl AudioDecoderInner {
         unsafe {
             loop {
                 // Try to receive a frame from the decoder
-                let ret = ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame);
+                match self.codec_ctx.receive_frame(self.frame) {
+                    Ok(()) => {
+                        // Successfully received a frame
+                        let audio_frame = resample_inner::convert_frame_to_audio_frame(
+                            self.frame,
+                            self.format_ctx,
+                            self.stream_index,
+                            self.output_format,
+                            self.output_sample_rate,
+                            self.output_channels,
+                            &mut self.swr_ctx,
+                            &mut self.swr_key,
+                        )?;
 
-                if ret == 0 {
-                    // Successfully received a frame
-                    let audio_frame = resample_inner::convert_frame_to_audio_frame(
-                        self.frame,
-                        self.format_ctx,
-                        self.stream_index,
-                        self.output_format,
-                        self.output_sample_rate,
-                        self.output_channels,
-                        &mut self.swr_ctx,
-                        &mut self.swr_key,
-                    )?;
+                        // Update position based on frame timestamp
+                        let pts = (*self.frame).pts;
+                        if pts != ff_sys::AV_NOPTS_VALUE {
+                            let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
+                            let time_base = (*(*stream)).time_base;
+                            let timestamp_secs =
+                                pts as f64 * time_base.num as f64 / time_base.den as f64;
+                            self.position = Duration::from_secs_f64(timestamp_secs);
+                        }
 
-                    // Update position based on frame timestamp
-                    let pts = (*self.frame).pts;
-                    if pts != ff_sys::AV_NOPTS_VALUE {
-                        let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
-                        let time_base = (*(*stream)).time_base;
-                        let timestamp_secs =
-                            pts as f64 * time_base.num as f64 / time_base.den as f64;
-                        self.position = Duration::from_secs_f64(timestamp_secs);
+                        return Ok(Some(audio_frame));
                     }
+                    Err(e) if e.is_eagain() => {
+                        // Need to send more packets to the decoder
+                        // Read a packet from the file
+                        let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
 
-                    return Ok(Some(audio_frame));
-                } else if ret == ff_sys::error_codes::EAGAIN {
-                    // Need to send more packets to the decoder
-                    // Read a packet from the file
-                    let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
-
-                    if read_ret == ff_sys::error_codes::EOF {
-                        // End of file - flush the decoder
-                        ff_sys::avcodec_send_packet(self.codec_ctx, ptr::null());
-                        self.eof = true;
-                        continue;
-                    } else if read_ret < 0 {
-                        return Err(if let Some(url) = &self.url {
-                            // Network source: map to typed variant so reconnect can detect it.
-                            crate::network::map_network_error(
-                                read_ret,
-                                crate::network::sanitize_url(url),
-                            )
-                        } else {
-                            DecodeError::Ffmpeg {
-                                code: read_ret,
-                                message: format!(
-                                    "Failed to read frame: {}",
-                                    ff_sys::av_error_string(read_ret)
-                                ),
-                            }
-                        });
-                    }
-
-                    // Check if this packet belongs to the audio stream
-                    if (*self.packet).stream_index == self.stream_index {
-                        // Send the packet to the decoder
-                        let send_ret = ff_sys::avcodec_send_packet(self.codec_ctx, self.packet);
-                        ff_sys::av_packet_unref(self.packet);
-
-                        if send_ret < 0 && send_ret != ff_sys::error_codes::EAGAIN {
-                            return Err(DecodeError::Ffmpeg {
-                                code: send_ret,
-                                message: format!(
-                                    "Failed to send packet: {}",
-                                    ff_sys::av_error_string(send_ret)
-                                ),
+                        if read_ret == ff_sys::error_codes::EOF {
+                            // End of file - flush the decoder
+                            let _ = self.codec_ctx.send_packet(ptr::null());
+                            self.eof = true;
+                            continue;
+                        } else if read_ret < 0 {
+                            return Err(if let Some(url) = &self.url {
+                                // Network source: map to typed variant so reconnect can detect it.
+                                crate::network::map_network_error(
+                                    read_ret,
+                                    crate::network::sanitize_url(url),
+                                )
+                            } else {
+                                DecodeError::Ffmpeg {
+                                    code: read_ret,
+                                    message: format!(
+                                        "Failed to read frame: {}",
+                                        ff_sys::av_error_string(read_ret)
+                                    ),
+                                }
                             });
                         }
-                    } else {
-                        // Not our stream, unref and continue
-                        ff_sys::av_packet_unref(self.packet);
+
+                        // Check if this packet belongs to the audio stream
+                        if (*self.packet).stream_index == self.stream_index {
+                            // Send the packet to the decoder
+                            let send_result = self.codec_ctx.send_packet(self.packet);
+                            ff_sys::av_packet_unref(self.packet);
+
+                            if let Err(se) = send_result
+                                && !se.is_eagain()
+                            {
+                                return Err(DecodeError::Ffmpeg {
+                                    code: se.code(),
+                                    message: format!(
+                                        "Failed to send packet: {}",
+                                        ff_sys::av_error_string(se.code())
+                                    ),
+                                });
+                            }
+                        } else {
+                            // Not our stream, unref and continue
+                            ff_sys::av_packet_unref(self.packet);
+                        }
                     }
-                } else if ret == ff_sys::error_codes::EOF {
-                    // Decoder has been fully flushed
-                    self.eof = true;
-                    return Ok(None);
-                } else {
-                    return Err(DecodeError::DecodingFailed {
-                        timestamp: Some(self.position),
-                        reason: ff_sys::av_error_string(ret),
-                    });
+                    Err(e) if e.is_eof() => {
+                        // Decoder has been fully flushed
+                        self.eof = true;
+                        return Ok(None);
+                    }
+                    Err(e) => {
+                        return Err(DecodeError::DecodingFailed {
+                            timestamp: Some(self.position),
+                            reason: ff_sys::av_error_string(e.code()),
+                        });
+                    }
                 }
             }
         }
@@ -624,10 +637,8 @@ impl AudioDecoderInner {
 
         // 3. Flush decoder buffers and reset the cached SwrContext so the
         //    resampler does not carry stale delay samples across the seek point.
-        // SAFETY: codec_ctx is valid (owned by AudioDecoderInner)
-        unsafe {
-            ff_sys::avcodec::flush_buffers(self.codec_ctx);
-        }
+        // SAFETY: the codec context was opened during construction.
+        unsafe { self.codec_ctx.flush_buffers() };
         self.swr_ctx = None;
         self.swr_key = None;
 
@@ -635,13 +646,10 @@ impl AudioDecoderInner {
         // SAFETY: codec_ctx and frame are valid
         unsafe {
             loop {
-                let ret = ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame);
-                if ret == ff_sys::error_codes::EAGAIN || ret == ff_sys::error_codes::EOF {
-                    break;
-                } else if ret == 0 {
-                    ff_sys::av_frame_unref(self.frame);
-                } else {
-                    break;
+                match self.codec_ctx.receive_frame(self.frame) {
+                    Ok(()) => ff_sys::av_frame_unref(self.frame),
+                    Err(e) if e.is_eagain() || e.is_eof() => break,
+                    Err(_) => break,
                 }
             }
         }
@@ -680,10 +688,8 @@ impl AudioDecoderInner {
 
     /// Flushes the decoder's internal buffers.
     pub(crate) fn flush(&mut self) {
-        // SAFETY: codec_ctx is valid and owned by this instance
-        unsafe {
-            ff_sys::avcodec::flush_buffers(self.codec_ctx);
-        }
+        // SAFETY: the codec context was opened during construction.
+        unsafe { self.codec_ctx.flush_buffers() };
         self.eof = false;
     }
 
@@ -771,10 +777,8 @@ impl AudioDecoderInner {
         self.stream_index = stream_index as i32;
 
         // Flush codec buffers to discard stale decoded state from before the drop.
-        // SAFETY: self.codec_ctx is valid and has not been freed.
-        unsafe {
-            ff_sys::avcodec::flush_buffers(self.codec_ctx);
-        }
+        // SAFETY: the codec context was opened during construction.
+        unsafe { self.codec_ctx.flush_buffers() };
 
         self.eof = false;
         Ok(())
@@ -795,14 +799,6 @@ impl Drop for AudioDecoderInner {
             // SAFETY: self.packet is valid and owned by this instance
             unsafe {
                 ff_sys::av_packet_free(&mut (self.packet as *mut _));
-            }
-        }
-
-        // Free codec context
-        if !self.codec_ctx.is_null() {
-            // SAFETY: self.codec_ctx is valid and owned by this instance
-            unsafe {
-                ff_sys::avcodec::free_context(&mut (self.codec_ctx as *mut _));
             }
         }
 

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -25,12 +25,11 @@ use std::ptr;
 use ff_format::time::{Rational, Timestamp};
 use ff_format::{PixelFormat, PooledBuffer, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket,
-    AVPixelFormat,
+    AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket, AVPixelFormat,
 };
 
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{AvCodecContextGuard, AvFormatContextGuard};
+use crate::shared::guards_inner::AvFormatContextGuard;
 use crate::shared::plane_inner::plane_row_ptr;
 
 // ── ImageDecoderInner ─────────────────────────────────────────────────────────
@@ -42,7 +41,7 @@ pub(crate) struct ImageDecoderInner {
     /// Format context for reading the image file.
     format_ctx: *mut AVFormatContext,
     /// Codec context for decoding the image.
-    codec_ctx: *mut AVCodecContext,
+    codec_ctx: ff_sys::CodecContext,
     /// Video stream index in the format context.
     stream_index: usize,
     /// Reusable packet for reading from file.
@@ -112,36 +111,45 @@ impl ImageDecoderInner {
             })?
         };
 
-        // 5. avcodec_alloc_context3
-        // SAFETY: codec pointer is valid; AvCodecContextGuard ensures cleanup.
-        let codec_ctx_guard = unsafe { AvCodecContextGuard::new(codec)? };
-        let codec_ctx = codec_ctx_guard.as_ptr();
+        // 5. avcodec_alloc_context3 (freed on drop by CodecContext).
+        // SAFETY: codec pointer is valid.
+        let mut codec_ctx =
+            unsafe { ff_sys::CodecContext::new(codec) }.map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate codec context: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         // 6. avcodec_parameters_to_context
         // SAFETY: All pointers are valid; stream_index was validated above.
         unsafe {
             let stream = (*format_ctx).streams.add(stream_index);
             let codecpar = (*(*stream)).codecpar;
-            ff_sys::avcodec::parameters_to_context(codec_ctx, codecpar).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
+            codec_ctx
+                .parameters_to_context(codecpar)
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: e.code(),
                     message: format!(
                         "Failed to copy codec parameters: {}",
-                        ff_sys::av_error_string(e)
+                        ff_sys::av_error_string(e.code())
                     ),
-                }
-            })?;
+                })?;
         }
 
         // 7. avcodec_open2
-        // SAFETY: codec_ctx and codec are valid; no hardware acceleration for images.
+        // SAFETY: codec is valid; no hardware acceleration for images; codec_ctx is owned.
         unsafe {
-            ff_sys::avcodec::open2(codec_ctx, codec, ptr::null_mut()).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
-                    message: format!("Failed to open codec: {}", ff_sys::av_error_string(e)),
-                }
-            })?;
+            codec_ctx
+                .open(codec, ptr::null_mut())
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: e.code(),
+                    message: format!(
+                        "Failed to open codec: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
+                })?;
         }
 
         // Allocate packet and frame.
@@ -164,7 +172,7 @@ impl ImageDecoderInner {
 
         Ok(Self {
             format_ctx: format_ctx_guard.into_raw(),
-            codec_ctx: codec_ctx_guard.into_raw(),
+            codec_ctx,
             stream_index,
             packet,
             frame,
@@ -174,13 +182,13 @@ impl ImageDecoderInner {
     /// Returns the image width in pixels.
     pub(crate) fn width(&self) -> u32 {
         // SAFETY: codec_ctx is valid for the lifetime of `self`.
-        unsafe { (*self.codec_ctx).width as u32 }
+        unsafe { (*self.codec_ctx.as_ptr()).width as u32 }
     }
 
     /// Returns the image height in pixels.
     pub(crate) fn height(&self) -> u32 {
         // SAFETY: codec_ctx is valid for the lifetime of `self`.
-        unsafe { (*self.codec_ctx).height as u32 }
+        unsafe { (*self.codec_ctx.as_ptr()).height as u32 }
     }
 
     /// Decodes the image, consuming `self` and returning a [`VideoFrame`].
@@ -190,7 +198,7 @@ impl ImageDecoderInner {
     /// 2. `avcodec_send_packet`
     /// 3. `avcodec_receive_frame`
     /// 4. Convert to [`VideoFrame`]
-    pub(crate) fn decode(self) -> Result<VideoFrame, DecodeError> {
+    pub(crate) fn decode(mut self) -> Result<VideoFrame, DecodeError> {
         // 1. av_read_frame
         // SAFETY: format_ctx and packet are valid.
         let ret = unsafe { ff_sys::av_read_frame(self.format_ctx, self.packet) };
@@ -202,28 +210,27 @@ impl ImageDecoderInner {
         }
 
         // 2. avcodec_send_packet
-        // SAFETY: codec_ctx and packet are valid; packet contains image data.
-        let ret = unsafe { ff_sys::avcodec_send_packet(self.codec_ctx, self.packet) };
+        // SAFETY: codec_ctx is owned; packet is valid and contains image data.
+        let send_result = unsafe { self.codec_ctx.send_packet(self.packet) };
         unsafe { ff_sys::av_packet_unref(self.packet) };
-        if ret < 0 {
+        if let Err(e) = send_result {
             return Err(DecodeError::Ffmpeg {
-                code: ret,
+                code: e.code(),
                 message: format!(
                     "Failed to send packet to decoder: {}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 ),
             });
         }
 
         // 3. avcodec_receive_frame
-        // SAFETY: codec_ctx and frame are valid.
-        let ret = unsafe { ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame) };
-        if ret < 0 {
+        // SAFETY: codec_ctx is owned; frame is valid.
+        if let Err(e) = unsafe { self.codec_ctx.receive_frame(self.frame) } {
             return Err(DecodeError::Ffmpeg {
-                code: ret,
+                code: e.code(),
                 message: format!(
                     "Failed to receive decoded frame: {}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 ),
             });
         }
@@ -540,9 +547,6 @@ impl Drop for ImageDecoderInner {
             }
             if !self.packet.is_null() {
                 ff_sys::av_packet_free(&mut (self.packet as *mut _));
-            }
-            if !self.codec_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut (self.codec_ctx as *mut _));
             }
             if !self.format_ctx.is_null() {
                 ff_sys::avformat::close_input(&mut (self.format_ctx as *mut _));

--- a/crates/ff-decode/src/shared/guards_inner.rs
+++ b/crates/ff-decode/src/shared/guards_inner.rs
@@ -13,7 +13,7 @@
 use std::path::Path;
 
 use ff_format::NetworkOptions;
-use ff_sys::{AVCodecContext, AVFormatContext, AVFrame, AVPacket};
+use ff_sys::{AVFormatContext, AVFrame, AVPacket};
 
 use crate::error::DecodeError;
 use crate::network::{map_network_error, sanitize_url};
@@ -95,50 +95,6 @@ impl Drop for AvFormatContextGuard {
             // SAFETY: self.0 is valid and owned by this guard
             unsafe {
                 ff_sys::avformat::close_input(&mut (self.0 as *mut _));
-            }
-        }
-    }
-}
-
-/// RAII guard for `AVCodecContext` to ensure proper cleanup.
-pub(crate) struct AvCodecContextGuard(*mut AVCodecContext);
-
-impl AvCodecContextGuard {
-    /// Creates a new guard by allocating a codec context.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure codec pointer is valid.
-    pub(crate) unsafe fn new(codec: *const ff_sys::AVCodec) -> Result<Self, DecodeError> {
-        // SAFETY: Caller ensures codec pointer is valid
-        let codec_ctx = unsafe {
-            ff_sys::avcodec::alloc_context3(codec).map_err(|e| DecodeError::Ffmpeg {
-                code: e,
-                message: format!("Failed to allocate codec context: {e}"),
-            })?
-        };
-        Ok(Self(codec_ctx))
-    }
-
-    /// Returns the raw pointer.
-    pub(crate) const fn as_ptr(&self) -> *mut AVCodecContext {
-        self.0
-    }
-
-    /// Consumes the guard and returns the raw pointer without dropping.
-    pub(crate) fn into_raw(self) -> *mut AVCodecContext {
-        let ptr = self.0;
-        std::mem::forget(self);
-        ptr
-    }
-}
-
-impl Drop for AvCodecContextGuard {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            // SAFETY: self.0 is valid and owned by this guard
-            unsafe {
-                ff_sys::avcodec::free_context(&mut (self.0 as *mut _));
             }
         }
     }

--- a/crates/ff-decode/src/video/decoder_inner/decoding.rs
+++ b/crates/ff-decode/src/video/decoder_inner/decoding.rs
@@ -37,112 +37,117 @@ impl VideoDecoderInner {
         unsafe {
             loop {
                 // Try to receive a frame from the decoder
-                let ret = ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame);
+                match self.codec_ctx.receive_frame(self.frame) {
+                    Ok(()) => {
+                        // Successfully received a frame — reset corrupt-stream counter.
+                        self.consecutive_invalid = 0;
 
-                if ret == 0 {
-                    // Successfully received a frame — reset corrupt-stream counter.
-                    self.consecutive_invalid = 0;
+                        // Check if this is a hardware frame and transfer to CPU memory if needed
+                        self.transfer_hardware_frame_if_needed()?;
 
-                    // Check if this is a hardware frame and transfer to CPU memory if needed
-                    self.transfer_hardware_frame_if_needed()?;
-
-                    // SAFETY: self.frame is valid and non-null after avcodec_receive_frame succeeded.
-                    let w = (*self.frame).width as u32;
-                    let h = (*self.frame).height as u32;
-                    if w > 32_768 || h > 32_768 {
-                        log::warn!(
-                            "frame rejected reason=unsupported_resolution width={w} height={h}"
-                        );
-                        return Err(DecodeError::UnsupportedResolution {
-                            width: w,
-                            height: h,
-                        });
-                    }
-
-                    let video_frame = self.convert_frame_to_video_frame()?;
-
-                    // Update position based on frame timestamp
-                    let pts = (*self.frame).pts;
-                    if pts != ff_sys::AV_NOPTS_VALUE {
-                        let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
-                        let time_base = (*(*stream)).time_base;
-                        let timestamp_secs =
-                            pts as f64 * time_base.num as f64 / time_base.den as f64;
-                        self.position = Duration::from_secs_f64(timestamp_secs);
-                    }
-
-                    return Ok(Some(video_frame));
-                } else if ret == ff_sys::error_codes::EAGAIN {
-                    // Need to send more packets to the decoder
-                    // Read a packet from the file
-                    let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
-
-                    if read_ret == ff_sys::error_codes::EOF {
-                        // End of file - flush the decoder
-                        ff_sys::avcodec_send_packet(self.codec_ctx, ptr::null());
-                        self.eof = true;
-                        continue;
-                    } else if read_ret < 0 {
-                        return Err(if let Some(url) = &self.url {
-                            // Network source: map to typed variant so reconnect can detect it.
-                            crate::network::map_network_error(
-                                read_ret,
-                                crate::network::sanitize_url(url),
-                            )
-                        } else {
-                            DecodeError::Ffmpeg {
-                                code: read_ret,
-                                message: format!(
-                                    "Failed to read frame: {}",
-                                    ff_sys::av_error_string(read_ret)
-                                ),
-                            }
-                        });
-                    }
-
-                    // Check if this packet belongs to the video stream
-                    if (*self.packet).stream_index == self.stream_index {
-                        // Send the packet to the decoder
-                        let send_ret = ff_sys::avcodec_send_packet(self.codec_ctx, self.packet);
-                        // SAFETY: self.packet is valid and non-null; pts is a plain i64 field.
-                        let pkt_pts = (*self.packet).pts;
-                        ff_sys::av_packet_unref(self.packet);
-
-                        if send_ret == ff_sys::error_codes::AVERROR_INVALIDDATA {
-                            log::warn!("packet skipped reason=invalid_data pts={pkt_pts}");
-                            self.consecutive_invalid += 1;
-                            if self.consecutive_invalid >= 32 {
-                                log::warn!(
-                                    "stream corrupted consecutive_invalid_packets={}",
-                                    self.consecutive_invalid
-                                );
-                                return Err(DecodeError::StreamCorrupted {
-                                    consecutive_invalid_packets: self.consecutive_invalid,
-                                });
-                            }
-                            // Do not return error; fall through to read the next packet.
-                        } else if send_ret < 0 && send_ret != ff_sys::error_codes::EAGAIN {
-                            return Err(DecodeError::Ffmpeg {
-                                code: send_ret,
-                                message: format!(
-                                    "Failed to send packet: {}",
-                                    ff_sys::av_error_string(send_ret)
-                                ),
+                        // SAFETY: self.frame is valid and non-null after receive_frame succeeded.
+                        let w = (*self.frame).width as u32;
+                        let h = (*self.frame).height as u32;
+                        if w > 32_768 || h > 32_768 {
+                            log::warn!(
+                                "frame rejected reason=unsupported_resolution width={w} height={h}"
+                            );
+                            return Err(DecodeError::UnsupportedResolution {
+                                width: w,
+                                height: h,
                             });
                         }
-                    } else {
-                        // Not our stream, unref and continue
-                        ff_sys::av_packet_unref(self.packet);
+
+                        let video_frame = self.convert_frame_to_video_frame()?;
+
+                        // Update position based on frame timestamp
+                        let pts = (*self.frame).pts;
+                        if pts != ff_sys::AV_NOPTS_VALUE {
+                            let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
+                            let time_base = (*(*stream)).time_base;
+                            let timestamp_secs =
+                                pts as f64 * time_base.num as f64 / time_base.den as f64;
+                            self.position = Duration::from_secs_f64(timestamp_secs);
+                        }
+
+                        return Ok(Some(video_frame));
                     }
-                } else if ret == ff_sys::error_codes::EOF {
-                    // Decoder has been fully flushed
-                    self.eof = true;
-                    return Ok(None);
-                } else {
-                    return Err(DecodeError::DecodingFailed {
-                        timestamp: Some(self.position),
-                        reason: ff_sys::av_error_string(ret),
-                    });
+                    Err(e) if e.is_eagain() => {
+                        // Need to send more packets to the decoder
+                        // Read a packet from the file
+                        let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
+
+                        if read_ret == ff_sys::error_codes::EOF {
+                            // End of file - flush the decoder
+                            let _ = self.codec_ctx.send_packet(ptr::null());
+                            self.eof = true;
+                            continue;
+                        } else if read_ret < 0 {
+                            return Err(if let Some(url) = &self.url {
+                                // Network source: map to typed variant so reconnect can detect it.
+                                crate::network::map_network_error(
+                                    read_ret,
+                                    crate::network::sanitize_url(url),
+                                )
+                            } else {
+                                DecodeError::Ffmpeg {
+                                    code: read_ret,
+                                    message: format!(
+                                        "Failed to read frame: {}",
+                                        ff_sys::av_error_string(read_ret)
+                                    ),
+                                }
+                            });
+                        }
+
+                        // Check if this packet belongs to the video stream
+                        if (*self.packet).stream_index == self.stream_index {
+                            // Send the packet to the decoder
+                            let send_result = self.codec_ctx.send_packet(self.packet);
+                            // SAFETY: self.packet is valid and non-null; pts is a plain i64 field.
+                            let pkt_pts = (*self.packet).pts;
+                            ff_sys::av_packet_unref(self.packet);
+
+                            if let Err(se) = send_result {
+                                if se.code() == ff_sys::error_codes::AVERROR_INVALIDDATA {
+                                    log::warn!("packet skipped reason=invalid_data pts={pkt_pts}");
+                                    self.consecutive_invalid += 1;
+                                    if self.consecutive_invalid >= 32 {
+                                        log::warn!(
+                                            "stream corrupted consecutive_invalid_packets={}",
+                                            self.consecutive_invalid
+                                        );
+                                        return Err(DecodeError::StreamCorrupted {
+                                            consecutive_invalid_packets: self.consecutive_invalid,
+                                        });
+                                    }
+                                    // Do not return error; fall through to read the next packet.
+                                } else if !se.is_eagain() {
+                                    return Err(DecodeError::Ffmpeg {
+                                        code: se.code(),
+                                        message: format!(
+                                            "Failed to send packet: {}",
+                                            ff_sys::av_error_string(se.code())
+                                        ),
+                                    });
+                                }
+                            }
+                        } else {
+                            // Not our stream, unref and continue
+                            ff_sys::av_packet_unref(self.packet);
+                        }
+                    }
+                    Err(e) if e.is_eof() => {
+                        // Decoder has been fully flushed
+                        self.eof = true;
+                        return Ok(None);
+                    }
+                    Err(e) => {
+                        return Err(DecodeError::DecodingFailed {
+                            timestamp: Some(self.position),
+                            reason: ff_sys::av_error_string(e.code()),
+                        });
+                    }
                 }
             }
         }

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -44,9 +44,7 @@ use ff_sys::{
 
 use crate::HardwareAccel;
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{
-    AvCodecContextGuard, AvFormatContextGuard, AvFrameGuard, AvPacketGuard,
-};
+use crate::shared::guards_inner::{AvFormatContextGuard, AvFrameGuard, AvPacketGuard};
 use crate::video::builder::OutputScale;
 use ff_common::FramePool;
 
@@ -71,7 +69,7 @@ pub(crate) struct VideoDecoderInner {
     /// Format context for reading the media file
     pub(super) format_ctx: *mut AVFormatContext,
     /// Codec context for decoding video frames
-    pub(super) codec_ctx: *mut AVCodecContext,
+    pub(super) codec_ctx: ff_sys::CodecContext,
     /// Video stream index in the format context
     pub(super) stream_index: i32,
     /// SwScale context for pixel format conversion and/or scaling (optional)
@@ -229,59 +227,69 @@ impl VideoDecoderInner {
             })?
         };
 
-        // Allocate codec context (with RAII guard)
-        // SAFETY: codec pointer is valid, AvCodecContextGuard ensures cleanup
-        let codec_ctx_guard = unsafe { AvCodecContextGuard::new(codec)? };
-        let codec_ctx = codec_ctx_guard.as_ptr();
+        // Allocate codec context (freed on drop by CodecContext).
+        // SAFETY: codec pointer is valid.
+        let mut codec_ctx =
+            unsafe { ff_sys::CodecContext::new(codec) }.map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate codec context: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         // Copy codec parameters from stream to context
-        // SAFETY: format_ctx and codec_ctx are valid, stream_index is valid
+        // SAFETY: format_ctx is valid, stream_index is valid; codec_ctx is owned
         unsafe {
             let stream = (*format_ctx).streams.add(stream_index as usize);
             let codecpar = (*(*stream)).codecpar;
-            ff_sys::avcodec::parameters_to_context(codec_ctx, codecpar).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
+            codec_ctx
+                .parameters_to_context(codecpar)
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: e.code(),
                     message: format!(
                         "Failed to copy codec parameters: {}",
-                        ff_sys::av_error_string(e)
+                        ff_sys::av_error_string(e.code())
                     ),
-                }
-            })?;
+                })?;
 
             // Set thread count
             if thread_count > 0 {
-                (*codec_ctx).thread_count = thread_count as i32;
+                (*codec_ctx.as_mut_ptr()).thread_count = thread_count as i32;
             }
         }
 
         // Initialize hardware acceleration if requested
         // SAFETY: codec_ctx is valid and not yet opened
         let (hw_device_ctx, active_hw_accel) =
-            unsafe { Self::init_hardware_accel(codec_ctx, hardware_accel)? };
+            unsafe { Self::init_hardware_accel(codec_ctx.as_mut_ptr(), hardware_accel)? };
 
         // Open the codec
-        // SAFETY: codec_ctx and codec are valid, hardware device context is set if requested
+        // SAFETY: codec is valid, hardware device context is set if requested; codec_ctx is owned
         unsafe {
-            ff_sys::avcodec::open2(codec_ctx, codec, ptr::null_mut()).map_err(|e| {
+            codec_ctx.open(codec, ptr::null_mut()).map_err(|e| {
                 // If codec opening failed, we still own our reference to hw_device_ctx
                 // but it will be cleaned up when codec_ctx is freed (which happens
-                // when codec_ctx_guard is dropped)
+                // when codec_ctx is dropped)
                 // Our reference in hw_device_ctx will be cleaned up here
                 if let Some(hw_ctx) = hw_device_ctx {
                     ff_sys::av_buffer_unref(&mut (hw_ctx as *mut _));
                 }
                 DecodeError::Ffmpeg {
-                    code: e,
-                    message: format!("Failed to open codec: {}", ff_sys::av_error_string(e)),
+                    code: e.code(),
+                    message: format!(
+                        "Failed to open codec: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
                 }
             })?;
         }
 
         // Extract stream information
         // SAFETY: All pointers are valid
-        let stream_info =
-            unsafe { Self::extract_stream_info(format_ctx, stream_index as i32, codec_ctx)? };
+        let stream_info = unsafe {
+            Self::extract_stream_info(format_ctx, stream_index as i32, codec_ctx.as_mut_ptr())?
+        };
 
         // Extract container information
         // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
@@ -296,7 +304,7 @@ impl VideoDecoderInner {
         Ok((
             Self {
                 format_ctx: format_ctx_guard.into_raw(),
-                codec_ctx: codec_ctx_guard.into_raw(),
+                codec_ctx,
                 stream_index: stream_index as i32,
                 sws_ctx: None,
                 sws_cache_key: None,
@@ -361,14 +369,6 @@ impl Drop for VideoDecoderInner {
             // SAFETY: self.packet is valid and owned by this instance
             unsafe {
                 ff_sys::av_packet_free(&mut (self.packet as *mut _));
-            }
-        }
-
-        // Free codec context
-        if !self.codec_ctx.is_null() {
-            // SAFETY: self.codec_ctx is valid and owned by this instance
-            unsafe {
-                ff_sys::avcodec::free_context(&mut (self.codec_ctx as *mut _));
             }
         }
 

--- a/crates/ff-decode/src/video/decoder_inner/seeking.rs
+++ b/crates/ff-decode/src/video/decoder_inner/seeking.rs
@@ -129,28 +129,21 @@ impl VideoDecoderInner {
         }
 
         // 3. Flush decoder buffers to clear any cached frames
-        // SAFETY: codec_ctx is valid: owned by VideoDecoderInner, initialized via avcodec_open2
-        unsafe {
-            ff_sys::avcodec::flush_buffers(self.codec_ctx);
-        }
+        // SAFETY: the codec context was opened during construction.
+        unsafe { self.codec_ctx.flush_buffers() };
 
         // 4. Drain any remaining frames from the decoder after flush
         // This ensures no stale frames are returned after the seek
-        // SAFETY:
-        // - codec_ctx is valid: owned by VideoDecoderInner, initialized via avcodec_open2
-        // - frame is valid: allocated in constructor, owned by VideoDecoderInner
+        // SAFETY: frame is valid: allocated in constructor, owned by VideoDecoderInner
         unsafe {
             loop {
-                let ret = ff_sys::avcodec_receive_frame(self.codec_ctx, self.frame);
-                if ret == ff_sys::error_codes::EAGAIN || ret == ff_sys::error_codes::EOF {
-                    // No more frames in the decoder buffer
-                    break;
-                } else if ret == 0 {
+                match self.codec_ctx.receive_frame(self.frame) {
                     // Got a frame, unref it and continue draining
-                    ff_sys::av_frame_unref(self.frame);
-                } else {
+                    Ok(()) => ff_sys::av_frame_unref(self.frame),
+                    // No more frames in the decoder buffer
+                    Err(e) if e.is_eagain() || e.is_eof() => break,
                     // Other error, break out
-                    break;
+                    Err(_) => break,
                 }
             }
         }
@@ -245,10 +238,8 @@ impl VideoDecoderInner {
     /// This clears any cached frames and resets the decoder state.
     /// The decoder is ready to receive new packets after flushing.
     pub(crate) fn flush(&mut self) {
-        // SAFETY: codec_ctx is valid and owned by this instance
-        unsafe {
-            ff_sys::avcodec::flush_buffers(self.codec_ctx);
-        }
+        // SAFETY: the codec context was opened during construction.
+        unsafe { self.codec_ctx.flush_buffers() };
         self.eof = false;
     }
 
@@ -545,10 +536,8 @@ impl VideoDecoderInner {
         self.stream_index = stream_index as i32;
 
         // Flush codec buffers to discard stale decoded state from before the drop.
-        // SAFETY: self.codec_ctx is valid and has not been freed.
-        unsafe {
-            ff_sys::avcodec::flush_buffers(self.codec_ctx);
-        }
+        // SAFETY: the codec context was opened during construction.
+        unsafe { self.codec_ctx.flush_buffers() };
 
         self.eof = false;
         Ok(())

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -1,0 +1,152 @@
+//! RAII owner for an `AVCodecContext`.
+//!
+//! [`CodecContext`] allocates a codec context and frees it exactly once on drop,
+//! replacing the manual `avcodec::alloc_context3` + `avcodec::free_context` pair.
+//! Its fallible methods return [`AvError`]. Packet / frame arguments stay raw
+//! pointers for now (owned Frame / Packet are a later step), so the
+//! pointer-taking methods are `unsafe`: the caller upholds the usual FFmpeg
+//! preconditions.
+
+use std::ptr::NonNull;
+
+use crate::{
+    AVCodec, AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AvError,
+    avcodec_free_context as ffi_avcodec_free_context,
+};
+
+/// An owned `AVCodecContext`.
+///
+/// The context is freed exactly once on drop. This is guaranteed by
+/// construction: the value owns a [`NonNull`] and is neither `Copy` nor `Clone`,
+/// so it drops exactly once and cannot be duplicated.
+#[derive(Debug)]
+pub struct CodecContext {
+    ptr: NonNull<AVCodecContext>,
+}
+
+impl CodecContext {
+    /// Allocates a codec context for `codec`.
+    ///
+    /// # Safety
+    ///
+    /// `codec` must be null (yielding a generic context) or a valid
+    /// `*const AVCodec` (for example from `avcodec::find_decoder`).
+    pub unsafe fn new(codec: *const AVCodec) -> Result<Self, AvError> {
+        // SAFETY: the caller upholds the `codec` precondition; `alloc_context3`
+        //         returns a non-null context or a negative error code.
+        let ptr = unsafe { crate::avcodec::alloc_context3(codec) }.map_err(AvError::new)?;
+        // `alloc_context3` returns `Ok` only with a non-null pointer.
+        NonNull::new(ptr)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })
+    }
+
+    /// Returns the context pointer for read-only use.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVCodecContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the context pointer for mutation and FFI calls.
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVCodecContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Copies stream parameters into the context.
+    ///
+    /// # Safety
+    ///
+    /// `par` must be a valid `*const AVCodecParameters`.
+    pub unsafe fn parameters_to_context(
+        &mut self,
+        par: *const AVCodecParameters,
+    ) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned context; the caller upholds `par`.
+        unsafe { crate::avcodec::parameters_to_context(self.ptr.as_ptr(), par) }
+            .map_err(AvError::new)
+    }
+
+    /// Opens the context with `codec` and optional dictionary `options`.
+    ///
+    /// # Safety
+    ///
+    /// `codec` must be a valid `*const AVCodec`, and `options` must be null or a
+    /// valid `*mut *mut AVDictionary`.
+    pub unsafe fn open(
+        &mut self,
+        codec: *const AVCodec,
+        options: *mut *mut AVDictionary,
+    ) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned context; the caller upholds
+        //         `codec` / `options`.
+        unsafe { crate::avcodec::open2(self.ptr.as_ptr(), codec, options) }.map_err(AvError::new)
+    }
+
+    /// Sends a packet to the decoder (a null packet flushes it).
+    ///
+    /// # Safety
+    ///
+    /// `pkt` must be null or a valid `*const AVPacket`.
+    pub unsafe fn send_packet(&mut self, pkt: *const AVPacket) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid open context; the caller upholds `pkt`.
+        unsafe { crate::avcodec::send_packet(self.ptr.as_ptr(), pkt) }.map_err(AvError::new)
+    }
+
+    /// Receives a decoded frame from the decoder.
+    ///
+    /// # Safety
+    ///
+    /// `frame` must be a valid `*mut AVFrame`.
+    pub unsafe fn receive_frame(&mut self, frame: *mut AVFrame) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid open context; the caller upholds `frame`.
+        unsafe { crate::avcodec::receive_frame(self.ptr.as_ptr(), frame) }.map_err(AvError::new)
+    }
+
+    /// Resets the codec's internal buffers (for example after a seek).
+    ///
+    /// # Safety
+    ///
+    /// The context must have been opened via [`open`](Self::open) first:
+    /// `avcodec_flush_buffers` reads codec-internal state that `avcodec_open2`
+    /// allocates, so calling it on an unopened context is undefined behaviour.
+    pub unsafe fn flush_buffers(&mut self) {
+        // SAFETY: the caller guarantees the context is opened; `flush_buffers`
+        //         reads no caller-supplied pointer.
+        unsafe { crate::avcodec::flush_buffers(self.ptr.as_ptr()) };
+    }
+}
+
+impl Drop for CodecContext {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
+        //         runs exactly once. `avcodec_free_context` frees it and writes
+        //         null into our local copy of the pointer, which is then discarded.
+        //         The raw binding is used directly so this type does not depend on
+        //         the `avcodec::free_context` wrapper (retired in #1490).
+        unsafe {
+            let mut raw = self.ptr.as_ptr();
+            ffi_avcodec_free_context(&mut raw);
+        }
+    }
+}
+
+// SAFETY: an `AVCodecContext` is not safe for concurrent access, but moving
+//         ownership between threads is sound because Rust's ownership model
+//         guarantees exclusive access.
+unsafe impl Send for CodecContext {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codec_context_new_should_allocate_and_drop_cleanly() {
+        // A null codec yields a generic context, so this does not depend on any
+        // specific decoder being present in the linked FFmpeg build.
+        // SAFETY: a null codec pointer is valid for `alloc_context3`.
+        let ctx = unsafe { CodecContext::new(std::ptr::null()) }.expect("alloc should succeed");
+        assert!(!ctx.as_ptr().is_null());
+        // Dropping `ctx` here frees the context exactly once (no panic / double free).
+    }
+}

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1121,3 +1121,72 @@ pub mod swscale {
         pub const SPLINE: i32 = 1024;
     }
 }
+
+// ── RAII owner stub (mirrors crate::codec_context::CodecContext) ──────────────
+// Under DOCS_RS the real `codec_context` module is cfg'd out (it depends on the
+// docsrs-gated `avcodec` wrapper); this shape-compatible stub keeps
+// `ff_sys::CodecContext` available so ff-decode compiles for docs.rs.
+#[derive(Debug)]
+pub struct CodecContext {
+    _ptr: std::ptr::NonNull<AVCodecContext>,
+}
+
+impl CodecContext {
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn new(_codec: *const AVCodec) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVCodecContext {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVCodecContext {
+        self._ptr.as_ptr()
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn parameters_to_context(
+        &mut self,
+        _par: *const AVCodecParameters,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn open(
+        &mut self,
+        _codec: *const AVCodec,
+        _options: *mut *mut AVDictionary,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn send_packet(&mut self, _pkt: *const AVPacket) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn receive_frame(&mut self, _frame: *mut AVFrame) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn flush_buffers(&mut self) {}
+}
+
+impl Drop for CodecContext {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for CodecContext {}

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -49,12 +49,16 @@ pub mod swresample;
 pub mod swscale;
 
 // ── Sub-modules ───────────────────────────────────────────────────────────────
+#[cfg(not(docsrs))]
+mod codec_context;
 mod constants;
 mod error;
 pub mod error_codes;
 mod utils;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
+#[cfg(not(docsrs))]
+pub use codec_context::CodecContext;
 pub use constants::{AV_NOPTS_VALUE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
 pub use utils::{av_error_string, ensure_initialized};

--- a/docs/adr/0003-ff-sys-safe-wrapper-layer.md
+++ b/docs/adr/0003-ff-sys-safe-wrapper-layer.md
@@ -43,9 +43,9 @@ it yet, and it will be implemented in a separate PR.
 ## Considered Options
 
 * **Curated two-layer design**: a `raw` boundary (bindgen, `allow`-all, `unsafe`)
-  and a `safe` module of RAII owned newtypes over `NonNull`, returning a typed
-  error, with `unsafe` localized and the module fully linted. Scoped to what the
-  family uses.
+  and a fully-linted `safe` layer of RAII owned newtypes over `NonNull` (flat
+  hand-written modules distinct from `mod raw`, not a single `mod safe`),
+  returning a typed error, with `unsafe` localized. Scoped to what the family uses.
 * **Status quo**: keep the thin `unsafe fn` free-function wrappers that return raw
   pointers and require manual free.
 * **Adopt an existing safe wrapper** (`rsmpeg`) and delete the hand-written layer.
@@ -55,16 +55,19 @@ it yet, and it will be implemented in a separate PR.
 ## Decision Outcome
 
 Chosen option: the **curated two-layer design**. The bindgen output moves behind a
-`raw` boundary that keeps `#![allow(warnings)]`; the hand-written layer becomes a
-`safe` module of owned newtypes (`CodecContext`, `SwrContext`, and the frame /
-packet owners) each wrapping `NonNull<T>` and freeing its resource in `Drop`, so
-manual `free_*` disappears from the API and a leak or double-free cannot survive an
-early return. Public signatures carry owned values and references, never raw
-pointers; fallible calls return a typed error (a newtype over `c_int` whose
-`Display` uses the existing `av_error_string`, with the `EAGAIN` / `EOF` drain
-states named). `unsafe` is placed at the real unsafety, and the `safe` module
-compiles under `#![deny(unsafe_op_in_unsafe_fn)]` with each block carrying a
-`// SAFETY:` note and full clippy, unlike the raw layer.
+`raw` boundary that keeps `#![allow(warnings)]`; the hand-written layer gains
+owned newtypes (`CodecContext`, `SwrContext`, and the frame / packet owners) each
+wrapping `NonNull<T>` and freeing its resource in `Drop`, so manual `free_*`
+disappears from the API and a leak or double-free cannot survive an early return.
+These live as flat, fully-linted modules (`codec_context`, `error`, the
+`avcodec` / `avformat` / ... wrappers) re-exported at the crate root
+(e.g. `ff_sys::CodecContext`), not a single `mod safe`; the "safe layer" is the
+whole hand-written surface distinct from `mod raw`. Public signatures carry owned
+values and references, never raw pointers; fallible calls return a typed error (a
+newtype over `c_int` whose `Display` uses the existing `av_error_string`, with the
+`EAGAIN` / `EOF` drain states named). `unsafe` is placed at the real unsafety, and
+the safe layer compiles under `#![deny(unsafe_op_in_unsafe_fn)]` with each block
+carrying a `// SAFETY:` note and full clippy, unlike the raw layer.
 
 The scope stays what the family needs (decode / encode / format / resample), not
 general coverage. This is the foundation on which call-order typestate
@@ -78,10 +81,10 @@ scope here and would be its own record.
 * Each owned newtype has a `Drop` test (a drop counter, or a Miri run over
   alloc → drop) proving the resource is freed exactly once; a manual-free API no
   longer exists to misuse.
-* The `safe` module compiles under `#![deny(unsafe_op_in_unsafe_fn)]` and the
+* The safe layer compiles under `#![deny(unsafe_op_in_unsafe_fn)]` and the
   workspace clippy gate; a raw `*mut` / `*const` or an un-annotated `unsafe` in its
   public surface fails review.
-* A grep / CI guard that `pub` signatures in the `safe` module name no raw pointer
+* A grep / CI guard that `pub` signatures in the safe layer name no raw pointer
   type.
 
 Until the PR lands, this record is the only statement of the direction; the status


### PR DESCRIPTION
## Objective

- `AVCodecContext` was held as a raw `*mut` and freed manually via `avcodec::free_context`, so every `?` / early-return path was a potential leak or double-free.
- First owned RAII type of the ff-sys hardening epic (ADR-0003, tracked in #1473); the base the drain-flush protocol (#1486) and owned Frame/Packet (#1480) build on.

## Solution

- Add `ff_sys::CodecContext`, an owned wrapper over `NonNull<AVCodecContext>` that frees the context exactly once on drop (via the raw `avcodec_free_context`, so it does not depend on the `avcodec::free_context` wrapper) and returns `AvError` from its fallible methods; `unsafe impl Send`, not `Sync`.
- Migrate the ff-decode audio/image/video decoders to it and remove the crate-local `AvCodecContextGuard`; per-frame codec ops become methods and the EAGAIN/EOF drain uses `AvError::is_eagain`/`is_eof` (behaviour-preserving; 211 ff-decode + 89 ff-sys unit tests pass).
- `flush_buffers` is `unsafe` (the context must be opened) with a `# Safety` doc, matching the underlying FFI precondition.
- Amend ADR-0003 wording: the safe layer is realized as flat, fully-linted modules distinct from `mod raw`, not a single `mod safe`.

ff-encode migration and removing `avcodec::free_context` are relocated to #1490.

Closes #1477