### PR TITLE
feat(ff-encode): migrate CodecContext access to the safe accessor API

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -20,14 +20,14 @@ use crate::audio::codec_options::{AudioCodecOptions, Mp3Quality};
 use crate::{AudioCodec, EncodeError};
 use ff_format::AudioFrame;
 use ff_sys::{
-    AVAudioFifo, AVChannelLayout, AVCodecContext, AVCodecID, AVCodecID_AV_CODEC_ID_AAC,
-    AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_DTS,
-    AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3,
-    AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
-    AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame,
-    av_frame_alloc, av_frame_free, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
-    av_packet_unref, av_write_trailer, avformat_alloc_output_context2, avformat_free_context,
-    avformat_new_stream, avformat_write_header, swresample,
+    AVAudioFifo, AVChannelLayout, AVCodecID, AVCodecID_AV_CODEC_ID_AAC, AVCodecID_AV_CODEC_ID_AC3,
+    AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3,
+    AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_NONE,
+    AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE,
+    AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame, av_frame_alloc, av_frame_free,
+    av_interleaved_write_frame, av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer,
+    avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
+    avformat_write_header, swresample,
 };
 use std::ffi::{CString, c_void};
 use std::ptr;
@@ -172,14 +172,11 @@ impl AudioEncoderInner {
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Configure codec context
-        (*codec_ctx.as_mut_ptr()).codec_id = codec_to_id(config.codec);
-        (*codec_ctx.as_mut_ptr()).sample_rate = config.sample_rate as i32;
+        codec_ctx.set_codec_id(codec_to_id(config.codec));
+        codec_ctx.set_sample_rate(config.sample_rate as i32);
 
         // Set channel layout using FFmpeg 7.x API
-        swresample::channel_layout::set_default(
-            &raw mut (*codec_ctx.as_mut_ptr()).ch_layout,
-            config.channels as i32,
-        );
+        codec_ctx.set_ch_layout_default(config.channels as i32);
 
         // Select the first sample format the codec actually supports; fall back to FLTP.
         // Reading sample_fmts before avcodec_open2 is required — the encoder uses
@@ -193,14 +190,14 @@ impl AudioEncoderInner {
                 ff_sys::swresample::sample_format::FLTP
             }
         };
-        (*codec_ctx.as_mut_ptr()).sample_fmt = target_fmt;
+        codec_ctx.set_sample_fmt(target_fmt);
 
         // Set bitrate
         if let Some(br) = config.bitrate {
-            (*codec_ctx.as_mut_ptr()).bit_rate = br as i64;
+            codec_ctx.set_bit_rate(br as i64);
         } else {
             // Default bitrate based on codec
-            (*codec_ctx.as_mut_ptr()).bit_rate = match config.codec {
+            codec_ctx.set_bit_rate(match config.codec {
                 AudioCodec::Aac => 192_000,
                 AudioCodec::Opus => 128_000,
                 AudioCodec::Mp3 => 192_000,
@@ -214,19 +211,20 @@ impl AudioEncoderInner {
                 AudioCodec::Dts => 0,  // Lossless/variable
                 AudioCodec::Alac => 0, // Lossless
                 _ => 192_000,
-            };
+            });
         }
 
         // Set time base
-        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
-        (*codec_ctx.as_mut_ptr()).time_base.den = config.sample_rate as i32;
+        codec_ctx.set_time_base(ff_sys::AVRational {
+            num: 1,
+            den: config.sample_rate as i32,
+        });
 
         // Apply per-codec options before opening the codec context.
         if let Some(opts) = &config.codec_options {
-            // SAFETY: codec_ctx is valid and allocated; priv_data is set by
-            // avcodec_alloc_context3. Options are applied before avcodec_open2
-            // so they take effect during codec initialisation.
-            Self::apply_codec_options(codec_ctx.as_mut_ptr(), opts, &encoder_name);
+            // Options are applied before avcodec_open2 so they take effect during
+            // codec initialisation.
+            Self::apply_codec_options(&mut codec_ctx, opts, &encoder_name);
         }
 
         // Open codec
@@ -238,7 +236,7 @@ impl AudioEncoderInner {
         // the encoder requires a fixed number of samples and does not advertise
         // VARIABLE_FRAME_SIZE.  AVAudioFifo handles both planar and packed
         // layouts internally and is backed by a ring-buffer (O(1) read/write).
-        let required = (*codec_ctx.as_mut_ptr()).frame_size as usize;
+        let required = codec_ctx.frame_size() as usize;
         let caps = (*codec_ptr).capabilities as u32;
         if required > 0 && caps & ff_sys::avcodec::codec_caps::VARIABLE_FRAME_SIZE == 0 {
             self.fifo =
@@ -263,7 +261,7 @@ impl AudioEncoderInner {
             });
         }
 
-        (*stream).time_base = (*codec_ctx.as_mut_ptr()).time_base;
+        (*stream).time_base = codec_ctx.time_base();
 
         // Copy ALL codec parameters (including extradata) from the open codec
         // context to the stream.  avcodec_parameters_from_context must be
@@ -280,139 +278,86 @@ impl AudioEncoderInner {
         Ok(())
     }
 
-    /// Apply per-codec options via `av_opt_set` before `avcodec_open2`.
+    /// Apply per-codec options before `avcodec_open2`.
     ///
-    /// All `av_opt_set` return values are checked; a negative value is logged
-    /// as a warning and the option is skipped (never returns an error).
-    unsafe fn apply_codec_options(
-        codec_ctx: *mut AVCodecContext,
+    /// All option failures are logged as a warning and the option is skipped
+    /// (never returns an error).
+    fn apply_codec_options(
+        codec_ctx: &mut ff_sys::CodecContext,
         opts: &AudioCodecOptions,
         encoder_name: &str,
     ) {
         match opts {
             AudioCodecOptions::Opus(opus) => {
                 // application
-                if let Ok(s) = CString::new(opus.application.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"application\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("application", opus.application.as_str())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=application value={} encoder={encoder_name}",
+                        opus.application.as_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=application value={} encoder={encoder_name}",
-                            opus.application.as_str()
-                        );
-                    }
                 }
                 // frame_duration (libopus expects microseconds)
                 if let Some(dur_ms) = opus.frame_duration_ms {
                     let dur_us_str = (i64::from(dur_ms) * 1000).to_string();
-                    if let Ok(s) = CString::new(dur_us_str.as_str()) {
-                        // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                        let ret = ff_sys::av_opt_set(
-                            (*codec_ctx).priv_data,
-                            b"frame_duration\0".as_ptr() as *const i8,
-                            s.as_ptr(),
-                            0,
+                    if codec_ctx.set_opt("frame_duration", &dur_us_str).is_err() {
+                        log::warn!(
+                            "av_opt_set failed option=frame_duration value={dur_us_str} \
+                             encoder={encoder_name}"
                         );
-                        if ret < 0 {
-                            log::warn!(
-                                "av_opt_set failed option=frame_duration value={dur_us_str} \
-                                 encoder={encoder_name}"
-                            );
-                        }
                     }
                 }
             }
             AudioCodecOptions::Aac(aac) => {
                 // profile (aac_low / aac_he / aac_he_v2)
                 let profile_str = aac.profile.as_str();
-                if let Ok(s) = CString::new(profile_str) {
-                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"profile\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx.set_opt("profile", profile_str).is_err() {
+                    log::warn!(
+                        "AAC profile={profile_str} not supported by encoder \
+                         encoder={encoder_name}"
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "AAC profile={profile_str} not supported by encoder \
-                             ret={ret} encoder={encoder_name}"
-                        );
-                    }
                 }
                 // vbr (libfdk_aac VBR quality 1–5)
-                if let Some(q) = aac.vbr_quality {
-                    let q_str = q.to_string();
-                    if let Ok(s) = CString::new(q_str.as_str()) {
-                        // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                        let ret = ff_sys::av_opt_set(
-                            (*codec_ctx).priv_data,
-                            b"vbr\0".as_ptr() as *const i8,
-                            s.as_ptr(),
-                            0,
-                        );
-                        if ret < 0 {
-                            log::warn!(
-                                "av_opt_set failed option=vbr value={q} \
-                                 encoder={encoder_name}"
-                            );
-                        }
-                    }
+                if let Some(q) = aac.vbr_quality
+                    && codec_ctx.set_opt("vbr", &q.to_string()).is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=vbr value={q} \
+                         encoder={encoder_name}"
+                    );
                 }
             }
             AudioCodecOptions::Mp3(mp3) => {
                 match mp3.quality {
                     Mp3Quality::Vbr(q) => {
                         // VBR mode: override bitrate to 0 and set the libmp3lame q scale.
-                        // SAFETY: codec_ctx is non-null; direct field write is safe.
-                        (*codec_ctx).bit_rate = 0;
-                        let q_str = q.to_string();
-                        if let Ok(s) = CString::new(q_str.as_str()) {
-                            // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                            let ret = ff_sys::av_opt_set(
-                                (*codec_ctx).priv_data,
-                                b"q\0".as_ptr() as *const i8,
-                                s.as_ptr(),
-                                0,
+                        codec_ctx.set_bit_rate(0);
+                        if codec_ctx.set_opt("q", &q.to_string()).is_err() {
+                            log::warn!(
+                                "av_opt_set failed option=q value={q} \
+                                 encoder={encoder_name}"
                             );
-                            if ret < 0 {
-                                log::warn!(
-                                    "av_opt_set failed option=q value={q} \
-                                     encoder={encoder_name}"
-                                );
-                            }
                         }
                     }
                     Mp3Quality::Cbr(bitrate) => {
                         // CBR mode: set the fixed bitrate directly on the codec context.
-                        // SAFETY: codec_ctx is non-null; direct field write is safe.
-                        (*codec_ctx).bit_rate = i64::from(bitrate);
+                        codec_ctx.set_bit_rate(i64::from(bitrate));
                     }
                 }
             }
             AudioCodecOptions::Flac(flac) => {
                 // compression_level
-                let level_str = flac.compression_level.to_string();
-                if let Ok(s) = CString::new(level_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; string is NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"compression_level\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("compression_level", &flac.compression_level.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=compression_level value={} \
+                         encoder={encoder_name}",
+                        flac.compression_level
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=compression_level value={} \
-                             encoder={encoder_name}",
-                            flac.compression_level
-                        );
-                    }
                 }
             }
         }

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -208,23 +208,23 @@ impl ImageEncoderInner {
         }
 
         // ── Step 3: Configure codec context ──────────────────────────────────
-        (*inner.codec_ctx.as_mut_ptr()).width = dst_width as i32;
-        (*inner.codec_ctx.as_mut_ptr()).height = dst_height as i32;
-        (*inner.codec_ctx.as_mut_ptr()).time_base = AVRational { num: 1, den: 1 };
-        (*inner.codec_ctx.as_mut_ptr()).pix_fmt = pix_fmt;
+        inner.codec_ctx.set_width(dst_width as i32);
+        inner.codec_ctx.set_height(dst_height as i32);
+        inner.codec_ctx.set_time_base(AVRational { num: 1, den: 1 });
+        inner.codec_ctx.set_pix_fmt(pix_fmt);
 
         // For MJPEG, declare full-range (JPEG) color so FFmpeg does not emit
         // "deprecated pixel format used" warnings that appear when using the
         // deprecated YUVJ420P format. Using YUV420P + AVCOL_RANGE_JPEG is the
         // recommended replacement since FFmpeg 5.x.
         if codec_id == AVCodecID_AV_CODEC_ID_MJPEG {
-            // SAFETY: codec_ctx is non-null; color_range is a plain integer field.
-            (*inner.codec_ctx.as_mut_ptr()).color_range = AVColorRange_AVCOL_RANGE_JPEG;
+            inner
+                .codec_ctx
+                .set_color_range(AVColorRange_AVCOL_RANGE_JPEG);
         }
 
         if let Some(q) = opts.quality {
-            // SAFETY: codec_ctx is non-null and freshly allocated.
-            apply_quality(inner.codec_ctx.as_mut_ptr(), codec_id, q);
+            apply_quality(&mut inner.codec_ctx, codec_id, q);
         }
 
         // ── Step 4: Open codec ────────────────────────────────────────────────
@@ -238,8 +238,8 @@ impl ImageEncoderInner {
         let par = (*stream).codecpar;
         (*par).codec_id = codec_id;
         (*par).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-        (*par).width = (*inner.codec_ctx.as_mut_ptr()).width;
-        (*par).height = (*inner.codec_ctx.as_mut_ptr()).height;
+        (*par).width = inner.codec_ctx.width();
+        (*par).height = inner.codec_ctx.height();
         (*par).format = pix_fmt;
 
         // ── Step 8: Open output file ──────────────────────────────────────────
@@ -564,64 +564,34 @@ fn pixel_format_to_av(fmt: PixelFormat) -> AVPixelFormat {
 ///
 /// Must be called after the codec context fields are set but before
 /// `avcodec_open2`.
-///
-/// # Safety
-///
-/// `codec_ctx` must be a valid, non-null pointer to an allocated
-/// `AVCodecContext` whose `priv_data` is valid (guaranteed after
-/// `avcodec_alloc_context3`).
-unsafe fn apply_quality(codec_ctx: *mut ff_sys::AVCodecContext, codec_id: AVCodecID, quality: u32) {
+fn apply_quality(codec_ctx: &mut ff_sys::CodecContext, codec_id: AVCodecID, quality: u32) {
     let q = quality.min(100);
 
     if codec_id == AVCodecID_AV_CODEC_ID_MJPEG {
         // Map 0–100 (100 = best) → MJPEG qscale 1–31 (1 = best, 31 = worst).
         let qscale = (1 + (100 - q) * 30 / 100) as i32;
-        (*codec_ctx).qmin = qscale;
-        (*codec_ctx).qmax = qscale;
+        codec_ctx.set_qmin(qscale);
+        codec_ctx.set_qmax(qscale);
         log::info!("MJPEG quality applied quality={q} qscale={qscale}");
     } else if codec_id == AVCodecID_AV_CODEC_ID_PNG {
         // Map 0–100 → compression_level 0–9 (9 = maximum compression).
         let level = q * 9 / 100;
-        if (*codec_ctx).priv_data.is_null() {
-            log::warn!("PNG compression_level: priv_data is null, skipping quality={q}");
-            return;
-        }
-        let Ok(key) = CString::new("compression_level") else {
-            return;
-        };
-        let Ok(val) = CString::new(level.to_string()) else {
-            return;
-        };
-        // SAFETY: priv_data is non-null; key/val are valid NUL-terminated strings.
-        let ret = ff_sys::av_opt_set((*codec_ctx).priv_data, key.as_ptr(), val.as_ptr(), 0);
-        if ret < 0 {
+        if let Err(e) = codec_ctx.set_opt("compression_level", &level.to_string()) {
             log::warn!(
                 "av_opt_set compression_level failed, ignoring \
                  quality={q} error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
         } else {
             log::info!("PNG compression_level applied quality={q} level={level}");
         }
     } else if codec_id == AVCodecID_AV_CODEC_ID_WEBP {
         // Direct 0–100 mapping for WebP quality.
-        if (*codec_ctx).priv_data.is_null() {
-            log::warn!("WebP quality: priv_data is null, skipping quality={q}");
-            return;
-        }
-        let Ok(key) = CString::new("quality") else {
-            return;
-        };
-        let Ok(val) = CString::new(q.to_string()) else {
-            return;
-        };
-        // SAFETY: priv_data is non-null; key/val are valid NUL-terminated strings.
-        let ret = ff_sys::av_opt_set((*codec_ctx).priv_data, key.as_ptr(), val.as_ptr(), 0);
-        if ret < 0 {
+        if let Err(e) = codec_ctx.set_opt("quality", &q.to_string()) {
             log::warn!(
                 "av_opt_set quality failed for WebP, ignoring \
                  quality={q} error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
         } else {
             log::info!("WebP quality applied quality={q}");

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -461,11 +461,10 @@ unsafe fn encode_frame_as_png_inner(
         }
     };
 
-    // SAFETY: codec_ctx is non-null (allocation succeeded).
-    (*codec_ctx.as_mut_ptr()).width = width;
-    (*codec_ctx.as_mut_ptr()).height = height;
-    (*codec_ctx.as_mut_ptr()).time_base = AVRational { num: 1, den: 1 };
-    (*codec_ctx.as_mut_ptr()).pix_fmt = pix_fmt;
+    codec_ctx.set_width(width);
+    codec_ctx.set_height(height);
+    codec_ctx.set_time_base(AVRational { num: 1, den: 1 });
+    codec_ctx.set_pix_fmt(pix_fmt);
 
     if let Err(e) = codec_ctx.open(codec, ptr::null_mut()) {
         drop(codec_ctx);
@@ -1216,16 +1215,15 @@ unsafe fn encode_gif_unsafe(
     let out_pix_fmt = (*first_frame).format;
 
     // Configure GIF encoder.
-    // SAFETY: codec_ctx is non-null.
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let fps_int = fps.round().max(1.0) as u32;
-    (*codec_ctx.as_mut_ptr()).width = out_width;
-    (*codec_ctx.as_mut_ptr()).height = out_height;
-    (*codec_ctx.as_mut_ptr()).time_base = AVRational {
+    codec_ctx.set_width(out_width);
+    codec_ctx.set_height(out_height);
+    codec_ctx.set_time_base(AVRational {
         num: 1,
         den: fps_int as i32,
-    };
-    (*codec_ctx.as_mut_ptr()).pix_fmt = out_pix_fmt;
+    });
+    codec_ctx.set_pix_fmt(out_pix_fmt);
 
     // Set GIF to loop infinitely (option "loop" = 0).
     // SAFETY: priv_data is valid after alloc_context3; av_opt_set handles unknown options gracefully.

--- a/crates/ff-encode/src/video/builder/mod.rs
+++ b/crates/ff-encode/src/video/builder/mod.rs
@@ -840,7 +840,6 @@ mod tests {
                 pass1_codec_ctx: None,
                 buffered_frames: Vec::new(),
                 two_pass_config: None,
-                stats_in_cstr: None,
                 subtitle_passthrough: None,
                 hdr10_metadata: None,
             }),

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -18,9 +18,9 @@ use super::options::audio_codec_to_id;
 use super::two_pass::AV_CODEC_FLAG_PASS1;
 use super::{
     AV_TIME_BASE, AVChapter, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P,
-    AudioCodec, CString, EncodeError, VideoCodec, VideoEncoderInner, av_interleaved_write_frame,
-    av_mallocz, av_packet_alloc, av_packet_free, av_packet_unref, avformat_free_context,
-    avformat_new_stream, ptr, swresample,
+    AudioCodec, EncodeError, VideoCodec, VideoEncoderInner, av_interleaved_write_frame, av_mallocz,
+    av_packet_alloc, av_packet_free, av_packet_unref, avformat_free_context, avformat_new_stream,
+    ptr,
 };
 
 impl VideoEncoderInner {
@@ -216,120 +216,94 @@ impl VideoEncoderInner {
         // fallback encoder is selected (e.g. libvpx-vp9 instead of libx264 for
         // H.264), the codec_id must match the actual encoder, not the requested
         // codec family, otherwise avcodec_open2 rejects it with EINVAL.
-        (*codec_ctx.as_mut_ptr()).codec_id = (*codec_ptr).id;
-        (*codec_ctx.as_mut_ptr()).width = width as i32;
-        (*codec_ctx.as_mut_ptr()).height = height as i32;
-        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
-        (*codec_ctx.as_mut_ptr()).time_base.den = (fps * 1000.0) as i32; // Use millisecond precision
-        (*codec_ctx.as_mut_ptr()).framerate.num = fps as i32;
-        (*codec_ctx.as_mut_ptr()).framerate.den = 1;
-        (*codec_ctx.as_mut_ptr()).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        codec_ctx.set_codec_id((*codec_ptr).id);
+        codec_ctx.set_width(width as i32);
+        codec_ctx.set_height(height as i32);
+        codec_ctx.set_time_base(ff_sys::AVRational {
+            num: 1,
+            den: (fps * 1000.0) as i32, // Use millisecond precision
+        });
+        codec_ctx.set_framerate(ff_sys::AVRational {
+            num: fps as i32,
+            den: 1,
+        });
+        codec_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
 
         // Set bitrate control mode
         match bitrate_mode {
             Some(BitrateMode::Cbr(bps)) => {
-                (*codec_ctx.as_mut_ptr()).bit_rate = *bps as i64;
+                codec_ctx.set_bit_rate(*bps as i64);
             }
             Some(BitrateMode::Vbr { target, max }) => {
-                (*codec_ctx.as_mut_ptr()).bit_rate = *target as i64;
-                (*codec_ctx.as_mut_ptr()).rc_max_rate = *max as i64;
-                (*codec_ctx.as_mut_ptr()).rc_buffer_size = (*max * 2) as i32;
+                codec_ctx.set_bit_rate(*target as i64);
+                codec_ctx.set_rc_max_rate(*max as i64);
+                codec_ctx.set_rc_buffer_size((*max * 2) as i32);
             }
             Some(BitrateMode::Crf(q)) => {
-                let crf_str = CString::new(q.to_string()).map_err(|_| EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Invalid CRF value".to_string(),
-                })?;
-                // SAFETY: priv_data, option name, and value are all valid pointers
-                let ret = ff_sys::av_opt_set(
-                    (*codec_ctx.as_mut_ptr()).priv_data,
-                    b"crf\0".as_ptr() as *const i8,
-                    crf_str.as_ptr(),
-                    0,
-                );
-                if ret < 0 {
+                if codec_ctx.set_opt("crf", &q.to_string()).is_err() {
                     log::warn!(
                         "crf option not supported by encoder, falling back to default bitrate \
                          encoder={encoder_name} crf={q}"
                     );
-                    (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
+                    codec_ctx.set_bit_rate(2_000_000);
                 }
             }
             None => {
                 // Default 2 Mbps
-                (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
+                codec_ctx.set_bit_rate(2_000_000);
             }
         }
 
         // Set preset for x264/x265
-        if encoder_name.contains("264") || encoder_name.contains("265") {
-            let preset_cstr = CString::new(preset).map_err(|_| EncodeError::Ffmpeg {
-                code: 0,
-                message: "Invalid preset value".to_string(),
-            })?;
-            // SAFETY: priv_data, option name, and value are all valid pointers
-            let ret = ff_sys::av_opt_set(
-                (*codec_ctx.as_mut_ptr()).priv_data,
-                b"preset\0".as_ptr() as *const i8,
-                preset_cstr.as_ptr(),
-                0,
+        if (encoder_name.contains("264") || encoder_name.contains("265"))
+            && codec_ctx.set_opt("preset", preset).is_err()
+        {
+            log::warn!(
+                "preset option not supported by encoder, ignoring \
+                 encoder={encoder_name} preset={preset}"
             );
-            if ret < 0 {
-                log::warn!(
-                    "preset option not supported by encoder, ignoring \
-                     encoder={encoder_name} preset={preset}"
-                );
-            }
         }
 
         // Apply per-codec options before opening the codec context.
         if let Some(opts) = codec_options {
-            // SAFETY: codec_ctx is valid and allocated; priv_data is set by
-            // avcodec_alloc_context3. Options are applied before avcodec_open2
-            // so they take effect during codec initialisation.
-            Self::apply_codec_options(codec_ctx.as_mut_ptr(), opts, &encoder_name);
+            // Options are applied before avcodec_open2 so they take effect during
+            // codec initialisation.
+            Self::apply_codec_options(&mut codec_ctx, opts, &encoder_name);
         }
 
         // Apply explicit pixel format override (takes priority over codec-option auto-select).
         if let Some(fmt) = pixel_format {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).pix_fmt = pixel_format_to_av(*fmt);
+            codec_ctx.set_pix_fmt(pixel_format_to_av(*fmt));
         }
 
         // Apply HDR10 color context: BT.2020 primaries, PQ transfer, BT.2020 NCL colorspace.
         if self.hdr10_metadata.is_some() {
-            // SAFETY: codec_ctx is valid and allocated; direct field writes are safe.
-            (*codec_ctx.as_mut_ptr()).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
-            (*codec_ctx.as_mut_ptr()).color_trc =
-                ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
-            (*codec_ctx.as_mut_ptr()).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
+            codec_ctx.set_color_primaries(ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020);
+            codec_ctx.set_color_trc(ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084);
+            codec_ctx.set_colorspace(ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL);
         }
 
         // Apply explicit color overrides (take priority over HDR10 automatic defaults).
         if let Some(cs) = color_space {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).colorspace = color_space_to_av(cs);
+            codec_ctx.set_colorspace(color_space_to_av(cs));
         }
         if let Some(trc) = color_transfer {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).color_trc = color_transfer_to_av(trc);
+            codec_ctx.set_color_trc(color_transfer_to_av(trc));
         }
         if let Some(cp) = color_primaries {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).color_primaries = color_primaries_to_av(cp);
+            codec_ctx.set_color_primaries(color_primaries_to_av(cp));
         }
 
         // For two-pass, set the pass-1 flag before opening the codec.
         if two_pass {
-            // SAFETY: codec_ctx is a valid allocated (but not yet opened) context.
-            (*codec_ctx.as_mut_ptr()).flags |= AV_CODEC_FLAG_PASS1;
+            codec_ctx.set_flags(codec_ctx.flags() | AV_CODEC_FLAG_PASS1);
         }
 
         // Open codec
         codec_ctx
             .open(selected_codec, ptr::null_mut())
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
-        let actual_pix_fmt = from_av_pixel_format((*codec_ctx.as_mut_ptr()).pix_fmt);
+        let actual_pix_fmt = from_av_pixel_format(codec_ctx.pix_fmt());
         log::info!(
             "codec opened codec={encoder_name} width={width} height={height} fps={fps} \
              pix_fmt={actual_pix_fmt}"
@@ -345,15 +319,15 @@ impl VideoEncoderInner {
             });
         }
 
-        (*stream).time_base = (*codec_ctx.as_mut_ptr()).time_base;
+        (*stream).time_base = codec_ctx.time_base();
 
         // Copy codec parameters to stream
         if !(*stream).codecpar.is_null() {
-            (*(*stream).codecpar).codec_id = (*codec_ctx.as_mut_ptr()).codec_id;
+            (*(*stream).codecpar).codec_id = codec_ctx.codec_id();
             (*(*stream).codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-            (*(*stream).codecpar).width = (*codec_ctx.as_mut_ptr()).width;
-            (*(*stream).codecpar).height = (*codec_ctx.as_mut_ptr()).height;
-            (*(*stream).codecpar).format = (*codec_ctx.as_mut_ptr()).pix_fmt;
+            (*(*stream).codecpar).width = codec_ctx.width();
+            (*(*stream).codecpar).height = codec_ctx.height();
+            (*(*stream).codecpar).format = codec_ctx.pix_fmt();
         }
 
         self.video_stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
@@ -398,14 +372,11 @@ impl VideoEncoderInner {
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Configure codec context
-        (*codec_ctx.as_mut_ptr()).codec_id = audio_codec_to_id(codec);
-        (*codec_ctx.as_mut_ptr()).sample_rate = sample_rate as i32;
+        codec_ctx.set_codec_id(audio_codec_to_id(codec));
+        codec_ctx.set_sample_rate(sample_rate as i32);
 
         // Set channel layout using FFmpeg 7.x API
-        swresample::channel_layout::set_default(
-            &raw mut (*codec_ctx.as_mut_ptr()).ch_layout,
-            channels as i32,
-        );
+        codec_ctx.set_ch_layout_default(channels as i32);
 
         // Use the first sample format the codec actually declares; fall back to
         // FLTP only when the codec exposes no preference.  FLTP is NOT valid for
@@ -418,14 +389,14 @@ impl VideoEncoderInner {
                 ff_sys::swresample::sample_format::FLTP
             }
         };
-        (*codec_ctx.as_mut_ptr()).sample_fmt = target_fmt;
+        codec_ctx.set_sample_fmt(target_fmt);
 
         // Set bitrate
         if let Some(br) = bitrate {
-            (*codec_ctx.as_mut_ptr()).bit_rate = br as i64;
+            codec_ctx.set_bit_rate(br as i64);
         } else {
             // Default bitrate based on codec
-            (*codec_ctx.as_mut_ptr()).bit_rate = match codec {
+            codec_ctx.set_bit_rate(match codec {
                 AudioCodec::Aac => 192_000,
                 AudioCodec::Opus => 128_000,
                 AudioCodec::Mp3 => 192_000,
@@ -439,12 +410,14 @@ impl VideoEncoderInner {
                 AudioCodec::Dts => 0,  // Lossless/variable
                 AudioCodec::Alac => 0, // Lossless
                 _ => 192_000,
-            };
+            });
         }
 
         // Set time base
-        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
-        (*codec_ctx.as_mut_ptr()).time_base.den = sample_rate as i32;
+        codec_ctx.set_time_base(ff_sys::AVRational {
+            num: 1,
+            den: sample_rate as i32,
+        });
 
         // Open codec
         codec_ctx
@@ -461,7 +434,7 @@ impl VideoEncoderInner {
             });
         }
 
-        (*stream).time_base = (*codec_ctx.as_mut_ptr()).time_base;
+        (*stream).time_base = codec_ctx.time_base();
 
         // Copy all codec parameters to the stream — including extradata (e.g. AAC
         // AudioSpecificConfig) that is only available after avcodec_open2.
@@ -476,9 +449,9 @@ impl VideoEncoderInner {
         }
 
         // Read the FIFO parameters before moving the owned context into `self`.
-        let frame_size = (*codec_ctx.as_mut_ptr()).frame_size;
-        let fifo_sample_fmt = (*codec_ctx.as_mut_ptr()).sample_fmt;
-        let fifo_nb_channels = (*codec_ctx.as_mut_ptr()).ch_layout.nb_channels;
+        let frame_size = codec_ctx.frame_size();
+        let fifo_sample_fmt = codec_ctx.sample_fmt();
+        let fifo_nb_channels = codec_ctx.channels();
 
         self.audio_stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
         self.audio_codec_ctx = Some(codec_ctx);
@@ -819,16 +792,11 @@ impl VideoEncoderInner {
 
     /// Cleanup FFmpeg resources.
     pub(super) unsafe fn cleanup(&mut self) {
-        // Free video codec context.
-        // For two-pass encoding, stats_in points into self.stats_in_cstr (Rust-owned).
-        // Null it out BEFORE the owned context is dropped (its Drop frees the codec
-        // context) so FFmpeg does not call av_free on the Rust-owned pointer.
-        if let Some(mut ctx) = self.video_codec_ctx.take() {
-            (*ctx.as_mut_ptr()).stats_in = ptr::null_mut();
-            // `ctx` drops here, freeing the codec context.
-        }
-        // Drop the owned CString now that the codec context no longer references it.
-        self.stats_in_cstr = None;
+        // Free video codec context. For two-pass encoding the context may still
+        // reference a Rust-owned `stats_in` buffer; `CodecContext::Drop` nulls the
+        // field before `avcodec_free_context`, so dropping the owned context here
+        // is sufficient.
+        self.video_codec_ctx = None;
 
         // Free pass-1 codec context (only set in two-pass mode); drops on assignment.
         self.pass1_codec_ctx = None;

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -111,12 +111,6 @@ pub(super) struct VideoEncoderInner {
     /// Stored configuration for reconstructing the pass-2 codec context.
     pub(super) two_pass_config: Option<VideoEncoderConfig>,
 
-    /// Owned `stats_in` C string that must outlive the pass-2 codec context.
-    ///
-    /// Nulled out in `cleanup()` before `avcodec_free_context` to prevent FFmpeg
-    /// from calling `av_free` on a Rust-allocated pointer.
-    pub(super) stats_in_cstr: Option<std::ffi::CString>,
-
     /// Subtitle passthrough info: (source_path, source_stream_index, output_stream_index).
     ///
     /// Set by `init_subtitle_passthrough`; read by `write_subtitle_packets`.
@@ -224,7 +218,6 @@ impl VideoEncoderInner {
                 pass1_codec_ctx: None,
                 buffered_frames: Vec::new(),
                 two_pass_config: None,
-                stats_in_cstr: None,
                 subtitle_passthrough: None,
                 hdr10_metadata: config.hdr10_metadata.clone(),
             };
@@ -1083,7 +1076,6 @@ mod tests {
             pass1_codec_ctx: None,
             buffered_frames: Vec::new(),
             two_pass_config: None,
-            stats_in_cstr: None,
             subtitle_passthrough: None,
             hdr10_metadata: None,
         }

--- a/crates/ff-encode/src/video/encoder_inner/options.rs
+++ b/crates/ff-encode/src/video/encoder_inner/options.rs
@@ -11,16 +11,15 @@
 #![allow(clippy::unused_self)]
 
 use super::{
-    AVCodecContext, AVCodecID, AVCodecID_AV_CODEC_ID_AAC, AVCodecID_AV_CODEC_ID_AC3,
-    AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_AV1, AVCodecID_AV_CODEC_ID_DNXHD,
-    AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FFV1,
-    AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC,
-    AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
-    AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS,
-    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG,
-    AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8,
-    AVCodecID_AV_CODEC_ID_VP9, AudioCodec, CString, EncodeError, VideoCodec, VideoEncoderInner,
-    avcodec,
+    AVCodecID, AVCodecID_AV_CODEC_ID_AAC, AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC,
+    AVCodecID_AV_CODEC_ID_AV1, AVCodecID_AV_CODEC_ID_DNXHD, AVCodecID_AV_CODEC_ID_DTS,
+    AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FFV1, AVCodecID_AV_CODEC_ID_FLAC,
+    AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC, AVCodecID_AV_CODEC_ID_MJPEG,
+    AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_MPEG2VIDEO, AVCodecID_AV_CODEC_ID_MPEG4,
+    AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
+    AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG, AVCodecID_AV_CODEC_ID_PRORES,
+    AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9, AudioCodec,
+    CString, EncodeError, VideoCodec, VideoEncoderInner, avcodec,
 };
 
 /// Convert VideoCodec to FFmpeg AVCodecID.
@@ -78,508 +77,284 @@ pub(super) fn audio_codec_to_id(codec: AudioCodec) -> AVCodecID {
 impl VideoEncoderInner {
     /// Apply per-codec options to an allocated (not yet opened) codec context.
     ///
-    /// All `av_opt_set` return values are checked; a negative value is logged
-    /// as a warning and skipped — it never propagates as an error.
-    ///
-    /// # Safety
-    ///
-    /// `codec_ctx` must be a valid non-null pointer to an allocated
-    /// `AVCodecContext` whose `priv_data` has been set by
-    /// `avcodec_alloc_context3`. Must be called **before** `avcodec_open2`.
-    pub(super) unsafe fn apply_codec_options(
-        codec_ctx: *mut AVCodecContext,
+    /// All option failures are logged as a warning and skipped — they never
+    /// propagate as an error. Must be called **before** `avcodec_open2`.
+    pub(super) fn apply_codec_options(
+        codec_ctx: &mut ff_sys::CodecContext,
         opts: &crate::video::codec_options::VideoCodecOptions,
         encoder_name: &str,
     ) {
         use crate::video::codec_options::VideoCodecOptions;
-        use std::ffi::CString;
 
         match opts {
             VideoCodecOptions::H264(h264) => {
                 // profile
-                if let Ok(s) = CString::new(h264.profile.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null (set by avcodec_alloc_context3);
-                    // option name and value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"profile\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx.set_opt("profile", h264.profile.as_str()).is_err() {
+                    log::warn!(
+                        "av_opt_set failed option=profile value={} encoder={encoder_name}",
+                        h264.profile.as_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=profile value={} encoder={encoder_name}",
-                            h264.profile.as_str()
-                        );
-                    }
                 }
                 // level (only when explicitly set)
-                if let Some(level) = h264.level {
-                    let level_str = level.to_string();
-                    if let Ok(s) = CString::new(level_str.as_str()) {
-                        // SAFETY: codec_ctx and priv_data are non-null; option name and
-                        // value are valid NUL-terminated C strings.
-                        let ret = ff_sys::av_opt_set(
-                            (*codec_ctx).priv_data,
-                            b"level\0".as_ptr() as *const i8,
-                            s.as_ptr(),
-                            0,
-                        );
-                        if ret < 0 {
-                            log::warn!(
-                                "av_opt_set failed option=level value={level} \
-                                 encoder={encoder_name}"
-                            );
-                        }
-                    }
+                if let Some(level) = h264.level
+                    && codec_ctx.set_opt("level", &level.to_string()).is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=level value={level} \
+                         encoder={encoder_name}"
+                    );
                 }
                 // Direct codec context fields.
-                // SAFETY: codec_ctx is a valid allocated AVCodecContext.
-                (*codec_ctx).max_b_frames = h264.bframes as i32;
-                (*codec_ctx).gop_size = h264.gop_size as i32;
-                (*codec_ctx).refs = h264.refs as i32;
+                codec_ctx.set_max_b_frames(h264.bframes as i32);
+                codec_ctx.set_gop_size(h264.gop_size as i32);
+                codec_ctx.set_refs(h264.refs as i32);
                 // preset (libx264-specific; hardware encoders return a negative value
                 // which we log and skip — never returned as an error)
                 if let Some(preset) = h264.preset
-                    && let Ok(s) = CString::new(preset.as_str())
+                    && codec_ctx.set_opt("preset", preset.as_str()).is_err()
                 {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name
-                    // and value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"preset\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                    log::warn!(
+                        "av_opt_set failed option=preset value={} \
+                         encoder={encoder_name}",
+                        preset.as_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=preset value={} \
-                             encoder={encoder_name}",
-                            preset.as_str()
-                        );
-                    }
                 }
                 // tune (libx264-specific; hardware encoders return a negative value
                 // which we log and skip — never returned as an error)
                 if let Some(tune) = h264.tune
-                    && let Ok(s) = CString::new(tune.as_str())
+                    && codec_ctx.set_opt("tune", tune.as_str()).is_err()
                 {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name
-                    // and value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tune\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                    log::warn!(
+                        "av_opt_set failed option=tune value={} \
+                         encoder={encoder_name}",
+                        tune.as_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tune value={} \
-                             encoder={encoder_name}",
-                            tune.as_str()
-                        );
-                    }
                 }
             }
             VideoCodecOptions::H265(h265) => {
                 // profile
-                if let Ok(s) = CString::new(h265.profile.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"profile\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx.set_opt("profile", h265.profile.as_str()).is_err() {
+                    log::warn!(
+                        "av_opt_set failed option=profile value={} encoder={encoder_name}",
+                        h265.profile.as_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=profile value={} encoder={encoder_name}",
-                            h265.profile.as_str()
-                        );
-                    }
                 }
                 // Auto-select yuv420p10le for Main10 (may be overridden by an explicit
                 // pixel_format() call applied after apply_codec_options returns).
                 if h265.profile == crate::video::codec_options::H265Profile::Main10 {
-                    // SAFETY: codec_ctx is valid; direct field write is safe.
-                    (*codec_ctx).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE;
+                    codec_ctx.set_pix_fmt(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P10LE);
                 }
                 // tier
-                if let Ok(s) = CString::new(h265.tier.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tier\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx.set_opt("tier", h265.tier.as_str()).is_err() {
+                    log::warn!(
+                        "av_opt_set failed option=tier value={} encoder={encoder_name}",
+                        h265.tier.as_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tier value={} encoder={encoder_name}",
-                            h265.tier.as_str()
-                        );
-                    }
                 }
                 // level (only when explicitly set)
-                if let Some(level) = h265.level {
-                    let level_str = level.to_string();
-                    if let Ok(s) = CString::new(level_str.as_str()) {
-                        // SAFETY: codec_ctx and priv_data are non-null; option name and
-                        // value are valid NUL-terminated C strings.
-                        let ret = ff_sys::av_opt_set(
-                            (*codec_ctx).priv_data,
-                            b"level\0".as_ptr() as *const i8,
-                            s.as_ptr(),
-                            0,
-                        );
-                        if ret < 0 {
-                            log::warn!(
-                                "av_opt_set failed option=level value={level} \
-                                 encoder={encoder_name}"
-                            );
-                        }
-                    }
+                if let Some(level) = h265.level
+                    && codec_ctx.set_opt("level", &level.to_string()).is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=level value={level} \
+                         encoder={encoder_name}"
+                    );
                 }
                 // preset (libx265-specific; hardware HEVC encoders return a negative value
                 // which we log and skip — never returned as an error)
                 if let Some(ref preset) = h265.preset
-                    && let Ok(s) = CString::new(preset.as_str())
+                    && codec_ctx.set_opt("preset", preset.as_str()).is_err()
                 {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name
-                    // and value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"preset\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                    log::warn!(
+                        "av_opt_set failed option=preset value={preset} \
+                         encoder={encoder_name}"
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=preset value={preset} \
-                             encoder={encoder_name}"
-                        );
-                    }
                 }
                 // x265-params raw passthrough (libx265 only)
                 if let Some(ref params) = h265.x265_params
-                    && let Ok(s) = CString::new(params.as_str())
+                    && codec_ctx.set_opt("x265-params", params.as_str()).is_err()
                 {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name
-                    // and value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"x265-params\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                    log::warn!(
+                        "av_opt_set failed option=x265-params value={params} \
+                         encoder={encoder_name}"
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=x265-params value={params} \
-                             encoder={encoder_name}"
-                        );
-                    }
                 }
             }
             VideoCodecOptions::Av1(av1) => {
                 // cpu-used
-                let cpu_used_str = av1.cpu_used.to_string();
-                if let Ok(s) = CString::new(cpu_used_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"cpu-used\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("cpu-used", &av1.cpu_used.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=cpu-used value={} encoder={encoder_name}",
+                        av1.cpu_used
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=cpu-used value={} encoder={encoder_name}",
-                            av1.cpu_used
-                        );
-                    }
                 }
                 // tile-rows
-                let tile_rows_str = av1.tile_rows.to_string();
-                if let Ok(s) = CString::new(tile_rows_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tile-rows\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("tile-rows", &av1.tile_rows.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=tile-rows value={} encoder={encoder_name}",
+                        av1.tile_rows
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tile-rows value={} encoder={encoder_name}",
-                            av1.tile_rows
-                        );
-                    }
                 }
                 // tile-columns
-                let tile_cols_str = av1.tile_cols.to_string();
-                if let Ok(s) = CString::new(tile_cols_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tile-columns\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("tile-columns", &av1.tile_cols.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=tile-columns value={} \
+                         encoder={encoder_name}",
+                        av1.tile_cols
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tile-columns value={} \
-                             encoder={encoder_name}",
-                            av1.tile_cols
-                        );
-                    }
                 }
                 // usage
-                if let Ok(s) = CString::new(av1.usage.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"usage\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx.set_opt("usage", av1.usage.as_str()).is_err() {
+                    log::warn!(
+                        "av_opt_set failed option=usage value={} encoder={encoder_name}",
+                        av1.usage.as_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=usage value={} encoder={encoder_name}",
-                            av1.usage.as_str()
-                        );
-                    }
                 }
             }
             VideoCodecOptions::Av1Svt(svt) => {
                 // preset (0–13)
-                let preset_str = svt.preset.to_string();
-                if let Ok(s) = CString::new(preset_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"preset\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("preset", &svt.preset.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=preset value={} \
+                         encoder={encoder_name}",
+                        svt.preset
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=preset value={} \
-                             encoder={encoder_name}",
-                            svt.preset
-                        );
-                    }
                 }
                 // tile-rows
-                let tile_rows_str = svt.tile_rows.to_string();
-                if let Ok(s) = CString::new(tile_rows_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tile_rows\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("tile_rows", &svt.tile_rows.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=tile_rows value={} \
+                         encoder={encoder_name}",
+                        svt.tile_rows
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tile_rows value={} \
-                             encoder={encoder_name}",
-                            svt.tile_rows
-                        );
-                    }
                 }
                 // tile-columns
-                let tile_cols_str = svt.tile_cols.to_string();
-                if let Ok(s) = CString::new(tile_cols_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tile_columns\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                if codec_ctx
+                    .set_opt("tile_columns", &svt.tile_cols.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=tile_columns value={} \
+                         encoder={encoder_name}",
+                        svt.tile_cols
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tile_columns value={} \
-                             encoder={encoder_name}",
-                            svt.tile_cols
-                        );
-                    }
                 }
                 // svtav1-params raw passthrough
                 if let Some(ref params) = svt.svtav1_params
-                    && let Ok(s) = CString::new(params.as_str())
+                    && codec_ctx.set_opt("svtav1-params", params.as_str()).is_err()
                 {
-                    // SAFETY: codec_ctx and priv_data are non-null; option name and
-                    // value are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"svtav1-params\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                    log::warn!(
+                        "av_opt_set failed option=svtav1-params value={params} \
+                         encoder={encoder_name}"
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=svtav1-params value={params} \
-                             encoder={encoder_name}"
-                        );
-                    }
                 }
             }
             VideoCodecOptions::Vp9(vp9) => {
                 // CQ mode: override bitrate to 0 and set crf
                 if let Some(cq) = vp9.cq_level {
-                    // SAFETY: codec_ctx is non-null; direct field write is safe.
-                    (*codec_ctx).bit_rate = 0;
-                    let cq_str = cq.to_string();
-                    if let Ok(s) = CString::new(cq_str.as_str()) {
-                        // SAFETY: codec_ctx and priv_data are non-null; strings are
-                        // NUL-terminated.
-                        let ret = ff_sys::av_opt_set(
-                            (*codec_ctx).priv_data,
-                            b"crf\0".as_ptr() as *const i8,
-                            s.as_ptr(),
-                            0,
-                        );
-                        if ret < 0 {
-                            log::warn!(
-                                "av_opt_set failed option=crf value={cq} \
-                                 encoder={encoder_name}"
-                            );
-                        }
-                    }
-                }
-                // cpu-used
-                let cpu_used_str = vp9.cpu_used.to_string();
-                if let Ok(s) = CString::new(cpu_used_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; strings are
-                    // NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"cpu-used\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
-                    );
-                    if ret < 0 {
+                    codec_ctx.set_bit_rate(0);
+                    if codec_ctx.set_opt("crf", &cq.to_string()).is_err() {
                         log::warn!(
-                            "av_opt_set failed option=cpu-used value={} \
-                             encoder={encoder_name}",
-                            vp9.cpu_used
-                        );
-                    }
-                }
-                // tile-columns
-                let tile_cols_str = vp9.tile_columns.to_string();
-                if let Ok(s) = CString::new(tile_cols_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; strings are
-                    // NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tile-columns\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
-                    );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tile-columns value={} \
-                             encoder={encoder_name}",
-                            vp9.tile_columns
-                        );
-                    }
-                }
-                // tile-rows
-                let tile_rows_str = vp9.tile_rows.to_string();
-                if let Ok(s) = CString::new(tile_rows_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; strings are
-                    // NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"tile-rows\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
-                    );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=tile-rows value={} \
-                             encoder={encoder_name}",
-                            vp9.tile_rows
-                        );
-                    }
-                }
-                // row-mt
-                let row_mt_str = if vp9.row_mt { "1" } else { "0" };
-                if let Ok(s) = CString::new(row_mt_str) {
-                    // SAFETY: codec_ctx and priv_data are non-null; strings are
-                    // NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"row-mt\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
-                    );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=row-mt value={row_mt_str} \
+                            "av_opt_set failed option=crf value={cq} \
                              encoder={encoder_name}"
                         );
                     }
+                }
+                // cpu-used
+                if codec_ctx
+                    .set_opt("cpu-used", &vp9.cpu_used.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=cpu-used value={} \
+                         encoder={encoder_name}",
+                        vp9.cpu_used
+                    );
+                }
+                // tile-columns
+                if codec_ctx
+                    .set_opt("tile-columns", &vp9.tile_columns.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=tile-columns value={} \
+                         encoder={encoder_name}",
+                        vp9.tile_columns
+                    );
+                }
+                // tile-rows
+                if codec_ctx
+                    .set_opt("tile-rows", &vp9.tile_rows.to_string())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=tile-rows value={} \
+                         encoder={encoder_name}",
+                        vp9.tile_rows
+                    );
+                }
+                // row-mt
+                let row_mt_str = if vp9.row_mt { "1" } else { "0" };
+                if codec_ctx.set_opt("row-mt", row_mt_str).is_err() {
+                    log::warn!(
+                        "av_opt_set failed option=row-mt value={row_mt_str} \
+                         encoder={encoder_name}"
+                    );
                 }
             }
             VideoCodecOptions::ProRes(prores) => {
                 // Set pixel format based on profile before avcodec_open2.
                 // 4444 profiles need yuva444p10le; 422 profiles need yuv422p10le.
-                // SAFETY: codec_ctx is non-null; direct field write is safe.
                 if prores.profile.is_4444() {
-                    (*codec_ctx).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE;
+                    codec_ctx.set_pix_fmt(ff_sys::AVPixelFormat_AV_PIX_FMT_YUVA444P10LE);
                 } else {
-                    (*codec_ctx).pix_fmt = ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE;
+                    codec_ctx.set_pix_fmt(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE);
                 }
 
-                // Apply profile via av_opt_set on priv_data.
-                let profile_str = prores.profile.profile_id().to_string();
-                if let Ok(s) = CString::new(profile_str.as_str()) {
-                    // SAFETY: codec_ctx and priv_data are non-null; strings are
-                    // NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"profile\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
-                    );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=profile value={} \
-                             encoder={encoder_name}",
-                            prores.profile.profile_id()
-                        );
-                    }
-                }
-
-                // Apply optional vendor tag.
-                if let Some(vendor) = prores.vendor
-                    && let Ok(s) = CString::new(vendor.as_ref())
+                // Apply profile via the private-option setter.
+                if codec_ctx
+                    .set_opt("profile", &prores.profile.profile_id().to_string())
+                    .is_err()
                 {
-                    // SAFETY: codec_ctx and priv_data are non-null; strings are
-                    // NUL-terminated.
-                    let ret = ff_sys::av_opt_set(
-                        (*codec_ctx).priv_data,
-                        b"vendor\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        0,
+                    log::warn!(
+                        "av_opt_set failed option=profile value={} \
+                         encoder={encoder_name}",
+                        prores.profile.profile_id()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=vendor \
+                }
+
+                // Apply optional vendor tag (a 4-byte FourCC). Pass the raw bytes
+                // via a CString so a non-ASCII tag is not mangled by a lossy
+                // UTF-8 conversion.
+                if let Some(vendor) = prores.vendor {
+                    match std::ffi::CString::new(&vendor[..]) {
+                        Ok(vendor_c) => {
+                            if codec_ctx.set_opt_cstr("vendor", &vendor_c).is_err() {
+                                log::warn!(
+                                    "av_opt_set failed option=vendor \
+                                     encoder={encoder_name}"
+                                );
+                            }
+                        }
+                        Err(_) => log::warn!(
+                            "prores vendor tag has an interior NUL; skipping \
                              encoder={encoder_name}"
-                        );
+                        ),
                     }
                 }
             }
@@ -587,40 +362,30 @@ impl VideoEncoderInner {
                 use ff_format::PixelFormat;
 
                 // Set pixel format based on variant before avcodec_open2.
-                // SAFETY: codec_ctx is non-null; direct field write is safe.
-                (*codec_ctx).pix_fmt = match dnxhd.variant.pixel_format() {
+                codec_ctx.set_pix_fmt(match dnxhd.variant.pixel_format() {
                     PixelFormat::Yuv422p => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
                     PixelFormat::Yuv422p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P10LE,
                     PixelFormat::Yuv444p10le => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV444P10LE,
                     _ => ff_sys::AVPixelFormat_AV_PIX_FMT_YUV422P,
-                };
+                });
 
                 // For DNxHD variants, override bit_rate with the required fixed rate.
                 if let Some(bps) = dnxhd.variant.fixed_bitrate_bps() {
-                    // SAFETY: codec_ctx is non-null; direct field write is safe.
-                    (*codec_ctx).bit_rate = bps;
+                    codec_ctx.set_bit_rate(bps);
                 }
 
-                // Apply vprofile via av_opt_set on codec_ctx with AV_OPT_SEARCH_CHILDREN.
-                // Using the codec context (not priv_data) with SEARCH_CHILDREN allows the
-                // option to be found in child objects including priv_data.
-                if let Ok(s) = CString::new(dnxhd.variant.vprofile_str()) {
-                    // SAFETY: codec_ctx is non-null and cast to *mut c_void as required
-                    // by av_opt_set. AV_OPT_SEARCH_CHILDREN (1) searches child objects.
-                    // Strings are valid NUL-terminated C strings.
-                    let ret = ff_sys::av_opt_set(
-                        codec_ctx as *mut std::ffi::c_void,
-                        b"vprofile\0".as_ptr() as *const i8,
-                        s.as_ptr(),
-                        ff_sys::AV_OPT_SEARCH_CHILDREN as i32,
+                // Apply vprofile on the codec context with AV_OPT_SEARCH_CHILDREN.
+                // Targeting the context (not priv_data) lets the option be found in
+                // child objects including priv_data.
+                if codec_ctx
+                    .set_opt_search_children("vprofile", dnxhd.variant.vprofile_str())
+                    .is_err()
+                {
+                    log::warn!(
+                        "av_opt_set failed option=vprofile value={} \
+                         encoder={encoder_name}",
+                        dnxhd.variant.vprofile_str()
                     );
-                    if ret < 0 {
-                        log::warn!(
-                            "av_opt_set failed option=vprofile value={} \
-                             encoder={encoder_name}",
-                            dnxhd.variant.vprofile_str()
-                        );
-                    }
                 }
             }
         }

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -90,19 +90,15 @@ impl VideoEncoderInner {
         })?)?;
 
         // ── Step 2: Collect stats_out (before freeing pass 1) ────────────────
-        // SAFETY: stats_out is either null or a valid C string owned by the
-        // codec context; it remains valid until the owned context is dropped below.
-        let pass1_ptr = self
+        let stats_out = self
             .pass1_codec_ctx
             .as_ref()
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Pass-1 codec context not initialized".to_string(),
             })?
-            .as_ptr();
-        let stats_str = if !(*pass1_ptr).stats_out.is_null() {
-            std::ffi::CStr::from_ptr((*pass1_ptr).stats_out)
-                .to_string_lossy()
-                .into_owned()
+            .stats_out();
+        let stats_str = if let Some(stats) = stats_out {
+            stats.to_string_lossy().into_owned()
         } else {
             log::warn!(
                 "two-pass pass-1 produced no stats_out; pass-2 quality may not improve \
@@ -226,124 +222,94 @@ impl VideoEncoderInner {
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Mirror the same codec configuration as pass 1.
-        (*codec_ctx.as_mut_ptr()).codec_id = codec_to_id(config.video_codec);
-        (*codec_ctx.as_mut_ptr()).width = width as i32;
-        (*codec_ctx.as_mut_ptr()).height = height as i32;
-        (*codec_ctx.as_mut_ptr()).time_base.num = 1;
-        (*codec_ctx.as_mut_ptr()).time_base.den = (fps * 1000.0) as i32;
-        (*codec_ctx.as_mut_ptr()).framerate.num = fps as i32;
-        (*codec_ctx.as_mut_ptr()).framerate.den = 1;
-        (*codec_ctx.as_mut_ptr()).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
+        codec_ctx.set_codec_id(codec_to_id(config.video_codec));
+        codec_ctx.set_width(width as i32);
+        codec_ctx.set_height(height as i32);
+        codec_ctx.set_time_base(ff_sys::AVRational {
+            num: 1,
+            den: (fps * 1000.0) as i32,
+        });
+        codec_ctx.set_framerate(ff_sys::AVRational {
+            num: fps as i32,
+            den: 1,
+        });
+        codec_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
 
         match config.video_bitrate_mode.as_ref() {
             Some(BitrateMode::Cbr(bps)) => {
-                (*codec_ctx.as_mut_ptr()).bit_rate = *bps as i64;
+                codec_ctx.set_bit_rate(*bps as i64);
             }
             Some(BitrateMode::Vbr { target, max }) => {
-                (*codec_ctx.as_mut_ptr()).bit_rate = *target as i64;
-                (*codec_ctx.as_mut_ptr()).rc_max_rate = *max as i64;
-                (*codec_ctx.as_mut_ptr()).rc_buffer_size = (*max * 2) as i32;
+                codec_ctx.set_bit_rate(*target as i64);
+                codec_ctx.set_rc_max_rate(*max as i64);
+                codec_ctx.set_rc_buffer_size((*max * 2) as i32);
             }
             Some(BitrateMode::Crf(q)) => {
-                let crf_str = CString::new(q.to_string()).map_err(|_| EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Invalid CRF value".to_string(),
-                })?;
-                // SAFETY: priv_data, option name, and value are all valid pointers.
-                let ret = ff_sys::av_opt_set(
-                    (*codec_ctx.as_mut_ptr()).priv_data,
-                    b"crf\0".as_ptr() as *const i8,
-                    crf_str.as_ptr(),
-                    0,
-                );
-                if ret < 0 {
+                if codec_ctx.set_opt("crf", &q.to_string()).is_err() {
                     log::warn!(
                         "crf option not supported by pass-2 encoder, falling back to default \
                          encoder={encoder_name} crf={q}"
                     );
-                    (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
+                    codec_ctx.set_bit_rate(2_000_000);
                 }
             }
             None => {
-                (*codec_ctx.as_mut_ptr()).bit_rate = 2_000_000;
+                codec_ctx.set_bit_rate(2_000_000);
             }
         }
 
-        if encoder_name.contains("264") || encoder_name.contains("265") {
-            let preset_cstr =
-                CString::new(config.preset.as_str()).map_err(|_| EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Invalid preset value".to_string(),
-                })?;
-            // SAFETY: priv_data, option name, and value are all valid pointers.
-            let ret = ff_sys::av_opt_set(
-                (*codec_ctx.as_mut_ptr()).priv_data,
-                b"preset\0".as_ptr() as *const i8,
-                preset_cstr.as_ptr(),
-                0,
+        if (encoder_name.contains("264") || encoder_name.contains("265"))
+            && codec_ctx.set_opt("preset", config.preset.as_str()).is_err()
+        {
+            log::warn!(
+                "preset option not supported by pass-2 encoder, ignoring \
+                 encoder={encoder_name} preset={}",
+                config.preset
             );
-            if ret < 0 {
-                log::warn!(
-                    "preset option not supported by pass-2 encoder, ignoring \
-                     encoder={encoder_name} preset={}",
-                    config.preset
-                );
-            }
         }
 
         // Apply per-codec options before opening the pass-2 codec context.
         if let Some(opts) = config.codec_options.as_ref() {
-            // SAFETY: codec_ctx is valid and allocated; priv_data is set by
-            // avcodec_alloc_context3. Options are applied before avcodec_open2
-            // so they take effect during codec initialisation.
-            Self::apply_codec_options(codec_ctx.as_mut_ptr(), opts, &encoder_name);
+            // Options are applied before avcodec_open2 so they take effect during
+            // codec initialisation.
+            Self::apply_codec_options(&mut codec_ctx, opts, &encoder_name);
         }
 
         // Apply explicit pixel format override for pass 2 (mirrors pass 1).
         if let Some(fmt) = config.pixel_format.as_ref() {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).pix_fmt = pixel_format_to_av(*fmt);
+            codec_ctx.set_pix_fmt(pixel_format_to_av(*fmt));
         }
 
         // Apply HDR10 color context for pass 2 (mirrors pass 1).
         if config.hdr10_metadata.is_some() {
-            // SAFETY: codec_ctx is valid and allocated; direct field writes are safe.
-            (*codec_ctx.as_mut_ptr()).color_primaries = ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020;
-            (*codec_ctx.as_mut_ptr()).color_trc =
-                ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084;
-            (*codec_ctx.as_mut_ptr()).colorspace = ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL;
+            codec_ctx.set_color_primaries(ff_sys::AVColorPrimaries_AVCOL_PRI_BT2020);
+            codec_ctx.set_color_trc(ff_sys::AVColorTransferCharacteristic_AVCOL_TRC_SMPTEST2084);
+            codec_ctx.set_colorspace(ff_sys::AVColorSpace_AVCOL_SPC_BT2020_NCL);
         }
 
         // Apply explicit color overrides for pass 2 (mirrors pass 1; take priority over HDR10).
         if let Some(cs) = config.color_space {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).colorspace = color_space_to_av(cs);
+            codec_ctx.set_colorspace(color_space_to_av(cs));
         }
         if let Some(trc) = config.color_transfer {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).color_trc = color_transfer_to_av(trc);
+            codec_ctx.set_color_trc(color_transfer_to_av(trc));
         }
         if let Some(cp) = config.color_primaries {
-            // SAFETY: codec_ctx is valid and allocated; direct field write is safe.
-            (*codec_ctx.as_mut_ptr()).color_primaries = color_primaries_to_av(cp);
+            codec_ctx.set_color_primaries(color_primaries_to_av(cp));
         }
 
         // Set the pass-2 flag and provide stats_in.
-        // SAFETY: codec_ctx is a valid allocated (but not yet opened) context.
-        (*codec_ctx.as_mut_ptr()).flags |= AV_CODEC_FLAG_PASS2;
+        codec_ctx.set_flags(codec_ctx.flags() | AV_CODEC_FLAG_PASS2);
 
-        // Point stats_in to our owned CString (kept alive in self.stats_in_cstr
-        // until cleanup() nulls the pointer and drops it).
+        // Hand the pass-1 statistics to the encoder. The CodecContext takes an
+        // owned copy and keeps it alive; its Drop nulls the raw field before the
+        // context is freed.
         if !stats.is_empty() {
             let stats_cstr = CString::new(stats).map_err(|_| EncodeError::Ffmpeg {
                 code: 0,
                 message: "Invalid stats string from pass 1".to_string(),
             })?;
-            // SAFETY: stats_cstr.as_ptr() is valid for the lifetime of stats_cstr,
-            // which is stored in self.stats_in_cstr and dropped only after the codec
-            // context is freed in cleanup().
-            (*codec_ctx.as_mut_ptr()).stats_in = stats_cstr.as_ptr().cast_mut();
-            self.stats_in_cstr = Some(stats_cstr);
+            codec_ctx.set_stats_in(&stats_cstr);
         }
 
         // Try to open the pass-2 codec with PASS2 flag. Some encoders (e.g. the
@@ -357,9 +323,8 @@ impl VideoEncoderInner {
             );
             // Null stats_in and drop the owned CString BEFORE re-opening so the
             // discarded pass-2 attempt never references the Rust-owned pointer.
-            (*codec_ctx.as_mut_ptr()).flags &= !AV_CODEC_FLAG_PASS2;
-            (*codec_ctx.as_mut_ptr()).stats_in = ptr::null_mut();
-            self.stats_in_cstr = None;
+            codec_ctx.set_flags(codec_ctx.flags() & !AV_CODEC_FLAG_PASS2);
+            codec_ctx.clear_stats_in();
             codec_ctx
                 .open(selected_codec, ptr::null_mut())
                 .map_err(|e| EncodeError::Ffmpeg {

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -7,11 +7,13 @@
 //! `open` (raw options dictionary), `parameters_to_context` (raw parameters), and
 //! `send_eof` / `flush_buffers` (opened-context precondition) remain `unsafe`.
 
+use std::ffi::{CStr, CString};
 use std::os::raw::c_int;
-use std::ptr::NonNull;
+use std::ptr::{self, NonNull};
 
 use crate::{
-    AVCodecContext, AVCodecParameters, AVDictionary, AVFrame, AVPacket, AVPixelFormat, AVRational,
+    AVCodecContext, AVCodecID, AVCodecParameters, AVColorPrimaries, AVColorRange, AVColorSpace,
+    AVColorTransferCharacteristic, AVDictionary, AVFrame, AVPacket, AVPixelFormat, AVRational,
     AVSampleFormat, AvError, Codec, CodecParameters, Frame, Packet,
     avcodec_free_context as ffi_avcodec_free_context,
 };
@@ -54,6 +56,13 @@ fn classify_receive(result: Result<(), c_int>) -> Result<ReceiveOutcome, AvError
 #[derive(Debug)]
 pub struct CodecContext {
     ptr: NonNull<AVCodecContext>,
+    /// Owned two-pass `stats_in` buffer, when one is set.
+    ///
+    /// FFmpeg's `stats_in` field must point to a NUL-terminated string that
+    /// outlives the codec context but that FFmpeg must not free. Storing the
+    /// [`CString`] here keeps it alive; [`Drop`] nulls the field before
+    /// `avcodec_free_context` so FFmpeg never `av_free`s this Rust-owned buffer.
+    stats_in: Option<CString>,
 }
 
 impl CodecContext {
@@ -71,7 +80,10 @@ impl CodecContext {
         // `alloc_context3` returns `Ok` only with a non-null pointer.
         NonNull::new(ptr)
             .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
-            .map(|ptr| Self { ptr })
+            .map(|ptr| Self {
+                ptr,
+                stats_in: None,
+            })
     }
 
     /// Returns the context pointer for read-only use.
@@ -142,6 +154,296 @@ impl CodecContext {
     pub fn height(&self) -> c_int {
         // SAFETY: `self.ptr` is a valid owned context; `height` is a plain field.
         unsafe { (*self.ptr.as_ptr()).height }
+    }
+
+    /// Sets the codec id.
+    pub fn set_codec_id(&mut self, codec_id: AVCodecID) {
+        // SAFETY: `self.ptr` is a valid owned context; `codec_id` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).codec_id = codec_id };
+    }
+
+    /// Sets the frame rate.
+    pub fn set_framerate(&mut self, framerate: AVRational) {
+        // SAFETY: `self.ptr` is a valid owned context; `framerate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).framerate = framerate };
+    }
+
+    /// Sets the target bit rate in bits per second.
+    pub fn set_bit_rate(&mut self, bit_rate: i64) {
+        // SAFETY: `self.ptr` is a valid owned context; `bit_rate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).bit_rate = bit_rate };
+    }
+
+    /// Sets the rate-control maximum bit rate.
+    pub fn set_rc_max_rate(&mut self, rc_max_rate: i64) {
+        // SAFETY: `self.ptr` is a valid owned context; `rc_max_rate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).rc_max_rate = rc_max_rate };
+    }
+
+    /// Sets the rate-control buffer size.
+    pub fn set_rc_buffer_size(&mut self, rc_buffer_size: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `rc_buffer_size` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).rc_buffer_size = rc_buffer_size };
+    }
+
+    /// Sets the color primaries.
+    pub fn set_color_primaries(&mut self, color_primaries: AVColorPrimaries) {
+        // SAFETY: `self.ptr` is a valid owned context; `color_primaries` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).color_primaries = color_primaries };
+    }
+
+    /// Sets the color transfer characteristic.
+    pub fn set_color_trc(&mut self, color_trc: AVColorTransferCharacteristic) {
+        // SAFETY: `self.ptr` is a valid owned context; `color_trc` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).color_trc = color_trc };
+    }
+
+    /// Sets the colorspace.
+    pub fn set_colorspace(&mut self, colorspace: AVColorSpace) {
+        // SAFETY: `self.ptr` is a valid owned context; `colorspace` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).colorspace = colorspace };
+    }
+
+    /// Sets the color range.
+    pub fn set_color_range(&mut self, color_range: AVColorRange) {
+        // SAFETY: `self.ptr` is a valid owned context; `color_range` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).color_range = color_range };
+    }
+
+    /// Sets the audio sample rate in Hz.
+    pub fn set_sample_rate(&mut self, sample_rate: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `sample_rate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).sample_rate = sample_rate };
+    }
+
+    /// Sets the audio sample format.
+    pub fn set_sample_fmt(&mut self, sample_fmt: AVSampleFormat) {
+        // SAFETY: `self.ptr` is a valid owned context; `sample_fmt` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).sample_fmt = sample_fmt };
+    }
+
+    /// Sets the maximum number of B-frames.
+    pub fn set_max_b_frames(&mut self, max_b_frames: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `max_b_frames` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).max_b_frames = max_b_frames };
+    }
+
+    /// Sets the group-of-pictures size.
+    pub fn set_gop_size(&mut self, gop_size: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `gop_size` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).gop_size = gop_size };
+    }
+
+    /// Sets the number of reference frames.
+    pub fn set_refs(&mut self, refs: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `refs` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).refs = refs };
+    }
+
+    /// Sets the minimum quantizer.
+    pub fn set_qmin(&mut self, qmin: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `qmin` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).qmin = qmin };
+    }
+
+    /// Sets the maximum quantizer.
+    pub fn set_qmax(&mut self, qmax: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `qmax` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).qmax = qmax };
+    }
+
+    /// Initialises `ch_layout` to the default native layout for `nb_channels`.
+    pub fn set_ch_layout_default(&mut self, nb_channels: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `av_channel_layout_default`
+        //         writes the default native layout into the `ch_layout` field.
+        unsafe {
+            crate::av_channel_layout_default(&raw mut (*self.ptr.as_ptr()).ch_layout, nb_channels);
+        }
+    }
+
+    /// Sets the codec flags bitmask.
+    pub fn set_flags(&mut self, flags: c_int) {
+        // SAFETY: `self.ptr` is a valid owned context; `flags` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).flags = flags };
+    }
+
+    /// Returns the codec flags bitmask.
+    #[must_use]
+    pub fn flags(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned context; `flags` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).flags }
+    }
+
+    /// Returns the time base.
+    #[must_use]
+    pub fn time_base(&self) -> AVRational {
+        // SAFETY: `self.ptr` is a valid owned context; `time_base` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).time_base }
+    }
+
+    /// Returns the codec id.
+    #[must_use]
+    pub fn codec_id(&self) -> AVCodecID {
+        // SAFETY: `self.ptr` is a valid owned context; `codec_id` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).codec_id }
+    }
+
+    /// Returns the encoder frame size (samples per audio frame).
+    #[must_use]
+    pub fn frame_size(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned context; `frame_size` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).frame_size }
+    }
+
+    /// Returns the audio sample rate in Hz.
+    #[must_use]
+    pub fn sample_rate(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned context; `sample_rate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).sample_rate }
+    }
+
+    /// Returns the number of audio channels.
+    #[must_use]
+    pub fn channels(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned context; `ch_layout.nb_channels` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).ch_layout.nb_channels }
+    }
+
+    /// Sets a private codec option to a string value.
+    ///
+    /// Targets the context's `priv_data`, matching a direct
+    /// `av_opt_set(ctx->priv_data, key, value, 0)`. The caller decides how to
+    /// react to a failure; this never logs or silently skips.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if `key` or `value` contains an interior NUL, or if
+    /// FFmpeg rejects the option.
+    pub fn set_opt(&mut self, key: &str, value: &str) -> Result<(), AvError> {
+        let key_c = CString::new(key).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        let val_c = CString::new(value).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        // SAFETY: `self.ptr` is a valid owned context whose `priv_data` is set by
+        //         `avcodec_alloc_context3`; `key_c`/`val_c` are valid NUL-terminated
+        //         C strings kept alive across the call, which copies both.
+        let ret = unsafe {
+            crate::av_opt_set(
+                (*self.ptr.as_ptr()).priv_data,
+                key_c.as_ptr(),
+                val_c.as_ptr(),
+                0,
+            )
+        };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Sets an option on the context itself, searching child objects.
+    ///
+    /// Targets the context (cast to the AVOptions object) with
+    /// `AV_OPT_SEARCH_CHILDREN`, matching a direct
+    /// `av_opt_set(ctx, key, value, AV_OPT_SEARCH_CHILDREN)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if `key` or `value` contains an interior NUL, or if
+    /// FFmpeg rejects the option.
+    /// Sets a codec-private option whose value is arbitrary bytes (not
+    /// necessarily UTF-8), preserving the raw bytes exactly (e.g. a 4-byte
+    /// FourCC tag). Targets `priv_data`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the key has an interior NUL or FFmpeg rejects
+    /// the option.
+    pub fn set_opt_cstr(&mut self, key: &str, value: &CStr) -> Result<(), AvError> {
+        let key_c = CString::new(key).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        // SAFETY: `self.ptr` is a valid owned context whose `priv_data` is set by
+        //         `avcodec_alloc_context3`; `key_c` and `value` are valid
+        //         NUL-terminated C strings kept alive across the call, which copies
+        //         both.
+        let ret = unsafe {
+            crate::av_opt_set(
+                (*self.ptr.as_ptr()).priv_data,
+                key_c.as_ptr(),
+                value.as_ptr(),
+                0,
+            )
+        };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Sets an option on the context (searching child objects), for options that
+    /// live on the encoder context itself rather than `priv_data`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the key/value has an interior NUL or FFmpeg
+    /// rejects the option.
+    pub fn set_opt_search_children(&mut self, key: &str, value: &str) -> Result<(), AvError> {
+        let key_c = CString::new(key).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        let val_c = CString::new(value).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        // SAFETY: `self.ptr` is a valid owned context usable as an AVOptions object;
+        //         `key_c`/`val_c` are valid NUL-terminated C strings kept alive
+        //         across the call, which copies both.
+        let ret = unsafe {
+            crate::av_opt_set(
+                self.ptr.as_ptr().cast(),
+                key_c.as_ptr(),
+                val_c.as_ptr(),
+                crate::AV_OPT_SEARCH_CHILDREN as c_int,
+            )
+        };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Stores a copy of the two-pass statistics and points `stats_in` at it.
+    ///
+    /// The copy is owned by this context; [`Drop`] nulls the raw `stats_in` field
+    /// before `avcodec_free_context`, so FFmpeg never frees the Rust-owned buffer.
+    pub fn set_stats_in(&mut self, stats: &CStr) {
+        // Store first, then take the pointer of the stored copy so the pointer we
+        // hand FFmpeg refers to a buffer this context keeps alive.
+        self.stats_in = Some(stats.to_owned());
+        if let Some(owned) = self.stats_in.as_ref() {
+            let stats_ptr = owned.as_ptr().cast_mut();
+            // SAFETY: `self.ptr` is a valid owned context; `stats_ptr` points into a
+            //         CString owned by `self.stats_in`, kept alive until Drop nulls
+            //         this field.
+            unsafe { (*self.ptr.as_ptr()).stats_in = stats_ptr };
+        }
+    }
+
+    /// Clears `stats_in` and drops the owned statistics buffer.
+    pub fn clear_stats_in(&mut self) {
+        // SAFETY: `self.ptr` is a valid owned context; nulling `stats_in` is sound.
+        unsafe { (*self.ptr.as_ptr()).stats_in = ptr::null_mut() };
+        self.stats_in = None;
+    }
+
+    /// Returns a copy of the encoder's two-pass statistics output, if any.
+    #[must_use]
+    pub fn stats_out(&self) -> Option<CString> {
+        // SAFETY: `self.ptr` is a valid owned context; `stats_out` is null or a
+        //         valid NUL-terminated C string owned by the context.
+        unsafe {
+            let p = (*self.ptr.as_ptr()).stats_out;
+            if p.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(p).to_owned())
+            }
+        }
     }
 
     /// Copies the parameters of `params` into the context (safe wrapper).
@@ -310,11 +612,18 @@ impl CodecContext {
 impl Drop for CodecContext {
     fn drop(&mut self) {
         // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
-        //         runs exactly once. `avcodec_free_context` frees it and writes
-        //         null into our local copy of the pointer, which is then discarded.
-        //         The raw binding is used directly so this type does not depend on
-        //         the `avcodec::free_context` wrapper (retired in #1490).
+        //         runs exactly once. When we own the `stats_in` buffer we null the
+        //         field first so `avcodec_free_context` does not `av_free` the
+        //         Rust-owned CString (a double-free); `self.stats_in` then drops
+        //         normally, freeing the Rust buffer. `avcodec_free_context` frees
+        //         the context and writes null into our local copy of the pointer,
+        //         which is then discarded. The raw binding is used directly so this
+        //         type does not depend on the `avcodec::free_context` wrapper
+        //         (retired in #1490).
         unsafe {
+            if self.stats_in.is_some() {
+                (*self.ptr.as_ptr()).stats_in = ptr::null_mut();
+            }
             let mut raw = self.ptr.as_ptr();
             ffi_avcodec_free_context(&mut raw);
         }
@@ -352,6 +661,69 @@ mod tests {
         assert_eq!(ctx.width(), 1920);
         assert_eq!(ctx.height(), 1080);
         assert_eq!(ctx.pix_fmt(), crate::AVPixelFormat_AV_PIX_FMT_YUV420P);
+    }
+
+    #[test]
+    fn set_then_get_should_round_trip_scalar_fields() {
+        let mut ctx = CodecContext::new(None).expect("alloc should succeed");
+        ctx.set_codec_id(crate::AVCodecID_AV_CODEC_ID_H264);
+        ctx.set_bit_rate(2_000_000);
+        ctx.set_sample_rate(48_000);
+        ctx.set_gop_size(12);
+        ctx.set_max_b_frames(2);
+        ctx.set_refs(3);
+        ctx.set_qmin(10);
+        ctx.set_qmax(40);
+        ctx.set_framerate(AVRational { num: 30, den: 1 });
+        ctx.set_flags(0);
+        ctx.set_flags(ctx.flags() | 0x0400);
+
+        assert_eq!(ctx.codec_id(), crate::AVCodecID_AV_CODEC_ID_H264);
+        assert_eq!(ctx.sample_rate(), 48_000);
+        assert_eq!(ctx.flags() & 0x0400, 0x0400);
+    }
+
+    #[test]
+    fn set_ch_layout_default_should_set_channel_count() {
+        let mut ctx = CodecContext::new(None).expect("alloc should succeed");
+        ctx.set_ch_layout_default(2);
+        assert_eq!(ctx.channels(), 2);
+    }
+
+    #[test]
+    fn set_opt_unknown_key_should_return_err() {
+        // A generic context has null `priv_data`; `av_opt_set` reports the unknown
+        // option as an error rather than applying it. This holds for any FFmpeg
+        // build, so the assertion is build-independent.
+        let mut ctx = CodecContext::new(None).expect("alloc should succeed");
+        assert!(ctx.set_opt("no_such_option_xyz", "0").is_err());
+    }
+
+    #[test]
+    fn set_opt_search_children_unknown_key_should_return_err() {
+        // The search-children path targets the context object; an unknown option
+        // is rejected on any FFmpeg build, so the assertion is build-independent.
+        let mut ctx = CodecContext::new(None).expect("alloc should succeed");
+        assert!(
+            ctx.set_opt_search_children("no_such_option_xyz", "0")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn stats_in_round_trip_should_drop_once() {
+        // Setting `stats_in` stores a Rust-owned CString and points the raw field
+        // at it. Drop must null the field before `avcodec_free_context` so neither
+        // FFmpeg nor Rust double-frees the buffer. Constructing, setting, and
+        // dropping cleanly (no panic / double free) exercises that invariant.
+        let stats = CString::new("frame stats data").expect("no interior NUL");
+        let mut ctx = CodecContext::new(None).expect("alloc should succeed");
+        ctx.set_stats_in(&stats);
+        // stats_out is null on a fresh generic context.
+        assert!(ctx.stats_out().is_none());
+        ctx.clear_stats_in();
+        ctx.set_stats_in(&stats);
+        // Dropping `ctx` here must not double-free the owned stats buffer.
     }
 
     #[test]

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1176,6 +1176,85 @@ impl CodecContext {
         0
     }
 
+    pub fn set_codec_id(&mut self, _codec_id: AVCodecID) {}
+    pub fn set_framerate(&mut self, _framerate: AVRational) {}
+    pub fn set_bit_rate(&mut self, _bit_rate: i64) {}
+    pub fn set_rc_max_rate(&mut self, _rc_max_rate: i64) {}
+    pub fn set_rc_buffer_size(&mut self, _rc_buffer_size: c_int) {}
+    pub fn set_color_primaries(&mut self, _color_primaries: AVColorPrimaries) {}
+    pub fn set_color_trc(&mut self, _color_trc: AVColorTransferCharacteristic) {}
+    pub fn set_colorspace(&mut self, _colorspace: AVColorSpace) {}
+    pub fn set_color_range(&mut self, _color_range: AVColorRange) {}
+    pub fn set_sample_rate(&mut self, _sample_rate: c_int) {}
+    pub fn set_sample_fmt(&mut self, _sample_fmt: AVSampleFormat) {}
+    pub fn set_max_b_frames(&mut self, _max_b_frames: c_int) {}
+    pub fn set_gop_size(&mut self, _gop_size: c_int) {}
+    pub fn set_refs(&mut self, _refs: c_int) {}
+    pub fn set_qmin(&mut self, _qmin: c_int) {}
+    pub fn set_qmax(&mut self, _qmax: c_int) {}
+    pub fn set_ch_layout_default(&mut self, _nb_channels: c_int) {}
+    pub fn set_flags(&mut self, _flags: c_int) {}
+
+    #[must_use]
+    pub fn flags(&self) -> c_int {
+        0
+    }
+    #[must_use]
+    pub fn time_base(&self) -> AVRational {
+        AVRational { num: 0, den: 1 }
+    }
+    #[must_use]
+    pub fn codec_id(&self) -> AVCodecID {
+        0
+    }
+    #[must_use]
+    pub fn frame_size(&self) -> c_int {
+        0
+    }
+    #[must_use]
+    pub fn sample_rate(&self) -> c_int {
+        0
+    }
+    #[must_use]
+    pub fn channels(&self) -> c_int {
+        0
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn set_opt(&mut self, _key: &str, _value: &str) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn set_opt_cstr(
+        &mut self,
+        _key: &str,
+        _value: &core::ffi::CStr,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn set_opt_search_children(
+        &mut self,
+        _key: &str,
+        _value: &str,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    pub fn set_stats_in(&mut self, _stats: &std::ffi::CStr) {}
+
+    pub fn clear_stats_in(&mut self) {}
+
+    #[must_use]
+    pub fn stats_out(&self) -> Option<std::ffi::CString> {
+        None
+    }
+
     /// # Errors
     /// Stub; never executed on docs.rs.
     pub fn apply_parameters(


### PR DESCRIPTION
## Objective

- ff-encode reached through `CodecContext::as_mut_ptr()` for ~95 codec-context field writes/reads, `av_opt_set` calls, and the 2-pass `stats_in`/`stats_out` handling — including a caller-held CString that had to outlive the context and be nulled before free. This is the CodecContext layer of #1508.

## Solution

- Add the `CodecContext` API to ff-sys: 19 field setters + 6 getters, `set_opt`/`set_opt_search_children` (string options) and `set_opt_cstr` (raw-byte values), and `set_stats_in`/`clear_stats_in`/`stats_out`.
- The 2-pass log CString now lives in a private `CodecContext` field; `Drop` nulls the raw `stats_in` before `avcodec_free_context`, so FFmpeg never frees the Rust-owned buffer and the caller no longer holds a parallel `stats_in_cstr`.
- Migrate all of ff-encode's codec-context field access + options + stats onto the accessors, preserving each option site's log-and-skip vs bitrate-fallback behaviour. The ProRes vendor FourCC goes through `set_opt_cstr` so a non-ASCII tag is not lossily converted.
- Frames/packets and the scale/convert paths stay raw; owned `Frame`/`Packet` adoption and the safe scale/convert are the follow-up #1512.

Closes #1508