### PR TITLE
feat(ff-sys): add raw-pointer-free safe API and migrate ff-decode

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -24,7 +24,6 @@
 
 use std::ffi::CStr;
 use std::path::Path;
-use std::ptr;
 use std::time::Duration;
 
 use ff_format::channel::ChannelLayout;
@@ -147,17 +146,11 @@ impl AudioDecoderInner {
         })?;
 
         // Detect live/streaming source via the AVFMT_TS_DISCONT flag on AVInputFormat.
-        // SAFETY: format_ctx is valid and non-null; iformat is set by avformat_open_input
-        //         and is non-null for all successfully opened formats.
-        let is_live = unsafe {
-            let iformat = (*ctx.as_ptr()).iformat;
-            !iformat.is_null() && ((*iformat).flags & ff_sys::AVFMT_TS_DISCONT) != 0
-        };
+        let is_live = (ctx.iformat_flags() & ff_sys::AVFMT_TS_DISCONT) != 0;
 
         // Find the audio stream
-        // SAFETY: format_ctx is valid
-        let (stream_index, codec_id) = unsafe { Self::find_audio_stream(ctx.as_mut_ptr()) }
-            .ok_or_else(|| DecodeError::NoAudioStream {
+        let (stream_index, codec_id) =
+            Self::find_audio_stream(&ctx).ok_or_else(|| DecodeError::NoAudioStream {
                 path: path.to_path_buf(),
             })?;
 
@@ -180,36 +173,37 @@ impl AudioDecoderInner {
             })?;
 
         // Copy codec parameters from stream to context
-        // SAFETY: format_ctx is valid, stream_index is valid; codec_ctx is owned
-        unsafe {
-            let stream = (*ctx.as_ptr()).streams.add(stream_index as usize);
-            let codecpar = (*(*stream)).codecpar;
-            codec_ctx
-                .parameters_to_context(codecpar)
-                .map_err(|e| DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to copy codec parameters: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                })?;
-        }
+        let codecpar = ctx
+            .stream(stream_index)
+            .ok_or_else(|| DecodeError::NoAudioStream {
+                path: path.to_path_buf(),
+            })?
+            .codecpar();
+        codec_ctx
+            .apply_parameters(&codecpar)
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to copy codec parameters: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         // Open the codec
-        // SAFETY: codec is valid; codec_ctx is owned
-        unsafe {
-            codec_ctx
-                .open(codec, ptr::null_mut())
-                .map_err(|e| DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to open codec: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                })?;
-        }
+        codec_ctx
+            .open_codec(codec)
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to open codec: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
-        // Extract stream information
+        // Extract stream information. `extract_stream_info` / `extract_container_info`
+        // still read fields with no safe accessor yet (codec-context sample_fmt,
+        // container bit_rate / iformat name), so they keep the raw pointer path;
+        // safe-ifying them is left to the ff-sys RAII follow-up.
         // SAFETY: All pointers are valid
         let stream_info = unsafe {
             Self::extract_stream_info(
@@ -267,29 +261,15 @@ impl AudioDecoderInner {
 
     /// Finds the first audio stream in the format context.
     ///
-    /// # Returns
-    ///
     /// Returns `Some((index, codec_id))` if an audio stream is found, `None` otherwise.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure `format_ctx` is valid and initialized.
-    unsafe fn find_audio_stream(format_ctx: *mut AVFormatContext) -> Option<(usize, AVCodecID)> {
-        // SAFETY: Caller ensures format_ctx is valid
-        unsafe {
-            let nb_streams = (*format_ctx).nb_streams as usize;
-
-            for i in 0..nb_streams {
-                let stream = (*format_ctx).streams.add(i);
-                let codecpar = (*(*stream)).codecpar;
-
-                if (*codecpar).codec_type == AVMediaType_AVMEDIA_TYPE_AUDIO {
-                    return Some((i, (*codecpar).codec_id));
-                }
+    fn find_audio_stream(format_ctx: &InputFormatContext) -> Option<(usize, AVCodecID)> {
+        for stream in format_ctx.streams() {
+            let codecpar = stream.codecpar();
+            if codecpar.codec_type() == AVMediaType_AVMEDIA_TYPE_AUDIO {
+                return Some((stream.index() as usize, codecpar.codec_id()));
             }
-
-            None
         }
+        None
     }
 
     /// Returns the human-readable codec name for a given `AVCodecID`.
@@ -489,10 +469,12 @@ impl AudioDecoderInner {
                     }
                 })? {
                     ff_sys::ReceiveOutcome::Frame => {
-                        // Successfully received a frame
+                        // Successfully received a frame.
+                        // SAFETY (within the enclosing unsafe block): `stream_index`
+                        // is valid for this decoder's context.
                         let audio_frame = resample_inner::convert_frame_to_audio_frame(
-                            self.frame.as_mut_ptr(),
-                            self.format_ctx.as_mut_ptr(),
+                            &self.frame,
+                            &self.format_ctx,
                             self.stream_index,
                             self.output_format,
                             self.output_sample_rate,
@@ -502,12 +484,11 @@ impl AudioDecoderInner {
                         )?;
 
                         // Update position based on frame timestamp
-                        let pts = (*self.frame.as_ptr()).pts;
-                        if pts != ff_sys::AV_NOPTS_VALUE {
-                            let stream = (*self.format_ctx.as_ptr())
-                                .streams
-                                .add(self.stream_index as usize);
-                            let time_base = (*(*stream)).time_base;
+                        let pts = self.frame.pts();
+                        if pts != ff_sys::AV_NOPTS_VALUE
+                            && let Some(stream) = self.format_ctx.stream(self.stream_index as usize)
+                        {
+                            let time_base = stream.time_base();
                             let timestamp_secs =
                                 pts as f64 * time_base.num as f64 / time_base.den as f64;
                             self.position = Duration::from_secs_f64(timestamp_secs);
@@ -547,7 +528,7 @@ impl AudioDecoderInner {
                         }
 
                         // Check if this packet belongs to the audio stream
-                        if (*self.packet.as_ptr()).stream_index == self.stream_index {
+                        if self.packet.stream_index() == self.stream_index {
                             // Send the packet to the decoder
                             let send_result = self.codec_ctx.send_packet(&self.packet);
                             self.packet.unref();
@@ -598,13 +579,12 @@ impl AudioDecoderInner {
 
     /// Converts a `Duration` to a presentation timestamp (PTS) in stream time_base units.
     fn duration_to_pts(&self, duration: Duration) -> i64 {
-        // SAFETY: format_ctx and stream_index are valid (owned by AudioDecoderInner)
-        let time_base = unsafe {
-            let stream = (*self.format_ctx.as_ptr())
-                .streams
-                .add(self.stream_index as usize);
-            (*(*stream)).time_base
-        };
+        // The stream index is valid for this decoder's context; fall back to a
+        // 1/1 time base if it is somehow absent (unreachable in practice).
+        let time_base = self
+            .format_ctx
+            .stream(self.stream_index as usize)
+            .map_or(ff_sys::AVRational { num: 1, den: 1 }, |s| s.time_base());
 
         // Convert: duration (seconds) * (time_base.den / time_base.num) = PTS
         let time_base_f64 = time_base.den as f64 / time_base.num as f64;
@@ -759,8 +739,7 @@ impl AudioDecoderInner {
             })?;
 
         // Re-find the audio stream (index may differ in theory after reconnect).
-        // SAFETY: self.format_ctx is valid.
-        let (stream_index, _) = unsafe { Self::find_audio_stream(self.format_ctx.as_mut_ptr()) }
+        let (stream_index, _) = Self::find_audio_stream(&self.format_ctx)
             .ok_or_else(|| DecodeError::NoAudioStream { path: url.into() })?;
         self.stream_index = stream_index as i32;
 

--- a/crates/ff-decode/src/audio/resample_inner.rs
+++ b/crates/ff-decode/src/audio/resample_inner.rs
@@ -22,7 +22,7 @@
 
 use ff_format::time::{Rational, Timestamp};
 use ff_format::{AudioFrame, SampleFormat};
-use ff_sys::{AVFormatContext, AVFrame, AVSampleFormat};
+use ff_sys::{AVSampleFormat, Frame, InputFormatContext};
 
 use crate::error::DecodeError;
 
@@ -150,14 +150,18 @@ unsafe fn create_channel_layout(channels: u32) -> ff_sys::AVChannelLayout {
 ///
 /// # Safety
 ///
-/// Caller must ensure `frame` is valid and `format` matches the actual frame format.
+/// Caller must ensure `format` matches the actual frame format.
 pub(crate) unsafe fn extract_planes(
-    frame: *const AVFrame,
+    frame: &Frame,
     nb_samples: usize,
     channels: u32,
     format: SampleFormat,
 ) -> Result<Vec<Vec<u8>>, DecodeError> {
-    // SAFETY: Caller ensures frame is valid and format matches actual frame format
+    // Plane data (`data[i]`) has no safe accessor by design, so it is read through
+    // the frame's raw pointer here; every other field goes through an accessor.
+    let frame_ptr = frame.as_ptr();
+    // SAFETY: `frame` is a valid owned frame and `format` matches its actual
+    //         sample format, so the plane pointers are valid for `plane_size` bytes.
     unsafe {
         let mut planes = Vec::new();
         let bytes_per_sample = format.bytes_per_sample();
@@ -168,7 +172,7 @@ pub(crate) unsafe fn extract_planes(
                 let plane_size = checked_buffer_size(nb_samples, bytes_per_sample, 1)?;
                 let mut plane_data = vec![0u8; plane_size];
 
-                let src_ptr = (*frame).data[ch];
+                let src_ptr = (*frame_ptr).data[ch];
                 std::ptr::copy_nonoverlapping(src_ptr, plane_data.as_mut_ptr(), plane_size);
 
                 planes.push(plane_data);
@@ -178,7 +182,7 @@ pub(crate) unsafe fn extract_planes(
             let plane_size = checked_buffer_size(nb_samples, bytes_per_sample, channels as usize)?;
             let mut plane_data = vec![0u8; plane_size];
 
-            let src_ptr = (*frame).data[0];
+            let src_ptr = (*frame_ptr).data[0];
             std::ptr::copy_nonoverlapping(src_ptr, plane_data.as_mut_ptr(), plane_size);
 
             planes.push(plane_data);
@@ -193,43 +197,45 @@ pub(crate) unsafe fn extract_planes(
 ///
 /// # Safety
 ///
-/// Caller must ensure `frame` and `format_ctx` are valid, and `stream_index`
-/// is a valid index into `format_ctx`'s stream list.
+/// Caller must ensure `stream_index` is a valid index into `format_ctx`'s stream
+/// list.
 pub(crate) unsafe fn av_frame_to_audio_frame(
-    frame: *const AVFrame,
-    format_ctx: *mut AVFormatContext,
+    frame: &Frame,
+    format_ctx: &InputFormatContext,
     stream_index: i32,
 ) -> Result<AudioFrame, DecodeError> {
-    // SAFETY: Caller ensures frame and format_ctx are valid
-    unsafe {
-        let nb_samples = checked_nb_samples((*frame).nb_samples)?;
-        let channels = (*frame).ch_layout.nb_channels as u32;
-        let sample_rate = (*frame).sample_rate as u32;
-        let format = convert_sample_format((*frame).format);
+    let nb_samples = checked_nb_samples(frame.nb_samples())?;
+    let channels = frame.channels() as u32;
+    let sample_rate = frame.sample_rate() as u32;
+    let format = convert_sample_format(frame.format());
 
-        // Extract timestamp
-        let pts = (*frame).pts;
-        let timestamp = if pts != ff_sys::AV_NOPTS_VALUE {
-            let stream = (*format_ctx).streams.add(stream_index as usize);
-            let time_base = (*(*stream)).time_base;
-            Timestamp::new(
-                pts as i64,
-                Rational::new(time_base.num as i32, time_base.den as i32),
-            )
-        } else {
-            Timestamp::invalid()
-        };
-
-        // Convert frame to planes
-        let planes = extract_planes(frame, nb_samples, channels, format)?;
-
-        AudioFrame::new(planes, nb_samples, channels, sample_rate, format, timestamp).map_err(|e| {
-            DecodeError::Ffmpeg {
-                code: 0,
-                message: format!("Failed to create AudioFrame: {e}"),
+    // Extract timestamp
+    let pts = frame.pts();
+    let timestamp = if pts != ff_sys::AV_NOPTS_VALUE {
+        match format_ctx.stream(stream_index as usize) {
+            Some(stream) => {
+                let time_base = stream.time_base();
+                Timestamp::new(
+                    pts,
+                    Rational::new(time_base.num as i32, time_base.den as i32),
+                )
             }
-        })
-    }
+            None => Timestamp::invalid(),
+        }
+    } else {
+        Timestamp::invalid()
+    };
+
+    // Convert frame to planes
+    // SAFETY: `format` was derived from `frame.format()`, so it matches the frame.
+    let planes = unsafe { extract_planes(frame, nb_samples, channels, format)? };
+
+    AudioFrame::new(planes, nb_samples, channels, sample_rate, format, timestamp).map_err(|e| {
+        DecodeError::Ffmpeg {
+            code: 0,
+            message: format!("Failed to create AudioFrame: {e}"),
+        }
+    })
 }
 
 /// Converts an `AVFrame` to an `AudioFrame`, applying sample format / sample
@@ -243,11 +249,12 @@ pub(crate) unsafe fn av_frame_to_audio_frame(
 ///
 /// # Safety
 ///
-/// Caller must ensure `frame` and `format_ctx` are valid.
+/// Caller must ensure `stream_index` is a valid index into `format_ctx`'s stream
+/// list.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn convert_frame_to_audio_frame(
-    frame: *mut AVFrame,
-    format_ctx: *mut AVFormatContext,
+    frame: &Frame,
+    format_ctx: &InputFormatContext,
     stream_index: i32,
     output_format: Option<SampleFormat>,
     output_sample_rate: Option<u32>,
@@ -255,17 +262,17 @@ pub(crate) unsafe fn convert_frame_to_audio_frame(
     swr_cache: &mut Option<ff_sys::ResampleContext>,
     swr_key: &mut Option<SwrKey>,
 ) -> Result<AudioFrame, DecodeError> {
-    // SAFETY: Caller ensures frame is valid
-    unsafe {
-        let nb_samples = checked_nb_samples((*frame).nb_samples)?;
-        let channels = (*frame).ch_layout.nb_channels as u32;
-        let sample_rate = (*frame).sample_rate as u32;
-        let src_format = (*frame).format;
+    let nb_samples = checked_nb_samples(frame.nb_samples())?;
+    let channels = frame.channels() as u32;
+    let sample_rate = frame.sample_rate() as u32;
+    let src_format = frame.format();
 
-        let needs_conversion =
-            output_format.is_some() || output_sample_rate.is_some() || output_channels.is_some();
+    let needs_conversion =
+        output_format.is_some() || output_sample_rate.is_some() || output_channels.is_some();
 
-        if needs_conversion {
+    if needs_conversion {
+        // SAFETY: forwarded to the resampler; the caller upholds `stream_index`.
+        unsafe {
             convert_with_swr(
                 frame,
                 nb_samples,
@@ -280,9 +287,10 @@ pub(crate) unsafe fn convert_frame_to_audio_frame(
                 swr_cache,
                 swr_key,
             )
-        } else {
-            av_frame_to_audio_frame(frame, format_ctx, stream_index)
         }
+    } else {
+        // SAFETY: the caller upholds `stream_index`.
+        unsafe { av_frame_to_audio_frame(frame, format_ctx, stream_index) }
     }
 }
 
@@ -297,10 +305,11 @@ pub(crate) unsafe fn convert_frame_to_audio_frame(
 ///
 /// # Safety
 ///
-/// Caller must ensure `frame` and `format_ctx` are valid.
+/// Caller must ensure `stream_index` is a valid index into `format_ctx`'s stream
+/// list.
 #[allow(clippy::too_many_arguments)]
 unsafe fn convert_with_swr(
-    frame: *mut AVFrame,
+    frame: &Frame,
     nb_samples: usize,
     src_channels: u32,
     src_sample_rate: u32,
@@ -308,7 +317,7 @@ unsafe fn convert_with_swr(
     output_format: Option<SampleFormat>,
     output_sample_rate: Option<u32>,
     output_channels: Option<u32>,
-    format_ctx: *mut AVFormatContext,
+    format_ctx: &InputFormatContext,
     stream_index: i32,
     swr_cache: &mut Option<ff_sys::ResampleContext>,
     swr_key: &mut Option<SwrKey>,
@@ -323,6 +332,7 @@ unsafe fn convert_with_swr(
         && src_sample_rate == dst_sample_rate
         && src_channels == dst_channels
     {
+        // SAFETY: the caller upholds `stream_index`.
         return unsafe { av_frame_to_audio_frame(frame, format_ctx, stream_index) };
     }
 
@@ -409,52 +419,50 @@ unsafe fn convert_with_swr(
 
     let mut out_buffer = vec![0u8; buffer_size];
 
-    // Prepare output pointers for swr_convert
-    let mut out_ptrs = if is_planar {
-        let plane_size = checked_buffer_size(out_samples, bytes_per_sample, 1)?;
-        (0..dst_channels)
-            .map(|i| {
-                let offset = i as usize * plane_size;
-                out_buffer[offset..].as_mut_ptr()
-            })
-            .collect::<Vec<_>>()
-    } else {
-        vec![out_buffer.as_mut_ptr()]
+    // Resample the source frame's samples into caller-owned output planes: one
+    // mutable slice per channel (planar) or a single interleaved slice (packed).
+    // The `out_slices` borrows of `out_buffer` end with this block, so the buffer
+    // can be read again below.
+    let converted_samples = {
+        let mut out_slices: Vec<&mut [u8]> = Vec::new();
+        if is_planar {
+            let plane_size = checked_buffer_size(out_samples, bytes_per_sample, 1)?;
+            let mut rest = out_buffer.as_mut_slice();
+            for _ in 0..dst_channels {
+                let (head, tail) = rest.split_at_mut(plane_size.min(rest.len()));
+                out_slices.push(head);
+                rest = tail;
+            }
+        } else {
+            out_slices.push(out_buffer.as_mut_slice());
+        }
+
+        // SAFETY: each `out_slices` plane is sized for `out_samples` (buffer_size
+        // above) and there is one entry per output plane; `frame` is a decoded
+        // audio frame holding `nb_samples` input samples.
+        unsafe { ctx.convert_into_planes(&mut out_slices, out_samples as i32, frame) }.map_err(
+            |e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to convert samples: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            },
+        )?
     };
 
-    // Get input data pointers from frame
-    // SAFETY: frame is valid
-    let in_ptrs = unsafe { (*frame).data };
-
-    // Convert samples using SwResample
-    // SAFETY: All pointers are valid and buffers are properly sized
-    let converted_samples = unsafe {
-        ctx.convert(
-            out_ptrs.as_mut_ptr(),
-            out_samples as i32,
-            in_ptrs.as_ptr() as *const *const u8,
-            nb_samples as i32,
-        )
-    }
-    .map_err(|e| DecodeError::Ffmpeg {
-        code: e.code(),
-        message: format!(
-            "Failed to convert samples: {}",
-            ff_sys::av_error_string(e.code())
-        ),
-    })?;
-
     // Extract timestamp from original frame
-    // SAFETY: frame is valid
-    let timestamp = unsafe {
-        let pts = (*frame).pts;
-        if pts != ff_sys::AV_NOPTS_VALUE {
-            let stream = (*format_ctx).streams.add(stream_index as usize);
-            let time_base = (*(*stream)).time_base;
-            Timestamp::new(pts, Rational::new(time_base.num, time_base.den))
-        } else {
-            Timestamp::invalid()
+    let pts = frame.pts();
+    let timestamp = if pts != ff_sys::AV_NOPTS_VALUE {
+        match format_ctx.stream(stream_index as usize) {
+            Some(stream) => {
+                let time_base = stream.time_base();
+                Timestamp::new(pts, Rational::new(time_base.num, time_base.den))
+            }
+            None => Timestamp::invalid(),
         }
+    } else {
+        Timestamp::invalid()
     };
 
     // Create planes for AudioFrame

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -25,8 +25,8 @@ use std::ptr;
 use ff_format::time::{Rational, Timestamp};
 use ff_format::{PixelFormat, PooledBuffer, VideoFrame};
 use ff_sys::{
-    AVCodecID, AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame,
-    InputFormatContext, Packet,
+    AVCodecID, AVFrame, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame, InputFormatContext,
+    Packet,
 };
 
 use crate::error::DecodeError;
@@ -83,9 +83,8 @@ impl ImageDecoderInner {
         })?;
 
         // 3. Find the video stream.
-        // SAFETY: format_ctx is valid.
-        let (stream_index, codec_id) = unsafe { Self::find_video_stream(ctx.as_mut_ptr()) }
-            .ok_or_else(|| DecodeError::NoVideoStream {
+        let (stream_index, codec_id) =
+            Self::find_video_stream(&ctx).ok_or_else(|| DecodeError::NoVideoStream {
                 path: path.to_path_buf(),
             })?;
 
@@ -116,34 +115,32 @@ impl ImageDecoderInner {
             })?;
 
         // 6. avcodec_parameters_to_context
-        // SAFETY: All pointers are valid; stream_index was validated above.
-        unsafe {
-            let stream = (*ctx.as_ptr()).streams.add(stream_index);
-            let codecpar = (*(*stream)).codecpar;
-            codec_ctx
-                .parameters_to_context(codecpar)
-                .map_err(|e| DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to copy codec parameters: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                })?;
-        }
+        let codecpar = ctx
+            .stream(stream_index)
+            .ok_or_else(|| DecodeError::NoVideoStream {
+                path: path.to_path_buf(),
+            })?
+            .codecpar();
+        codec_ctx
+            .apply_parameters(&codecpar)
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to copy codec parameters: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         // 7. avcodec_open2
-        // SAFETY: codec is valid; no hardware acceleration for images; codec_ctx is owned.
-        unsafe {
-            codec_ctx
-                .open(codec, ptr::null_mut())
-                .map_err(|e| DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to open codec: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                })?;
-        }
+        codec_ctx
+            .open_codec(codec)
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to open codec: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         // Allocate packet and frame (owned; free on drop, including on an early
         // return from a later `?` — the packet frees itself if the frame alloc fails).
@@ -172,12 +169,18 @@ impl ImageDecoderInner {
     }
 
     /// Returns the image width in pixels.
+    ///
+    /// Reads `AVCodecContext::width` via the raw pointer: there is no safe
+    /// codec-context dimension accessor yet (retained for the ff-sys RAII follow-up).
     pub(crate) fn width(&self) -> u32 {
         // SAFETY: codec_ctx is valid for the lifetime of `self`.
         unsafe { (*self.codec_ctx.as_ptr()).width as u32 }
     }
 
     /// Returns the image height in pixels.
+    ///
+    /// Reads `AVCodecContext::height` via the raw pointer: there is no safe
+    /// codec-context dimension accessor yet (retained for the ff-sys RAII follow-up).
     pub(crate) fn height(&self) -> u32 {
         // SAFETY: codec_ctx is valid for the lifetime of `self`.
         unsafe { (*self.codec_ctx.as_ptr()).height as u32 }
@@ -249,25 +252,16 @@ impl ImageDecoderInner {
 
         // 4. Convert to VideoFrame.
         // SAFETY: frame is valid and contains decoded image data.
-        let video_frame = unsafe { self.av_frame_to_video_frame(self.frame.as_ptr())? };
+        let video_frame = unsafe { self.av_frame_to_video_frame(&self.frame)? };
         Ok(video_frame)
     }
 
     /// Finds the first video stream in the format context.
-    ///
-    /// # Safety
-    ///
-    /// `format_ctx` must be a valid, fully initialized `AVFormatContext`.
-    unsafe fn find_video_stream(format_ctx: *mut AVFormatContext) -> Option<(usize, AVCodecID)> {
-        // SAFETY: Caller ensures format_ctx is valid.
-        unsafe {
-            let nb_streams = (*format_ctx).nb_streams as usize;
-            for i in 0..nb_streams {
-                let stream = (*format_ctx).streams.add(i);
-                let codecpar = (*(*stream)).codecpar;
-                if (*codecpar).codec_type == AVMediaType_AVMEDIA_TYPE_VIDEO {
-                    return Some((i, (*codecpar).codec_id));
-                }
+    fn find_video_stream(format_ctx: &InputFormatContext) -> Option<(usize, AVCodecID)> {
+        for stream in format_ctx.streams() {
+            let codecpar = stream.codecpar();
+            if codecpar.codec_type() == AVMediaType_AVMEDIA_TYPE_VIDEO {
+                return Some((stream.index() as usize, codecpar.codec_id()));
             }
         }
         None
@@ -310,44 +304,48 @@ impl ImageDecoderInner {
         }
     }
 
-    /// Converts a decoded `AVFrame` to a [`VideoFrame`].
+    /// Converts a decoded owned [`Frame`] to a [`VideoFrame`].
+    ///
+    /// Scalar fields are read through accessors; only the plane data copy in
+    /// [`extract_planes_and_strides`](Self::extract_planes_and_strides) touches the
+    /// raw `AVFrame` pointer (no safe plane accessor by design).
     ///
     /// # Safety
     ///
-    /// `frame` must be a valid, fully decoded `AVFrame` owned by `self`.
-    unsafe fn av_frame_to_video_frame(
-        &self,
-        frame: *const AVFrame,
-    ) -> Result<VideoFrame, DecodeError> {
-        // SAFETY: Caller ensures frame is valid.
-        unsafe {
-            let width = (*frame).width as u32;
-            let height = (*frame).height as u32;
-            let format = Self::convert_pixel_format((*frame).format);
+    /// `frame` must hold a fully decoded image whose pixel format the copy expects.
+    unsafe fn av_frame_to_video_frame(&self, frame: &Frame) -> Result<VideoFrame, DecodeError> {
+        let width = frame.width() as u32;
+        let height = frame.height() as u32;
+        let format = Self::convert_pixel_format(frame.format());
 
-            // Extract timestamp (images often have no meaningful PTS).
-            let pts = (*frame).pts;
-            let timestamp = if pts == ff_sys::AV_NOPTS_VALUE {
-                Timestamp::default()
-            } else {
-                let stream = (*self.format_ctx.as_ptr()).streams.add(self.stream_index);
-                let time_base = (*(*stream)).time_base;
-                Timestamp::new(
-                    pts as i64,
-                    Rational::new(time_base.num as i32, time_base.den as i32),
-                )
-            };
-
-            let (planes, strides) = Self::extract_planes_and_strides(frame, width, height, format)?;
-
-            // Images are always key frames.
-            VideoFrame::new(planes, strides, width, height, format, timestamp, true).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: 0,
-                    message: format!("Failed to create VideoFrame: {e}"),
+        // Extract timestamp (images often have no meaningful PTS).
+        let pts = frame.pts();
+        let timestamp = if pts == ff_sys::AV_NOPTS_VALUE {
+            Timestamp::default()
+        } else {
+            match self.format_ctx.stream(self.stream_index) {
+                Some(stream) => {
+                    let time_base = stream.time_base();
+                    Timestamp::new(
+                        pts,
+                        Rational::new(time_base.num as i32, time_base.den as i32),
+                    )
                 }
-            })
-        }
+                None => Timestamp::default(),
+            }
+        };
+
+        // SAFETY: `format` is derived from `frame.format()`, so it matches the frame.
+        let (planes, strides) =
+            unsafe { Self::extract_planes_and_strides(frame.as_ptr(), width, height, format)? };
+
+        // Images are always key frames.
+        VideoFrame::new(planes, strides, width, height, format, timestamp, true).map_err(|e| {
+            DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("Failed to create VideoFrame: {e}"),
+            }
+        })
     }
 
     /// Extracts pixel data from an `AVFrame` into [`PooledBuffer`] planes.

--- a/crates/ff-decode/src/video/decoder_inner/context.rs
+++ b/crates/ff-decode/src/video/decoder_inner/context.rs
@@ -1,36 +1,21 @@
 use super::{
     AVCodecContext, AVCodecID, AVFormatContext, AVMediaType_AVMEDIA_TYPE_VIDEO, CStr,
-    ContainerInfo, DecodeError, Duration, Rational, VideoDecoderInner, VideoStreamInfo,
+    ContainerInfo, DecodeError, Duration, InputFormatContext, Rational, VideoDecoderInner,
+    VideoStreamInfo,
 };
 
 impl VideoDecoderInner {
     /// Finds the first video stream in the format context.
     ///
-    /// # Returns
-    ///
     /// Returns `Some((index, codec_id))` if a video stream is found, `None` otherwise.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure `format_ctx` is valid and initialized.
-    pub(super) unsafe fn find_video_stream(
-        format_ctx: *mut AVFormatContext,
-    ) -> Option<(usize, AVCodecID)> {
-        // SAFETY: Caller ensures format_ctx is valid
-        unsafe {
-            let nb_streams = (*format_ctx).nb_streams as usize;
-
-            for i in 0..nb_streams {
-                let stream = (*format_ctx).streams.add(i);
-                let codecpar = (*(*stream)).codecpar;
-
-                if (*codecpar).codec_type == AVMediaType_AVMEDIA_TYPE_VIDEO {
-                    return Some((i, (*codecpar).codec_id));
-                }
+    pub(super) fn find_video_stream(format_ctx: &InputFormatContext) -> Option<(usize, AVCodecID)> {
+        for stream in format_ctx.streams() {
+            let codecpar = stream.codecpar();
+            if codecpar.codec_type() == AVMediaType_AVMEDIA_TYPE_VIDEO {
+                return Some((stream.index() as usize, codecpar.codec_id()));
             }
-
-            None
         }
+        None
     }
 
     /// Returns the human-readable codec name for a given `AVCodecID`.

--- a/crates/ff-decode/src/video/decoder_inner/decoding.rs
+++ b/crates/ff-decode/src/video/decoder_inner/decoding.rs
@@ -1,5 +1,5 @@
 use super::{
-    AVFrame, Arc, DecodeError, Duration, OutputScale, PixelFormat, PooledBuffer, Rational,
+    AVFrame, Arc, DecodeError, Duration, Frame, OutputScale, PixelFormat, PooledBuffer, Rational,
     Timestamp, VideoDecoderInner, VideoFrame,
 };
 use crate::shared::plane_inner::plane_row_ptr;
@@ -50,9 +50,8 @@ impl VideoDecoderInner {
                         // Check if this is a hardware frame and transfer to CPU memory if needed
                         self.transfer_hardware_frame_if_needed()?;
 
-                        // SAFETY: self.frame is valid and non-null after receive_frame succeeded.
-                        let w = (*self.frame.as_ptr()).width as u32;
-                        let h = (*self.frame.as_ptr()).height as u32;
+                        let w = self.frame.width() as u32;
+                        let h = self.frame.height() as u32;
                         if w > 32_768 || h > 32_768 {
                             log::warn!(
                                 "frame rejected reason=unsupported_resolution width={w} height={h}"
@@ -66,12 +65,11 @@ impl VideoDecoderInner {
                         let video_frame = self.convert_frame_to_video_frame()?;
 
                         // Update position based on frame timestamp
-                        let pts = (*self.frame.as_ptr()).pts;
-                        if pts != ff_sys::AV_NOPTS_VALUE {
-                            let stream = (*self.format_ctx.as_ptr())
-                                .streams
-                                .add(self.stream_index as usize);
-                            let time_base = (*(*stream)).time_base;
+                        let pts = self.frame.pts();
+                        if pts != ff_sys::AV_NOPTS_VALUE
+                            && let Some(stream) = self.format_ctx.stream(self.stream_index as usize)
+                        {
+                            let time_base = stream.time_base();
                             let timestamp_secs =
                                 pts as f64 * time_base.num as f64 / time_base.den as f64;
                             self.position = Duration::from_secs_f64(timestamp_secs);
@@ -111,11 +109,10 @@ impl VideoDecoderInner {
                         }
 
                         // Check if this packet belongs to the video stream
-                        if (*self.packet.as_ptr()).stream_index == self.stream_index {
+                        if self.packet.stream_index() == self.stream_index {
                             // Send the packet to the decoder
                             let send_result = self.codec_ctx.send_packet(&self.packet);
-                            // SAFETY: self.packet is valid and non-null; pts is a plain i64 field.
-                            let pkt_pts = (*self.packet.as_ptr()).pts;
+                            let pkt_pts = self.packet.pts();
                             self.packet.unref();
 
                             if let Err(se) = send_result {
@@ -157,34 +154,35 @@ impl VideoDecoderInner {
         }
     }
 
-    /// Converts an AVFrame to a VideoFrame, applying pixel format conversion if needed.
+    /// Converts the decoder's current frame to a VideoFrame, applying pixel format
+    /// conversion if needed.
     unsafe fn convert_frame_to_video_frame(&mut self) -> Result<VideoFrame, DecodeError> {
-        // SAFETY: Caller ensures self.frame is valid
+        let src_width = self.frame.width() as u32;
+        let src_height = self.frame.height() as u32;
+        let src_format = self.frame.format();
+
+        // Determine output format
+        let dst_format = if let Some(fmt) = self.output_format {
+            Self::pixel_format_to_av(fmt)
+        } else {
+            src_format
+        };
+
+        // Determine output dimensions
+        let (dst_width, dst_height) = self.resolve_output_dims(src_width, src_height);
+
+        // Check if conversion or scaling is needed
+        let needs_conversion =
+            src_format != dst_format || dst_width != src_width || dst_height != src_height;
+
+        // SAFETY: `self.frame` holds a valid decoded frame in `src_format`.
         unsafe {
-            let src_width = (*self.frame.as_ptr()).width as u32;
-            let src_height = (*self.frame.as_ptr()).height as u32;
-            let src_format = (*self.frame.as_ptr()).format;
-
-            // Determine output format
-            let dst_format = if let Some(fmt) = self.output_format {
-                Self::pixel_format_to_av(fmt)
-            } else {
-                src_format
-            };
-
-            // Determine output dimensions
-            let (dst_width, dst_height) = self.resolve_output_dims(src_width, src_height);
-
-            // Check if conversion or scaling is needed
-            let needs_conversion =
-                src_format != dst_format || dst_width != src_width || dst_height != src_height;
-
             if needs_conversion {
                 self.convert_with_sws(
                     src_width, src_height, src_format, dst_width, dst_height, dst_format,
                 )
             } else {
-                self.av_frame_to_video_frame(self.frame.as_ptr())
+                self.av_frame_to_video_frame(&self.frame)
             }
         }
     }
@@ -218,43 +216,53 @@ impl VideoDecoderInner {
         }
     }
 
-    /// Converts an AVFrame to a VideoFrame.
+    /// Converts an owned [`Frame`] to a [`VideoFrame`].
+    ///
+    /// Scalar fields are read through the frame's accessors; only the plane data
+    /// copy in [`extract_planes_and_strides`](Self::extract_planes_and_strides)
+    /// still touches the raw `AVFrame` pointer (no safe plane accessor by design).
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `frame`'s pixel format is one the decoder produced,
+    /// so the plane copy reads the correct plane sizes.
     pub(super) unsafe fn av_frame_to_video_frame(
         &self,
-        frame: *const AVFrame,
+        frame: &Frame,
     ) -> Result<VideoFrame, DecodeError> {
-        // SAFETY: Caller ensures frame and format_ctx are valid
-        unsafe {
-            let width = (*frame).width as u32;
-            let height = (*frame).height as u32;
-            let format = Self::convert_pixel_format((*frame).format);
+        let width = frame.width() as u32;
+        let height = frame.height() as u32;
+        let format = Self::convert_pixel_format(frame.format());
 
-            // Extract timestamp
-            let pts = (*frame).pts;
-            let timestamp = if pts != ff_sys::AV_NOPTS_VALUE {
-                let stream = (*self.format_ctx.as_ptr())
-                    .streams
-                    .add(self.stream_index as usize);
-                let time_base = (*(*stream)).time_base;
-                Timestamp::new(
-                    pts as i64,
-                    Rational::new(time_base.num as i32, time_base.den as i32),
-                )
-            } else {
-                Timestamp::default()
-            };
-
-            // Convert frame to planes and strides
-            let (planes, strides) =
-                self.extract_planes_and_strides(frame, width, height, format)?;
-
-            VideoFrame::new(planes, strides, width, height, format, timestamp, false).map_err(|e| {
-                DecodeError::Ffmpeg {
-                    code: 0,
-                    message: format!("Failed to create VideoFrame: {e}"),
+        // Extract timestamp
+        let pts = frame.pts();
+        let timestamp = if pts != ff_sys::AV_NOPTS_VALUE {
+            match self.format_ctx.stream(self.stream_index as usize) {
+                Some(stream) => {
+                    let time_base = stream.time_base();
+                    Timestamp::new(
+                        pts,
+                        Rational::new(time_base.num as i32, time_base.den as i32),
+                    )
                 }
-            })
-        }
+                None => Timestamp::default(),
+            }
+        } else {
+            Timestamp::default()
+        };
+
+        // Convert frame to planes and strides. The plane data is read via the raw
+        // AVFrame pointer inside `extract_planes_and_strides`.
+        // SAFETY: `format` is derived from `frame.format()`, so it matches the frame.
+        let (planes, strides) =
+            unsafe { self.extract_planes_and_strides(frame.as_ptr(), width, height, format)? };
+
+        VideoFrame::new(planes, strides, width, height, format, timestamp, false).map_err(|e| {
+            DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("Failed to create VideoFrame: {e}"),
+            }
+        })
     }
 
     /// Allocates a buffer, optionally using the frame pool.

--- a/crates/ff-decode/src/video/decoder_inner/format_convert.rs
+++ b/crates/ff-decode/src/video/decoder_inner/format_convert.rs
@@ -219,9 +219,9 @@ impl VideoDecoderInner {
                 ),
             })?;
 
-            (*dst_frame.as_mut_ptr()).width = dst_width as i32;
-            (*dst_frame.as_mut_ptr()).height = dst_height as i32;
-            (*dst_frame.as_mut_ptr()).format = dst_format;
+            dst_frame.set_width(dst_width as i32);
+            dst_frame.set_height(dst_height as i32);
+            dst_frame.set_format(dst_format);
 
             // Allocate buffer for destination frame
             dst_frame.get_buffer(0).map_err(|e| DecodeError::Ffmpeg {
@@ -232,26 +232,24 @@ impl VideoDecoderInner {
                 ),
             })?;
 
-            // Perform conversion/scaling (src_height is the number of input rows to process)
+            // Perform conversion/scaling from the decoder's frame into the owned
+            // destination frame (the number of input rows to process is read
+            // internally from the source frame's height).
+            // SAFETY: `dst_frame` was allocated via `get_buffer` just above and its
+            // geometry matches the context; `self.frame` is a decoded source frame.
+            // (Already inside an `unsafe` block above.)
             sws_ctx
-                .scale(
-                    (*self.frame.as_ptr()).data.as_ptr() as *const *const u8,
-                    (*self.frame.as_ptr()).linesize.as_ptr(),
-                    0,
-                    src_height as i32,
-                    (*dst_frame.as_ptr()).data.as_ptr() as *const *mut u8,
-                    (*dst_frame.as_ptr()).linesize.as_ptr(),
-                )
+                .scale_frames(&self.frame, &mut dst_frame)
                 .map_err(|e| DecodeError::Ffmpeg {
                     code: 0,
                     message: format!("Failed to scale frame: {e}"),
                 })?;
 
             // Copy timestamp
-            (*dst_frame.as_mut_ptr()).pts = (*self.frame.as_ptr()).pts;
+            dst_frame.set_pts(self.frame.pts());
 
             // Convert to VideoFrame
-            let video_frame = self.av_frame_to_video_frame(dst_frame.as_ptr())?;
+            let video_frame = self.av_frame_to_video_frame(&dst_frame)?;
 
             // dst_frame is automatically freed when it drops at scope end
 

--- a/crates/ff-decode/src/video/decoder_inner/hardware.rs
+++ b/crates/ff-decode/src/video/decoder_inner/hardware.rs
@@ -169,8 +169,7 @@ impl VideoDecoderInner {
     ///
     /// Caller must ensure `self.frame` contains a valid decoded frame.
     pub(super) unsafe fn transfer_hardware_frame_if_needed(&mut self) -> Result<(), DecodeError> {
-        // SAFETY: self.frame is valid and owned by this instance
-        let frame_format = unsafe { (*self.frame.as_ptr()).format };
+        let frame_format = self.frame.format();
 
         if !Self::is_hardware_format(frame_format) {
             // Not a hardware frame, no transfer needed
@@ -186,8 +185,10 @@ impl VideoDecoderInner {
             ),
         })?;
 
-        // Transfer data from hardware frame to software frame
-        // SAFETY: self.frame and sw_frame are valid
+        // Transfer data from the hardware frame to the software frame. This FFI
+        // call takes raw `AVFrame` pointers; a safe hw-frame-transfer wrapper is
+        // retained for the ff-sys RAII follow-up (the hw-accel API surface).
+        // SAFETY: self.frame and sw_frame are valid owned frames.
         let ret = unsafe {
             ff_sys::av_hwframe_transfer_data(
                 sw_frame.as_mut_ptr(),
@@ -208,13 +209,10 @@ impl VideoDecoderInner {
         }
 
         // Copy metadata (pts, duration, etc.) from hardware frame to software frame
-        // SAFETY: Both frames are valid
-        unsafe {
-            (*sw_frame.as_mut_ptr()).pts = (*self.frame.as_ptr()).pts;
-            (*sw_frame.as_mut_ptr()).pkt_dts = (*self.frame.as_ptr()).pkt_dts;
-            (*sw_frame.as_mut_ptr()).duration = (*self.frame.as_ptr()).duration;
-            (*sw_frame.as_mut_ptr()).time_base = (*self.frame.as_ptr()).time_base;
-        }
+        sw_frame.set_pts(self.frame.pts());
+        sw_frame.set_pkt_dts(self.frame.pkt_dts());
+        sw_frame.set_duration(self.frame.duration());
+        sw_frame.set_time_base(self.frame.time_base());
 
         // Replace self.frame with the software frame. `move_ref` transfers
         // sw_frame's buffers into self.frame, leaving sw_frame blank (freed on

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -185,17 +185,11 @@ impl VideoDecoderInner {
         })?;
 
         // Detect live/streaming source via the AVFMT_TS_DISCONT flag on AVInputFormat.
-        // SAFETY: format_ctx is valid and non-null; iformat is set by avformat_open_input
-        //         and is non-null for all successfully opened formats.
-        let is_live = unsafe {
-            let iformat = (*ctx.as_ptr()).iformat;
-            !iformat.is_null() && ((*iformat).flags & ff_sys::AVFMT_TS_DISCONT) != 0
-        };
+        let is_live = (ctx.iformat_flags() & ff_sys::AVFMT_TS_DISCONT) != 0;
 
         // Find the video stream
-        // SAFETY: format_ctx is valid
-        let (stream_index, codec_id) = unsafe { Self::find_video_stream(ctx.as_mut_ptr()) }
-            .ok_or_else(|| DecodeError::NoVideoStream {
+        let (stream_index, codec_id) =
+            Self::find_video_stream(&ctx).ok_or_else(|| DecodeError::NoVideoStream {
                 path: path.to_path_buf(),
             })?;
 
@@ -230,53 +224,57 @@ impl VideoDecoderInner {
             })?;
 
         // Copy codec parameters from stream to context
-        // SAFETY: format_ctx is valid, stream_index is valid; codec_ctx is owned
-        unsafe {
-            let stream = (*ctx.as_ptr()).streams.add(stream_index as usize);
-            let codecpar = (*(*stream)).codecpar;
-            codec_ctx
-                .parameters_to_context(codecpar)
-                .map_err(|e| DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to copy codec parameters: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                })?;
+        let codecpar = ctx
+            .stream(stream_index)
+            .ok_or_else(|| DecodeError::NoVideoStream {
+                path: path.to_path_buf(),
+            })?
+            .codecpar();
+        codec_ctx
+            .apply_parameters(&codecpar)
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to copy codec parameters: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
-            // Set thread count
-            if thread_count > 0 {
-                (*codec_ctx.as_mut_ptr()).thread_count = thread_count as i32;
-            }
+        // Set thread count
+        if thread_count > 0 {
+            codec_ctx.set_thread_count(thread_count as i32);
         }
 
-        // Initialize hardware acceleration if requested
+        // Initialize hardware acceleration if requested. The hw device / frames
+        // wiring stays on the raw `AVCodecContext` pointer (retained for the ff-sys
+        // RAII follow-up, which adds a dedicated hw-accel API).
         // SAFETY: codec_ctx is valid and not yet opened
         let (hw_device_ctx, active_hw_accel) =
             unsafe { Self::init_hardware_accel(codec_ctx.as_mut_ptr(), hardware_accel)? };
 
         // Open the codec
-        // SAFETY: codec is valid, hardware device context is set if requested; codec_ctx is owned
-        unsafe {
-            codec_ctx.open(codec, ptr::null_mut()).map_err(|e| {
-                // If codec opening failed, we still own our reference to hw_device_ctx
-                // but it will be cleaned up when codec_ctx is freed (which happens
-                // when codec_ctx is dropped)
-                // Our reference in hw_device_ctx will be cleaned up here
-                if let Some(hw_ctx) = hw_device_ctx {
-                    ff_sys::av_buffer_unref(&mut (hw_ctx as *mut _));
-                }
-                DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to open codec: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                }
-            })?;
-        }
+        codec_ctx.open_codec(codec).map_err(|e| {
+            // If codec opening failed, we still own our reference to hw_device_ctx
+            // but it will be cleaned up when codec_ctx is freed (which happens
+            // when codec_ctx is dropped)
+            // Our reference in hw_device_ctx will be cleaned up here
+            if let Some(hw_ctx) = hw_device_ctx {
+                // SAFETY: hw_ctx is a valid buffer reference we own.
+                unsafe { ff_sys::av_buffer_unref(&mut (hw_ctx as *mut _)) };
+            }
+            DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to open codec: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            }
+        })?;
 
-        // Extract stream information
+        // Extract stream information. `extract_stream_info` / `extract_container_info`
+        // still read fields with no safe accessor yet (codec-context pix_fmt,
+        // stream avg_frame_rate, container bit_rate / iformat name), so they keep the
+        // raw pointer path; safe-ifying them is left to the ff-sys RAII follow-up.
         // SAFETY: All pointers are valid
         let stream_info = unsafe {
             Self::extract_stream_info(

--- a/crates/ff-decode/src/video/decoder_inner/seeking.rs
+++ b/crates/ff-decode/src/video/decoder_inner/seeking.rs
@@ -36,17 +36,13 @@ impl VideoDecoderInner {
     ///
     /// av_seek_frame expects timestamps in stream time_base units when using a specific stream_index.
     fn duration_to_pts(&self, duration: Duration) -> i64 {
-        // Convert duration to stream time_base units for seeking
-        // SAFETY:
-        // - format_ctx is valid: owned by VideoDecoderInner, initialized in constructor via avformat_open_input
-        // - stream_index is valid: validated during decoder creation (find_stream_info + codec opening)
-        // - streams array access is valid: guaranteed by FFmpeg after successful avformat_open_input
-        let time_base = unsafe {
-            let stream = (*self.format_ctx.as_ptr())
-                .streams
-                .add(self.stream_index as usize);
-            (*(*stream)).time_base
-        };
+        // Convert duration to stream time_base units for seeking. The stream index
+        // was validated during decoder creation; fall back to a 1/1 time base if it
+        // is somehow absent (unreachable in practice).
+        let time_base = self
+            .format_ctx
+            .stream(self.stream_index as usize)
+            .map_or(ff_sys::AVRational { num: 1, den: 1 }, |s| s.time_base());
 
         // Convert: duration (seconds) * (time_base.den / time_base.num) = PTS
         let time_base_f64 = time_base.den as f64 / time_base.num as f64;
@@ -301,130 +297,104 @@ impl VideoDecoderInner {
             av_format,
         );
 
-        // SAFETY: We're creating temporary FFmpeg objects for scaling
-        unsafe {
-            // Reuse the cached SwScale context when the key matches; otherwise
-            // build a fresh owned context into the cache slot. The cache key is
-            // only set after scaling succeeds, so an error after a rebuild leaves
-            // the freshly built context keyless — it is dropped/replaced on the
-            // next call rather than being reused with a stale key.
-            let is_cached =
-                self.thumbnail_cache_key == Some(cache_key) && self.thumbnail_sws_ctx.is_some();
+        // Reuse the cached SwScale context when the key matches; otherwise build a
+        // fresh owned context into the cache slot. The cache key is only set after
+        // scaling succeeds, so an error after a rebuild leaves the freshly built
+        // context keyless — it is dropped/replaced on the next call rather than
+        // being reused with a stale key.
+        let is_cached =
+            self.thumbnail_cache_key == Some(cache_key) && self.thumbnail_sws_ctx.is_some();
 
-            if !is_cached {
-                // Drop any stale cached context, then build the replacement.
-                self.thumbnail_sws_ctx = None;
-                self.thumbnail_cache_key = None;
+        if !is_cached {
+            // Drop any stale cached context, then build the replacement.
+            self.thumbnail_sws_ctx = None;
+            self.thumbnail_cache_key = None;
 
-                self.thumbnail_sws_ctx = Some(
-                    ff_sys::ScaleContext::new(
-                        src_width as i32,
-                        src_height as i32,
-                        av_format,
-                        scaled_width as i32,
-                        scaled_height as i32,
-                        av_format,
-                        ff_sys::swscale::scale_flags::BILINEAR,
-                    )
-                    .map_err(|e| DecodeError::Ffmpeg {
-                        code: 0,
-                        message: format!("Failed to create scaling context: {e}"),
-                    })?,
-                );
-            }
-
-            let Some(sws_ctx) = self.thumbnail_sws_ctx.as_mut() else {
-                return Err(DecodeError::Ffmpeg {
+            self.thumbnail_sws_ctx = Some(
+                ff_sys::ScaleContext::new(
+                    src_width as i32,
+                    src_height as i32,
+                    av_format,
+                    scaled_width as i32,
+                    scaled_height as i32,
+                    av_format,
+                    ff_sys::swscale::scale_flags::BILINEAR,
+                )
+                .map_err(|e| DecodeError::Ffmpeg {
                     code: 0,
-                    message: "SwsContext not initialized".to_string(),
-                });
-            };
-
-            // Set up source frame with VideoFrame data (owned; freed on scope exit).
-            let mut src_frame = ff_sys::Frame::new().map_err(|e| DecodeError::Ffmpeg {
-                code: e.code(),
-                message: format!(
-                    "Failed to allocate frame: {}",
-                    ff_sys::av_error_string(e.code())
-                ),
-            })?;
-
-            (*src_frame.as_mut_ptr()).width = src_width as i32;
-            (*src_frame.as_mut_ptr()).height = src_height as i32;
-            (*src_frame.as_mut_ptr()).format = av_format;
-
-            // Set up source frame data pointers directly from VideoFrame (no copy)
-            let planes = frame.planes();
-            let strides = frame.strides();
-
-            for (i, plane_data) in planes.iter().enumerate() {
-                if i >= ff_sys::AV_NUM_DATA_POINTERS as usize {
-                    break;
-                }
-                (*src_frame.as_mut_ptr()).data[i] = plane_data.as_ref().as_ptr().cast_mut();
-                (*src_frame.as_mut_ptr()).linesize[i] = strides[i] as i32;
-            }
-
-            // Allocate destination frame (owned; freed on scope exit).
-            let mut dst_frame = ff_sys::Frame::new().map_err(|e| DecodeError::Ffmpeg {
-                code: e.code(),
-                message: format!(
-                    "Failed to allocate frame: {}",
-                    ff_sys::av_error_string(e.code())
-                ),
-            })?;
-
-            (*dst_frame.as_mut_ptr()).width = scaled_width as i32;
-            (*dst_frame.as_mut_ptr()).height = scaled_height as i32;
-            (*dst_frame.as_mut_ptr()).format = av_format;
-
-            // Allocate buffer for destination frame
-            if let Err(e) = dst_frame.get_buffer(0) {
-                // On a rebuild the freshly built context stays in the cache slot
-                // but keyless (thumbnail_cache_key was cleared above), so it is
-                // dropped/replaced on the next call rather than reused.
-                return Err(DecodeError::Ffmpeg {
-                    code: e.code(),
-                    message: format!(
-                        "Failed to allocate destination frame buffer: {}",
-                        ff_sys::av_error_string(e.code())
-                    ),
-                });
-            }
-
-            // Perform scaling
-            let scale_result = sws_ctx.scale(
-                (*src_frame.as_ptr()).data.as_ptr() as *const *const u8,
-                (*src_frame.as_ptr()).linesize.as_ptr(),
-                0,
-                src_height as i32,
-                (*dst_frame.as_ptr()).data.as_ptr() as *const *mut u8,
-                (*dst_frame.as_ptr()).linesize.as_ptr(),
+                    message: format!("Failed to create scaling context: {e}"),
+                })?,
             );
-
-            if let Err(e) = scale_result {
-                // On a rebuild the freshly built context stays in the cache slot
-                // but keyless (thumbnail_cache_key was cleared above), so it is
-                // dropped/replaced on the next call rather than reused.
-                return Err(DecodeError::Ffmpeg {
-                    code: 0,
-                    message: format!("Failed to scale frame: {e}"),
-                });
-            }
-
-            // Scaling successful - record the cache key for the (re)built context.
-            if !is_cached {
-                self.thumbnail_cache_key = Some(cache_key);
-            }
-
-            // Copy timestamp
-            (*dst_frame.as_mut_ptr()).pts = frame.timestamp().pts();
-
-            // Convert destination frame to VideoFrame
-            let video_frame = self.av_frame_to_video_frame(dst_frame.as_ptr())?;
-
-            Ok(video_frame)
         }
+
+        let Some(sws_ctx) = self.thumbnail_sws_ctx.as_mut() else {
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: "SwsContext not initialized".to_string(),
+            });
+        };
+
+        // Borrow the source planes and strides directly from the VideoFrame; the
+        // scaler reads them in place, so no scratch source frame is needed.
+        let src_planes: Vec<&[u8]> = frame.planes().iter().map(AsRef::as_ref).collect();
+        let src_strides: Vec<i32> = frame.strides().iter().map(|&s| s as i32).collect();
+
+        // Allocate the destination frame (owned; freed on scope exit).
+        let mut dst_frame = ff_sys::Frame::new().map_err(|e| DecodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Failed to allocate frame: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
+
+        dst_frame.set_width(scaled_width as i32);
+        dst_frame.set_height(scaled_height as i32);
+        dst_frame.set_format(av_format);
+
+        // Allocate buffer for destination frame
+        if let Err(e) = dst_frame.get_buffer(0) {
+            // On a rebuild the freshly built context stays in the cache slot but
+            // keyless (thumbnail_cache_key was cleared above), so it is
+            // dropped/replaced on the next call rather than reused.
+            return Err(DecodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to allocate destination frame buffer: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            });
+        }
+
+        // Perform scaling from the borrowed source planes into the owned frame.
+        // SAFETY: `src_planes`/`src_strides` are the source frame's own planes and
+        // positive strides sized for `src_height`; `dst_frame` was allocated via
+        // `get_buffer` with the context's output geometry.
+        if let Err(e) = unsafe {
+            sws_ctx.scale_planes(&src_planes, &src_strides, src_height as i32, &mut dst_frame)
+        } {
+            // On a rebuild the freshly built context stays in the cache slot but
+            // keyless (thumbnail_cache_key was cleared above), so it is
+            // dropped/replaced on the next call rather than reused.
+            return Err(DecodeError::Ffmpeg {
+                code: 0,
+                message: format!("Failed to scale frame: {e}"),
+            });
+        }
+
+        // Scaling successful - record the cache key for the (re)built context.
+        if !is_cached {
+            self.thumbnail_cache_key = Some(cache_key);
+        }
+
+        // Copy timestamp
+        dst_frame.set_pts(frame.timestamp().pts());
+
+        // Convert destination frame to VideoFrame.
+        // SAFETY: `dst_frame` holds valid scaled image data in `av_format`.
+        let video_frame = unsafe { self.av_frame_to_video_frame(&dst_frame)? };
+
+        Ok(video_frame)
     }
 
     // ── Reconnect helpers ─────────────────────────────────────────────────────
@@ -488,8 +458,7 @@ impl VideoDecoderInner {
             })?;
 
         // Re-find the video stream (index may differ in theory after reconnect).
-        // SAFETY: self.format_ctx is valid.
-        let (stream_index, _) = unsafe { Self::find_video_stream(self.format_ctx.as_mut_ptr()) }
+        let (stream_index, _) = Self::find_video_stream(&self.format_ctx)
             .ok_or_else(|| DecodeError::NoVideoStream { path: url.into() })?;
         self.stream_index = stream_index as i32;
 

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -11,8 +11,8 @@ use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
-    AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AvError, Codec, Frame,
-    Packet, avcodec_free_context as ffi_avcodec_free_context,
+    AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AvError, Codec,
+    CodecParameters, Frame, Packet, avcodec_free_context as ffi_avcodec_free_context,
 };
 
 /// The outcome of a [`CodecContext::receive_frame`] call.
@@ -85,6 +85,29 @@ impl CodecContext {
         self.ptr.as_ptr()
     }
 
+    /// Sets the number of decoding/encoding threads.
+    pub fn set_thread_count(&mut self, thread_count: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `thread_count` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).thread_count = thread_count };
+    }
+
+    /// Copies the parameters of `params` into the context (safe wrapper).
+    ///
+    /// This is the borrowed-handle counterpart of the raw
+    /// [`parameters_to_context`](Self::parameters_to_context); it takes a
+    /// [`CodecParameters`] borrowed from an [`InputFormatContext`](crate::InputFormatContext)
+    /// stream, so no raw pointer is exposed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the parameters cannot be copied.
+    pub fn apply_parameters(&mut self, params: &CodecParameters<'_>) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned context; `params` wraps a valid
+        //         `AVCodecParameters` borrowed from a live format context.
+        unsafe { crate::avcodec::parameters_to_context(self.ptr.as_ptr(), params.as_raw()) }
+            .map_err(AvError::new)
+    }
+
     /// Copies stream parameters into the context.
     ///
     /// # Safety
@@ -96,6 +119,21 @@ impl CodecContext {
     ) -> Result<(), AvError> {
         // SAFETY: `self.ptr` is a valid owned context; the caller upholds `par`.
         unsafe { crate::avcodec::parameters_to_context(self.ptr.as_ptr(), par) }
+            .map_err(AvError::new)
+    }
+
+    /// Opens the context with `codec` using default options (safe wrapper).
+    ///
+    /// This is the safe counterpart of the raw [`open`](Self::open); it always
+    /// passes a null options dictionary, which every ff-decode call site uses.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the codec cannot be opened.
+    pub fn open_codec(&mut self, codec: Codec) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned context and `codec` is a valid static
+        //         codec; a null options pointer is accepted by `avcodec_open2`.
+        unsafe { crate::avcodec::open2(self.ptr.as_ptr(), codec.as_ptr(), std::ptr::null_mut()) }
             .map_err(AvError::new)
     }
 

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -111,6 +111,7 @@ pub struct AVCodecParameters {
 }
 
 pub struct AVStream {
+    pub index: c_int,
     pub codecpar: *mut AVCodecParameters,
     pub nb_frames: i64,
     pub duration: i64,
@@ -1151,6 +1152,23 @@ impl CodecContext {
         self._ptr.as_ptr()
     }
 
+    pub fn set_thread_count(&mut self, _thread_count: c_int) {}
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn apply_parameters(
+        &mut self,
+        _params: &CodecParameters<'_>,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn open_codec(&mut self, _codec: Codec) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
     /// # Safety
     /// Stub; never executed on docs.rs.
     pub unsafe fn parameters_to_context(
@@ -1270,6 +1288,30 @@ impl InputFormatContext {
         self._ptr.as_ptr()
     }
 
+    #[must_use]
+    pub fn nb_streams(&self) -> u32 {
+        0
+    }
+
+    #[must_use]
+    pub fn duration(&self) -> i64 {
+        0
+    }
+
+    #[must_use]
+    pub fn iformat_flags(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn stream(&self, _index: usize) -> Option<StreamRef<'_>> {
+        None
+    }
+
+    pub fn streams(&self) -> impl Iterator<Item = StreamRef<'_>> + '_ {
+        std::iter::empty()
+    }
+
     /// # Errors
     /// Stub; never executed on docs.rs.
     pub fn find_stream_info(&mut self) -> Result<(), crate::AvError> {
@@ -1314,6 +1356,55 @@ impl Drop for InputFormatContext {
 // SAFETY: stub; never executed on docs.rs.
 unsafe impl Send for InputFormatContext {}
 
+// ── Borrowed stream / params stubs (mirror crate::format_context) ─────────────
+
+#[derive(Clone, Copy, Debug)]
+pub struct StreamRef<'a> {
+    _ptr: std::ptr::NonNull<AVStream>,
+    _marker: std::marker::PhantomData<&'a InputFormatContext>,
+}
+
+impl<'a> StreamRef<'a> {
+    #[must_use]
+    pub fn index(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn time_base(&self) -> AVRational {
+        AVRational { num: 0, den: 1 }
+    }
+
+    #[must_use]
+    pub fn codecpar(&self) -> CodecParameters<'a> {
+        // SAFETY: stub; never executed on docs.rs.
+        unsafe {
+            CodecParameters {
+                _ptr: std::ptr::NonNull::new_unchecked(ptr::null_mut()),
+                _marker: std::marker::PhantomData,
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CodecParameters<'a> {
+    _ptr: std::ptr::NonNull<AVCodecParameters>,
+    _marker: std::marker::PhantomData<&'a InputFormatContext>,
+}
+
+impl CodecParameters<'_> {
+    #[must_use]
+    pub fn codec_type(&self) -> AVMediaType {
+        0
+    }
+
+    #[must_use]
+    pub fn codec_id(&self) -> AVCodecID {
+        0
+    }
+}
+
 // ── Owned Frame / Packet / Codec stubs (mirror crate::{frame,packet,codec}) ───
 // Under DOCS_RS the real modules are cfg'd out; these shape-compatible stubs keep
 // `ff_sys::{Frame, Packet, Codec}` available for docs.rs.
@@ -1338,6 +1429,54 @@ impl Frame {
     #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut AVFrame {
         self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn width(&self) -> c_int {
+        0
+    }
+    pub fn set_width(&mut self, _width: c_int) {}
+    #[must_use]
+    pub fn height(&self) -> c_int {
+        0
+    }
+    pub fn set_height(&mut self, _height: c_int) {}
+    #[must_use]
+    pub fn format(&self) -> c_int {
+        0
+    }
+    pub fn set_format(&mut self, _format: c_int) {}
+    #[must_use]
+    pub fn pts(&self) -> i64 {
+        0
+    }
+    pub fn set_pts(&mut self, _pts: i64) {}
+    #[must_use]
+    pub fn pkt_dts(&self) -> i64 {
+        0
+    }
+    pub fn set_pkt_dts(&mut self, _pkt_dts: i64) {}
+    #[must_use]
+    pub fn duration(&self) -> i64 {
+        0
+    }
+    pub fn set_duration(&mut self, _duration: i64) {}
+    #[must_use]
+    pub fn time_base(&self) -> AVRational {
+        AVRational { num: 0, den: 1 }
+    }
+    pub fn set_time_base(&mut self, _time_base: AVRational) {}
+    #[must_use]
+    pub fn nb_samples(&self) -> c_int {
+        0
+    }
+    #[must_use]
+    pub fn sample_rate(&self) -> c_int {
+        0
+    }
+    #[must_use]
+    pub fn channels(&self) -> c_int {
+        0
     }
 
     pub fn unref(&mut self) {}
@@ -1384,6 +1523,16 @@ impl Packet {
     #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut AVPacket {
         self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn stream_index(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn pts(&self) -> i64 {
+        0
     }
 
     pub fn unref(&mut self) {}
@@ -1453,14 +1602,30 @@ impl ScaleContext {
         Err(crate::AvError::new(-1))
     }
 
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const SwsContext {
-        self._ptr.as_ptr()
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn scale_frames(
+        &mut self,
+        _src: &Frame,
+        _dst: &mut Frame,
+    ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
     }
 
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut SwsContext {
-        self._ptr.as_ptr()
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn scale_planes(
+        &mut self,
+        _src: &[&[u8]],
+        _src_strides: &[c_int],
+        _src_h: c_int,
+        _dst: &mut Frame,
+    ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
     }
 
     /// # Errors
@@ -1512,14 +1677,17 @@ impl ResampleContext {
         Err(crate::AvError::new(-1))
     }
 
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const SwrContext {
-        self._ptr.as_ptr()
-    }
-
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut SwrContext {
-        self._ptr.as_ptr()
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn convert_into_planes(
+        &mut self,
+        _dst: &mut [&mut [u8]],
+        _dst_count: c_int,
+        _src: &Frame,
+    ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
     }
 
     /// # Errors

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -10,12 +10,16 @@
 //! The mux (output) lifecycle is a separate owner (`OutputFormatContext`,
 //! tracked in #1493); this type covers demuxing only.
 
+use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::path::Path;
 use std::ptr::NonNull;
 use std::time::Duration;
 
-use crate::{AVFormatContext, AvError, Packet, avformat_close_input as ffi_avformat_close_input};
+use crate::{
+    AVCodecID, AVCodecParameters, AVFormatContext, AVMediaType, AVRational, AVStream, AvError,
+    Packet, avformat_close_input as ffi_avformat_close_input,
+};
 
 /// An owned input (demux) `AVFormatContext`.
 ///
@@ -91,6 +95,62 @@ impl InputFormatContext {
     #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
         self.ptr.as_ptr()
+    }
+
+    /// Returns the number of streams in the container.
+    #[must_use]
+    pub fn nb_streams(&self) -> u32 {
+        // SAFETY: `self.ptr` is a valid owned demux context; `nb_streams` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).nb_streams }
+    }
+
+    /// Returns the container duration in `AV_TIME_BASE` units (microseconds).
+    #[must_use]
+    pub fn duration(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned demux context; `duration` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).duration }
+    }
+
+    /// Returns the `AVInputFormat` flags, or `0` when the format is unset.
+    ///
+    /// Used to detect live/streaming sources (`AVFMT_TS_DISCONT`).
+    #[must_use]
+    pub fn iformat_flags(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned demux context. `iformat` is set for
+        //         every successfully opened input, but we null-check it defensively
+        //         and read `flags` (a plain field) only when it is present.
+        unsafe {
+            let iformat = (*self.ptr.as_ptr()).iformat;
+            if iformat.is_null() {
+                0
+            } else {
+                (*iformat).flags
+            }
+        }
+    }
+
+    /// Returns a borrowed handle to stream `index`, or `None` when out of range.
+    #[must_use]
+    pub fn stream(&self, index: usize) -> Option<StreamRef<'_>> {
+        // SAFETY: `self.ptr` is a valid owned demux context. We bound-check `index`
+        //         against `nb_streams` before indexing the `streams` array, and the
+        //         entries are valid stream pointers set by FFmpeg on open.
+        unsafe {
+            let ctx = self.ptr.as_ptr();
+            if index >= (*ctx).nb_streams as usize {
+                return None;
+            }
+            let stream_ptr = *(*ctx).streams.add(index);
+            NonNull::new(stream_ptr).map(|ptr| StreamRef {
+                ptr,
+                _marker: PhantomData,
+            })
+        }
+    }
+
+    /// Iterates the container's streams as borrowed handles.
+    pub fn streams(&self) -> impl Iterator<Item = StreamRef<'_>> + '_ {
+        (0..self.nb_streams() as usize).filter_map(move |i| self.stream(i))
     }
 
     /// Reads stream information, populating per-stream codec parameters.
@@ -173,6 +233,80 @@ impl Drop for InputFormatContext {
 //         ownership between threads is sound because Rust's ownership model
 //         guarantees exclusive access.
 unsafe impl Send for InputFormatContext {}
+
+/// A borrowed handle to one `AVStream` of an [`InputFormatContext`].
+///
+/// The lifetime ties the handle to the owning format context borrow, so it
+/// cannot outlive the context. It exposes only safe scalar accessors and the
+/// stream's [`codecpar`](StreamRef::codecpar); the raw `*mut AVStream` is
+/// private.
+#[derive(Clone, Copy, Debug)]
+pub struct StreamRef<'a> {
+    ptr: NonNull<AVStream>,
+    _marker: PhantomData<&'a InputFormatContext>,
+}
+
+impl<'a> StreamRef<'a> {
+    /// Returns the stream index within its container.
+    #[must_use]
+    pub fn index(&self) -> c_int {
+        // SAFETY: `self.ptr` borrows a valid stream from a live format context.
+        unsafe { (*self.ptr.as_ptr()).index }
+    }
+
+    /// Returns the stream's time base.
+    #[must_use]
+    pub fn time_base(&self) -> AVRational {
+        // SAFETY: `self.ptr` borrows a valid stream from a live format context.
+        unsafe { (*self.ptr.as_ptr()).time_base }
+    }
+
+    /// Returns a borrowed handle to the stream's codec parameters.
+    #[must_use]
+    pub fn codecpar(&self) -> CodecParameters<'a> {
+        // SAFETY: `self.ptr` borrows a valid stream. FFmpeg allocates `codecpar`
+        //         together with the stream, so it is non-null for a demuxed stream.
+        unsafe {
+            let par = (*self.ptr.as_ptr()).codecpar;
+            CodecParameters {
+                ptr: NonNull::new_unchecked(par),
+                _marker: PhantomData,
+            }
+        }
+    }
+}
+
+/// A borrowed handle to an `AVCodecParameters` owned by a stream.
+///
+/// Exposes the scalar fields ff-decode reads and hands its raw pointer to the
+/// safe [`CodecContext::apply_parameters`](crate::CodecContext::apply_parameters)
+/// via a crate-private accessor; the raw pointer is not part of the public API.
+#[derive(Clone, Copy, Debug)]
+pub struct CodecParameters<'a> {
+    ptr: NonNull<AVCodecParameters>,
+    _marker: PhantomData<&'a InputFormatContext>,
+}
+
+impl CodecParameters<'_> {
+    /// Returns the media type (video / audio / ...).
+    #[must_use]
+    pub fn codec_type(&self) -> AVMediaType {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).codec_type }
+    }
+
+    /// Returns the codec id.
+    #[must_use]
+    pub fn codec_id(&self) -> AVCodecID {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).codec_id }
+    }
+
+    /// Returns the underlying raw pointer for FFI calls within the crate.
+    pub(crate) fn as_raw(&self) -> *const AVCodecParameters {
+        self.ptr.as_ptr()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ff-sys/src/frame.rs
+++ b/crates/ff-sys/src/frame.rs
@@ -3,17 +3,20 @@
 //! [`Frame`] allocates a frame and frees it exactly once on drop, replacing the
 //! manual `av_frame_alloc` + `av_frame_free` pair. Ownership is unique;
 //! [`try_clone`](Frame::try_clone) makes a ref-counted copy (`av_frame_ref`)
-//! rather than a deep copy. Raw field access (data / linesize / pts / ...) is
-//! still done through [`as_mut_ptr`](Frame::as_mut_ptr) for now (typed field
-//! accessors are a later step).
+//! rather than a deep copy. Scalar fields (width / height / format / pts / ...)
+//! are read and written through the typed accessors below; plane data
+//! (`data` / `linesize`) is not exposed as a raw-pointer accessor — it is handled
+//! by the swscale / swresample safe APIs ([`ScaleContext`](crate::ScaleContext),
+//! [`ResampleContext`](crate::ResampleContext)).
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
-    AVFrame, AvError, av_frame_alloc as ffi_av_frame_alloc, av_frame_free as ffi_av_frame_free,
-    av_frame_get_buffer as ffi_av_frame_get_buffer, av_frame_move_ref as ffi_av_frame_move_ref,
-    av_frame_ref as ffi_av_frame_ref, av_frame_unref as ffi_av_frame_unref,
+    AVFrame, AVRational, AvError, av_frame_alloc as ffi_av_frame_alloc,
+    av_frame_free as ffi_av_frame_free, av_frame_get_buffer as ffi_av_frame_get_buffer,
+    av_frame_move_ref as ffi_av_frame_move_ref, av_frame_ref as ffi_av_frame_ref,
+    av_frame_unref as ffi_av_frame_unref,
 };
 
 /// An owned `AVFrame`.
@@ -51,6 +54,129 @@ impl Frame {
     #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut AVFrame {
         self.ptr.as_ptr()
+    }
+
+    // ── Scalar field accessors ────────────────────────────────────────────────
+    //
+    // Each getter reads one plain scalar field of the frame; each setter writes
+    // one. They let downstream crates configure and inspect a frame without
+    // dereferencing the raw `AVFrame` pointer. Plane data (`data` / `linesize`)
+    // is deliberately not exposed here (that would leak a raw pointer type); the
+    // swscale / swresample safe APIs handle it.
+
+    /// Returns the frame width in pixels (video frames).
+    #[must_use]
+    pub fn width(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned frame; `width` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).width }
+    }
+
+    /// Sets the frame width in pixels (video frames).
+    pub fn set_width(&mut self, width: c_int) {
+        // SAFETY: `self.ptr` is a valid owned frame; `width` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).width = width };
+    }
+
+    /// Returns the frame height in pixels (video frames).
+    #[must_use]
+    pub fn height(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned frame; `height` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).height }
+    }
+
+    /// Sets the frame height in pixels (video frames).
+    pub fn set_height(&mut self, height: c_int) {
+        // SAFETY: `self.ptr` is a valid owned frame; `height` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).height = height };
+    }
+
+    /// Returns the frame format (an `AVPixelFormat` or `AVSampleFormat` value).
+    #[must_use]
+    pub fn format(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned frame; `format` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).format }
+    }
+
+    /// Sets the frame format (an `AVPixelFormat` or `AVSampleFormat` value).
+    pub fn set_format(&mut self, format: c_int) {
+        // SAFETY: `self.ptr` is a valid owned frame; `format` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).format = format };
+    }
+
+    /// Returns the presentation timestamp (in the frame's time base).
+    #[must_use]
+    pub fn pts(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned frame; `pts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pts }
+    }
+
+    /// Sets the presentation timestamp (in the frame's time base).
+    pub fn set_pts(&mut self, pts: i64) {
+        // SAFETY: `self.ptr` is a valid owned frame; `pts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pts = pts };
+    }
+
+    /// Returns the DTS copied from the packet that produced this frame.
+    #[must_use]
+    pub fn pkt_dts(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned frame; `pkt_dts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pkt_dts }
+    }
+
+    /// Sets the DTS field of the frame.
+    pub fn set_pkt_dts(&mut self, pkt_dts: i64) {
+        // SAFETY: `self.ptr` is a valid owned frame; `pkt_dts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pkt_dts = pkt_dts };
+    }
+
+    /// Returns the frame duration (in the frame's time base).
+    #[must_use]
+    pub fn duration(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned frame; `duration` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).duration }
+    }
+
+    /// Sets the frame duration (in the frame's time base).
+    pub fn set_duration(&mut self, duration: i64) {
+        // SAFETY: `self.ptr` is a valid owned frame; `duration` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).duration = duration };
+    }
+
+    /// Returns the frame's time base.
+    #[must_use]
+    pub fn time_base(&self) -> AVRational {
+        // SAFETY: `self.ptr` is a valid owned frame; `time_base` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).time_base }
+    }
+
+    /// Sets the frame's time base.
+    pub fn set_time_base(&mut self, time_base: AVRational) {
+        // SAFETY: `self.ptr` is a valid owned frame; `time_base` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).time_base = time_base };
+    }
+
+    /// Returns the number of audio samples per channel (audio frames).
+    #[must_use]
+    pub fn nb_samples(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned frame; `nb_samples` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).nb_samples }
+    }
+
+    /// Returns the audio sample rate in Hz (audio frames).
+    #[must_use]
+    pub fn sample_rate(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned frame; `sample_rate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).sample_rate }
+    }
+
+    /// Returns the number of audio channels (audio frames).
+    ///
+    /// Reads `ch_layout.nb_channels`.
+    #[must_use]
+    pub fn channels(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned frame; `ch_layout.nb_channels` is a
+        //         plain field of the embedded channel-layout struct.
+        unsafe { (*self.ptr.as_ptr()).ch_layout.nb_channels }
     }
 
     /// Unreferences the frame's buffers, returning it to a blank state.
@@ -159,6 +285,37 @@ mod tests {
             );
         }
         // Both `frame` and `clone` drop independently (ref-counted), no double free.
+    }
+
+    #[test]
+    fn scalar_accessors_should_round_trip_set_and_get() {
+        let mut frame = Frame::new().expect("frame allocation should succeed");
+        frame.set_width(1920);
+        frame.set_height(1080);
+        frame.set_format(crate::AVPixelFormat_AV_PIX_FMT_RGBA);
+        frame.set_pts(12_345);
+        frame.set_pkt_dts(6_789);
+        frame.set_duration(33);
+        frame.set_time_base(AVRational { num: 1, den: 30 });
+
+        assert_eq!(frame.width(), 1920);
+        assert_eq!(frame.height(), 1080);
+        assert_eq!(frame.format(), crate::AVPixelFormat_AV_PIX_FMT_RGBA);
+        assert_eq!(frame.pts(), 12_345);
+        assert_eq!(frame.pkt_dts(), 6_789);
+        assert_eq!(frame.duration(), 33);
+        let tb = frame.time_base();
+        assert_eq!((tb.num, tb.den), (1, 30));
+    }
+
+    #[test]
+    fn audio_accessors_should_read_sample_fields() {
+        // A fresh frame reports zeroed audio fields; the getters read them without
+        // touching the plane data.
+        let frame = Frame::new().expect("frame allocation should succeed");
+        assert_eq!(frame.nb_samples(), 0);
+        assert_eq!(frame.sample_rate(), 0);
+        assert_eq!(frame.channels(), 0);
     }
 
     #[test]

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -76,7 +76,7 @@ pub use codec_context::{CodecContext, ReceiveOutcome};
 pub use constants::{AV_NOPTS_VALUE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
 #[cfg(not(docsrs))]
-pub use format_context::InputFormatContext;
+pub use format_context::{CodecParameters, InputFormatContext, StreamRef};
 #[cfg(not(docsrs))]
 pub use frame::Frame;
 #[cfg(not(docsrs))]

--- a/crates/ff-sys/src/packet.rs
+++ b/crates/ff-sys/src/packet.rs
@@ -3,9 +3,8 @@
 //! [`Packet`] allocates a packet and frees it exactly once on drop, replacing
 //! the manual `av_packet_alloc` + `av_packet_free` pair. Ownership is unique;
 //! [`try_clone`](Packet::try_clone) makes a ref-counted copy (`av_packet_ref`).
-//! Raw field access (stream_index / pts / ...) is still done through
-//! [`as_mut_ptr`](Packet::as_mut_ptr) for now (typed field accessors are a later
-//! step).
+//! Scalar fields ([`stream_index`](Packet::stream_index) / [`pts`](Packet::pts))
+//! are read through the typed accessors below.
 
 use std::ptr::NonNull;
 
@@ -50,6 +49,20 @@ impl Packet {
     #[must_use]
     pub fn as_mut_ptr(&mut self) -> *mut AVPacket {
         self.ptr.as_ptr()
+    }
+
+    /// Returns the index of the stream this packet belongs to.
+    #[must_use]
+    pub fn stream_index(&self) -> std::os::raw::c_int {
+        // SAFETY: `self.ptr` is a valid owned packet; `stream_index` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).stream_index }
+    }
+
+    /// Returns the presentation timestamp (in the stream's time base).
+    #[must_use]
+    pub fn pts(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned packet; `pts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pts }
     }
 
     /// Unreferences the packet's buffer, returning it to a blank state.

--- a/crates/ff-sys/src/resample_context.rs
+++ b/crates/ff-sys/src/resample_context.rs
@@ -4,17 +4,19 @@
 //! context, and frees it exactly once on drop, replacing the manual
 //! `swresample::alloc_set_opts2` + `swresample::init` + `swr_free`
 //! sequence. The value is always initialized once constructed (there is no
-//! un-initialized state), so the query methods are safe;
-//! [`convert`](ResampleContext::convert) stays `unsafe` because it takes raw
-//! plane pointers (owned Frame handling is a later step), and [`new`](Self::new)
-//! is `unsafe` because it takes raw channel-layout pointers.
+//! un-initialized state), so the query methods are safe. The safe
+//! [`convert_into_planes`](ResampleContext::convert_into_planes) method resamples
+//! an owned [`Frame`]'s audio into caller-provided plane slices;
+//! [`convert`](ResampleContext::convert) stays `unsafe` for callers that still
+//! pass raw plane pointers, and [`new`](Self::new) is `unsafe` because it takes
+//! raw channel-layout pointers.
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
-    AVChannelLayout, AVSampleFormat, AvError, SwrContext, swr_free as ffi_swr_free,
-    swr_get_out_samples as ffi_swr_get_out_samples,
+    AV_NUM_DATA_POINTERS, AVChannelLayout, AVSampleFormat, AvError, Frame, SwrContext,
+    swr_free as ffi_swr_free, swr_get_out_samples as ffi_swr_get_out_samples,
 };
 
 /// An owned, initialized `SwrContext`.
@@ -73,16 +75,63 @@ impl ResampleContext {
         Ok(me)
     }
 
-    /// Returns the context pointer for read-only use.
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const SwrContext {
-        self.ptr.as_ptr()
-    }
+    /// Resamples / reformats an owned source [`Frame`]'s audio into the
+    /// caller-provided output plane slices (safe wrapper).
+    ///
+    /// `dst` holds one mutable byte slice per output plane (one per channel for
+    /// planar formats, a single interleaved slice for packed formats) and
+    /// `dst_count` is the number of samples per channel the buffers can hold. The
+    /// input samples and their count are read from `src`. Returns the number of
+    /// samples produced per channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if conversion fails.
+    ///
+    /// # Safety
+    ///
+    /// `swr_convert` writes up to `dst_count` samples into each output plane, a
+    /// bound the slice types cannot express. The caller must ensure:
+    /// - each `dst[i]` is at least `dst_count * bytes_per_sample` bytes;
+    /// - `dst` has one entry per output plane the configured format needs
+    ///   (planar formats need one plane per channel); at most
+    ///   [`AV_NUM_DATA_POINTERS`] planes are forwarded, so a planar output with
+    ///   more than that many channels is not supported here;
+    /// - `src` is a valid audio [`Frame`] whose planes hold `src.nb_samples`
+    ///   input samples.
+    /// An undersized or missing `dst` plane is an out-of-bounds / null write.
+    pub unsafe fn convert_into_planes(
+        &mut self,
+        dst: &mut [&mut [u8]],
+        dst_count: c_int,
+        src: &Frame,
+    ) -> Result<c_int, AvError> {
+        // Build fixed-size output / input pointer arrays. Unused entries stay
+        // null, matching how FFmpeg treats absent planes.
+        const PLANES: usize = AV_NUM_DATA_POINTERS as usize;
+        let mut out_ptrs: [*mut u8; PLANES] = [std::ptr::null_mut(); PLANES];
+        for (i, plane) in dst.iter_mut().enumerate().take(PLANES) {
+            out_ptrs[i] = plane.as_mut_ptr();
+        }
 
-    /// Returns the context pointer for mutation and FFI calls.
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut SwrContext {
-        self.ptr.as_ptr()
+        let src_ptr = src.as_ptr();
+        // SAFETY: `self.ptr` is a valid initialized context. `out_ptrs` describes
+        //         the caller's mutable output planes and `in_ptrs` a local copy of
+        //         `src`'s plane pointers, both valid for the duration of the call;
+        //         `swr_convert` reads/writes only within them for the sample counts
+        //         given.
+        unsafe {
+            let in_ptrs = (*src_ptr).data;
+            let in_count = (*src_ptr).nb_samples;
+            crate::swresample::convert(
+                self.ptr.as_ptr(),
+                out_ptrs.as_mut_ptr(),
+                dst_count,
+                in_ptrs.as_ptr() as *const *const u8,
+                in_count,
+            )
+        }
+        .map_err(AvError::new)
     }
 
     /// Converts (resamples / reformats) audio samples into the output buffers.
@@ -163,7 +212,10 @@ mod tests {
             )
         }
         .expect("context creation should succeed");
-        assert!(!ctx.as_ptr().is_null());
+        // `get_out_samples` exercises the initialized context without touching a
+        // raw pointer; a non-negative estimate confirms it is live.
+        let mut ctx = ctx;
+        assert!(ctx.get_out_samples(1024) >= 0);
         // Dropping `ctx` frees the context exactly once (no panic / double free).
     }
 
@@ -185,5 +237,49 @@ mod tests {
             )
         };
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn convert_into_planes_should_write_resampled_samples() {
+        // Identity stereo S16 resample (48k -> 48k): exercises the safe plane-slice
+        // convert end to end without a rate change or buffering delay.
+        let out_layout = channel_layout::stereo();
+        let in_layout = channel_layout::stereo();
+        // SAFETY: the two layouts are valid for the duration of the call.
+        let mut ctx = unsafe {
+            ResampleContext::new(
+                &out_layout,
+                sample_format::S16,
+                48000,
+                &in_layout,
+                sample_format::S16,
+                48000,
+            )
+        }
+        .expect("context creation should succeed");
+
+        let samples: c_int = 256;
+        let mut src = crate::Frame::new().expect("frame allocation should succeed");
+        // SAFETY: set the audio fields on a fresh frame, then allocate its buffer.
+        unsafe {
+            let p = src.as_mut_ptr();
+            (*p).format = sample_format::S16;
+            (*p).nb_samples = samples;
+            (*p).sample_rate = 48000;
+            channel_layout::set_default(&raw mut (*p).ch_layout, 2);
+        }
+        src.get_buffer(0).expect("src buffer alloc should succeed");
+
+        // Packed S16 stereo output: one plane of `samples * 2ch * 2 bytes`.
+        let mut out = vec![0u8; samples as usize * 2 * 2];
+        let mut dst: [&mut [u8]; 1] = [out.as_mut_slice()];
+        // SAFETY: `dst[0]` is sized for `samples` stereo S16 samples; `src` holds
+        //         `samples` input samples.
+        let produced = unsafe { ctx.convert_into_planes(&mut dst, samples, &src) }
+            .expect("conversion should succeed");
+        assert_eq!(
+            produced, samples,
+            "identity resample returns all input samples"
+        );
     }
 }

--- a/crates/ff-sys/src/scale_context.rs
+++ b/crates/ff-sys/src/scale_context.rs
@@ -3,13 +3,19 @@
 //! [`ScaleContext`] allocates a scaling context and frees it exactly once on
 //! drop, replacing the manual `swscale::get_context` + `sws_freeContext`
 //! pair. Its constructor is safe (it takes only dimensions, pixel formats, and
-//! flags); [`scale`](ScaleContext::scale) stays `unsafe` because it takes raw
-//! plane pointers (owned Frame handling is a later step).
+//! flags). The safe [`scale_frames`](ScaleContext::scale_frames) /
+//! [`scale_planes`](ScaleContext::scale_planes) methods drive the scaler from
+//! owned [`Frame`] / borrowed plane slices; the raw
+//! [`scale`](ScaleContext::scale) stays `unsafe` for callers that still pass raw
+//! plane pointers.
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
 
-use crate::{AVPixelFormat, AvError, SwsContext, sws_freeContext as ffi_sws_freeContext};
+use crate::{
+    AV_NUM_DATA_POINTERS, AVPixelFormat, AvError, Frame, SwsContext,
+    sws_freeContext as ffi_sws_freeContext,
+};
 
 /// An owned `SwsContext`.
 ///
@@ -49,16 +55,107 @@ impl ScaleContext {
             .map(|ptr| Self { ptr })
     }
 
-    /// Returns the context pointer for read-only use.
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const SwsContext {
-        self.ptr.as_ptr()
+    /// Scales / converts an owned source [`Frame`] into an owned destination
+    /// [`Frame`] (safe wrapper).
+    ///
+    /// Reads the source's plane pointers and strides and the destination's, so
+    /// callers never touch a raw `AVFrame` field. Returns the height of the
+    /// output slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if scaling fails.
+    ///
+    /// # Safety
+    ///
+    /// `sws_scale` reads/writes the frames' planes using their own strides and
+    /// heights, which the type system cannot bound. The caller must ensure:
+    /// - `dst` has its buffers allocated ([`Frame::get_buffer`]) and sized for
+    ///   this context's **output** geometry (a null/undersized `dst` plane is an
+    ///   out-of-bounds write);
+    /// - `src`'s geometry matches this context's **input** geometry.
+    pub unsafe fn scale_frames(&mut self, src: &Frame, dst: &mut Frame) -> Result<c_int, AvError> {
+        let src_ptr = src.as_ptr();
+        let dst_ptr = dst.as_mut_ptr();
+        // SAFETY: `src` / `dst` are valid owned frames; `src`'s planes are readable
+        //         and `dst`'s buffers are allocated by the caller. The plane and
+        //         stride arrays live in the `AVFrame`s and are sized for the formats
+        //         this context was built for, so `sws_scale` stays within them.
+        unsafe {
+            let src_slice_h = (*src_ptr).height;
+            crate::swscale::scale(
+                self.ptr.as_ptr(),
+                (*src_ptr).data.as_ptr() as *const *const u8,
+                (*src_ptr).linesize.as_ptr(),
+                0,
+                src_slice_h,
+                (*dst_ptr).data.as_ptr() as *const *mut u8,
+                (*dst_ptr).linesize.as_ptr(),
+            )
+        }
+        .map_err(AvError::new)
     }
 
-    /// Returns the context pointer for mutation and FFI calls.
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut SwsContext {
-        self.ptr.as_ptr()
+    /// Scales / converts borrowed source plane slices into an owned destination
+    /// [`Frame`] (safe wrapper).
+    ///
+    /// `src` holds one byte slice per source plane and `src_strides` the matching
+    /// per-plane stride (line size in bytes); `src_h` is the number of source rows
+    /// to process. The destination must already have its buffers allocated.
+    ///
+    /// The strides are taken as-is (top-down, positive) following the
+    /// `av_image_copy` convention, so this path never reintroduces the
+    /// negative-linesize row inversion.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if scaling fails.
+    ///
+    /// # Safety
+    ///
+    /// `sws_scale` reads up to `src_strides[i] * src_h` bytes from each `src[i]`,
+    /// a bound the slice types cannot express. The caller must ensure:
+    /// - `src.len() == src_strides.len()` and both describe this context's input
+    ///   planes;
+    /// - each `src[i]` is at least `src_strides[i] * src_h` bytes (per-plane
+    ///   height per the pixel format's subsampling);
+    /// - `dst` has its buffers allocated ([`Frame::get_buffer`]) and sized for
+    ///   this context's output geometry.
+    /// A shorter slice or mismatched stride is an out-of-bounds read.
+    pub unsafe fn scale_planes(
+        &mut self,
+        src: &[&[u8]],
+        src_strides: &[c_int],
+        src_h: c_int,
+        dst: &mut Frame,
+    ) -> Result<c_int, AvError> {
+        // Build fixed-size plane / stride arrays from the borrowed slices. Unused
+        // entries stay null / zero, matching how FFmpeg frames leave absent planes.
+        const PLANES: usize = AV_NUM_DATA_POINTERS as usize;
+        let mut src_ptrs: [*const u8; PLANES] = [std::ptr::null(); PLANES];
+        let mut strides: [c_int; PLANES] = [0; PLANES];
+        for (i, (plane, &stride)) in src.iter().zip(src_strides).enumerate().take(PLANES) {
+            src_ptrs[i] = plane.as_ptr();
+            strides[i] = stride;
+        }
+
+        let dst_ptr = dst.as_mut_ptr();
+        // SAFETY: `src_ptrs` / `strides` describe the borrowed source planes for
+        //         the duration of the call; `dst` is a valid owned frame whose
+        //         buffers the caller allocated. `sws_scale` reads/writes only within
+        //         the sized planes.
+        unsafe {
+            crate::swscale::scale(
+                self.ptr.as_ptr(),
+                src_ptrs.as_ptr(),
+                strides.as_ptr(),
+                0,
+                src_h,
+                (*dst_ptr).data.as_ptr() as *const *mut u8,
+                (*dst_ptr).linesize.as_ptr(),
+            )
+        }
+        .map_err(AvError::new)
     }
 
     /// Scales / converts a slice of the source image into the destination.
@@ -125,7 +222,7 @@ mod tests {
     fn new_should_allocate_and_drop_cleanly() {
         // A plain RGB downscale context needs no file or codec, so this does not
         // depend on anything beyond the linked libswscale.
-        let ctx = ScaleContext::new(
+        let _ctx = ScaleContext::new(
             640,
             480,
             AVPixelFormat_AV_PIX_FMT_RGB24,
@@ -135,8 +232,93 @@ mod tests {
             crate::swscale::scale_flags::BILINEAR,
         )
         .expect("context creation should succeed");
-        assert!(!ctx.as_ptr().is_null());
-        // Dropping `ctx` frees the context exactly once (no panic / double free).
+        // Dropping `_ctx` frees the context exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn scale_frames_should_downscale_an_rgb_frame() {
+        // A plain RGB24 downscale needs no file or codec. Build a source frame
+        // with allocated buffers and a destination frame, then scale.
+        let mut src = Frame::new().expect("frame allocation should succeed");
+        src.set_format(AVPixelFormat_AV_PIX_FMT_RGB24);
+        src.set_width(64);
+        src.set_height(64);
+        src.get_buffer(0).expect("src buffer alloc should succeed");
+
+        let mut dst = Frame::new().expect("frame allocation should succeed");
+        dst.set_format(AVPixelFormat_AV_PIX_FMT_RGB24);
+        dst.set_width(32);
+        dst.set_height(32);
+        dst.get_buffer(0).expect("dst buffer alloc should succeed");
+
+        let mut ctx = ScaleContext::new(
+            64,
+            64,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            32,
+            32,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            crate::swscale::scale_flags::BILINEAR,
+        )
+        .expect("context creation should succeed");
+
+        // SAFETY: both frames are get_buffer'd RGB24 at the context geometry.
+        let out_h = unsafe { ctx.scale_frames(&src, &mut dst) }.expect("scaling should succeed");
+        assert_eq!(out_h, 32, "should process all 32 output rows");
+    }
+
+    #[test]
+    fn scale_frames_should_preserve_vertical_row_order() {
+        // RK-008 guard: a vertical row inversion would swap top and bottom. Paint
+        // the source's top half bright and bottom half dark; after an identity-size
+        // scale the destination must keep the top bright and the bottom dark.
+        let (w, h) = (16i32, 16i32);
+        let mut src = Frame::new().expect("frame allocation should succeed");
+        src.set_format(AVPixelFormat_AV_PIX_FMT_RGB24);
+        src.set_width(w);
+        src.set_height(h);
+        src.get_buffer(0).expect("src buffer alloc should succeed");
+        // SAFETY: `src` has a get_buffer'd RGB24 plane of `linesize * h` bytes.
+        unsafe {
+            let p = src.as_mut_ptr();
+            let data = (*p).data[0];
+            let stride = (*p).linesize[0] as usize;
+            for y in 0..h as usize {
+                let val = if y < h as usize / 2 { 200u8 } else { 40u8 };
+                std::ptr::write_bytes(data.add(y * stride), val, w as usize * 3);
+            }
+        }
+
+        let mut dst = Frame::new().expect("frame allocation should succeed");
+        dst.set_format(AVPixelFormat_AV_PIX_FMT_RGB24);
+        dst.set_width(w);
+        dst.set_height(h);
+        dst.get_buffer(0).expect("dst buffer alloc should succeed");
+
+        let mut ctx = ScaleContext::new(
+            w,
+            h,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            w,
+            h,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            crate::swscale::scale_flags::BILINEAR,
+        )
+        .expect("context creation should succeed");
+        // SAFETY: both frames are get_buffer'd RGB24 at the context geometry.
+        unsafe { ctx.scale_frames(&src, &mut dst) }.expect("scaling should succeed");
+
+        // SAFETY: `dst` is a get_buffer'd RGB24 plane.
+        let (top, bottom) = unsafe {
+            let p = dst.as_ptr();
+            let data = (*p).data[0];
+            let stride = (*p).linesize[0] as usize;
+            (*data, *data.add((h as usize - 1) * stride))
+        };
+        assert!(
+            top > bottom,
+            "top row ({top}) must stay brighter than bottom ({bottom}); a row inversion would flip this"
+        );
     }
 
     #[test]
@@ -151,5 +333,40 @@ mod tests {
             crate::swscale::scale_flags::BILINEAR,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn scale_planes_should_downscale_from_borrowed_planes() {
+        // Feed a single RGB24 plane (borrowed Vec) through the plane-slice path.
+        let src_w = 64usize;
+        let src_h = 64usize;
+        let src_stride = src_w * 3;
+        let src_buf = vec![0u8; src_stride * src_h];
+        let src_planes: [&[u8]; 1] = [src_buf.as_slice()];
+        let src_strides: [c_int; 1] = [src_stride as c_int];
+
+        let mut dst = Frame::new().expect("frame allocation should succeed");
+        dst.set_format(AVPixelFormat_AV_PIX_FMT_RGB24);
+        dst.set_width(32);
+        dst.set_height(32);
+        dst.get_buffer(0).expect("dst buffer alloc should succeed");
+
+        let mut ctx = ScaleContext::new(
+            src_w as c_int,
+            src_h as c_int,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            32,
+            32,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            crate::swscale::scale_flags::BILINEAR,
+        )
+        .expect("context creation should succeed");
+
+        // SAFETY: the single plane is sized `src_stride * src_h`; `dst` is
+        // get_buffer'd at the context's output geometry.
+        let out_h =
+            unsafe { ctx.scale_planes(&src_planes, &src_strides, src_h as c_int, &mut dst) }
+                .expect("plane scaling should succeed");
+        assert_eq!(out_h, 32, "should process all 32 output rows");
     }
 }


### PR DESCRIPTION
## Objective

- The ff-sys owned types (Frame / Packet / CodecContext / InputFormatContext) still exposed `as_ptr` / `as_mut_ptr`, so ff-decode reached through raw pointers for every field access, scale, resample, and stream lookup. This is the foundation (sub-scope A+B of #1497) for a raw-pointer-free safe surface.

## Solution

- Add scalar field accessors (Frame, Packet), a CodecContext thread-count setter and safe `open_codec` / `apply_parameters`, and InputFormatContext stream/count/duration accessors, plus new lifetime-bound `StreamRef` / `CodecParameters` borrowed handles.
- Add slice/frame-based `scale_frames` / `scale_planes` / `convert_into_planes`. They take slices/frames rather than raw pointers, but stay `unsafe fn` (with `# Safety`) because the caller still guarantees the buffer sizes and geometry the underlying `sws_scale` / `swr_convert` require — the types cannot bound those.
- Migrate ff-decode's decode / seek / resample paths onto the accessors and safe scale/convert; `find_*_stream` returns the real `AVStream` index. The hw-accel wiring, the plane-copy path, and the metadata-extraction helpers keep a documented raw path for the follow-up.
- Remove the unused `as_ptr` / `as_mut_ptr` from ScaleContext / ResampleContext. The raw variants and the other types' escape hatches stay for the not-yet-migrated crates.
- Tests: accessor round-trips, a scale test that guards against a vertical row inversion, and a convert round-trip.

Follow-ups: #1505 migrates ff-encode / ff-stream / ff-preview / ff-filter and adds the slice-based scale/convert + metadata accessors; #1506 seals the layer (removes the remaining escape hatches, privatizes the raw wrappers) and carries the original "no raw pointer in a public signature" criterion.

Closes #1497