### PR TITLE
feat(ff-sys): RAII resample and scale contexts (SwrContext / SwsContext)

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -59,7 +59,7 @@ pub(crate) struct AudioDecoderInner {
     /// Target output channel count (if remixing is needed)
     output_channels: Option<u32>,
     /// Cached `SwrContext` — reused across frames to preserve FIR filter state.
-    swr_ctx: Option<resample_inner::SwrContextGuard>,
+    swr_ctx: Option<ff_sys::ResampleContext>,
     /// Key for the cached context; rebuilt when source or target parameters change.
     swr_key: Option<resample_inner::SwrKey>,
     /// Whether the source is a live/streaming input (seeking is not supported)

--- a/crates/ff-decode/src/audio/resample_inner.rs
+++ b/crates/ff-decode/src/audio/resample_inner.rs
@@ -20,11 +20,9 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::if_not_else)]
 
-use std::ptr;
-
 use ff_format::time::{Rational, Timestamp};
 use ff_format::{AudioFrame, SampleFormat};
-use ff_sys::{AVFormatContext, AVFrame, AVSampleFormat, SwrContext};
+use ff_sys::{AVFormatContext, AVFrame, AVSampleFormat};
 
 use crate::error::DecodeError;
 
@@ -68,27 +66,13 @@ fn checked_buffer_size(
         })
 }
 
-// ── SwrContext RAII guard ─────────────────────────────────────────────────────
-
-/// RAII guard for `SwrContext` to ensure proper cleanup.
-pub(crate) struct SwrContextGuard(pub(crate) *mut SwrContext);
+// ── SwrContext cache key ──────────────────────────────────────────────────────
 
 /// Cache key that identifies a unique (src → dst) resampling configuration.
-/// Stored alongside `SwrContextGuard` so the context can be reused across
-/// frames without reinitialising the FIR filter state on every call.
+/// Stored alongside the cached `ResampleContext` so the context can be reused
+/// across frames without reinitialising the FIR filter state on every call.
 /// (src_format, src_rate, src_channels, dst_format, dst_rate, dst_channels)
 pub(crate) type SwrKey = (i32, u32, u32, i32, u32, u32);
-
-impl Drop for SwrContextGuard {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            // SAFETY: self.0 is valid and owned by this guard
-            unsafe {
-                ff_sys::swr_free(&mut (self.0 as *mut _));
-            }
-        }
-    }
-}
 
 // ── Format conversion helpers ─────────────────────────────────────────────────
 
@@ -268,7 +252,7 @@ pub(crate) unsafe fn convert_frame_to_audio_frame(
     output_format: Option<SampleFormat>,
     output_sample_rate: Option<u32>,
     output_channels: Option<u32>,
-    swr_cache: &mut Option<SwrContextGuard>,
+    swr_cache: &mut Option<ff_sys::ResampleContext>,
     swr_key: &mut Option<SwrKey>,
 ) -> Result<AudioFrame, DecodeError> {
     // SAFETY: Caller ensures frame is valid
@@ -326,7 +310,7 @@ unsafe fn convert_with_swr(
     output_channels: Option<u32>,
     format_ctx: *mut AVFormatContext,
     stream_index: i32,
-    swr_cache: &mut Option<SwrContextGuard>,
+    swr_cache: &mut Option<ff_sys::ResampleContext>,
     swr_key: &mut Option<SwrKey>,
 ) -> Result<AudioFrame, DecodeError> {
     // Determine target parameters
@@ -362,79 +346,48 @@ unsafe fn convert_with_swr(
         let mut src_ch_layout = unsafe { create_channel_layout(src_channels) };
         let mut dst_ch_layout = unsafe { create_channel_layout(dst_channels) };
 
-        // Allocate and configure SwrContext
-        let mut new_ctx: *mut SwrContext = ptr::null_mut();
-
-        // SAFETY: FFmpeg API call with valid parameters; new_ctx is initialised to null
-        let ret = unsafe {
-            ff_sys::swr_alloc_set_opts2(
-                &raw mut new_ctx,
+        // Allocate, configure, and initialize the resampler (RAII). On init
+        // failure the context is freed internally, so no manual swr_free remains.
+        // SAFETY: dst_ch_layout / src_ch_layout are valid for this call.
+        let result = unsafe {
+            ff_sys::ResampleContext::new(
                 &raw const dst_ch_layout,
                 dst_format,
                 dst_sample_rate as i32,
                 &raw const src_ch_layout,
                 src_format,
                 src_sample_rate as i32,
-                0,
-                ptr::null_mut(),
             )
         };
 
-        if ret < 0 {
-            unsafe {
-                ff_sys::av_channel_layout_uninit(&raw mut src_ch_layout);
-                ff_sys::av_channel_layout_uninit(&raw mut dst_ch_layout);
-            }
-            return Err(DecodeError::Ffmpeg {
-                code: ret,
-                message: format!(
-                    "Failed to allocate SwrContext: {}",
-                    ff_sys::av_error_string(ret)
-                ),
-            });
-        }
-
-        // Initialize the resampler
-        // SAFETY: new_ctx is valid after swr_alloc_set_opts2 succeeded
-        let ret = unsafe { ff_sys::swr_init(new_ctx) };
-        if ret < 0 {
-            unsafe {
-                ff_sys::av_channel_layout_uninit(&raw mut src_ch_layout);
-                ff_sys::av_channel_layout_uninit(&raw mut dst_ch_layout);
-                ff_sys::swr_free(&mut (new_ctx as *mut _));
-            }
-            return Err(DecodeError::Ffmpeg {
-                code: ret,
-                message: format!(
-                    "Failed to initialize SwrContext: {}",
-                    ff_sys::av_error_string(ret)
-                ),
-            });
-        }
-
+        // Uninitialize the channel layouts on every path (success or error).
         unsafe {
             ff_sys::av_channel_layout_uninit(&raw mut src_ch_layout);
             ff_sys::av_channel_layout_uninit(&raw mut dst_ch_layout);
         }
 
-        *swr_cache = Some(SwrContextGuard(new_ctx));
+        let new_ctx = result.map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to build SwrContext: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
+
+        *swr_cache = Some(new_ctx);
         *swr_key = Some(key);
     }
 
     // SAFETY: swr_cache is always Some after the rebuild block above
-    let swr_ctx = match swr_cache.as_ref() {
-        Some(guard) => guard.0,
-        None => {
-            return Err(DecodeError::Ffmpeg {
-                code: 0,
-                message: "SwrContext missing after initialisation".to_string(),
-            });
-        }
+    let Some(ctx) = swr_cache.as_mut() else {
+        return Err(DecodeError::Ffmpeg {
+            code: 0,
+            message: "SwrContext missing after initialisation".to_string(),
+        });
     };
 
     // Calculate output sample count (includes buffered delay from previous frames)
-    // SAFETY: swr_ctx is valid and initialized
-    let out_samples = unsafe { ff_sys::swr_get_out_samples(swr_ctx, nb_samples as i32) };
+    let out_samples = ctx.get_out_samples(nb_samples as i32);
 
     if out_samples < 0 {
         return Err(DecodeError::Ffmpeg {
@@ -476,24 +429,20 @@ unsafe fn convert_with_swr(
     // Convert samples using SwResample
     // SAFETY: All pointers are valid and buffers are properly sized
     let converted_samples = unsafe {
-        ff_sys::swr_convert(
-            swr_ctx,
+        ctx.convert(
             out_ptrs.as_mut_ptr(),
             out_samples as i32,
-            in_ptrs.as_ptr() as *mut *const u8,
+            in_ptrs.as_ptr() as *const *const u8,
             nb_samples as i32,
         )
-    };
-
-    if converted_samples < 0 {
-        return Err(DecodeError::Ffmpeg {
-            code: converted_samples,
-            message: format!(
-                "Failed to convert samples: {}",
-                ff_sys::av_error_string(converted_samples)
-            ),
-        });
     }
+    .map_err(|e| DecodeError::Ffmpeg {
+        code: e.code(),
+        message: format!(
+            "Failed to convert samples: {}",
+            ff_sys::av_error_string(e.code())
+        ),
+    })?;
 
     // Extract timestamp from original frame
     // SAFETY: frame is valid

--- a/crates/ff-decode/src/video/decoder_inner/format_convert.rs
+++ b/crates/ff-decode/src/video/decoder_inner/format_convert.rs
@@ -185,30 +185,26 @@ impl VideoDecoderInner {
                 src_width, src_height, src_format, dst_width, dst_height, dst_format,
             );
             if self.sws_cache_key != Some(cache_key) {
-                // Free the old context if it exists.
-                if let Some(old_ctx) = self.sws_ctx.take() {
-                    ff_sys::swscale::free_context(old_ctx);
-                }
-
-                let ctx = ff_sys::swscale::get_context(
-                    src_width as i32,
-                    src_height as i32,
-                    src_format,
-                    dst_width as i32,
-                    dst_height as i32,
-                    dst_format,
-                    ff_sys::swscale::scale_flags::BILINEAR,
-                )
-                .map_err(|e| DecodeError::Ffmpeg {
-                    code: 0,
-                    message: format!("Failed to create sws context: {e}"),
-                })?;
-
-                self.sws_ctx = Some(ctx);
+                // The old context (if any) drops on reassignment.
+                self.sws_ctx = Some(
+                    ff_sys::ScaleContext::new(
+                        src_width as i32,
+                        src_height as i32,
+                        src_format,
+                        dst_width as i32,
+                        dst_height as i32,
+                        dst_format,
+                        ff_sys::swscale::scale_flags::BILINEAR,
+                    )
+                    .map_err(|e| DecodeError::Ffmpeg {
+                        code: 0,
+                        message: format!("Failed to create sws context: {e}"),
+                    })?,
+                );
                 self.sws_cache_key = Some(cache_key);
             }
 
-            let Some(sws_ctx) = self.sws_ctx else {
+            let Some(sws_ctx) = self.sws_ctx.as_mut() else {
                 return Err(DecodeError::Ffmpeg {
                     code: 0,
                     message: "SwsContext not initialized".to_string(),
@@ -236,19 +232,19 @@ impl VideoDecoderInner {
             }
 
             // Perform conversion/scaling (src_height is the number of input rows to process)
-            ff_sys::swscale::scale(
-                sws_ctx,
-                (*self.frame).data.as_ptr() as *const *const u8,
-                (*self.frame).linesize.as_ptr(),
-                0,
-                src_height as i32,
-                (*dst_frame).data.as_ptr() as *const *mut u8,
-                (*dst_frame).linesize.as_ptr(),
-            )
-            .map_err(|e| DecodeError::Ffmpeg {
-                code: 0,
-                message: format!("Failed to scale frame: {e}"),
-            })?;
+            sws_ctx
+                .scale(
+                    (*self.frame).data.as_ptr() as *const *const u8,
+                    (*self.frame).linesize.as_ptr(),
+                    0,
+                    src_height as i32,
+                    (*dst_frame).data.as_ptr() as *const *mut u8,
+                    (*dst_frame).linesize.as_ptr(),
+                )
+                .map_err(|e| DecodeError::Ffmpeg {
+                    code: 0,
+                    message: format!("Failed to scale frame: {e}"),
+                })?;
 
             // Copy timestamp
             (*dst_frame).pts = (*self.frame).pts;

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -39,7 +39,7 @@ use ff_format::{PixelFormat, VideoFrame, VideoStreamInfo};
 use ff_sys::{
     AVBufferRef, AVCodecContext, AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace,
     AVFormatContext, AVFrame, AVHWDeviceType, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket,
-    AVPixelFormat, InputFormatContext, SwsContext,
+    AVPixelFormat, InputFormatContext,
 };
 
 use crate::HardwareAccel;
@@ -75,7 +75,7 @@ pub(crate) struct VideoDecoderInner {
     /// Video stream index in the format context
     pub(super) stream_index: i32,
     /// SwScale context for pixel format conversion and/or scaling (optional)
-    pub(super) sws_ctx: Option<*mut SwsContext>,
+    pub(super) sws_ctx: Option<ff_sys::ScaleContext>,
     /// Cache key for the main sws_ctx: (src_w, src_h, src_fmt, dst_w, dst_h, dst_fmt)
     pub(super) sws_cache_key: Option<(u32, u32, i32, u32, u32, i32)>,
     /// Target output pixel format (if conversion is needed)
@@ -93,7 +93,7 @@ pub(crate) struct VideoDecoderInner {
     /// Reusable frame for decoding
     pub(super) frame: *mut AVFrame,
     /// Cached SwScale context for thumbnail generation
-    pub(super) thumbnail_sws_ctx: Option<*mut SwsContext>,
+    pub(super) thumbnail_sws_ctx: Option<ff_sys::ScaleContext>,
     /// Last thumbnail dimensions (for cache invalidation)
     pub(super) thumbnail_cache_key: Option<(u32, u32, u32, u32, AVPixelFormat)>,
     /// Hardware device context (if hardware acceleration is active)
@@ -333,21 +333,8 @@ impl VideoDecoderInner {
 
 impl Drop for VideoDecoderInner {
     fn drop(&mut self) {
-        // Free SwScale context if allocated
-        if let Some(sws_ctx) = self.sws_ctx {
-            // SAFETY: sws_ctx is valid and owned by this instance
-            unsafe {
-                ff_sys::swscale::free_context(sws_ctx);
-            }
-        }
-
-        // Free cached thumbnail SwScale context if allocated
-        if let Some(thumbnail_ctx) = self.thumbnail_sws_ctx {
-            // SAFETY: thumbnail_ctx is valid and owned by this instance
-            unsafe {
-                ff_sys::swscale::free_context(thumbnail_ctx);
-            }
-        }
+        // The `sws_ctx` and `thumbnail_sws_ctx` (owned `ScaleContext`) free
+        // themselves when this struct drops.
 
         // Free hardware device context if allocated
         if let Some(hw_ctx) = self.hw_device_ctx {

--- a/crates/ff-decode/src/video/decoder_inner/seeking.rs
+++ b/crates/ff-decode/src/video/decoder_inner/seeking.rs
@@ -306,21 +306,21 @@ impl VideoDecoderInner {
 
         // SAFETY: We're creating temporary FFmpeg objects for scaling
         unsafe {
-            // Check if we can reuse the cached SwScale context
-            let (sws_ctx, is_cached) = if let (Some(cached_ctx), Some(cached_key)) =
-                (self.thumbnail_sws_ctx, self.thumbnail_cache_key)
-            {
-                if cached_key == cache_key {
-                    // Cache hit - reuse existing context
-                    (cached_ctx, true)
-                } else {
-                    // Cache miss - free old context and create new one
-                    ff_sys::swscale::free_context(cached_ctx);
-                    // Clear cache immediately to prevent dangling pointer
-                    self.thumbnail_sws_ctx = None;
-                    self.thumbnail_cache_key = None;
+            // Reuse the cached SwScale context when the key matches; otherwise
+            // build a fresh owned context into the cache slot. The cache key is
+            // only set after scaling succeeds, so an error after a rebuild leaves
+            // the freshly built context keyless — it is dropped/replaced on the
+            // next call rather than being reused with a stale key.
+            let is_cached =
+                self.thumbnail_cache_key == Some(cache_key) && self.thumbnail_sws_ctx.is_some();
 
-                    let new_ctx = ff_sys::swscale::get_context(
+            if !is_cached {
+                // Drop any stale cached context, then build the replacement.
+                self.thumbnail_sws_ctx = None;
+                self.thumbnail_cache_key = None;
+
+                self.thumbnail_sws_ctx = Some(
+                    ff_sys::ScaleContext::new(
                         src_width as i32,
                         src_height as i32,
                         av_format,
@@ -332,29 +332,15 @@ impl VideoDecoderInner {
                     .map_err(|e| DecodeError::Ffmpeg {
                         code: 0,
                         message: format!("Failed to create scaling context: {e}"),
-                    })?;
+                    })?,
+                );
+            }
 
-                    // Don't cache yet - will cache after successful scaling
-                    (new_ctx, false)
-                }
-            } else {
-                // No cache - create new context
-                let new_ctx = ff_sys::swscale::get_context(
-                    src_width as i32,
-                    src_height as i32,
-                    av_format,
-                    scaled_width as i32,
-                    scaled_height as i32,
-                    av_format,
-                    ff_sys::swscale::scale_flags::BILINEAR,
-                )
-                .map_err(|e| DecodeError::Ffmpeg {
+            let Some(sws_ctx) = self.thumbnail_sws_ctx.as_mut() else {
+                return Err(DecodeError::Ffmpeg {
                     code: 0,
-                    message: format!("Failed to create scaling context: {e}"),
-                })?;
-
-                // Don't cache yet - will cache after successful scaling
-                (new_ctx, false)
+                    message: "SwsContext not initialized".to_string(),
+                });
             };
 
             // Set up source frame with VideoFrame data
@@ -388,10 +374,9 @@ impl VideoDecoderInner {
             // Allocate buffer for destination frame
             let buffer_ret = ff_sys::av_frame_get_buffer(dst_frame, 0);
             if buffer_ret < 0 {
-                // Clean up context if not cached
-                if !is_cached {
-                    ff_sys::swscale::free_context(sws_ctx);
-                }
+                // On a rebuild the freshly built context stays in the cache slot
+                // but keyless (thumbnail_cache_key was cleared above), so it is
+                // dropped/replaced on the next call rather than reused.
                 return Err(DecodeError::Ffmpeg {
                     code: buffer_ret,
                     message: format!(
@@ -402,8 +387,7 @@ impl VideoDecoderInner {
             }
 
             // Perform scaling
-            let scale_result = ff_sys::swscale::scale(
-                sws_ctx,
+            let scale_result = sws_ctx.scale(
                 (*src_frame).data.as_ptr() as *const *const u8,
                 (*src_frame).linesize.as_ptr(),
                 0,
@@ -413,19 +397,17 @@ impl VideoDecoderInner {
             );
 
             if let Err(e) = scale_result {
-                // Clean up context if not cached
-                if !is_cached {
-                    ff_sys::swscale::free_context(sws_ctx);
-                }
+                // On a rebuild the freshly built context stays in the cache slot
+                // but keyless (thumbnail_cache_key was cleared above), so it is
+                // dropped/replaced on the next call rather than reused.
                 return Err(DecodeError::Ffmpeg {
                     code: 0,
                     message: format!("Failed to scale frame: {e}"),
                 });
             }
 
-            // Scaling successful - cache the context if it's new
+            // Scaling successful - record the cache key for the (re)built context.
             if !is_cached {
-                self.thumbnail_sws_ctx = Some(sws_ctx);
                 self.thumbnail_cache_key = Some(cache_key);
             }
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1298,3 +1298,123 @@ impl Drop for InputFormatContext {
 
 // SAFETY: stub; never executed on docs.rs.
 unsafe impl Send for InputFormatContext {}
+
+// ── RAII owner stub (mirrors crate::scale_context::ScaleContext) ──────────────
+// Under DOCS_RS the real `scale_context` module is cfg'd out; this
+// shape-compatible stub keeps `ff_sys::ScaleContext` available for docs.rs.
+
+#[derive(Debug)]
+pub struct ScaleContext {
+    _ptr: std::ptr::NonNull<SwsContext>,
+}
+
+impl ScaleContext {
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn new(
+        _src_w: c_int,
+        _src_h: c_int,
+        _src_fmt: AVPixelFormat,
+        _dst_w: c_int,
+        _dst_h: c_int,
+        _dst_fmt: AVPixelFormat,
+        _flags: c_int,
+    ) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const SwsContext {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut SwsContext {
+        self._ptr.as_ptr()
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn scale(
+        &mut self,
+        _src: *const *const u8,
+        _src_stride: *const c_int,
+        _src_slice_y: c_int,
+        _src_slice_h: c_int,
+        _dst: *const *mut u8,
+        _dst_stride: *const c_int,
+    ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+}
+
+impl Drop for ScaleContext {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for ScaleContext {}
+
+// ── RAII owner stub (mirrors crate::resample_context::ResampleContext) ────────
+// Under DOCS_RS the real `resample_context` module is cfg'd out; this
+// shape-compatible stub keeps `ff_sys::ResampleContext` available for docs.rs.
+
+#[derive(Debug)]
+pub struct ResampleContext {
+    _ptr: std::ptr::NonNull<SwrContext>,
+}
+
+impl ResampleContext {
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn new(
+        _out_ch_layout: *const AVChannelLayout,
+        _out_sample_fmt: AVSampleFormat,
+        _out_sample_rate: c_int,
+        _in_ch_layout: *const AVChannelLayout,
+        _in_sample_fmt: AVSampleFormat,
+        _in_sample_rate: c_int,
+    ) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const SwrContext {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut SwrContext {
+        self._ptr.as_ptr()
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn convert(
+        &mut self,
+        _out: *mut *mut u8,
+        _out_count: c_int,
+        _in_: *const *const u8,
+        _in_count: c_int,
+    ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub fn get_out_samples(&mut self, _in_samples: c_int) -> c_int {
+        0
+    }
+}
+
+impl Drop for ResampleContext {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for ResampleContext {}

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -56,6 +56,10 @@ mod error;
 pub mod error_codes;
 #[cfg(not(docsrs))]
 mod format_context;
+#[cfg(not(docsrs))]
+mod resample_context;
+#[cfg(not(docsrs))]
+mod scale_context;
 mod utils;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
@@ -65,5 +69,9 @@ pub use constants::{AV_NOPTS_VALUE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
 #[cfg(not(docsrs))]
 pub use format_context::InputFormatContext;
+#[cfg(not(docsrs))]
+pub use resample_context::ResampleContext;
+#[cfg(not(docsrs))]
+pub use scale_context::ScaleContext;
 pub use utils::{av_error_string, ensure_initialized};
 // check_av_error! is re-exported at the crate root automatically via #[macro_export]

--- a/crates/ff-sys/src/resample_context.rs
+++ b/crates/ff-sys/src/resample_context.rs
@@ -1,0 +1,189 @@
+//! RAII owner for an `SwrContext` (libswresample audio resampling).
+//!
+//! [`ResampleContext`] allocates, configures, and initializes a resampling
+//! context, and frees it exactly once on drop, replacing the manual
+//! `swresample::alloc_set_opts2` + `swresample::init` + `swresample::free`
+//! sequence. The value is always initialized once constructed (there is no
+//! un-initialized state), so the query methods are safe;
+//! [`convert`](ResampleContext::convert) stays `unsafe` because it takes raw
+//! plane pointers (owned Frame handling is a later step), and [`new`](Self::new)
+//! is `unsafe` because it takes raw channel-layout pointers.
+
+use std::os::raw::c_int;
+use std::ptr::NonNull;
+
+use crate::{
+    AVChannelLayout, AVSampleFormat, AvError, SwrContext, swr_free as ffi_swr_free,
+    swr_get_out_samples as ffi_swr_get_out_samples,
+};
+
+/// An owned, initialized `SwrContext`.
+///
+/// The context is freed exactly once on drop. This is guaranteed by
+/// construction: the value owns a [`NonNull`] and is neither `Copy` nor `Clone`,
+/// so it drops exactly once and cannot be duplicated.
+#[derive(Debug)]
+pub struct ResampleContext {
+    ptr: NonNull<SwrContext>,
+}
+
+impl ResampleContext {
+    /// Allocates, configures, and initializes a resampling context for the
+    /// given input / output audio parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the parameters are invalid or initialization
+    /// fails.
+    ///
+    /// # Safety
+    ///
+    /// `out_ch_layout` and `in_ch_layout` must be valid `*const AVChannelLayout`
+    /// pointers for the duration of the call.
+    pub unsafe fn new(
+        out_ch_layout: *const AVChannelLayout,
+        out_sample_fmt: AVSampleFormat,
+        out_sample_rate: c_int,
+        in_ch_layout: *const AVChannelLayout,
+        in_sample_fmt: AVSampleFormat,
+        in_sample_rate: c_int,
+    ) -> Result<Self, AvError> {
+        // SAFETY: the caller upholds the channel-layout pointers; `alloc_set_opts2`
+        //         validates the sample rates and returns a non-null context or an
+        //         error code.
+        let ptr = unsafe {
+            crate::swresample::alloc_set_opts2(
+                out_ch_layout,
+                out_sample_fmt,
+                out_sample_rate,
+                in_ch_layout,
+                in_sample_fmt,
+                in_sample_rate,
+            )
+        }
+        .map_err(AvError::new)?;
+        // `alloc_set_opts2` returns `Ok` only with a non-null context. Wrap it in
+        // the owned type *before* initializing, so an `init` failure drops `self`
+        // (Drop = `swr_free`) rather than leaking the allocated context.
+        let me = NonNull::new(ptr)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })?;
+        // SAFETY: `me.ptr` is a freshly allocated and configured context.
+        unsafe { crate::swresample::init(me.ptr.as_ptr()) }.map_err(AvError::new)?;
+        Ok(me)
+    }
+
+    /// Returns the context pointer for read-only use.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const SwrContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the context pointer for mutation and FFI calls.
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut SwrContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Converts (resamples / reformats) audio samples into the output buffers.
+    ///
+    /// Returns the number of samples produced per channel. Passing a null `in_`
+    /// with `in_count` 0 flushes buffered samples.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if conversion fails.
+    ///
+    /// # Safety
+    ///
+    /// `out` / `in_` and their counts must describe buffers valid for this
+    /// context's configured formats (or a null `in_` with a zero count).
+    pub unsafe fn convert(
+        &mut self,
+        out: *mut *mut u8,
+        out_count: c_int,
+        in_: *const *const u8,
+        in_count: c_int,
+    ) -> Result<c_int, AvError> {
+        // SAFETY: `self.ptr` is a valid initialized context; the caller upholds
+        //         the sample buffers.
+        unsafe { crate::swresample::convert(self.ptr.as_ptr(), out, out_count, in_, in_count) }
+            .map_err(AvError::new)
+    }
+
+    /// Returns the number of output samples a `swr_convert` with `in_samples`
+    /// input samples would currently produce (including buffered delay).
+    #[must_use]
+    pub fn get_out_samples(&mut self, in_samples: c_int) -> c_int {
+        // SAFETY: `self.ptr` is a valid initialized context; the query takes no
+        //         caller-supplied pointer.
+        unsafe { ffi_swr_get_out_samples(self.ptr.as_ptr(), in_samples) }
+    }
+}
+
+impl Drop for ResampleContext {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
+        //         runs exactly once. `swr_free` frees it and writes null into our
+        //         local copy of the pointer, which is then discarded. The raw
+        //         binding is used directly so this type does not depend on the
+        //         `swresample::free` wrapper.
+        unsafe {
+            let mut raw = self.ptr.as_ptr();
+            ffi_swr_free(&mut raw);
+        }
+    }
+}
+
+// SAFETY: an `SwrContext` is not safe for concurrent access, but moving ownership
+//         between threads is sound because Rust's ownership model guarantees
+//         exclusive access.
+unsafe impl Send for ResampleContext {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swresample::{channel_layout, sample_format};
+
+    #[test]
+    fn new_should_allocate_init_and_drop_cleanly() {
+        // Standard stereo layouts need no file or codec, so this depends only on
+        // the linked libswresample.
+        let out_layout = channel_layout::stereo();
+        let in_layout = channel_layout::stereo();
+        // SAFETY: the two layouts are valid for the duration of the call.
+        let ctx = unsafe {
+            ResampleContext::new(
+                &out_layout,
+                sample_format::FLTP,
+                48000,
+                &in_layout,
+                sample_format::S16,
+                44100,
+            )
+        }
+        .expect("context creation should succeed");
+        assert!(!ctx.as_ptr().is_null());
+        // Dropping `ctx` frees the context exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn new_should_error_on_invalid_params() {
+        // A zero output sample rate is rejected by `alloc_set_opts2` (EINVAL), so
+        // construction fails deterministically without allocating a context.
+        let out_layout = channel_layout::stereo();
+        let in_layout = channel_layout::stereo();
+        // SAFETY: the two layouts are valid for the duration of the call.
+        let result = unsafe {
+            ResampleContext::new(
+                &out_layout,
+                sample_format::FLTP,
+                0,
+                &in_layout,
+                sample_format::S16,
+                44100,
+            )
+        };
+        assert!(result.is_err());
+    }
+}

--- a/crates/ff-sys/src/scale_context.rs
+++ b/crates/ff-sys/src/scale_context.rs
@@ -1,0 +1,155 @@
+//! RAII owner for an `SwsContext` (libswscale scaling / pixel-format conversion).
+//!
+//! [`ScaleContext`] allocates a scaling context and frees it exactly once on
+//! drop, replacing the manual `swscale::get_context` + `swscale::free_context`
+//! pair. Its constructor is safe (it takes only dimensions, pixel formats, and
+//! flags); [`scale`](ScaleContext::scale) stays `unsafe` because it takes raw
+//! plane pointers (owned Frame handling is a later step).
+
+use std::os::raw::c_int;
+use std::ptr::NonNull;
+
+use crate::{AVPixelFormat, AvError, SwsContext, sws_freeContext as ffi_sws_freeContext};
+
+/// An owned `SwsContext`.
+///
+/// The context is freed exactly once on drop. This is guaranteed by
+/// construction: the value owns a [`NonNull`] and is neither `Copy` nor `Clone`,
+/// so it drops exactly once and cannot be duplicated.
+#[derive(Debug)]
+pub struct ScaleContext {
+    ptr: NonNull<SwsContext>,
+}
+
+impl ScaleContext {
+    /// Allocates a scaling context for the given source / destination geometry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the dimensions are invalid or the format
+    /// combination is unsupported.
+    pub fn new(
+        src_w: c_int,
+        src_h: c_int,
+        src_fmt: AVPixelFormat,
+        dst_w: c_int,
+        dst_h: c_int,
+        dst_fmt: AVPixelFormat,
+        flags: c_int,
+    ) -> Result<Self, AvError> {
+        // SAFETY: `get_context` initialises FFmpeg and validates the dimensions;
+        //         the returned context is owned by `self` and freed on drop.
+        let ptr = unsafe {
+            crate::swscale::get_context(src_w, src_h, src_fmt, dst_w, dst_h, dst_fmt, flags)
+        }
+        .map_err(AvError::new)?;
+        // `get_context` returns `Ok` only with a non-null context.
+        NonNull::new(ptr)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })
+    }
+
+    /// Returns the context pointer for read-only use.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const SwsContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the context pointer for mutation and FFI calls.
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut SwsContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Scales / converts a slice of the source image into the destination.
+    ///
+    /// Returns the height of the output slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if scaling fails.
+    ///
+    /// # Safety
+    ///
+    /// The plane and stride arrays must be valid and sized for the formats and
+    /// dimensions this context was created for.
+    pub unsafe fn scale(
+        &mut self,
+        src: *const *const u8,
+        src_stride: *const c_int,
+        src_slice_y: c_int,
+        src_slice_h: c_int,
+        dst: *const *mut u8,
+        dst_stride: *const c_int,
+    ) -> Result<c_int, AvError> {
+        // SAFETY: `self.ptr` is a valid owned scaling context; the caller upholds
+        //         the plane / stride arrays.
+        unsafe {
+            crate::swscale::scale(
+                self.ptr.as_ptr(),
+                src,
+                src_stride,
+                src_slice_y,
+                src_slice_h,
+                dst,
+                dst_stride,
+            )
+        }
+        .map_err(AvError::new)
+    }
+}
+
+impl Drop for ScaleContext {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
+        //         runs exactly once. `sws_freeContext` takes the context pointer
+        //         by value and frees it. The raw binding is used directly so this
+        //         type does not depend on the `swscale::free_context` wrapper.
+        unsafe {
+            ffi_sws_freeContext(self.ptr.as_ptr());
+        }
+    }
+}
+
+// SAFETY: an `SwsContext` is not safe for concurrent access, but moving ownership
+//         between threads is sound because Rust's ownership model guarantees
+//         exclusive access.
+unsafe impl Send for ScaleContext {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AVPixelFormat_AV_PIX_FMT_RGB24;
+
+    #[test]
+    fn new_should_allocate_and_drop_cleanly() {
+        // A plain RGB downscale context needs no file or codec, so this does not
+        // depend on anything beyond the linked libswscale.
+        let ctx = ScaleContext::new(
+            640,
+            480,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            320,
+            240,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            crate::swscale::scale_flags::BILINEAR,
+        )
+        .expect("context creation should succeed");
+        assert!(!ctx.as_ptr().is_null());
+        // Dropping `ctx` frees the context exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn new_should_error_on_zero_dimensions() {
+        let result = ScaleContext::new(
+            0,
+            480,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            320,
+            240,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            crate::swscale::scale_flags::BILINEAR,
+        );
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Objective

- Continue the ff-sys RAII hardening (ADR-0003) for the two remaining decode contexts: the audio resampler (`SwrContext`) and video scaler (`SwsContext`) were held in ff-decode as a hand-rolled `SwrContextGuard` and as raw `Option<*mut SwsContext>` fields, freed manually in `Drop` and on every cache rebuild / error path, which is easy to leak.

## Solution

- Add `ff_sys::ScaleContext` (owns `NonNull<SwsContext>`, frees on drop via `sws_freeContext`) and `ff_sys::ResampleContext` (owns `NonNull<SwrContext>`, frees via `swr_free`). `ScaleContext::new` is safe (dimensions/formats/flags only); `ResampleContext::new` is `unsafe` (raw channel-layout pointers) and does `alloc_set_opts2` + `init` in one call so the value is always initialized, wrapping the pointer before `init` so an init failure drops it rather than leaking. `scale`/`convert` stay `unsafe`; `get_out_samples` is safe. `Send` only; a docs.rs stub keeps `DOCS_RS` building.
- Migrate ff-decode audio (`SwrContextGuard` -> `Option<ResampleContext>`; owned rebuild + per-frame methods) and video (`sws_ctx`/`thumbnail_sws_ctx` -> `Option<ScaleContext>`; manual `sws_freeContext` removed from `Drop` and the rebuild/error paths).
- The thumbnail cache path drops its `is_cached` manual-free bookkeeping in favour of the owned context; on a build failure the previous context and its cache key are retained consistently (the cache key is still recorded only after a successful scale).
- Kept the owned surface to what ff-decode needs (no unused `get_delay`). Scope is the two types plus ff-decode; the ff-encode / ff-stream / ff-preview consumers are relocated to #1495.

Closes #1479