### PR TITLE
feat(ff-filter): migrate effects and the ff-sys test decoder to CodecContext

### DIFF
--- a/crates/ff-filter/src/effects/effects_inner.rs
+++ b/crates/ff-filter/src/effects/effects_inner.rs
@@ -509,21 +509,18 @@ pub(super) unsafe fn transform_vidstab_unsafe(
 
     // ── Find the best available H.264 encoder ─────────────────────────────────
     let enc_codec = {
-        let candidates: &[&std::ffi::CStr] = &[
-            c"h264_nvenc",
-            c"h264_qsv",
-            c"h264_amf",
-            c"h264_videotoolbox",
-            c"libx264",
-            c"mpeg4",
+        let candidates: &[&str] = &[
+            "h264_nvenc",
+            "h264_qsv",
+            "h264_amf",
+            "h264_videotoolbox",
+            "libx264",
+            "mpeg4",
         ];
-        let mut found: Option<*const ff_sys::AVCodec> = None;
+        let mut found: Option<ff_sys::Codec> = None;
         for name in candidates {
-            if let Some(c) = ff_sys::avcodec::find_encoder_by_name(name.as_ptr()) {
-                log::info!(
-                    "stabilization transform selected encoder encoder={}",
-                    name.to_string_lossy()
-                );
+            if let Some(c) = ff_sys::Codec::find_encoder_by_name(name) {
+                log::info!("stabilization transform selected encoder encoder={name}");
                 found = Some(c);
                 break;
             }
@@ -544,34 +541,33 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     };
 
     // ── Allocate and configure the encoder context ────────────────────────────
-    let mut enc_ctx = match ff_sys::avcodec::alloc_context3(enc_codec) {
+    let mut enc_ctx = match ff_sys::CodecContext::new(Some(enc_codec)) {
         Ok(ctx) => ctx,
-        Err(code) => {
+        Err(e) => {
             let mut fp = first_frame;
             ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
             let mut g = graph;
             ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
             return Err(FilterError::Ffmpeg {
-                code,
+                code: e.code(),
                 message: "avcodec_alloc_context3 failed".to_string(),
             });
         }
     };
 
-    (*enc_ctx).width = frame_width;
-    (*enc_ctx).height = frame_height;
-    (*enc_ctx).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
-    (*enc_ctx).time_base = filter_tb;
+    (*enc_ctx.as_mut_ptr()).width = frame_width;
+    (*enc_ctx.as_mut_ptr()).height = frame_height;
+    (*enc_ctx.as_mut_ptr()).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
+    (*enc_ctx.as_mut_ptr()).time_base = filter_tb;
 
-    if let Err(code) = ff_sys::avcodec::open2(enc_ctx, enc_codec, std::ptr::null_mut()) {
+    if let Err(e) = enc_ctx.open(enc_codec, std::ptr::null_mut()) {
         let mut fp = first_frame;
         ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
-        ff_sys::avcodec::free_context(&raw mut enc_ctx);
         let mut g = graph;
         ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(FilterError::Ffmpeg {
-            code,
-            message: format!("avcodec_open2 failed code={code}"),
+            code: e.code(),
+            message: format!("avcodec_open2 failed code={}", e.code()),
         });
     }
 
@@ -586,7 +582,6 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     if ret < 0 || out_ctx.is_null() {
         let mut fp = first_frame;
         ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
-        ff_sys::avcodec::free_context(&raw mut enc_ctx);
         let mut g = graph;
         ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(FilterError::Ffmpeg {
@@ -600,7 +595,6 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     if out_stream.is_null() {
         let mut fp = first_frame;
         ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
-        ff_sys::avcodec::free_context(&raw mut enc_ctx);
         ff_sys::avformat_free_context(out_ctx);
         let mut g = graph;
         ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -610,16 +604,15 @@ pub(super) unsafe fn transform_vidstab_unsafe(
         });
     }
 
-    if let Err(code) = ff_sys::avcodec::parameters_from_context((*out_stream).codecpar, enc_ctx) {
+    if let Err(e) = enc_ctx.parameters_from_context((*out_stream).codecpar) {
         let mut fp = first_frame;
         ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
-        ff_sys::avcodec::free_context(&raw mut enc_ctx);
         ff_sys::avformat_free_context(out_ctx);
         let mut g = graph;
         ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(FilterError::Ffmpeg {
-            code,
-            message: format!("avcodec_parameters_from_context failed code={code}"),
+            code: e.code(),
+            message: format!("avcodec_parameters_from_context failed code={}", e.code()),
         });
     }
 
@@ -629,7 +622,6 @@ pub(super) unsafe fn transform_vidstab_unsafe(
         Err(code) => {
             let mut fp = first_frame;
             ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
-            ff_sys::avcodec::free_context(&raw mut enc_ctx);
             ff_sys::avformat_free_context(out_ctx);
             let mut g = graph;
             ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
@@ -646,7 +638,6 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     if ret < 0 {
         let mut fp = first_frame;
         ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
-        ff_sys::avcodec::free_context(&raw mut enc_ctx);
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
         let mut g = graph;
@@ -665,7 +656,6 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     if pkt.is_null() {
         let mut fp = first_frame;
         ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
-        ff_sys::avcodec::free_context(&raw mut enc_ctx);
         ff_sys::av_write_trailer(out_ctx);
         ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
         ff_sys::avformat_free_context(out_ctx);
@@ -678,8 +668,8 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     }
 
     // ── Encode first frame ────────────────────────────────────────────────────
-    let _ = ff_sys::avcodec::send_frame(enc_ctx, first_frame);
-    drain_encoded_packets(enc_ctx, pkt, out_ctx, stream_tb);
+    let _ = enc_ctx.send_frame(first_frame);
+    drain_encoded_packets(enc_ctx.as_mut_ptr(), pkt, out_ctx, stream_tb);
     let mut fp = first_frame;
     ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
 
@@ -695,18 +685,17 @@ pub(super) unsafe fn transform_vidstab_unsafe(
             ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
             break;
         }
-        let _ = ff_sys::avcodec::send_frame(enc_ctx, frame);
-        drain_encoded_packets(enc_ctx, pkt, out_ctx, stream_tb);
+        let _ = enc_ctx.send_frame(frame);
+        drain_encoded_packets(enc_ctx.as_mut_ptr(), pkt, out_ctx, stream_tb);
         ff_sys::av_frame_free(std::ptr::addr_of_mut!(fp));
     }
 
     // ── Flush the encoder ─────────────────────────────────────────────────────
-    let _ = ff_sys::avcodec::send_frame(enc_ctx, std::ptr::null());
-    drain_encoded_packets(enc_ctx, pkt, out_ctx, stream_tb);
+    let _ = enc_ctx.send_frame(std::ptr::null());
+    drain_encoded_packets(enc_ctx.as_mut_ptr(), pkt, out_ctx, stream_tb);
 
     // ── Finalize output ───────────────────────────────────────────────────────
     ff_sys::av_packet_free(&raw mut pkt);
-    ff_sys::avcodec::free_context(&raw mut enc_ctx);
     ff_sys::av_write_trailer(out_ctx);
     ff_sys::avformat::close_output(std::ptr::addr_of_mut!((*out_ctx).pb));
     ff_sys::avformat_free_context(out_ctx);

--- a/crates/ff-sys/src/swresample/mod.rs
+++ b/crates/ff-sys/src/swresample/mod.rs
@@ -46,7 +46,7 @@ mod tests {
     /// Helper struct to manage decoded audio context.
     struct AudioDecoder {
         format_ctx: *mut crate::AVFormatContext,
-        codec_ctx: *mut crate::AVCodecContext,
+        codec_ctx: crate::CodecContext,
         stream_index: i32,
         frame: *mut crate::AVFrame,
         packet: *mut crate::AVPacket,
@@ -56,7 +56,7 @@ mod tests {
         /// Open an audio file and prepare for decoding.
         unsafe fn open(path: &std::path::Path) -> Result<Self, i32> {
             use crate::{
-                AVMediaType_AVMEDIA_TYPE_AUDIO, av_frame_alloc, av_packet_alloc, avcodec,
+                AVMediaType_AVMEDIA_TYPE_AUDIO, av_frame_alloc, av_packet_alloc,
                 avformat::{close_input, find_stream_info, open_input},
             };
 
@@ -87,22 +87,21 @@ mod tests {
             let codecpar = (*stream).codecpar;
 
             // Find decoder
-            let codec =
-                avcodec::find_decoder((*codecpar).codec_id).ok_or(crate::error_codes::EINVAL)?;
+            let codec = crate::Codec::find_decoder((*codecpar).codec_id)
+                .ok_or(crate::error_codes::EINVAL)?;
 
-            // Allocate codec context
-            let codec_ctx = avcodec::alloc_context3(codec)?;
+            // Allocate, configure, and open the owned codec context (frees on drop).
+            let mut codec_ctx = crate::CodecContext::new(Some(codec)).map_err(|e| e.code())?;
+            codec_ctx
+                .parameters_to_context(codecpar)
+                .map_err(|e| e.code())?;
+            codec_ctx
+                .open(codec, std::ptr::null_mut())
+                .map_err(|e| e.code())?;
 
-            // Copy parameters
-            avcodec::parameters_to_context(codec_ctx, codecpar)?;
-
-            // Open codec
-            avcodec::open2(codec_ctx, codec, std::ptr::null_mut())?;
-
-            // Allocate frame and packet
+            // Allocate frame and packet. On failure the owned `codec_ctx` drops (frees).
             let frame = av_frame_alloc();
             if frame.is_null() {
-                avcodec::free_context(&mut (codec_ctx as *mut _));
                 close_input(&mut (format_ctx as *mut _));
                 return Err(crate::error_codes::ENOMEM);
             }
@@ -110,7 +109,6 @@ mod tests {
             let packet = av_packet_alloc();
             if packet.is_null() {
                 crate::av_frame_free(&mut (frame as *mut _));
-                avcodec::free_context(&mut (codec_ctx as *mut _));
                 close_input(&mut (format_ctx as *mut _));
                 return Err(crate::error_codes::ENOMEM);
             }
@@ -131,7 +129,7 @@ mod tests {
 
             loop {
                 // Try to receive a frame from the decoder
-                match avcodec::receive_frame(self.codec_ctx, self.frame) {
+                match avcodec::receive_frame(self.codec_ctx.as_mut_ptr(), self.frame) {
                     Ok(()) => return Some(&*self.frame),
                     Err(e) if e == error_codes::EAGAIN => {
                         // Need more input
@@ -151,8 +149,9 @@ mod tests {
                         }
                         Err(_) => {
                             // EOF or error - flush decoder
-                            let _ = avcodec::send_packet(self.codec_ctx, std::ptr::null());
-                            match avcodec::receive_frame(self.codec_ctx, self.frame) {
+                            let _ =
+                                avcodec::send_packet(self.codec_ctx.as_mut_ptr(), std::ptr::null());
+                            match avcodec::receive_frame(self.codec_ctx.as_mut_ptr(), self.frame) {
                                 Ok(()) => return Some(&*self.frame),
                                 Err(_) => return None,
                             }
@@ -161,24 +160,24 @@ mod tests {
                 }
 
                 // Send packet to decoder
-                let _ = avcodec::send_packet(self.codec_ctx, self.packet);
+                let _ = avcodec::send_packet(self.codec_ctx.as_mut_ptr(), self.packet);
                 crate::av_packet_unref(self.packet);
             }
         }
 
         /// Get sample format of the decoded audio.
         unsafe fn sample_format(&self) -> crate::AVSampleFormat {
-            (*self.codec_ctx).sample_fmt
+            (*self.codec_ctx.as_ptr()).sample_fmt
         }
 
         /// Get sample rate of the decoded audio.
         unsafe fn sample_rate(&self) -> i32 {
-            (*self.codec_ctx).sample_rate
+            (*self.codec_ctx.as_ptr()).sample_rate
         }
 
         /// Get channel layout of the decoded audio.
         unsafe fn channel_layout(&self) -> &crate::AVChannelLayout {
-            &(*self.codec_ctx).ch_layout
+            &(*self.codec_ctx.as_ptr()).ch_layout
         }
     }
 
@@ -194,12 +193,12 @@ mod tests {
                 if !self.frame.is_null() {
                     crate::av_frame_free(&mut self.frame);
                 }
-                if !self.codec_ctx.is_null() {
-                    crate::avcodec::free_context(&mut self.codec_ctx);
-                }
                 if !self.format_ctx.is_null() {
                     crate::avformat::close_input(&mut self.format_ctx);
                 }
+                // `codec_ctx` (owned CodecContext) frees itself via field drop
+                // after this body; the codec and format contexts are independent
+                // allocations, so the order is sound.
             }
         }
     }


### PR DESCRIPTION
## Objective

- Continue retiring the manual `avcodec::free_context` (ADR-0003) by moving the small, self-contained remaining codec-context consumers onto the owned `ff_sys::CodecContext`. A survey corrected the original scope: ff-remux and ff-preview hold no codec context (their `free_context` sites are `avformat_free_context` / `swscale::free_context`), and ff-stream is a large, higher-risk migration (~84 sites, live-streaming transcode + ABR), so those are handled separately.

## Solution

- ff-filter: the vidstab transform encode path allocated a local `*mut AVCodecContext` and freed it manually on eight paths. It now uses `CodecContext::new` / `open` / `send_frame` / `parameters_from_context` and the safe `Codec::find_encoder_by_name`, so the context frees on drop; the eight manual `free_context` calls are removed while the unrelated `avformat_free_context(out_ctx)` and graph frees are preserved.
- ff-sys: the audio decoder scaffold in `swresample`'s test module holds its codec context as an owned `CodecContext` (`Codec::find_decoder` + the decode methods sourced from `as_mut_ptr()`), dropping the manual `free_context` in its construction error paths and `Drop`.
- The remaining ff-stream migration and the actual removal of `avcodec::free_context` from ff-sys are relocated to #1501.

Refs #1499