### PR TITLE
feat(ff-sys): add slice-scale and read accessors, migrate the small consumers

### DIFF
--- a/crates/ff-decode/src/audio/decoder_inner.rs
+++ b/crates/ff-decode/src/audio/decoder_inner.rs
@@ -30,10 +30,7 @@ use ff_format::channel::ChannelLayout;
 use ff_format::codec::AudioCodec;
 use ff_format::container::ContainerInfo;
 use ff_format::{AudioFrame, AudioStreamInfo, NetworkOptions, SampleFormat};
-use ff_sys::{
-    AVCodecContext, AVCodecID, AVFormatContext, AVMediaType_AVMEDIA_TYPE_AUDIO, Frame,
-    InputFormatContext, Packet,
-};
+use ff_sys::{AVCodecID, AVMediaType_AVMEDIA_TYPE_AUDIO, Frame, InputFormatContext, Packet};
 
 use super::resample_inner;
 
@@ -200,22 +197,18 @@ impl AudioDecoderInner {
                 ),
             })?;
 
-        // Extract stream information. `extract_stream_info` / `extract_container_info`
-        // still read fields with no safe accessor yet (codec-context sample_fmt,
-        // container bit_rate / iformat name), so they keep the raw pointer path;
-        // safe-ifying them is left to the ff-sys RAII follow-up.
-        // SAFETY: All pointers are valid
-        let stream_info = unsafe {
-            Self::extract_stream_info(
-                ctx.as_mut_ptr(),
-                stream_index as i32,
-                codec_ctx.as_mut_ptr(),
-            )?
-        };
+        // Extract stream and container information through the borrowed
+        // stream / codec-context accessors.
+        let duration_val = ctx.duration();
+        let stream = ctx
+            .stream(stream_index)
+            .ok_or_else(|| DecodeError::NoAudioStream {
+                path: path.to_path_buf(),
+            })?;
+        let stream_info = Self::extract_stream_info(stream, &codec_ctx, duration_val)?;
 
         // Extract container information
-        // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
-        let container_info = unsafe { Self::extract_container_info(ctx.as_mut_ptr()) };
+        let container_info = Self::extract_container_info(&ctx);
 
         // Allocate packet and frame (owned; free on drop, including on an early
         // return from a later `?` in this constructor).
@@ -283,26 +276,20 @@ impl AudioDecoderInner {
         unsafe { CStr::from_ptr(name_ptr).to_string_lossy().into_owned() }
     }
 
-    /// Extracts audio stream information from FFmpeg structures.
-    unsafe fn extract_stream_info(
-        format_ctx: *mut AVFormatContext,
-        stream_index: i32,
-        codec_ctx: *mut AVCodecContext,
+    /// Extracts audio stream information from the borrowed stream and codec
+    /// context.
+    fn extract_stream_info(
+        stream: ff_sys::StreamRef<'_>,
+        codec_ctx: &ff_sys::CodecContext,
+        duration_val: i64,
     ) -> Result<AudioStreamInfo, DecodeError> {
-        // SAFETY: Caller ensures all pointers are valid
-        let (sample_rate, channels, sample_fmt, duration_val, channel_layout, codec_id) = unsafe {
-            let stream = (*format_ctx).streams.add(stream_index as usize);
-            let codecpar = (*(*stream)).codecpar;
-
-            (
-                (*codecpar).sample_rate as u32,
-                (*codecpar).ch_layout.nb_channels as u32,
-                (*codec_ctx).sample_fmt,
-                (*format_ctx).duration,
-                (*codecpar).ch_layout,
-                (*codecpar).codec_id,
-            )
-        };
+        let codecpar = stream.codecpar();
+        let stream_index = stream.index();
+        let channel_layout = codecpar.ch_layout();
+        let sample_rate = codecpar.sample_rate() as u32;
+        let channels = channel_layout.nb_channels as u32;
+        let sample_fmt = codec_ctx.sample_fmt();
+        let codec_id = codecpar.codec_id();
 
         // Extract duration
         let duration = if duration_val > 0 {
@@ -339,40 +326,24 @@ impl AudioDecoderInner {
         Ok(builder.build())
     }
 
-    /// Extracts container-level information from the `AVFormatContext`.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure `format_ctx` is valid and `avformat_find_stream_info` has been called.
-    unsafe fn extract_container_info(format_ctx: *mut AVFormatContext) -> ContainerInfo {
-        // SAFETY: Caller ensures format_ctx is valid
-        unsafe {
-            let format_name = if (*format_ctx).iformat.is_null() {
-                String::new()
-            } else {
-                let ptr = (*(*format_ctx).iformat).name;
-                if ptr.is_null() {
-                    String::new()
-                } else {
-                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
-                }
-            };
+    /// Extracts container-level information from the format context.
+    fn extract_container_info(format_ctx: &InputFormatContext) -> ContainerInfo {
+        let format_name = format_ctx.iformat_name().unwrap_or_default();
 
-            let bit_rate = {
-                let br = (*format_ctx).bit_rate;
-                if br > 0 { Some(br as u64) } else { None }
-            };
+        let bit_rate = {
+            let br = format_ctx.bit_rate();
+            if br > 0 { Some(br as u64) } else { None }
+        };
 
-            let nb_streams = (*format_ctx).nb_streams as u32;
+        let nb_streams = format_ctx.nb_streams();
 
-            let mut builder = ContainerInfo::builder()
-                .format_name(format_name)
-                .nb_streams(nb_streams);
-            if let Some(br) = bit_rate {
-                builder = builder.bit_rate(br);
-            }
-            builder.build()
+        let mut builder = ContainerInfo::builder()
+            .format_name(format_name)
+            .nb_streams(nb_streams);
+        if let Some(br) = bit_rate {
+            builder = builder.bit_rate(br);
         }
+        builder.build()
     }
 
     /// Converts FFmpeg channel layout to our `ChannelLayout` enum.

--- a/crates/ff-decode/src/image/decoder_inner.rs
+++ b/crates/ff-decode/src/image/decoder_inner.rs
@@ -169,21 +169,13 @@ impl ImageDecoderInner {
     }
 
     /// Returns the image width in pixels.
-    ///
-    /// Reads `AVCodecContext::width` via the raw pointer: there is no safe
-    /// codec-context dimension accessor yet (retained for the ff-sys RAII follow-up).
     pub(crate) fn width(&self) -> u32 {
-        // SAFETY: codec_ctx is valid for the lifetime of `self`.
-        unsafe { (*self.codec_ctx.as_ptr()).width as u32 }
+        self.codec_ctx.width() as u32
     }
 
     /// Returns the image height in pixels.
-    ///
-    /// Reads `AVCodecContext::height` via the raw pointer: there is no safe
-    /// codec-context dimension accessor yet (retained for the ff-sys RAII follow-up).
     pub(crate) fn height(&self) -> u32 {
-        // SAFETY: codec_ctx is valid for the lifetime of `self`.
-        unsafe { (*self.codec_ctx.as_ptr()).height as u32 }
+        self.codec_ctx.height() as u32
     }
 
     /// Decodes the image, consuming `self` and returning a [`VideoFrame`].

--- a/crates/ff-decode/src/video/decoder_inner/context.rs
+++ b/crates/ff-decode/src/video/decoder_inner/context.rs
@@ -1,7 +1,6 @@
 use super::{
-    AVCodecContext, AVCodecID, AVFormatContext, AVMediaType_AVMEDIA_TYPE_VIDEO, CStr,
-    ContainerInfo, DecodeError, Duration, InputFormatContext, Rational, VideoDecoderInner,
-    VideoStreamInfo,
+    AVCodecID, AVMediaType_AVMEDIA_TYPE_VIDEO, CStr, ContainerInfo, DecodeError, Duration,
+    InputFormatContext, Rational, VideoDecoderInner, VideoStreamInfo,
 };
 
 impl VideoDecoderInner {
@@ -29,39 +28,23 @@ impl VideoDecoderInner {
         unsafe { CStr::from_ptr(name_ptr).to_string_lossy().into_owned() }
     }
 
-    /// Extracts video stream information from FFmpeg structures.
-    pub(super) unsafe fn extract_stream_info(
-        format_ctx: *mut AVFormatContext,
-        stream_index: i32,
-        codec_ctx: *mut AVCodecContext,
+    /// Extracts video stream information from the borrowed stream and codec
+    /// context.
+    pub(super) fn extract_stream_info(
+        stream: ff_sys::StreamRef<'_>,
+        codec_ctx: &ff_sys::CodecContext,
+        duration_val: i64,
     ) -> Result<VideoStreamInfo, DecodeError> {
-        // SAFETY: Caller ensures all pointers are valid
-        let (
-            width,
-            height,
-            fps_rational,
-            duration_val,
-            pix_fmt,
-            color_space_val,
-            color_range_val,
-            color_primaries_val,
-            codec_id,
-        ) = unsafe {
-            let stream = (*format_ctx).streams.add(stream_index as usize);
-            let codecpar = (*(*stream)).codecpar;
-
-            (
-                (*codecpar).width as u32,
-                (*codecpar).height as u32,
-                (*(*stream)).avg_frame_rate,
-                (*format_ctx).duration,
-                (*codec_ctx).pix_fmt,
-                (*codecpar).color_space,
-                (*codecpar).color_range,
-                (*codecpar).color_primaries,
-                (*codecpar).codec_id,
-            )
-        };
+        let codecpar = stream.codecpar();
+        let stream_index = stream.index();
+        let width = codecpar.width() as u32;
+        let height = codecpar.height() as u32;
+        let fps_rational = stream.avg_frame_rate();
+        let pix_fmt = codec_ctx.pix_fmt();
+        let color_space_val = codecpar.color_space();
+        let color_range_val = codecpar.color_range();
+        let color_primaries_val = codecpar.color_primaries();
+        let codec_id = codecpar.codec_id();
 
         // Extract frame rate
         let frame_rate = if fps_rational.den != 0 {
@@ -114,39 +97,23 @@ impl VideoDecoderInner {
         Ok(builder.build())
     }
 
-    /// Extracts container-level information from the `AVFormatContext`.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure `format_ctx` is valid and `avformat_find_stream_info` has been called.
-    pub(super) unsafe fn extract_container_info(format_ctx: *mut AVFormatContext) -> ContainerInfo {
-        // SAFETY: Caller ensures format_ctx is valid
-        unsafe {
-            let format_name = if (*format_ctx).iformat.is_null() {
-                String::new()
-            } else {
-                let ptr = (*(*format_ctx).iformat).name;
-                if ptr.is_null() {
-                    String::new()
-                } else {
-                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
-                }
-            };
+    /// Extracts container-level information from the format context.
+    pub(super) fn extract_container_info(format_ctx: &InputFormatContext) -> ContainerInfo {
+        let format_name = format_ctx.iformat_name().unwrap_or_default();
 
-            let bit_rate = {
-                let br = (*format_ctx).bit_rate;
-                if br > 0 { Some(br as u64) } else { None }
-            };
+        let bit_rate = {
+            let br = format_ctx.bit_rate();
+            if br > 0 { Some(br as u64) } else { None }
+        };
 
-            let nb_streams = (*format_ctx).nb_streams as u32;
+        let nb_streams = format_ctx.nb_streams();
 
-            let mut builder = ContainerInfo::builder()
-                .format_name(format_name)
-                .nb_streams(nb_streams);
-            if let Some(br) = bit_rate {
-                builder = builder.bit_rate(br);
-            }
-            builder.build()
+        let mut builder = ContainerInfo::builder()
+            .format_name(format_name)
+            .nb_streams(nb_streams);
+        if let Some(br) = bit_rate {
+            builder = builder.bit_rate(br);
         }
+        builder.build()
     }
 }

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -37,9 +37,9 @@ use ff_format::container::ContainerInfo;
 use ff_format::time::{Rational, Timestamp};
 use ff_format::{PixelFormat, VideoFrame, VideoStreamInfo};
 use ff_sys::{
-    AVBufferRef, AVCodecContext, AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace,
-    AVFormatContext, AVFrame, AVHWDeviceType, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame,
-    InputFormatContext, Packet,
+    AVBufferRef, AVCodecContext, AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace, AVFrame,
+    AVHWDeviceType, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame, InputFormatContext,
+    Packet,
 };
 
 use crate::HardwareAccel;
@@ -271,22 +271,18 @@ impl VideoDecoderInner {
             }
         })?;
 
-        // Extract stream information. `extract_stream_info` / `extract_container_info`
-        // still read fields with no safe accessor yet (codec-context pix_fmt,
-        // stream avg_frame_rate, container bit_rate / iformat name), so they keep the
-        // raw pointer path; safe-ifying them is left to the ff-sys RAII follow-up.
-        // SAFETY: All pointers are valid
-        let stream_info = unsafe {
-            Self::extract_stream_info(
-                ctx.as_mut_ptr(),
-                stream_index as i32,
-                codec_ctx.as_mut_ptr(),
-            )?
-        };
+        // Extract stream and container information through the borrowed
+        // stream / codec-context accessors.
+        let duration_val = ctx.duration();
+        let stream = ctx
+            .stream(stream_index)
+            .ok_or_else(|| DecodeError::NoVideoStream {
+                path: path.to_path_buf(),
+            })?;
+        let stream_info = Self::extract_stream_info(stream, &codec_ctx, duration_val)?;
 
         // Extract container information
-        // SAFETY: format_ctx is valid and avformat_find_stream_info has been called
-        let container_info = unsafe { Self::extract_container_info(ctx.as_mut_ptr()) };
+        let container_info = Self::extract_container_info(&ctx);
 
         // Allocate packet and frame (owned; free on drop, including on an early
         // return from a later `?` in this constructor).

--- a/crates/ff-filter/src/effects/effects_inner.rs
+++ b/crates/ff-filter/src/effects/effects_inner.rs
@@ -555,10 +555,10 @@ pub(super) unsafe fn transform_vidstab_unsafe(
         }
     };
 
-    (*enc_ctx.as_mut_ptr()).width = frame_width;
-    (*enc_ctx.as_mut_ptr()).height = frame_height;
-    (*enc_ctx.as_mut_ptr()).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
-    (*enc_ctx.as_mut_ptr()).time_base = filter_tb;
+    enc_ctx.set_width(frame_width);
+    enc_ctx.set_height(frame_height);
+    enc_ctx.set_pix_fmt(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P);
+    enc_ctx.set_time_base(filter_tb);
 
     if let Err(e) = enc_ctx.open(enc_codec, std::ptr::null_mut()) {
         let mut fp = first_frame;

--- a/crates/ff-preview/src/playback/playback_inner.rs
+++ b/crates/ff-preview/src/playback/playback_inner.rs
@@ -116,42 +116,35 @@ impl SwsRgbaConverter {
         let total = rgba_stride * dst_h as usize;
         dst.resize(total, 0u8);
 
-        // Collect per-plane pointers and strides from the VideoFrame.
+        // Collect per-plane borrowed slices and strides from the VideoFrame.
         // VideoFrame stores at most 4 planes.
         let n = frame.num_planes().min(4);
-        let mut src_ptrs: [*const u8; 4] = [std::ptr::null(); 4];
-        let mut src_strides: [i32; 4] = [0i32; 4];
+        let mut src_planes: Vec<&[u8]> = Vec::with_capacity(n);
+        let mut src_strides: Vec<i32> = Vec::with_capacity(n);
         for i in 0..n {
             if let (Some(plane), Some(stride)) = (frame.plane(i), frame.stride(i)) {
-                src_ptrs[i] = plane.as_ptr();
-                src_strides[i] = stride as i32;
+                src_planes.push(plane);
+                src_strides.push(stride as i32);
             }
         }
 
-        let dst_ptr = dst.as_mut_ptr();
-        let dst_stride_val = rgba_stride as i32;
-        let mut dst_ptrs: [*mut u8; 4] = [
-            dst_ptr,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        ];
-        let dst_strides: [i32; 4] = [dst_stride_val, 0, 0, 0];
+        let dst_strides: [i32; 1] = [rgba_stride as i32];
+        let mut dst_slices: [&mut [u8]; 1] = [dst.as_mut_slice()];
 
         let Some(ctx) = self.ctx.as_mut() else {
             log::warn!("sws_scale skipped: scaling context not initialized");
             return false;
         };
-        // SAFETY: ctx is initialized (created above); src and dst pointers are valid
-        // for the lifetime of this call; buffer sizes match dst_w * dst_h * 4 bytes.
+        // SAFETY: ctx is initialized (created above); each src plane is sized for
+        // `src_h` rows at its stride, and the single RGBA dst plane is sized
+        // `dst_w * dst_h * 4` bytes (resized above) at `rgba_stride`.
         let result = unsafe {
-            ctx.scale(
-                src_ptrs.as_ptr(),
-                src_strides.as_ptr(),
-                0,
+            ctx.scale_slices(
+                &src_planes,
+                &src_strides,
                 src_h as i32,
-                dst_ptrs.as_mut_ptr().cast::<*mut u8>(),
-                dst_strides.as_ptr(),
+                &mut dst_slices,
+                &dst_strides,
             )
         };
         match result {

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -11,8 +11,9 @@ use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
-    AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AvError, Codec,
-    CodecParameters, Frame, Packet, avcodec_free_context as ffi_avcodec_free_context,
+    AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AVPixelFormat, AVRational,
+    AVSampleFormat, AvError, Codec, CodecParameters, Frame, Packet,
+    avcodec_free_context as ffi_avcodec_free_context,
 };
 
 /// The outcome of a [`CodecContext::receive_frame`] call.
@@ -89,6 +90,58 @@ impl CodecContext {
     pub fn set_thread_count(&mut self, thread_count: c_int) {
         // SAFETY: `self.ptr` is a valid owned context; `thread_count` is a plain field.
         unsafe { (*self.ptr.as_ptr()).thread_count = thread_count };
+    }
+
+    /// Sets the coded picture width.
+    pub fn set_width(&mut self, width: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `width` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).width = width };
+    }
+
+    /// Sets the coded picture height.
+    pub fn set_height(&mut self, height: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `height` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).height = height };
+    }
+
+    /// Sets the pixel format.
+    pub fn set_pix_fmt(&mut self, pix_fmt: AVPixelFormat) {
+        // SAFETY: `self.ptr` is a valid owned context; `pix_fmt` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pix_fmt = pix_fmt };
+    }
+
+    /// Sets the time base.
+    pub fn set_time_base(&mut self, time_base: AVRational) {
+        // SAFETY: `self.ptr` is a valid owned context; `time_base` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).time_base = time_base };
+    }
+
+    /// Returns the pixel format.
+    #[must_use]
+    pub fn pix_fmt(&self) -> AVPixelFormat {
+        // SAFETY: `self.ptr` is a valid owned context; `pix_fmt` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pix_fmt }
+    }
+
+    /// Returns the sample format.
+    #[must_use]
+    pub fn sample_fmt(&self) -> AVSampleFormat {
+        // SAFETY: `self.ptr` is a valid owned context; `sample_fmt` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).sample_fmt }
+    }
+
+    /// Returns the coded picture width.
+    #[must_use]
+    pub fn width(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned context; `width` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).width }
+    }
+
+    /// Returns the coded picture height.
+    #[must_use]
+    pub fn height(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned context; `height` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).height }
     }
 
     /// Copies the parameters of `params` into the context (safe wrapper).
@@ -284,6 +337,29 @@ mod tests {
         let ctx = CodecContext::new(None).expect("alloc should succeed");
         assert!(!ctx.as_ptr().is_null());
         // Dropping `ctx` here frees the context exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn set_then_get_should_round_trip_dimensions_and_formats() {
+        // A `None` codec yields a generic context whose scalar fields can be set
+        // and read back without opening any codec.
+        let mut ctx = CodecContext::new(None).expect("alloc should succeed");
+        ctx.set_width(1920);
+        ctx.set_height(1080);
+        ctx.set_pix_fmt(crate::AVPixelFormat_AV_PIX_FMT_YUV420P);
+        ctx.set_time_base(AVRational { num: 1, den: 30 });
+
+        assert_eq!(ctx.width(), 1920);
+        assert_eq!(ctx.height(), 1080);
+        assert_eq!(ctx.pix_fmt(), crate::AVPixelFormat_AV_PIX_FMT_YUV420P);
+    }
+
+    #[test]
+    fn sample_fmt_should_read_back_default() {
+        // A fresh generic context reports its (default) sample format without a
+        // codec being opened; reading it must not panic.
+        let ctx = CodecContext::new(None).expect("alloc should succeed");
+        let _ = ctx.sample_fmt();
     }
 
     #[test]

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1154,6 +1154,28 @@ impl CodecContext {
 
     pub fn set_thread_count(&mut self, _thread_count: c_int) {}
 
+    pub fn set_width(&mut self, _width: c_int) {}
+    pub fn set_height(&mut self, _height: c_int) {}
+    pub fn set_pix_fmt(&mut self, _pix_fmt: AVPixelFormat) {}
+    pub fn set_time_base(&mut self, _time_base: AVRational) {}
+
+    #[must_use]
+    pub fn pix_fmt(&self) -> AVPixelFormat {
+        0
+    }
+    #[must_use]
+    pub fn sample_fmt(&self) -> AVSampleFormat {
+        0
+    }
+    #[must_use]
+    pub fn width(&self) -> c_int {
+        0
+    }
+    #[must_use]
+    pub fn height(&self) -> c_int {
+        0
+    }
+
     /// # Errors
     /// Stub; never executed on docs.rs.
     pub fn apply_parameters(
@@ -1304,6 +1326,16 @@ impl InputFormatContext {
     }
 
     #[must_use]
+    pub fn bit_rate(&self) -> i64 {
+        0
+    }
+
+    #[must_use]
+    pub fn iformat_name(&self) -> Option<String> {
+        None
+    }
+
+    #[must_use]
     pub fn stream(&self, _index: usize) -> Option<StreamRef<'_>> {
         None
     }
@@ -1376,6 +1408,11 @@ impl<'a> StreamRef<'a> {
     }
 
     #[must_use]
+    pub fn avg_frame_rate(&self) -> AVRational {
+        AVRational { num: 0, den: 1 }
+    }
+
+    #[must_use]
     pub fn codecpar(&self) -> CodecParameters<'a> {
         // SAFETY: stub; never executed on docs.rs.
         unsafe {
@@ -1402,6 +1439,41 @@ impl CodecParameters<'_> {
     #[must_use]
     pub fn codec_id(&self) -> AVCodecID {
         0
+    }
+
+    #[must_use]
+    pub fn width(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn height(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn sample_rate(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn color_space(&self) -> AVColorSpace {
+        0
+    }
+
+    #[must_use]
+    pub fn color_range(&self) -> AVColorRange {
+        0
+    }
+
+    #[must_use]
+    pub fn color_primaries(&self) -> AVColorPrimaries {
+        0
+    }
+
+    #[must_use]
+    pub fn ch_layout(&self) -> AVChannelLayout {
+        AVChannelLayout::default()
     }
 }
 
@@ -1624,6 +1696,21 @@ impl ScaleContext {
         _src_strides: &[c_int],
         _src_h: c_int,
         _dst: &mut Frame,
+    ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn scale_slices(
+        &mut self,
+        _src: &[&[u8]],
+        _src_strides: &[c_int],
+        _src_h: c_int,
+        _dst: &mut [&mut [u8]],
+        _dst_strides: &[c_int],
     ) -> Result<c_int, crate::AvError> {
         Err(crate::AvError::new(-1))
     }

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -10,6 +10,7 @@
 //! The mux (output) lifecycle is a separate owner (`OutputFormatContext`,
 //! tracked in #1493); this type covers demuxing only.
 
+use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::path::Path;
@@ -17,8 +18,9 @@ use std::ptr::NonNull;
 use std::time::Duration;
 
 use crate::{
-    AVCodecID, AVCodecParameters, AVFormatContext, AVMediaType, AVRational, AVStream, AvError,
-    Packet, avformat_close_input as ffi_avformat_close_input,
+    AVChannelLayout, AVCodecID, AVCodecParameters, AVColorPrimaries, AVColorRange, AVColorSpace,
+    AVFormatContext, AVMediaType, AVRational, AVStream, AvError, Packet,
+    avformat_close_input as ffi_avformat_close_input,
 };
 
 /// An owned input (demux) `AVFormatContext`.
@@ -126,6 +128,34 @@ impl InputFormatContext {
             } else {
                 (*iformat).flags
             }
+        }
+    }
+
+    /// Returns the container's overall bit rate in bits per second, or `0` when
+    /// unknown.
+    #[must_use]
+    pub fn bit_rate(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned demux context; `bit_rate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).bit_rate }
+    }
+
+    /// Returns the input format's short name (for example `"mov,mp4,..."`), or
+    /// `None` when the format or its name is unset.
+    #[must_use]
+    pub fn iformat_name(&self) -> Option<String> {
+        // SAFETY: `self.ptr` is a valid owned demux context. `iformat` is set for
+        //         every successfully opened input, but we null-check both it and
+        //         its `name` pointer defensively before reading the C string.
+        unsafe {
+            let iformat = (*self.ptr.as_ptr()).iformat;
+            if iformat.is_null() {
+                return None;
+            }
+            let name = (*iformat).name;
+            if name.is_null() {
+                return None;
+            }
+            Some(CStr::from_ptr(name).to_string_lossy().into_owned())
         }
     }
 
@@ -261,6 +291,13 @@ impl<'a> StreamRef<'a> {
         unsafe { (*self.ptr.as_ptr()).time_base }
     }
 
+    /// Returns the stream's average frame rate (may be `0/0` when unknown).
+    #[must_use]
+    pub fn avg_frame_rate(&self) -> AVRational {
+        // SAFETY: `self.ptr` borrows a valid stream from a live format context.
+        unsafe { (*self.ptr.as_ptr()).avg_frame_rate }
+    }
+
     /// Returns a borrowed handle to the stream's codec parameters.
     #[must_use]
     pub fn codecpar(&self) -> CodecParameters<'a> {
@@ -300,6 +337,56 @@ impl CodecParameters<'_> {
     pub fn codec_id(&self) -> AVCodecID {
         // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
         unsafe { (*self.ptr.as_ptr()).codec_id }
+    }
+
+    /// Returns the coded width in pixels (0 for non-video streams).
+    #[must_use]
+    pub fn width(&self) -> c_int {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).width }
+    }
+
+    /// Returns the coded height in pixels (0 for non-video streams).
+    #[must_use]
+    pub fn height(&self) -> c_int {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).height }
+    }
+
+    /// Returns the audio sample rate in Hz (0 for non-audio streams).
+    #[must_use]
+    pub fn sample_rate(&self) -> c_int {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).sample_rate }
+    }
+
+    /// Returns the color space.
+    #[must_use]
+    pub fn color_space(&self) -> AVColorSpace {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).color_space }
+    }
+
+    /// Returns the color range.
+    #[must_use]
+    pub fn color_range(&self) -> AVColorRange {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).color_range }
+    }
+
+    /// Returns the color primaries.
+    #[must_use]
+    pub fn color_primaries(&self) -> AVColorPrimaries {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream.
+        unsafe { (*self.ptr.as_ptr()).color_primaries }
+    }
+
+    /// Returns a copy of the channel layout (order / channel count / mask).
+    #[must_use]
+    pub fn ch_layout(&self) -> AVChannelLayout {
+        // SAFETY: `self.ptr` borrows valid codec parameters from a live stream;
+        //         `ch_layout` is a plain POD field copied out by value.
+        unsafe { (*self.ptr.as_ptr()).ch_layout }
     }
 
     /// Returns the underlying raw pointer for FFI calls within the crate.

--- a/crates/ff-sys/src/scale_context.rs
+++ b/crates/ff-sys/src/scale_context.rs
@@ -158,6 +158,79 @@ impl ScaleContext {
         .map_err(AvError::new)
     }
 
+    /// Scales / converts borrowed source plane slices into borrowed destination
+    /// plane slices (safe wrapper).
+    ///
+    /// `src` holds one byte slice per source plane and `src_strides` the matching
+    /// per-plane stride (line size in bytes); `src_h` is the number of source rows
+    /// to process. `dst` holds one mutable byte slice per destination plane and
+    /// `dst_strides` their per-plane strides. This is the fully borrowed-slice
+    /// counterpart of [`scale_planes`](Self::scale_planes) for callers whose
+    /// destination is a plain buffer rather than an owned [`Frame`].
+    ///
+    /// The strides are taken as-is (top-down, positive) following the
+    /// `av_image_copy` convention, so this path never reintroduces the
+    /// negative-linesize row inversion.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if scaling fails.
+    ///
+    /// # Safety
+    ///
+    /// `sws_scale` reads up to `src_strides[i] * src_h` bytes from each `src[i]`
+    /// and writes up to `dst_strides[i] * out_h` bytes into each `dst[i]`, bounds
+    /// the slice types cannot express. The caller must ensure:
+    /// - `src.len() == src_strides.len()` and `dst.len() == dst_strides.len()`,
+    ///   both describing this context's input / output planes;
+    /// - each `src[i]` is at least `src_strides[i] * src_h` bytes (per-plane
+    ///   height per the pixel format's subsampling);
+    /// - each `dst[i]` is at least `dst_strides[i] * out_h` bytes for this
+    ///   context's output geometry;
+    /// - no stride is negative.
+    /// A shorter slice or mismatched stride is an out-of-bounds read / write.
+    pub unsafe fn scale_slices(
+        &mut self,
+        src: &[&[u8]],
+        src_strides: &[c_int],
+        src_h: c_int,
+        dst: &mut [&mut [u8]],
+        dst_strides: &[c_int],
+    ) -> Result<c_int, AvError> {
+        // Build fixed-size plane / stride arrays from the borrowed slices. Unused
+        // entries stay null / zero, matching how FFmpeg frames leave absent planes.
+        const PLANES: usize = AV_NUM_DATA_POINTERS as usize;
+        let mut src_ptrs: [*const u8; PLANES] = [std::ptr::null(); PLANES];
+        let mut src_line: [c_int; PLANES] = [0; PLANES];
+        for (i, (plane, &stride)) in src.iter().zip(src_strides).enumerate().take(PLANES) {
+            src_ptrs[i] = plane.as_ptr();
+            src_line[i] = stride;
+        }
+
+        let mut dst_ptrs: [*mut u8; PLANES] = [std::ptr::null_mut(); PLANES];
+        let mut dst_line: [c_int; PLANES] = [0; PLANES];
+        for (i, (plane, &stride)) in dst.iter_mut().zip(dst_strides).enumerate().take(PLANES) {
+            dst_ptrs[i] = plane.as_mut_ptr();
+            dst_line[i] = stride;
+        }
+
+        // SAFETY: `src_ptrs` / `dst_ptrs` and their stride arrays describe the
+        //         borrowed planes for the duration of the call; `sws_scale`
+        //         reads/writes only within the sized planes.
+        unsafe {
+            crate::swscale::scale(
+                self.ptr.as_ptr(),
+                src_ptrs.as_ptr(),
+                src_line.as_ptr(),
+                0,
+                src_h,
+                dst_ptrs.as_ptr(),
+                dst_line.as_ptr(),
+            )
+        }
+        .map_err(AvError::new)
+    }
+
     /// Scales / converts a slice of the source image into the destination.
     ///
     /// Returns the height of the output slice.
@@ -368,5 +441,100 @@ mod tests {
             unsafe { ctx.scale_planes(&src_planes, &src_strides, src_h as c_int, &mut dst) }
                 .expect("plane scaling should succeed");
         assert_eq!(out_h, 32, "should process all 32 output rows");
+    }
+
+    #[test]
+    fn scale_slices_should_downscale_from_borrowed_slices() {
+        // Feed a single RGB24 plane (borrowed Vec) in and a borrowed Vec out
+        // through the fully-slice path.
+        let src_w = 64usize;
+        let src_h = 64usize;
+        let src_stride = src_w * 3;
+        let src_buf = vec![0u8; src_stride * src_h];
+        let src_planes: [&[u8]; 1] = [src_buf.as_slice()];
+        let src_strides: [c_int; 1] = [src_stride as c_int];
+
+        let dst_w = 32usize;
+        let dst_h = 32usize;
+        let dst_stride = dst_w * 3;
+        let mut dst_buf = vec![0u8; dst_stride * dst_h];
+        let mut dst_planes: [&mut [u8]; 1] = [dst_buf.as_mut_slice()];
+        let dst_strides: [c_int; 1] = [dst_stride as c_int];
+
+        let mut ctx = ScaleContext::new(
+            src_w as c_int,
+            src_h as c_int,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            dst_w as c_int,
+            dst_h as c_int,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            crate::swscale::scale_flags::BILINEAR,
+        )
+        .expect("context creation should succeed");
+
+        // SAFETY: the single src plane is sized `src_stride * src_h`; the single
+        // dst plane is sized `dst_stride * dst_h`.
+        let out_h = unsafe {
+            ctx.scale_slices(
+                &src_planes,
+                &src_strides,
+                src_h as c_int,
+                &mut dst_planes,
+                &dst_strides,
+            )
+        }
+        .expect("slice scaling should succeed");
+        assert_eq!(out_h, dst_h as c_int, "should process all 32 output rows");
+    }
+
+    #[test]
+    fn scale_slices_should_preserve_vertical_row_order() {
+        // RK-008 guard: strides are taken as-is (positive), so an identity-size
+        // scale must keep the source's top-half brightness on top.
+        let (w, h) = (16usize, 16usize);
+        let stride = w * 3;
+        let mut src_buf = vec![0u8; stride * h];
+        for y in 0..h {
+            let val = if y < h / 2 { 200u8 } else { 40u8 };
+            for b in &mut src_buf[y * stride..y * stride + w * 3] {
+                *b = val;
+            }
+        }
+        let src_planes: [&[u8]; 1] = [src_buf.as_slice()];
+        let src_strides: [c_int; 1] = [stride as c_int];
+
+        let mut dst_buf = vec![0u8; stride * h];
+        let mut dst_planes: [&mut [u8]; 1] = [dst_buf.as_mut_slice()];
+        let dst_strides: [c_int; 1] = [stride as c_int];
+
+        let mut ctx = ScaleContext::new(
+            w as c_int,
+            h as c_int,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            w as c_int,
+            h as c_int,
+            AVPixelFormat_AV_PIX_FMT_RGB24,
+            crate::swscale::scale_flags::BILINEAR,
+        )
+        .expect("context creation should succeed");
+
+        // SAFETY: both single planes are sized `stride * h`.
+        unsafe {
+            ctx.scale_slices(
+                &src_planes,
+                &src_strides,
+                h as c_int,
+                &mut dst_planes,
+                &dst_strides,
+            )
+        }
+        .expect("slice scaling should succeed");
+
+        let top = dst_buf[0];
+        let bottom = dst_buf[(h - 1) * stride];
+        assert!(
+            top > bottom,
+            "top row ({top}) must stay brighter than bottom ({bottom}); a row inversion would flip this"
+        );
     }
 }


### PR DESCRIPTION
## Objective

- After #1497, ff-preview still scaled through a raw `ScaleContext::scale`, ff-decode kept a set of raw-pointer metadata reads, and the consumers lacked the read-accessors and the Vec-to-Vec scale needed to go raw-pointer-free. This is sub-scope C-a of #1505: the accessor + slice-scale foundation, delivered with the fully-completable small consumers.

## Solution

- Add `ScaleContext::scale_slices` (borrowed source and destination plane slices — the Vec-to-Vec case), kept `unsafe fn` because the caller still guarantees the plane sizes `sws_scale` requires; plus `CodecContext` dimension/format setters and getters, `CodecParameters` dimension/color/channel-layout getters, `StreamRef::avg_frame_rate`, and `InputFormatContext` `bit_rate` / `iformat_name`.
- Migrate ff-preview's `SwsRgbaConverter` to `scale_slices`; migrate ff-decode's metadata helpers to the new accessors (they become safe fns, closing the raw-pointer sites #1497 retained); migrate ff-filter's four encoder field-writes to setters.
- Tests: `scale_slices` (a downscale and a vertical-row-order guard) and `CodecContext` setter/getter round-trips.

ff-encode (#1508), ff-stream (#1509), and ff-filter's frame/packet drain path (#1510) are relocated to follow-ups; the seal (#1506) and guards (#1481) come after them.

Closes #1505