### PR TITLE
feat(ff-sys): RAII InputFormatContext for the demux lifecycle

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -33,12 +33,13 @@ use ff_format::container::ContainerInfo;
 use ff_format::{AudioFrame, AudioStreamInfo, NetworkOptions, SampleFormat};
 use ff_sys::{
     AVCodecContext, AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_AUDIO, AVPacket,
+    InputFormatContext,
 };
 
 use super::resample_inner;
 
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{AvFormatContextGuard, AvFrameGuard, AvPacketGuard};
+use crate::shared::guards_inner::{AvFrameGuard, AvPacketGuard, open_input_ctx, open_url_ctx};
 
 /// Internal decoder state holding FFmpeg contexts.
 ///
@@ -46,7 +47,7 @@ use crate::shared::guards_inner::{AvFormatContextGuard, AvFrameGuard, AvPacketGu
 /// for proper cleanup when dropped.
 pub(crate) struct AudioDecoderInner {
     /// Format context for reading the media file
-    format_ctx: *mut AVFormatContext,
+    format_ctx: InputFormatContext,
     /// Codec context for decoding audio frames
     codec_ctx: ff_sys::CodecContext,
     /// Audio stream index in the format context
@@ -122,48 +123,42 @@ impl AudioDecoderInner {
             crate::network::check_srt_url(path_str)?;
         }
 
-        // Open the input source (with RAII guard)
-        // SAFETY: Path is valid, AvFormatContextGuard ensures cleanup
-        let format_ctx_guard = unsafe {
-            if is_network_url {
-                let network = network_opts.unwrap_or_default();
-                log::info!(
-                    "opening network audio source url={} connect_timeout_ms={} read_timeout_ms={}",
-                    crate::network::sanitize_url(path_str),
-                    network.connect_timeout.as_millis(),
-                    network.read_timeout.as_millis()
-                );
-                AvFormatContextGuard::new_url(path_str, &network)?
-            } else {
-                AvFormatContextGuard::new(path)?
-            }
+        // Open the input source (owned demux context).
+        let mut ctx = if is_network_url {
+            let network = network_opts.unwrap_or_default();
+            log::info!(
+                "opening network audio source url={} connect_timeout_ms={} read_timeout_ms={}",
+                crate::network::sanitize_url(path_str),
+                network.connect_timeout.as_millis(),
+                network.read_timeout.as_millis()
+            );
+            open_url_ctx(path_str, &network)?
+        } else {
+            open_input_ctx(path)?
         };
-        let format_ctx = format_ctx_guard.as_ptr();
 
         // Read stream information
-        // SAFETY: format_ctx is valid and owned by guard
-        unsafe {
-            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| DecodeError::Ffmpeg {
-                code: e,
-                message: format!("Failed to find stream info: {}", ff_sys::av_error_string(e)),
-            })?;
-        }
+        ctx.find_stream_info().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to find stream info: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         // Detect live/streaming source via the AVFMT_TS_DISCONT flag on AVInputFormat.
         // SAFETY: format_ctx is valid and non-null; iformat is set by avformat_open_input
         //         and is non-null for all successfully opened formats.
         let is_live = unsafe {
-            let iformat = (*format_ctx).iformat;
+            let iformat = (*ctx.as_ptr()).iformat;
             !iformat.is_null() && ((*iformat).flags & ff_sys::AVFMT_TS_DISCONT) != 0
         };
 
         // Find the audio stream
         // SAFETY: format_ctx is valid
-        let (stream_index, codec_id) =
-            unsafe { Self::find_audio_stream(format_ctx) }.ok_or_else(|| {
-                DecodeError::NoAudioStream {
-                    path: path.to_path_buf(),
-                }
+        let (stream_index, codec_id) = unsafe { Self::find_audio_stream(ctx.as_mut_ptr()) }
+            .ok_or_else(|| DecodeError::NoAudioStream {
+                path: path.to_path_buf(),
             })?;
 
         // Find the decoder for this codec
@@ -191,7 +186,7 @@ impl AudioDecoderInner {
         // Copy codec parameters from stream to context
         // SAFETY: format_ctx is valid, stream_index is valid; codec_ctx is owned
         unsafe {
-            let stream = (*format_ctx).streams.add(stream_index as usize);
+            let stream = (*ctx.as_ptr()).streams.add(stream_index as usize);
             let codecpar = (*(*stream)).codecpar;
             codec_ctx
                 .parameters_to_context(codecpar)
@@ -221,12 +216,16 @@ impl AudioDecoderInner {
         // Extract stream information
         // SAFETY: All pointers are valid
         let stream_info = unsafe {
-            Self::extract_stream_info(format_ctx, stream_index as i32, codec_ctx.as_mut_ptr())?
+            Self::extract_stream_info(
+                ctx.as_mut_ptr(),
+                stream_index as i32,
+                codec_ctx.as_mut_ptr(),
+            )?
         };
 
         // Extract container information
         // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
-        let container_info = unsafe { Self::extract_container_info(format_ctx) };
+        let container_info = unsafe { Self::extract_container_info(ctx.as_mut_ptr()) };
 
         // Allocate packet and frame (with RAII guards)
         // SAFETY: FFmpeg is initialized, guards ensure cleanup
@@ -236,7 +235,7 @@ impl AudioDecoderInner {
         // All initialization successful - transfer ownership to AudioDecoderInner
         Ok((
             Self {
-                format_ctx: format_ctx_guard.into_raw(),
+                format_ctx: ctx,
                 codec_ctx,
                 stream_index: stream_index as i32,
                 output_format,
@@ -485,7 +484,7 @@ impl AudioDecoderInner {
                         // Successfully received a frame
                         let audio_frame = resample_inner::convert_frame_to_audio_frame(
                             self.frame,
-                            self.format_ctx,
+                            self.format_ctx.as_mut_ptr(),
                             self.stream_index,
                             self.output_format,
                             self.output_sample_rate,
@@ -497,7 +496,9 @@ impl AudioDecoderInner {
                         // Update position based on frame timestamp
                         let pts = (*self.frame).pts;
                         if pts != ff_sys::AV_NOPTS_VALUE {
-                            let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
+                            let stream = (*self.format_ctx.as_ptr())
+                                .streams
+                                .add(self.stream_index as usize);
                             let time_base = (*(*stream)).time_base;
                             let timestamp_secs =
                                 pts as f64 * time_base.num as f64 / time_base.den as f64;
@@ -509,29 +510,32 @@ impl AudioDecoderInner {
                     ff_sys::ReceiveOutcome::NeedInput => {
                         // Need to send more packets to the decoder
                         // Read a packet from the file
-                        let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
-
-                        if read_ret == ff_sys::error_codes::EOF {
-                            // End of file - flush the decoder
-                            let _ = self.codec_ctx.send_eof();
-                            self.eof = true;
-                            continue;
-                        } else if read_ret < 0 {
-                            return Err(if let Some(url) = &self.url {
-                                // Network source: map to typed variant so reconnect can detect it.
-                                crate::network::map_network_error(
-                                    read_ret,
-                                    crate::network::sanitize_url(url),
-                                )
-                            } else {
-                                DecodeError::Ffmpeg {
-                                    code: read_ret,
-                                    message: format!(
-                                        "Failed to read frame: {}",
-                                        ff_sys::av_error_string(read_ret)
-                                    ),
-                                }
-                            });
+                        match self.format_ctx.read_frame(self.packet) {
+                            Ok(()) => {}
+                            Err(e) if e.is_eof() => {
+                                // End of file - flush the decoder
+                                let _ = self.codec_ctx.send_eof();
+                                self.eof = true;
+                                continue;
+                            }
+                            Err(e) => {
+                                let read_ret = e.code();
+                                return Err(if let Some(url) = &self.url {
+                                    // Network source: map to typed variant so reconnect can detect it.
+                                    crate::network::map_network_error(
+                                        read_ret,
+                                        crate::network::sanitize_url(url),
+                                    )
+                                } else {
+                                    DecodeError::Ffmpeg {
+                                        code: read_ret,
+                                        message: format!(
+                                            "Failed to read frame: {}",
+                                            ff_sys::av_error_string(read_ret)
+                                        ),
+                                    }
+                                });
+                            }
                         }
 
                         // Check if this packet belongs to the audio stream
@@ -588,7 +592,9 @@ impl AudioDecoderInner {
     fn duration_to_pts(&self, duration: Duration) -> i64 {
         // SAFETY: format_ctx and stream_index are valid (owned by AudioDecoderInner)
         let time_base = unsafe {
-            let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
+            let stream = (*self.format_ctx.as_ptr())
+                .streams
+                .add(self.stream_index as usize);
             (*(*stream)).time_base
         };
 
@@ -625,14 +631,12 @@ impl AudioDecoderInner {
         }
 
         // 2. Seek in the format context
-        // SAFETY: format_ctx and stream_index are valid
-        unsafe {
-            ff_sys::avformat::seek_frame(self.format_ctx, self.stream_index, timestamp, flags)
-                .map_err(|e| DecodeError::SeekFailed {
-                    target: position,
-                    reason: ff_sys::av_error_string(e),
-                })?;
-        }
+        self.format_ctx
+            .seek_frame(self.stream_index, timestamp, flags)
+            .map_err(|e| DecodeError::SeekFailed {
+                target: position,
+                reason: ff_sys::av_error_string(e.code()),
+            })?;
 
         // 3. Flush decoder buffers and reset the cached SwrContext so the
         //    resampler does not carry stale delay samples across the seek point.
@@ -736,41 +740,24 @@ impl AudioDecoderInner {
     /// Closes the current `AVFormatContext`, re-opens the URL, re-reads stream info,
     /// re-finds the audio stream, and flushes the codec.
     fn reopen(&mut self, url: &str) -> Result<(), DecodeError> {
-        // Close the current format context. `avformat_close_input` sets the pointer
-        // to null — this matches the null check in Drop so no double-free occurs.
-        // SAFETY: self.format_ctx is valid and owned exclusively by self.
-        unsafe {
-            ff_sys::avformat::close_input(std::ptr::addr_of_mut!(self.format_ctx));
-        }
-
-        // Re-open the URL with the stored network timeouts.
-        // SAFETY: url is a valid UTF-8 network URL string.
-        self.format_ctx = unsafe {
-            ff_sys::avformat::open_input_url(
-                url,
-                self.network_opts.connect_timeout,
-                self.network_opts.read_timeout,
-            )
-            .map_err(|e| crate::network::map_network_error(e, crate::network::sanitize_url(url)))?
-        };
+        // Re-open the URL with the stored network timeouts. Assigning the fresh
+        // context drops the previous one, which closes and frees it.
+        self.format_ctx = open_url_ctx(url, &self.network_opts)?;
 
         // Re-read stream information.
-        // SAFETY: self.format_ctx is valid and freshly opened.
-        unsafe {
-            ff_sys::avformat::find_stream_info(self.format_ctx).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
-                    message: format!(
-                        "reconnect find_stream_info failed: {}",
-                        ff_sys::av_error_string(e)
-                    ),
-                }
+        self.format_ctx
+            .find_stream_info()
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "reconnect find_stream_info failed: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
             })?;
-        }
 
         // Re-find the audio stream (index may differ in theory after reconnect).
         // SAFETY: self.format_ctx is valid.
-        let (stream_index, _) = unsafe { Self::find_audio_stream(self.format_ctx) }
+        let (stream_index, _) = unsafe { Self::find_audio_stream(self.format_ctx.as_mut_ptr()) }
             .ok_or_else(|| DecodeError::NoAudioStream { path: url.into() })?;
         self.stream_index = stream_index as i32;
 
@@ -800,13 +787,8 @@ impl Drop for AudioDecoderInner {
             }
         }
 
-        // Close format context
-        if !self.format_ctx.is_null() {
-            // SAFETY: self.format_ctx is valid and owned by this instance
-            unsafe {
-                ff_sys::avformat::close_input(&mut (self.format_ctx as *mut _));
-            }
-        }
+        // The `format_ctx` (InputFormatContext) drops automatically after this
+        // Drop body, closing the demux context last.
     }
 }
 

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -26,10 +26,11 @@ use ff_format::time::{Rational, Timestamp};
 use ff_format::{PixelFormat, PooledBuffer, VideoFrame};
 use ff_sys::{
     AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket, AVPixelFormat,
+    InputFormatContext,
 };
 
 use crate::error::DecodeError;
-use crate::shared::guards_inner::AvFormatContextGuard;
+use crate::shared::guards_inner::open_input_ctx;
 use crate::shared::plane_inner::plane_row_ptr;
 
 // ── ImageDecoderInner ─────────────────────────────────────────────────────────
@@ -39,7 +40,7 @@ use crate::shared::plane_inner::plane_row_ptr;
 /// Holds raw FFmpeg pointers and is responsible for proper cleanup in `Drop`.
 pub(crate) struct ImageDecoderInner {
     /// Format context for reading the image file.
-    format_ctx: *mut AVFormatContext,
+    format_ctx: InputFormatContext,
     /// Codec context for decoding the image.
     codec_ctx: ff_sys::CodecContext,
     /// Video stream index in the format context.
@@ -70,26 +71,22 @@ impl ImageDecoderInner {
         ff_sys::ensure_initialized();
 
         // 1. avformat_open_input
-        // SAFETY: Path is valid; AvFormatContextGuard ensures cleanup on error.
-        let format_ctx_guard = unsafe { AvFormatContextGuard::new(path)? };
-        let format_ctx = format_ctx_guard.as_ptr();
+        let mut ctx = open_input_ctx(path)?;
 
         // 2. avformat_find_stream_info
-        // SAFETY: format_ctx is valid and owned by the guard.
-        unsafe {
-            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| DecodeError::Ffmpeg {
-                code: e,
-                message: format!("Failed to find stream info: {}", ff_sys::av_error_string(e)),
-            })?;
-        }
+        ctx.find_stream_info().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to find stream info: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         // 3. Find the video stream.
         // SAFETY: format_ctx is valid.
-        let (stream_index, codec_id) =
-            unsafe { Self::find_video_stream(format_ctx) }.ok_or_else(|| {
-                DecodeError::NoVideoStream {
-                    path: path.to_path_buf(),
-                }
+        let (stream_index, codec_id) = unsafe { Self::find_video_stream(ctx.as_mut_ptr()) }
+            .ok_or_else(|| DecodeError::NoVideoStream {
+                path: path.to_path_buf(),
             })?;
 
         // 4. avcodec_find_decoder
@@ -125,7 +122,7 @@ impl ImageDecoderInner {
         // 6. avcodec_parameters_to_context
         // SAFETY: All pointers are valid; stream_index was validated above.
         unsafe {
-            let stream = (*format_ctx).streams.add(stream_index);
+            let stream = (*ctx.as_ptr()).streams.add(stream_index);
             let codecpar = (*(*stream)).codecpar;
             codec_ctx
                 .parameters_to_context(codecpar)
@@ -171,7 +168,7 @@ impl ImageDecoderInner {
         }
 
         Ok(Self {
-            format_ctx: format_ctx_guard.into_raw(),
+            format_ctx: ctx,
             codec_ctx,
             stream_index,
             packet,
@@ -201,8 +198,8 @@ impl ImageDecoderInner {
     pub(crate) fn decode(mut self) -> Result<VideoFrame, DecodeError> {
         // 1. av_read_frame
         // SAFETY: format_ctx and packet are valid.
-        let ret = unsafe { ff_sys::av_read_frame(self.format_ctx, self.packet) };
-        if ret < 0 {
+        if let Err(e) = unsafe { self.format_ctx.read_frame(self.packet) } {
+            let ret = e.code();
             return Err(DecodeError::Ffmpeg {
                 code: ret,
                 message: format!("Failed to read frame: {}", ff_sys::av_error_string(ret)),
@@ -342,7 +339,7 @@ impl ImageDecoderInner {
             let timestamp = if pts == ff_sys::AV_NOPTS_VALUE {
                 Timestamp::default()
             } else {
-                let stream = (*self.format_ctx).streams.add(self.stream_index);
+                let stream = (*self.format_ctx.as_ptr()).streams.add(self.stream_index);
                 let time_base = (*(*stream)).time_base;
                 Timestamp::new(
                     pts as i64,
@@ -572,10 +569,9 @@ impl Drop for ImageDecoderInner {
             if !self.packet.is_null() {
                 ff_sys::av_packet_free(&mut (self.packet as *mut _));
             }
-            if !self.format_ctx.is_null() {
-                ff_sys::avformat::close_input(&mut (self.format_ctx as *mut _));
-            }
         }
+        // The `format_ctx` (InputFormatContext) drops automatically after this
+        // Drop body, closing the demux context last.
     }
 }
 

--- a/crates/ff-decode/src/shared/guards_inner.rs
+++ b/crates/ff-decode/src/shared/guards_inner.rs
@@ -1,10 +1,12 @@
 //! Shared RAII guards over raw `FFmpeg` pointers used by the audio, image, and
-//! video decoders.
+//! video decoders, plus input-context open helpers.
 //!
 //! Each guard owns a `*mut` `FFmpeg` handle and frees it in `Drop`. The
 //! constructors are the union of what the three decoders need — every method is
-//! used by at least one decoder. All `unsafe` is isolated here per the project's
-//! unsafe-code convention (`*_inner.rs` files only).
+//! used by at least one decoder. The open helpers wrap
+//! [`ff_sys::InputFormatContext`] constructors with the decoders' `DecodeError`
+//! mapping. All `unsafe` is isolated here per the project's unsafe-code
+//! convention (`*_inner.rs` files only).
 
 #![allow(unsafe_code)]
 #![allow(clippy::ptr_as_ptr)]
@@ -13,91 +15,42 @@
 use std::path::Path;
 
 use ff_format::NetworkOptions;
-use ff_sys::{AVFormatContext, AVFrame, AVPacket};
+use ff_sys::{AVFrame, AVPacket};
 
 use crate::error::DecodeError;
 use crate::network::{map_network_error, sanitize_url};
 
-/// RAII guard for `AVFormatContext` to ensure proper cleanup.
-pub(crate) struct AvFormatContextGuard(*mut AVFormatContext);
-
-impl AvFormatContextGuard {
-    /// Creates a new guard by opening an input file.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure FFmpeg is initialized and path is valid.
-    pub(crate) unsafe fn new(path: &Path) -> Result<Self, DecodeError> {
-        // SAFETY: Caller ensures FFmpeg is initialized and path is valid
-        let format_ctx = unsafe {
-            ff_sys::avformat::open_input(path).map_err(|e| DecodeError::Ffmpeg {
-                code: e,
-                message: format!("Failed to open file: {}", ff_sys::av_error_string(e)),
-            })?
-        };
-        Ok(Self(format_ctx))
-    }
-
-    /// Opens an image sequence using the `image2` demuxer.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure FFmpeg is initialized and path is valid.
-    pub(crate) unsafe fn new_image_sequence(
-        path: &Path,
-        framerate: u32,
-    ) -> Result<Self, DecodeError> {
-        // SAFETY: Caller ensures FFmpeg is initialized and path is a valid image-sequence pattern
-        let format_ctx = unsafe {
-            ff_sys::avformat::open_input_image_sequence(path, framerate).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
-                    message: format!(
-                        "Failed to open image sequence: {}",
-                        ff_sys::av_error_string(e)
-                    ),
-                }
-            })?
-        };
-        Ok(Self(format_ctx))
-    }
-
-    /// Opens a network URL using the supplied network options.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure FFmpeg is initialized and URL is valid.
-    pub(crate) unsafe fn new_url(url: &str, network: &NetworkOptions) -> Result<Self, DecodeError> {
-        // SAFETY: Caller ensures FFmpeg is initialized and URL is valid
-        let format_ctx = unsafe {
-            ff_sys::avformat::open_input_url(url, network.connect_timeout, network.read_timeout)
-                .map_err(|e| map_network_error(e, sanitize_url(url)))?
-        };
-        Ok(Self(format_ctx))
-    }
-
-    /// Returns the raw pointer.
-    pub(crate) const fn as_ptr(&self) -> *mut AVFormatContext {
-        self.0
-    }
-
-    /// Consumes the guard and returns the raw pointer without dropping.
-    pub(crate) fn into_raw(self) -> *mut AVFormatContext {
-        let ptr = self.0;
-        std::mem::forget(self);
-        ptr
-    }
+/// Opens an input file, returning the owned demux context.
+pub(crate) fn open_input_ctx(path: &Path) -> Result<ff_sys::InputFormatContext, DecodeError> {
+    ff_sys::InputFormatContext::open(path).map_err(|e| DecodeError::Ffmpeg {
+        code: e.code(),
+        message: format!("Failed to open file: {}", ff_sys::av_error_string(e.code())),
+    })
 }
 
-impl Drop for AvFormatContextGuard {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            // SAFETY: self.0 is valid and owned by this guard
-            unsafe {
-                ff_sys::avformat::close_input(&mut (self.0 as *mut _));
-            }
+/// Opens an image sequence via the `image2` demuxer, returning the owned demux context.
+pub(crate) fn open_image_sequence_ctx(
+    path: &Path,
+    framerate: u32,
+) -> Result<ff_sys::InputFormatContext, DecodeError> {
+    ff_sys::InputFormatContext::open_image_sequence(path, framerate).map_err(|e| {
+        DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to open image sequence: {}",
+                ff_sys::av_error_string(e.code())
+            ),
         }
-    }
+    })
+}
+
+/// Opens a network URL with the supplied network options, returning the owned demux context.
+pub(crate) fn open_url_ctx(
+    url: &str,
+    network: &NetworkOptions,
+) -> Result<ff_sys::InputFormatContext, DecodeError> {
+    ff_sys::InputFormatContext::open_url(url, network.connect_timeout, network.read_timeout)
+        .map_err(|e| map_network_error(e.code(), sanitize_url(url)))
 }
 
 /// RAII guard for `AVPacket` to ensure proper cleanup.

--- a/crates/ff-decode/src/video/decoder_inner/decoding.rs
+++ b/crates/ff-decode/src/video/decoder_inner/decoding.rs
@@ -68,7 +68,9 @@ impl VideoDecoderInner {
                         // Update position based on frame timestamp
                         let pts = (*self.frame).pts;
                         if pts != ff_sys::AV_NOPTS_VALUE {
-                            let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
+                            let stream = (*self.format_ctx.as_ptr())
+                                .streams
+                                .add(self.stream_index as usize);
                             let time_base = (*(*stream)).time_base;
                             let timestamp_secs =
                                 pts as f64 * time_base.num as f64 / time_base.den as f64;
@@ -80,29 +82,32 @@ impl VideoDecoderInner {
                     ff_sys::ReceiveOutcome::NeedInput => {
                         // Need to send more packets to the decoder
                         // Read a packet from the file
-                        let read_ret = ff_sys::av_read_frame(self.format_ctx, self.packet);
-
-                        if read_ret == ff_sys::error_codes::EOF {
-                            // End of file - flush the decoder
-                            let _ = self.codec_ctx.send_eof();
-                            self.eof = true;
-                            continue;
-                        } else if read_ret < 0 {
-                            return Err(if let Some(url) = &self.url {
-                                // Network source: map to typed variant so reconnect can detect it.
-                                crate::network::map_network_error(
-                                    read_ret,
-                                    crate::network::sanitize_url(url),
-                                )
-                            } else {
-                                DecodeError::Ffmpeg {
-                                    code: read_ret,
-                                    message: format!(
-                                        "Failed to read frame: {}",
-                                        ff_sys::av_error_string(read_ret)
-                                    ),
-                                }
-                            });
+                        match self.format_ctx.read_frame(self.packet) {
+                            Ok(()) => {}
+                            Err(e) if e.is_eof() => {
+                                // End of file - flush the decoder
+                                let _ = self.codec_ctx.send_eof();
+                                self.eof = true;
+                                continue;
+                            }
+                            Err(e) => {
+                                let read_ret = e.code();
+                                return Err(if let Some(url) = &self.url {
+                                    // Network source: map to typed variant so reconnect can detect it.
+                                    crate::network::map_network_error(
+                                        read_ret,
+                                        crate::network::sanitize_url(url),
+                                    )
+                                } else {
+                                    DecodeError::Ffmpeg {
+                                        code: read_ret,
+                                        message: format!(
+                                            "Failed to read frame: {}",
+                                            ff_sys::av_error_string(read_ret)
+                                        ),
+                                    }
+                                });
+                            }
                         }
 
                         // Check if this packet belongs to the video stream
@@ -227,7 +232,9 @@ impl VideoDecoderInner {
             // Extract timestamp
             let pts = (*frame).pts;
             let timestamp = if pts != ff_sys::AV_NOPTS_VALUE {
-                let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
+                let stream = (*self.format_ctx.as_ptr())
+                    .streams
+                    .add(self.stream_index as usize);
                 let time_base = (*(*stream)).time_base;
                 Timestamp::new(
                     pts as i64,

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -39,12 +39,14 @@ use ff_format::{PixelFormat, VideoFrame, VideoStreamInfo};
 use ff_sys::{
     AVBufferRef, AVCodecContext, AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace,
     AVFormatContext, AVFrame, AVHWDeviceType, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket,
-    AVPixelFormat, SwsContext,
+    AVPixelFormat, InputFormatContext, SwsContext,
 };
 
 use crate::HardwareAccel;
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{AvFormatContextGuard, AvFrameGuard, AvPacketGuard};
+use crate::shared::guards_inner::{
+    AvFrameGuard, AvPacketGuard, open_image_sequence_ctx, open_input_ctx, open_url_ctx,
+};
 use crate::video::builder::OutputScale;
 use ff_common::FramePool;
 
@@ -67,7 +69,7 @@ mod seeking;
 /// for proper cleanup when dropped.
 pub(crate) struct VideoDecoderInner {
     /// Format context for reading the media file
-    pub(super) format_ctx: *mut AVFormatContext,
+    pub(super) format_ctx: InputFormatContext,
     /// Codec context for decoding video frames
     pub(super) codec_ctx: ff_sys::CodecContext,
     /// Video stream index in the format context
@@ -158,51 +160,45 @@ impl VideoDecoderInner {
             crate::network::check_srt_url(path_str)?;
         }
 
-        // Open the input (with RAII guard for cleanup on error).
-        // SAFETY: Path/URL is valid; AvFormatContextGuard ensures cleanup.
-        let format_ctx_guard = unsafe {
-            if is_network_url {
-                let network = network_opts.unwrap_or_default();
-                log::info!(
-                    "opening network source url={} connect_timeout_ms={} read_timeout_ms={}",
-                    crate::network::sanitize_url(path_str),
-                    network.connect_timeout.as_millis(),
-                    network.read_timeout.as_millis(),
-                );
-                AvFormatContextGuard::new_url(path_str, &network)?
-            } else if is_image_sequence {
-                let fps = frame_rate.unwrap_or(25);
-                AvFormatContextGuard::new_image_sequence(path, fps)?
-            } else {
-                AvFormatContextGuard::new(path)?
-            }
+        // Open the input (owned demux context).
+        let mut ctx = if is_network_url {
+            let network = network_opts.unwrap_or_default();
+            log::info!(
+                "opening network source url={} connect_timeout_ms={} read_timeout_ms={}",
+                crate::network::sanitize_url(path_str),
+                network.connect_timeout.as_millis(),
+                network.read_timeout.as_millis(),
+            );
+            open_url_ctx(path_str, &network)?
+        } else if is_image_sequence {
+            let fps = frame_rate.unwrap_or(25);
+            open_image_sequence_ctx(path, fps)?
+        } else {
+            open_input_ctx(path)?
         };
-        let format_ctx = format_ctx_guard.as_ptr();
 
         // Read stream information
-        // SAFETY: format_ctx is valid and owned by guard
-        unsafe {
-            ff_sys::avformat::find_stream_info(format_ctx).map_err(|e| DecodeError::Ffmpeg {
-                code: e,
-                message: format!("Failed to find stream info: {}", ff_sys::av_error_string(e)),
-            })?;
-        }
+        ctx.find_stream_info().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to find stream info: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         // Detect live/streaming source via the AVFMT_TS_DISCONT flag on AVInputFormat.
         // SAFETY: format_ctx is valid and non-null; iformat is set by avformat_open_input
         //         and is non-null for all successfully opened formats.
         let is_live = unsafe {
-            let iformat = (*format_ctx).iformat;
+            let iformat = (*ctx.as_ptr()).iformat;
             !iformat.is_null() && ((*iformat).flags & ff_sys::AVFMT_TS_DISCONT) != 0
         };
 
         // Find the video stream
         // SAFETY: format_ctx is valid
-        let (stream_index, codec_id) =
-            unsafe { Self::find_video_stream(format_ctx) }.ok_or_else(|| {
-                DecodeError::NoVideoStream {
-                    path: path.to_path_buf(),
-                }
+        let (stream_index, codec_id) = unsafe { Self::find_video_stream(ctx.as_mut_ptr()) }
+            .ok_or_else(|| DecodeError::NoVideoStream {
+                path: path.to_path_buf(),
             })?;
 
         // Find the decoder for this codec
@@ -241,7 +237,7 @@ impl VideoDecoderInner {
         // Copy codec parameters from stream to context
         // SAFETY: format_ctx is valid, stream_index is valid; codec_ctx is owned
         unsafe {
-            let stream = (*format_ctx).streams.add(stream_index as usize);
+            let stream = (*ctx.as_ptr()).streams.add(stream_index as usize);
             let codecpar = (*(*stream)).codecpar;
             codec_ctx
                 .parameters_to_context(codecpar)
@@ -288,12 +284,16 @@ impl VideoDecoderInner {
         // Extract stream information
         // SAFETY: All pointers are valid
         let stream_info = unsafe {
-            Self::extract_stream_info(format_ctx, stream_index as i32, codec_ctx.as_mut_ptr())?
+            Self::extract_stream_info(
+                ctx.as_mut_ptr(),
+                stream_index as i32,
+                codec_ctx.as_mut_ptr(),
+            )?
         };
 
         // Extract container information
         // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
-        let container_info = unsafe { Self::extract_container_info(format_ctx) };
+        let container_info = unsafe { Self::extract_container_info(ctx.as_mut_ptr()) };
 
         // Allocate packet and frame (with RAII guards)
         // SAFETY: FFmpeg is initialized, guards ensure cleanup
@@ -303,7 +303,7 @@ impl VideoDecoderInner {
         // All initialization successful - transfer ownership to VideoDecoderInner
         Ok((
             Self {
-                format_ctx: format_ctx_guard.into_raw(),
+                format_ctx: ctx,
                 codec_ctx,
                 stream_index: stream_index as i32,
                 sws_ctx: None,
@@ -372,13 +372,8 @@ impl Drop for VideoDecoderInner {
             }
         }
 
-        // Close format context
-        if !self.format_ctx.is_null() {
-            // SAFETY: self.format_ctx is valid and owned by this instance
-            unsafe {
-                ff_sys::avformat::close_input(&mut (self.format_ctx as *mut _));
-            }
-        }
+        // The `format_ctx` (InputFormatContext) drops automatically after this
+        // Drop body, closing the demux context last.
     }
 }
 

--- a/crates/ff-decode/src/video/decoder_inner/seeking.rs
+++ b/crates/ff-decode/src/video/decoder_inner/seeking.rs
@@ -1,6 +1,6 @@
 use super::{
     AvFrameGuard, DecodeError, Duration, KEYFRAME_SEEK_TOLERANCE_SECS, VideoDecoderInner,
-    VideoFrame,
+    VideoFrame, open_url_ctx,
 };
 
 impl VideoDecoderInner {
@@ -42,7 +42,9 @@ impl VideoDecoderInner {
         // - stream_index is valid: validated during decoder creation (find_stream_info + codec opening)
         // - streams array access is valid: guaranteed by FFmpeg after successful avformat_open_input
         let time_base = unsafe {
-            let stream = (*self.format_ctx).streams.add(self.stream_index as usize);
+            let stream = (*self.format_ctx.as_ptr())
+                .streams
+                .add(self.stream_index as usize);
             (*(*stream)).time_base
         };
 
@@ -111,22 +113,12 @@ impl VideoDecoderInner {
 
         // 2. Seek in the format context (file is NOT reopened)
         // Use av_seek_frame with the stream index and timestamp in stream time_base units
-        // SAFETY:
-        // - format_ctx is valid: owned by VideoDecoderInner, initialized via avformat_open_input
-        // - stream_index is valid: validated during decoder creation
-        // - timestamp is valid: converted from Duration using stream's time_base
-        unsafe {
-            ff_sys::avformat::seek_frame(
-                self.format_ctx,
-                self.stream_index as i32,
-                timestamp,
-                flags,
-            )
+        self.format_ctx
+            .seek_frame(self.stream_index as i32, timestamp, flags)
             .map_err(|e| DecodeError::SeekFailed {
                 target: position,
-                reason: ff_sys::av_error_string(e),
+                reason: ff_sys::av_error_string(e.code()),
             })?;
-        }
 
         // 3. Flush decoder buffers to clear any cached frames
         // SAFETY: the codec context was opened during construction.
@@ -492,41 +484,24 @@ impl VideoDecoderInner {
     /// Closes the current `AVFormatContext`, re-opens the URL, re-reads stream info,
     /// re-finds the video stream, and flushes the codec.
     fn reopen(&mut self, url: &str) -> Result<(), DecodeError> {
-        // Close the current format context. `avformat_close_input` sets the pointer
-        // to null — this matches the null check in Drop so no double-free occurs.
-        // SAFETY: self.format_ctx is valid and owned exclusively by self.
-        unsafe {
-            ff_sys::avformat::close_input(std::ptr::addr_of_mut!(self.format_ctx));
-        }
-
-        // Re-open the URL with the stored network timeouts.
-        // SAFETY: url is a valid UTF-8 network URL string.
-        self.format_ctx = unsafe {
-            ff_sys::avformat::open_input_url(
-                url,
-                self.network_opts.connect_timeout,
-                self.network_opts.read_timeout,
-            )
-            .map_err(|e| crate::network::map_network_error(e, crate::network::sanitize_url(url)))?
-        };
+        // Re-open the URL with the stored network timeouts. Assigning the fresh
+        // context drops the previous one, which closes and frees it.
+        self.format_ctx = open_url_ctx(url, &self.network_opts)?;
 
         // Re-read stream information.
-        // SAFETY: self.format_ctx is valid and freshly opened.
-        unsafe {
-            ff_sys::avformat::find_stream_info(self.format_ctx).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: e,
-                    message: format!(
-                        "reconnect find_stream_info failed: {}",
-                        ff_sys::av_error_string(e)
-                    ),
-                }
+        self.format_ctx
+            .find_stream_info()
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "reconnect find_stream_info failed: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
             })?;
-        }
 
         // Re-find the video stream (index may differ in theory after reconnect).
         // SAFETY: self.format_ctx is valid.
-        let (stream_index, _) = unsafe { Self::find_video_stream(self.format_ctx) }
+        let (stream_index, _) = unsafe { Self::find_video_stream(self.format_ctx.as_mut_ptr()) }
             .ok_or_else(|| DecodeError::NoVideoStream { path: url.into() })?;
         self.stream_index = stream_index as i32;
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1208,3 +1208,93 @@ impl Drop for CodecContext {
 
 // SAFETY: stub; never executed on docs.rs.
 unsafe impl Send for CodecContext {}
+
+// ── RAII owner stub (mirrors crate::format_context::InputFormatContext) ───────
+// Under DOCS_RS the real `format_context` module is cfg'd out (it depends on the
+// docsrs-gated `avformat` wrapper); this shape-compatible stub keeps
+// `ff_sys::InputFormatContext` available so ff-decode compiles for docs.rs.
+
+#[derive(Debug)]
+pub struct InputFormatContext {
+    _ptr: std::ptr::NonNull<AVFormatContext>,
+}
+
+impl InputFormatContext {
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn open(_path: &std::path::Path) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn open_url(
+        _url: &str,
+        _connect_timeout: std::time::Duration,
+        _read_timeout: std::time::Duration,
+    ) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn open_image_sequence(
+        _path: &std::path::Path,
+        _framerate: u32,
+    ) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVFormatContext {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
+        self._ptr.as_ptr()
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn find_stream_info(&mut self) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn seek_frame(
+        &mut self,
+        _stream_index: c_int,
+        _timestamp: i64,
+        _flags: c_int,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn seek_file(
+        &mut self,
+        _stream_index: c_int,
+        _min_ts: i64,
+        _ts: i64,
+        _max_ts: i64,
+        _flags: c_int,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn read_frame(&mut self, _pkt: *mut AVPacket) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+}
+
+impl Drop for InputFormatContext {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for InputFormatContext {}

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -1,0 +1,191 @@
+//! RAII owner for an input (demux) `AVFormatContext`.
+//!
+//! [`InputFormatContext`] opens a demuxing context and frees it exactly once on
+//! drop, replacing the manual `avformat::open_input*` + `avformat::close_input`
+//! pair. Its fallible methods return [`AvError`]. The packet argument of
+//! [`read_frame`](InputFormatContext::read_frame) stays a raw pointer for now
+//! (an owned Packet is a later step), so that method is `unsafe`: the caller
+//! upholds the usual FFmpeg preconditions.
+//!
+//! The mux (output) lifecycle is a separate owner (`OutputFormatContext`,
+//! tracked in #1493); this type covers demuxing only.
+
+use std::os::raw::c_int;
+use std::path::Path;
+use std::ptr::NonNull;
+use std::time::Duration;
+
+use crate::{AVFormatContext, AVPacket, AvError, avformat_close_input as ffi_avformat_close_input};
+
+/// An owned input (demux) `AVFormatContext`.
+///
+/// The context is freed exactly once on drop. This is guaranteed by
+/// construction: the value owns a [`NonNull`] and is neither `Copy` nor `Clone`,
+/// so it drops exactly once and cannot be duplicated.
+#[derive(Debug)]
+pub struct InputFormatContext {
+    ptr: NonNull<AVFormatContext>,
+}
+
+impl InputFormatContext {
+    /// Opens a media file and reads its header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the path is invalid or the file cannot be
+    /// opened as a recognised media format.
+    pub fn open(path: &Path) -> Result<Self, AvError> {
+        // SAFETY: `open_input` initialises FFmpeg and validates the path; the
+        //         returned context is owned by `self` and freed on drop.
+        let ptr = unsafe { crate::avformat::open_input(path) }.map_err(AvError::new)?;
+        Self::from_raw(ptr)
+    }
+
+    /// Opens a network URL with connect/read timeouts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the URL is invalid, the host is unreachable,
+    /// the connection times out, or the format is not recognised.
+    pub fn open_url(
+        url: &str,
+        connect_timeout: Duration,
+        read_timeout: Duration,
+    ) -> Result<Self, AvError> {
+        // SAFETY: `open_input_url` initialises FFmpeg and validates the URL; the
+        //         returned context is owned by `self` and freed on drop.
+        let ptr = unsafe { crate::avformat::open_input_url(url, connect_timeout, read_timeout) }
+            .map_err(AvError::new)?;
+        Self::from_raw(ptr)
+    }
+
+    /// Opens an image sequence using the `image2` demuxer at `framerate`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the path is invalid, the sequence cannot be
+    /// opened, or the `image2` demuxer is unavailable.
+    pub fn open_image_sequence(path: &Path, framerate: u32) -> Result<Self, AvError> {
+        // SAFETY: `open_input_image_sequence` initialises FFmpeg and validates the
+        //         path; the returned context is owned by `self` and freed on drop.
+        let ptr = unsafe { crate::avformat::open_input_image_sequence(path, framerate) }
+            .map_err(AvError::new)?;
+        Self::from_raw(ptr)
+    }
+
+    /// Wraps a freshly opened, non-null context pointer in the owned type.
+    fn from_raw(ptr: *mut AVFormatContext) -> Result<Self, AvError> {
+        // The `open_*` wrappers return `Ok` only with a non-null context.
+        NonNull::new(ptr)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })
+    }
+
+    /// Returns the context pointer for read-only use.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVFormatContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the context pointer for mutation and FFI calls.
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Reads stream information, populating per-stream codec parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if stream information cannot be read.
+    pub fn find_stream_info(&mut self) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned demux context.
+        unsafe { crate::avformat::find_stream_info(self.ptr.as_ptr()) }.map_err(AvError::new)
+    }
+
+    /// Seeks to `timestamp` (in `stream_index`'s time base) using `flags`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if seeking fails.
+    pub fn seek_frame(
+        &mut self,
+        stream_index: c_int,
+        timestamp: i64,
+        flags: c_int,
+    ) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned demux context.
+        unsafe { crate::avformat::seek_frame(self.ptr.as_ptr(), stream_index, timestamp, flags) }
+            .map_err(AvError::new)
+    }
+
+    /// Seeks to `ts` within the `[min_ts, max_ts]` window using `flags`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if seeking fails.
+    pub fn seek_file(
+        &mut self,
+        stream_index: c_int,
+        min_ts: i64,
+        ts: i64,
+        max_ts: i64,
+        flags: c_int,
+    ) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned demux context.
+        unsafe {
+            crate::avformat::seek_file(self.ptr.as_ptr(), stream_index, min_ts, ts, max_ts, flags)
+        }
+        .map_err(AvError::new)
+    }
+
+    /// Reads the next packet into `pkt`.
+    ///
+    /// End-of-stream surfaces as an [`AvError`] for which [`AvError::is_eof`]
+    /// returns `true`, rather than a distinct outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] on read failure or at end-of-stream (`EOF`).
+    ///
+    /// # Safety
+    ///
+    /// `pkt` must be a valid, allocated `*mut AVPacket`.
+    pub unsafe fn read_frame(&mut self, pkt: *mut AVPacket) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned demux context; the caller upholds `pkt`.
+        unsafe { crate::avformat::read_frame(self.ptr.as_ptr(), pkt) }.map_err(AvError::new)
+    }
+}
+
+impl Drop for InputFormatContext {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
+        //         runs exactly once. `avformat_close_input` closes the input and
+        //         frees the context, writing null into our local copy of the
+        //         pointer, which is then discarded. The raw binding is used
+        //         directly so this type does not depend on the
+        //         `avformat::close_input` wrapper.
+        unsafe {
+            let mut raw = self.ptr.as_ptr();
+            ffi_avformat_close_input(&mut raw);
+        }
+    }
+}
+
+// SAFETY: an `AVFormatContext` is not safe for concurrent access, but moving
+//         ownership between threads is sound because Rust's ownership model
+//         guarantees exclusive access.
+unsafe impl Send for InputFormatContext {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_should_error_on_missing_path() {
+        // Opening a guaranteed-nonexistent path fails without allocating a
+        // context (the error path returns before any owned value is built).
+        let result = InputFormatContext::open(Path::new("/nonexistent/path/to/file.mp4"));
+        assert!(result.is_err());
+    }
+}

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -54,6 +54,8 @@ mod codec_context;
 mod constants;
 mod error;
 pub mod error_codes;
+#[cfg(not(docsrs))]
+mod format_context;
 mod utils;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
@@ -61,5 +63,7 @@ mod utils;
 pub use codec_context::{CodecContext, ReceiveOutcome};
 pub use constants::{AV_NOPTS_VALUE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
+#[cfg(not(docsrs))]
+pub use format_context::InputFormatContext;
 pub use utils::{av_error_string, ensure_initialized};
 // check_av_error! is re-exported at the crate root automatically via #[macro_export]


### PR DESCRIPTION
## Objective

- Evolve ff-sys from raw pointer handling toward owned RAII types (ADR-0003): the input `AVFormatContext` was held as a raw `*mut` in three ff-decode decoders, allocated through a hand-rolled `AvFormatContextGuard`, and freed by a manual `avformat_close_input` in each `Drop` and reconnect path, which is easy to leak on an early return.

## Solution

- Add `ff_sys::InputFormatContext`, an owned type over `NonNull<AVFormatContext>` that frees the context exactly once on drop. Constructors (`open`/`open_url`/`open_image_sequence`) and `find_stream_info`/`seek_frame`/`seek_file` are safe; `read_frame` stays `unsafe` (raw `AVPacket` argument). `Send` only; a docs.rs stub keeps `DOCS_RS` builds compiling.
- Migrate the three ff-decode decoders onto it: replace `AvFormatContextGuard` with three open helpers that preserve the existing `DecodeError` mapping, change the `format_ctx` field to the owned type, route the per-frame reads through `read_frame`, and remove the manual `close_input` from each `Drop` (the field now frees the context last).
- The reconnect `reopen` path is now a move-assign of a freshly opened context: the previous context is dropped after the new open succeeds, and on the error path it is retained rather than left dangling (memory-safe; the previous close-then-open ordering is intentionally changed).
- Scope is the demux lifecycle plus ff-decode. The mux `OutputFormatContext` and the remaining format-context consumers are relocated to #1493.

Closes #1478