### PR TITLE
feat(ff-sys): typed send/receive drain-flush protocol on CodecContext

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -475,8 +475,13 @@ impl AudioDecoderInner {
         unsafe {
             loop {
                 // Try to receive a frame from the decoder
-                match self.codec_ctx.receive_frame(self.frame) {
-                    Ok(()) => {
+                match self.codec_ctx.receive_frame(self.frame).map_err(|e| {
+                    DecodeError::DecodingFailed {
+                        timestamp: Some(self.position),
+                        reason: ff_sys::av_error_string(e.code()),
+                    }
+                })? {
+                    ff_sys::ReceiveOutcome::Frame => {
                         // Successfully received a frame
                         let audio_frame = resample_inner::convert_frame_to_audio_frame(
                             self.frame,
@@ -501,14 +506,14 @@ impl AudioDecoderInner {
 
                         return Ok(Some(audio_frame));
                     }
-                    Err(e) if e.is_eagain() => {
+                    ff_sys::ReceiveOutcome::NeedInput => {
                         // Need to send more packets to the decoder
                         // Read a packet from the file
                         let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
 
                         if read_ret == ff_sys::error_codes::EOF {
                             // End of file - flush the decoder
-                            let _ = self.codec_ctx.send_packet(ptr::null());
+                            let _ = self.codec_ctx.send_eof();
                             self.eof = true;
                             continue;
                         } else if read_ret < 0 {
@@ -551,16 +556,10 @@ impl AudioDecoderInner {
                             ff_sys::av_packet_unref(self.packet);
                         }
                     }
-                    Err(e) if e.is_eof() => {
+                    ff_sys::ReceiveOutcome::Drained => {
                         // Decoder has been fully flushed
                         self.eof = true;
                         return Ok(None);
-                    }
-                    Err(e) => {
-                        return Err(DecodeError::DecodingFailed {
-                            timestamp: Some(self.position),
-                            reason: ff_sys::av_error_string(e.code()),
-                        });
                     }
                 }
             }
@@ -645,12 +644,11 @@ impl AudioDecoderInner {
         // 4. Drain any remaining frames from the decoder after flush
         // SAFETY: codec_ctx and frame are valid
         unsafe {
-            loop {
-                match self.codec_ctx.receive_frame(self.frame) {
-                    Ok(()) => ff_sys::av_frame_unref(self.frame),
-                    Err(e) if e.is_eagain() || e.is_eof() => break,
-                    Err(_) => break,
-                }
+            // Drain while frames are produced. NeedInput / Drained / real errors all
+            // end draining (preserves the pre-migration `Err(_) => break` behaviour that
+            // swallowed errors here).
+            while let Ok(ff_sys::ReceiveOutcome::Frame) = self.codec_ctx.receive_frame(self.frame) {
+                ff_sys::av_frame_unref(self.frame);
             }
         }
 

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -225,14 +225,38 @@ impl ImageDecoderInner {
 
         // 3. avcodec_receive_frame
         // SAFETY: codec_ctx is owned; frame is valid.
-        if let Err(e) = unsafe { self.codec_ctx.receive_frame(self.frame) } {
-            return Err(DecodeError::Ffmpeg {
-                code: e.code(),
-                message: format!(
-                    "Failed to receive decoded frame: {}",
-                    ff_sys::av_error_string(e.code())
-                ),
-            });
+        match unsafe {
+            self.codec_ctx
+                .receive_frame(self.frame)
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: e.code(),
+                    message: format!(
+                        "Failed to receive decoded frame: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
+                })?
+        } {
+            ff_sys::ReceiveOutcome::Frame => {}
+            // Preserve the pre-migration behaviour: a bare EAGAIN/EOF from this
+            // single receive was surfaced as a `Ffmpeg` error with that raw code.
+            ff_sys::ReceiveOutcome::NeedInput => {
+                return Err(DecodeError::Ffmpeg {
+                    code: ff_sys::error_codes::EAGAIN,
+                    message: format!(
+                        "Failed to receive decoded frame: {}",
+                        ff_sys::av_error_string(ff_sys::error_codes::EAGAIN)
+                    ),
+                });
+            }
+            ff_sys::ReceiveOutcome::Drained => {
+                return Err(DecodeError::Ffmpeg {
+                    code: ff_sys::error_codes::EOF,
+                    message: format!(
+                        "Failed to receive decoded frame: {}",
+                        ff_sys::av_error_string(ff_sys::error_codes::EOF)
+                    ),
+                });
+            }
         }
 
         // 4. Convert to VideoFrame.

--- a/crates/ff-decode/src/video/decoder_inner/decoding.rs
+++ b/crates/ff-decode/src/video/decoder_inner/decoding.rs
@@ -1,6 +1,6 @@
 use super::{
     AVFrame, Arc, DecodeError, Duration, OutputScale, PixelFormat, PooledBuffer, Rational,
-    Timestamp, VideoDecoderInner, VideoFrame, ptr,
+    Timestamp, VideoDecoderInner, VideoFrame,
 };
 use crate::shared::plane_inner::plane_row_ptr;
 
@@ -37,8 +37,13 @@ impl VideoDecoderInner {
         unsafe {
             loop {
                 // Try to receive a frame from the decoder
-                match self.codec_ctx.receive_frame(self.frame) {
-                    Ok(()) => {
+                match self.codec_ctx.receive_frame(self.frame).map_err(|e| {
+                    DecodeError::DecodingFailed {
+                        timestamp: Some(self.position),
+                        reason: ff_sys::av_error_string(e.code()),
+                    }
+                })? {
+                    ff_sys::ReceiveOutcome::Frame => {
                         // Successfully received a frame — reset corrupt-stream counter.
                         self.consecutive_invalid = 0;
 
@@ -72,14 +77,14 @@ impl VideoDecoderInner {
 
                         return Ok(Some(video_frame));
                     }
-                    Err(e) if e.is_eagain() => {
+                    ff_sys::ReceiveOutcome::NeedInput => {
                         // Need to send more packets to the decoder
                         // Read a packet from the file
                         let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
 
                         if read_ret == ff_sys::error_codes::EOF {
                             // End of file - flush the decoder
-                            let _ = self.codec_ctx.send_packet(ptr::null());
+                            let _ = self.codec_ctx.send_eof();
                             self.eof = true;
                             continue;
                         } else if read_ret < 0 {
@@ -137,16 +142,10 @@ impl VideoDecoderInner {
                             ff_sys::av_packet_unref(self.packet);
                         }
                     }
-                    Err(e) if e.is_eof() => {
+                    ff_sys::ReceiveOutcome::Drained => {
                         // Decoder has been fully flushed
                         self.eof = true;
                         return Ok(None);
-                    }
-                    Err(e) => {
-                        return Err(DecodeError::DecodingFailed {
-                            timestamp: Some(self.position),
-                            reason: ff_sys::av_error_string(e.code()),
-                        });
                     }
                 }
             }

--- a/crates/ff-decode/src/video/decoder_inner/seeking.rs
+++ b/crates/ff-decode/src/video/decoder_inner/seeking.rs
@@ -136,15 +136,10 @@ impl VideoDecoderInner {
         // This ensures no stale frames are returned after the seek
         // SAFETY: frame is valid: allocated in constructor, owned by VideoDecoderInner
         unsafe {
-            loop {
-                match self.codec_ctx.receive_frame(self.frame) {
-                    // Got a frame, unref it and continue draining
-                    Ok(()) => ff_sys::av_frame_unref(self.frame),
-                    // No more frames in the decoder buffer
-                    Err(e) if e.is_eagain() || e.is_eof() => break,
-                    // Other error, break out
-                    Err(_) => break,
-                }
+            // Drain while frames are produced. NeedInput / Drained / any error all stop
+            // draining (preserves the pre-migration `Err(_) => break` behaviour).
+            while let Ok(ff_sys::ReceiveOutcome::Frame) = self.codec_ctx.receive_frame(self.frame) {
+                ff_sys::av_frame_unref(self.frame);
             }
         }
 

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -7,12 +7,41 @@
 //! pointer-taking methods are `unsafe`: the caller upholds the usual FFmpeg
 //! preconditions.
 
+use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
     AVCodec, AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AvError,
     avcodec_free_context as ffi_avcodec_free_context,
 };
+
+/// The outcome of a [`CodecContext::receive_frame`] call.
+///
+/// Encodes FFmpeg's `EAGAIN` / `EOF` drain states as named variants so callers
+/// never branch on raw return codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiveOutcome {
+    /// A frame was written into the output frame.
+    Frame,
+    /// The decoder needs more input (`EAGAIN`): send another packet, or
+    /// [`send_eof`](CodecContext::send_eof) to begin draining.
+    NeedInput,
+    /// The decoder is fully drained (`EOF`): no more frames will be produced.
+    Drained,
+}
+
+/// Maps a raw `avcodec::receive_frame` result to a [`ReceiveOutcome`].
+///
+/// `EAGAIN` and `EOF` are expected drain states, not errors; any other negative
+/// code is a real error.
+fn classify_receive(result: Result<(), c_int>) -> Result<ReceiveOutcome, AvError> {
+    match result {
+        Ok(()) => Ok(ReceiveOutcome::Frame),
+        Err(code) if code == crate::error_codes::EAGAIN => Ok(ReceiveOutcome::NeedInput),
+        Err(code) if code == crate::error_codes::EOF => Ok(ReceiveOutcome::Drained),
+        Err(code) => Err(AvError::new(code)),
+    }
+}
 
 /// An owned `AVCodecContext`.
 ///
@@ -93,14 +122,35 @@ impl CodecContext {
         unsafe { crate::avcodec::send_packet(self.ptr.as_ptr(), pkt) }.map_err(AvError::new)
     }
 
-    /// Receives a decoded frame from the decoder.
+    /// Signals end-of-stream by sending a null packet, so the decoder enters
+    /// draining and all buffered frames can be pulled.
+    ///
+    /// After this, loop [`receive_frame`](Self::receive_frame) until it returns
+    /// [`ReceiveOutcome::Drained`]. This is the one supported way to drain, so a
+    /// caller cannot forget the flush.
+    ///
+    /// # Safety
+    ///
+    /// The context must have been opened via [`open`](Self::open) first.
+    pub unsafe fn send_eof(&mut self) -> Result<(), AvError> {
+        // SAFETY: the caller guarantees the context is opened; a null packet is
+        //         the documented end-of-stream signal for `avcodec_send_packet`.
+        unsafe { self.send_packet(std::ptr::null()) }
+    }
+
+    /// Receives a decoded frame, returning a typed [`ReceiveOutcome`].
+    ///
+    /// `EAGAIN` (need input) and `EOF` (drained) are returned as
+    /// [`ReceiveOutcome::NeedInput`] / [`ReceiveOutcome::Drained`] rather than
+    /// errors; only other negative codes are `Err`.
     ///
     /// # Safety
     ///
     /// `frame` must be a valid `*mut AVFrame`.
-    pub unsafe fn receive_frame(&mut self, frame: *mut AVFrame) -> Result<(), AvError> {
+    pub unsafe fn receive_frame(&mut self, frame: *mut AVFrame) -> Result<ReceiveOutcome, AvError> {
         // SAFETY: `self.ptr` is a valid open context; the caller upholds `frame`.
-        unsafe { crate::avcodec::receive_frame(self.ptr.as_ptr(), frame) }.map_err(AvError::new)
+        let result = unsafe { crate::avcodec::receive_frame(self.ptr.as_ptr(), frame) };
+        classify_receive(result)
     }
 
     /// Resets the codec's internal buffers (for example after a seek).
@@ -148,5 +198,31 @@ mod tests {
         let ctx = unsafe { CodecContext::new(std::ptr::null()) }.expect("alloc should succeed");
         assert!(!ctx.as_ptr().is_null());
         // Dropping `ctx` here frees the context exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn receive_outcome_should_classify_ok_as_frame() {
+        assert_eq!(classify_receive(Ok(())), Ok(ReceiveOutcome::Frame));
+    }
+
+    #[test]
+    fn receive_outcome_should_classify_eagain_as_need_input() {
+        assert_eq!(
+            classify_receive(Err(crate::error_codes::EAGAIN)),
+            Ok(ReceiveOutcome::NeedInput)
+        );
+    }
+
+    #[test]
+    fn receive_outcome_should_classify_eof_as_drained() {
+        assert_eq!(
+            classify_receive(Err(crate::error_codes::EOF)),
+            Ok(ReceiveOutcome::Drained)
+        );
+    }
+
+    #[test]
+    fn receive_outcome_should_classify_other_code_as_error() {
+        assert_eq!(classify_receive(Err(-22)), Err(AvError::new(-22)));
     }
 }

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1126,6 +1126,15 @@ pub mod swscale {
 // Under DOCS_RS the real `codec_context` module is cfg'd out (it depends on the
 // docsrs-gated `avcodec` wrapper); this shape-compatible stub keeps
 // `ff_sys::CodecContext` available so ff-decode compiles for docs.rs.
+
+/// Stub mirror of `crate::codec_context::ReceiveOutcome`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiveOutcome {
+    Frame,
+    NeedInput,
+    Drained,
+}
+
 #[derive(Debug)]
 pub struct CodecContext {
     _ptr: std::ptr::NonNull<AVCodecContext>,
@@ -1175,7 +1184,16 @@ impl CodecContext {
 
     /// # Safety
     /// Stub; never executed on docs.rs.
-    pub unsafe fn receive_frame(&mut self, _frame: *mut AVFrame) -> Result<(), crate::AvError> {
+    pub unsafe fn send_eof(&mut self) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn receive_frame(
+        &mut self,
+        _frame: *mut AVFrame,
+    ) -> Result<ReceiveOutcome, crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -58,7 +58,7 @@ mod utils;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 #[cfg(not(docsrs))]
-pub use codec_context::CodecContext;
+pub use codec_context::{CodecContext, ReceiveOutcome};
 pub use constants::{AV_NOPTS_VALUE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
 pub use utils::{av_error_string, ensure_initialized};


### PR DESCRIPTION
## Objective

- FFmpeg's `send_packet` / `receive_frame` drain dance (`EAGAIN`, `EOF`, send NULL to drain) is its most error-prone pattern, and the codebase already hit the flush footgun.
- Type the drain state on the owned `CodecContext` so consumers cannot branch on raw codes or forget the flush (ADR-0003, tracked in #1473; builds on #1476 `AvError` and #1477 `CodecContext`).

## Solution

- Add `ReceiveOutcome { Frame, NeedInput, Drained }` (a closed set, so not `#[non_exhaustive]`) and change `CodecContext::receive_frame` to return it via a pure `classify_receive` (`Ok`→`Frame`, `EAGAIN`→`NeedInput`, `EOF`→`Drained`, other→`Err`), unit-tested without FFmpeg.
- Add `CodecContext::send_eof` (send the null packet) as the one supported drain entry; it is `unsafe` because it carries the open-context precondition even with no pointer argument.
- Migrate the ff-decode audio/image/video decode and seek-drain loops to the typed outcome, behaviour-preserving; `send_packet(null)` becomes `send_eof()`. Update the docs.rs stubs so the DOCS_RS builds stay green.
- `send_packet` stays `Result<(), AvError>`; ff-encode's protocol adoption is relocated to #1490 (ff-encode is not yet on `CodecContext`).

Closes #1486