### PR TITLE
feat(ff-encode): migrate swr/sws contexts to owned resample/scale contexts

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -25,9 +25,9 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3,
     AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
     AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame,
-    SwrContext, av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc,
-    av_packet_free, av_packet_unref, av_write_trailer, avformat_alloc_output_context2,
-    avformat_free_context, avformat_new_stream, avformat_write_header, swresample,
+    av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
+    av_packet_unref, av_write_trailer, avformat_alloc_output_context2, avformat_free_context,
+    avformat_new_stream, avformat_write_header, swresample,
 };
 use std::ffi::{CString, c_void};
 use std::ptr;
@@ -44,7 +44,7 @@ pub(super) struct AudioEncoderInner {
     pub(super) stream_index: i32,
 
     /// Resampling context for audio format conversion
-    pub(super) swr_ctx: Option<*mut SwrContext>,
+    pub(super) swr_ctx: Option<ff_sys::ResampleContext>,
 
     /// Sample counter
     pub(super) sample_count: u64,
@@ -689,26 +689,21 @@ impl AudioEncoderInner {
             || !swresample::channel_layout::is_equal(&raw const src_ch_layout, target_ch_layout);
 
         if needs_resampling {
-            // Initialize resampler if needed
+            // Initialize resampler if needed (RAII: allocates, configures, and
+            // initializes internally; frees itself on drop).
             if self.swr_ctx.is_none() {
-                let swr_ctx = swresample::alloc_set_opts2(
-                    target_ch_layout,
-                    target_format,
-                    target_sample_rate,
-                    &raw const src_ch_layout,
-                    src_format,
-                    src_sample_rate,
-                )
-                .map_err(EncodeError::from_ffmpeg_error)?;
-
-                swresample::init(swr_ctx).map_err(EncodeError::from_ffmpeg_error)?;
-                self.swr_ctx = Some(swr_ctx);
+                self.swr_ctx = Some(
+                    ff_sys::ResampleContext::new(
+                        target_ch_layout,
+                        target_format,
+                        target_sample_rate,
+                        &raw const src_ch_layout,
+                        src_format,
+                        src_sample_rate,
+                    )
+                    .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?,
+                );
             }
-
-            let swr_ctx = self.swr_ctx.ok_or_else(|| EncodeError::Ffmpeg {
-                code: 0,
-                message: "Resampling context not initialized".to_string(),
-            })?;
 
             // Estimate output sample count
             let out_samples = swresample::estimate_output_samples(
@@ -748,14 +743,20 @@ impl AudioEncoderInner {
             };
 
             // Convert
-            let samples_out = swresample::convert(
-                swr_ctx,
-                (*dst).data.as_mut_ptr().cast(),
-                out_samples,
-                in_ptrs.as_ptr(),
-                src.samples() as i32,
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
+            let samples_out = self
+                .swr_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Resampling context not initialized".to_string(),
+                })?
+                .convert(
+                    (*dst).data.as_mut_ptr().cast(),
+                    out_samples,
+                    in_ptrs.as_ptr(),
+                    src.samples() as i32,
+                )
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
             (*dst).nb_samples = samples_out;
         } else {
@@ -914,10 +915,8 @@ impl AudioEncoderInner {
         // Free audio codec context (owned CodecContext frees itself when dropped).
         self.codec_ctx = None;
 
-        // Free resampling context
-        if let Some(mut ctx) = self.swr_ctx.take() {
-            swresample::free(&raw mut ctx);
-        }
+        // Free resampling context (owned ResampleContext drops on assignment).
+        self.swr_ctx = None;
 
         // Close output file
         if !self.format_ctx.is_null() {

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -90,7 +90,7 @@ struct ImageEncoderInner {
     codec_ctx: ff_sys::CodecContext,
     dst_frame: *mut ff_sys::AVFrame,
     packet: *mut ff_sys::AVPacket,
-    sws_ctx: Option<*mut ff_sys::SwsContext>,
+    sws_ctx: Option<ff_sys::ScaleContext>,
     dst_width: u32,
     dst_height: u32,
     pix_fmt: AVPixelFormat,
@@ -298,19 +298,19 @@ impl ImageEncoderInner {
             || src.height() != self.dst_height;
 
         if needs_conversion {
-            let sws_ctx = swscale::get_context(
-                src.width() as i32,
-                src.height() as i32,
-                src_fmt,
-                self.dst_width as i32,
-                self.dst_height as i32,
-                self.pix_fmt,
-                swscale::scale_flags::BILINEAR,
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
-
-            // Store so Drop frees it if scale panics.
-            self.sws_ctx = Some(sws_ctx);
+            // Store so Drop frees it if scale panics (RAII: frees on drop).
+            self.sws_ctx = Some(
+                ff_sys::ScaleContext::new(
+                    src.width() as i32,
+                    src.height() as i32,
+                    src_fmt,
+                    self.dst_width as i32,
+                    self.dst_height as i32,
+                    self.pix_fmt,
+                    swscale::scale_flags::BILINEAR,
+                )
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?,
+            );
 
             let mut src_data: [*const u8; MAX_PLANES] = [ptr::null(); MAX_PLANES];
             let mut src_linesize: [i32; MAX_PLANES] = [0; MAX_PLANES];
@@ -321,22 +321,28 @@ impl ImageEncoderInner {
                 }
             }
 
-            let scale_result = swscale::scale(
-                sws_ctx,
-                src_data.as_ptr(),
-                src_linesize.as_ptr(),
-                0,
-                src.height() as i32,
-                (*self.dst_frame).data.as_mut_ptr().cast_const(),
-                (*self.dst_frame).linesize.as_mut_ptr(),
-            );
+            let dst_data = (*self.dst_frame).data.as_mut_ptr().cast_const();
+            let dst_linesize = (*self.dst_frame).linesize.as_mut_ptr();
+            let scale_result = self
+                .sws_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Scaling context not initialized".to_string(),
+                })?
+                .scale(
+                    src_data.as_ptr(),
+                    src_linesize.as_ptr(),
+                    0,
+                    src.height() as i32,
+                    dst_data,
+                    dst_linesize,
+                );
 
-            // Free immediately — single use; Drop handles null case.
-            if let Some(sws) = self.sws_ctx.take() {
-                swscale::free_context(sws);
-            }
+            // Drop the context now — single use; the owned field frees it.
+            self.sws_ctx = None;
 
-            scale_result.map_err(EncodeError::from_ffmpeg_error)?;
+            scale_result.map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
         } else {
             // Direct plane copy — same format and dimensions.
             for (i, plane) in src.planes().iter().enumerate() {
@@ -450,10 +456,8 @@ impl Drop for ImageEncoderInner {
                 // SAFETY: packet is non-null and owned by this struct.
                 av_packet_free(&raw mut self.packet);
             }
-            if let Some(sws) = self.sws_ctx.take() {
-                // SAFETY: sws is a valid SwsContext that hasn't been freed yet.
-                swscale::free_context(sws);
-            }
+            // sws_ctx is an owned Option<ff_sys::ScaleContext>; it frees itself
+            // via field drop (after this manual body), so no manual free here.
             // codec_ctx is an owned ff_sys::CodecContext; it frees itself when the
             // struct is dropped (after this manual cleanup runs).
             if !self.format_ctx.is_null() {

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -30,7 +30,7 @@ use ff_sys::{
     av_write_trailer, avfilter_get_by_name, avfilter_graph_alloc, avfilter_graph_config,
     avfilter_graph_create_filter, avfilter_graph_free, avfilter_link, avformat,
     avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header, swscale,
+    avformat_write_header,
 };
 
 use crate::PreviewImageError;
@@ -350,22 +350,21 @@ unsafe fn encode_frame_as_png(
         }
         // SAFETY: src_pix_fmt and AVPixelFormat_AV_PIX_FMT_RGB24 are valid;
         // frame and cf buffers are allocated and large enough.
-        let sws_ctx = swscale::get_context(
+        let mut sws_ctx = ff_sys::ScaleContext::new(
             width,
             height,
             src_pix_fmt,
             width,
             height,
             AVPixelFormat_AV_PIX_FMT_RGB24,
-            swscale::scale_flags::BILINEAR,
+            ff_sys::swscale::scale_flags::BILINEAR,
         )
         .map_err(|e| {
             let mut f = cf;
             av_frame_free(std::ptr::addr_of_mut!(f));
-            PreviewImageError::from_ffmpeg_error(e)
+            PreviewImageError::from_ffmpeg_error(e.code())
         })?;
-        let scale_ret = swscale::scale(
-            sws_ctx,
+        let scale_ret = sws_ctx.scale(
             (*frame).data.as_ptr().cast::<*const u8>(),
             (*frame).linesize.as_ptr(),
             0,
@@ -373,11 +372,11 @@ unsafe fn encode_frame_as_png(
             (*cf).data.as_mut_ptr().cast_const(),
             (*cf).linesize.as_mut_ptr(),
         );
-        swscale::free_context(sws_ctx);
+        // sws_ctx drops at the end of this scope, freeing the context.
         if let Err(e) = scale_ret {
             let mut f = cf;
             av_frame_free(std::ptr::addr_of_mut!(f));
-            return Err(PreviewImageError::from_ffmpeg_error(e));
+            return Err(PreviewImageError::from_ffmpeg_error(e.code()));
         }
         cf
     } else {

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -20,7 +20,7 @@ use super::{
     AV_TIME_BASE, AVChapter, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P,
     AudioCodec, CString, EncodeError, VideoCodec, VideoEncoderInner, av_interleaved_write_frame,
     av_mallocz, av_packet_alloc, av_packet_free, av_packet_unref, avformat_free_context,
-    avformat_new_stream, ptr, swresample, swscale,
+    avformat_new_stream, ptr, swresample,
 };
 
 impl VideoEncoderInner {
@@ -836,15 +836,11 @@ impl VideoEncoderInner {
         // Free audio codec context; drops on assignment.
         self.audio_codec_ctx = None;
 
-        // Free scaling context
-        if let Some(ctx) = self.sws_ctx.take() {
-            swscale::free_context(ctx);
-        }
+        // Free scaling context (owned ScaleContext drops on assignment).
+        self.sws_ctx = None;
 
-        // Free resampling context
-        if let Some(mut ctx) = self.swr_ctx.take() {
-            swresample::free(&raw mut ctx);
-        }
+        // Free resampling context (owned ResampleContext drops on assignment).
+        self.swr_ctx = None;
 
         // Free audio FIFO
         if let Some(fifo) = self.audio_fifo.take() {

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -14,7 +14,7 @@ use super::color::{pixel_format_to_av, sample_format_to_av};
 use super::{
     AVChannelLayout, AVCodecContext, AVFrame, AVPixelFormat, AudioFrame, EncodeError,
     VideoEncoderInner, VideoFrame, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
-    av_packet_unref, ptr, swresample, swscale,
+    av_packet_unref, ptr, swresample,
 };
 
 /// Maximum number of planes in AVFrame data/linesize arrays.
@@ -118,24 +118,20 @@ impl VideoEncoderInner {
             || self.last_src_format != Some(src_fmt);
 
         if needs_new_context || self.sws_ctx.is_none() {
-            // Free old context if exists
-            if let Some(ctx) = self.sws_ctx.take() {
-                swscale::free_context(ctx);
-            }
-
-            // Create new SwsContext with fast BILINEAR algorithm
-            let sws = swscale::get_context(
-                src_width as i32,
-                src_height as i32,
-                src_fmt,
-                target_width as i32,
-                target_height as i32,
-                target_fmt,
-                ff_sys::swscale::scale_flags::BILINEAR, // Fast scaling algorithm
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
-
-            self.sws_ctx = Some(sws);
+            // Create a new scaling context with the fast BILINEAR algorithm.
+            // The old context (if any) drops on reassignment.
+            self.sws_ctx = Some(
+                ff_sys::ScaleContext::new(
+                    src_width as i32,
+                    src_height as i32,
+                    src_fmt,
+                    target_width as i32,
+                    target_height as i32,
+                    target_fmt,
+                    ff_sys::swscale::scale_flags::BILINEAR, // Fast scaling algorithm
+                )
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?,
+            );
             self.last_src_width = Some(src_width);
             self.last_src_height = Some(src_height);
             self.last_src_format = Some(src_fmt);
@@ -219,7 +215,7 @@ impl VideoEncoderInner {
 
     /// Scale frame using SwsContext (when formats or dimensions differ).
     pub(super) unsafe fn scale_frame(
-        &self,
+        &mut self,
         src: &VideoFrame,
         dst: *mut AVFrame,
         target_fmt: AVPixelFormat,
@@ -254,22 +250,22 @@ impl VideoEncoderInner {
             }
         }
 
-        // Perform scaling/conversion
-        let sws_ctx = self.sws_ctx.ok_or_else(|| EncodeError::Ffmpeg {
-            code: 0,
-            message: "Scaling context not initialized".to_string(),
-        })?;
-
-        swscale::scale(
-            sws_ctx,
-            src_data.as_ptr(),
-            src_linesize.as_ptr(),
-            0,
-            src.height() as i32,
-            (*dst).data.as_mut_ptr().cast_const(),
-            (*dst).linesize.as_mut_ptr(),
-        )
-        .map_err(EncodeError::from_ffmpeg_error)?;
+        // Perform scaling/conversion using the cached scaling context.
+        self.sws_ctx
+            .as_mut()
+            .ok_or_else(|| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Scaling context not initialized".to_string(),
+            })?
+            .scale(
+                src_data.as_ptr(),
+                src_linesize.as_ptr(),
+                0,
+                src.height() as i32,
+                (*dst).data.as_mut_ptr().cast_const(),
+                (*dst).linesize.as_mut_ptr(),
+            )
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         Ok(())
     }
@@ -429,26 +425,21 @@ impl VideoEncoderInner {
             || !swresample::channel_layout::is_equal(&raw const src_ch_layout, target_ch_layout);
 
         if needs_resampling {
-            // Initialize resampler if needed
+            // Initialize resampler if needed (RAII: allocates, configures, and
+            // initializes internally; frees itself on drop).
             if self.swr_ctx.is_none() {
-                let swr_ctx = swresample::alloc_set_opts2(
-                    target_ch_layout,
-                    target_format,
-                    target_sample_rate,
-                    &raw const src_ch_layout,
-                    src_format,
-                    src_sample_rate,
-                )
-                .map_err(EncodeError::from_ffmpeg_error)?;
-
-                swresample::init(swr_ctx).map_err(EncodeError::from_ffmpeg_error)?;
-                self.swr_ctx = Some(swr_ctx);
+                self.swr_ctx = Some(
+                    ff_sys::ResampleContext::new(
+                        target_ch_layout,
+                        target_format,
+                        target_sample_rate,
+                        &raw const src_ch_layout,
+                        src_format,
+                        src_sample_rate,
+                    )
+                    .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?,
+                );
             }
-
-            let swr_ctx = self.swr_ctx.ok_or_else(|| EncodeError::Ffmpeg {
-                code: 0,
-                message: "Resampling context not initialized".to_string(),
-            })?;
 
             // Estimate output sample count
             let out_samples = swresample::estimate_output_samples(
@@ -488,14 +479,20 @@ impl VideoEncoderInner {
             };
 
             // Convert
-            let samples_out = swresample::convert(
-                swr_ctx,
-                (*dst).data.as_mut_ptr().cast(),
-                out_samples,
-                in_ptrs.as_ptr(),
-                src.samples() as i32,
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
+            let samples_out = self
+                .swr_ctx
+                .as_mut()
+                .ok_or_else(|| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Resampling context not initialized".to_string(),
+                })?
+                .convert(
+                    (*dst).data.as_mut_ptr().cast(),
+                    out_samples,
+                    in_ptrs.as_ptr(),
+                    src.samples() as i32,
+                )
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
             (*dst).nb_samples = samples_out;
         } else {

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -40,11 +40,10 @@ use ff_sys::{
     AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
     AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, SwrContext, SwsContext, av_frame_alloc, av_frame_free,
-    av_interleaved_write_frame, av_mallocz, av_packet_alloc, av_packet_free,
-    av_packet_new_side_data, av_packet_unref, av_write_trailer, avcodec,
-    avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header, swresample, swscale,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, av_frame_alloc, av_frame_free, av_interleaved_write_frame,
+    av_mallocz, av_packet_alloc, av_packet_free, av_packet_new_side_data, av_packet_unref,
+    av_write_trailer, avcodec, avformat_alloc_output_context2, avformat_free_context,
+    avformat_new_stream, avformat_write_header, swresample,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -67,10 +66,10 @@ pub(super) struct VideoEncoderInner {
     pub(super) audio_stream_index: i32,
 
     /// Scaling context for pixel format conversion
-    pub(super) sws_ctx: Option<*mut SwsContext>,
+    pub(super) sws_ctx: Option<ff_sys::ScaleContext>,
 
     /// Resampling context for audio format conversion
-    pub(super) swr_ctx: Option<*mut SwrContext>,
+    pub(super) swr_ctx: Option<ff_sys::ResampleContext>,
 
     /// Sample FIFO for fixed-frame-size codecs (AAC, FLAC, ALAC …).
     /// `None` for variable-frame-size codecs (PCM, Vorbis) where `frame_size == 0`.

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -111,6 +111,44 @@ fn test_encode_different_resolutions() {
 }
 
 #[test]
+fn test_scaler_should_rebuild_when_source_dimensions_change() {
+    // Drive the video scale path AND its dimension-change cache-rebuild through a
+    // single encoder: the source frames differ from the encoder's output size (so
+    // libswscale runs), and their sizes change between pushes (so the cached
+    // ScaleContext is rebuilt, dropping the old one exactly once). MPEG-4 is
+    // always available and needs no filters, so this runs unconditionally in CI.
+    let output_path = test_output_path("test_scaler_rebuild.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    let result = VideoEncoder::create(&output_path)
+        .video(640, 480, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .build();
+
+    let mut encoder = match result {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Encoder creation failed (no suitable codec): {}", e);
+            return; // Skip test
+        }
+    };
+
+    // Two different source geometries, both != the 640x480 output, so each is
+    // scaled; the change between them forces one context rebuild (move-assign).
+    let source_sizes = [(320, 240), (800, 600), (800, 600), (320, 240)];
+    for (width, height) in source_sizes {
+        let frame = create_black_frame(width, height);
+        encoder
+            .push_video(&frame)
+            .expect("Failed to push scaled video frame");
+    }
+
+    encoder.finish().expect("Failed to finish encoding");
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
 fn test_encode_different_framerates() {
     // Note: MPEG-4 supports max 65535 for timebase denominator (≈65 fps)
     let framerates = [24.0, 30.0, 60.0];

--- a/crates/ff-preview/src/playback/playback_inner.rs
+++ b/crates/ff-preview/src/playback/playback_inner.rs
@@ -36,22 +36,17 @@ pub(crate) fn audio_frame_to_f32(frame: &AudioFrame) -> Vec<f32> {
 /// [`convert_to`](Self::convert_to) accepts explicit output dimensions so that overlay
 /// layers can be scaled to match the primary video track's canvas size before compositing.
 pub(crate) struct SwsRgbaConverter {
-    /// Nullable: `null` before the first `convert` call or after a geometry change.
-    ctx: *mut ff_sys::SwsContext,
+    /// `None` before the first `convert` call or after a geometry change.
+    /// The owned [`ff_sys::ScaleContext`] frees the underlying `SwsContext` on drop.
+    ctx: Option<ff_sys::ScaleContext>,
     /// Cached `(src_w, src_h, format, dst_w, dst_h)` so geometry changes can be detected.
     cache_key: Option<(u32, u32, PixelFormat, u32, u32)>,
 }
 
-// SAFETY: `SwsContext` is not thread-safe per the FFmpeg docs, but
-// `SwsRgbaConverter` owns its context exclusively and is only ever accessed
-// from the single presentation thread that calls `PreviewPlayer::run()`.
-// No concurrent access to `ctx` can occur.
-unsafe impl Send for SwsRgbaConverter {}
-
 impl SwsRgbaConverter {
     pub(crate) fn new() -> Self {
         Self {
-            ctx: std::ptr::null_mut(),
+            ctx: None,
             cache_key: None,
         }
     }
@@ -91,30 +86,25 @@ impl SwsRgbaConverter {
 
         // Re-create the context when geometry, format, or output size changes.
         if self.cache_key.as_ref() != Some(&key) {
-            // SAFETY: ctx is either null or was returned by get_context; freeing
-            // a null pointer is explicitly documented as safe by free_context.
-            unsafe { ff_sys::swscale::free_context(self.ctx) };
-            self.ctx = std::ptr::null_mut();
-
             let src_fmt = pixel_format_to_av(fmt);
             let dst_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_RGBA;
-            // SAFETY: dimensions are > 0 (checked above); formats are valid AV constants.
-            match unsafe {
-                ff_sys::swscale::get_context(
-                    src_w as i32,
-                    src_h as i32,
-                    src_fmt,
-                    dst_w as i32,
-                    dst_h as i32,
-                    dst_fmt,
-                    ff_sys::swscale::scale_flags::FAST_BILINEAR,
-                )
-            } {
-                Ok(ctx) => self.ctx = ctx,
-                Err(code) => {
+            // The old context (if any) drops on reassignment.
+            // Dimensions are > 0 (checked above); formats are valid AV constants.
+            match ff_sys::ScaleContext::new(
+                src_w as i32,
+                src_h as i32,
+                src_fmt,
+                dst_w as i32,
+                dst_h as i32,
+                dst_fmt,
+                ff_sys::swscale::scale_flags::FAST_BILINEAR,
+            ) {
+                Ok(ctx) => self.ctx = Some(ctx),
+                Err(e) => {
                     log::warn!(
                         "sws_getContext failed format={fmt:?} src={src_w}x{src_h} \
-                         dst={dst_w}x{dst_h} code={code}"
+                         dst={dst_w}x{dst_h} code={code}",
+                        code = e.code()
                     );
                     return false;
                 }
@@ -148,11 +138,14 @@ impl SwsRgbaConverter {
         ];
         let dst_strides: [i32; 4] = [dst_stride_val, 0, 0, 0];
 
-        // SAFETY: ctx is non-null (created above); src and dst pointers are valid
+        let Some(ctx) = self.ctx.as_mut() else {
+            log::warn!("sws_scale skipped: scaling context not initialized");
+            return false;
+        };
+        // SAFETY: ctx is initialized (created above); src and dst pointers are valid
         // for the lifetime of this call; buffer sizes match dst_w * dst_h * 4 bytes.
         let result = unsafe {
-            ff_sys::swscale::scale(
-                self.ctx,
+            ctx.scale(
                 src_ptrs.as_ptr(),
                 src_strides.as_ptr(),
                 0,
@@ -163,20 +156,14 @@ impl SwsRgbaConverter {
         };
         match result {
             Ok(_) => true,
-            Err(code) => {
-                log::warn!("sws_scale failed src={src_w}x{src_h} dst={dst_w}x{dst_h} code={code}");
+            Err(e) => {
+                log::warn!(
+                    "sws_scale failed src={src_w}x{src_h} dst={dst_w}x{dst_h} code={}",
+                    e.code()
+                );
                 false
             }
         }
-    }
-}
-
-impl Drop for SwsRgbaConverter {
-    fn drop(&mut self) {
-        // SAFETY: ctx is either null (safe no-op per free_context docs) or was
-        // returned by get_context; we have exclusive ownership so no concurrent
-        // access is possible.
-        unsafe { ff_sys::swscale::free_context(self.ctx) };
     }
 }
 
@@ -277,5 +264,31 @@ mod tests {
             "non-F32 frame should return an empty Vec, got {} samples",
             out.len()
         );
+    }
+
+    #[test]
+    fn convert_to_should_rebuild_scaler_when_source_geometry_changes() {
+        // Drive the cache-rebuild move-assign path: a second convert with a
+        // different source geometry replaces the cached `ScaleContext`, dropping
+        // the old one exactly once. Pure libswscale (no filters), so this runs in
+        // CI. RGBA in / RGBA out keeps the conversion format-agnostic.
+        let mut converter = SwsRgbaConverter::new();
+        let mut dst = Vec::new();
+
+        // First geometry: 8x8 -> 16x16 builds the initial context.
+        let frame_a = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+        assert!(converter.convert_to(&frame_a, &mut dst, 16, 16));
+        assert_eq!(dst.len(), 16 * 16 * 4);
+
+        // Second geometry: 4x4 -> 16x16 changes the cache key, so the context is
+        // rebuilt (old ScaleContext drops on reassignment).
+        let frame_b = VideoFrame::from_rgba(4, 4, vec![200u8; 4 * 4 * 4]).unwrap();
+        assert!(converter.convert_to(&frame_b, &mut dst, 16, 16));
+        assert_eq!(dst.len(), 16 * 16 * 4);
+
+        // Third convert reuses the cached context (same geometry as the second).
+        let frame_c = VideoFrame::from_rgba(4, 4, vec![50u8; 4 * 4 * 4]).unwrap();
+        assert!(converter.convert_to(&frame_c, &mut dst, 16, 16));
+        assert_eq!(dst.len(), 16 * 16 * 4);
     }
 }


### PR DESCRIPTION
## Objective

- Remove the last raw `*mut SwrContext` / `*mut SwsContext` holders (and their manual `swr_free` / `sws_freeContext`) in ff-encode and ff-preview, so resample/scale contexts are freed by ownership rather than by hand.

## Solution

- ff-encode: the audio/video resampler and video/image scaler fields become `Option<ff_sys::ResampleContext>` / `Option<ff_sys::ScaleContext>`; the video-encode and preview PNG scale paths construct via the owned types and free via field/local drop. The dimension-change cache-rebuild is a move-assignment, so the old context drops exactly once on reassignment and is retained on error.
- ff-preview: `SwsRgbaConverter` holds an `Option<ScaleContext>`; its manual `unsafe impl Send` and `Drop` are removed because the struct now auto-derives `Send` and the owned field frees itself.
- `scale_frame` takes `&mut self` for the mutable scale borrow. Behaviour is unchanged: scaling/resampling math, the cache-rebuild guard, and error mapping are preserved.
- Add regression coverage that drives both the scale path and its cache-rebuild: a single video encoder scaling frames of changing source dimensions, and a `SwsRgbaConverter` unit test converting two source geometries.
- ff-stream keeps its swr/sws in the same structs as its codec contexts, so those are migrated together in a follow-up.

Closes #1495