### PR TITLE
feat(ff-encode): migrate codec contexts to ff_sys::CodecContext

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -26,7 +26,7 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
     AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame,
     SwrContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc,
-    av_packet_free, av_packet_unref, av_write_trailer, avcodec, avformat_alloc_output_context2,
+    av_packet_free, av_packet_unref, av_write_trailer, avformat_alloc_output_context2,
     avformat_free_context, avformat_new_stream, avformat_write_header, swresample,
 };
 use std::ffi::{CString, c_void};
@@ -38,7 +38,7 @@ pub(super) struct AudioEncoderInner {
     pub(super) format_ctx: *mut AVFormatContext,
 
     /// Audio codec context
-    pub(super) codec_ctx: Option<*mut AVCodecContext>,
+    pub(super) codec_ctx: Option<ff_sys::CodecContext>,
 
     /// Audio stream index
     pub(super) stream_index: i32,
@@ -159,31 +159,25 @@ impl AudioEncoderInner {
         let encoder_name = self.select_audio_encoder(config.codec)?;
         self.actual_codec.clone_from(&encoder_name);
 
-        let c_encoder_name =
-            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
-                code: 0,
-                message: "Invalid encoder name".to_string(),
-            })?;
-
-        let codec_ptr =
-            avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
-                EncodeError::NoSuitableEncoder {
-                    codec: format!("{:?}", config.codec),
-                    tried: vec![encoder_name.clone()],
-                }
-            })?;
+        let codec = ff_sys::Codec::find_encoder_by_name(&encoder_name).ok_or_else(|| {
+            EncodeError::NoSuitableEncoder {
+                codec: format!("{:?}", config.codec),
+                tried: vec![encoder_name.clone()],
+            }
+        })?;
+        let codec_ptr = codec.as_ptr();
 
         // Allocate codec context
-        let mut codec_ctx =
-            avcodec::alloc_context3(codec_ptr).map_err(EncodeError::from_ffmpeg_error)?;
+        let mut codec_ctx = ff_sys::CodecContext::new(Some(codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Configure codec context
-        (*codec_ctx).codec_id = codec_to_id(config.codec);
-        (*codec_ctx).sample_rate = config.sample_rate as i32;
+        (*codec_ctx.as_mut_ptr()).codec_id = codec_to_id(config.codec);
+        (*codec_ctx.as_mut_ptr()).sample_rate = config.sample_rate as i32;
 
         // Set channel layout using FFmpeg 7.x API
         swresample::channel_layout::set_default(
-            &raw mut (*codec_ctx).ch_layout,
+            &raw mut (*codec_ctx.as_mut_ptr()).ch_layout,
             config.channels as i32,
         );
 
@@ -199,14 +193,14 @@ impl AudioEncoderInner {
                 ff_sys::swresample::sample_format::FLTP
             }
         };
-        (*codec_ctx).sample_fmt = target_fmt;
+        (*codec_ctx.as_mut_ptr()).sample_fmt = target_fmt;
 
         // Set bitrate
         if let Some(br) = config.bitrate {
-            (*codec_ctx).bit_rate = br as i64;
+            (*codec_ctx.as_mut_ptr()).bit_rate = br as i64;
         } else {
             // Default bitrate based on codec
-            (*codec_ctx).bit_rate = match config.codec {
+            (*codec_ctx.as_mut_ptr()).bit_rate = match config.codec {
                 AudioCodec::Aac => 192_000,
                 AudioCodec::Opus => 128_000,
                 AudioCodec::Mp3 => 192_000,
@@ -224,26 +218,27 @@ impl AudioEncoderInner {
         }
 
         // Set time base
-        (*codec_ctx).time_base.num = 1;
-        (*codec_ctx).time_base.den = config.sample_rate as i32;
+        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
+        (*codec_ctx.as_mut_ptr()).time_base.den = config.sample_rate as i32;
 
         // Apply per-codec options before opening the codec context.
         if let Some(opts) = &config.codec_options {
             // SAFETY: codec_ctx is valid and allocated; priv_data is set by
             // avcodec_alloc_context3. Options are applied before avcodec_open2
             // so they take effect during codec initialisation.
-            Self::apply_codec_options(codec_ctx, opts, &encoder_name);
+            Self::apply_codec_options(codec_ctx.as_mut_ptr(), opts, &encoder_name);
         }
 
         // Open codec
-        avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut())
-            .map_err(EncodeError::from_ffmpeg_error)?;
+        codec_ctx
+            .open(codec, ptr::null_mut())
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // After open2, frame_size is populated.  Allocate an AVAudioFifo when
         // the encoder requires a fixed number of samples and does not advertise
         // VARIABLE_FRAME_SIZE.  AVAudioFifo handles both planar and packed
         // layouts internally and is backed by a ring-buffer (O(1) read/write).
-        let required = (*codec_ctx).frame_size as usize;
+        let required = (*codec_ctx.as_mut_ptr()).frame_size as usize;
         let caps = (*codec_ptr).capabilities as u32;
         if required > 0 && caps & ff_sys::avcodec::codec_caps::VARIABLE_FRAME_SIZE == 0 {
             self.fifo =
@@ -261,22 +256,23 @@ impl AudioEncoderInner {
         // Create stream
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
-            avcodec::free_context(&raw mut codec_ctx);
+            // The owned codec_ctx frees itself on return.
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "Cannot create stream".to_string(),
             });
         }
 
-        (*stream).time_base = (*codec_ctx).time_base;
+        (*stream).time_base = (*codec_ctx.as_mut_ptr()).time_base;
 
         // Copy ALL codec parameters (including extradata) from the open codec
         // context to the stream.  avcodec_parameters_from_context must be
         // called after avcodec_open2 because some codecs (e.g. FLAC, AAC)
         // populate extradata only after the codec is opened.  Manual field
         // copies would miss extradata, causing avformat_write_header to fail.
-        avcodec::parameters_from_context((*stream).codecpar, codec_ctx)
-            .map_err(EncodeError::from_ffmpeg_error)?;
+        codec_ctx
+            .parameters_from_context((*stream).codecpar)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         self.stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
         self.codec_ctx = Some(codec_ctx);
@@ -442,14 +438,8 @@ impl AudioEncoderInner {
 
         // Try each candidate
         for &name in &candidates {
-            unsafe {
-                let c_name = CString::new(name).map_err(|_| EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Invalid encoder name".to_string(),
-                })?;
-                if avcodec::find_encoder_by_name(c_name.as_ptr()).is_some() {
-                    return Ok(name.to_string());
-                }
+            if ff_sys::Codec::find_encoder_by_name(name).is_some() {
+                return Ok(name.to_string());
             }
         }
 
@@ -463,9 +453,11 @@ impl AudioEncoderInner {
     pub(super) fn push_frame(&mut self, frame: &AudioFrame) -> Result<(), EncodeError> {
         // SAFETY: self is properly initialised; all raw FFmpeg pointers are valid and exclusively owned.
         unsafe {
-            let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
-                reason: "Audio codec not initialized".to_string(),
-            })?;
+            if self.codec_ctx.is_none() {
+                return Err(EncodeError::InvalidConfig {
+                    reason: "Audio codec not initialized".to_string(),
+                });
+            }
 
             if !self.fifo.is_null() {
                 // Fixed-frame-size path: convert → write into AVAudioFifo → drain
@@ -507,7 +499,7 @@ impl AudioEncoderInner {
                 // Drain all complete frames from the FIFO
                 let frame_size = self.frame_size as i32;
                 while swresample::audio_fifo::size(self.fifo) >= frame_size {
-                    self.drain_fifo_frame(codec_ctx, frame_size, false)?;
+                    self.drain_fifo_frame(frame_size, false)?;
                 }
             } else {
                 // Direct path: send frame straight to the encoder.
@@ -527,14 +519,20 @@ impl AudioEncoderInner {
 
                 (*av_frame).pts = self.sample_count as i64;
 
-                let send_result = avcodec::send_frame(codec_ctx, av_frame);
+                let send_result = self
+                    .codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Audio codec not initialized".to_string(),
+                    })?
+                    .send_frame(av_frame);
                 if let Err(e) = send_result {
                     av_frame_free(&raw mut av_frame);
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Failed to send audio frame: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     });
                 }
@@ -559,10 +557,17 @@ impl AudioEncoderInner {
     /// only in the EOF flush called from [`Self::finish`].
     unsafe fn drain_fifo_frame(
         &mut self,
-        codec_ctx: *mut AVCodecContext,
         frame_size: i32,
         zero_pad: bool,
     ) -> Result<(), EncodeError> {
+        let codec_ctx = self
+            .codec_ctx
+            .as_mut()
+            .ok_or_else(|| EncodeError::InvalidConfig {
+                reason: "Audio codec not initialized".to_string(),
+            })?
+            .as_mut_ptr();
+
         let mut av_frame = av_frame_alloc();
         if av_frame.is_null() {
             return Err(EncodeError::Ffmpeg {
@@ -629,12 +634,21 @@ impl AudioEncoderInner {
         }
         // nb_samples stays as frame_size: the encoder always receives a full frame.
 
-        let send_result = avcodec::send_frame(codec_ctx, av_frame);
+        let send_result = self
+            .codec_ctx
+            .as_mut()
+            .ok_or_else(|| EncodeError::InvalidConfig {
+                reason: "Audio codec not initialized".to_string(),
+            })?
+            .send_frame(av_frame);
         av_frame_free(&raw mut av_frame);
 
         send_result.map_err(|e| EncodeError::Ffmpeg {
-            code: e,
-            message: format!("Failed to send audio frame: {}", ff_sys::av_error_string(e)),
+            code: e.code(),
+            message: format!(
+                "Failed to send audio frame: {}",
+                ff_sys::av_error_string(e.code())
+            ),
         })?;
 
         self.receive_packets()?;
@@ -649,9 +663,13 @@ impl AudioEncoderInner {
         src: &AudioFrame,
         dst: *mut AVFrame,
     ) -> Result<(), EncodeError> {
-        let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
-            reason: "Audio codec not initialized".to_string(),
-        })?;
+        let codec_ctx = self
+            .codec_ctx
+            .as_ref()
+            .ok_or_else(|| EncodeError::InvalidConfig {
+                reason: "Audio codec not initialized".to_string(),
+            })?
+            .as_ptr();
 
         let target_sample_rate = (*codec_ctx).sample_rate;
         let target_format = (*codec_ctx).sample_fmt;
@@ -785,9 +803,11 @@ impl AudioEncoderInner {
 
     /// Receive encoded packets from the encoder.
     unsafe fn receive_packets(&mut self) -> Result<(), EncodeError> {
-        let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
-            reason: "Audio codec not initialized".to_string(),
-        })?;
+        if self.codec_ctx.is_none() {
+            return Err(EncodeError::InvalidConfig {
+                reason: "Audio codec not initialized".to_string(),
+            });
+        }
 
         let mut packet = av_packet_alloc();
         if packet.is_null() {
@@ -798,21 +818,28 @@ impl AudioEncoderInner {
         }
 
         loop {
-            match avcodec::receive_packet(codec_ctx, packet) {
-                Ok(()) => {
+            let recv = self
+                .codec_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Audio codec not initialized".to_string(),
+                })?
+                .receive_packet(packet);
+            match recv {
+                Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
                 }
-                Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                Ok(ff_sys::ReceiveOutcome::NeedInput | ff_sys::ReceiveOutcome::Drained) => {
                     // No more packets available
                     break;
                 }
                 Err(e) => {
                     av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Error receiving audio packet: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     });
                 }
@@ -847,17 +874,19 @@ impl AudioEncoderInner {
             // Flush any remaining samples from the AVAudioFifo (silence-padded to a
             // full frame so the encoder always receives its required frame_size).
             if !self.fifo.is_null() && swresample::audio_fifo::size(self.fifo) > 0 {
-                let codec_ctx = self.codec_ctx.ok_or_else(|| EncodeError::InvalidConfig {
-                    reason: "Audio codec not initialized".to_string(),
-                })?;
-                self.drain_fifo_frame(codec_ctx, self.frame_size as i32, true)?;
+                self.drain_fifo_frame(self.frame_size as i32, true)?;
             }
 
             // Flush audio encoder
-            if let Some(codec_ctx) = self.codec_ctx {
+            if self.codec_ctx.is_some() {
                 // Send NULL frame to flush
-                avcodec::send_frame(codec_ctx, ptr::null())
-                    .map_err(EncodeError::from_ffmpeg_error)?;
+                self.codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Audio codec not initialized".to_string(),
+                    })?
+                    .send_frame(ptr::null())
+                    .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_packets()?;
             }
 
@@ -882,10 +911,8 @@ impl AudioEncoderInner {
             self.fifo = ptr::null_mut();
         }
 
-        // Free audio codec context
-        if let Some(mut ctx) = self.codec_ctx.take() {
-            avcodec::free_context(&raw mut ctx);
-        }
+        // Free audio codec context (owned CodecContext frees itself when dropped).
+        self.codec_ctx = None;
 
         // Free resampling context
         if let Some(mut ctx) = self.swr_ctx.take() {

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -6,10 +6,14 @@
 //! ## Resource management
 //!
 //! [`ImageEncoderInner`] owns every FFmpeg pointer allocated during a single
-//! still-image encode. Its [`Drop`] implementation frees them in the order
-//! mandated by FFmpeg: frame → packet → sws_ctx → codec_ctx → format_ctx.
-//! Because `Drop` runs on every exit path — including panics and early `?`
-//! returns — no manual cleanup is needed at individual error sites.
+//! still-image encode. Its [`Drop`] implementation frees the raw handles
+//! (frame → packet → sws_ctx → format_ctx); `codec_ctx` is an owned
+//! [`ff_sys::CodecContext`] that frees itself when the struct drops, after the
+//! manual cleanup body has run. The encoder's `AVCodecContext` and the output
+//! `AVFormatContext` are independent allocations with no cross-reference, so
+//! this order is sound. Because `Drop` runs on every exit path — including
+//! panics and early `?` returns — no manual cleanup is needed at individual
+//! error sites.
 
 // Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
 #![allow(unsafe_code)]
@@ -35,7 +39,7 @@ use ff_sys::{
     AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_BGR24, AVPixelFormat_AV_PIX_FMT_RGB24,
     AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, av_frame_alloc, av_frame_free,
     av_interleaved_write_frame, av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer,
-    avcodec, avformat, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
     avformat_write_header, swscale,
 };
 
@@ -67,17 +71,23 @@ pub(super) struct ImageEncodeOptions {
 ///
 /// # Drop contract
 ///
-/// Resources are released in the following order to satisfy FFmpeg's lifetime
-/// requirements:
+/// The manual `Drop` body releases the raw handles in this order:
 ///
 /// 1. `dst_frame` — `av_frame_free`
 /// 2. `packet`    — `av_packet_free`
 /// 3. `sws_ctx`   — `sws_freeContext`
-/// 4. `codec_ctx` — `avcodec_free_context`
-/// 5. `format_ctx`— IO close (`avio_closep`) then `avformat_free_context`
+/// 4. `format_ctx`— IO close (`avio_closep`) then `avformat_free_context`
+///
+/// `codec_ctx` is an owned [`ff_sys::CodecContext`]; it frees itself via field
+/// drop *after* the manual body, so the `AVCodecContext` is released last. That
+/// is sound because the encoder's `AVCodecContext` and the output
+/// `AVFormatContext` are independent allocations that do not reference each
+/// other. (The audio/video encoders hold their codec contexts as `Option` and
+/// take them to `None` before freeing `format_ctx`; here `codec_ctx` is a
+/// by-value field that is always present, so it is simply dropped last.)
 struct ImageEncoderInner {
     format_ctx: *mut AVFormatContext,
-    codec_ctx: *mut ff_sys::AVCodecContext,
+    codec_ctx: ff_sys::CodecContext,
     dst_frame: *mut ff_sys::AVFrame,
     packet: *mut ff_sys::AVPacket,
     sws_ctx: Option<*mut ff_sys::SwsContext>,
@@ -108,10 +118,19 @@ impl ImageEncoderInner {
             .pixel_format
             .map_or_else(|| preferred_pix_fmt(codec_id), pixel_format_to_av);
 
-        // Start with everything null so Drop is safe from the very first field.
+        // Find the encoder and allocate the owned codec context up front so the
+        // struct can hold it by value; the remaining raw pointers start null and
+        // are filled in as they are allocated.
+        let codec = ff_sys::Codec::find_encoder(codec_id).ok_or(EncodeError::UnsupportedCodec {
+            codec: format!("codec_id={codec_id}"),
+        })?;
+        let codec_ctx = ff_sys::CodecContext::new(Some(codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
+
+        // Start with the raw pointers null so Drop is safe from the very first field.
         let mut inner = Self {
             format_ctx: ptr::null_mut(),
-            codec_ctx: ptr::null_mut(),
+            codec_ctx,
             dst_frame: ptr::null_mut(),
             packet: ptr::null_mut(),
             sws_ctx: None,
@@ -188,19 +207,11 @@ impl ImageEncoderInner {
             });
         }
 
-        // ── Step 3: Find encoder ──────────────────────────────────────────────
-        let codec = avcodec::find_encoder(codec_id).ok_or(EncodeError::UnsupportedCodec {
-            codec: format!("codec_id={codec_id}"),
-        })?;
-
-        // ── Step 4: Allocate codec context ────────────────────────────────────
-        inner.codec_ctx = avcodec::alloc_context3(codec).map_err(EncodeError::from_ffmpeg_error)?;
-
-        // ── Step 5: Configure codec context ──────────────────────────────────
-        (*inner.codec_ctx).width = dst_width as i32;
-        (*inner.codec_ctx).height = dst_height as i32;
-        (*inner.codec_ctx).time_base = AVRational { num: 1, den: 1 };
-        (*inner.codec_ctx).pix_fmt = pix_fmt;
+        // ── Step 3: Configure codec context ──────────────────────────────────
+        (*inner.codec_ctx.as_mut_ptr()).width = dst_width as i32;
+        (*inner.codec_ctx.as_mut_ptr()).height = dst_height as i32;
+        (*inner.codec_ctx.as_mut_ptr()).time_base = AVRational { num: 1, den: 1 };
+        (*inner.codec_ctx.as_mut_ptr()).pix_fmt = pix_fmt;
 
         // For MJPEG, declare full-range (JPEG) color so FFmpeg does not emit
         // "deprecated pixel format used" warnings that appear when using the
@@ -208,25 +219,27 @@ impl ImageEncoderInner {
         // recommended replacement since FFmpeg 5.x.
         if codec_id == AVCodecID_AV_CODEC_ID_MJPEG {
             // SAFETY: codec_ctx is non-null; color_range is a plain integer field.
-            (*inner.codec_ctx).color_range = AVColorRange_AVCOL_RANGE_JPEG;
+            (*inner.codec_ctx.as_mut_ptr()).color_range = AVColorRange_AVCOL_RANGE_JPEG;
         }
 
         if let Some(q) = opts.quality {
             // SAFETY: codec_ctx is non-null and freshly allocated.
-            apply_quality(inner.codec_ctx, codec_id, q);
+            apply_quality(inner.codec_ctx.as_mut_ptr(), codec_id, q);
         }
 
-        // ── Step 6: Open codec ────────────────────────────────────────────────
-        avcodec::open2(inner.codec_ctx, codec, ptr::null_mut())
-            .map_err(EncodeError::from_ffmpeg_error)?;
+        // ── Step 4: Open codec ────────────────────────────────────────────────
+        inner
+            .codec_ctx
+            .open(codec, ptr::null_mut())
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        // ── Step 7: Copy parameters to stream ─────────────────────────────────
+        // ── Step 5: Copy parameters to stream ─────────────────────────────────
         // SAFETY: stream is non-null (checked above); codec_ctx is open.
         let par = (*stream).codecpar;
         (*par).codec_id = codec_id;
         (*par).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-        (*par).width = (*inner.codec_ctx).width;
-        (*par).height = (*inner.codec_ctx).height;
+        (*par).width = (*inner.codec_ctx.as_mut_ptr()).width;
+        (*par).height = (*inner.codec_ctx.as_mut_ptr()).height;
         (*par).format = pix_fmt;
 
         // ── Step 8: Open output file ──────────────────────────────────────────
@@ -357,14 +370,17 @@ impl ImageEncoderInner {
         (*self.dst_frame).pts = 0;
 
         // ── Send frame → encoder ──────────────────────────────────────────────
-        avcodec::send_frame(self.codec_ctx, self.dst_frame)
-            .map_err(EncodeError::from_ffmpeg_error)?;
+        self.codec_ctx
+            .send_frame(self.dst_frame)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Receive packets ───────────────────────────────────────────────────
         self.drain_packets(false)?;
 
         // ── Flush encoder ─────────────────────────────────────────────────────
-        avcodec::send_frame(self.codec_ctx, ptr::null()).map_err(EncodeError::from_ffmpeg_error)?;
+        self.codec_ctx
+            .send_frame(ptr::null())
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Drain remaining packets ───────────────────────────────────────────
         self.drain_packets(true)?;
@@ -387,8 +403,12 @@ impl ImageEncoderInner {
     /// `self.codec_ctx`, `self.packet`, and `self.format_ctx` must all be valid.
     unsafe fn drain_packets(&mut self, until_eof: bool) -> Result<(), EncodeError> {
         loop {
-            match avcodec::receive_packet(self.codec_ctx, self.packet) {
-                Ok(()) => {
+            match self
+                .codec_ctx
+                .receive_packet(self.packet)
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?
+            {
+                ff_sys::ReceiveOutcome::Frame => {
                     (*self.packet).stream_index = 0;
                     let ret = av_interleaved_write_frame(self.format_ctx, self.packet);
                     av_packet_unref(self.packet);
@@ -396,9 +416,12 @@ impl ImageEncoderInner {
                         return Err(EncodeError::from_ffmpeg_error(ret));
                     }
                 }
-                Err(e) if e == ff_sys::error_codes::EOF => break,
-                Err(e) if !until_eof && e == ff_sys::error_codes::EAGAIN => break,
-                Err(e) => return Err(EncodeError::from_ffmpeg_error(e)),
+                ff_sys::ReceiveOutcome::Drained => break,
+                ff_sys::ReceiveOutcome::NeedInput => {
+                    if !until_eof {
+                        break;
+                    }
+                }
             }
         }
         Ok(())
@@ -411,12 +434,13 @@ impl Drop for ImageEncoderInner {
         // null (never allocated, or already freed) or a valid owned allocation.
         // We check for null before each free to make Drop idempotent.
         //
-        // Release order per the issue #154 Drop contract:
+        // Release order for the raw handles (see the struct's Drop contract):
         //   1. dst_frame  — av_frame_free  (sets pointer to null)
         //   2. packet     — av_packet_free (sets pointer to null)
         //   3. sws_ctx    — sws_freeContext
-        //   4. codec_ctx  — avcodec_free_context (sets pointer to null)
-        //   5. format_ctx — avio_closep (if pb still open) + avformat_free_context
+        //   4. format_ctx — avio_closep (if pb still open) + avformat_free_context
+        // `codec_ctx` (owned CodecContext) frees itself last via field drop,
+        // after this body; sound as the two contexts are independent.
         unsafe {
             if !self.dst_frame.is_null() {
                 // SAFETY: dst_frame is non-null and owned by this struct.
@@ -430,11 +454,8 @@ impl Drop for ImageEncoderInner {
                 // SAFETY: sws is a valid SwsContext that hasn't been freed yet.
                 swscale::free_context(sws);
             }
-            if !self.codec_ctx.is_null() {
-                // SAFETY: codec_ctx is non-null and owned by this struct.
-                // avcodec_free_context sets the pointer to null after freeing.
-                avcodec::free_context(&raw mut self.codec_ctx);
-            }
+            // codec_ctx is an owned ff_sys::CodecContext; it frees itself when the
+            // struct is dropped (after this manual cleanup runs).
             if !self.format_ctx.is_null() {
                 // SAFETY: format_ctx is non-null and owned by this struct.
                 // Close the IO context if it hasn't been closed yet (it is set
@@ -619,8 +640,8 @@ unsafe fn apply_quality(codec_ctx: *mut ff_sys::AVCodecContext, codec_id: AVCode
 /// Encode a single `VideoFrame` and write it to `path`.
 ///
 /// Resources are managed via [`ImageEncoderInner`]'s [`Drop`] implementation,
-/// which frees frame → packet → sws_ctx → codec_ctx → format_ctx regardless
-/// of whether encoding succeeds or fails.
+/// which frees frame → packet → sws_ctx → format_ctx (the owned `codec_ctx`
+/// drops itself last) regardless of whether encoding succeeds or fails.
 ///
 pub(super) fn encode_image(
     path: &Path,
@@ -764,16 +785,17 @@ mod tests {
         );
     }
 
-    // Verify Drop does not panic on a zero-initialised (all-null) inner struct.
-    // This guards the partial-allocation cleanup path exercised when `open`
-    // returns early with an error before every field is set.
+    // Verify Drop does not panic on a partially-initialised inner struct whose
+    // raw pointers are all null. This guards the partial-allocation cleanup path
+    // exercised when `open` returns early with an error before every field is set.
     #[test]
     fn drop_on_uninitialised_inner_should_not_panic() {
-        // We deliberately construct an all-null inner and drop it.
-        // SAFETY: all pointers are null; Drop checks for null before freeing.
+        // A `None` codec yields a generic owned context that frees itself on drop;
+        // the raw pointers are null, so the manual Drop checks skip them.
+        // SAFETY: all raw pointers are null; Drop checks for null before freeing.
         let inner = ImageEncoderInner {
             format_ctx: ptr::null_mut(),
-            codec_ctx: ptr::null_mut(),
+            codec_ctx: ff_sys::CodecContext::new(None).expect("generic context alloc"),
             dst_frame: ptr::null_mut(),
             packet: ptr::null_mut(),
             sws_ctx: None,

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -27,7 +27,7 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_GIF, AVCodecID_AV_CODEC_ID_PNG, AVPixelFormat_AV_PIX_FMT_RGB24,
     AVRational, av_buffersink_get_frame, av_frame_alloc, av_frame_free, av_frame_get_buffer,
     av_interleaved_write_frame, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref,
-    av_write_trailer, avcodec, avfilter_get_by_name, avfilter_graph_alloc, avfilter_graph_config,
+    av_write_trailer, avfilter_get_by_name, avfilter_graph_alloc, avfilter_graph_config,
     avfilter_graph_create_filter, avfilter_graph_free, avfilter_link, avformat,
     avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
     avformat_write_header, swscale,
@@ -447,31 +447,31 @@ unsafe fn encode_frame_as_png_inner(
     }
 
     // ── Find and open PNG encoder ─────────────────────────────────────────────
-    let Some(codec) = avcodec::find_encoder(AVCodecID_AV_CODEC_ID_PNG) else {
+    let Some(codec) = ff_sys::Codec::find_encoder(AVCodecID_AV_CODEC_ID_PNG) else {
         avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::UnsupportedCodec {
             codec: "png".to_string(),
         });
     };
 
-    let codec_ctx = match avcodec::alloc_context3(codec) {
+    let mut codec_ctx = match ff_sys::CodecContext::new(Some(codec)) {
         Ok(ctx) => ctx,
         Err(e) => {
             avformat_free_context(fmt_ctx);
-            return Err(PreviewImageError::from_ffmpeg_error(e));
+            return Err(PreviewImageError::from_ffmpeg_error(e.code()));
         }
     };
 
-    // SAFETY: codec_ctx is non-null (alloc_context3 succeeded).
-    (*codec_ctx).width = width;
-    (*codec_ctx).height = height;
-    (*codec_ctx).time_base = AVRational { num: 1, den: 1 };
-    (*codec_ctx).pix_fmt = pix_fmt;
+    // SAFETY: codec_ctx is non-null (allocation succeeded).
+    (*codec_ctx.as_mut_ptr()).width = width;
+    (*codec_ctx.as_mut_ptr()).height = height;
+    (*codec_ctx.as_mut_ptr()).time_base = AVRational { num: 1, den: 1 };
+    (*codec_ctx.as_mut_ptr()).pix_fmt = pix_fmt;
 
-    if let Err(e) = avcodec::open2(codec_ctx, codec, ptr::null_mut()) {
-        avcodec::free_context(&mut { codec_ctx });
+    if let Err(e) = codec_ctx.open(codec, ptr::null_mut()) {
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
-        return Err(PreviewImageError::from_ffmpeg_error(e));
+        return Err(PreviewImageError::from_ffmpeg_error(e.code()));
     }
 
     // Copy codec parameters to stream.
@@ -487,8 +487,7 @@ unsafe fn encode_frame_as_png_inner(
     let io_ctx = match avformat::open_output(output, avformat::avio_flags::WRITE) {
         Ok(ctx) => ctx,
         Err(e) => {
-            let mut cc = codec_ctx;
-            avcodec::free_context(&raw mut cc);
+            drop(codec_ctx);
             avformat_free_context(fmt_ctx);
             return Err(PreviewImageError::from_ffmpeg_error(e));
         }
@@ -498,8 +497,7 @@ unsafe fn encode_frame_as_png_inner(
     let ret = avformat_write_header(fmt_ctx, ptr::null_mut());
     if ret < 0 {
         avformat::close_output(&raw mut (*fmt_ctx).pb);
-        let mut cc = codec_ctx;
-        avcodec::free_context(&raw mut cc);
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::from_ffmpeg_error(ret));
     }
@@ -509,8 +507,7 @@ unsafe fn encode_frame_as_png_inner(
     if packet.is_null() {
         av_write_trailer(fmt_ctx);
         avformat::close_output(&raw mut (*fmt_ctx).pb);
-        let mut cc = codec_ctx;
-        avcodec::free_context(&raw mut cc);
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::Ffmpeg {
             code: 0,
@@ -522,18 +519,21 @@ unsafe fn encode_frame_as_png_inner(
     (*frame).pts = 0;
 
     let encode_result = (|| -> Result<(), PreviewImageError> {
-        avcodec::send_frame(codec_ctx, frame).map_err(PreviewImageError::from_ffmpeg_error)?;
-        drain_packets(codec_ctx, fmt_ctx, packet, false)?;
-        avcodec::send_frame(codec_ctx, ptr::null())
-            .map_err(PreviewImageError::from_ffmpeg_error)?;
-        drain_packets(codec_ctx, fmt_ctx, packet, true)?;
+        codec_ctx
+            .send_frame(frame)
+            .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
+        drain_packets(&mut codec_ctx, fmt_ctx, packet, false)?;
+        codec_ctx
+            .send_frame(ptr::null())
+            .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
+        drain_packets(&mut codec_ctx, fmt_ctx, packet, true)?;
         Ok(())
     })();
 
     av_write_trailer(fmt_ctx);
     avformat::close_output(&raw mut (*fmt_ctx).pb);
     av_packet_free(&mut { packet });
-    avcodec::free_context(&mut { codec_ctx });
+    drop(codec_ctx);
     avformat_free_context(fmt_ctx);
 
     encode_result
@@ -548,14 +548,17 @@ unsafe fn encode_frame_as_png_inner(
 ///
 /// `codec_ctx`, `fmt_ctx`, and `packet` must all be valid non-null pointers.
 unsafe fn drain_packets(
-    codec_ctx: *mut ff_sys::AVCodecContext,
+    codec_ctx: &mut ff_sys::CodecContext,
     fmt_ctx: *mut ff_sys::AVFormatContext,
     packet: *mut ff_sys::AVPacket,
     until_eof: bool,
 ) -> Result<(), PreviewImageError> {
     loop {
-        match avcodec::receive_packet(codec_ctx, packet) {
-            Ok(()) => {
+        match codec_ctx
+            .receive_packet(packet)
+            .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?
+        {
+            ff_sys::ReceiveOutcome::Frame => {
                 (*packet).stream_index = 0;
                 let ret = av_interleaved_write_frame(fmt_ctx, packet);
                 av_packet_unref(packet);
@@ -563,9 +566,12 @@ unsafe fn drain_packets(
                     return Err(PreviewImageError::from_ffmpeg_error(ret));
                 }
             }
-            Err(e) if e == ff_sys::error_codes::EOF => break,
-            Err(e) if !until_eof && e == ff_sys::error_codes::EAGAIN => break,
-            Err(e) => return Err(PreviewImageError::from_ffmpeg_error(e)),
+            ff_sys::ReceiveOutcome::Drained => break,
+            ff_sys::ReceiveOutcome::NeedInput => {
+                if !until_eof {
+                    break;
+                }
+            }
         }
     }
     Ok(())
@@ -1162,7 +1168,7 @@ unsafe fn encode_gif_unsafe(
         });
     }
 
-    let Some(codec) = avcodec::find_encoder(AVCodecID_AV_CODEC_ID_GIF) else {
+    let Some(codec) = ff_sys::Codec::find_encoder(AVCodecID_AV_CODEC_ID_GIF) else {
         avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -1171,20 +1177,20 @@ unsafe fn encode_gif_unsafe(
         });
     };
 
-    let codec_ctx = match avcodec::alloc_context3(codec) {
+    let mut codec_ctx = match ff_sys::CodecContext::new(Some(codec)) {
         Ok(ctx) => ctx,
         Err(e) => {
             avformat_free_context(fmt_ctx);
             let mut g = graph;
             avfilter_graph_free(std::ptr::addr_of_mut!(g));
-            return Err(PreviewImageError::from_ffmpeg_error(e));
+            return Err(PreviewImageError::from_ffmpeg_error(e.code()));
         }
     };
 
     // Pull a first frame to discover width/height/pix_fmt from the filter output.
     let first_frame = av_frame_alloc();
     if first_frame.is_null() {
-        avcodec::free_context(&mut { codec_ctx });
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -1197,7 +1203,7 @@ unsafe fn encode_gif_unsafe(
     if ret < 0 {
         let mut f = first_frame;
         av_frame_free(std::ptr::addr_of_mut!(f));
-        avcodec::free_context(&mut { codec_ctx });
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -1214,31 +1220,31 @@ unsafe fn encode_gif_unsafe(
     // SAFETY: codec_ctx is non-null.
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let fps_int = fps.round().max(1.0) as u32;
-    (*codec_ctx).width = out_width;
-    (*codec_ctx).height = out_height;
-    (*codec_ctx).time_base = AVRational {
+    (*codec_ctx.as_mut_ptr()).width = out_width;
+    (*codec_ctx.as_mut_ptr()).height = out_height;
+    (*codec_ctx.as_mut_ptr()).time_base = AVRational {
         num: 1,
         den: fps_int as i32,
     };
-    (*codec_ctx).pix_fmt = out_pix_fmt;
+    (*codec_ctx.as_mut_ptr()).pix_fmt = out_pix_fmt;
 
     // Set GIF to loop infinitely (option "loop" = 0).
     // SAFETY: priv_data is valid after alloc_context3; av_opt_set handles unknown options gracefully.
     let _ = av_opt_set(
-        (*codec_ctx).priv_data.cast(),
+        (*codec_ctx.as_mut_ptr()).priv_data.cast(),
         c"loop".as_ptr(),
         c"0".as_ptr(),
         0,
     );
 
-    if let Err(e) = avcodec::open2(codec_ctx, codec, ptr::null_mut()) {
+    if let Err(e) = codec_ctx.open(codec, ptr::null_mut()) {
         let mut f = first_frame;
         av_frame_free(std::ptr::addr_of_mut!(f));
-        avcodec::free_context(&mut { codec_ctx });
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
-        return Err(PreviewImageError::from_ffmpeg_error(e));
+        return Err(PreviewImageError::from_ffmpeg_error(e.code()));
     }
 
     // Copy codec parameters to stream.
@@ -1256,7 +1262,7 @@ unsafe fn encode_gif_unsafe(
         Err(e) => {
             let mut f = first_frame;
             av_frame_free(std::ptr::addr_of_mut!(f));
-            avcodec::free_context(&mut { codec_ctx });
+            drop(codec_ctx);
             avformat_free_context(fmt_ctx);
             let mut g = graph;
             avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -1270,7 +1276,7 @@ unsafe fn encode_gif_unsafe(
         avformat::close_output(&raw mut (*fmt_ctx).pb);
         let mut f = first_frame;
         av_frame_free(std::ptr::addr_of_mut!(f));
-        avcodec::free_context(&mut { codec_ctx });
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -1283,7 +1289,7 @@ unsafe fn encode_gif_unsafe(
         avformat::close_output(&raw mut (*fmt_ctx).pb);
         let mut f = first_frame;
         av_frame_free(std::ptr::addr_of_mut!(f));
-        avcodec::free_context(&mut { codec_ctx });
+        drop(codec_ctx);
         avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -1300,9 +1306,10 @@ unsafe fn encode_gif_unsafe(
         // Encode the first frame we already pulled.
         (*first_frame).pts = frame_counter;
         frame_counter += 1;
-        avcodec::send_frame(codec_ctx, first_frame)
-            .map_err(PreviewImageError::from_ffmpeg_error)?;
-        drain_packets(codec_ctx, fmt_ctx, packet, false)?;
+        codec_ctx
+            .send_frame(first_frame)
+            .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
+        drain_packets(&mut codec_ctx, fmt_ctx, packet, false)?;
 
         // Pull and encode remaining frames.
         loop {
@@ -1318,18 +1325,20 @@ unsafe fn encode_gif_unsafe(
             }
             (*frame).pts = frame_counter;
             frame_counter += 1;
-            let send_result =
-                avcodec::send_frame(codec_ctx, frame).map_err(PreviewImageError::from_ffmpeg_error);
+            let send_result = codec_ctx
+                .send_frame(frame)
+                .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()));
             let mut f = frame;
             av_frame_free(std::ptr::addr_of_mut!(f));
             send_result?;
-            drain_packets(codec_ctx, fmt_ctx, packet, false)?;
+            drain_packets(&mut codec_ctx, fmt_ctx, packet, false)?;
         }
 
         // Flush encoder.
-        avcodec::send_frame(codec_ctx, ptr::null())
-            .map_err(PreviewImageError::from_ffmpeg_error)?;
-        drain_packets(codec_ctx, fmt_ctx, packet, true)?;
+        codec_ctx
+            .send_frame(ptr::null())
+            .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
+        drain_packets(&mut codec_ctx, fmt_ctx, packet, true)?;
         Ok(())
     })();
 
@@ -1338,7 +1347,7 @@ unsafe fn encode_gif_unsafe(
     av_packet_free(&mut { packet });
     let mut f = first_frame;
     av_frame_free(std::ptr::addr_of_mut!(f));
-    avcodec::free_context(&mut { codec_ctx });
+    drop(codec_ctx);
     avformat_free_context(fmt_ctx);
     let mut g = graph;
     avfilter_graph_free(std::ptr::addr_of_mut!(g));

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -19,7 +19,7 @@ use super::two_pass::AV_CODEC_FLAG_PASS1;
 use super::{
     AV_TIME_BASE, AVChapter, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P,
     AudioCodec, CString, EncodeError, VideoCodec, VideoEncoderInner, av_interleaved_write_frame,
-    av_mallocz, av_packet_alloc, av_packet_free, av_packet_unref, avcodec, avformat_free_context,
+    av_mallocz, av_packet_alloc, av_packet_free, av_packet_unref, avformat_free_context,
     avformat_new_stream, ptr, swresample, swscale,
 };
 
@@ -198,47 +198,42 @@ impl VideoEncoderInner {
         let encoder_name = self.select_video_encoder(codec, hardware_encoder)?;
         self.actual_video_codec.clone_from(&encoder_name);
 
-        let c_encoder_name =
-            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
-                code: 0,
-                message: "Invalid encoder name".to_string(),
-            })?;
-
-        let codec_ptr =
-            avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
+        let selected_codec =
+            ff_sys::Codec::find_encoder_by_name(&encoder_name).ok_or_else(|| {
                 EncodeError::NoSuitableEncoder {
                     codec: format!("{:?}", codec),
                     tried: vec![encoder_name.clone()],
                 }
             })?;
+        let codec_ptr = selected_codec.as_ptr();
 
         // Allocate codec context
-        let mut codec_ctx =
-            avcodec::alloc_context3(codec_ptr).map_err(EncodeError::from_ffmpeg_error)?;
+        let mut codec_ctx = ff_sys::CodecContext::new(Some(selected_codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Configure codec context.
         // Use the encoder's own codec_id rather than codec_to_id(codec): when a
         // fallback encoder is selected (e.g. libvpx-vp9 instead of libx264 for
         // H.264), the codec_id must match the actual encoder, not the requested
         // codec family, otherwise avcodec_open2 rejects it with EINVAL.
-        (*codec_ctx).codec_id = (*codec_ptr).id;
-        (*codec_ctx).width = width as i32;
-        (*codec_ctx).height = height as i32;
-        (*codec_ctx).time_base.num = 1;
-        (*codec_ctx).time_base.den = (fps * 1000.0) as i32; // Use millisecond precision
-        (*codec_ctx).framerate.num = fps as i32;
-        (*codec_ctx).framerate.den = 1;
-        (*codec_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*codec_ctx.as_mut_ptr()).codec_id = (*codec_ptr).id;
+        (*codec_ctx.as_mut_ptr()).width = width as i32;
+        (*codec_ctx.as_mut_ptr()).height = height as i32;
+        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
+        (*codec_ctx.as_mut_ptr()).time_base.den = (fps * 1000.0) as i32; // Use millisecond precision
+        (*codec_ctx.as_mut_ptr()).framerate.num = fps as i32;
+        (*codec_ctx.as_mut_ptr()).framerate.den = 1;
+        (*codec_ctx.as_mut_ptr()).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
 
         // Set bitrate control mode
         match bitrate_mode {
             Some(BitrateMode::Cbr(bps)) => {
-                (*codec_ctx).bit_rate = *bps as i64;
+                (*codec_ctx.as_mut_ptr()).bit_rate = *bps as i64;
             }
             Some(BitrateMode::Vbr { target, max }) => {
-                (*codec_ctx).bit_rate = *target as i64;
-                (*codec_ctx).rc_max_rate = *max as i64;
-                (*codec_ctx).rc_buffer_size = (*max * 2) as i32;
+                (*codec_ctx.as_mut_ptr()).bit_rate = *target as i64;
+                (*codec_ctx.as_mut_ptr()).rc_max_rate = *max as i64;
+                (*codec_ctx.as_mut_ptr()).rc_buffer_size = (*max * 2) as i32;
             }
             Some(BitrateMode::Crf(q)) => {
                 let crf_str = CString::new(q.to_string()).map_err(|_| EncodeError::Ffmpeg {
@@ -247,7 +242,7 @@ impl VideoEncoderInner {
                 })?;
                 // SAFETY: priv_data, option name, and value are all valid pointers
                 let ret = ff_sys::av_opt_set(
-                    (*codec_ctx).priv_data,
+                    (*codec_ctx.as_mut_ptr()).priv_data,
                     b"crf\0".as_ptr() as *const i8,
                     crf_str.as_ptr(),
                     0,
@@ -257,12 +252,12 @@ impl VideoEncoderInner {
                         "crf option not supported by encoder, falling back to default bitrate \
                          encoder={encoder_name} crf={q}"
                     );
-                    (*codec_ctx).bit_rate = 2_000_000;
+                    (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
                 }
             }
             None => {
                 // Default 2 Mbps
-                (*codec_ctx).bit_rate = 2_000_000;
+                (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
             }
         }
 
@@ -274,7 +269,7 @@ impl VideoEncoderInner {
             })?;
             // SAFETY: priv_data, option name, and value are all valid pointers
             let ret = ff_sys::av_opt_set(
-                (*codec_ctx).priv_data,
+                (*codec_ctx.as_mut_ptr()).priv_data,
                 b"preset\0".as_ptr() as *const i8,
                 preset_cstr.as_ptr(),
                 0,
@@ -292,47 +287,49 @@ impl VideoEncoderInner {
             // SAFETY: codec_ctx is valid and allocated; priv_data is set by
             // avcodec_alloc_context3. Options are applied before avcodec_open2
             // so they take effect during codec initialisation.
-            Self::apply_codec_options(codec_ctx, opts, &encoder_name);
+            Self::apply_codec_options(codec_ctx.as_mut_ptr(), opts, &encoder_name);
         }
 
         // Apply explicit pixel format override (takes priority over codec-option auto-select).
         if let Some(fmt) = pixel_format {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).pix_fmt = pixel_format_to_av(*fmt);
+            (*codec_ctx.as_mut_ptr()).pix_fmt = pixel_format_to_av(*fmt);
         }
 
         // Apply HDR10 color context: BT.2020 primaries, PQ transfer, BT.2020 NCL colorspace.
         if self.hdr10_metadata.is_some() {
             // SAFETY: codec_ctx is valid and allocated; direct field writes are safe.
-            (*codec_ctx).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
-            (*codec_ctx).color_trc = ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
-            (*codec_ctx).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
+            (*codec_ctx.as_mut_ptr()).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
+            (*codec_ctx.as_mut_ptr()).color_trc =
+                ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
+            (*codec_ctx.as_mut_ptr()).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
         }
 
         // Apply explicit color overrides (take priority over HDR10 automatic defaults).
         if let Some(cs) = color_space {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).colorspace = color_space_to_av(cs);
+            (*codec_ctx.as_mut_ptr()).colorspace = color_space_to_av(cs);
         }
         if let Some(trc) = color_transfer {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).color_trc = color_transfer_to_av(trc);
+            (*codec_ctx.as_mut_ptr()).color_trc = color_transfer_to_av(trc);
         }
         if let Some(cp) = color_primaries {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).color_primaries = color_primaries_to_av(cp);
+            (*codec_ctx.as_mut_ptr()).color_primaries = color_primaries_to_av(cp);
         }
 
         // For two-pass, set the pass-1 flag before opening the codec.
         if two_pass {
             // SAFETY: codec_ctx is a valid allocated (but not yet opened) context.
-            (*codec_ctx).flags |= AV_CODEC_FLAG_PASS1;
+            (*codec_ctx.as_mut_ptr()).flags |= AV_CODEC_FLAG_PASS1;
         }
 
         // Open codec
-        avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut())
-            .map_err(EncodeError::from_ffmpeg_error)?;
-        let actual_pix_fmt = from_av_pixel_format((*codec_ctx).pix_fmt);
+        codec_ctx
+            .open(selected_codec, ptr::null_mut())
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
+        let actual_pix_fmt = from_av_pixel_format((*codec_ctx.as_mut_ptr()).pix_fmt);
         log::info!(
             "codec opened codec={encoder_name} width={width} height={height} fps={fps} \
              pix_fmt={actual_pix_fmt}"
@@ -341,22 +338,22 @@ impl VideoEncoderInner {
         // Create stream
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
-            avcodec::free_context(&raw mut codec_ctx);
+            // The owned codec_ctx frees itself on return.
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "Cannot create stream".to_string(),
             });
         }
 
-        (*stream).time_base = (*codec_ctx).time_base;
+        (*stream).time_base = (*codec_ctx.as_mut_ptr()).time_base;
 
         // Copy codec parameters to stream
         if !(*stream).codecpar.is_null() {
-            (*(*stream).codecpar).codec_id = (*codec_ctx).codec_id;
+            (*(*stream).codecpar).codec_id = (*codec_ctx.as_mut_ptr()).codec_id;
             (*(*stream).codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-            (*(*stream).codecpar).width = (*codec_ctx).width;
-            (*(*stream).codecpar).height = (*codec_ctx).height;
-            (*(*stream).codecpar).format = (*codec_ctx).pix_fmt;
+            (*(*stream).codecpar).width = (*codec_ctx.as_mut_ptr()).width;
+            (*(*stream).codecpar).height = (*codec_ctx.as_mut_ptr()).height;
+            (*(*stream).codecpar).format = (*codec_ctx.as_mut_ptr()).pix_fmt;
         }
 
         self.video_stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
@@ -387,30 +384,28 @@ impl VideoEncoderInner {
         let encoder_name = self.select_audio_encoder(codec)?;
         self.actual_audio_codec.clone_from(&encoder_name);
 
-        let c_encoder_name =
-            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
-                code: 0,
-                message: "Invalid encoder name".to_string(),
-            })?;
-
-        let codec_ptr =
-            avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
+        let selected_codec =
+            ff_sys::Codec::find_encoder_by_name(&encoder_name).ok_or_else(|| {
                 EncodeError::NoSuitableEncoder {
                     codec: format!("{:?}", codec),
                     tried: vec![encoder_name.clone()],
                 }
             })?;
+        let codec_ptr = selected_codec.as_ptr();
 
         // Allocate codec context
-        let mut codec_ctx =
-            avcodec::alloc_context3(codec_ptr).map_err(EncodeError::from_ffmpeg_error)?;
+        let mut codec_ctx = ff_sys::CodecContext::new(Some(selected_codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Configure codec context
-        (*codec_ctx).codec_id = audio_codec_to_id(codec);
-        (*codec_ctx).sample_rate = sample_rate as i32;
+        (*codec_ctx.as_mut_ptr()).codec_id = audio_codec_to_id(codec);
+        (*codec_ctx.as_mut_ptr()).sample_rate = sample_rate as i32;
 
         // Set channel layout using FFmpeg 7.x API
-        swresample::channel_layout::set_default(&raw mut (*codec_ctx).ch_layout, channels as i32);
+        swresample::channel_layout::set_default(
+            &raw mut (*codec_ctx.as_mut_ptr()).ch_layout,
+            channels as i32,
+        );
 
         // Use the first sample format the codec actually declares; fall back to
         // FLTP only when the codec exposes no preference.  FLTP is NOT valid for
@@ -423,14 +418,14 @@ impl VideoEncoderInner {
                 ff_sys::swresample::sample_format::FLTP
             }
         };
-        (*codec_ctx).sample_fmt = target_fmt;
+        (*codec_ctx.as_mut_ptr()).sample_fmt = target_fmt;
 
         // Set bitrate
         if let Some(br) = bitrate {
-            (*codec_ctx).bit_rate = br as i64;
+            (*codec_ctx.as_mut_ptr()).bit_rate = br as i64;
         } else {
             // Default bitrate based on codec
-            (*codec_ctx).bit_rate = match codec {
+            (*codec_ctx.as_mut_ptr()).bit_rate = match codec {
                 AudioCodec::Aac => 192_000,
                 AudioCodec::Opus => 128_000,
                 AudioCodec::Mp3 => 192_000,
@@ -448,24 +443,25 @@ impl VideoEncoderInner {
         }
 
         // Set time base
-        (*codec_ctx).time_base.num = 1;
-        (*codec_ctx).time_base.den = sample_rate as i32;
+        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
+        (*codec_ctx.as_mut_ptr()).time_base.den = sample_rate as i32;
 
         // Open codec
-        avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut())
-            .map_err(EncodeError::from_ffmpeg_error)?;
+        codec_ctx
+            .open(selected_codec, ptr::null_mut())
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Create stream
         let stream = avformat_new_stream(self.format_ctx, codec_ptr);
         if stream.is_null() {
-            avcodec::free_context(&raw mut codec_ctx);
+            // The owned codec_ctx frees itself on return.
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "Cannot create stream".to_string(),
             });
         }
 
-        (*stream).time_base = (*codec_ctx).time_base;
+        (*stream).time_base = (*codec_ctx.as_mut_ptr()).time_base;
 
         // Copy all codec parameters to the stream — including extradata (e.g. AAC
         // AudioSpecificConfig) that is only available after avcodec_open2.
@@ -474,20 +470,25 @@ impl VideoEncoderInner {
         // propagated correctly so container muxers and hardware decoders can
         // identify and decode the stream.
         if !(*stream).codecpar.is_null() {
-            avcodec::parameters_from_context((*stream).codecpar, codec_ctx)
-                .map_err(EncodeError::from_ffmpeg_error)?;
+            codec_ctx
+                .parameters_from_context((*stream).codecpar)
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
         }
+
+        // Read the FIFO parameters before moving the owned context into `self`.
+        let frame_size = (*codec_ctx.as_mut_ptr()).frame_size;
+        let fifo_sample_fmt = (*codec_ctx.as_mut_ptr()).sample_fmt;
+        let fifo_nb_channels = (*codec_ctx.as_mut_ptr()).ch_layout.nb_channels;
 
         self.audio_stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
         self.audio_codec_ctx = Some(codec_ctx);
 
         // Allocate sample FIFO for codecs that require a fixed frame_size (AAC, FLAC, ALAC …).
         // Leave audio_fifo as None for variable-frame-size codecs (frame_size == 0).
-        let frame_size = (*codec_ctx).frame_size;
         if frame_size > 0 {
             let fifo = ff_sys::swresample::audio_fifo::alloc(
-                (*codec_ctx).sample_fmt,
-                (*codec_ctx).ch_layout.nb_channels,
+                fifo_sample_fmt,
+                fifo_nb_channels,
                 frame_size * 2,
             )
             .map_err(EncodeError::from_ffmpeg_error)?;
@@ -517,14 +518,8 @@ impl VideoEncoderInner {
 
         // Try each candidate
         for &name in &candidates {
-            unsafe {
-                let c_name = CString::new(name).map_err(|_| EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Invalid encoder name".to_string(),
-                })?;
-                if avcodec::find_encoder_by_name(c_name.as_ptr()).is_some() {
-                    return Ok(name.to_string());
-                }
+            if ff_sys::Codec::find_encoder_by_name(name).is_some() {
+                return Ok(name.to_string());
             }
         }
 
@@ -826,23 +821,20 @@ impl VideoEncoderInner {
     pub(super) unsafe fn cleanup(&mut self) {
         // Free video codec context.
         // For two-pass encoding, stats_in points into self.stats_in_cstr (Rust-owned).
-        // Null it out BEFORE avcodec_free_context so FFmpeg does not call av_free on it.
+        // Null it out BEFORE the owned context is dropped (its Drop frees the codec
+        // context) so FFmpeg does not call av_free on the Rust-owned pointer.
         if let Some(mut ctx) = self.video_codec_ctx.take() {
-            (*ctx).stats_in = ptr::null_mut();
-            avcodec::free_context(&raw mut ctx);
+            (*ctx.as_mut_ptr()).stats_in = ptr::null_mut();
+            // `ctx` drops here, freeing the codec context.
         }
         // Drop the owned CString now that the codec context no longer references it.
         self.stats_in_cstr = None;
 
-        // Free pass-1 codec context (only set in two-pass mode).
-        if let Some(mut ctx) = self.pass1_codec_ctx.take() {
-            avcodec::free_context(&raw mut ctx);
-        }
+        // Free pass-1 codec context (only set in two-pass mode); drops on assignment.
+        self.pass1_codec_ctx = None;
 
-        // Free audio codec context
-        if let Some(mut ctx) = self.audio_codec_ctx.take() {
-            avcodec::free_context(&raw mut ctx);
-        }
+        // Free audio codec context; drops on assignment.
+        self.audio_codec_ctx = None;
 
         // Free scaling context
         if let Some(ctx) = self.sws_ctx.take() {

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -14,7 +14,7 @@ use super::color::{pixel_format_to_av, sample_format_to_av};
 use super::{
     AVChannelLayout, AVCodecContext, AVFrame, AVPixelFormat, AudioFrame, EncodeError,
     VideoEncoderInner, VideoFrame, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
-    av_packet_unref, avcodec, ptr, swresample, swscale,
+    av_packet_unref, ptr, swresample, swscale,
 };
 
 /// Maximum number of planes in AVFrame data/linesize arrays.
@@ -35,8 +35,7 @@ impl VideoEncoderInner {
     ///
     /// `codec_ctx` must be a valid, open `AVCodecContext`.
     pub(super) unsafe fn drain_pass1_packets(
-        &self,
-        codec_ctx: *mut AVCodecContext,
+        codec_ctx: &mut ff_sys::CodecContext,
     ) -> Result<(), EncodeError> {
         let mut packet = av_packet_alloc();
         if packet.is_null() {
@@ -47,21 +46,21 @@ impl VideoEncoderInner {
         }
 
         loop {
-            match avcodec::receive_packet(codec_ctx, packet) {
-                Ok(()) => {
+            match codec_ctx.receive_packet(packet) {
+                Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Discard — do not write to the format context.
                     av_packet_unref(packet);
                 }
-                Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                Ok(ff_sys::ReceiveOutcome::NeedInput | ff_sys::ReceiveOutcome::Drained) => {
                     break;
                 }
                 Err(e) => {
                     av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Error receiving packet from pass-1 encoder: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     });
                 }
@@ -326,11 +325,11 @@ impl VideoEncoderInner {
 
     /// Receive encoded packets from the encoder.
     pub(super) unsafe fn receive_packets(&mut self) -> Result<(), EncodeError> {
-        let codec_ctx = self
-            .video_codec_ctx
-            .ok_or_else(|| EncodeError::InvalidConfig {
+        if self.video_codec_ctx.is_none() {
+            return Err(EncodeError::InvalidConfig {
                 reason: "Video codec not initialized".to_string(),
-            })?;
+            });
+        }
 
         let mut packet = av_packet_alloc();
         if packet.is_null() {
@@ -341,19 +340,29 @@ impl VideoEncoderInner {
         }
 
         loop {
-            match avcodec::receive_packet(codec_ctx, packet) {
-                Ok(()) => {
+            let recv = self
+                .video_codec_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Video codec not initialized".to_string(),
+                })?
+                .receive_packet(packet);
+            match recv {
+                Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
                 }
-                Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                Ok(ff_sys::ReceiveOutcome::NeedInput | ff_sys::ReceiveOutcome::Drained) => {
                     // No more packets available
                     break;
                 }
                 Err(e) => {
                     av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
-                        message: format!("Error receiving packet: {}", ff_sys::av_error_string(e)),
+                        code: e.code(),
+                        message: format!(
+                            "Error receiving packet: {}",
+                            ff_sys::av_error_string(e.code())
+                        ),
                     });
                 }
             }
@@ -396,9 +405,11 @@ impl VideoEncoderInner {
     ) -> Result<(), EncodeError> {
         let codec_ctx = self
             .audio_codec_ctx
+            .as_ref()
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio codec not initialized".to_string(),
-            })?;
+            })?
+            .as_ptr();
 
         let target_sample_rate = (*codec_ctx).sample_rate;
         let target_format = (*codec_ctx).sample_fmt;
@@ -532,11 +543,11 @@ impl VideoEncoderInner {
 
     /// Receive encoded audio packets from the encoder.
     pub(super) unsafe fn receive_audio_packets(&mut self) -> Result<(), EncodeError> {
-        let codec_ctx = self
-            .audio_codec_ctx
-            .ok_or_else(|| EncodeError::InvalidConfig {
+        if self.audio_codec_ctx.is_none() {
+            return Err(EncodeError::InvalidConfig {
                 reason: "Audio codec not initialized".to_string(),
-            })?;
+            });
+        }
 
         let mut packet = av_packet_alloc();
         if packet.is_null() {
@@ -547,21 +558,28 @@ impl VideoEncoderInner {
         }
 
         loop {
-            match avcodec::receive_packet(codec_ctx, packet) {
-                Ok(()) => {
+            let recv = self
+                .audio_codec_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Audio codec not initialized".to_string(),
+                })?
+                .receive_packet(packet);
+            match recv {
+                Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
                 }
-                Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
+                Ok(ff_sys::ReceiveOutcome::NeedInput | ff_sys::ReceiveOutcome::Drained) => {
                     // No more packets available
                     break;
                 }
                 Err(e) => {
                     av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Error receiving audio packet: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     });
                 }

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -55,10 +55,10 @@ pub(super) struct VideoEncoderInner {
     pub(super) format_ctx: *mut AVFormatContext,
 
     /// Video codec context
-    pub(super) video_codec_ctx: Option<*mut AVCodecContext>,
+    pub(super) video_codec_ctx: Option<ff_sys::CodecContext>,
 
     /// Audio codec context (for future use)
-    pub(super) audio_codec_ctx: Option<*mut AVCodecContext>,
+    pub(super) audio_codec_ctx: Option<ff_sys::CodecContext>,
 
     /// Video stream index
     pub(super) video_stream_index: i32,
@@ -104,7 +104,7 @@ pub(super) struct VideoEncoderInner {
     pub(super) two_pass: bool,
 
     /// Pass-1 codec context (two-pass mode only; None in single-pass and after pass 1 completes).
-    pub(super) pass1_codec_ctx: Option<*mut AVCodecContext>,
+    pub(super) pass1_codec_ctx: Option<ff_sys::CodecContext>,
 
     /// Buffered YUV420P frame data for pass-2 re-encoding (two-pass mode only).
     pub(super) buffered_frames: Vec<TwoPassFrame>,
@@ -326,9 +326,11 @@ impl VideoEncoderInner {
             if self.two_pass {
                 let pass1_ctx = self
                     .pass1_codec_ctx
+                    .as_mut()
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Pass-1 codec context not initialized".to_string(),
-                    })?;
+                    })?
+                    .as_mut_ptr();
 
                 // Convert the incoming frame to YUV420P (the pass-1 codec's format).
                 let mut av_frame = av_frame_alloc();
@@ -378,19 +380,30 @@ impl VideoEncoderInner {
                 // Send to pass-1 encoder and discard the encoded output.
                 // time_base.den = fps * 1000, so one frame duration = 1000 ticks.
                 (*av_frame).pts = self.frame_count as i64 * 1000;
-                let send_result = avcodec::send_frame(pass1_ctx, av_frame);
+                let send_result = self
+                    .pass1_codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Pass-1 codec context not initialized".to_string(),
+                    })?
+                    .send_frame(av_frame);
                 if let Err(e) = send_result {
                     av_frame_free(&raw mut av_frame);
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Failed to send frame to pass-1 encoder: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     });
                 }
 
-                let drain_result = self.drain_pass1_packets(pass1_ctx);
+                let drain_result =
+                    Self::drain_pass1_packets(self.pass1_codec_ctx.as_mut().ok_or_else(|| {
+                        EncodeError::InvalidConfig {
+                            reason: "Pass-1 codec context not initialized".to_string(),
+                        }
+                    })?);
                 av_frame_free(&raw mut av_frame);
                 drain_result?;
 
@@ -401,9 +414,11 @@ impl VideoEncoderInner {
             // ── Single-pass path ─────────────────────────────────────────────────
             let codec_ctx = self
                 .video_codec_ctx
+                .as_mut()
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
-                })?;
+                })?
+                .as_mut_ptr();
 
             // Allocate AVFrame
             let mut av_frame = av_frame_alloc();
@@ -426,12 +441,21 @@ impl VideoEncoderInner {
             (*av_frame).pts = self.frame_count as i64 * 1000;
 
             // Send frame to encoder
-            let send_result = avcodec::send_frame(codec_ctx, av_frame);
+            let send_result = self
+                .video_codec_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Video codec not initialized".to_string(),
+                })?
+                .send_frame(av_frame);
             if let Err(e) = send_result {
                 av_frame_free(&raw mut av_frame);
                 return Err(EncodeError::Ffmpeg {
-                    code: e,
-                    message: format!("Failed to send frame: {}", ff_sys::av_error_string(e)),
+                    code: e.code(),
+                    message: format!(
+                        "Failed to send frame: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
                 });
             }
 
@@ -462,9 +486,11 @@ impl VideoEncoderInner {
         unsafe {
             let codec_ctx = self
                 .audio_codec_ctx
+                .as_mut()
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Audio codec not initialized".to_string(),
-                })?;
+                })?
+                .as_mut_ptr();
 
             let frame_size = (*codec_ctx).frame_size;
 
@@ -484,14 +510,20 @@ impl VideoEncoderInner {
             // ── Variable frame-size path (PCM, Vorbis …) ────────────────────
             if frame_size <= 0 || self.audio_fifo.is_none() {
                 (*av_frame).pts = self.audio_sample_count as i64;
-                let send_result = avcodec::send_frame(codec_ctx, av_frame);
+                let send_result = self
+                    .audio_codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Audio codec not initialized".to_string(),
+                    })?
+                    .send_frame(av_frame);
                 av_frame_free(&raw mut av_frame);
                 if let Err(e) = send_result {
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Failed to send audio frame: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     });
                 }
@@ -555,14 +587,20 @@ impl VideoEncoderInner {
                 }
 
                 (*out_frame).pts = self.audio_sample_count as i64;
-                let send_result = avcodec::send_frame(codec_ctx, out_frame);
+                let send_result = self
+                    .audio_codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Audio codec not initialized".to_string(),
+                    })?
+                    .send_frame(out_frame);
                 av_frame_free(&raw mut out_frame);
                 if let Err(e) = send_result {
                     return Err(EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Failed to send audio frame: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     });
                 }
@@ -584,17 +622,31 @@ impl VideoEncoderInner {
             }
 
             // Single-pass: flush video encoder
-            if let Some(codec_ctx) = self.video_codec_ctx {
+            if self.video_codec_ctx.is_some() {
                 // Send NULL frame to flush
-                avcodec::send_frame(codec_ctx, ptr::null())
-                    .map_err(EncodeError::from_ffmpeg_error)?;
+                self.video_codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Video codec not initialized".to_string(),
+                    })?
+                    .send_frame(ptr::null())
+                    .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_packets()?;
             }
 
             // Flush remaining FIFO samples (fixed-frame-size codecs only).
             // The last chunk may be smaller than frame_size; send it as-is so the
             // encoder can write a short final frame before the NULL-frame flush.
-            if let (Some(fifo), Some(codec_ctx)) = (self.audio_fifo, self.audio_codec_ctx) {
+            if let Some(fifo) = self.audio_fifo
+                && self.audio_codec_ctx.is_some()
+            {
+                let codec_ctx = self
+                    .audio_codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Audio codec not initialized".to_string(),
+                    })?
+                    .as_mut_ptr();
                 let remaining = ff_sys::swresample::audio_fifo::size(fifo);
                 if remaining > 0 {
                     let mut out_frame = av_frame_alloc();
@@ -613,7 +665,13 @@ impl VideoEncoderInner {
                                 remaining,
                             );
                             (*out_frame).pts = self.audio_sample_count as i64;
-                            let _ = avcodec::send_frame(codec_ctx, out_frame);
+                            let _ = self
+                                .audio_codec_ctx
+                                .as_mut()
+                                .ok_or_else(|| EncodeError::InvalidConfig {
+                                    reason: "Audio codec not initialized".to_string(),
+                                })?
+                                .send_frame(out_frame);
                             let _ = self.receive_audio_packets();
                             self.audio_sample_count += remaining as u64;
                         }
@@ -623,10 +681,15 @@ impl VideoEncoderInner {
             }
 
             // Flush audio encoder
-            if let Some(codec_ctx) = self.audio_codec_ctx {
+            if self.audio_codec_ctx.is_some() {
                 // Send NULL frame to flush
-                avcodec::send_frame(codec_ctx, ptr::null())
-                    .map_err(EncodeError::from_ffmpeg_error)?;
+                self.audio_codec_ctx
+                    .as_mut()
+                    .ok_or_else(|| EncodeError::InvalidConfig {
+                        reason: "Audio codec not initialized".to_string(),
+                    })?
+                    .send_frame(ptr::null())
+                    .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_audio_packets()?;
             }
 

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -16,7 +16,7 @@ use super::color::{
 use super::options::codec_to_id;
 use super::{
     AVPixelFormat_AV_PIX_FMT_YUV420P, CString, EncodeError, VideoEncoderConfig, VideoEncoderInner,
-    av_frame_alloc, av_frame_free, av_write_trailer, avcodec, avformat_write_header, ptr,
+    av_frame_alloc, av_frame_free, av_write_trailer, avformat_write_header, ptr,
 };
 
 /// FFmpeg pass-1 encoding flag: collect two-pass statistics, discard encoded output.
@@ -59,28 +59,48 @@ impl VideoEncoderInner {
     /// All FFmpeg resources must be valid at the point of the call.
     pub(super) unsafe fn run_pass2(&mut self) -> Result<(), EncodeError> {
         // ── Step 1: Flush pass-1 encoder ────────────────────────────────────
-        let mut pass1_ctx = self
-            .pass1_codec_ctx
-            .ok_or_else(|| EncodeError::InvalidConfig {
+        if self.pass1_codec_ctx.is_none() {
+            return Err(EncodeError::InvalidConfig {
                 reason: "Pass-1 codec context not available".to_string(),
-            })?;
-
-        // SAFETY: pass1_ctx is a valid open codec context.
-        if let Err(e) = avcodec::send_frame(pass1_ctx, ptr::null())
-            && e != ff_sys::error_codes::EOF
-        {
-            return Err(EncodeError::Ffmpeg {
-                code: e,
-                message: format!("pass1 flush send_frame: {}", ff_sys::av_error_string(e)),
             });
         }
-        self.drain_pass1_packets(pass1_ctx)?;
 
-        // ── Step 2: Collect stats_out ────────────────────────────────────────
+        // SAFETY: the pass-1 context is valid and open. The flush send tolerates EOF.
+        if let Err(e) = self
+            .pass1_codec_ctx
+            .as_mut()
+            .ok_or_else(|| EncodeError::InvalidConfig {
+                reason: "Pass-1 codec context not initialized".to_string(),
+            })?
+            .send_frame(ptr::null())
+            && e.code() != ff_sys::error_codes::EOF
+        {
+            return Err(EncodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "pass1 flush send_frame: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            });
+        }
+        Self::drain_pass1_packets(self.pass1_codec_ctx.as_mut().ok_or_else(|| {
+            EncodeError::InvalidConfig {
+                reason: "Pass-1 codec context not initialized".to_string(),
+            }
+        })?)?;
+
+        // ── Step 2: Collect stats_out (before freeing pass 1) ────────────────
         // SAFETY: stats_out is either null or a valid C string owned by the
-        // codec context; it remains valid until avcodec_free_context is called.
-        let stats_str = if !(*pass1_ctx).stats_out.is_null() {
-            std::ffi::CStr::from_ptr((*pass1_ctx).stats_out)
+        // codec context; it remains valid until the owned context is dropped below.
+        let pass1_ptr = self
+            .pass1_codec_ctx
+            .as_ref()
+            .ok_or_else(|| EncodeError::InvalidConfig {
+                reason: "Pass-1 codec context not initialized".to_string(),
+            })?
+            .as_ptr();
+        let stats_str = if !(*pass1_ptr).stats_out.is_null() {
+            std::ffi::CStr::from_ptr((*pass1_ptr).stats_out)
                 .to_string_lossy()
                 .into_owned()
         } else {
@@ -93,9 +113,7 @@ impl VideoEncoderInner {
         };
         log::info!("two-pass pass-1 complete stats_len={}", stats_str.len());
 
-        // ── Step 3: Free pass-1 codec context ───────────────────────────────
-        // SAFETY: pass1_ctx is no longer needed; we own it exclusively.
-        avcodec::free_context(&raw mut pass1_ctx);
+        // ── Step 3: Free pass-1 codec context (owned context drops → frees) ──
         self.pass1_codec_ctx = None;
 
         // ── Step 4: Set up pass-2 codec context ─────────────────────────────
@@ -139,14 +157,23 @@ impl VideoEncoderInner {
         }
 
         // ── Step 7: Flush pass-2 encoder and write trailer ───────────────────
-        if let Some(codec_ctx) = self.video_codec_ctx {
-            // SAFETY: codec_ctx is a valid open pass-2 codec context.
-            if let Err(e) = avcodec::send_frame(codec_ctx, ptr::null())
-                && e != ff_sys::error_codes::EOF
+        if self.video_codec_ctx.is_some() {
+            // SAFETY: the pass-2 codec context is valid and open. Flush tolerates EOF.
+            if let Err(e) = self
+                .video_codec_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Video codec not initialized".to_string(),
+                })?
+                .send_frame(ptr::null())
+                && e.code() != ff_sys::error_codes::EOF
             {
                 return Err(EncodeError::Ffmpeg {
-                    code: e,
-                    message: format!("pass2 flush send_frame: {}", ff_sys::av_error_string(e)),
+                    code: e.code(),
+                    message: format!(
+                        "pass2 flush send_frame: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
                 });
             }
             self.receive_packets()?;
@@ -187,41 +214,35 @@ impl VideoEncoderInner {
         let fps = config.video_fps.unwrap_or(30.0);
         let encoder_name = self.actual_video_codec.clone();
 
-        let c_encoder_name =
-            CString::new(encoder_name.as_str()).map_err(|_| EncodeError::Ffmpeg {
-                code: 0,
-                message: "Invalid encoder name for pass 2".to_string(),
-            })?;
-
-        let codec_ptr =
-            avcodec::find_encoder_by_name(c_encoder_name.as_ptr()).ok_or_else(|| {
+        let selected_codec =
+            ff_sys::Codec::find_encoder_by_name(&encoder_name).ok_or_else(|| {
                 EncodeError::NoSuitableEncoder {
                     codec: encoder_name.clone(),
                     tried: vec![encoder_name.clone()],
                 }
             })?;
 
-        let codec_ctx =
-            avcodec::alloc_context3(codec_ptr).map_err(EncodeError::from_ffmpeg_error)?;
+        let mut codec_ctx = ff_sys::CodecContext::new(Some(selected_codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Mirror the same codec configuration as pass 1.
-        (*codec_ctx).codec_id = codec_to_id(config.video_codec);
-        (*codec_ctx).width = width as i32;
-        (*codec_ctx).height = height as i32;
-        (*codec_ctx).time_base.num = 1;
-        (*codec_ctx).time_base.den = (fps * 1000.0) as i32;
-        (*codec_ctx).framerate.num = fps as i32;
-        (*codec_ctx).framerate.den = 1;
-        (*codec_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*codec_ctx.as_mut_ptr()).codec_id = codec_to_id(config.video_codec);
+        (*codec_ctx.as_mut_ptr()).width = width as i32;
+        (*codec_ctx.as_mut_ptr()).height = height as i32;
+        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
+        (*codec_ctx.as_mut_ptr()).time_base.den = (fps * 1000.0) as i32;
+        (*codec_ctx.as_mut_ptr()).framerate.num = fps as i32;
+        (*codec_ctx.as_mut_ptr()).framerate.den = 1;
+        (*codec_ctx.as_mut_ptr()).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
 
         match config.video_bitrate_mode.as_ref() {
             Some(BitrateMode::Cbr(bps)) => {
-                (*codec_ctx).bit_rate = *bps as i64;
+                (*codec_ctx.as_mut_ptr()).bit_rate = *bps as i64;
             }
             Some(BitrateMode::Vbr { target, max }) => {
-                (*codec_ctx).bit_rate = *target as i64;
-                (*codec_ctx).rc_max_rate = *max as i64;
-                (*codec_ctx).rc_buffer_size = (*max * 2) as i32;
+                (*codec_ctx.as_mut_ptr()).bit_rate = *target as i64;
+                (*codec_ctx.as_mut_ptr()).rc_max_rate = *max as i64;
+                (*codec_ctx.as_mut_ptr()).rc_buffer_size = (*max * 2) as i32;
             }
             Some(BitrateMode::Crf(q)) => {
                 let crf_str = CString::new(q.to_string()).map_err(|_| EncodeError::Ffmpeg {
@@ -230,7 +251,7 @@ impl VideoEncoderInner {
                 })?;
                 // SAFETY: priv_data, option name, and value are all valid pointers.
                 let ret = ff_sys::av_opt_set(
-                    (*codec_ctx).priv_data,
+                    (*codec_ctx.as_mut_ptr()).priv_data,
                     b"crf\0".as_ptr() as *const i8,
                     crf_str.as_ptr(),
                     0,
@@ -240,11 +261,11 @@ impl VideoEncoderInner {
                         "crf option not supported by pass-2 encoder, falling back to default \
                          encoder={encoder_name} crf={q}"
                     );
-                    (*codec_ctx).bit_rate = 2_000_000;
+                    (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
                 }
             }
             None => {
-                (*codec_ctx).bit_rate = 2_000_000;
+                (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
             }
         }
 
@@ -256,7 +277,7 @@ impl VideoEncoderInner {
                 })?;
             // SAFETY: priv_data, option name, and value are all valid pointers.
             let ret = ff_sys::av_opt_set(
-                (*codec_ctx).priv_data,
+                (*codec_ctx.as_mut_ptr()).priv_data,
                 b"preset\0".as_ptr() as *const i8,
                 preset_cstr.as_ptr(),
                 0,
@@ -275,40 +296,41 @@ impl VideoEncoderInner {
             // SAFETY: codec_ctx is valid and allocated; priv_data is set by
             // avcodec_alloc_context3. Options are applied before avcodec_open2
             // so they take effect during codec initialisation.
-            Self::apply_codec_options(codec_ctx, opts, &encoder_name);
+            Self::apply_codec_options(codec_ctx.as_mut_ptr(), opts, &encoder_name);
         }
 
         // Apply explicit pixel format override for pass 2 (mirrors pass 1).
         if let Some(fmt) = config.pixel_format.as_ref() {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).pix_fmt = pixel_format_to_av(*fmt);
+            (*codec_ctx.as_mut_ptr()).pix_fmt = pixel_format_to_av(*fmt);
         }
 
         // Apply HDR10 color context for pass 2 (mirrors pass 1).
         if config.hdr10_metadata.is_some() {
             // SAFETY: codec_ctx is valid and allocated; direct field writes are safe.
-            (*codec_ctx).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
-            (*codec_ctx).color_trc = ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
-            (*codec_ctx).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
+            (*codec_ctx.as_mut_ptr()).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
+            (*codec_ctx.as_mut_ptr()).color_trc =
+                ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
+            (*codec_ctx.as_mut_ptr()).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
         }
 
         // Apply explicit color overrides for pass 2 (mirrors pass 1; take priority over HDR10).
         if let Some(cs) = config.color_space {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).colorspace = color_space_to_av(cs);
+            (*codec_ctx.as_mut_ptr()).colorspace = color_space_to_av(cs);
         }
         if let Some(trc) = config.color_transfer {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).color_trc = color_transfer_to_av(trc);
+            (*codec_ctx.as_mut_ptr()).color_trc = color_transfer_to_av(trc);
         }
         if let Some(cp) = config.color_primaries {
             // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx).color_primaries = color_primaries_to_av(cp);
+            (*codec_ctx.as_mut_ptr()).color_primaries = color_primaries_to_av(cp);
         }
 
         // Set the pass-2 flag and provide stats_in.
         // SAFETY: codec_ctx is a valid allocated (but not yet opened) context.
-        (*codec_ctx).flags |= AV_CODEC_FLAG_PASS2;
+        (*codec_ctx.as_mut_ptr()).flags |= AV_CODEC_FLAG_PASS2;
 
         // Point stats_in to our owned CString (kept alive in self.stats_in_cstr
         // until cleanup() nulls the pointer and drops it).
@@ -320,7 +342,7 @@ impl VideoEncoderInner {
             // SAFETY: stats_cstr.as_ptr() is valid for the lifetime of stats_cstr,
             // which is stored in self.stats_in_cstr and dropped only after the codec
             // context is freed in cleanup().
-            (*codec_ctx).stats_in = stats_cstr.as_ptr().cast_mut();
+            (*codec_ctx.as_mut_ptr()).stats_in = stats_cstr.as_ptr().cast_mut();
             self.stats_in_cstr = Some(stats_cstr);
         }
 
@@ -328,23 +350,25 @@ impl VideoEncoderInner {
         // native mpeg4 encoder without meaningful stats) do not support PASS2 and
         // return AVERROR(EPERM). In that case, fall back to opening without the
         // flag so the caller still gets a valid encoder and usable output.
-        if avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut()).is_err() {
+        if codec_ctx.open(selected_codec, ptr::null_mut()).is_err() {
             log::warn!(
                 "two-pass pass-2 codec rejected AV_CODEC_FLAG_PASS2, \
                  falling back to single-pass mode codec={encoder_name}"
             );
-            (*codec_ctx).flags &= !AV_CODEC_FLAG_PASS2;
-            (*codec_ctx).stats_in = ptr::null_mut();
+            // Null stats_in and drop the owned CString BEFORE re-opening so the
+            // discarded pass-2 attempt never references the Rust-owned pointer.
+            (*codec_ctx.as_mut_ptr()).flags &= !AV_CODEC_FLAG_PASS2;
+            (*codec_ctx.as_mut_ptr()).stats_in = ptr::null_mut();
             self.stats_in_cstr = None;
-            avcodec::open2(codec_ctx, codec_ptr, ptr::null_mut()).map_err(|e| {
-                EncodeError::Ffmpeg {
-                    code: e,
+            codec_ctx
+                .open(selected_codec, ptr::null_mut())
+                .map_err(|e| EncodeError::Ffmpeg {
+                    code: e.code(),
                     message: format!(
                         "pass2 avcodec_open2 fallback: {}",
-                        ff_sys::av_error_string(e)
+                        ff_sys::av_error_string(e.code())
                     ),
-                }
-            })?;
+                })?;
         }
         log::info!(
             "two-pass pass-2 codec opened codec={encoder_name} width={width} height={height}"
@@ -364,11 +388,11 @@ impl VideoEncoderInner {
     /// Must only be called from `run_pass2`. `self.video_codec_ctx` and
     /// `self.format_ctx` must be valid and the output file must be open.
     unsafe fn push_two_pass_frame(&mut self, tf: &TwoPassFrame) -> Result<(), EncodeError> {
-        let codec_ctx = self
-            .video_codec_ctx
-            .ok_or_else(|| EncodeError::InvalidConfig {
+        if self.video_codec_ctx.is_none() {
+            return Err(EncodeError::InvalidConfig {
                 reason: "Pass-2 codec context not initialized".to_string(),
-            })?;
+            });
+        }
 
         let mut av_frame = av_frame_alloc();
         if av_frame.is_null() {
@@ -431,14 +455,20 @@ impl VideoEncoderInner {
         (*av_frame).pts = tf.pts;
 
         // Send to pass-2 encoder.
-        let send_result = avcodec::send_frame(codec_ctx, av_frame);
+        let send_result = self
+            .video_codec_ctx
+            .as_mut()
+            .ok_or_else(|| EncodeError::InvalidConfig {
+                reason: "Video codec not initialized".to_string(),
+            })?
+            .send_frame(av_frame);
         if let Err(e) = send_result {
             av_frame_free(&raw mut av_frame);
             return Err(EncodeError::Ffmpeg {
-                code: e,
+                code: e.code(),
                 message: format!(
                     "Failed to send frame to pass-2 encoder: {}",
-                    ff_sys::av_error_string(e)
+                    ff_sys::av_error_string(e.code())
                 ),
             });
         }

--- a/crates/ff-sys/src/codec.rs
+++ b/crates/ff-sys/src/codec.rs
@@ -5,6 +5,7 @@
 //! owned by the library, so this is a `Copy` borrowed handle with no `Drop`; it
 //! replaces the raw `*const AVCodec` in the safe API.
 
+use std::ffi::CString;
 use std::ptr::NonNull;
 
 use crate::{AVCodec, AVCodecID};
@@ -27,6 +28,31 @@ impl Codec {
         NonNull::new(ptr.cast_mut()).map(|ptr| Self { ptr })
     }
 
+    /// Finds an encoder by codec id, returning `None` when none is registered.
+    ///
+    /// A pure table lookup with no precondition, so it is a safe fn.
+    #[must_use]
+    pub fn find_encoder(codec_id: AVCodecID) -> Option<Self> {
+        // SAFETY: `find_encoder` is a pure table lookup that dereferences no
+        //         caller pointer; it returns a valid static codec pointer or `None`.
+        let ptr = unsafe { crate::avcodec::find_encoder(codec_id) }?;
+        NonNull::new(ptr.cast_mut()).map(|ptr| Self { ptr })
+    }
+
+    /// Finds an encoder by name (e.g. `"libx264"`), returning `None` when none is
+    /// registered or `name` contains an interior null byte.
+    ///
+    /// A pure table lookup with no precondition, so it is a safe fn.
+    #[must_use]
+    pub fn find_encoder_by_name(name: &str) -> Option<Self> {
+        let c_name = CString::new(name).ok()?;
+        // SAFETY: `c_name` is a valid NUL-terminated C string that outlives the
+        //         call; `find_encoder_by_name` reads only that string and returns a
+        //         valid static codec pointer or `None`.
+        let ptr = unsafe { crate::avcodec::find_encoder_by_name(c_name.as_ptr()) }?;
+        NonNull::new(ptr.cast_mut()).map(|ptr| Self { ptr })
+    }
+
     /// Returns the underlying codec pointer for FFI calls.
     #[must_use]
     pub const fn as_ptr(&self) -> *const AVCodec {
@@ -43,6 +69,14 @@ mod tests {
         // `AV_CODEC_ID_NONE` is the sentinel with no registered decoder, so the
         // lookup is deterministically empty regardless of the linked FFmpeg build.
         let result = Codec::find_decoder(crate::AVCodecID_AV_CODEC_ID_NONE);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_encoder_should_return_none_for_codec_none() {
+        // `AV_CODEC_ID_NONE` has no registered encoder, so the lookup is
+        // deterministically empty regardless of the linked FFmpeg build.
+        let result = Codec::find_encoder(crate::AVCodecID_AV_CODEC_ID_NONE);
         assert!(result.is_none());
     }
 }

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -11,8 +11,8 @@ use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
-    AVCodecContext, AVCodecParameters, AVDictionary, AvError, Codec, Frame, Packet,
-    avcodec_free_context as ffi_avcodec_free_context,
+    AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AvError, Codec, Frame,
+    Packet, avcodec_free_context as ffi_avcodec_free_context,
 };
 
 /// The outcome of a [`CodecContext::receive_frame`] call.
@@ -21,7 +21,9 @@ use crate::{
 /// never branch on raw return codes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReceiveOutcome {
-    /// A frame was written into the output frame.
+    /// An output unit is available: a decoded frame from
+    /// [`receive_frame`](CodecContext::receive_frame), or an encoded packet from
+    /// [`receive_packet`](CodecContext::receive_packet).
     Frame,
     /// The decoder needs more input (`EAGAIN`): send another packet, or
     /// [`send_eof`](CodecContext::send_eof) to begin draining.
@@ -169,6 +171,48 @@ impl CodecContext {
         // SAFETY: the caller guarantees the context is opened; `flush_buffers`
         //         reads no caller-supplied pointer.
         unsafe { crate::avcodec::flush_buffers(self.ptr.as_ptr()) };
+    }
+
+    /// Sends a frame to the encoder (a null frame flushes it, entering draining).
+    ///
+    /// After sending a null frame, loop [`receive_packet`](Self::receive_packet)
+    /// until it returns [`ReceiveOutcome::Drained`] to collect the buffered packets.
+    ///
+    /// # Safety
+    ///
+    /// `frame` must be null or a valid `*const AVFrame`.
+    pub unsafe fn send_frame(&mut self, frame: *const AVFrame) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid open encoder context; the caller upholds `frame`.
+        unsafe { crate::avcodec::send_frame(self.ptr.as_ptr(), frame) }.map_err(AvError::new)
+    }
+
+    /// Receives an encoded packet, returning a typed [`ReceiveOutcome`].
+    ///
+    /// `EAGAIN` (need input) and `EOF` (drained) are returned as
+    /// [`ReceiveOutcome::NeedInput`] / [`ReceiveOutcome::Drained`] rather than
+    /// errors; only other negative codes are `Err`.
+    ///
+    /// # Safety
+    ///
+    /// `pkt` must be a valid `*mut AVPacket`.
+    pub unsafe fn receive_packet(&mut self, pkt: *mut AVPacket) -> Result<ReceiveOutcome, AvError> {
+        // SAFETY: `self.ptr` is a valid open encoder context; the caller upholds `pkt`.
+        let result = unsafe { crate::avcodec::receive_packet(self.ptr.as_ptr(), pkt) };
+        classify_receive(result)
+    }
+
+    /// Copies this context's parameters into `par` (encoder → stream codecpar).
+    ///
+    /// # Safety
+    ///
+    /// `par` must be a valid `*mut AVCodecParameters`.
+    pub unsafe fn parameters_from_context(
+        &self,
+        par: *mut AVCodecParameters,
+    ) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid context; the caller upholds `par`.
+        unsafe { crate::avcodec::parameters_from_context(par, self.ptr.as_ptr()) }
+            .map_err(AvError::new)
     }
 }
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1197,6 +1197,30 @@ impl CodecContext {
     /// # Safety
     /// Stub; never executed on docs.rs.
     pub unsafe fn flush_buffers(&mut self) {}
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn send_frame(&mut self, _frame: *const AVFrame) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn receive_packet(
+        &mut self,
+        _pkt: *mut AVPacket,
+    ) -> Result<ReceiveOutcome, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn parameters_from_context(
+        &self,
+        _par: *mut AVCodecParameters,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
 }
 
 impl Drop for CodecContext {
@@ -1392,6 +1416,16 @@ pub struct Codec {
 impl Codec {
     #[must_use]
     pub fn find_decoder(_codec_id: AVCodecID) -> Option<Self> {
+        None
+    }
+
+    #[must_use]
+    pub fn find_encoder(_codec_id: AVCodecID) -> Option<Self> {
+        None
+    }
+
+    #[must_use]
+    pub fn find_encoder_by_name(_name: &str) -> Option<Self> {
         None
     }
 


### PR DESCRIPTION
## Objective

- Move the remaining first-party consumer, ff-encode, off the raw `*mut AVCodecContext` + manual `avcodec::free_context` onto the owned `ff_sys::CodecContext` (ADR-0003), so the encoders no longer hand-manage codec-context lifetimes and free-on-error paths.

## Solution

- Add the encoder surface to `ff_sys::CodecContext` (`send_frame`, `receive_packet` returning `ReceiveOutcome`, `parameters_from_context` — all `unsafe` raw-pointer methods) plus safe encoder finders (`Codec::find_encoder` / `find_encoder_by_name`), with docs.rs stubs. `ReceiveOutcome::Frame`'s doc now covers both a decoded frame and an encoded packet.
- Migrate the five codec-context holders (audio, image, and the video encoder's video / audio / pass1 contexts) and the preview locals to the owned type, removing every manual `free_context`; the owned contexts free on drop. The receive loops become a typed `ReceiveOutcome` match while each site's send-side EOF policy is preserved (two-pass tolerates `EOF`, audio finish propagates it).
- Preserve the two-pass `stats_in` lifetime across the RAII change: `stats_out` is copied before the pass-1 context drops, and `stats_in` is nulled before the owned pass-2 context is dropped or re-opened, so FFmpeg never reads the Rust-owned `CString` after it is freed.
- Scope is the ff-encode migration + drain adoption. Removing `avcodec::free_context` from ff-sys and migrating the remaining consumers (ff-stream / ff-remux / ff-filter / ff-preview) are relocated to #1499.

Closes #1490