### PR TITLE
feat(ff-sys): owned Frame/Packet/Codec and a safer decode API

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -32,14 +32,14 @@ use ff_format::codec::AudioCodec;
 use ff_format::container::ContainerInfo;
 use ff_format::{AudioFrame, AudioStreamInfo, NetworkOptions, SampleFormat};
 use ff_sys::{
-    AVCodecContext, AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_AUDIO, AVPacket,
-    InputFormatContext,
+    AVCodecContext, AVCodecID, AVFormatContext, AVMediaType_AVMEDIA_TYPE_AUDIO, Frame,
+    InputFormatContext, Packet,
 };
 
 use super::resample_inner;
 
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{AvFrameGuard, AvPacketGuard, open_input_ctx, open_url_ctx};
+use crate::shared::guards_inner::{open_input_ctx, open_url_ctx};
 
 /// Internal decoder state holding FFmpeg contexts.
 ///
@@ -69,9 +69,9 @@ pub(crate) struct AudioDecoderInner {
     /// Current playback position
     position: Duration,
     /// Reusable packet for reading from file
-    packet: *mut AVPacket,
+    packet: Packet,
     /// Reusable frame for decoding
-    frame: *mut AVFrame,
+    frame: Frame,
     /// URL used to open this source — `None` for file-path sources.
     url: Option<String>,
     /// Network options used for the initial open (timeouts, reconnect config).
@@ -164,18 +164,14 @@ impl AudioDecoderInner {
         // Find the decoder for this codec
         // SAFETY: codec_id is valid from FFmpeg
         let codec_name = unsafe { Self::extract_codec_name(codec_id) };
-        let codec = unsafe {
-            ff_sys::avcodec::find_decoder(codec_id).ok_or_else(|| {
-                DecodeError::UnsupportedCodec {
-                    codec: format!("{codec_name} (codec_id={codec_id:?})"),
-                }
-            })?
-        };
+        let codec =
+            ff_sys::Codec::find_decoder(codec_id).ok_or_else(|| DecodeError::UnsupportedCodec {
+                codec: format!("{codec_name} (codec_id={codec_id:?})"),
+            })?;
 
         // Allocate codec context (freed on drop by CodecContext).
-        // SAFETY: codec pointer is valid.
         let mut codec_ctx =
-            unsafe { ff_sys::CodecContext::new(codec) }.map_err(|e| DecodeError::Ffmpeg {
+            ff_sys::CodecContext::new(Some(codec)).map_err(|e| DecodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(
                     "Failed to allocate codec context: {}",
@@ -227,10 +223,22 @@ impl AudioDecoderInner {
         // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
         let container_info = unsafe { Self::extract_container_info(ctx.as_mut_ptr()) };
 
-        // Allocate packet and frame (with RAII guards)
-        // SAFETY: FFmpeg is initialized, guards ensure cleanup
-        let packet_guard = unsafe { AvPacketGuard::new()? };
-        let frame_guard = unsafe { AvFrameGuard::new()? };
+        // Allocate packet and frame (owned; free on drop, including on an early
+        // return from a later `?` in this constructor).
+        let packet = Packet::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate packet: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
+        let frame = Frame::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate frame: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         // All initialization successful - transfer ownership to AudioDecoderInner
         Ok((
@@ -246,8 +254,8 @@ impl AudioDecoderInner {
                 is_live,
                 eof: false,
                 position: Duration::ZERO,
-                packet: packet_guard.into_raw(),
-                frame: frame_guard.into_raw(),
+                packet,
+                frame,
                 url,
                 network_opts: stored_network_opts,
                 reconnect_count: 0,
@@ -474,7 +482,7 @@ impl AudioDecoderInner {
         unsafe {
             loop {
                 // Try to receive a frame from the decoder
-                match self.codec_ctx.receive_frame(self.frame).map_err(|e| {
+                match self.codec_ctx.receive_frame(&mut self.frame).map_err(|e| {
                     DecodeError::DecodingFailed {
                         timestamp: Some(self.position),
                         reason: ff_sys::av_error_string(e.code()),
@@ -483,7 +491,7 @@ impl AudioDecoderInner {
                     ff_sys::ReceiveOutcome::Frame => {
                         // Successfully received a frame
                         let audio_frame = resample_inner::convert_frame_to_audio_frame(
-                            self.frame,
+                            self.frame.as_mut_ptr(),
                             self.format_ctx.as_mut_ptr(),
                             self.stream_index,
                             self.output_format,
@@ -494,7 +502,7 @@ impl AudioDecoderInner {
                         )?;
 
                         // Update position based on frame timestamp
-                        let pts = (*self.frame).pts;
+                        let pts = (*self.frame.as_ptr()).pts;
                         if pts != ff_sys::AV_NOPTS_VALUE {
                             let stream = (*self.format_ctx.as_ptr())
                                 .streams
@@ -510,7 +518,7 @@ impl AudioDecoderInner {
                     ff_sys::ReceiveOutcome::NeedInput => {
                         // Need to send more packets to the decoder
                         // Read a packet from the file
-                        match self.format_ctx.read_frame(self.packet) {
+                        match self.format_ctx.read_frame(&mut self.packet) {
                             Ok(()) => {}
                             Err(e) if e.is_eof() => {
                                 // End of file - flush the decoder
@@ -539,10 +547,10 @@ impl AudioDecoderInner {
                         }
 
                         // Check if this packet belongs to the audio stream
-                        if (*self.packet).stream_index == self.stream_index {
+                        if (*self.packet.as_ptr()).stream_index == self.stream_index {
                             // Send the packet to the decoder
-                            let send_result = self.codec_ctx.send_packet(self.packet);
-                            ff_sys::av_packet_unref(self.packet);
+                            let send_result = self.codec_ctx.send_packet(&self.packet);
+                            self.packet.unref();
 
                             if let Err(se) = send_result
                                 && !se.is_eagain()
@@ -557,7 +565,7 @@ impl AudioDecoderInner {
                             }
                         } else {
                             // Not our stream, unref and continue
-                            ff_sys::av_packet_unref(self.packet);
+                            self.packet.unref();
                         }
                     }
                     ff_sys::ReceiveOutcome::Drained => {
@@ -624,11 +632,8 @@ impl AudioDecoderInner {
         let flags = ff_sys::avformat::seek_flags::BACKWARD;
 
         // 1. Clear any pending packet and frame
-        // SAFETY: packet and frame are valid (owned by AudioDecoderInner)
-        unsafe {
-            ff_sys::av_packet_unref(self.packet);
-            ff_sys::av_frame_unref(self.frame);
-        }
+        self.packet.unref();
+        self.frame.unref();
 
         // 2. Seek in the format context
         self.format_ctx
@@ -646,14 +651,12 @@ impl AudioDecoderInner {
         self.swr_key = None;
 
         // 4. Drain any remaining frames from the decoder after flush
-        // SAFETY: codec_ctx and frame are valid
-        unsafe {
-            // Drain while frames are produced. NeedInput / Drained / real errors all
-            // end draining (preserves the pre-migration `Err(_) => break` behaviour that
-            // swallowed errors here).
-            while let Ok(ff_sys::ReceiveOutcome::Frame) = self.codec_ctx.receive_frame(self.frame) {
-                ff_sys::av_frame_unref(self.frame);
-            }
+        // Drain while frames are produced. NeedInput / Drained / real errors all
+        // end draining (preserves the pre-migration `Err(_) => break` behaviour that
+        // swallowed errors here).
+        while let Ok(ff_sys::ReceiveOutcome::Frame) = self.codec_ctx.receive_frame(&mut self.frame)
+        {
+            self.frame.unref();
         }
 
         // 5. Reset internal state
@@ -770,27 +773,9 @@ impl AudioDecoderInner {
     }
 }
 
-impl Drop for AudioDecoderInner {
-    fn drop(&mut self) {
-        // Free frame and packet
-        if !self.frame.is_null() {
-            // SAFETY: self.frame is valid and owned by this instance
-            unsafe {
-                ff_sys::av_frame_free(&mut (self.frame as *mut _));
-            }
-        }
-
-        if !self.packet.is_null() {
-            // SAFETY: self.packet is valid and owned by this instance
-            unsafe {
-                ff_sys::av_packet_free(&mut (self.packet as *mut _));
-            }
-        }
-
-        // The `format_ctx` (InputFormatContext) drops automatically after this
-        // Drop body, closing the demux context last.
-    }
-}
+// All fields own their FFmpeg resources (`Frame`, `Packet`, `CodecContext`,
+// `InputFormatContext`, `ResampleContext`) and free themselves on drop, so no
+// manual `Drop` impl is required.
 
 // SAFETY: AudioDecoderInner manages FFmpeg contexts which are thread-safe when not shared.
 // We don't expose mutable access across threads, so Send is safe.

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -25,8 +25,8 @@ use std::ptr;
 use ff_format::time::{Rational, Timestamp};
 use ff_format::{PixelFormat, PooledBuffer, VideoFrame};
 use ff_sys::{
-    AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket, AVPixelFormat,
-    InputFormatContext,
+    AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame,
+    InputFormatContext, Packet,
 };
 
 use crate::error::DecodeError;
@@ -46,9 +46,9 @@ pub(crate) struct ImageDecoderInner {
     /// Video stream index in the format context.
     stream_index: usize,
     /// Reusable packet for reading from file.
-    packet: *mut AVPacket,
+    packet: Packet,
     /// Reusable frame for decoding.
-    frame: *mut AVFrame,
+    frame: Frame,
 }
 
 // SAFETY: `ImageDecoderInner` owns all FFmpeg contexts exclusively.
@@ -100,18 +100,14 @@ impl ImageDecoderInner {
                 CStr::from_ptr(name_ptr).to_string_lossy().into_owned()
             }
         };
-        let codec = unsafe {
-            ff_sys::avcodec::find_decoder(codec_id).ok_or_else(|| {
-                DecodeError::UnsupportedCodec {
-                    codec: format!("{codec_name} (codec_id={codec_id:?})"),
-                }
-            })?
-        };
+        let codec =
+            ff_sys::Codec::find_decoder(codec_id).ok_or_else(|| DecodeError::UnsupportedCodec {
+                codec: format!("{codec_name} (codec_id={codec_id:?})"),
+            })?;
 
         // 5. avcodec_alloc_context3 (freed on drop by CodecContext).
-        // SAFETY: codec pointer is valid.
         let mut codec_ctx =
-            unsafe { ff_sys::CodecContext::new(codec) }.map_err(|e| DecodeError::Ffmpeg {
+            ff_sys::CodecContext::new(Some(codec)).map_err(|e| DecodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(
                     "Failed to allocate codec context: {}",
@@ -149,23 +145,22 @@ impl ImageDecoderInner {
                 })?;
         }
 
-        // Allocate packet and frame.
-        // SAFETY: FFmpeg is initialized.
-        let packet = unsafe { ff_sys::av_packet_alloc() };
-        if packet.is_null() {
-            return Err(DecodeError::Ffmpeg {
-                code: 0,
-                message: "Failed to allocate packet".to_string(),
-            });
-        }
-        let frame = unsafe { ff_sys::av_frame_alloc() };
-        if frame.is_null() {
-            unsafe { ff_sys::av_packet_free(&mut (packet as *mut _)) };
-            return Err(DecodeError::Ffmpeg {
-                code: 0,
-                message: "Failed to allocate frame".to_string(),
-            });
-        }
+        // Allocate packet and frame (owned; free on drop, including on an early
+        // return from a later `?` — the packet frees itself if the frame alloc fails).
+        let packet = Packet::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate packet: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
+        let frame = Frame::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate frame: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         Ok(Self {
             format_ctx: ctx,
@@ -197,8 +192,7 @@ impl ImageDecoderInner {
     /// 4. Convert to [`VideoFrame`]
     pub(crate) fn decode(mut self) -> Result<VideoFrame, DecodeError> {
         // 1. av_read_frame
-        // SAFETY: format_ctx and packet are valid.
-        if let Err(e) = unsafe { self.format_ctx.read_frame(self.packet) } {
+        if let Err(e) = self.format_ctx.read_frame(&mut self.packet) {
             let ret = e.code();
             return Err(DecodeError::Ffmpeg {
                 code: ret,
@@ -207,9 +201,8 @@ impl ImageDecoderInner {
         }
 
         // 2. avcodec_send_packet
-        // SAFETY: codec_ctx is owned; packet is valid and contains image data.
-        let send_result = unsafe { self.codec_ctx.send_packet(self.packet) };
-        unsafe { ff_sys::av_packet_unref(self.packet) };
+        let send_result = self.codec_ctx.send_packet(&self.packet);
+        self.packet.unref();
         if let Err(e) = send_result {
             return Err(DecodeError::Ffmpeg {
                 code: e.code(),
@@ -221,18 +214,16 @@ impl ImageDecoderInner {
         }
 
         // 3. avcodec_receive_frame
-        // SAFETY: codec_ctx is owned; frame is valid.
-        match unsafe {
-            self.codec_ctx
-                .receive_frame(self.frame)
-                .map_err(|e| DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to receive decoded frame: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                })?
-        } {
+        match self
+            .codec_ctx
+            .receive_frame(&mut self.frame)
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to receive decoded frame: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })? {
             ff_sys::ReceiveOutcome::Frame => {}
             // Preserve the pre-migration behaviour: a bare EAGAIN/EOF from this
             // single receive was surfaced as a `Ffmpeg` error with that raw code.
@@ -258,7 +249,7 @@ impl ImageDecoderInner {
 
         // 4. Convert to VideoFrame.
         // SAFETY: frame is valid and contains decoded image data.
-        let video_frame = unsafe { self.av_frame_to_video_frame(self.frame)? };
+        let video_frame = unsafe { self.av_frame_to_video_frame(self.frame.as_ptr())? };
         Ok(video_frame)
     }
 
@@ -558,22 +549,9 @@ impl ImageDecoderInner {
     }
 }
 
-impl Drop for ImageDecoderInner {
-    fn drop(&mut self) {
-        // SAFETY: All pointers are exclusively owned by this struct and were
-        // allocated by the corresponding FFmpeg alloc functions.
-        unsafe {
-            if !self.frame.is_null() {
-                ff_sys::av_frame_free(&mut (self.frame as *mut _));
-            }
-            if !self.packet.is_null() {
-                ff_sys::av_packet_free(&mut (self.packet as *mut _));
-            }
-        }
-        // The `format_ctx` (InputFormatContext) drops automatically after this
-        // Drop body, closing the demux context last.
-    }
-}
+// All fields own their FFmpeg resources (`Frame`, `Packet`, `CodecContext`,
+// `InputFormatContext`) and free themselves on drop, so no manual `Drop` impl is
+// required.
 
 #[cfg(test)]
 mod tests {

--- a/crates/ff-decode/src/shared/guards_inner.rs
+++ b/crates/ff-decode/src/shared/guards_inner.rs
@@ -1,12 +1,8 @@
-//! Shared RAII guards over raw `FFmpeg` pointers used by the audio, image, and
-//! video decoders, plus input-context open helpers.
+//! Input-context open helpers for the audio, image, and video decoders.
 //!
-//! Each guard owns a `*mut` `FFmpeg` handle and frees it in `Drop`. The
-//! constructors are the union of what the three decoders need — every method is
-//! used by at least one decoder. The open helpers wrap
-//! [`ff_sys::InputFormatContext`] constructors with the decoders' `DecodeError`
-//! mapping. All `unsafe` is isolated here per the project's unsafe-code
-//! convention (`*_inner.rs` files only).
+//! The open helpers wrap [`ff_sys::InputFormatContext`] constructors with the
+//! decoders' `DecodeError` mapping. All `unsafe` is isolated here per the
+//! project's unsafe-code convention (`*_inner.rs` files only).
 
 #![allow(unsafe_code)]
 #![allow(clippy::ptr_as_ptr)]
@@ -15,7 +11,6 @@
 use std::path::Path;
 
 use ff_format::NetworkOptions;
-use ff_sys::{AVFrame, AVPacket};
 
 use crate::error::DecodeError;
 use crate::network::{map_network_error, sanitize_url};
@@ -51,89 +46,4 @@ pub(crate) fn open_url_ctx(
 ) -> Result<ff_sys::InputFormatContext, DecodeError> {
     ff_sys::InputFormatContext::open_url(url, network.connect_timeout, network.read_timeout)
         .map_err(|e| map_network_error(e.code(), sanitize_url(url)))
-}
-
-/// RAII guard for `AVPacket` to ensure proper cleanup.
-pub(crate) struct AvPacketGuard(*mut AVPacket);
-
-impl AvPacketGuard {
-    /// Creates a new guard by allocating a packet.
-    ///
-    /// # Safety
-    ///
-    /// Must be called after FFmpeg initialization.
-    pub(crate) unsafe fn new() -> Result<Self, DecodeError> {
-        // SAFETY: Caller ensures FFmpeg is initialized
-        let packet = unsafe { ff_sys::av_packet_alloc() };
-        if packet.is_null() {
-            return Err(DecodeError::Ffmpeg {
-                code: 0,
-                message: "Failed to allocate packet".to_string(),
-            });
-        }
-        Ok(Self(packet))
-    }
-
-    /// Consumes the guard and returns the raw pointer without dropping.
-    pub(crate) fn into_raw(self) -> *mut AVPacket {
-        let ptr = self.0;
-        std::mem::forget(self);
-        ptr
-    }
-}
-
-impl Drop for AvPacketGuard {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            // SAFETY: self.0 is valid and owned by this guard
-            unsafe {
-                ff_sys::av_packet_free(&mut (self.0 as *mut _));
-            }
-        }
-    }
-}
-
-/// RAII guard for `AVFrame` to ensure proper cleanup.
-pub(crate) struct AvFrameGuard(*mut AVFrame);
-
-impl AvFrameGuard {
-    /// Creates a new guard by allocating a frame.
-    ///
-    /// # Safety
-    ///
-    /// Must be called after FFmpeg initialization.
-    pub(crate) unsafe fn new() -> Result<Self, DecodeError> {
-        // SAFETY: Caller ensures FFmpeg is initialized
-        let frame = unsafe { ff_sys::av_frame_alloc() };
-        if frame.is_null() {
-            return Err(DecodeError::Ffmpeg {
-                code: 0,
-                message: "Failed to allocate frame".to_string(),
-            });
-        }
-        Ok(Self(frame))
-    }
-
-    /// Returns the raw pointer.
-    pub(crate) const fn as_ptr(&self) -> *mut AVFrame {
-        self.0
-    }
-
-    /// Consumes the guard and returns the raw pointer without dropping.
-    pub(crate) fn into_raw(self) -> *mut AVFrame {
-        let ptr = self.0;
-        std::mem::forget(self);
-        ptr
-    }
-}
-
-impl Drop for AvFrameGuard {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            // SAFETY: self.0 is valid and owned by this guard
-            unsafe {
-                ff_sys::av_frame_free(&mut (self.0 as *mut _));
-            }
-        }
-    }
 }

--- a/crates/ff-decode/src/video/decoder_inner/decoding.rs
+++ b/crates/ff-decode/src/video/decoder_inner/decoding.rs
@@ -37,7 +37,7 @@ impl VideoDecoderInner {
         unsafe {
             loop {
                 // Try to receive a frame from the decoder
-                match self.codec_ctx.receive_frame(self.frame).map_err(|e| {
+                match self.codec_ctx.receive_frame(&mut self.frame).map_err(|e| {
                     DecodeError::DecodingFailed {
                         timestamp: Some(self.position),
                         reason: ff_sys::av_error_string(e.code()),
@@ -51,8 +51,8 @@ impl VideoDecoderInner {
                         self.transfer_hardware_frame_if_needed()?;
 
                         // SAFETY: self.frame is valid and non-null after receive_frame succeeded.
-                        let w = (*self.frame).width as u32;
-                        let h = (*self.frame).height as u32;
+                        let w = (*self.frame.as_ptr()).width as u32;
+                        let h = (*self.frame.as_ptr()).height as u32;
                         if w > 32_768 || h > 32_768 {
                             log::warn!(
                                 "frame rejected reason=unsupported_resolution width={w} height={h}"
@@ -66,7 +66,7 @@ impl VideoDecoderInner {
                         let video_frame = self.convert_frame_to_video_frame()?;
 
                         // Update position based on frame timestamp
-                        let pts = (*self.frame).pts;
+                        let pts = (*self.frame.as_ptr()).pts;
                         if pts != ff_sys::AV_NOPTS_VALUE {
                             let stream = (*self.format_ctx.as_ptr())
                                 .streams
@@ -82,7 +82,7 @@ impl VideoDecoderInner {
                     ff_sys::ReceiveOutcome::NeedInput => {
                         // Need to send more packets to the decoder
                         // Read a packet from the file
-                        match self.format_ctx.read_frame(self.packet) {
+                        match self.format_ctx.read_frame(&mut self.packet) {
                             Ok(()) => {}
                             Err(e) if e.is_eof() => {
                                 // End of file - flush the decoder
@@ -111,12 +111,12 @@ impl VideoDecoderInner {
                         }
 
                         // Check if this packet belongs to the video stream
-                        if (*self.packet).stream_index == self.stream_index {
+                        if (*self.packet.as_ptr()).stream_index == self.stream_index {
                             // Send the packet to the decoder
-                            let send_result = self.codec_ctx.send_packet(self.packet);
+                            let send_result = self.codec_ctx.send_packet(&self.packet);
                             // SAFETY: self.packet is valid and non-null; pts is a plain i64 field.
-                            let pkt_pts = (*self.packet).pts;
-                            ff_sys::av_packet_unref(self.packet);
+                            let pkt_pts = (*self.packet.as_ptr()).pts;
+                            self.packet.unref();
 
                             if let Err(se) = send_result {
                                 if se.code() == ff_sys::error_codes::AVERROR_INVALIDDATA {
@@ -144,7 +144,7 @@ impl VideoDecoderInner {
                             }
                         } else {
                             // Not our stream, unref and continue
-                            ff_sys::av_packet_unref(self.packet);
+                            self.packet.unref();
                         }
                     }
                     ff_sys::ReceiveOutcome::Drained => {
@@ -161,9 +161,9 @@ impl VideoDecoderInner {
     unsafe fn convert_frame_to_video_frame(&mut self) -> Result<VideoFrame, DecodeError> {
         // SAFETY: Caller ensures self.frame is valid
         unsafe {
-            let src_width = (*self.frame).width as u32;
-            let src_height = (*self.frame).height as u32;
-            let src_format = (*self.frame).format;
+            let src_width = (*self.frame.as_ptr()).width as u32;
+            let src_height = (*self.frame.as_ptr()).height as u32;
+            let src_format = (*self.frame.as_ptr()).format;
 
             // Determine output format
             let dst_format = if let Some(fmt) = self.output_format {
@@ -184,7 +184,7 @@ impl VideoDecoderInner {
                     src_width, src_height, src_format, dst_width, dst_height, dst_format,
                 )
             } else {
-                self.av_frame_to_video_frame(self.frame)
+                self.av_frame_to_video_frame(self.frame.as_ptr())
             }
         }
     }

--- a/crates/ff-decode/src/video/decoder_inner/format_convert.rs
+++ b/crates/ff-decode/src/video/decoder_inner/format_convert.rs
@@ -1,7 +1,6 @@
 use super::{
-    AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace, AVPixelFormat, AvFrameGuard,
-    ColorPrimaries, ColorRange, ColorSpace, DecodeError, PixelFormat, VideoCodec,
-    VideoDecoderInner, VideoFrame,
+    AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace, AVPixelFormat, ColorPrimaries,
+    ColorRange, ColorSpace, DecodeError, PixelFormat, VideoCodec, VideoDecoderInner, VideoFrame,
 };
 
 impl VideoDecoderInner {
@@ -211,35 +210,37 @@ impl VideoDecoderInner {
                 });
             };
 
-            // Allocate destination frame (with RAII guard)
-            let dst_frame_guard = AvFrameGuard::new()?;
-            let dst_frame = dst_frame_guard.as_ptr();
+            // Allocate destination frame (owned; freed on scope exit by Drop).
+            let mut dst_frame = ff_sys::Frame::new().map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate frame: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
-            (*dst_frame).width = dst_width as i32;
-            (*dst_frame).height = dst_height as i32;
-            (*dst_frame).format = dst_format;
+            (*dst_frame.as_mut_ptr()).width = dst_width as i32;
+            (*dst_frame.as_mut_ptr()).height = dst_height as i32;
+            (*dst_frame.as_mut_ptr()).format = dst_format;
 
             // Allocate buffer for destination frame
-            let buffer_ret = ff_sys::av_frame_get_buffer(dst_frame, 0);
-            if buffer_ret < 0 {
-                return Err(DecodeError::Ffmpeg {
-                    code: buffer_ret,
-                    message: format!(
-                        "Failed to allocate frame buffer: {}",
-                        ff_sys::av_error_string(buffer_ret)
-                    ),
-                });
-            }
+            dst_frame.get_buffer(0).map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate frame buffer: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
             // Perform conversion/scaling (src_height is the number of input rows to process)
             sws_ctx
                 .scale(
-                    (*self.frame).data.as_ptr() as *const *const u8,
-                    (*self.frame).linesize.as_ptr(),
+                    (*self.frame.as_ptr()).data.as_ptr() as *const *const u8,
+                    (*self.frame.as_ptr()).linesize.as_ptr(),
                     0,
                     src_height as i32,
-                    (*dst_frame).data.as_ptr() as *const *mut u8,
-                    (*dst_frame).linesize.as_ptr(),
+                    (*dst_frame.as_ptr()).data.as_ptr() as *const *mut u8,
+                    (*dst_frame.as_ptr()).linesize.as_ptr(),
                 )
                 .map_err(|e| DecodeError::Ffmpeg {
                     code: 0,
@@ -247,12 +248,12 @@ impl VideoDecoderInner {
                 })?;
 
             // Copy timestamp
-            (*dst_frame).pts = (*self.frame).pts;
+            (*dst_frame.as_mut_ptr()).pts = (*self.frame.as_ptr()).pts;
 
             // Convert to VideoFrame
-            let video_frame = self.av_frame_to_video_frame(dst_frame)?;
+            let video_frame = self.av_frame_to_video_frame(dst_frame.as_ptr())?;
 
-            // dst_frame is automatically freed when guard drops
+            // dst_frame is automatically freed when it drops at scope end
 
             Ok(video_frame)
         }

--- a/crates/ff-decode/src/video/decoder_inner/hardware.rs
+++ b/crates/ff-decode/src/video/decoder_inner/hardware.rs
@@ -170,36 +170,34 @@ impl VideoDecoderInner {
     /// Caller must ensure `self.frame` contains a valid decoded frame.
     pub(super) unsafe fn transfer_hardware_frame_if_needed(&mut self) -> Result<(), DecodeError> {
         // SAFETY: self.frame is valid and owned by this instance
-        let frame_format = unsafe { (*self.frame).format };
+        let frame_format = unsafe { (*self.frame.as_ptr()).format };
 
         if !Self::is_hardware_format(frame_format) {
             // Not a hardware frame, no transfer needed
             return Ok(());
         }
 
-        // Create a temporary software frame for transfer
-        // SAFETY: FFmpeg is initialized
-        let sw_frame = unsafe { ff_sys::av_frame_alloc() };
-        if sw_frame.is_null() {
-            return Err(DecodeError::Ffmpeg {
-                code: 0,
-                message: "Failed to allocate software frame for hardware transfer".to_string(),
-            });
-        }
+        // Create a temporary software frame for transfer (owned; freed on scope exit).
+        let mut sw_frame = ff_sys::Frame::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate software frame for hardware transfer: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         // Transfer data from hardware frame to software frame
         // SAFETY: self.frame and sw_frame are valid
         let ret = unsafe {
             ff_sys::av_hwframe_transfer_data(
-                sw_frame, self.frame, 0, // flags: currently unused
+                sw_frame.as_mut_ptr(),
+                self.frame.as_ptr(),
+                0, // flags: currently unused
             )
         };
 
         if ret < 0 {
-            // Transfer failed, clean up
-            unsafe {
-                ff_sys::av_frame_free(&mut (sw_frame as *mut _));
-            }
+            // Transfer failed; sw_frame frees itself on return.
             return Err(DecodeError::Ffmpeg {
                 code: ret,
                 message: format!(
@@ -212,19 +210,17 @@ impl VideoDecoderInner {
         // Copy metadata (pts, duration, etc.) from hardware frame to software frame
         // SAFETY: Both frames are valid
         unsafe {
-            (*sw_frame).pts = (*self.frame).pts;
-            (*sw_frame).pkt_dts = (*self.frame).pkt_dts;
-            (*sw_frame).duration = (*self.frame).duration;
-            (*sw_frame).time_base = (*self.frame).time_base;
+            (*sw_frame.as_mut_ptr()).pts = (*self.frame.as_ptr()).pts;
+            (*sw_frame.as_mut_ptr()).pkt_dts = (*self.frame.as_ptr()).pkt_dts;
+            (*sw_frame.as_mut_ptr()).duration = (*self.frame.as_ptr()).duration;
+            (*sw_frame.as_mut_ptr()).time_base = (*self.frame.as_ptr()).time_base;
         }
 
-        // Replace self.frame with the software frame
-        // SAFETY: self.frame is valid and owned by this instance
-        unsafe {
-            ff_sys::av_frame_unref(self.frame);
-            ff_sys::av_frame_move_ref(self.frame, sw_frame);
-            ff_sys::av_frame_free(&mut (sw_frame as *mut _));
-        }
+        // Replace self.frame with the software frame. `move_ref` transfers
+        // sw_frame's buffers into self.frame, leaving sw_frame blank (freed on
+        // scope exit).
+        self.frame.unref();
+        self.frame.move_ref(&mut sw_frame);
 
         Ok(())
     }

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -38,15 +38,13 @@ use ff_format::time::{Rational, Timestamp};
 use ff_format::{PixelFormat, VideoFrame, VideoStreamInfo};
 use ff_sys::{
     AVBufferRef, AVCodecContext, AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace,
-    AVFormatContext, AVFrame, AVHWDeviceType, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPacket,
-    AVPixelFormat, InputFormatContext,
+    AVFormatContext, AVFrame, AVHWDeviceType, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame,
+    InputFormatContext, Packet,
 };
 
 use crate::HardwareAccel;
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{
-    AvFrameGuard, AvPacketGuard, open_image_sequence_ctx, open_input_ctx, open_url_ctx,
-};
+use crate::shared::guards_inner::{open_image_sequence_ctx, open_input_ctx, open_url_ctx};
 use crate::video::builder::OutputScale;
 use ff_common::FramePool;
 
@@ -89,9 +87,9 @@ pub(crate) struct VideoDecoderInner {
     /// Current playback position
     pub(super) position: Duration,
     /// Reusable packet for reading from file
-    pub(super) packet: *mut AVPacket,
+    pub(super) packet: Packet,
     /// Reusable frame for decoding
-    pub(super) frame: *mut AVFrame,
+    pub(super) frame: Frame,
     /// Cached SwScale context for thumbnail generation
     pub(super) thumbnail_sws_ctx: Option<ff_sys::ScaleContext>,
     /// Last thumbnail dimensions (for cache invalidation)
@@ -204,29 +202,26 @@ impl VideoDecoderInner {
         // Find the decoder for this codec
         // SAFETY: codec_id is valid from FFmpeg
         let codec_name = unsafe { Self::extract_codec_name(codec_id) };
-        let codec = unsafe {
-            ff_sys::avcodec::find_decoder(codec_id).ok_or_else(|| {
-                // Distinguish between a totally unknown codec ID and a known codec
-                // whose decoder was not compiled into this FFmpeg build.
-                if codec_id == ff_sys::AVCodecID_AV_CODEC_ID_EXR {
-                    DecodeError::DecoderUnavailable {
-                        codec: "exr".to_string(),
-                        hint: "Requires FFmpeg built with EXR support \
-                               (--enable-decoder=exr)"
-                            .to_string(),
-                    }
-                } else {
-                    DecodeError::UnsupportedCodec {
-                        codec: format!("{codec_name} (codec_id={codec_id:?})"),
-                    }
+        let codec = ff_sys::Codec::find_decoder(codec_id).ok_or_else(|| {
+            // Distinguish between a totally unknown codec ID and a known codec
+            // whose decoder was not compiled into this FFmpeg build.
+            if codec_id == ff_sys::AVCodecID_AV_CODEC_ID_EXR {
+                DecodeError::DecoderUnavailable {
+                    codec: "exr".to_string(),
+                    hint: "Requires FFmpeg built with EXR support \
+                           (--enable-decoder=exr)"
+                        .to_string(),
                 }
-            })?
-        };
+            } else {
+                DecodeError::UnsupportedCodec {
+                    codec: format!("{codec_name} (codec_id={codec_id:?})"),
+                }
+            }
+        })?;
 
         // Allocate codec context (freed on drop by CodecContext).
-        // SAFETY: codec pointer is valid.
         let mut codec_ctx =
-            unsafe { ff_sys::CodecContext::new(codec) }.map_err(|e| DecodeError::Ffmpeg {
+            ff_sys::CodecContext::new(Some(codec)).map_err(|e| DecodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(
                     "Failed to allocate codec context: {}",
@@ -295,10 +290,22 @@ impl VideoDecoderInner {
         // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
         let container_info = unsafe { Self::extract_container_info(ctx.as_mut_ptr()) };
 
-        // Allocate packet and frame (with RAII guards)
-        // SAFETY: FFmpeg is initialized, guards ensure cleanup
-        let packet_guard = unsafe { AvPacketGuard::new()? };
-        let frame_guard = unsafe { AvFrameGuard::new()? };
+        // Allocate packet and frame (owned; free on drop, including on an early
+        // return from a later `?` in this constructor).
+        let packet = Packet::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate packet: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
+        let frame = Frame::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate frame: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         // All initialization successful - transfer ownership to VideoDecoderInner
         Ok((
@@ -313,8 +320,8 @@ impl VideoDecoderInner {
                 is_live,
                 eof: false,
                 position: Duration::ZERO,
-                packet: packet_guard.into_raw(),
-                frame: frame_guard.into_raw(),
+                packet,
+                frame,
                 thumbnail_sws_ctx: None,
                 thumbnail_cache_key: None,
                 hw_device_ctx,
@@ -344,23 +351,9 @@ impl Drop for VideoDecoderInner {
             }
         }
 
-        // Free frame and packet
-        if !self.frame.is_null() {
-            // SAFETY: self.frame is valid and owned by this instance
-            unsafe {
-                ff_sys::av_frame_free(&mut (self.frame as *mut _));
-            }
-        }
-
-        if !self.packet.is_null() {
-            // SAFETY: self.packet is valid and owned by this instance
-            unsafe {
-                ff_sys::av_packet_free(&mut (self.packet as *mut _));
-            }
-        }
-
-        // The `format_ctx` (InputFormatContext) drops automatically after this
-        // Drop body, closing the demux context last.
+        // The owned `frame` (Frame) and `packet` (Packet) free themselves when
+        // this struct drops. The `format_ctx` (InputFormatContext) drops
+        // automatically after this Drop body, closing the demux context last.
     }
 }
 

--- a/crates/ff-decode/src/video/decoder_inner/seeking.rs
+++ b/crates/ff-decode/src/video/decoder_inner/seeking.rs
@@ -1,6 +1,6 @@
 use super::{
-    AvFrameGuard, DecodeError, Duration, KEYFRAME_SEEK_TOLERANCE_SECS, VideoDecoderInner,
-    VideoFrame, open_url_ctx,
+    DecodeError, Duration, KEYFRAME_SEEK_TOLERANCE_SECS, VideoDecoderInner, VideoFrame,
+    open_url_ctx,
 };
 
 impl VideoDecoderInner {
@@ -106,10 +106,8 @@ impl VideoDecoderInner {
         // SAFETY:
         // - packet is valid: allocated in constructor, owned by VideoDecoderInner
         // - frame is valid: allocated in constructor, owned by VideoDecoderInner
-        unsafe {
-            ff_sys::av_packet_unref(self.packet);
-            ff_sys::av_frame_unref(self.frame);
-        }
+        self.packet.unref();
+        self.frame.unref();
 
         // 2. Seek in the format context (file is NOT reopened)
         // Use av_seek_frame with the stream index and timestamp in stream time_base units
@@ -127,12 +125,11 @@ impl VideoDecoderInner {
         // 4. Drain any remaining frames from the decoder after flush
         // This ensures no stale frames are returned after the seek
         // SAFETY: frame is valid: allocated in constructor, owned by VideoDecoderInner
-        unsafe {
-            // Drain while frames are produced. NeedInput / Drained / any error all stop
-            // draining (preserves the pre-migration `Err(_) => break` behaviour).
-            while let Ok(ff_sys::ReceiveOutcome::Frame) = self.codec_ctx.receive_frame(self.frame) {
-                ff_sys::av_frame_unref(self.frame);
-            }
+        // Drain while frames are produced. NeedInput / Drained / any error all stop
+        // draining (preserves the pre-migration `Err(_) => break` behaviour).
+        while let Ok(ff_sys::ReceiveOutcome::Frame) = self.codec_ctx.receive_frame(&mut self.frame)
+        {
+            self.frame.unref();
         }
 
         // 5. Reset internal state
@@ -343,13 +340,18 @@ impl VideoDecoderInner {
                 });
             };
 
-            // Set up source frame with VideoFrame data
-            let src_frame_guard = AvFrameGuard::new()?;
-            let src_frame = src_frame_guard.as_ptr();
+            // Set up source frame with VideoFrame data (owned; freed on scope exit).
+            let mut src_frame = ff_sys::Frame::new().map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate frame: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
-            (*src_frame).width = src_width as i32;
-            (*src_frame).height = src_height as i32;
-            (*src_frame).format = av_format;
+            (*src_frame.as_mut_ptr()).width = src_width as i32;
+            (*src_frame.as_mut_ptr()).height = src_height as i32;
+            (*src_frame.as_mut_ptr()).format = av_format;
 
             // Set up source frame data pointers directly from VideoFrame (no copy)
             let planes = frame.planes();
@@ -359,41 +361,45 @@ impl VideoDecoderInner {
                 if i >= ff_sys::AV_NUM_DATA_POINTERS as usize {
                     break;
                 }
-                (*src_frame).data[i] = plane_data.as_ref().as_ptr().cast_mut();
-                (*src_frame).linesize[i] = strides[i] as i32;
+                (*src_frame.as_mut_ptr()).data[i] = plane_data.as_ref().as_ptr().cast_mut();
+                (*src_frame.as_mut_ptr()).linesize[i] = strides[i] as i32;
             }
 
-            // Allocate destination frame
-            let dst_frame_guard = AvFrameGuard::new()?;
-            let dst_frame = dst_frame_guard.as_ptr();
+            // Allocate destination frame (owned; freed on scope exit).
+            let mut dst_frame = ff_sys::Frame::new().map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate frame: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
-            (*dst_frame).width = scaled_width as i32;
-            (*dst_frame).height = scaled_height as i32;
-            (*dst_frame).format = av_format;
+            (*dst_frame.as_mut_ptr()).width = scaled_width as i32;
+            (*dst_frame.as_mut_ptr()).height = scaled_height as i32;
+            (*dst_frame.as_mut_ptr()).format = av_format;
 
             // Allocate buffer for destination frame
-            let buffer_ret = ff_sys::av_frame_get_buffer(dst_frame, 0);
-            if buffer_ret < 0 {
+            if let Err(e) = dst_frame.get_buffer(0) {
                 // On a rebuild the freshly built context stays in the cache slot
                 // but keyless (thumbnail_cache_key was cleared above), so it is
                 // dropped/replaced on the next call rather than reused.
                 return Err(DecodeError::Ffmpeg {
-                    code: buffer_ret,
+                    code: e.code(),
                     message: format!(
                         "Failed to allocate destination frame buffer: {}",
-                        ff_sys::av_error_string(buffer_ret)
+                        ff_sys::av_error_string(e.code())
                     ),
                 });
             }
 
             // Perform scaling
             let scale_result = sws_ctx.scale(
-                (*src_frame).data.as_ptr() as *const *const u8,
-                (*src_frame).linesize.as_ptr(),
+                (*src_frame.as_ptr()).data.as_ptr() as *const *const u8,
+                (*src_frame.as_ptr()).linesize.as_ptr(),
                 0,
                 src_height as i32,
-                (*dst_frame).data.as_ptr() as *const *mut u8,
-                (*dst_frame).linesize.as_ptr(),
+                (*dst_frame.as_ptr()).data.as_ptr() as *const *mut u8,
+                (*dst_frame.as_ptr()).linesize.as_ptr(),
             );
 
             if let Err(e) = scale_result {
@@ -412,10 +418,10 @@ impl VideoDecoderInner {
             }
 
             // Copy timestamp
-            (*dst_frame).pts = frame.timestamp().pts();
+            (*dst_frame.as_mut_ptr()).pts = frame.timestamp().pts();
 
             // Convert destination frame to VideoFrame
-            let video_frame = self.av_frame_to_video_frame(dst_frame)?;
+            let video_frame = self.av_frame_to_video_frame(dst_frame.as_ptr())?;
 
             Ok(video_frame)
         }

--- a/crates/ff-sys/src/codec.rs
+++ b/crates/ff-sys/src/codec.rs
@@ -1,0 +1,48 @@
+//! Borrowed handle to a static FFmpeg `AVCodec`.
+//!
+//! [`Codec`] wraps a `*const AVCodec` returned by a finder such as
+//! [`find_decoder`](Codec::find_decoder). FFmpeg codecs are static singletons
+//! owned by the library, so this is a `Copy` borrowed handle with no `Drop`; it
+//! replaces the raw `*const AVCodec` in the safe API.
+
+use std::ptr::NonNull;
+
+use crate::{AVCodec, AVCodecID};
+
+/// A borrowed handle to a static FFmpeg codec.
+#[derive(Clone, Copy, Debug)]
+pub struct Codec {
+    ptr: NonNull<AVCodec>,
+}
+
+impl Codec {
+    /// Finds a decoder by codec id, returning `None` when none is registered.
+    ///
+    /// This is a pure table lookup with no precondition, so it is a safe fn.
+    #[must_use]
+    pub fn find_decoder(codec_id: AVCodecID) -> Option<Self> {
+        // SAFETY: `find_decoder` is a pure table lookup that dereferences no
+        //         caller pointer; it returns a valid static codec pointer or `None`.
+        let ptr = unsafe { crate::avcodec::find_decoder(codec_id) }?;
+        NonNull::new(ptr.cast_mut()).map(|ptr| Self { ptr })
+    }
+
+    /// Returns the underlying codec pointer for FFI calls.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVCodec {
+        self.ptr.as_ptr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_decoder_should_return_none_for_codec_none() {
+        // `AV_CODEC_ID_NONE` is the sentinel with no registered decoder, so the
+        // lookup is deterministically empty regardless of the linked FFmpeg build.
+        let result = Codec::find_decoder(crate::AVCodecID_AV_CODEC_ID_NONE);
+        assert!(result.is_none());
+    }
+}

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -2,16 +2,16 @@
 //!
 //! [`CodecContext`] allocates a codec context and frees it exactly once on drop,
 //! replacing the manual `avcodec::alloc_context3` + `avcodec::free_context` pair.
-//! Its fallible methods return [`AvError`]. Packet / frame arguments stay raw
-//! pointers for now (owned Frame / Packet are a later step), so the
-//! pointer-taking methods are `unsafe`: the caller upholds the usual FFmpeg
-//! preconditions.
+//! Its fallible methods return [`AvError`]. Packet / frame arguments are the owned
+//! [`Packet`] / [`Frame`] types, so `send_packet` / `receive_frame` are safe;
+//! `open` (raw options dictionary), `parameters_to_context` (raw parameters), and
+//! `send_eof` / `flush_buffers` (opened-context precondition) remain `unsafe`.
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
-    AVCodec, AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AvError,
+    AVCodecContext, AVCodecParameters, AVDictionary, AvError, Codec, Frame, Packet,
     avcodec_free_context as ffi_avcodec_free_context,
 };
 
@@ -54,16 +54,17 @@ pub struct CodecContext {
 }
 
 impl CodecContext {
-    /// Allocates a codec context for `codec`.
+    /// Allocates a codec context for `codec`, or a generic context when `None`.
     ///
-    /// # Safety
+    /// # Errors
     ///
-    /// `codec` must be null (yielding a generic context) or a valid
-    /// `*const AVCodec` (for example from `avcodec::find_decoder`).
-    pub unsafe fn new(codec: *const AVCodec) -> Result<Self, AvError> {
-        // SAFETY: the caller upholds the `codec` precondition; `alloc_context3`
-        //         returns a non-null context or a negative error code.
-        let ptr = unsafe { crate::avcodec::alloc_context3(codec) }.map_err(AvError::new)?;
+    /// Returns an [`AvError`] if allocation fails.
+    pub fn new(codec: Option<Codec>) -> Result<Self, AvError> {
+        let codec_ptr = codec.map_or(std::ptr::null(), |c| c.as_ptr());
+        // SAFETY: `codec_ptr` is null (yielding a generic context) or a valid static
+        //         codec pointer from `Codec`; `alloc_context3` returns a non-null
+        //         context or a negative error code.
+        let ptr = unsafe { crate::avcodec::alloc_context3(codec_ptr) }.map_err(AvError::new)?;
         // `alloc_context3` returns `Ok` only with a non-null pointer.
         NonNull::new(ptr)
             .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
@@ -100,26 +101,27 @@ impl CodecContext {
     ///
     /// # Safety
     ///
-    /// `codec` must be a valid `*const AVCodec`, and `options` must be null or a
-    /// valid `*mut *mut AVDictionary`.
+    /// `options` must be null or a valid `*mut *mut AVDictionary`.
     pub unsafe fn open(
         &mut self,
-        codec: *const AVCodec,
+        codec: Codec,
         options: *mut *mut AVDictionary,
     ) -> Result<(), AvError> {
-        // SAFETY: `self.ptr` is a valid owned context; the caller upholds
-        //         `codec` / `options`.
-        unsafe { crate::avcodec::open2(self.ptr.as_ptr(), codec, options) }.map_err(AvError::new)
+        // SAFETY: `self.ptr` is a valid owned context and `codec` is a valid static
+        //         codec; the caller upholds `options`.
+        unsafe { crate::avcodec::open2(self.ptr.as_ptr(), codec.as_ptr(), options) }
+            .map_err(AvError::new)
     }
 
-    /// Sends a packet to the decoder (a null packet flushes it).
+    /// Sends a packet to the decoder.
     ///
-    /// # Safety
+    /// # Errors
     ///
-    /// `pkt` must be null or a valid `*const AVPacket`.
-    pub unsafe fn send_packet(&mut self, pkt: *const AVPacket) -> Result<(), AvError> {
-        // SAFETY: `self.ptr` is a valid open context; the caller upholds `pkt`.
-        unsafe { crate::avcodec::send_packet(self.ptr.as_ptr(), pkt) }.map_err(AvError::new)
+    /// Returns an [`AvError`] if the decoder cannot accept the packet.
+    pub fn send_packet(&mut self, pkt: &Packet) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid open context; `pkt` is a valid owned packet.
+        unsafe { crate::avcodec::send_packet(self.ptr.as_ptr(), pkt.as_ptr()) }
+            .map_err(AvError::new)
     }
 
     /// Signals end-of-stream by sending a null packet, so the decoder enters
@@ -135,7 +137,8 @@ impl CodecContext {
     pub unsafe fn send_eof(&mut self) -> Result<(), AvError> {
         // SAFETY: the caller guarantees the context is opened; a null packet is
         //         the documented end-of-stream signal for `avcodec_send_packet`.
-        unsafe { self.send_packet(std::ptr::null()) }
+        unsafe { crate::avcodec::send_packet(self.ptr.as_ptr(), std::ptr::null()) }
+            .map_err(AvError::new)
     }
 
     /// Receives a decoded frame, returning a typed [`ReceiveOutcome`].
@@ -144,12 +147,14 @@ impl CodecContext {
     /// [`ReceiveOutcome::NeedInput`] / [`ReceiveOutcome::Drained`] rather than
     /// errors; only other negative codes are `Err`.
     ///
-    /// # Safety
+    /// # Errors
     ///
-    /// `frame` must be a valid `*mut AVFrame`.
-    pub unsafe fn receive_frame(&mut self, frame: *mut AVFrame) -> Result<ReceiveOutcome, AvError> {
-        // SAFETY: `self.ptr` is a valid open context; the caller upholds `frame`.
-        let result = unsafe { crate::avcodec::receive_frame(self.ptr.as_ptr(), frame) };
+    /// Returns an [`AvError`] on a real decode error (`EAGAIN` / `EOF` are typed
+    /// outcomes, not errors).
+    pub fn receive_frame(&mut self, frame: &mut Frame) -> Result<ReceiveOutcome, AvError> {
+        // SAFETY: `self.ptr` is a valid open context; `frame` is a valid owned frame.
+        let result =
+            unsafe { crate::avcodec::receive_frame(self.ptr.as_ptr(), frame.as_mut_ptr()) };
         classify_receive(result)
     }
 
@@ -192,10 +197,9 @@ mod tests {
 
     #[test]
     fn codec_context_new_should_allocate_and_drop_cleanly() {
-        // A null codec yields a generic context, so this does not depend on any
+        // A `None` codec yields a generic context, so this does not depend on any
         // specific decoder being present in the linked FFmpeg build.
-        // SAFETY: a null codec pointer is valid for `alloc_context3`.
-        let ctx = unsafe { CodecContext::new(std::ptr::null()) }.expect("alloc should succeed");
+        let ctx = CodecContext::new(None).expect("alloc should succeed");
         assert!(!ctx.as_ptr().is_null());
         // Dropping `ctx` here frees the context exactly once (no panic / double free).
     }

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1141,9 +1141,9 @@ pub struct CodecContext {
 }
 
 impl CodecContext {
-    /// # Safety
+    /// # Errors
     /// Stub; never executed on docs.rs.
-    pub unsafe fn new(_codec: *const AVCodec) -> Result<Self, crate::AvError> {
+    pub fn new(_codec: Option<Codec>) -> Result<Self, crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 
@@ -1170,15 +1170,15 @@ impl CodecContext {
     /// Stub; never executed on docs.rs.
     pub unsafe fn open(
         &mut self,
-        _codec: *const AVCodec,
+        _codec: Codec,
         _options: *mut *mut AVDictionary,
     ) -> Result<(), crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 
-    /// # Safety
+    /// # Errors
     /// Stub; never executed on docs.rs.
-    pub unsafe fn send_packet(&mut self, _pkt: *const AVPacket) -> Result<(), crate::AvError> {
+    pub fn send_packet(&mut self, _pkt: &Packet) -> Result<(), crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 
@@ -1188,12 +1188,9 @@ impl CodecContext {
         Err(crate::AvError::new(-1))
     }
 
-    /// # Safety
+    /// # Errors
     /// Stub; never executed on docs.rs.
-    pub unsafe fn receive_frame(
-        &mut self,
-        _frame: *mut AVFrame,
-    ) -> Result<ReceiveOutcome, crate::AvError> {
+    pub fn receive_frame(&mut self, _frame: &mut Frame) -> Result<ReceiveOutcome, crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 
@@ -1285,9 +1282,9 @@ impl InputFormatContext {
         Err(crate::AvError::new(-1))
     }
 
-    /// # Safety
+    /// # Errors
     /// Stub; never executed on docs.rs.
-    pub unsafe fn read_frame(&mut self, _pkt: *mut AVPacket) -> Result<(), crate::AvError> {
+    pub fn read_frame(&mut self, _pkt: &mut Packet) -> Result<(), crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 }
@@ -1298,6 +1295,111 @@ impl Drop for InputFormatContext {
 
 // SAFETY: stub; never executed on docs.rs.
 unsafe impl Send for InputFormatContext {}
+
+// ── Owned Frame / Packet / Codec stubs (mirror crate::{frame,packet,codec}) ───
+// Under DOCS_RS the real modules are cfg'd out; these shape-compatible stubs keep
+// `ff_sys::{Frame, Packet, Codec}` available for docs.rs.
+
+#[derive(Debug)]
+pub struct Frame {
+    _ptr: std::ptr::NonNull<AVFrame>,
+}
+
+impl Frame {
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn new() -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVFrame {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVFrame {
+        self._ptr.as_ptr()
+    }
+
+    pub fn unref(&mut self) {}
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn get_buffer(&mut self, _align: c_int) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    pub fn move_ref(&mut self, _src: &mut Frame) {}
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn try_clone(&self) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+}
+
+impl Drop for Frame {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for Frame {}
+
+#[derive(Debug)]
+pub struct Packet {
+    _ptr: std::ptr::NonNull<AVPacket>,
+}
+
+impl Packet {
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn new() -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVPacket {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVPacket {
+        self._ptr.as_ptr()
+    }
+
+    pub fn unref(&mut self) {}
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn try_clone(&self) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+}
+
+impl Drop for Packet {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for Packet {}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Codec {
+    _ptr: std::ptr::NonNull<AVCodec>,
+}
+
+impl Codec {
+    #[must_use]
+    pub fn find_decoder(_codec_id: AVCodecID) -> Option<Self> {
+        None
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVCodec {
+        self._ptr.as_ptr()
+    }
+}
 
 // ── RAII owner stub (mirrors crate::scale_context::ScaleContext) ──────────────
 // Under DOCS_RS the real `scale_context` module is cfg'd out; this

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::ptr::NonNull;
 use std::time::Duration;
 
-use crate::{AVFormatContext, AVPacket, AvError, avformat_close_input as ffi_avformat_close_input};
+use crate::{AVFormatContext, AvError, Packet, avformat_close_input as ffi_avformat_close_input};
 
 /// An owned input (demux) `AVFormatContext`.
 ///
@@ -147,13 +147,10 @@ impl InputFormatContext {
     /// # Errors
     ///
     /// Returns an [`AvError`] on read failure or at end-of-stream (`EOF`).
-    ///
-    /// # Safety
-    ///
-    /// `pkt` must be a valid, allocated `*mut AVPacket`.
-    pub unsafe fn read_frame(&mut self, pkt: *mut AVPacket) -> Result<(), AvError> {
-        // SAFETY: `self.ptr` is a valid owned demux context; the caller upholds `pkt`.
-        unsafe { crate::avformat::read_frame(self.ptr.as_ptr(), pkt) }.map_err(AvError::new)
+    pub fn read_frame(&mut self, pkt: &mut Packet) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned demux context; `pkt` is a valid owned packet.
+        unsafe { crate::avformat::read_frame(self.ptr.as_ptr(), pkt.as_mut_ptr()) }
+            .map_err(AvError::new)
     }
 }
 

--- a/crates/ff-sys/src/frame.rs
+++ b/crates/ff-sys/src/frame.rs
@@ -1,0 +1,190 @@
+//! RAII owner for an `AVFrame`.
+//!
+//! [`Frame`] allocates a frame and frees it exactly once on drop, replacing the
+//! manual `av_frame_alloc` + `av_frame_free` pair. Ownership is unique;
+//! [`try_clone`](Frame::try_clone) makes a ref-counted copy (`av_frame_ref`)
+//! rather than a deep copy. Raw field access (data / linesize / pts / ...) is
+//! still done through [`as_mut_ptr`](Frame::as_mut_ptr) for now (typed field
+//! accessors are a later step).
+
+use std::os::raw::c_int;
+use std::ptr::NonNull;
+
+use crate::{
+    AVFrame, AvError, av_frame_alloc as ffi_av_frame_alloc, av_frame_free as ffi_av_frame_free,
+    av_frame_get_buffer as ffi_av_frame_get_buffer, av_frame_move_ref as ffi_av_frame_move_ref,
+    av_frame_ref as ffi_av_frame_ref, av_frame_unref as ffi_av_frame_unref,
+};
+
+/// An owned `AVFrame`.
+///
+/// The frame is freed exactly once on drop. This is guaranteed by construction:
+/// the value owns a [`NonNull`] and is neither `Copy` nor `Clone`, so it drops
+/// exactly once and cannot be duplicated (a ref-counted copy is made explicitly
+/// via [`try_clone`](Self::try_clone)).
+#[derive(Debug)]
+pub struct Frame {
+    ptr: NonNull<AVFrame>,
+}
+
+impl Frame {
+    /// Allocates a new, empty frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if allocation fails.
+    pub fn new() -> Result<Self, AvError> {
+        // SAFETY: `av_frame_alloc` takes no arguments and returns a fresh frame or null.
+        let ptr = unsafe { ffi_av_frame_alloc() };
+        NonNull::new(ptr)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })
+    }
+
+    /// Returns the frame pointer for read-only use.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVFrame {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the frame pointer for mutation and FFI calls.
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVFrame {
+        self.ptr.as_ptr()
+    }
+
+    /// Unreferences the frame's buffers, returning it to a blank state.
+    pub fn unref(&mut self) {
+        // SAFETY: `self.ptr` is a valid owned frame.
+        unsafe { ffi_av_frame_unref(self.ptr.as_ptr()) };
+    }
+
+    /// Allocates data buffers for the frame according to its already-set
+    /// `format` / dimensions (video) or `nb_samples` / channel layout (audio).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the frame's parameters are unset/invalid or
+    /// allocation fails.
+    pub fn get_buffer(&mut self, align: c_int) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned frame; `av_frame_get_buffer` validates
+        //         the frame's parameters and returns an error code rather than
+        //         faulting when they are unset.
+        let ret = unsafe { ffi_av_frame_get_buffer(self.ptr.as_ptr(), align) };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Moves `src`'s buffers into `self`, leaving `src` blank (but still valid).
+    pub fn move_ref(&mut self, src: &mut Frame) {
+        // SAFETY: `self` and `src` are valid owned frames; `av_frame_move_ref`
+        //         transfers ownership of `src`'s buffers into `self` and resets
+        //         `src` to a blank frame (which remains safe to drop).
+        unsafe { ffi_av_frame_move_ref(self.ptr.as_ptr(), src.ptr.as_ptr()) };
+    }
+
+    /// Makes a ref-counted copy of this frame (`av_frame_ref`), sharing the
+    /// underlying buffers rather than deep-copying.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the copy cannot be allocated / referenced.
+    pub fn try_clone(&self) -> Result<Self, AvError> {
+        let dst = Self::new()?;
+        // SAFETY: `dst` is a fresh blank frame and `self` is a valid frame;
+        //         `av_frame_ref` ref-counts `self`'s buffers into `dst`.
+        let ret = unsafe { ffi_av_frame_ref(dst.ptr.as_ptr(), self.ptr.as_ptr()) };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(dst)
+        }
+    }
+}
+
+impl Drop for Frame {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own the frame (NonNull, not Copy/Clone), so this runs
+        //         exactly once. `av_frame_free` frees it and writes null into our
+        //         local copy of the pointer, which is then discarded.
+        unsafe {
+            let mut raw = self.ptr.as_ptr();
+            ffi_av_frame_free(&mut raw);
+        }
+    }
+}
+
+// SAFETY: an `AVFrame` is not safe for concurrent access, but moving ownership
+//         between threads is sound because Rust's ownership model guarantees
+//         exclusive access.
+unsafe impl Send for Frame {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_should_allocate_and_drop_cleanly() {
+        let frame = Frame::new().expect("frame allocation should succeed");
+        assert!(!frame.as_ptr().is_null());
+        // Dropping `frame` frees it exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn try_clone_should_produce_an_independent_owner() {
+        let mut frame = Frame::new().expect("frame allocation should succeed");
+        // `av_frame_ref` needs referenced buffers, so give the frame a small valid
+        // RGBA image first (no file / codec needed).
+        // SAFETY: `frame` is a valid owned frame; setting these plain scalar fields
+        //         before `get_buffer` is how FFmpeg expects a video frame configured.
+        unsafe {
+            (*frame.as_mut_ptr()).format = crate::AVPixelFormat_AV_PIX_FMT_RGBA;
+            (*frame.as_mut_ptr()).width = 16;
+            (*frame.as_mut_ptr()).height = 16;
+        }
+        frame
+            .get_buffer(0)
+            .expect("buffer allocation should succeed");
+        let clone = frame.try_clone().expect("ref-count clone should succeed");
+        // A ref-counted clone shares the same underlying buffer (not a deep copy).
+        // SAFETY: both frames are valid owned frames with an allocated buffer.
+        unsafe {
+            assert_eq!(
+                (*clone.as_ptr()).data[0],
+                (*frame.as_ptr()).data[0],
+                "try_clone should share the ref-counted buffer"
+            );
+        }
+        // Both `frame` and `clone` drop independently (ref-counted), no double free.
+    }
+
+    #[test]
+    fn move_ref_should_transfer_buffer_and_blank_the_source() {
+        let mut src = Frame::new().expect("frame allocation should succeed");
+        // SAFETY: `src` is a valid owned frame; setting these plain scalar fields
+        //         before `get_buffer` is how FFmpeg expects a video frame configured.
+        unsafe {
+            (*src.as_mut_ptr()).format = crate::AVPixelFormat_AV_PIX_FMT_RGBA;
+            (*src.as_mut_ptr()).width = 16;
+            (*src.as_mut_ptr()).height = 16;
+        }
+        src.get_buffer(0).expect("buffer allocation should succeed");
+        let mut dst = Frame::new().expect("frame allocation should succeed");
+        dst.move_ref(&mut src);
+        // SAFETY: both frames are valid owned frames.
+        unsafe {
+            assert!(
+                !(*dst.as_ptr()).data[0].is_null(),
+                "dst should own the moved buffer"
+            );
+            assert!(
+                (*src.as_ptr()).data[0].is_null(),
+                "src should be blank after the move"
+            );
+        }
+        // Both drop cleanly: `dst` frees the moved buffer, `src` is blank.
+    }
+}

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -50,12 +50,18 @@ pub mod swscale;
 
 // ── Sub-modules ───────────────────────────────────────────────────────────────
 #[cfg(not(docsrs))]
+mod codec;
+#[cfg(not(docsrs))]
 mod codec_context;
 mod constants;
 mod error;
 pub mod error_codes;
 #[cfg(not(docsrs))]
 mod format_context;
+#[cfg(not(docsrs))]
+mod frame;
+#[cfg(not(docsrs))]
+mod packet;
 #[cfg(not(docsrs))]
 mod resample_context;
 #[cfg(not(docsrs))]
@@ -64,11 +70,17 @@ mod utils;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 #[cfg(not(docsrs))]
+pub use codec::Codec;
+#[cfg(not(docsrs))]
 pub use codec_context::{CodecContext, ReceiveOutcome};
 pub use constants::{AV_NOPTS_VALUE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
 #[cfg(not(docsrs))]
 pub use format_context::InputFormatContext;
+#[cfg(not(docsrs))]
+pub use frame::Frame;
+#[cfg(not(docsrs))]
+pub use packet::Packet;
 #[cfg(not(docsrs))]
 pub use resample_context::ResampleContext;
 #[cfg(not(docsrs))]

--- a/crates/ff-sys/src/packet.rs
+++ b/crates/ff-sys/src/packet.rs
@@ -1,0 +1,115 @@
+//! RAII owner for an `AVPacket`.
+//!
+//! [`Packet`] allocates a packet and frees it exactly once on drop, replacing
+//! the manual `av_packet_alloc` + `av_packet_free` pair. Ownership is unique;
+//! [`try_clone`](Packet::try_clone) makes a ref-counted copy (`av_packet_ref`).
+//! Raw field access (stream_index / pts / ...) is still done through
+//! [`as_mut_ptr`](Packet::as_mut_ptr) for now (typed field accessors are a later
+//! step).
+
+use std::ptr::NonNull;
+
+use crate::{
+    AVPacket, AvError, av_packet_alloc as ffi_av_packet_alloc,
+    av_packet_free as ffi_av_packet_free, av_packet_ref as ffi_av_packet_ref,
+    av_packet_unref as ffi_av_packet_unref,
+};
+
+/// An owned `AVPacket`.
+///
+/// The packet is freed exactly once on drop. This is guaranteed by construction:
+/// the value owns a [`NonNull`] and is neither `Copy` nor `Clone`, so it drops
+/// exactly once and cannot be duplicated (a ref-counted copy is made explicitly
+/// via [`try_clone`](Self::try_clone)).
+#[derive(Debug)]
+pub struct Packet {
+    ptr: NonNull<AVPacket>,
+}
+
+impl Packet {
+    /// Allocates a new, empty packet.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if allocation fails.
+    pub fn new() -> Result<Self, AvError> {
+        // SAFETY: `av_packet_alloc` takes no arguments and returns a fresh packet or null.
+        let ptr = unsafe { ffi_av_packet_alloc() };
+        NonNull::new(ptr)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })
+    }
+
+    /// Returns the packet pointer for read-only use.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVPacket {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the packet pointer for mutation and FFI calls.
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVPacket {
+        self.ptr.as_ptr()
+    }
+
+    /// Unreferences the packet's buffer, returning it to a blank state.
+    pub fn unref(&mut self) {
+        // SAFETY: `self.ptr` is a valid owned packet.
+        unsafe { ffi_av_packet_unref(self.ptr.as_ptr()) };
+    }
+
+    /// Makes a ref-counted copy of this packet (`av_packet_ref`), sharing the
+    /// underlying buffer rather than deep-copying.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the copy cannot be allocated / referenced.
+    pub fn try_clone(&self) -> Result<Self, AvError> {
+        let dst = Self::new()?;
+        // SAFETY: `dst` is a fresh blank packet and `self` is a valid packet;
+        //         `av_packet_ref` ref-counts `self`'s buffer into `dst`.
+        let ret = unsafe { ffi_av_packet_ref(dst.ptr.as_ptr(), self.ptr.as_ptr()) };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(dst)
+        }
+    }
+}
+
+impl Drop for Packet {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own the packet (NonNull, not Copy/Clone), so this runs
+        //         exactly once. `av_packet_free` frees it and writes null into our
+        //         local copy of the pointer, which is then discarded.
+        unsafe {
+            let mut raw = self.ptr.as_ptr();
+            ffi_av_packet_free(&mut raw);
+        }
+    }
+}
+
+// SAFETY: an `AVPacket` is not safe for concurrent access, but moving ownership
+//         between threads is sound because Rust's ownership model guarantees
+//         exclusive access.
+unsafe impl Send for Packet {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_should_allocate_and_drop_cleanly() {
+        let packet = Packet::new().expect("packet allocation should succeed");
+        assert!(!packet.as_ptr().is_null());
+        // Dropping `packet` frees it exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn try_clone_should_produce_an_independent_owner() {
+        let packet = Packet::new().expect("packet allocation should succeed");
+        let clone = packet.try_clone().expect("ref-count clone should succeed");
+        assert!(!clone.as_ptr().is_null());
+        // Both `packet` and `clone` drop independently (ref-counted), no double free.
+    }
+}


### PR DESCRIPTION
## Objective

- Continue making the ff-sys safe layer raw-pointer-free (ADR-0003): the decoders held `frame: *mut AVFrame` / `packet: *mut AVPacket` behind hand-rolled guards, and the codec/demux methods (`send_packet` / `receive_frame` / `read_frame`) took raw frame/packet pointers and were `unsafe`, which pushes lifetime and validity obligations onto every caller.

## Solution

- Add owned `ff_sys::Frame` (AVFrame) and `ff_sys::Packet` (AVPacket): free exactly once on drop, with a fallible ref-counting `try_clone` (`av_frame_ref` / `av_packet_ref`); `Frame` also exposes `unref` / `get_buffer` / `move_ref`. Add `ff_sys::Codec`, a `Copy` handle over a static `AVCodec` with a safe `find_decoder`. `Send` only; docs.rs stubs added.
- Make `CodecContext::new(Option<Codec>)`, `send_packet(&Packet)`, `receive_frame(&mut Frame)` and `InputFormatContext::read_frame(&mut Packet)` safe. This is sound because `avcodec_send_packet` / `avcodec_receive_frame` return `EINVAL` (guarded by `avcodec_is_open`) rather than faulting on an unopened context; `open` (raw options), `send_eof` and `flush_buffers` keep their `unsafe` (the latter would NULL-deref on an unopened context).
- Migrate the three ff-decode decoders onto the owned types: drop the frame/packet guards, route the lifecycle through the owned methods (including the hardware-transfer `move_ref`), and remove the now-empty manual frees from `Drop`. Raw field access continues through the `as_ptr` / `as_mut_ptr` escape hatch.
- Scope is the owned types plus the ff-decode migration. Removing the escape hatch (typed field accessors), the `scale` / `convert` safe-ification, and the other frame/packet consumers (ff-encode / ff-stream / ff-preview) are relocated to #1497.

Closes #1480