### PR TITLE
feat(ff-stream): migrate codec/swr/sws contexts to owned RAII and remove free wrappers

### DIFF
--- a/crates/ff-stream/src/codec_utils.rs
+++ b/crates/ff-stream/src/codec_utils.rs
@@ -17,8 +17,8 @@
 #![allow(clippy::ref_as_ptr)]
 
 use ff_sys::{
-    AVCodec, AVCodecContext, AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE,
-    AVRational, AVSampleFormat, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
+    AVCodecContext, AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE, AVRational,
+    AVSampleFormat, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
     av_packet_rescale_ts, av_packet_unref, av_rescale_q,
 };
 
@@ -58,7 +58,7 @@ pub(crate) fn ffmpeg_err_msg(msg: &str) -> StreamError {
 /// # Safety
 ///
 /// Must be called after `ff_sys::ensure_initialized()`.
-pub(crate) unsafe fn select_h264_encoder(log_prefix: &str) -> Option<*const AVCodec> {
+pub(crate) unsafe fn select_h264_encoder(log_prefix: &str) -> Option<ff_sys::Codec> {
     let candidates = [
         "h264_nvenc",
         "h264_qsv",
@@ -68,9 +68,7 @@ pub(crate) unsafe fn select_h264_encoder(log_prefix: &str) -> Option<*const AVCo
         "mpeg4",
     ];
     for name in candidates {
-        if let Ok(c_name) = std::ffi::CString::new(name)
-            && let Some(codec) = ff_sys::avcodec::find_encoder_by_name(c_name.as_ptr())
-        {
+        if let Some(codec) = ff_sys::Codec::find_encoder_by_name(name) {
             log::info!("{log_prefix} selected video encoder encoder={name}");
             return Some(codec);
         }
@@ -90,12 +88,13 @@ pub(crate) unsafe fn open_aac_encoder(
     nb_channels: i32,
     bit_rate: i64,
     log_prefix: &str,
-) -> Result<*mut AVCodecContext, StreamError> {
-    let codec = ff_sys::avcodec::find_encoder_by_name(c"aac".as_ptr())
-        .or_else(|| ff_sys::avcodec::find_encoder_by_name(c"libfdk_aac".as_ptr()))
+) -> Result<ff_sys::CodecContext, StreamError> {
+    let codec = ff_sys::Codec::find_encoder_by_name("aac")
+        .or_else(|| ff_sys::Codec::find_encoder_by_name("libfdk_aac"))
         .ok_or_else(|| ffmpeg_err_msg("no AAC encoder available (tried aac, libfdk_aac)"))?;
 
-    let mut ctx = ff_sys::avcodec::alloc_context3(codec).map_err(ffmpeg_err)?;
+    let mut enc = ff_sys::CodecContext::new(Some(codec)).map_err(|e| ffmpeg_err(e.code()))?;
+    let ctx = enc.as_mut_ptr();
 
     (*ctx).sample_rate = sample_rate;
     (*ctx).sample_fmt = ff_sys::swresample::sample_format::FLTP;
@@ -104,16 +103,15 @@ pub(crate) unsafe fn open_aac_encoder(
     (*ctx).time_base.den = sample_rate;
     ff_sys::swresample::channel_layout::set_default(&mut (*ctx).ch_layout, nb_channels);
 
-    ff_sys::avcodec::open2(ctx, codec, std::ptr::null_mut()).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut ctx as *mut *mut _);
-        ffmpeg_err(e)
-    })?;
+    // On open failure `enc` drops (Drop = avcodec_free_context), so no manual free.
+    enc.open(codec, std::ptr::null_mut())
+        .map_err(|e| ffmpeg_err(e.code()))?;
 
     log::info!(
         "{log_prefix} aac encoder opened \
          sample_rate={sample_rate} channels={nb_channels} bit_rate={bit_rate}"
     );
-    Ok(ctx)
+    Ok(enc)
 }
 
 // ============================================================================

--- a/crates/ff-stream/src/dash_inner/context.rs
+++ b/crates/ff-stream/src/dash_inner/context.rs
@@ -2,7 +2,7 @@
 
 use std::ptr;
 
-use ff_sys::{AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, SwrContext, SwsContext};
+use ff_sys::{AVFormatContext, AVFrame, AVPixelFormat};
 use ff_sys::{av_frame_free, avformat_free_context};
 
 // ============================================================================
@@ -10,12 +10,15 @@ use ff_sys::{av_frame_free, avformat_free_context};
 // ============================================================================
 
 /// Per-rendition encoder state for the ABR DASH mux loop.
+///
+/// The owned `vid_enc_ctx` / `sws_ctx` are freed on drop, so a `Vec<RenditionState>`
+/// releases every rendition's contexts automatically when it goes out of scope.
 pub(super) struct RenditionState {
-    pub(super) vid_enc_ctx: *mut AVCodecContext,
+    pub(super) vid_enc_ctx: ff_sys::CodecContext,
     pub(super) vid_out_stream_idx: i32,
     pub(super) enc_width: i32,
     pub(super) enc_height: i32,
-    pub(super) sws_ctx: *mut SwsContext,
+    pub(super) sws_ctx: Option<ff_sys::ScaleContext>,
     pub(super) last_src_fmt: Option<AVPixelFormat>,
     pub(super) last_src_w: Option<i32>,
     pub(super) last_src_h: Option<i32>,
@@ -24,36 +27,6 @@ pub(super) struct RenditionState {
 // ============================================================================
 // Cleanup helpers (safe to call with null pointers)
 // ============================================================================
-
-pub(super) unsafe fn cleanup_decoders(
-    mut vid_dec_ctx: *mut AVCodecContext,
-    mut aud_dec_ctx: *mut AVCodecContext,
-    input_ctx: *mut *mut AVFormatContext,
-) {
-    if !vid_dec_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-    }
-    if !aud_dec_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut aud_dec_ctx as *mut *mut _);
-    }
-    ff_sys::avformat::close_input(input_ctx);
-}
-
-pub(super) unsafe fn cleanup_encoders(
-    mut vid_enc_ctx: *mut AVCodecContext,
-    mut aud_enc_ctx: *mut AVCodecContext,
-    mut swr_ctx: *mut SwrContext,
-) {
-    if !vid_enc_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-    }
-    if !aud_enc_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-    }
-    if !swr_ctx.is_null() {
-        ff_sys::swresample::free(&mut swr_ctx);
-    }
-}
 
 pub(super) unsafe fn cleanup_output_ctx(mut out_ctx: *mut AVFormatContext) {
     if !out_ctx.is_null() {
@@ -81,20 +54,4 @@ pub(super) unsafe fn free_frames(
     if !aud_enc.is_null() {
         av_frame_free(&mut aud_enc as *mut *mut _);
     }
-}
-
-/// Free all encoder contexts and `SwsContext`s in `states`.
-///
-/// Safe to call at any point after the Vec starts being populated.
-pub(super) unsafe fn cleanup_renditions(states: &mut Vec<RenditionState>) {
-    for state in states.iter_mut() {
-        if !state.vid_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut state.vid_enc_ctx as *mut *mut _);
-        }
-        if !state.sws_ctx.is_null() {
-            ff_sys::swscale::free_context(state.sws_ctx);
-            state.sws_ctx = ptr::null_mut();
-        }
-    }
-    states.clear();
 }

--- a/crates/ff-stream/src/dash_inner/streams.rs
+++ b/crates/ff-stream/src/dash_inner/streams.rs
@@ -1,9 +1,6 @@
 //! Video/audio stream helpers: encoder selection, AAC encoder open, FPS detection.
 
-use std::ffi::CString;
-use std::ptr;
-
-use ff_sys::{AVCodecContext, AVFormatContext};
+use ff_sys::AVFormatContext;
 
 use crate::error::StreamError;
 
@@ -14,7 +11,7 @@ use super::ffmpeg_err_msg;
 // Helper: select best available H.264 encoder
 // ============================================================================
 
-pub(super) unsafe fn select_h264_encoder() -> Option<*const ff_sys::AVCodec> {
+pub(super) unsafe fn select_h264_encoder() -> Option<ff_sys::Codec> {
     let candidates = [
         "h264_nvenc",
         "h264_qsv",
@@ -24,9 +21,7 @@ pub(super) unsafe fn select_h264_encoder() -> Option<*const ff_sys::AVCodec> {
         "mpeg4",
     ];
     for name in candidates {
-        if let Ok(c_name) = CString::new(name)
-            && let Some(codec) = ff_sys::avcodec::find_encoder_by_name(c_name.as_ptr())
-        {
+        if let Some(codec) = ff_sys::Codec::find_encoder_by_name(name) {
             log::info!("dash selected video encoder encoder={name}");
             return Some(codec);
         }
@@ -41,12 +36,13 @@ pub(super) unsafe fn select_h264_encoder() -> Option<*const ff_sys::AVCodec> {
 pub(super) unsafe fn open_aac_encoder(
     sample_rate: i32,
     nb_channels: i32,
-) -> Result<*mut AVCodecContext, StreamError> {
-    let codec = ff_sys::avcodec::find_encoder_by_name(c"aac".as_ptr())
-        .or_else(|| ff_sys::avcodec::find_encoder_by_name(c"libfdk_aac".as_ptr()))
+) -> Result<ff_sys::CodecContext, StreamError> {
+    let codec = ff_sys::Codec::find_encoder_by_name("aac")
+        .or_else(|| ff_sys::Codec::find_encoder_by_name("libfdk_aac"))
         .ok_or_else(|| ffmpeg_err_msg("no AAC encoder available"))?;
 
-    let mut ctx = ff_sys::avcodec::alloc_context3(codec).map_err(ffmpeg_err)?;
+    let mut enc = ff_sys::CodecContext::new(Some(codec)).map_err(|e| ffmpeg_err(e.code()))?;
+    let ctx = enc.as_mut_ptr();
 
     (*ctx).sample_rate = sample_rate;
     (*ctx).sample_fmt = ff_sys::swresample::sample_format::FLTP;
@@ -55,13 +51,12 @@ pub(super) unsafe fn open_aac_encoder(
     (*ctx).time_base.den = sample_rate;
     ff_sys::swresample::channel_layout::set_default(&mut (*ctx).ch_layout, nb_channels);
 
-    ff_sys::avcodec::open2(ctx, codec, ptr::null_mut()).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut ctx as *mut *mut _);
-        ffmpeg_err(e)
-    })?;
+    // On open failure `enc` drops (Drop = avcodec_free_context), so no manual free.
+    enc.open(codec, std::ptr::null_mut())
+        .map_err(|e| ffmpeg_err(e.code()))?;
 
     log::info!("dash aac encoder opened sample_rate={sample_rate} channels={nb_channels}");
-    Ok(ctx)
+    Ok(enc)
 }
 
 // ============================================================================

--- a/crates/ff-stream/src/dash_inner/write.rs
+++ b/crates/ff-stream/src/dash_inner/write.rs
@@ -4,19 +4,15 @@ use std::ffi::CString;
 use std::ptr;
 
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVPictureType_AV_PICTURE_TYPE_I,
-    AVPictureType_AV_PICTURE_TYPE_NONE, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, SwrContext,
-    av_frame_alloc, av_frame_get_buffer, av_frame_unref, av_opt_set, av_packet_alloc,
-    av_packet_free, av_packet_unref, av_rescale_q, av_write_trailer,
-    avformat_alloc_output_context2, avformat_new_stream, avformat_write_header,
+    AVFormatContext, AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, av_frame_alloc, av_frame_get_buffer,
+    av_frame_unref, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref, av_rescale_q,
+    av_write_trailer, avformat_alloc_output_context2, avformat_new_stream, avformat_write_header,
 };
 
 use crate::error::StreamError;
 
-use super::context::{
-    RenditionState, cleanup_decoders, cleanup_encoders, cleanup_output_ctx, cleanup_renditions,
-    free_frames,
-};
+use super::context::{RenditionState, cleanup_output_ctx, free_frames};
 use super::streams::{detect_fps, open_aac_encoder, select_h264_encoder};
 use super::{ffmpeg_err, ffmpeg_err_msg};
 
@@ -75,25 +71,28 @@ pub(super) unsafe fn write_dash_unsafe(
 
     // ── 4. Open input video decoder ────────────────────────────────────────────
     let vid_codec_id = (*video_codecpar).codec_id;
-    let vid_decoder = ff_sys::avcodec::find_decoder(vid_codec_id)
+    let vid_decoder = ff_sys::Codec::find_decoder(vid_codec_id)
         .ok_or_else(|| ffmpeg_err_msg("no video decoder available for input stream"))?;
 
-    let mut vid_dec_ctx = ff_sys::avcodec::alloc_context3(vid_decoder).map_err(ffmpeg_err)?;
+    let mut vid_dec_ctx =
+        ff_sys::CodecContext::new(Some(vid_decoder)).map_err(|e| ffmpeg_err(e.code()))?;
 
-    ff_sys::avcodec::parameters_to_context(vid_dec_ctx, video_codecpar).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    vid_dec_ctx
+        .parameters_to_context(video_codecpar)
+        .map_err(|e| {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
-    ff_sys::avcodec::open2(vid_dec_ctx, vid_decoder, ptr::null_mut()).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    vid_dec_ctx
+        .open(vid_decoder, ptr::null_mut())
+        .map_err(|e| {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
     // ── 5. Open input audio decoder (optional) ────────────────────────────────
-    let mut aud_dec_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_dec_ctx: Option<ff_sys::CodecContext> = None;
     let mut aud_sample_rate: i32 = 44100;
     let mut aud_nb_channels: i32 = 2;
 
@@ -102,21 +101,20 @@ pub(super) unsafe fn write_dash_unsafe(
         let audio_codecpar = (*audio_stream).codecpar;
         let aud_codec_id = (*audio_codecpar).codec_id;
 
-        if let Some(aud_decoder) = ff_sys::avcodec::find_decoder(aud_codec_id) {
-            if let Ok(ctx) = ff_sys::avcodec::alloc_context3(aud_decoder) {
-                aud_dec_ctx = ctx;
-                if ff_sys::avcodec::parameters_to_context(aud_dec_ctx, audio_codecpar).is_ok()
-                    && ff_sys::avcodec::open2(aud_dec_ctx, aud_decoder, ptr::null_mut()).is_ok()
+        if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
+            if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
+                if ctx.parameters_to_context(audio_codecpar).is_ok()
+                    && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
                 {
-                    aud_sample_rate = (*aud_dec_ctx).sample_rate;
-                    aud_nb_channels = (*aud_dec_ctx).ch_layout.nb_channels;
+                    aud_sample_rate = (*ctx.as_ptr()).sample_rate;
+                    aud_nb_channels = (*ctx.as_ptr()).ch_layout.nb_channels;
+                    aud_dec_ctx = Some(ctx);
                     log::info!(
                         "dash audio decoder opened sample_rate={aud_sample_rate} \
                          channels={aud_nb_channels}"
                     );
                 } else {
-                    ff_sys::avcodec::free_context(&mut aud_dec_ctx as *mut *mut _);
-                    aud_dec_ctx = ptr::null_mut();
+                    // `ctx` drops here (frees the decoder context).
                     audio_stream_idx = -1;
                     log::warn!("dash audio decoder open failed, skipping audio");
                 }
@@ -144,7 +142,7 @@ pub(super) unsafe fn write_dash_unsafe(
         c_manifest.as_ptr(),
     );
     if ret < 0 || out_ctx.is_null() {
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err(ret));
     }
 
@@ -169,65 +167,66 @@ pub(super) unsafe fn write_dash_unsafe(
     // ── 8. Open H.264 video encoder ───────────────────────────────────────────
     let vid_enc_codec = select_h264_encoder().ok_or_else(|| {
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err_msg("no H.264 encoder available (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)")
     })?;
 
-    let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+    let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-        ffmpeg_err(e)
+        ff_sys::avformat::close_input(&mut input_ctx);
+        ffmpeg_err(e.code())
     })?;
+    let venc = vid_enc_ctx.as_mut_ptr();
 
-    (*vid_enc_ctx).width = enc_width;
-    (*vid_enc_ctx).height = enc_height;
-    (*vid_enc_ctx).time_base.num = 1;
-    (*vid_enc_ctx).time_base.den = fps_int;
-    (*vid_enc_ctx).framerate.num = fps_int;
-    (*vid_enc_ctx).framerate.den = 1;
-    (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-    (*vid_enc_ctx).bit_rate = 2_000_000;
+    (*venc).width = enc_width;
+    (*venc).height = enc_height;
+    (*venc).time_base.num = 1;
+    (*venc).time_base.den = fps_int;
+    (*venc).framerate.num = fps_int;
+    (*venc).framerate.den = 1;
+    (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+    (*venc).bit_rate = 2_000_000;
 
-    ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-        cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    // On error the owned `vid_enc_ctx` / decoders drop; only the raw format
+    // contexts need explicit teardown.
+    vid_enc_ctx
+        .open(vid_enc_codec, ptr::null_mut())
+        .map_err(|e| {
+            cleanup_output_ctx(out_ctx);
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────
-    let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+    let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
     if vid_out_stream.is_null() {
-        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot create video output stream"));
     }
-    (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+    (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
     let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
     // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-    ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
-        |e| {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+    vid_enc_ctx
+        .parameters_from_context((*vid_out_stream).codecpar)
+        .map_err(|e| {
             cleanup_output_ctx(out_ctx);
-            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-            ffmpeg_err(e)
-        },
-    )?;
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
-    let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_enc_ctx: Option<ff_sys::CodecContext> = None;
     let mut aud_out_stream_idx: i32 = -1;
-    let mut swr_ctx: *mut SwrContext = ptr::null_mut();
+    let mut swr_ctx: Option<ff_sys::ResampleContext> = None;
 
     if audio_stream_idx >= 0 {
         match open_aac_encoder(aud_sample_rate, aud_nb_channels) {
             Ok(ctx) => {
-                aud_enc_ctx = ctx;
                 let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
                 if aud_out_stream.is_null() {
-                    ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                    // `ctx` drops here (frees the codec context).
                     log::warn!("dash cannot create audio output stream, skipping audio");
                     audio_stream_idx = -1;
                 } else {
@@ -235,44 +234,35 @@ pub(super) unsafe fn write_dash_unsafe(
                     (*aud_out_stream).time_base.den = aud_sample_rate;
                     aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-                    // SAFETY: aud_out_stream and aud_enc_ctx are valid; avcodec_open2 called.
-                    if ff_sys::avcodec::parameters_from_context(
-                        (*aud_out_stream).codecpar,
-                        aud_enc_ctx,
-                    )
-                    .is_err()
+                    // SAFETY: aud_out_stream and ctx are valid; avcodec_open2 called.
+                    if ctx
+                        .parameters_from_context((*aud_out_stream).codecpar)
+                        .is_err()
                     {
                         log::warn!("dash audio stream codecpar copy failed");
                     }
 
-                    // Set up resampler: decoded audio → FLTP at aud_sample_rate
-                    let enc_ch_layout = &(*aud_enc_ctx).ch_layout;
-                    let enc_sample_fmt = (*aud_enc_ctx).sample_fmt;
-                    let enc_sample_rate = (*aud_enc_ctx).sample_rate;
-                    let dec_ch_layout = &(*aud_dec_ctx).ch_layout;
-                    let dec_sample_fmt = (*aud_dec_ctx).sample_fmt;
-                    let dec_sample_rate = (*aud_dec_ctx).sample_rate;
-
-                    if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
-                        enc_ch_layout,
-                        enc_sample_fmt,
-                        enc_sample_rate,
-                        dec_ch_layout,
-                        dec_sample_fmt,
-                        dec_sample_rate,
-                    ) {
-                        if ff_sys::swresample::init(ctx).is_ok() {
-                            swr_ctx = ctx;
+                    // Set up resampler: decoded audio → FLTP at aud_sample_rate.
+                    if let Some(dec) = aud_dec_ctx.as_ref() {
+                        let enc_ptr = ctx.as_ptr();
+                        let dec_ptr = dec.as_ptr();
+                        if let Ok(swr) = ff_sys::ResampleContext::new(
+                            &(*enc_ptr).ch_layout,
+                            (*enc_ptr).sample_fmt,
+                            (*enc_ptr).sample_rate,
+                            &(*dec_ptr).ch_layout,
+                            (*dec_ptr).sample_fmt,
+                            (*dec_ptr).sample_rate,
+                        ) {
+                            swr_ctx = Some(swr);
+                            aud_enc_ctx = Some(ctx);
                         } else {
-                            let mut swr_tmp = ctx;
-                            ff_sys::swresample::free(&mut swr_tmp);
-                            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                            log::warn!("dash swr init failed, skipping audio");
+                            // `ctx` drops here.
+                            log::warn!("dash swr alloc failed, skipping audio");
                             audio_stream_idx = -1;
                         }
                     } else {
-                        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                        log::warn!("dash swr alloc failed, skipping audio");
+                        log::warn!("dash audio decoder missing, skipping audio");
                         audio_stream_idx = -1;
                     }
                 }
@@ -290,9 +280,8 @@ pub(super) unsafe fn write_dash_unsafe(
         ff_sys::avformat::avio_flags::WRITE,
     )
     .map_err(|e| {
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err(e)
     })?;
     (*out_ctx).pb = pb;
@@ -300,9 +289,8 @@ pub(super) unsafe fn write_dash_unsafe(
     let ret = avformat_write_header(out_ctx, ptr::null_mut());
     if ret < 0 {
         ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err(ret));
     }
 
@@ -321,9 +309,8 @@ pub(super) unsafe fn write_dash_unsafe(
     if pkt.is_null() {
         av_write_trailer(out_ctx);
         ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate packet"));
     }
 
@@ -341,16 +328,15 @@ pub(super) unsafe fn write_dash_unsafe(
         av_packet_free(&mut pkt);
         av_write_trailer(out_ctx);
         ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate frame"));
     }
 
     // ── 13. Decode–encode loop ─────────────────────────────────────────────────
     let mut video_frame_count: u64 = 0;
     let mut audio_sample_count: i64 = 0;
-    let mut sws_ctx: *mut ff_sys::SwsContext = ptr::null_mut();
+    let mut sws_ctx: Option<ff_sys::ScaleContext> = None;
     let mut last_src_fmt: Option<ff_sys::AVPixelFormat> = None;
     let mut last_src_w: Option<i32> = None;
     let mut last_src_h: Option<i32> = None;
@@ -360,14 +346,14 @@ pub(super) unsafe fn write_dash_unsafe(
         num: 1,
         den: fps_int,
     };
-    // SAFETY: aud_enc_ctx (if non-null) is valid after avcodec_open2.
-    let aud_frame_period = if !aud_enc_ctx.is_null() {
+    // SAFETY: aud_enc_ctx (if present) is valid after avcodec_open2.
+    let aud_frame_period = if let Some(aud) = aud_enc_ctx.as_ref() {
         AVRational {
-            num: (*aud_enc_ctx).frame_size,
-            den: (*aud_enc_ctx).sample_rate,
+            num: (*aud.as_ptr()).frame_size,
+            den: (*aud.as_ptr()).sample_rate,
         }
     } else {
-        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is null
+        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is None
     };
 
     loop {
@@ -385,14 +371,14 @@ pub(super) unsafe fn write_dash_unsafe(
 
         if stream_idx == video_stream_idx {
             // ── Video path ────────────────────────────────────────────────────
-            if ff_sys::avcodec::send_packet(vid_dec_ctx, pkt).is_err() {
+            if ff_sys::avcodec::send_packet(vid_dec_ctx.as_mut_ptr(), pkt).is_err() {
                 av_packet_unref(pkt);
                 continue;
             }
             av_packet_unref(pkt);
 
             loop {
-                match ff_sys::avcodec::receive_frame(vid_dec_ctx, vid_dec_frame) {
+                match ff_sys::avcodec::receive_frame(vid_dec_ctx.as_mut_ptr(), vid_dec_frame) {
                     Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
                         break;
                     }
@@ -418,11 +404,8 @@ pub(super) unsafe fn write_dash_unsafe(
                     || last_src_w != Some(src_w)
                     || last_src_h != Some(src_h)
                 {
-                    if !sws_ctx.is_null() {
-                        ff_sys::swscale::free_context(sws_ctx);
-                        sws_ctx = ptr::null_mut();
-                    }
-                    if let Ok(ctx) = ff_sys::swscale::get_context(
+                    // Move-assign the new context; the old one (if any) drops here.
+                    if let Ok(ctx) = ff_sys::ScaleContext::new(
                         src_w,
                         src_h,
                         src_fmt,
@@ -431,7 +414,7 @@ pub(super) unsafe fn write_dash_unsafe(
                         AVPixelFormat_AV_PIX_FMT_YUV420P,
                         ff_sys::swscale::scale_flags::BILINEAR,
                     ) {
-                        sws_ctx = ctx;
+                        sws_ctx = Some(ctx);
                         last_src_fmt = Some(src_fmt);
                         last_src_w = Some(src_w);
                         last_src_h = Some(src_h);
@@ -452,7 +435,7 @@ pub(super) unsafe fn write_dash_unsafe(
                         num: 1,
                         den: fps_int,
                     },
-                    (*vid_enc_ctx).time_base,
+                    (*vid_enc_ctx.as_ptr()).time_base,
                 );
 
                 let buf_ret = av_frame_get_buffer(vid_enc_frame, 0);
@@ -462,21 +445,25 @@ pub(super) unsafe fn write_dash_unsafe(
                 }
 
                 // Scale decoded frame into encoder frame
-                let scale_ok = ff_sys::swscale::scale(
-                    sws_ctx,
-                    (*vid_dec_frame).data.as_ptr() as *const *const u8,
-                    (*vid_dec_frame).linesize.as_ptr(),
-                    0,
-                    src_h,
-                    (*vid_enc_frame).data.as_mut_ptr().cast_const(),
-                    (*vid_enc_frame).linesize.as_mut_ptr(),
-                );
+                let scaled = if let Some(sws) = sws_ctx.as_mut() {
+                    sws.scale(
+                        (*vid_dec_frame).data.as_ptr() as *const *const u8,
+                        (*vid_dec_frame).linesize.as_ptr(),
+                        0,
+                        src_h,
+                        (*vid_enc_frame).data.as_mut_ptr().cast_const(),
+                        (*vid_enc_frame).linesize.as_mut_ptr(),
+                    )
+                    .is_ok()
+                } else {
+                    false
+                };
 
-                if scale_ok.is_ok()
-                    && ff_sys::avcodec::send_frame(vid_enc_ctx, vid_enc_frame).is_ok()
+                if scaled
+                    && ff_sys::avcodec::send_frame(vid_enc_ctx.as_mut_ptr(), vid_enc_frame).is_ok()
                 {
                     crate::codec_utils::drain_encoder(
-                        vid_enc_ctx,
+                        vid_enc_ctx.as_mut_ptr(),
                         out_ctx,
                         vid_out_stream_idx,
                         "dash",
@@ -488,16 +475,19 @@ pub(super) unsafe fn write_dash_unsafe(
                 av_frame_unref(vid_dec_frame);
                 video_frame_count += 1;
             }
-        } else if stream_idx == audio_stream_idx && !aud_dec_ctx.is_null() {
+        } else if stream_idx == audio_stream_idx
+            && let Some(aud_dec_ptr) = aud_dec_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr)
+            && let Some(aud_enc_ptr) = aud_enc_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr)
+        {
             // ── Audio path ────────────────────────────────────────────────────
-            if ff_sys::avcodec::send_packet(aud_dec_ctx, pkt).is_err() {
+            if ff_sys::avcodec::send_packet(aud_dec_ptr, pkt).is_err() {
                 av_packet_unref(pkt);
                 continue;
             }
             av_packet_unref(pkt);
 
             loop {
-                match ff_sys::avcodec::receive_frame(aud_dec_ctx, aud_dec_frame) {
+                match ff_sys::avcodec::receive_frame(aud_dec_ptr, aud_dec_frame) {
                     Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
                         break;
                     }
@@ -505,18 +495,18 @@ pub(super) unsafe fn write_dash_unsafe(
                     Ok(()) => {}
                 }
 
-                let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                    (*aud_enc_ctx).frame_size
+                let enc_frame_size = if (*aud_enc_ptr).frame_size > 0 {
+                    (*aud_enc_ptr).frame_size
                 } else {
                     (*aud_dec_frame).nb_samples
                 };
 
-                (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
-                (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+                (*aud_enc_frame).format = (*aud_enc_ptr).sample_fmt;
+                (*aud_enc_frame).sample_rate = (*aud_enc_ptr).sample_rate;
                 (*aud_enc_frame).nb_samples = enc_frame_size;
                 let _ = ff_sys::swresample::channel_layout::copy(
                     &mut (*aud_enc_frame).ch_layout,
-                    &(*aud_enc_ctx).ch_layout,
+                    &(*aud_enc_ptr).ch_layout,
                 );
 
                 let buf_ret = av_frame_get_buffer(aud_enc_frame, 0);
@@ -528,22 +518,26 @@ pub(super) unsafe fn write_dash_unsafe(
                 let in_data = (*aud_dec_frame).data.as_ptr() as *const *const u8;
                 let in_samples = (*aud_dec_frame).nb_samples;
 
-                let samples_out = ff_sys::swresample::convert(
-                    swr_ctx,
-                    (*aud_enc_frame).data.as_mut_ptr(),
-                    enc_frame_size,
-                    in_data,
-                    in_samples,
-                );
+                let samples_out = if let Some(swr) = swr_ctx.as_mut() {
+                    swr.convert(
+                        (*aud_enc_frame).data.as_mut_ptr(),
+                        enc_frame_size,
+                        in_data,
+                        in_samples,
+                    )
+                    .ok()
+                } else {
+                    None
+                };
 
-                if let Ok(n) = samples_out
+                if let Some(n) = samples_out
                     && n > 0
                 {
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
-                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                    if ff_sys::avcodec::send_frame(aud_enc_ptr, aud_enc_frame).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc_ctx,
+                            aud_enc_ptr,
                             out_ctx,
                             aud_out_stream_idx,
                             "dash",
@@ -562,44 +556,50 @@ pub(super) unsafe fn write_dash_unsafe(
     }
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
-    let _ = ff_sys::avcodec::send_frame(vid_enc_ctx, ptr::null());
+    let _ = vid_enc_ctx.send_frame(ptr::null());
     crate::codec_utils::drain_encoder(
-        vid_enc_ctx,
+        vid_enc_ctx.as_mut_ptr(),
         out_ctx,
         vid_out_stream_idx,
         "dash",
         vid_frame_period,
     );
 
-    if !aud_enc_ctx.is_null() {
+    if let Some(aud_enc_ptr) = aud_enc_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr) {
         // Flush resampler
-        if !swr_ctx.is_null() {
-            let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                (*aud_enc_ctx).frame_size
+        if swr_ctx.is_some() {
+            let enc_frame_size = if (*aud_enc_ptr).frame_size > 0 {
+                (*aud_enc_ptr).frame_size
             } else {
                 1024
             };
-            (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
-            (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+            (*aud_enc_frame).format = (*aud_enc_ptr).sample_fmt;
+            (*aud_enc_frame).sample_rate = (*aud_enc_ptr).sample_rate;
             (*aud_enc_frame).nb_samples = enc_frame_size;
             let _ = ff_sys::swresample::channel_layout::copy(
                 &mut (*aud_enc_frame).ch_layout,
-                &(*aud_enc_ctx).ch_layout,
+                &(*aud_enc_ptr).ch_layout,
             );
             if av_frame_get_buffer(aud_enc_frame, 0) == 0 {
-                if let Ok(n) = ff_sys::swresample::convert(
-                    swr_ctx,
-                    (*aud_enc_frame).data.as_mut_ptr(),
-                    enc_frame_size,
-                    ptr::null(),
-                    0,
-                ) && n > 0
+                let flushed = if let Some(swr) = swr_ctx.as_mut() {
+                    swr.convert(
+                        (*aud_enc_frame).data.as_mut_ptr(),
+                        enc_frame_size,
+                        ptr::null(),
+                        0,
+                    )
+                    .ok()
+                } else {
+                    None
+                };
+                if let Some(n) = flushed
+                    && n > 0
                 {
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
-                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                    if ff_sys::avcodec::send_frame(aud_enc_ptr, aud_enc_frame).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc_ctx,
+                            aud_enc_ptr,
                             out_ctx,
                             aud_out_stream_idx,
                             "dash",
@@ -610,9 +610,9 @@ pub(super) unsafe fn write_dash_unsafe(
                 av_frame_unref(aud_enc_frame);
             }
         }
-        let _ = ff_sys::avcodec::send_frame(aud_enc_ctx, ptr::null());
+        let _ = ff_sys::avcodec::send_frame(aud_enc_ptr, ptr::null());
         crate::codec_utils::drain_encoder(
-            aud_enc_ctx,
+            aud_enc_ptr,
             out_ctx,
             aud_out_stream_idx,
             "dash",
@@ -625,16 +625,13 @@ pub(super) unsafe fn write_dash_unsafe(
     // pb was already closed after avformat_write_header; skip double-close.
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
+    // Owned encoder / decoder / resample / scale contexts drop on scope exit;
+    // only the raw frames and format contexts need explicit teardown.
     free_frames(vid_dec_frame, vid_enc_frame, aud_dec_frame, aud_enc_frame);
     av_packet_free(&mut pkt);
 
-    if !sws_ctx.is_null() {
-        ff_sys::swscale::free_context(sws_ctx);
-    }
-
-    cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
     cleanup_output_ctx(out_ctx);
-    cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+    ff_sys::avformat::close_input(&mut input_ctx);
 
     log::info!(
         "dash write complete video_frames={video_frame_count} \
@@ -696,25 +693,28 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
     // ── 4. Open input video decoder ────────────────────────────────────────────
     let vid_codec_id = (*video_codecpar).codec_id;
-    let vid_decoder = ff_sys::avcodec::find_decoder(vid_codec_id)
+    let vid_decoder = ff_sys::Codec::find_decoder(vid_codec_id)
         .ok_or_else(|| ffmpeg_err_msg("no video decoder available for input stream"))?;
 
-    let mut vid_dec_ctx = ff_sys::avcodec::alloc_context3(vid_decoder).map_err(ffmpeg_err)?;
+    let mut vid_dec_ctx =
+        ff_sys::CodecContext::new(Some(vid_decoder)).map_err(|e| ffmpeg_err(e.code()))?;
 
-    ff_sys::avcodec::parameters_to_context(vid_dec_ctx, video_codecpar).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    vid_dec_ctx
+        .parameters_to_context(video_codecpar)
+        .map_err(|e| {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
-    ff_sys::avcodec::open2(vid_dec_ctx, vid_decoder, ptr::null_mut()).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    vid_dec_ctx
+        .open(vid_decoder, ptr::null_mut())
+        .map_err(|e| {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
     // ── 5. Open input audio decoder (optional) ────────────────────────────────
-    let mut aud_dec_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_dec_ctx: Option<ff_sys::CodecContext> = None;
     let mut aud_sample_rate: i32 = 44100;
     let mut aud_nb_channels: i32 = 2;
 
@@ -723,21 +723,20 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         let audio_codecpar = (*audio_stream).codecpar;
         let aud_codec_id = (*audio_codecpar).codec_id;
 
-        if let Some(aud_decoder) = ff_sys::avcodec::find_decoder(aud_codec_id) {
-            if let Ok(ctx) = ff_sys::avcodec::alloc_context3(aud_decoder) {
-                aud_dec_ctx = ctx;
-                if ff_sys::avcodec::parameters_to_context(aud_dec_ctx, audio_codecpar).is_ok()
-                    && ff_sys::avcodec::open2(aud_dec_ctx, aud_decoder, ptr::null_mut()).is_ok()
+        if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
+            if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
+                if ctx.parameters_to_context(audio_codecpar).is_ok()
+                    && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
                 {
-                    aud_sample_rate = (*aud_dec_ctx).sample_rate;
-                    aud_nb_channels = (*aud_dec_ctx).ch_layout.nb_channels;
+                    aud_sample_rate = (*ctx.as_ptr()).sample_rate;
+                    aud_nb_channels = (*ctx.as_ptr()).ch_layout.nb_channels;
+                    aud_dec_ctx = Some(ctx);
                     log::info!(
                         "dash abr audio decoder opened sample_rate={aud_sample_rate} \
                          channels={aud_nb_channels}"
                     );
                 } else {
-                    ff_sys::avcodec::free_context(&mut aud_dec_ctx as *mut *mut _);
-                    aud_dec_ctx = ptr::null_mut();
+                    // `ctx` drops here (frees the decoder context).
                     audio_stream_idx = -1;
                     log::warn!("dash abr audio decoder open failed, skipping audio");
                 }
@@ -765,7 +764,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         c_manifest.as_ptr(),
     );
     if ret < 0 || out_ctx.is_null() {
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err(ret));
     }
 
@@ -790,7 +789,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     // ── 8. Select H.264 encoder (shared across all renditions) ────────────────
     let Some(vid_enc_codec) = select_h264_encoder() else {
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg(
             "no H.264 encoder available (tried h264_nvenc, h264_qsv, h264_amf, \
              h264_videotoolbox, libx264, mpeg4)",
@@ -798,58 +797,54 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     };
 
     // ── 9. Create one encoder + output stream per rendition ───────────────────
+    // On any error the `rendition_states` Vec drops all prior renditions'
+    // owned encoder / scale contexts; only the raw format contexts need
+    // explicit teardown.
     let mut rendition_states: Vec<RenditionState> = Vec::with_capacity(renditions.len());
 
     for &(target_bitrate, target_width, target_height) in renditions {
-        let mut enc_ctx = match ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(ffmpeg_err) {
+        let mut enc_ctx = match ff_sys::CodecContext::new(Some(vid_enc_codec)) {
             Ok(ctx) => ctx,
             Err(e) => {
-                cleanup_renditions(&mut rendition_states);
                 cleanup_output_ctx(out_ctx);
-                cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-                return Err(e);
+                ff_sys::avformat::close_input(&mut input_ctx);
+                return Err(ffmpeg_err(e.code()));
             }
         };
+        let ecptr = enc_ctx.as_mut_ptr();
 
-        (*enc_ctx).width = target_width;
-        (*enc_ctx).height = target_height;
-        (*enc_ctx).time_base.num = 1;
-        (*enc_ctx).time_base.den = fps_int;
-        (*enc_ctx).framerate.num = fps_int;
-        (*enc_ctx).framerate.den = 1;
-        (*enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-        (*enc_ctx).bit_rate = target_bitrate;
+        (*ecptr).width = target_width;
+        (*ecptr).height = target_height;
+        (*ecptr).time_base.num = 1;
+        (*ecptr).time_base.den = fps_int;
+        (*ecptr).framerate.num = fps_int;
+        (*ecptr).framerate.den = 1;
+        (*ecptr).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*ecptr).bit_rate = target_bitrate;
 
-        if let Err(e) =
-            ff_sys::avcodec::open2(enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(ffmpeg_err)
-        {
-            ff_sys::avcodec::free_context(&mut enc_ctx as *mut *mut _);
-            cleanup_renditions(&mut rendition_states);
+        if let Err(e) = enc_ctx.open(vid_enc_codec, ptr::null_mut()) {
+            // `enc_ctx` and the prior renditions drop on return.
             cleanup_output_ctx(out_ctx);
-            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-            return Err(e);
+            ff_sys::avformat::close_input(&mut input_ctx);
+            return Err(ffmpeg_err(e.code()));
         }
 
-        let out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+        let out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
         if out_stream.is_null() {
-            ff_sys::avcodec::free_context(&mut enc_ctx as *mut *mut _);
-            cleanup_renditions(&mut rendition_states);
             cleanup_output_ctx(out_ctx);
-            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+            ff_sys::avformat::close_input(&mut input_ctx);
             return Err(ffmpeg_err_msg(
                 "cannot create video output stream for rendition",
             ));
         }
-        (*out_stream).time_base = (*enc_ctx).time_base;
+        (*out_stream).time_base = (*enc_ctx.as_ptr()).time_base;
         let stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
         // SAFETY: out_stream and enc_ctx are valid; avcodec_open2 has been called.
-        if let Err(e) = ff_sys::avcodec::parameters_from_context((*out_stream).codecpar, enc_ctx) {
-            ff_sys::avcodec::free_context(&mut enc_ctx as *mut *mut _);
-            cleanup_renditions(&mut rendition_states);
+        if let Err(e) = enc_ctx.parameters_from_context((*out_stream).codecpar) {
             cleanup_output_ctx(out_ctx);
-            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-            return Err(ffmpeg_err(e));
+            ff_sys::avformat::close_input(&mut input_ctx);
+            return Err(ffmpeg_err(e.code()));
         }
 
         log::info!(
@@ -862,7 +857,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
             vid_out_stream_idx: stream_idx,
             enc_width: target_width,
             enc_height: target_height,
-            sws_ctx: ptr::null_mut(),
+            sws_ctx: None,
             last_src_fmt: None,
             last_src_w: None,
             last_src_h: None,
@@ -870,17 +865,16 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     }
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
-    let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_enc_ctx: Option<ff_sys::CodecContext> = None;
     let mut aud_out_stream_idx: i32 = -1;
-    let mut swr_ctx: *mut ff_sys::SwrContext = ptr::null_mut();
+    let mut swr_ctx: Option<ff_sys::ResampleContext> = None;
 
     if audio_stream_idx >= 0 {
         match open_aac_encoder(aud_sample_rate, aud_nb_channels) {
             Ok(ctx) => {
-                aud_enc_ctx = ctx;
                 let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
                 if aud_out_stream.is_null() {
-                    ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                    // `ctx` drops here (frees the codec context).
                     log::warn!("dash abr cannot create audio output stream, skipping audio");
                     audio_stream_idx = -1;
                 } else {
@@ -888,45 +882,38 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                     (*aud_out_stream).time_base.den = aud_sample_rate;
                     aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
+                    let enc_ptr = ctx.as_ptr();
                     if !(*aud_out_stream).codecpar.is_null() {
-                        (*(*aud_out_stream).codecpar).codec_id = (*aud_enc_ctx).codec_id;
+                        (*(*aud_out_stream).codecpar).codec_id = (*enc_ptr).codec_id;
                         (*(*aud_out_stream).codecpar).codec_type =
                             ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO;
-                        (*(*aud_out_stream).codecpar).sample_rate = (*aud_enc_ctx).sample_rate;
-                        (*(*aud_out_stream).codecpar).format = (*aud_enc_ctx).sample_fmt;
+                        (*(*aud_out_stream).codecpar).sample_rate = (*enc_ptr).sample_rate;
+                        (*(*aud_out_stream).codecpar).format = (*enc_ptr).sample_fmt;
                         let _ = ff_sys::swresample::channel_layout::copy(
                             &mut (*(*aud_out_stream).codecpar).ch_layout,
-                            &(*aud_enc_ctx).ch_layout,
+                            &(*enc_ptr).ch_layout,
                         );
                     }
 
-                    let enc_ch_layout = &(*aud_enc_ctx).ch_layout;
-                    let enc_sample_fmt = (*aud_enc_ctx).sample_fmt;
-                    let enc_sample_rate = (*aud_enc_ctx).sample_rate;
-                    let dec_ch_layout = &(*aud_dec_ctx).ch_layout;
-                    let dec_sample_fmt = (*aud_dec_ctx).sample_fmt;
-                    let dec_sample_rate = (*aud_dec_ctx).sample_rate;
-
-                    if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
-                        enc_ch_layout,
-                        enc_sample_fmt,
-                        enc_sample_rate,
-                        dec_ch_layout,
-                        dec_sample_fmt,
-                        dec_sample_rate,
-                    ) {
-                        if ff_sys::swresample::init(ctx).is_ok() {
-                            swr_ctx = ctx;
+                    if let Some(dec) = aud_dec_ctx.as_ref() {
+                        let dec_ptr = dec.as_ptr();
+                        if let Ok(swr) = ff_sys::ResampleContext::new(
+                            &(*enc_ptr).ch_layout,
+                            (*enc_ptr).sample_fmt,
+                            (*enc_ptr).sample_rate,
+                            &(*dec_ptr).ch_layout,
+                            (*dec_ptr).sample_fmt,
+                            (*dec_ptr).sample_rate,
+                        ) {
+                            swr_ctx = Some(swr);
+                            aud_enc_ctx = Some(ctx);
                         } else {
-                            let mut swr_tmp = ctx;
-                            ff_sys::swresample::free(&mut swr_tmp);
-                            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                            log::warn!("dash abr swr init failed, skipping audio");
+                            // `ctx` drops here.
+                            log::warn!("dash abr swr alloc failed, skipping audio");
                             audio_stream_idx = -1;
                         }
                     } else {
-                        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                        log::warn!("dash abr swr alloc failed, skipping audio");
+                        log::warn!("dash abr audio decoder missing, skipping audio");
                         audio_stream_idx = -1;
                     }
                 }
@@ -944,10 +931,8 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         ff_sys::avformat::avio_flags::WRITE,
     )
     .map_err(|e| {
-        cleanup_encoders(aud_enc_ctx, ptr::null_mut(), swr_ctx);
-        cleanup_renditions(&mut rendition_states);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err(e)
     })?;
     (*out_ctx).pb = pb;
@@ -955,10 +940,8 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     let ret = avformat_write_header(out_ctx, ptr::null_mut());
     if ret < 0 {
         ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_encoders(aud_enc_ctx, ptr::null_mut(), swr_ctx);
-        cleanup_renditions(&mut rendition_states);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err(ret));
     }
 
@@ -976,10 +959,8 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     let mut pkt = av_packet_alloc();
     if pkt.is_null() {
         av_write_trailer(out_ctx);
-        cleanup_encoders(aud_enc_ctx, ptr::null_mut(), swr_ctx);
-        cleanup_renditions(&mut rendition_states);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate packet"));
     }
 
@@ -996,10 +977,8 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         free_frames(vid_dec_frame, vid_enc_frame, aud_dec_frame, aud_enc_frame);
         av_packet_free(&mut pkt);
         av_write_trailer(out_ctx);
-        cleanup_encoders(aud_enc_ctx, ptr::null_mut(), swr_ctx);
-        cleanup_renditions(&mut rendition_states);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate frame"));
     }
 
@@ -1012,14 +991,14 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         num: 1,
         den: fps_int,
     };
-    // SAFETY: aud_enc_ctx (if non-null) is valid after avcodec_open2.
-    let aud_frame_period = if !aud_enc_ctx.is_null() {
+    // SAFETY: aud_enc_ctx (if present) is valid after avcodec_open2.
+    let aud_frame_period = if let Some(aud) = aud_enc_ctx.as_ref() {
         AVRational {
-            num: (*aud_enc_ctx).frame_size,
-            den: (*aud_enc_ctx).sample_rate,
+            num: (*aud.as_ptr()).frame_size,
+            den: (*aud.as_ptr()).sample_rate,
         }
     } else {
-        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is null
+        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is None
     };
 
     loop {
@@ -1036,14 +1015,14 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
         if stream_idx == video_stream_idx {
             // ── Video path ────────────────────────────────────────────────────
-            if ff_sys::avcodec::send_packet(vid_dec_ctx, pkt).is_err() {
+            if ff_sys::avcodec::send_packet(vid_dec_ctx.as_mut_ptr(), pkt).is_err() {
                 av_packet_unref(pkt);
                 continue;
             }
             av_packet_unref(pkt);
 
             loop {
-                match ff_sys::avcodec::receive_frame(vid_dec_ctx, vid_dec_frame) {
+                match ff_sys::avcodec::receive_frame(vid_dec_ctx.as_mut_ptr(), vid_dec_frame) {
                     Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
                         break;
                     }
@@ -1068,11 +1047,8 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                         || state.last_src_w != Some(src_w)
                         || state.last_src_h != Some(src_h)
                     {
-                        if !state.sws_ctx.is_null() {
-                            ff_sys::swscale::free_context(state.sws_ctx);
-                            state.sws_ctx = ptr::null_mut();
-                        }
-                        if let Ok(ctx) = ff_sys::swscale::get_context(
+                        // Move-assign the new context; the old one (if any) drops here.
+                        if let Ok(ctx) = ff_sys::ScaleContext::new(
                             src_w,
                             src_h,
                             src_fmt,
@@ -1081,7 +1057,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                             AVPixelFormat_AV_PIX_FMT_YUV420P,
                             ff_sys::swscale::scale_flags::BILINEAR,
                         ) {
-                            state.sws_ctx = ctx;
+                            state.sws_ctx = Some(ctx);
                             state.last_src_fmt = Some(src_fmt);
                             state.last_src_w = Some(src_w);
                             state.last_src_h = Some(src_h);
@@ -1100,28 +1076,36 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                             num: 1,
                             den: fps_int,
                         },
-                        (*state.vid_enc_ctx).time_base,
+                        (*state.vid_enc_ctx.as_ptr()).time_base,
                     );
 
                     if av_frame_get_buffer(vid_enc_frame, 0) < 0 {
                         continue;
                     }
 
-                    let scale_ok = ff_sys::swscale::scale(
-                        state.sws_ctx,
-                        (*vid_dec_frame).data.as_ptr() as *const *const u8,
-                        (*vid_dec_frame).linesize.as_ptr(),
-                        0,
-                        src_h,
-                        (*vid_enc_frame).data.as_mut_ptr().cast_const(),
-                        (*vid_enc_frame).linesize.as_mut_ptr(),
-                    );
+                    let scaled = if let Some(sws) = state.sws_ctx.as_mut() {
+                        sws.scale(
+                            (*vid_dec_frame).data.as_ptr() as *const *const u8,
+                            (*vid_dec_frame).linesize.as_ptr(),
+                            0,
+                            src_h,
+                            (*vid_enc_frame).data.as_mut_ptr().cast_const(),
+                            (*vid_enc_frame).linesize.as_mut_ptr(),
+                        )
+                        .is_ok()
+                    } else {
+                        false
+                    };
 
-                    if scale_ok.is_ok()
-                        && ff_sys::avcodec::send_frame(state.vid_enc_ctx, vid_enc_frame).is_ok()
+                    if scaled
+                        && ff_sys::avcodec::send_frame(
+                            state.vid_enc_ctx.as_mut_ptr(),
+                            vid_enc_frame,
+                        )
+                        .is_ok()
                     {
                         crate::codec_utils::drain_encoder(
-                            state.vid_enc_ctx,
+                            state.vid_enc_ctx.as_mut_ptr(),
                             out_ctx,
                             state.vid_out_stream_idx,
                             "dash",
@@ -1135,16 +1119,19 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 av_frame_unref(vid_dec_frame);
                 video_frame_count += 1;
             }
-        } else if stream_idx == audio_stream_idx && !aud_dec_ctx.is_null() {
+        } else if stream_idx == audio_stream_idx
+            && let Some(aud_dec_ptr) = aud_dec_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr)
+            && let Some(aud_enc_ptr) = aud_enc_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr)
+        {
             // ── Audio path ────────────────────────────────────────────────────
-            if ff_sys::avcodec::send_packet(aud_dec_ctx, pkt).is_err() {
+            if ff_sys::avcodec::send_packet(aud_dec_ptr, pkt).is_err() {
                 av_packet_unref(pkt);
                 continue;
             }
             av_packet_unref(pkt);
 
             loop {
-                match ff_sys::avcodec::receive_frame(aud_dec_ctx, aud_dec_frame) {
+                match ff_sys::avcodec::receive_frame(aud_dec_ptr, aud_dec_frame) {
                     Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
                         break;
                     }
@@ -1152,18 +1139,18 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                     Ok(()) => {}
                 }
 
-                let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                    (*aud_enc_ctx).frame_size
+                let enc_frame_size = if (*aud_enc_ptr).frame_size > 0 {
+                    (*aud_enc_ptr).frame_size
                 } else {
                     (*aud_dec_frame).nb_samples
                 };
 
-                (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
-                (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+                (*aud_enc_frame).format = (*aud_enc_ptr).sample_fmt;
+                (*aud_enc_frame).sample_rate = (*aud_enc_ptr).sample_rate;
                 (*aud_enc_frame).nb_samples = enc_frame_size;
                 let _ = ff_sys::swresample::channel_layout::copy(
                     &mut (*aud_enc_frame).ch_layout,
-                    &(*aud_enc_ctx).ch_layout,
+                    &(*aud_enc_ptr).ch_layout,
                 );
 
                 let buf_ret = av_frame_get_buffer(aud_enc_frame, 0);
@@ -1175,22 +1162,26 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 let in_data = (*aud_dec_frame).data.as_ptr() as *const *const u8;
                 let in_samples = (*aud_dec_frame).nb_samples;
 
-                let samples_out = ff_sys::swresample::convert(
-                    swr_ctx,
-                    (*aud_enc_frame).data.as_mut_ptr(),
-                    enc_frame_size,
-                    in_data,
-                    in_samples,
-                );
+                let samples_out = if let Some(swr) = swr_ctx.as_mut() {
+                    swr.convert(
+                        (*aud_enc_frame).data.as_mut_ptr(),
+                        enc_frame_size,
+                        in_data,
+                        in_samples,
+                    )
+                    .ok()
+                } else {
+                    None
+                };
 
-                if let Ok(n) = samples_out
+                if let Some(n) = samples_out
                     && n > 0
                 {
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
-                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                    if ff_sys::avcodec::send_frame(aud_enc_ptr, aud_enc_frame).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc_ctx,
+                            aud_enc_ptr,
                             out_ctx,
                             aud_out_stream_idx,
                             "dash",
@@ -1209,10 +1200,10 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     }
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
-    for state in &rendition_states {
-        let _ = ff_sys::avcodec::send_frame(state.vid_enc_ctx, ptr::null());
+    for state in &mut rendition_states {
+        let _ = state.vid_enc_ctx.send_frame(ptr::null());
         crate::codec_utils::drain_encoder(
-            state.vid_enc_ctx,
+            state.vid_enc_ctx.as_mut_ptr(),
             out_ctx,
             state.vid_out_stream_idx,
             "dash",
@@ -1220,34 +1211,40 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         );
     }
 
-    if !aud_enc_ctx.is_null() {
-        if !swr_ctx.is_null() {
-            let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                (*aud_enc_ctx).frame_size
+    if let Some(aud_enc_ptr) = aud_enc_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr) {
+        if swr_ctx.is_some() {
+            let enc_frame_size = if (*aud_enc_ptr).frame_size > 0 {
+                (*aud_enc_ptr).frame_size
             } else {
                 1024
             };
-            (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
-            (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+            (*aud_enc_frame).format = (*aud_enc_ptr).sample_fmt;
+            (*aud_enc_frame).sample_rate = (*aud_enc_ptr).sample_rate;
             (*aud_enc_frame).nb_samples = enc_frame_size;
             let _ = ff_sys::swresample::channel_layout::copy(
                 &mut (*aud_enc_frame).ch_layout,
-                &(*aud_enc_ctx).ch_layout,
+                &(*aud_enc_ptr).ch_layout,
             );
             if av_frame_get_buffer(aud_enc_frame, 0) == 0 {
-                if let Ok(n) = ff_sys::swresample::convert(
-                    swr_ctx,
-                    (*aud_enc_frame).data.as_mut_ptr(),
-                    enc_frame_size,
-                    ptr::null(),
-                    0,
-                ) && n > 0
+                let flushed = if let Some(swr) = swr_ctx.as_mut() {
+                    swr.convert(
+                        (*aud_enc_frame).data.as_mut_ptr(),
+                        enc_frame_size,
+                        ptr::null(),
+                        0,
+                    )
+                    .ok()
+                } else {
+                    None
+                };
+                if let Some(n) = flushed
+                    && n > 0
                 {
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
-                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                    if ff_sys::avcodec::send_frame(aud_enc_ptr, aud_enc_frame).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc_ctx,
+                            aud_enc_ptr,
                             out_ctx,
                             aud_out_stream_idx,
                             "dash",
@@ -1258,9 +1255,9 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 av_frame_unref(aud_enc_frame);
             }
         }
-        let _ = ff_sys::avcodec::send_frame(aud_enc_ctx, ptr::null());
+        let _ = ff_sys::avcodec::send_frame(aud_enc_ptr, ptr::null());
         crate::codec_utils::drain_encoder(
-            aud_enc_ctx,
+            aud_enc_ptr,
             out_ctx,
             aud_out_stream_idx,
             "dash",
@@ -1272,12 +1269,13 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     av_write_trailer(out_ctx);
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
+    // Owned encoder / decoder / resample / scale contexts (including every
+    // rendition in the Vec) drop on scope exit; only the raw frames and format
+    // contexts need explicit teardown.
     free_frames(vid_dec_frame, vid_enc_frame, aud_dec_frame, aud_enc_frame);
     av_packet_free(&mut pkt);
-    cleanup_encoders(aud_enc_ctx, ptr::null_mut(), swr_ctx);
-    cleanup_renditions(&mut rendition_states);
     cleanup_output_ctx(out_ctx);
-    cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+    ff_sys::avformat::close_input(&mut input_ctx);
 
     log::info!(
         "dash abr write complete video_frames={video_frame_count} \

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -25,12 +25,11 @@ use std::path::Path;
 use std::ptr;
 
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVFrame, AVPictureType_AV_PICTURE_TYPE_I,
-    AVPictureType_AV_PICTURE_TYPE_NONE, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P,
-    AVRational, SwrContext, SwsContext, av_frame_alloc, av_frame_free, av_frame_get_buffer,
-    av_frame_unref, av_opt_set, av_packet_alloc, av_packet_free, av_packet_unref, av_rescale_q,
-    av_write_trailer, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header,
+    AVFormatContext, AVFrame, AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
+    AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, av_frame_alloc, av_frame_free,
+    av_frame_get_buffer, av_frame_unref, av_opt_set, av_packet_alloc, av_packet_free,
+    av_packet_unref, av_rescale_q, av_write_trailer, avformat_alloc_output_context2,
+    avformat_free_context, avformat_new_stream, avformat_write_header,
 };
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
@@ -141,25 +140,28 @@ unsafe fn write_hls_unsafe(
 
     // ── 4. Open input video decoder ────────────────────────────────────────────
     let vid_codec_id = (*video_codecpar).codec_id;
-    let vid_decoder = ff_sys::avcodec::find_decoder(vid_codec_id)
+    let vid_decoder = ff_sys::Codec::find_decoder(vid_codec_id)
         .ok_or_else(|| ffmpeg_err_msg("no video decoder available for input stream"))?;
 
-    let mut vid_dec_ctx = ff_sys::avcodec::alloc_context3(vid_decoder).map_err(ffmpeg_err)?;
+    let mut vid_dec_ctx =
+        ff_sys::CodecContext::new(Some(vid_decoder)).map_err(|e| ffmpeg_err(e.code()))?;
 
-    ff_sys::avcodec::parameters_to_context(vid_dec_ctx, video_codecpar).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    vid_dec_ctx
+        .parameters_to_context(video_codecpar)
+        .map_err(|e| {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
-    ff_sys::avcodec::open2(vid_dec_ctx, vid_decoder, ptr::null_mut()).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    vid_dec_ctx
+        .open(vid_decoder, ptr::null_mut())
+        .map_err(|e| {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
     // ── 5. Open input audio decoder (optional) ────────────────────────────────
-    let mut aud_dec_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_dec_ctx: Option<ff_sys::CodecContext> = None;
     let mut aud_sample_rate: i32 = 44100;
     let mut aud_nb_channels: i32 = 2;
 
@@ -168,21 +170,20 @@ unsafe fn write_hls_unsafe(
         let audio_codecpar = (*audio_stream).codecpar;
         let aud_codec_id = (*audio_codecpar).codec_id;
 
-        if let Some(aud_decoder) = ff_sys::avcodec::find_decoder(aud_codec_id) {
-            if let Ok(ctx) = ff_sys::avcodec::alloc_context3(aud_decoder) {
-                aud_dec_ctx = ctx;
-                if ff_sys::avcodec::parameters_to_context(aud_dec_ctx, audio_codecpar).is_ok()
-                    && ff_sys::avcodec::open2(aud_dec_ctx, aud_decoder, ptr::null_mut()).is_ok()
+        if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
+            if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
+                if ctx.parameters_to_context(audio_codecpar).is_ok()
+                    && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
                 {
-                    aud_sample_rate = (*aud_dec_ctx).sample_rate;
-                    aud_nb_channels = (*aud_dec_ctx).ch_layout.nb_channels;
+                    aud_sample_rate = (*ctx.as_ptr()).sample_rate;
+                    aud_nb_channels = (*ctx.as_ptr()).ch_layout.nb_channels;
+                    aud_dec_ctx = Some(ctx);
                     log::info!(
                         "hls audio decoder opened sample_rate={aud_sample_rate} \
                          channels={aud_nb_channels}"
                     );
                 } else {
-                    ff_sys::avcodec::free_context(&mut aud_dec_ctx as *mut *mut _);
-                    aud_dec_ctx = ptr::null_mut();
+                    // `ctx` drops here (frees the decoder context).
                     audio_stream_idx = -1;
                     log::warn!("hls audio decoder open failed, skipping audio");
                 }
@@ -210,7 +211,7 @@ unsafe fn write_hls_unsafe(
         c_playlist.as_ptr(),
     );
     if ret < 0 || out_ctx.is_null() {
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err(ret));
     }
 
@@ -268,70 +269,71 @@ unsafe fn write_hls_unsafe(
     // ── 8. Open H.264 video encoder ───────────────────────────────────────────
     let vid_enc_codec = crate::codec_utils::select_h264_encoder("hls").ok_or_else(|| {
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err_msg("no H.264 encoder available (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)")
     })?;
 
-    let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+    let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-        ffmpeg_err(e)
+        ff_sys::avformat::close_input(&mut input_ctx);
+        ffmpeg_err(e.code())
     })?;
+    let venc = vid_enc_ctx.as_mut_ptr();
 
-    (*vid_enc_ctx).width = enc_width;
-    (*vid_enc_ctx).height = enc_height;
-    (*vid_enc_ctx).time_base.num = 1;
-    (*vid_enc_ctx).time_base.den = fps_int;
-    (*vid_enc_ctx).framerate.num = fps_int;
-    (*vid_enc_ctx).framerate.den = 1;
-    (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-    (*vid_enc_ctx).bit_rate = if target_bitrate > 0 {
+    (*venc).width = enc_width;
+    (*venc).height = enc_height;
+    (*venc).time_base.num = 1;
+    (*venc).time_base.den = fps_int;
+    (*venc).framerate.num = fps_int;
+    (*venc).framerate.den = 1;
+    (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+    (*venc).bit_rate = if target_bitrate > 0 {
         target_bitrate
     } else {
         2_000_000
     };
 
-    ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
-        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-        cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-        ffmpeg_err(e)
-    })?;
+    // On error the owned `vid_enc_ctx` / decoders drop; only the raw format
+    // contexts need explicit teardown.
+    vid_enc_ctx
+        .open(vid_enc_codec, ptr::null_mut())
+        .map_err(|e| {
+            cleanup_output_ctx(out_ctx);
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────
-    let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+    let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
     if vid_out_stream.is_null() {
-        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot create video output stream"));
     }
-    (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+    (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
     let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
     // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-    ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
-        |e| {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+    vid_enc_ctx
+        .parameters_from_context((*vid_out_stream).codecpar)
+        .map_err(|e| {
             cleanup_output_ctx(out_ctx);
-            cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
-            ffmpeg_err(e)
-        },
-    )?;
+            ff_sys::avformat::close_input(&mut input_ctx);
+            ffmpeg_err(e.code())
+        })?;
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
-    let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
+    let mut aud_enc_ctx: Option<ff_sys::CodecContext> = None;
     let mut aud_out_stream_idx: i32 = -1;
-    let mut swr_ctx: *mut SwrContext = ptr::null_mut();
+    let mut swr_ctx: Option<ff_sys::ResampleContext> = None;
 
     if audio_stream_idx >= 0 {
         match crate::codec_utils::open_aac_encoder(aud_sample_rate, aud_nb_channels, 192_000, "hls")
         {
             Ok(ctx) => {
-                aud_enc_ctx = ctx;
                 let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
                 if aud_out_stream.is_null() {
-                    ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                    // `ctx` drops here (frees the codec context).
                     log::warn!("hls cannot create audio output stream, skipping audio");
                     audio_stream_idx = -1;
                 } else {
@@ -339,44 +341,35 @@ unsafe fn write_hls_unsafe(
                     (*aud_out_stream).time_base.den = aud_sample_rate;
                     aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-                    // SAFETY: aud_out_stream and aud_enc_ctx are valid; avcodec_open2 called.
-                    if ff_sys::avcodec::parameters_from_context(
-                        (*aud_out_stream).codecpar,
-                        aud_enc_ctx,
-                    )
-                    .is_err()
+                    // SAFETY: aud_out_stream and ctx are valid; avcodec_open2 called.
+                    if ctx
+                        .parameters_from_context((*aud_out_stream).codecpar)
+                        .is_err()
                     {
                         log::warn!("hls audio stream codecpar copy failed");
                     }
 
-                    // Set up resampler: decoded audio → FLTP at aud_sample_rate
-                    let enc_ch_layout = &(*aud_enc_ctx).ch_layout;
-                    let enc_sample_fmt = (*aud_enc_ctx).sample_fmt;
-                    let enc_sample_rate = (*aud_enc_ctx).sample_rate;
-                    let dec_ch_layout = &(*aud_dec_ctx).ch_layout;
-                    let dec_sample_fmt = (*aud_dec_ctx).sample_fmt;
-                    let dec_sample_rate = (*aud_dec_ctx).sample_rate;
-
-                    if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
-                        enc_ch_layout,
-                        enc_sample_fmt,
-                        enc_sample_rate,
-                        dec_ch_layout,
-                        dec_sample_fmt,
-                        dec_sample_rate,
-                    ) {
-                        if ff_sys::swresample::init(ctx).is_ok() {
-                            swr_ctx = ctx;
+                    // Set up resampler: decoded audio → FLTP at aud_sample_rate.
+                    if let Some(dec) = aud_dec_ctx.as_ref() {
+                        let enc_ptr = ctx.as_ptr();
+                        let dec_ptr = dec.as_ptr();
+                        if let Ok(swr) = ff_sys::ResampleContext::new(
+                            &(*enc_ptr).ch_layout,
+                            (*enc_ptr).sample_fmt,
+                            (*enc_ptr).sample_rate,
+                            &(*dec_ptr).ch_layout,
+                            (*dec_ptr).sample_fmt,
+                            (*dec_ptr).sample_rate,
+                        ) {
+                            swr_ctx = Some(swr);
+                            aud_enc_ctx = Some(ctx);
                         } else {
-                            let mut swr_tmp = ctx;
-                            ff_sys::swresample::free(&mut swr_tmp);
-                            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                            log::warn!("hls swr init failed, skipping audio");
+                            // `ctx` drops here.
+                            log::warn!("hls swr alloc failed, skipping audio");
                             audio_stream_idx = -1;
                         }
                     } else {
-                        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                        log::warn!("hls swr alloc failed, skipping audio");
+                        log::warn!("hls audio decoder missing, skipping audio");
                         audio_stream_idx = -1;
                     }
                 }
@@ -394,9 +387,8 @@ unsafe fn write_hls_unsafe(
         ff_sys::avformat::avio_flags::WRITE,
     )
     .map_err(|e| {
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err(e)
     })?;
     (*out_ctx).pb = pb;
@@ -404,9 +396,8 @@ unsafe fn write_hls_unsafe(
     let ret = avformat_write_header(out_ctx, ptr::null_mut());
     if ret < 0 {
         ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err(ret));
     }
 
@@ -418,7 +409,7 @@ unsafe fn write_hls_unsafe(
     log::info!(
         "hls output context ready width={enc_width} height={enc_height} fps={video_fps:.1} \
          bit_rate={} audio={}",
-        (*vid_enc_ctx).bit_rate,
+        (*vid_enc_ctx.as_ptr()).bit_rate,
         audio_stream_idx >= 0,
     );
 
@@ -427,9 +418,8 @@ unsafe fn write_hls_unsafe(
     if pkt.is_null() {
         av_write_trailer(out_ctx);
         ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate packet"));
     }
 
@@ -447,16 +437,15 @@ unsafe fn write_hls_unsafe(
         av_packet_free(&mut pkt);
         av_write_trailer(out_ctx);
         ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
         cleanup_output_ctx(out_ctx);
-        cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+        ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate frame"));
     }
 
     // ── 13. Decode–encode loop ─────────────────────────────────────────────────
     let mut video_frame_count: u64 = 0;
     let mut audio_sample_count: i64 = 0;
-    let mut sws_ctx: *mut SwsContext = ptr::null_mut();
+    let mut sws_ctx: Option<ff_sys::ScaleContext> = None;
     let mut last_src_fmt: Option<AVPixelFormat> = None;
     let mut last_src_w: Option<i32> = None;
     let mut last_src_h: Option<i32> = None;
@@ -468,14 +457,14 @@ unsafe fn write_hls_unsafe(
         num: 1,
         den: fps_int,
     };
-    // SAFETY: aud_enc_ctx (if non-null) is valid after avcodec_open2.
-    let aud_frame_period = if !aud_enc_ctx.is_null() {
+    // SAFETY: aud_enc_ctx (if present) is valid after avcodec_open2.
+    let aud_frame_period = if let Some(aud) = aud_enc_ctx.as_ref() {
         AVRational {
-            num: (*aud_enc_ctx).frame_size,
-            den: (*aud_enc_ctx).sample_rate,
+            num: (*aud.as_ptr()).frame_size,
+            den: (*aud.as_ptr()).sample_rate,
         }
     } else {
-        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is null
+        AVRational { num: 1, den: 48000 } // unused; aud_enc_ctx is None
     };
 
     loop {
@@ -493,14 +482,14 @@ unsafe fn write_hls_unsafe(
 
         if stream_idx == video_stream_idx {
             // ── Video path ────────────────────────────────────────────────────
-            if ff_sys::avcodec::send_packet(vid_dec_ctx, pkt).is_err() {
+            if ff_sys::avcodec::send_packet(vid_dec_ctx.as_mut_ptr(), pkt).is_err() {
                 av_packet_unref(pkt);
                 continue;
             }
             av_packet_unref(pkt);
 
             loop {
-                match ff_sys::avcodec::receive_frame(vid_dec_ctx, vid_dec_frame) {
+                match ff_sys::avcodec::receive_frame(vid_dec_ctx.as_mut_ptr(), vid_dec_frame) {
                     Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
                         break;
                     }
@@ -526,11 +515,8 @@ unsafe fn write_hls_unsafe(
                     || last_src_w != Some(src_w)
                     || last_src_h != Some(src_h)
                 {
-                    if !sws_ctx.is_null() {
-                        ff_sys::swscale::free_context(sws_ctx);
-                        sws_ctx = ptr::null_mut();
-                    }
-                    if let Ok(ctx) = ff_sys::swscale::get_context(
+                    // Move-assign the new context; the old one (if any) drops here.
+                    if let Ok(ctx) = ff_sys::ScaleContext::new(
                         src_w,
                         src_h,
                         src_fmt,
@@ -539,7 +525,7 @@ unsafe fn write_hls_unsafe(
                         AVPixelFormat_AV_PIX_FMT_YUV420P,
                         ff_sys::swscale::scale_flags::BILINEAR,
                     ) {
-                        sws_ctx = ctx;
+                        sws_ctx = Some(ctx);
                         last_src_fmt = Some(src_fmt);
                         last_src_w = Some(src_w);
                         last_src_h = Some(src_h);
@@ -560,7 +546,7 @@ unsafe fn write_hls_unsafe(
                         num: 1,
                         den: fps_int,
                     },
-                    (*vid_enc_ctx).time_base,
+                    (*vid_enc_ctx.as_ptr()).time_base,
                 );
 
                 let buf_ret = av_frame_get_buffer(vid_enc_frame, 0);
@@ -570,21 +556,25 @@ unsafe fn write_hls_unsafe(
                 }
 
                 // Scale decoded frame into encoder frame
-                let scale_ok = ff_sys::swscale::scale(
-                    sws_ctx,
-                    (*vid_dec_frame).data.as_ptr() as *const *const u8,
-                    (*vid_dec_frame).linesize.as_ptr(),
-                    0,
-                    src_h,
-                    (*vid_enc_frame).data.as_mut_ptr().cast_const(),
-                    (*vid_enc_frame).linesize.as_mut_ptr(),
-                );
+                let scaled = if let Some(sws) = sws_ctx.as_mut() {
+                    sws.scale(
+                        (*vid_dec_frame).data.as_ptr() as *const *const u8,
+                        (*vid_dec_frame).linesize.as_ptr(),
+                        0,
+                        src_h,
+                        (*vid_enc_frame).data.as_mut_ptr().cast_const(),
+                        (*vid_enc_frame).linesize.as_mut_ptr(),
+                    )
+                    .is_ok()
+                } else {
+                    false
+                };
 
-                if scale_ok.is_ok()
-                    && ff_sys::avcodec::send_frame(vid_enc_ctx, vid_enc_frame).is_ok()
+                if scaled
+                    && ff_sys::avcodec::send_frame(vid_enc_ctx.as_mut_ptr(), vid_enc_frame).is_ok()
                 {
                     crate::codec_utils::drain_encoder(
-                        vid_enc_ctx,
+                        vid_enc_ctx.as_mut_ptr(),
                         out_ctx,
                         vid_out_stream_idx,
                         "hls",
@@ -596,16 +586,19 @@ unsafe fn write_hls_unsafe(
                 av_frame_unref(vid_dec_frame);
                 video_frame_count += 1;
             }
-        } else if stream_idx == audio_stream_idx && !aud_dec_ctx.is_null() {
+        } else if stream_idx == audio_stream_idx
+            && let Some(aud_dec_ptr) = aud_dec_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr)
+            && let Some(aud_enc_ptr) = aud_enc_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr)
+        {
             // ── Audio path ────────────────────────────────────────────────────
-            if ff_sys::avcodec::send_packet(aud_dec_ctx, pkt).is_err() {
+            if ff_sys::avcodec::send_packet(aud_dec_ptr, pkt).is_err() {
                 av_packet_unref(pkt);
                 continue;
             }
             av_packet_unref(pkt);
 
             loop {
-                match ff_sys::avcodec::receive_frame(aud_dec_ctx, aud_dec_frame) {
+                match ff_sys::avcodec::receive_frame(aud_dec_ptr, aud_dec_frame) {
                     Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
                         break;
                     }
@@ -613,18 +606,18 @@ unsafe fn write_hls_unsafe(
                     Ok(()) => {}
                 }
 
-                let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                    (*aud_enc_ctx).frame_size
+                let enc_frame_size = if (*aud_enc_ptr).frame_size > 0 {
+                    (*aud_enc_ptr).frame_size
                 } else {
                     (*aud_dec_frame).nb_samples
                 };
 
-                (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
-                (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+                (*aud_enc_frame).format = (*aud_enc_ptr).sample_fmt;
+                (*aud_enc_frame).sample_rate = (*aud_enc_ptr).sample_rate;
                 (*aud_enc_frame).nb_samples = enc_frame_size;
                 let _ = ff_sys::swresample::channel_layout::copy(
                     &mut (*aud_enc_frame).ch_layout,
-                    &(*aud_enc_ctx).ch_layout,
+                    &(*aud_enc_ptr).ch_layout,
                 );
 
                 let buf_ret = av_frame_get_buffer(aud_enc_frame, 0);
@@ -636,22 +629,26 @@ unsafe fn write_hls_unsafe(
                 let in_data = (*aud_dec_frame).data.as_ptr() as *const *const u8;
                 let in_samples = (*aud_dec_frame).nb_samples;
 
-                let samples_out = ff_sys::swresample::convert(
-                    swr_ctx,
-                    (*aud_enc_frame).data.as_mut_ptr(),
-                    enc_frame_size,
-                    in_data,
-                    in_samples,
-                );
+                let samples_out = if let Some(swr) = swr_ctx.as_mut() {
+                    swr.convert(
+                        (*aud_enc_frame).data.as_mut_ptr(),
+                        enc_frame_size,
+                        in_data,
+                        in_samples,
+                    )
+                    .ok()
+                } else {
+                    None
+                };
 
-                if let Ok(n) = samples_out
+                if let Some(n) = samples_out
                     && n > 0
                 {
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
-                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                    if ff_sys::avcodec::send_frame(aud_enc_ptr, aud_enc_frame).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc_ctx,
+                            aud_enc_ptr,
                             out_ctx,
                             aud_out_stream_idx,
                             "hls",
@@ -670,44 +667,50 @@ unsafe fn write_hls_unsafe(
     }
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
-    let _ = ff_sys::avcodec::send_frame(vid_enc_ctx, ptr::null());
+    let _ = vid_enc_ctx.send_frame(ptr::null());
     crate::codec_utils::drain_encoder(
-        vid_enc_ctx,
+        vid_enc_ctx.as_mut_ptr(),
         out_ctx,
         vid_out_stream_idx,
         "hls",
         vid_frame_period,
     );
 
-    if !aud_enc_ctx.is_null() {
+    if let Some(aud_enc_ptr) = aud_enc_ctx.as_mut().map(ff_sys::CodecContext::as_mut_ptr) {
         // Flush resampler
-        if !swr_ctx.is_null() {
-            let enc_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                (*aud_enc_ctx).frame_size
+        if swr_ctx.is_some() {
+            let enc_frame_size = if (*aud_enc_ptr).frame_size > 0 {
+                (*aud_enc_ptr).frame_size
             } else {
                 1024
             };
-            (*aud_enc_frame).format = (*aud_enc_ctx).sample_fmt;
-            (*aud_enc_frame).sample_rate = (*aud_enc_ctx).sample_rate;
+            (*aud_enc_frame).format = (*aud_enc_ptr).sample_fmt;
+            (*aud_enc_frame).sample_rate = (*aud_enc_ptr).sample_rate;
             (*aud_enc_frame).nb_samples = enc_frame_size;
             let _ = ff_sys::swresample::channel_layout::copy(
                 &mut (*aud_enc_frame).ch_layout,
-                &(*aud_enc_ctx).ch_layout,
+                &(*aud_enc_ptr).ch_layout,
             );
             if av_frame_get_buffer(aud_enc_frame, 0) == 0 {
-                if let Ok(n) = ff_sys::swresample::convert(
-                    swr_ctx,
-                    (*aud_enc_frame).data.as_mut_ptr(),
-                    enc_frame_size,
-                    ptr::null(),
-                    0,
-                ) && n > 0
+                let flushed = if let Some(swr) = swr_ctx.as_mut() {
+                    swr.convert(
+                        (*aud_enc_frame).data.as_mut_ptr(),
+                        enc_frame_size,
+                        ptr::null(),
+                        0,
+                    )
+                    .ok()
+                } else {
+                    None
+                };
+                if let Some(n) = flushed
+                    && n > 0
                 {
                     (*aud_enc_frame).nb_samples = n;
                     (*aud_enc_frame).pts = audio_sample_count;
-                    if ff_sys::avcodec::send_frame(aud_enc_ctx, aud_enc_frame).is_ok() {
+                    if ff_sys::avcodec::send_frame(aud_enc_ptr, aud_enc_frame).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc_ctx,
+                            aud_enc_ptr,
                             out_ctx,
                             aud_out_stream_idx,
                             "hls",
@@ -718,9 +721,9 @@ unsafe fn write_hls_unsafe(
                 av_frame_unref(aud_enc_frame);
             }
         }
-        let _ = ff_sys::avcodec::send_frame(aud_enc_ctx, ptr::null());
+        let _ = ff_sys::avcodec::send_frame(aud_enc_ptr, ptr::null());
         crate::codec_utils::drain_encoder(
-            aud_enc_ctx,
+            aud_enc_ptr,
             out_ctx,
             aud_out_stream_idx,
             "hls",
@@ -733,16 +736,13 @@ unsafe fn write_hls_unsafe(
     // pb was already closed after avformat_write_header; skip double-close.
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
+    // Owned encoder / decoder / resample / scale contexts drop on scope exit;
+    // only the raw frames and format contexts need explicit teardown.
     free_frames(vid_dec_frame, vid_enc_frame, aud_dec_frame, aud_enc_frame);
     av_packet_free(&mut pkt);
 
-    if !sws_ctx.is_null() {
-        ff_sys::swscale::free_context(sws_ctx);
-    }
-
-    cleanup_encoders(vid_enc_ctx, aud_enc_ctx, swr_ctx);
     cleanup_output_ctx(out_ctx);
-    cleanup_decoders(vid_dec_ctx, aud_dec_ctx, &mut input_ctx);
+    ff_sys::avformat::close_input(&mut input_ctx);
 
     log::info!(
         "hls write complete video_frames={video_frame_count} \
@@ -808,36 +808,6 @@ unsafe fn detect_fps(stream: *mut ff_sys::AVStream, fmt_ctx: *mut AVFormatContex
 // ============================================================================
 // Cleanup helpers (safe to call with null pointers)
 // ============================================================================
-
-unsafe fn cleanup_decoders(
-    mut vid_dec_ctx: *mut AVCodecContext,
-    mut aud_dec_ctx: *mut AVCodecContext,
-    input_ctx: *mut *mut AVFormatContext,
-) {
-    if !vid_dec_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut vid_dec_ctx as *mut *mut _);
-    }
-    if !aud_dec_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut aud_dec_ctx as *mut *mut _);
-    }
-    ff_sys::avformat::close_input(input_ctx);
-}
-
-unsafe fn cleanup_encoders(
-    mut vid_enc_ctx: *mut AVCodecContext,
-    mut aud_enc_ctx: *mut AVCodecContext,
-    mut swr_ctx: *mut SwrContext,
-) {
-    if !vid_enc_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-    }
-    if !aud_enc_ctx.is_null() {
-        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-    }
-    if !swr_ctx.is_null() {
-        ff_sys::swresample::free(&mut swr_ctx);
-    }
-}
 
 unsafe fn cleanup_output_ctx(mut out_ctx: *mut AVFormatContext) {
     if !out_ctx.is_null() {

--- a/crates/ff-stream/src/live_dash_inner.rs
+++ b/crates/ff-stream/src/live_dash_inner.rs
@@ -23,7 +23,7 @@ use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
     avformat_free_context, avformat_new_stream, avformat_write_header,
 };
 
@@ -205,48 +205,50 @@ impl LiveDashInner {
                 )
             })?;
 
-        let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
             avformat_free_context(out_ctx);
-            ffmpeg_err(e)
+            ffmpeg_err(e.code())
         })?;
+        let venc = vid_enc_ctx.as_mut_ptr();
 
-        (*vid_enc_ctx).width = enc_width;
-        (*vid_enc_ctx).height = enc_height;
-        (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-        (*vid_enc_ctx).time_base.num = 1;
-        (*vid_enc_ctx).time_base.den = fps_int;
-        (*vid_enc_ctx).framerate.num = fps_int;
-        (*vid_enc_ctx).framerate.den = 1;
-        (*vid_enc_ctx).gop_size = fps_int * segment_secs as i32;
-        (*vid_enc_ctx).bit_rate = video_bitrate as i64;
+        (*venc).width = enc_width;
+        (*venc).height = enc_height;
+        (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*venc).time_base.num = 1;
+        (*venc).time_base.den = fps_int;
+        (*venc).framerate.num = fps_int;
+        (*venc).framerate.den = 1;
+        (*venc).gop_size = fps_int * segment_secs as i32;
+        (*venc).bit_rate = video_bitrate as i64;
 
-        ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e)
-        })?;
+        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
+        // raw format context needs an explicit free.
+        vid_enc_ctx
+            .open(vid_enc_codec, ptr::null_mut())
+            .map_err(|e| {
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 4. Add video output stream ────────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
-        (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+        (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
         let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
-            |e| {
-                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+        vid_enc_ctx
+            .parameters_from_context((*vid_out_stream).codecpar)
+            .map_err(|e| {
                 avformat_free_context(out_ctx);
-                ffmpeg_err(e)
-            },
-        )?;
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 5. Open AAC audio encoder and add audio stream (optional) ─────────
-        let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
+        let mut aud_enc_ctx: Option<ff_sys::CodecContext> = None;
         let mut aud_out_stream_idx: i32 = -1;
         let mut aud_sample_rate = 44100i32;
         let mut aud_frame_size = 1024i32;
@@ -256,31 +258,29 @@ impl LiveDashInner {
 
             match crate::codec_utils::open_aac_encoder(sr, nc, abr, "live_dash") {
                 Ok(ctx) => {
-                    aud_enc_ctx = ctx;
-                    aud_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                        (*aud_enc_ctx).frame_size
+                    aud_frame_size = if (*ctx.as_ptr()).frame_size > 0 {
+                        (*ctx.as_ptr()).frame_size
                     } else {
                         1024
                     };
 
                     let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
                     if aud_out_stream.is_null() {
-                        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                        // `ctx` drops here (frees the codec context).
                         log::warn!("live_dash cannot create audio output stream, skipping audio");
                     } else {
                         (*aud_out_stream).time_base.num = 1;
                         (*aud_out_stream).time_base.den = sr;
                         aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-                        // SAFETY: aud_out_stream and aud_enc_ctx are valid.
-                        if ff_sys::avcodec::parameters_from_context(
-                            (*aud_out_stream).codecpar,
-                            aud_enc_ctx,
-                        )
-                        .is_err()
+                        // SAFETY: aud_out_stream and ctx are valid.
+                        if ctx
+                            .parameters_from_context((*aud_out_stream).codecpar)
+                            .is_err()
                         {
                             log::warn!("live_dash audio stream codecpar copy failed");
                         }
+                        aud_enc_ctx = Some(ctx);
                     }
                 }
                 Err(e) => {
@@ -295,10 +295,6 @@ impl LiveDashInner {
             ff_sys::avformat::avio_flags::WRITE,
         )
         .map_err(|e| {
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             ffmpeg_err(e)
         })?;
@@ -307,10 +303,6 @@ impl LiveDashInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err(ret));
         }
@@ -342,10 +334,8 @@ impl LiveDashInner {
             false, // close_pb_after_trailer: pb already closed after header write
         )
         .inspect_err(|_| {
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
+            // error; only the raw format context needs an explicit free.
             avformat_free_context(out_ctx);
         })?;
 

--- a/crates/ff-stream/src/live_hls_inner.rs
+++ b/crates/ff-stream/src/live_hls_inner.rs
@@ -23,7 +23,7 @@ use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
     avformat_free_context, avformat_new_stream, avformat_write_header,
 };
 
@@ -233,48 +233,50 @@ impl LiveHlsInner {
                 )
             })?;
 
-        let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
             avformat_free_context(out_ctx);
-            ffmpeg_err(e)
+            ffmpeg_err(e.code())
         })?;
+        let venc = vid_enc_ctx.as_mut_ptr();
 
-        (*vid_enc_ctx).width = enc_width;
-        (*vid_enc_ctx).height = enc_height;
-        (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-        (*vid_enc_ctx).time_base.num = 1;
-        (*vid_enc_ctx).time_base.den = fps_int;
-        (*vid_enc_ctx).framerate.num = fps_int;
-        (*vid_enc_ctx).framerate.den = 1;
-        (*vid_enc_ctx).gop_size = fps_int * segment_secs as i32;
-        (*vid_enc_ctx).bit_rate = video_bitrate as i64;
+        (*venc).width = enc_width;
+        (*venc).height = enc_height;
+        (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*venc).time_base.num = 1;
+        (*venc).time_base.den = fps_int;
+        (*venc).framerate.num = fps_int;
+        (*venc).framerate.den = 1;
+        (*venc).gop_size = fps_int * segment_secs as i32;
+        (*venc).bit_rate = video_bitrate as i64;
 
-        ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e)
-        })?;
+        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
+        // raw format context needs an explicit free.
+        vid_enc_ctx
+            .open(vid_enc_codec, ptr::null_mut())
+            .map_err(|e| {
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 4. Add video output stream ────────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
-        (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+        (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
         let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
-            |e| {
-                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+        vid_enc_ctx
+            .parameters_from_context((*vid_out_stream).codecpar)
+            .map_err(|e| {
                 avformat_free_context(out_ctx);
-                ffmpeg_err(e)
-            },
-        )?;
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 5. Open AAC audio encoder and add audio stream (optional) ─────────
-        let mut aud_enc_ctx: *mut AVCodecContext = ptr::null_mut();
+        let mut aud_enc_ctx: Option<ff_sys::CodecContext> = None;
         let mut aud_out_stream_idx: i32 = -1;
         let mut aud_sample_rate = 44100i32;
         let mut aud_frame_size = 1024i32;
@@ -284,31 +286,29 @@ impl LiveHlsInner {
 
             match crate::codec_utils::open_aac_encoder(sr, nc, abr, "live_hls") {
                 Ok(ctx) => {
-                    aud_enc_ctx = ctx;
-                    aud_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-                        (*aud_enc_ctx).frame_size
+                    aud_frame_size = if (*ctx.as_ptr()).frame_size > 0 {
+                        (*ctx.as_ptr()).frame_size
                     } else {
                         1024
                     };
 
                     let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
                     if aud_out_stream.is_null() {
-                        ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
+                        // `ctx` drops here (frees the codec context).
                         log::warn!("live_hls cannot create audio output stream, skipping audio");
                     } else {
                         (*aud_out_stream).time_base.num = 1;
                         (*aud_out_stream).time_base.den = sr;
                         aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
-                        // SAFETY: aud_out_stream and aud_enc_ctx are valid.
-                        if ff_sys::avcodec::parameters_from_context(
-                            (*aud_out_stream).codecpar,
-                            aud_enc_ctx,
-                        )
-                        .is_err()
+                        // SAFETY: aud_out_stream and ctx are valid.
+                        if ctx
+                            .parameters_from_context((*aud_out_stream).codecpar)
+                            .is_err()
                         {
                             log::warn!("live_hls audio stream codecpar copy failed");
                         }
+                        aud_enc_ctx = Some(ctx);
                     }
                 }
                 Err(e) => {
@@ -323,10 +323,6 @@ impl LiveHlsInner {
             ff_sys::avformat::avio_flags::WRITE,
         )
         .map_err(|e| {
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             ffmpeg_err(e)
         })?;
@@ -335,10 +331,6 @@ impl LiveHlsInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err(ret));
         }
@@ -371,10 +363,8 @@ impl LiveHlsInner {
             false, // close_pb_after_trailer: pb already closed after header write
         )
         .inspect_err(|_| {
-            if !aud_enc_ctx.is_null() {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            }
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
+            // error; only the raw format context needs an explicit free.
             avformat_free_context(out_ctx);
         })?;
 

--- a/crates/ff-stream/src/muxer_core.rs
+++ b/crates/ff-stream/src/muxer_core.rs
@@ -20,9 +20,9 @@ use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P,
-    AVRational, AVSampleFormat, SwrContext, SwsContext, av_frame_alloc, av_frame_free,
-    av_frame_get_buffer, av_frame_unref, av_rescale_q, av_write_trailer, avformat_free_context,
+    AVFormatContext, AVFrame, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational,
+    AVSampleFormat, av_frame_alloc, av_frame_free, av_frame_get_buffer, av_frame_unref,
+    av_rescale_q, av_write_trailer, avformat_free_context,
 };
 
 use crate::codec_utils::{
@@ -44,13 +44,13 @@ use crate::error::StreamError;
 /// calls to any method are safe no-ops (Drop will be a no-op too).
 pub(crate) struct MuxerCore {
     pub(crate) out_ctx: *mut AVFormatContext,
-    pub(crate) vid_enc_ctx: *mut AVCodecContext,
-    /// Null when audio is not configured (optional for HLS/DASH).
-    pub(crate) aud_enc_ctx: *mut AVCodecContext,
-    /// Null until first `push_audio_unsafe` call; recreated if input format changes.
-    pub(crate) swr_ctx: *mut SwrContext,
-    /// Null until swscale is needed; recreated if source dimensions/format change.
-    pub(crate) sws_ctx: *mut SwsContext,
+    pub(crate) vid_enc_ctx: ff_sys::CodecContext,
+    /// `None` when audio is not configured (optional for HLS/DASH).
+    pub(crate) aud_enc_ctx: Option<ff_sys::CodecContext>,
+    /// `None` until first `push_audio_unsafe` call; recreated if input format changes.
+    pub(crate) swr_ctx: Option<ff_sys::ResampleContext>,
+    /// `None` until swscale is needed; recreated if source dimensions/format change.
+    pub(crate) sws_ctx: Option<ff_sys::ScaleContext>,
     pub(crate) vid_enc_frame: *mut AVFrame,
     pub(crate) aud_enc_frame: *mut AVFrame,
     pub(crate) vid_out_stream_idx: i32,
@@ -96,15 +96,15 @@ impl MuxerCore {
     ///
     /// # Safety
     ///
-    /// - `out_ctx` and `vid_enc_ctx` must be non-null and valid.
-    /// - `aud_enc_ctx` may be null (audio is optional for HLS/DASH outputs).
-    /// - On `Err` the caller is responsible for freeing its own contexts;
-    ///   `MuxerCore` does not free them in this case.
+    /// - `out_ctx` must be non-null and valid.
+    /// - `aud_enc_ctx` may be `None` (audio is optional for HLS/DASH outputs).
+    /// - The `vid_enc_ctx` / `aud_enc_ctx` owned contexts are moved in; on `Err`
+    ///   they drop here, so the caller must not free them.
     #[allow(clippy::too_many_arguments)]
     pub(crate) unsafe fn new(
         out_ctx: *mut AVFormatContext,
-        vid_enc_ctx: *mut AVCodecContext,
-        aud_enc_ctx: *mut AVCodecContext,
+        vid_enc_ctx: ff_sys::CodecContext,
+        aud_enc_ctx: Option<ff_sys::CodecContext>,
         vid_out_stream_idx: i32,
         aud_out_stream_idx: i32,
         fps_int: i32,
@@ -132,8 +132,8 @@ impl MuxerCore {
             out_ctx,
             vid_enc_ctx,
             aud_enc_ctx,
-            swr_ctx: ptr::null_mut(),
-            sws_ctx: ptr::null_mut(),
+            swr_ctx: None,
+            sws_ctx: None,
             vid_enc_frame,
             aud_enc_frame,
             vid_out_stream_idx,
@@ -180,32 +180,27 @@ impl MuxerCore {
                 || self.last_sws_src_w != Some(src_w)
                 || self.last_sws_src_h != Some(src_h)
             {
-                if !self.sws_ctx.is_null() {
-                    ff_sys::swscale::free_context(self.sws_ctx);
-                    self.sws_ctx = ptr::null_mut();
-                }
-                match ff_sys::swscale::get_context(
-                    src_w,
-                    src_h,
-                    src_fmt,
-                    self.enc_width,
-                    self.enc_height,
-                    AVPixelFormat_AV_PIX_FMT_YUV420P,
-                    ff_sys::swscale::scale_flags::BILINEAR,
-                ) {
-                    Ok(ctx) => {
-                        self.sws_ctx = ctx;
-                        self.last_sws_src_fmt = Some(src_fmt);
-                        self.last_sws_src_w = Some(src_w);
-                        self.last_sws_src_h = Some(src_h);
-                    }
-                    Err(_) => {
-                        return Err(ffmpeg_err_msg(&format!(
+                // Move-assign the new context; the old one (if any) drops here.
+                self.sws_ctx = Some(
+                    ff_sys::ScaleContext::new(
+                        src_w,
+                        src_h,
+                        src_fmt,
+                        self.enc_width,
+                        self.enc_height,
+                        AVPixelFormat_AV_PIX_FMT_YUV420P,
+                        ff_sys::swscale::scale_flags::BILINEAR,
+                    )
+                    .map_err(|_| {
+                        ffmpeg_err_msg(&format!(
                             "{} swscale context creation failed for video frame",
                             self.log_prefix
-                        )));
-                    }
-                }
+                        ))
+                    })?,
+                );
+                self.last_sws_src_fmt = Some(src_fmt);
+                self.last_sws_src_w = Some(src_w);
+                self.last_sws_src_h = Some(src_h);
             }
 
             (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
@@ -229,18 +224,22 @@ impl MuxerCore {
                 src_linesize[i] = stride as i32;
             }
 
-            ff_sys::swscale::scale(
-                self.sws_ctx,
-                src_data.as_ptr(),
-                src_linesize.as_ptr(),
-                0,
-                src_h,
-                (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
-                (*self.vid_enc_frame).linesize.as_mut_ptr(),
-            )
-            .map_err(|_| {
-                ffmpeg_err_msg(&format!("{} swscale conversion failed", self.log_prefix))
-            })?;
+            self.sws_ctx
+                .as_mut()
+                .ok_or_else(|| {
+                    ffmpeg_err_msg(&format!("{} swscale context missing", self.log_prefix))
+                })?
+                .scale(
+                    src_data.as_ptr(),
+                    src_linesize.as_ptr(),
+                    0,
+                    src_h,
+                    (*self.vid_enc_frame).data.as_mut_ptr().cast_const(),
+                    (*self.vid_enc_frame).linesize.as_mut_ptr(),
+                )
+                .map_err(|_| {
+                    ffmpeg_err_msg(&format!("{} swscale conversion failed", self.log_prefix))
+                })?;
         } else {
             // Same format and dimensions — copy planes directly.
             (*self.vid_enc_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
@@ -288,10 +287,10 @@ impl MuxerCore {
             }
         }
 
-        if ff_sys::avcodec::send_frame(self.vid_enc_ctx, self.vid_enc_frame).is_ok() {
+        if self.vid_enc_ctx.send_frame(self.vid_enc_frame).is_ok() {
             // SAFETY: vid_enc_ctx and out_ctx are valid; vid_out_stream_idx is valid.
             drain_encoder(
-                self.vid_enc_ctx,
+                self.vid_enc_ctx.as_mut_ptr(),
                 self.out_ctx,
                 self.vid_out_stream_idx,
                 self.log_prefix,
@@ -317,9 +316,13 @@ impl MuxerCore {
     /// `self` must have been initialised by the enclosing inner type's
     /// `open_unsafe` and must not yet be finished.
     pub(crate) unsafe fn push_audio_unsafe(&mut self, frame: &AudioFrame) {
-        if self.aud_enc_ctx.is_null() || self.aud_out_stream_idx < 0 {
+        if self.aud_enc_ctx.is_none() || self.aud_out_stream_idx < 0 {
             return; // audio not configured
         }
+        let aud_ptr = match self.aud_enc_ctx.as_mut() {
+            Some(c) => c.as_mut_ptr(),
+            None => return,
+        };
 
         let in_fmt = sample_format_to_av(frame.format());
         let in_rate = frame.sample_rate() as i32;
@@ -330,16 +333,11 @@ impl MuxerCore {
             || self.last_swr_in_rate != Some(in_rate)
             || self.last_swr_in_channels != Some(in_channels)
         {
-            if !self.swr_ctx.is_null() {
-                let mut swr_tmp = self.swr_ctx;
-                ff_sys::swresample::free(&mut swr_tmp);
-                self.swr_ctx = ptr::null_mut();
-            }
-
             let in_layout = ff_sys::swresample::channel_layout::with_channels(in_channels);
-            let enc_ch_layout = &(*self.aud_enc_ctx).ch_layout;
+            let enc_ch_layout = &(*aud_ptr).ch_layout;
 
-            if let Ok(ctx) = ff_sys::swresample::alloc_set_opts2(
+            // Move-assign the new resampler; the old one (if any) drops here.
+            if let Ok(ctx) = ff_sys::ResampleContext::new(
                 enc_ch_layout,
                 ff_sys::swresample::sample_format::FLTP,
                 self.aud_sample_rate,
@@ -347,17 +345,10 @@ impl MuxerCore {
                 in_fmt,
                 in_rate,
             ) {
-                if ff_sys::swresample::init(ctx).is_ok() {
-                    self.swr_ctx = ctx;
-                    self.last_swr_in_fmt = Some(in_fmt);
-                    self.last_swr_in_rate = Some(in_rate);
-                    self.last_swr_in_channels = Some(in_channels);
-                } else {
-                    let mut swr_tmp = ctx;
-                    ff_sys::swresample::free(&mut swr_tmp);
-                    log::warn!("{} swr init failed, dropping audio frame", self.log_prefix);
-                    return;
-                }
+                self.swr_ctx = Some(ctx);
+                self.last_swr_in_fmt = Some(in_fmt);
+                self.last_swr_in_rate = Some(in_rate);
+                self.last_swr_in_channels = Some(in_channels);
             } else {
                 log::warn!("{} swr alloc failed, dropping audio frame", self.log_prefix);
                 return;
@@ -370,7 +361,7 @@ impl MuxerCore {
         (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
         let _ = ff_sys::swresample::channel_layout::copy(
             &mut (*self.aud_enc_frame).ch_layout,
-            &(*self.aud_enc_ctx).ch_layout,
+            &(*aud_ptr).ch_layout,
         );
 
         let buf_ret = av_frame_get_buffer(self.aud_enc_frame, 0);
@@ -386,27 +377,29 @@ impl MuxerCore {
             in_data[i] = plane.as_ptr();
         }
 
-        let samples_out = ff_sys::swresample::convert(
-            self.swr_ctx,
-            (*self.aud_enc_frame).data.as_mut_ptr(),
-            self.aud_frame_size,
-            in_data.as_ptr(),
-            frame.samples() as i32,
-        );
+        let dst_data = (*self.aud_enc_frame).data.as_mut_ptr();
+        let out_count = self.aud_frame_size;
+        let in_ptr = in_data.as_ptr();
+        let in_count = frame.samples() as i32;
+        let samples_out = if let Some(swr) = self.swr_ctx.as_mut() {
+            swr.convert(dst_data, out_count, in_ptr, in_count).ok()
+        } else {
+            None
+        };
 
-        if let Ok(n) = samples_out
+        if let Some(n) = samples_out
             && n > 0
         {
             (*self.aud_enc_frame).nb_samples = n;
             (*self.aud_enc_frame).pts = self.audio_pts;
-            if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok() {
+            if ff_sys::avcodec::send_frame(aud_ptr, self.aud_enc_frame).is_ok() {
                 let aud_frame_period = AVRational {
-                    num: (*self.aud_enc_ctx).frame_size,
-                    den: (*self.aud_enc_ctx).sample_rate,
+                    num: (*aud_ptr).frame_size,
+                    den: (*aud_ptr).sample_rate,
                 };
                 // SAFETY: aud_enc_ctx and out_ctx are valid; aud_out_stream_idx is valid.
                 drain_encoder(
-                    self.aud_enc_ctx,
+                    aud_ptr,
                     self.out_ctx,
                     self.aud_out_stream_idx,
                     self.log_prefix,
@@ -434,9 +427,9 @@ impl MuxerCore {
     /// `open_unsafe`. This method must be called at most once.
     pub(crate) unsafe fn flush_and_close_unsafe(&mut self) {
         // ── Flush video encoder ───────────────────────────────────────────────
-        let _ = ff_sys::avcodec::send_frame(self.vid_enc_ctx, ptr::null());
+        let _ = self.vid_enc_ctx.send_frame(ptr::null());
         drain_encoder(
-            self.vid_enc_ctx,
+            self.vid_enc_ctx.as_mut_ptr(),
             self.out_ctx,
             self.vid_out_stream_idx,
             self.log_prefix,
@@ -447,36 +440,42 @@ impl MuxerCore {
         );
 
         // ── Flush audio encoder ───────────────────────────────────────────────
-        if !self.aud_enc_ctx.is_null() && self.aud_out_stream_idx >= 0 {
+        if self.aud_out_stream_idx >= 0
+            && let Some(aud_ptr) = self
+                .aud_enc_ctx
+                .as_mut()
+                .map(ff_sys::CodecContext::as_mut_ptr)
+        {
             // Drain any remaining resampler buffered samples.
-            if !self.swr_ctx.is_null() {
+            if self.swr_ctx.is_some() {
                 (*self.aud_enc_frame).format = ff_sys::swresample::sample_format::FLTP;
                 (*self.aud_enc_frame).sample_rate = self.aud_sample_rate;
                 (*self.aud_enc_frame).nb_samples = self.aud_frame_size;
                 let _ = ff_sys::swresample::channel_layout::copy(
                     &mut (*self.aud_enc_frame).ch_layout,
-                    &(*self.aud_enc_ctx).ch_layout,
+                    &(*aud_ptr).ch_layout,
                 );
 
                 if av_frame_get_buffer(self.aud_enc_frame, 0) == 0 {
-                    if let Ok(n) = ff_sys::swresample::convert(
-                        self.swr_ctx,
-                        (*self.aud_enc_frame).data.as_mut_ptr(),
-                        self.aud_frame_size,
-                        ptr::null(),
-                        0,
-                    ) && n > 0
+                    let dst_data = (*self.aud_enc_frame).data.as_mut_ptr();
+                    let out_count = self.aud_frame_size;
+                    let flushed = if let Some(swr) = self.swr_ctx.as_mut() {
+                        swr.convert(dst_data, out_count, ptr::null(), 0).ok()
+                    } else {
+                        None
+                    };
+                    if let Some(n) = flushed
+                        && n > 0
                     {
                         (*self.aud_enc_frame).nb_samples = n;
                         (*self.aud_enc_frame).pts = self.audio_pts;
-                        if ff_sys::avcodec::send_frame(self.aud_enc_ctx, self.aud_enc_frame).is_ok()
-                        {
+                        if ff_sys::avcodec::send_frame(aud_ptr, self.aud_enc_frame).is_ok() {
                             let aud_frame_period = AVRational {
-                                num: (*self.aud_enc_ctx).frame_size,
-                                den: (*self.aud_enc_ctx).sample_rate,
+                                num: (*aud_ptr).frame_size,
+                                den: (*aud_ptr).sample_rate,
                             };
                             drain_encoder(
-                                self.aud_enc_ctx,
+                                aud_ptr,
                                 self.out_ctx,
                                 self.aud_out_stream_idx,
                                 self.log_prefix,
@@ -489,13 +488,13 @@ impl MuxerCore {
             }
 
             // Flush the AAC encoder itself.
-            let _ = ff_sys::avcodec::send_frame(self.aud_enc_ctx, ptr::null());
+            let _ = ff_sys::avcodec::send_frame(aud_ptr, ptr::null());
             let aud_frame_period = AVRational {
-                num: (*self.aud_enc_ctx).frame_size,
-                den: (*self.aud_enc_ctx).sample_rate,
+                num: (*aud_ptr).frame_size,
+                den: (*aud_ptr).sample_rate,
             };
             drain_encoder(
-                self.aud_enc_ctx,
+                aud_ptr,
                 self.out_ctx,
                 self.aud_out_stream_idx,
                 self.log_prefix,
@@ -531,7 +530,7 @@ impl MuxerCore {
                 num: 1,
                 den: self.fps_int,
             },
-            (*self.vid_enc_ctx).time_base,
+            (*self.vid_enc_ctx.as_ptr()).time_base,
         );
     }
 
@@ -548,15 +547,11 @@ impl MuxerCore {
     ///
     /// Must only be called when no other reference to the contained pointers exists.
     unsafe fn free_all(&mut self) {
-        if !self.sws_ctx.is_null() {
-            ff_sys::swscale::free_context(self.sws_ctx);
-            self.sws_ctx = ptr::null_mut();
-        }
-        if !self.swr_ctx.is_null() {
-            let mut swr_tmp = self.swr_ctx;
-            ff_sys::swresample::free(&mut swr_tmp);
-            self.swr_ctx = ptr::null_mut();
-        }
+        // Owned scale / resample / audio-codec contexts drop when set to `None`;
+        // a second call re-`None`s them, so this is idempotent. The `vid_enc_ctx`
+        // field is not an `Option` — it drops exactly once when the struct drops.
+        self.sws_ctx = None;
+        self.swr_ctx = None;
         if !self.vid_enc_frame.is_null() {
             av_frame_free(&mut (self.vid_enc_frame as *mut _));
             self.vid_enc_frame = ptr::null_mut();
@@ -565,14 +560,7 @@ impl MuxerCore {
             av_frame_free(&mut (self.aud_enc_frame as *mut _));
             self.aud_enc_frame = ptr::null_mut();
         }
-        if !self.aud_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.aud_enc_ctx as *mut *mut _);
-            self.aud_enc_ctx = ptr::null_mut();
-        }
-        if !self.vid_enc_ctx.is_null() {
-            ff_sys::avcodec::free_context(&mut self.vid_enc_ctx as *mut *mut _);
-            self.vid_enc_ctx = ptr::null_mut();
-        }
+        self.aud_enc_ctx = None;
         if !self.out_ctx.is_null() {
             // For RTMP/SRT: close pb if still open (Drop path where
             // flush_and_close_unsafe was not called).

--- a/crates/ff-stream/src/rtmp_inner.rs
+++ b/crates/ff-stream/src/rtmp_inner.rs
@@ -146,56 +146,57 @@ impl RtmpInner {
             )
         })?;
 
-        let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
             avformat_free_context(out_ctx);
-            ffmpeg_err(e)
+            ffmpeg_err(e.code())
         })?;
+        let venc = vid_enc_ctx.as_mut_ptr();
 
-        (*vid_enc_ctx).width = enc_width;
-        (*vid_enc_ctx).height = enc_height;
-        (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-        (*vid_enc_ctx).time_base.num = 1;
-        (*vid_enc_ctx).time_base.den = fps_int;
-        (*vid_enc_ctx).framerate.num = fps_int;
-        (*vid_enc_ctx).framerate.den = 1;
+        (*venc).width = enc_width;
+        (*venc).height = enc_height;
+        (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*venc).time_base.num = 1;
+        (*venc).time_base.den = fps_int;
+        (*venc).framerate.num = fps_int;
+        (*venc).framerate.den = 1;
         // GOP size of 2 s gives a reasonable keyframe interval for RTMP.
-        (*vid_enc_ctx).gop_size = fps_int * 2;
-        (*vid_enc_ctx).bit_rate = video_bitrate as i64;
+        (*venc).gop_size = fps_int * 2;
+        (*venc).bit_rate = video_bitrate as i64;
 
-        ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e)
-        })?;
+        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
+        // raw format context needs an explicit free.
+        vid_enc_ctx
+            .open(vid_enc_codec, ptr::null_mut())
+            .map_err(|e| {
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 3. Add video output stream ─────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
-        (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+        (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
         let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
-            |e| {
-                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+        vid_enc_ctx
+            .parameters_from_context((*vid_out_stream).codecpar)
+            .map_err(|e| {
                 avformat_free_context(out_ctx);
-                ffmpeg_err(e)
-            },
-        )?;
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 4. Open AAC audio encoder ──────────────────────────────────────
-        let mut aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "rtmp")
+        let aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "rtmp")
             .inspect_err(|_| {
-                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
                 avformat_free_context(out_ctx);
             })?;
 
-        let aud_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-            (*aud_enc_ctx).frame_size
+        let aud_frame_size = if (*aud_enc_ctx.as_ptr()).frame_size > 0 {
+            (*aud_enc_ctx.as_ptr()).frame_size
         } else {
             1024
         };
@@ -203,8 +204,6 @@ impl RtmpInner {
         // ── 5. Add audio output stream ─────────────────────────────────────
         let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
         if aud_out_stream.is_null() {
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create audio output stream"));
         }
@@ -213,7 +212,8 @@ impl RtmpInner {
         let aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
         // SAFETY: aud_out_stream and aud_enc_ctx are valid.
-        if ff_sys::avcodec::parameters_from_context((*aud_out_stream).codecpar, aud_enc_ctx)
+        if aud_enc_ctx
+            .parameters_from_context((*aud_out_stream).codecpar)
             .is_err()
         {
             log::warn!("rtmp audio stream codecpar copy failed");
@@ -225,8 +225,6 @@ impl RtmpInner {
         // SAFETY: url is a valid null-terminated C string (validated above).
         let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
             .map_err(|e| {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
                 avformat_free_context(out_ctx);
                 ffmpeg_err(e)
             })?;
@@ -235,8 +233,6 @@ impl RtmpInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err(ret));
         }
@@ -253,7 +249,7 @@ impl RtmpInner {
         let core = MuxerCore::new(
             out_ctx,
             vid_enc_ctx,
-            aud_enc_ctx,
+            Some(aud_enc_ctx),
             vid_out_stream_idx,
             aud_out_stream_idx,
             fps_int,
@@ -265,8 +261,8 @@ impl RtmpInner {
             true, // close_pb_after_trailer: pb stays open for streaming
         )
         .inspect_err(|_| {
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
+            // error; only the raw format context needs an explicit free.
             avformat_free_context(out_ctx);
         })?;
 

--- a/crates/ff-stream/src/srt_output_inner.rs
+++ b/crates/ff-stream/src/srt_output_inner.rs
@@ -147,56 +147,57 @@ impl SrtInner {
             )
         })?;
 
-        let mut vid_enc_ctx = ff_sys::avcodec::alloc_context3(vid_enc_codec).map_err(|e| {
+        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
             avformat_free_context(out_ctx);
-            ffmpeg_err(e)
+            ffmpeg_err(e.code())
         })?;
+        let venc = vid_enc_ctx.as_mut_ptr();
 
-        (*vid_enc_ctx).width = enc_width;
-        (*vid_enc_ctx).height = enc_height;
-        (*vid_enc_ctx).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-        (*vid_enc_ctx).time_base.num = 1;
-        (*vid_enc_ctx).time_base.den = fps_int;
-        (*vid_enc_ctx).framerate.num = fps_int;
-        (*vid_enc_ctx).framerate.den = 1;
+        (*venc).width = enc_width;
+        (*venc).height = enc_height;
+        (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        (*venc).time_base.num = 1;
+        (*venc).time_base.den = fps_int;
+        (*venc).framerate.num = fps_int;
+        (*venc).framerate.den = 1;
         // GOP size of 2 s gives a reasonable keyframe interval for MPEG-TS/SRT.
-        (*vid_enc_ctx).gop_size = fps_int * 2;
-        (*vid_enc_ctx).bit_rate = video_bitrate as i64;
+        (*venc).gop_size = fps_int * 2;
+        (*venc).bit_rate = video_bitrate as i64;
 
-        ff_sys::avcodec::open2(vid_enc_ctx, vid_enc_codec, ptr::null_mut()).map_err(|e| {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e)
-        })?;
+        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
+        // raw format context needs an explicit free.
+        vid_enc_ctx
+            .open(vid_enc_codec, ptr::null_mut())
+            .map_err(|e| {
+                avformat_free_context(out_ctx);
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 3. Add video output stream ─────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec);
+        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
-        (*vid_out_stream).time_base = (*vid_enc_ctx).time_base;
+        (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
         let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        ff_sys::avcodec::parameters_from_context((*vid_out_stream).codecpar, vid_enc_ctx).map_err(
-            |e| {
-                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+        vid_enc_ctx
+            .parameters_from_context((*vid_out_stream).codecpar)
+            .map_err(|e| {
                 avformat_free_context(out_ctx);
-                ffmpeg_err(e)
-            },
-        )?;
+                ffmpeg_err(e.code())
+            })?;
 
         // ── 4. Open AAC audio encoder ──────────────────────────────────────
-        let mut aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "srt")
+        let aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "srt")
             .inspect_err(|_| {
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
-            avformat_free_context(out_ctx);
-        })?;
+                avformat_free_context(out_ctx);
+            })?;
 
-        let aud_frame_size = if (*aud_enc_ctx).frame_size > 0 {
-            (*aud_enc_ctx).frame_size
+        let aud_frame_size = if (*aud_enc_ctx.as_ptr()).frame_size > 0 {
+            (*aud_enc_ctx.as_ptr()).frame_size
         } else {
             1024
         };
@@ -204,8 +205,6 @@ impl SrtInner {
         // ── 5. Add audio output stream ─────────────────────────────────────
         let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
         if aud_out_stream.is_null() {
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create audio output stream"));
         }
@@ -214,7 +213,8 @@ impl SrtInner {
         let aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
 
         // SAFETY: aud_out_stream and aud_enc_ctx are valid.
-        if ff_sys::avcodec::parameters_from_context((*aud_out_stream).codecpar, aud_enc_ctx)
+        if aud_enc_ctx
+            .parameters_from_context((*aud_out_stream).codecpar)
             .is_err()
         {
             log::warn!("srt audio stream codecpar copy failed");
@@ -226,8 +226,6 @@ impl SrtInner {
         // SAFETY: url is a valid null-terminated C string (validated above).
         let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
             .map_err(|e| {
-                ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-                ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
                 avformat_free_context(out_ctx);
                 ffmpeg_err(e)
             })?;
@@ -236,8 +234,6 @@ impl SrtInner {
         let ret = avformat_write_header(out_ctx, ptr::null_mut());
         if ret < 0 {
             ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
             avformat_free_context(out_ctx);
             return Err(ffmpeg_err(ret));
         }
@@ -254,7 +250,7 @@ impl SrtInner {
         let core = MuxerCore::new(
             out_ctx,
             vid_enc_ctx,
-            aud_enc_ctx,
+            Some(aud_enc_ctx),
             vid_out_stream_idx,
             aud_out_stream_idx,
             fps_int,
@@ -266,8 +262,8 @@ impl SrtInner {
             true, // close_pb_after_trailer: pb stays open for streaming
         )
         .inspect_err(|_| {
-            ff_sys::avcodec::free_context(&mut aud_enc_ctx as *mut *mut _);
-            ff_sys::avcodec::free_context(&mut vid_enc_ctx as *mut *mut _);
+            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
+            // error; only the raw format context needs an explicit free.
             avformat_free_context(out_ctx);
         })?;
 

--- a/crates/ff-sys/benches/swresample_bench.rs
+++ b/crates/ff-sys/benches/swresample_bench.rs
@@ -7,7 +7,7 @@ use std::os::raw::c_int;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use ff_sys::swresample::{
-    alloc_set_opts2, channel_layout, convert, estimate_output_samples, free, init, sample_format,
+    alloc_set_opts2, channel_layout, convert, estimate_output_samples, init, sample_format,
 };
 
 /// Benchmark context creation for different configurations.
@@ -38,7 +38,7 @@ fn bench_context_creation(c: &mut Criterion) {
                 .expect("Context creation should succeed");
 
                 init(ctx).expect("Init should succeed");
-                free(&mut (ctx as *mut _));
+                ff_sys::swr_free(&mut (ctx as *mut _));
             });
         });
     }
@@ -101,7 +101,7 @@ fn bench_resampling_rates(c: &mut Criterion) {
                     black_box(num_samples as c_int),
                 );
 
-                free(&mut ctx);
+                ff_sys::swr_free(&mut ctx);
             });
         });
     }
@@ -185,7 +185,7 @@ fn bench_format_conversion(c: &mut Criterion) {
                     );
                 }
 
-                free(&mut ctx);
+                ff_sys::swr_free(&mut ctx);
             });
         });
     }
@@ -258,7 +258,7 @@ fn bench_channel_conversion(c: &mut Criterion) {
                     black_box(num_samples as c_int),
                 );
 
-                free(&mut ctx);
+                ff_sys::swr_free(&mut ctx);
             });
         });
     }
@@ -329,7 +329,7 @@ fn bench_chunk_sizes(c: &mut Criterion) {
                     offset += samples_to_process;
                 }
 
-                free(&mut ctx);
+                ff_sys::swr_free(&mut ctx);
             });
         });
     }
@@ -385,7 +385,7 @@ fn bench_real_audio_processing(c: &mut Criterion) {
                 black_box(num_samples as c_int),
             );
 
-            free(&mut ctx);
+            ff_sys::swr_free(&mut ctx);
         });
     });
 
@@ -423,7 +423,7 @@ fn bench_real_audio_processing(c: &mut Criterion) {
                 black_box(num_samples as c_int),
             );
 
-            free(&mut ctx);
+            ff_sys::swr_free(&mut ctx);
         });
     });
 
@@ -461,7 +461,7 @@ fn bench_real_audio_processing(c: &mut Criterion) {
                 black_box(num_samples as c_int),
             );
 
-            free(&mut ctx);
+            ff_sys::swr_free(&mut ctx);
         });
     });
 

--- a/crates/ff-sys/benches/swscale_bench.rs
+++ b/crates/ff-sys/benches/swscale_bench.rs
@@ -6,7 +6,7 @@ use std::hint::black_box;
 use std::os::raw::c_int;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use ff_sys::swscale::{free_context, get_context, scale, scale_flags};
+use ff_sys::swscale::{get_context, scale, scale_flags};
 use ff_sys::{AVPixelFormat_AV_PIX_FMT_RGB24, AVPixelFormat_AV_PIX_FMT_RGBA};
 
 /// Load test image from assets directory.
@@ -44,7 +44,7 @@ fn bench_context_creation(c: &mut Criterion) {
                     scale_flags::BILINEAR,
                 )
                 .expect("Context creation should succeed");
-                free_context(ctx);
+                ff_sys::sws_freeContext(ctx);
             });
         });
     }
@@ -116,7 +116,7 @@ fn bench_scaling_algorithms(c: &mut Criterion) {
                 .expect("Scaling should succeed");
             });
 
-            free_context(ctx);
+            ff_sys::sws_freeContext(ctx);
         });
     }
 
@@ -181,7 +181,7 @@ fn bench_scaling_resolutions(c: &mut Criterion) {
                 .expect("Scaling should succeed");
             });
 
-            free_context(ctx);
+            ff_sys::sws_freeContext(ctx);
         });
     }
 
@@ -240,7 +240,7 @@ fn bench_format_conversion(c: &mut Criterion) {
                 .expect("Conversion should succeed");
             });
 
-            free_context(ctx);
+            ff_sys::sws_freeContext(ctx);
         }
     });
 

--- a/crates/ff-sys/src/avcodec.rs
+++ b/crates/ff-sys/src/avcodec.rs
@@ -20,8 +20,7 @@ use crate::{
     avcodec_find_decoder_by_name as ffi_avcodec_find_decoder_by_name,
     avcodec_find_encoder as ffi_avcodec_find_encoder,
     avcodec_find_encoder_by_name as ffi_avcodec_find_encoder_by_name,
-    avcodec_flush_buffers as ffi_avcodec_flush_buffers,
-    avcodec_free_context as ffi_avcodec_free_context, avcodec_open2 as ffi_avcodec_open2,
+    avcodec_flush_buffers as ffi_avcodec_flush_buffers, avcodec_open2 as ffi_avcodec_open2,
     avcodec_parameters_from_context as ffi_avcodec_parameters_from_context,
     avcodec_parameters_to_context as ffi_avcodec_parameters_to_context,
     avcodec_receive_frame as ffi_avcodec_receive_frame,
@@ -159,7 +158,8 @@ pub unsafe fn find_encoder_by_name(name: *const i8) -> Option<*const AVCodec> {
 ///
 /// # Safety
 ///
-/// The returned context must be freed using `free_context()` when no longer needed.
+/// The returned context must be freed with `crate::avcodec_free_context` (or
+/// wrapped in [`CodecContext`](crate::CodecContext)) when no longer needed.
 pub unsafe fn alloc_context3(codec: *const AVCodec) -> Result<*mut AVCodecContext, c_int> {
     ensure_initialized();
 
@@ -171,35 +171,6 @@ pub unsafe fn alloc_context3(codec: *const AVCodec) -> Result<*mut AVCodecContex
         Err(crate::error_codes::ENOMEM)
     } else {
         Ok(ctx)
-    }
-}
-
-/// Free a codec context and set the pointer to null.
-///
-/// # Arguments
-///
-/// * `ctx` - Pointer to a pointer to the context to free
-///
-/// # Safety
-///
-/// - The context must have been allocated by `alloc_context3()`.
-/// - After this call, `*ctx` will be set to null.
-/// - The context pointer must not be used after this call.
-///
-/// # Null Safety
-///
-/// This function safely handles:
-/// - `ctx` being null
-/// - `*ctx` being null
-pub unsafe fn free_context(ctx: *mut *mut AVCodecContext) {
-    // SAFETY: `ctx` is checked for null before it is dereferenced (short-circuit),
-    // and `*ctx` is checked for null before being freed. The caller guarantees any
-    // non-null `*ctx` was allocated by `alloc_context3` and is not used afterwards;
-    // FFmpeg frees it and writes null back into `*ctx`.
-    unsafe {
-        if !ctx.is_null() && !(*ctx).is_null() {
-            ffi_avcodec_free_context(ctx);
-        }
     }
 }
 
@@ -613,34 +584,6 @@ mod tests {
         unsafe {
             let codec = find_encoder_by_name(ptr::null());
             assert!(codec.is_none());
-        }
-    }
-
-    #[test]
-    fn test_alloc_and_free_context() {
-        unsafe {
-            // Allocate a generic context (no specific codec)
-            let ctx_result = alloc_context3(ptr::null());
-            assert!(ctx_result.is_ok(), "Context allocation should succeed");
-
-            let mut ctx = ctx_result.unwrap();
-            assert!(!ctx.is_null());
-
-            // Free the context
-            free_context(&mut ctx);
-            assert!(ctx.is_null(), "Context should be null after free");
-        }
-    }
-
-    #[test]
-    fn test_free_context_null_safety() {
-        unsafe {
-            // Passing a null pointer should not crash
-            free_context(ptr::null_mut());
-
-            // Passing a pointer to null should not crash
-            let mut null_ctx: *mut AVCodecContext = ptr::null_mut();
-            free_context(&mut null_ctx);
         }
     }
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -839,8 +839,6 @@ pub mod avcodec {
         Err(-1)
     }
 
-    pub unsafe fn free_context(_ctx: *mut *mut AVCodecContext) {}
-
     pub unsafe fn parameters_to_context(
         _codec_ctx: *mut AVCodecContext,
         _par: *const AVCodecParameters,
@@ -930,8 +928,6 @@ pub mod swresample {
     pub unsafe fn is_initialized(_ctx: *const SwrContext) -> bool {
         false
     }
-
-    pub unsafe fn free(_ctx: *mut *mut SwrContext) {}
 
     pub unsafe fn convert(
         _s: *mut SwrContext,
@@ -1080,8 +1076,6 @@ pub mod swscale {
     ) -> Result<*mut SwsContext, c_int> {
         Err(-1)
     }
-
-    pub unsafe fn free_context(_ctx: *mut SwsContext) {}
 
     pub unsafe fn scale(
         _ctx: *mut SwsContext,

--- a/crates/ff-sys/src/resample_context.rs
+++ b/crates/ff-sys/src/resample_context.rs
@@ -2,7 +2,7 @@
 //!
 //! [`ResampleContext`] allocates, configures, and initializes a resampling
 //! context, and frees it exactly once on drop, replacing the manual
-//! `swresample::alloc_set_opts2` + `swresample::init` + `swresample::free`
+//! `swresample::alloc_set_opts2` + `swresample::init` + `swr_free`
 //! sequence. The value is always initialized once constructed (there is no
 //! un-initialized state), so the query methods are safe;
 //! [`convert`](ResampleContext::convert) stays `unsafe` because it takes raw

--- a/crates/ff-sys/src/scale_context.rs
+++ b/crates/ff-sys/src/scale_context.rs
@@ -1,7 +1,7 @@
 //! RAII owner for an `SwsContext` (libswscale scaling / pixel-format conversion).
 //!
 //! [`ScaleContext`] allocates a scaling context and frees it exactly once on
-//! drop, replacing the manual `swscale::get_context` + `swscale::free_context`
+//! drop, replacing the manual `swscale::get_context` + `sws_freeContext`
 //! pair. Its constructor is safe (it takes only dimensions, pixel formats, and
 //! flags); [`scale`](ScaleContext::scale) stays `unsafe` because it takes raw
 //! plane pointers (owned Frame handling is a later step).

--- a/crates/ff-sys/src/swresample/context.rs
+++ b/crates/ff-sys/src/swresample/context.rs
@@ -4,8 +4,8 @@ use std::os::raw::c_int;
 
 use crate::{
     AVChannelLayout, AVSampleFormat, SwrContext, ensure_initialized, swr_alloc as ffi_swr_alloc,
-    swr_alloc_set_opts2 as ffi_swr_alloc_set_opts2, swr_free as ffi_swr_free,
-    swr_init as ffi_swr_init, swr_is_initialized as ffi_swr_is_initialized,
+    swr_alloc_set_opts2 as ffi_swr_alloc_set_opts2, swr_init as ffi_swr_init,
+    swr_is_initialized as ffi_swr_is_initialized,
 };
 
 /// Allocate an empty SwrContext.
@@ -20,7 +20,8 @@ use crate::{
 ///
 /// # Safety
 ///
-/// The returned context must be freed using `free()` when no longer needed.
+/// The returned context must be freed with `crate::swr_free` (or wrapped in
+/// [`ResampleContext`](crate::ResampleContext)) when no longer needed.
 pub unsafe fn alloc() -> Result<*mut SwrContext, c_int> {
     ensure_initialized();
 
@@ -56,7 +57,8 @@ pub unsafe fn alloc() -> Result<*mut SwrContext, c_int> {
 /// # Safety
 ///
 /// - The returned context must be initialized with `init()` before use.
-/// - The returned context must be freed using `free()` when no longer needed.
+/// - The returned context must be freed with `crate::swr_free` (or wrapped in
+///   [`ResampleContext`](crate::ResampleContext)) when no longer needed.
 /// - Channel layout pointers must be valid for the duration of this call.
 pub unsafe fn alloc_set_opts2(
     out_ch_layout: *const AVChannelLayout,
@@ -162,64 +164,10 @@ pub unsafe fn is_initialized(ctx: *const SwrContext) -> bool {
     unsafe { ffi_swr_is_initialized(ctx.cast_mut()) != 0 }
 }
 
-/// Free a resampling context.
-///
-/// # Arguments
-///
-/// * `ctx` - Pointer to a pointer to the context to free
-///
-/// # Safety
-///
-/// - The context must have been allocated by `alloc()` or `alloc_set_opts2()`.
-/// - After this call, `*ctx` will be set to null.
-/// - The context pointer must not be used after this call.
-///
-/// # Null Safety
-///
-/// This function safely handles:
-/// - `ctx` being null
-/// - `*ctx` being null
-pub unsafe fn free(ctx: *mut *mut SwrContext) {
-    // SAFETY: `ctx` is checked non-null before `*ctx` is dereferenced (via
-    // short-circuit `&&`); `*ctx` is either null or a context allocated by
-    // `alloc`/`alloc_set_opts2`, which swr_free frees and sets to null.
-    unsafe {
-        if !ctx.is_null() && !(*ctx).is_null() {
-            ffi_swr_free(ctx);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::swresample::{channel_layout, sample_format};
-
-    #[test]
-    fn test_alloc_and_free() {
-        unsafe {
-            let ctx_result = alloc();
-            assert!(ctx_result.is_ok(), "Context allocation should succeed");
-
-            let mut ctx = ctx_result.unwrap();
-            assert!(!ctx.is_null());
-
-            free(&mut ctx);
-            assert!(ctx.is_null(), "Context should be null after free");
-        }
-    }
-
-    #[test]
-    fn test_free_null_safety() {
-        unsafe {
-            // Passing a null pointer should not crash
-            free(std::ptr::null_mut());
-
-            // Passing a pointer to null should not crash
-            let mut null_ctx: *mut SwrContext = std::ptr::null_mut();
-            free(&mut null_ctx);
-        }
-    }
 
     #[test]
     fn test_alloc_set_opts2_and_init() {
@@ -251,7 +199,20 @@ mod tests {
             // Now it should be initialized
             assert!(is_initialized(ctx));
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
+        }
+    }
+
+    #[test]
+    fn alloc_should_allocate_an_uninitialized_context() {
+        // `alloc` is the bare `swr_alloc` wrapper (no options set); it yields an
+        // allocated-but-uninitialized context, freed via the raw binding.
+        unsafe {
+            let mut ctx = alloc().expect("swr_alloc should succeed");
+            assert!(!ctx.is_null());
+            assert!(!is_initialized(ctx), "bare alloc must be uninitialized");
+            crate::swr_free(&mut ctx);
+            assert!(ctx.is_null(), "context should be null after free");
         }
     }
 
@@ -279,7 +240,7 @@ mod tests {
             let init_result = init(ctx);
             assert!(init_result.is_ok());
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
         }
     }
 

--- a/crates/ff-sys/src/swresample/convert.rs
+++ b/crates/ff-sys/src/swresample/convert.rs
@@ -129,7 +129,7 @@ mod tests {
     #![allow(unsafe_op_in_unsafe_fn)]
 
     use super::*;
-    use crate::swresample::{alloc_set_opts2, channel_layout, free, init, sample_format};
+    use crate::swresample::{alloc_set_opts2, channel_layout, init, sample_format};
 
     // ========================================================================
     // Conversion tests
@@ -179,7 +179,7 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(result.unwrap_err(), crate::error_codes::EINVAL);
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
         }
     }
 
@@ -251,7 +251,7 @@ mod tests {
                 "Output should contain data"
             );
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
         }
     }
 
@@ -318,7 +318,7 @@ mod tests {
                 expected_max
             );
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
         }
     }
 
@@ -356,7 +356,7 @@ mod tests {
             let delay = get_delay(ctx, 48000);
             assert_eq!(delay, 0, "Initial delay should be 0");
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
         }
     }
 
@@ -445,7 +445,7 @@ mod tests {
                 assert!(result.is_ok(), "Conversion should succeed on each pass");
             }
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
         }
     }
 
@@ -498,7 +498,7 @@ mod tests {
             // Flush should succeed (return >= 0)
             assert!(result.is_ok(), "Flush should succeed");
 
-            free(&mut ctx);
+            crate::swr_free(&mut ctx);
         }
     }
 }

--- a/crates/ff-sys/src/swresample/mod.rs
+++ b/crates/ff-sys/src/swresample/mod.rs
@@ -18,7 +18,7 @@ pub mod audio_fifo;
 pub mod channel_layout;
 pub mod sample_format;
 
-pub use context::{alloc, alloc_set_opts2, free, init, is_initialized};
+pub use context::{alloc, alloc_set_opts2, init, is_initialized};
 pub use convert::{convert, estimate_output_samples, get_delay};
 
 #[cfg(test)]
@@ -297,7 +297,7 @@ mod tests {
                 total_output_samples += flushed as usize;
             }
 
-            free(&mut swr_ctx);
+            crate::swr_free(&mut swr_ctx);
 
             // Verify we processed some audio
             assert!(frames_processed > 0, "Should process at least one frame");
@@ -403,8 +403,8 @@ mod tests {
                 }
             }
 
-            free(&mut swr_to_s16);
-            free(&mut swr_to_fltp);
+            crate::swr_free(&mut swr_to_s16);
+            crate::swr_free(&mut swr_to_fltp);
 
             assert!(frames_processed > 0, "Should process frames through chain");
             println!(
@@ -520,8 +520,8 @@ mod tests {
                 }
             }
 
-            free(&mut swr_to_mono);
-            free(&mut swr_to_stereo);
+            crate::swr_free(&mut swr_to_mono);
+            crate::swr_free(&mut swr_to_stereo);
 
             assert!(frames_processed > 0, "Should process frames");
             println!(

--- a/crates/ff-sys/src/swscale.rs
+++ b/crates/ff-sys/src/swscale.rs
@@ -14,8 +14,7 @@
 use std::os::raw::c_int;
 
 use crate::{
-    AVPixelFormat, SwsContext, ensure_initialized, sws_freeContext as ffi_sws_freeContext,
-    sws_getContext as ffi_sws_getContext,
+    AVPixelFormat, SwsContext, ensure_initialized, sws_getContext as ffi_sws_getContext,
     sws_isSupportedEndiannessConversion as ffi_sws_isSupportedEndiannessConversion,
     sws_isSupportedInput as ffi_sws_isSupportedInput,
     sws_isSupportedOutput as ffi_sws_isSupportedOutput, sws_scale as ffi_sws_scale,
@@ -153,7 +152,8 @@ pub mod scale_flags {
 ///
 /// # Safety
 ///
-/// - The returned context must be freed using `free_context()` when no longer needed.
+/// - The returned context must be freed with `crate::sws_freeContext` (or wrapped in
+///   [`ScaleContext`](crate::ScaleContext)) when no longer needed.
 /// - The context is not thread-safe; use separate contexts for different threads.
 ///
 /// # Errors
@@ -177,7 +177,7 @@ pub mod scale_flags {
 ///         scale_flags::LANCZOS,
 ///     )?;
 ///     // Use context...
-///     free_context(ctx);
+///     crate::sws_freeContext(ctx);
 /// }
 /// ```
 pub unsafe fn get_context(
@@ -219,30 +219,6 @@ pub unsafe fn get_context(
         Err(crate::error_codes::ENOMEM)
     } else {
         Ok(ctx)
-    }
-}
-
-/// Free a scaling context.
-///
-/// # Arguments
-///
-/// * `ctx` - The scaling context to free
-///
-/// # Safety
-///
-/// - The context must have been allocated by `get_context()`.
-/// - The context pointer must not be used after this call.
-///
-/// # Null Safety
-///
-/// This function safely handles a null pointer.
-pub unsafe fn free_context(ctx: *mut SwsContext) {
-    if !ctx.is_null() {
-        // SAFETY: `ctx` is non-null here and, per this function's contract, was
-        // allocated by `get_context` and has not been freed already.
-        unsafe {
-            ffi_sws_freeContext(ctx);
-        }
     }
 }
 
@@ -446,7 +422,7 @@ mod tests {
             assert!(!ctx.is_null());
 
             // Free the context
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -467,7 +443,7 @@ mod tests {
             assert!(ctx_result.is_ok(), "YUV to RGB context should succeed");
 
             let ctx = ctx_result.unwrap();
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -488,7 +464,7 @@ mod tests {
             assert!(ctx_result.is_ok(), "Lanczos context should succeed");
 
             let ctx = ctx_result.unwrap();
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -533,14 +509,6 @@ mod tests {
             );
             assert!(result.is_err());
             assert_eq!(result.unwrap_err(), crate::error_codes::EINVAL);
-        }
-    }
-
-    #[test]
-    fn test_free_context_null() {
-        // Freeing a null pointer should not crash
-        unsafe {
-            free_context(std::ptr::null_mut());
         }
     }
 
@@ -599,7 +567,7 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(result.unwrap_err(), crate::error_codes::EINVAL);
 
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -634,7 +602,7 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(result.unwrap_err(), crate::error_codes::EINVAL);
 
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -706,7 +674,7 @@ mod tests {
                     "Algorithm {algo} should create valid context"
                 );
 
-                free_context(ctx_result.unwrap());
+                crate::sws_freeContext(ctx_result.unwrap());
             }
         }
     }
@@ -793,7 +761,7 @@ mod tests {
                 "Output image should contain significant data"
             );
 
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -852,7 +820,7 @@ mod tests {
                 "Should process all output rows"
             );
 
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -924,7 +892,7 @@ mod tests {
             assert_eq!(src_g, dst_g, "Green channel should match");
             assert_eq!(src_b, dst_b, "Blue channel should match");
 
-            free_context(ctx);
+            crate::sws_freeContext(ctx);
         }
     }
 
@@ -994,7 +962,7 @@ mod tests {
                     name
                 );
 
-                free_context(ctx);
+                crate::sws_freeContext(ctx);
             }
         }
     }


### PR DESCRIPTION
## Objective

- ff-stream was the last crate holding raw `*mut AVCodecContext` / `SwrContext` / `SwsContext` with manual `avcodec::free_context` / `swscale::free_context` / `swresample::free`, so those wrappers could not be removed and a missed free on any transcode/ABR error path could leak.

## Solution

- Migrate ff-stream's codec, resample, and scale contexts to the owned `ff_sys::CodecContext` / `ResampleContext` / `ScaleContext` RAII types; the ~84 + 8 + 8 manual free calls and the context-only cleanup helpers are gone, and every error path releases via drop.
- `MuxerCore` holds the video encoder by value and the audio encoder / resampler / scaler as Options; `free_all`/`Drop` keep the format-context teardown and free each context exactly once. `RenditionState` (dash ABR) owns its encoder + scaler in a `Vec` that releases them on drop.
- `open_aac_encoder` returns an owned `CodecContext`, `select_h264_encoder` returns a `Codec`, and `drain_encoder` keeps its raw internal borrow (callers pass `as_mut_ptr()`).
- Remove the three now-unused wrapper functions from ff-sys with their unit tests and docs.rs stubs; restore a bare `swresample::alloc` smoke test and update the sibling alloc/get Safety docs and owned-type module docs to the raw bindings.
- Streaming behaviour (keyframe forcing, segment options, PTS/DTS, trailer/pb timing, ABR stream layout) and the swr/sws dimension-change cache are preserved.

Closes #1501
Closes #1499