### PR TITLE
feat(ff-encode): adopt owned Frame/Packet in the image and audio encoders

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -24,8 +24,7 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3,
     AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_NONE,
     AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE,
-    AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, AVFrame, av_frame_alloc, av_frame_free,
-    av_interleaved_write_frame, av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer,
+    AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, av_interleaved_write_frame, av_write_trailer,
     avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
     avformat_write_header, swresample,
 };
@@ -407,31 +406,22 @@ impl AudioEncoderInner {
             if !self.fifo.is_null() {
                 // Fixed-frame-size path: convert → write into AVAudioFifo → drain
                 // complete frames.  AVAudioFifo manages the ring buffer internally.
-                let mut av_frame = av_frame_alloc();
-                if av_frame.is_null() {
-                    return Err(EncodeError::Ffmpeg {
-                        code: 0,
-                        message: "Cannot allocate frame".to_string(),
-                    });
-                }
+                let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Cannot allocate frame".to_string(),
+                })?;
 
-                let convert_result = self.convert_audio_frame(frame, av_frame);
-                if let Err(e) = convert_result {
-                    av_frame_free(&raw mut av_frame);
-                    return Err(e);
-                }
+                self.convert_audio_frame(frame, &mut av_frame)?;
 
-                let nb_samples = (*av_frame).nb_samples;
+                let nb_samples = av_frame.nb_samples();
 
                 // Write converted samples into AVAudioFifo.
                 // SAFETY: av_frame data buffers were allocated by convert_audio_frame
                 let write_result = swresample::audio_fifo::write(
                     self.fifo,
-                    (*av_frame).data.as_ptr().cast::<*mut c_void>(),
+                    (*av_frame.as_ptr()).data.as_ptr().cast::<*mut c_void>(),
                     nb_samples,
                 );
-
-                av_frame_free(&raw mut av_frame);
 
                 write_result.map_err(|e| EncodeError::Ffmpeg {
                     code: e,
@@ -448,43 +438,30 @@ impl AudioEncoderInner {
                 }
             } else {
                 // Direct path: send frame straight to the encoder.
-                let mut av_frame = av_frame_alloc();
-                if av_frame.is_null() {
-                    return Err(EncodeError::Ffmpeg {
-                        code: 0,
-                        message: "Cannot allocate frame".to_string(),
-                    });
-                }
+                let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Cannot allocate frame".to_string(),
+                })?;
 
-                let convert_result = self.convert_audio_frame(frame, av_frame);
-                if let Err(e) = convert_result {
-                    av_frame_free(&raw mut av_frame);
-                    return Err(e);
-                }
+                self.convert_audio_frame(frame, &mut av_frame)?;
 
-                (*av_frame).pts = self.sample_count as i64;
+                av_frame.set_pts(self.sample_count as i64);
 
-                let send_result = self
-                    .codec_ctx
+                self.codec_ctx
                     .as_mut()
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(av_frame);
-                if let Err(e) = send_result {
-                    av_frame_free(&raw mut av_frame);
-                    return Err(EncodeError::Ffmpeg {
+                    .send_frame(av_frame.as_ptr())
+                    .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
                             "Failed to send audio frame: {}",
                             ff_sys::av_error_string(e.code())
                         ),
-                    });
-                }
+                    })?;
 
-                let receive_result = self.receive_packets();
-                av_frame_free(&raw mut av_frame);
-                receive_result?;
+                self.receive_packets()?;
 
                 self.sample_count += frame.samples() as u64;
             }
@@ -513,47 +490,43 @@ impl AudioEncoderInner {
             })?
             .as_mut_ptr();
 
-        let mut av_frame = av_frame_alloc();
-        if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate frame".to_string(),
-            });
+        let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+            code: 0,
+            message: "Cannot allocate frame".to_string(),
+        })?;
+
+        // Configure the audio scalar fields from the codec context. These have no
+        // typed setter, so they are written through the frame pointer.
+        // SAFETY: `av_frame` is a valid owned frame; `codec_ctx` is a valid codec
+        //         context; these are plain fields.
+        {
+            let p = av_frame.as_mut_ptr();
+            (*p).format = (*codec_ctx).sample_fmt;
+            (*p).sample_rate = (*codec_ctx).sample_rate;
+            (*p).nb_samples = frame_size;
+            (*p).pts = self.sample_count as i64;
         }
 
-        (*av_frame).format = (*codec_ctx).sample_fmt;
-        (*av_frame).sample_rate = (*codec_ctx).sample_rate;
-        (*av_frame).nb_samples = frame_size;
-        (*av_frame).pts = self.sample_count as i64;
-
-        if let Err(e) = swresample::channel_layout::copy(
-            &raw mut (*av_frame).ch_layout,
+        swresample::channel_layout::copy(
+            &raw mut (*av_frame.as_mut_ptr()).ch_layout,
             &raw const (*codec_ctx).ch_layout,
-        ) {
-            av_frame_free(&raw mut av_frame);
-            return Err(EncodeError::from_ffmpeg_error(e));
-        }
+        )
+        .map_err(EncodeError::from_ffmpeg_error)?;
 
-        let ret = ff_sys::av_frame_get_buffer(av_frame, 0);
-        if ret < 0 {
-            av_frame_free(&raw mut av_frame);
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!(
-                    "Cannot allocate audio frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                ),
-            });
-        }
+        av_frame.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Cannot allocate audio frame buffer: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         if zero_pad {
-            // Zero all plane buffers so the unread tail is silence, not garbage.
-            // linesize[i] gives the allocated size of each plane in bytes.
-            // SAFETY: av_frame_get_buffer guarantees data[i] and linesize[i] are consistent
-            for i in 0..8 {
-                if !(*av_frame).data[i].is_null() {
-                    let sz = (*av_frame).linesize[i].max(0) as usize;
-                    ptr::write_bytes((*av_frame).data[i], 0, sz);
+            // Zero all plane sample regions so the unread tail is silence, not
+            // garbage. Each plane slice spans exactly the frame's sample bytes.
+            for i in 0..ff_sys::AV_NUM_DATA_POINTERS as usize {
+                if let Some(plane) = av_frame.audio_plane_mut(i) {
+                    plane.fill(0);
                 }
             }
         }
@@ -562,39 +535,34 @@ impl AudioEncoderInner {
         // For zero_pad=false: FIFO has >= frame_size samples → returns exactly frame_size.
         // For zero_pad=true:  FIFO has < frame_size samples → returns < frame_size;
         //                     the zeroed tail provides silence padding.
-        // SAFETY: av_frame_get_buffer allocated the plane buffers; they are large enough
-        if let Err(e) = swresample::audio_fifo::read(
+        // SAFETY: get_buffer allocated the plane buffers; they are large enough
+        swresample::audio_fifo::read(
             self.fifo,
-            (*av_frame).data.as_ptr().cast::<*mut c_void>(),
+            (*av_frame.as_ptr()).data.as_ptr().cast::<*mut c_void>(),
             frame_size,
-        ) {
-            av_frame_free(&raw mut av_frame);
-            return Err(EncodeError::Ffmpeg {
-                code: e,
-                message: format!(
-                    "Failed to read from audio FIFO: {}",
-                    ff_sys::av_error_string(e)
-                ),
-            });
-        }
+        )
+        .map_err(|e| EncodeError::Ffmpeg {
+            code: e,
+            message: format!(
+                "Failed to read from audio FIFO: {}",
+                ff_sys::av_error_string(e)
+            ),
+        })?;
         // nb_samples stays as frame_size: the encoder always receives a full frame.
 
-        let send_result = self
-            .codec_ctx
+        self.codec_ctx
             .as_mut()
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio codec not initialized".to_string(),
             })?
-            .send_frame(av_frame);
-        av_frame_free(&raw mut av_frame);
-
-        send_result.map_err(|e| EncodeError::Ffmpeg {
-            code: e.code(),
-            message: format!(
-                "Failed to send audio frame: {}",
-                ff_sys::av_error_string(e.code())
-            ),
-        })?;
+            .send_frame(av_frame.as_ptr())
+            .map_err(|e| EncodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Failed to send audio frame: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         self.receive_packets()?;
         self.sample_count += frame_size as u64;
@@ -602,11 +570,12 @@ impl AudioEncoderInner {
         Ok(())
     }
 
-    /// Convert AudioFrame to AVFrame with resampling if needed.
+    /// Convert AudioFrame into an owned output [`ff_sys::Frame`] with resampling
+    /// if needed.
     unsafe fn convert_audio_frame(
         &mut self,
         src: &AudioFrame,
-        dst: *mut AVFrame,
+        dst: &mut ff_sys::Frame,
     ) -> Result<(), EncodeError> {
         let codec_ctx = self
             .codec_ctx
@@ -657,37 +626,40 @@ impl AudioEncoderInner {
                 src.samples() as i32,
             );
 
-            // Set frame properties
-            (*dst).format = target_format;
-            (*dst).sample_rate = target_sample_rate;
-            (*dst).nb_samples = out_samples;
-
-            // Copy target channel layout
-            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, target_ch_layout)
-                .map_err(EncodeError::from_ffmpeg_error)?;
-
-            // Allocate frame buffer
-            let ret = ff_sys::av_frame_get_buffer(dst, 0);
-            if ret < 0 {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!(
-                        "Cannot allocate audio frame buffer: {}",
-                        ff_sys::av_error_string(ret)
-                    ),
-                });
+            // Set frame properties. These audio scalar fields have no typed
+            // setter, so they are written through the frame pointer.
+            // SAFETY: `dst` is a valid owned frame; these are plain fields.
+            {
+                let p = dst.as_mut_ptr();
+                (*p).format = target_format;
+                (*p).sample_rate = target_sample_rate;
+                (*p).nb_samples = out_samples;
             }
 
-            // Prepare input pointers
-            let in_ptrs: Vec<*const u8> = if src.format().is_planar() {
-                // Planar: one pointer per channel
-                src.planes().iter().map(|p| p.as_ptr()).collect()
+            // Copy target channel layout
+            swresample::channel_layout::copy(
+                &raw mut (*dst.as_mut_ptr()).ch_layout,
+                target_ch_layout,
+            )
+            .map_err(EncodeError::from_ffmpeg_error)?;
+
+            // Allocate frame buffer
+            dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Cannot allocate audio frame buffer: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
+
+            // Prepare input plane slices (planar: one per channel; packed: one).
+            let in_planes: Vec<&[u8]> = if src.format().is_planar() {
+                src.planes().iter().map(Vec::as_slice).collect()
             } else {
-                // Packed: single pointer
-                vec![src.planes()[0].as_ptr()]
+                vec![src.planes()[0].as_slice()]
             };
 
-            // Convert
+            // Convert into the output frame's planes.
             let samples_out = self
                 .swr_ctx
                 .as_mut()
@@ -695,52 +667,50 @@ impl AudioEncoderInner {
                     code: 0,
                     message: "Resampling context not initialized".to_string(),
                 })?
-                .convert(
-                    (*dst).data.as_mut_ptr().cast(),
-                    out_samples,
-                    in_ptrs.as_ptr(),
-                    src.samples() as i32,
-                )
+                .convert_into_frame(dst, &in_planes, src.samples() as i32)
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-            (*dst).nb_samples = samples_out;
+            // SAFETY: `dst` is a valid owned frame; `nb_samples` is a plain field.
+            (*dst.as_mut_ptr()).nb_samples = samples_out;
         } else {
-            // No resampling needed, direct copy
-            (*dst).format = src_format;
-            (*dst).sample_rate = src_sample_rate;
-            (*dst).nb_samples = src.samples() as i32;
-
-            // Copy channel layout
-            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, &raw const src_ch_layout)
-                .map_err(EncodeError::from_ffmpeg_error)?;
-
-            // Allocate frame buffer
-            let ret = ff_sys::av_frame_get_buffer(dst, 0);
-            if ret < 0 {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!(
-                        "Cannot allocate audio frame buffer: {}",
-                        ff_sys::av_error_string(ret)
-                    ),
-                });
+            // No resampling needed, direct copy. These audio scalar fields have no
+            // typed setter, so they are written through the frame pointer.
+            // SAFETY: `dst` is a valid owned frame; these are plain fields.
+            {
+                let p = dst.as_mut_ptr();
+                (*p).format = src_format;
+                (*p).sample_rate = src_sample_rate;
+                (*p).nb_samples = src.samples() as i32;
             }
 
-            // Copy audio data
+            // Copy channel layout
+            swresample::channel_layout::copy(
+                &raw mut (*dst.as_mut_ptr()).ch_layout,
+                &raw const src_ch_layout,
+            )
+            .map_err(EncodeError::from_ffmpeg_error)?;
+
+            // Allocate frame buffer
+            dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Cannot allocate audio frame buffer: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
+
+            // Copy audio data into the destination frame's planes.
             if src.format().is_planar() {
-                // Copy each plane
                 for (i, plane) in src.planes().iter().enumerate() {
-                    if i < (*dst).data.len() && !(*dst).data[i].is_null() {
-                        let size = plane.len();
-                        ptr::copy_nonoverlapping(plane.as_ptr(), (*dst).data[i], size);
+                    if let Some(dst_plane) = dst.audio_plane_mut(i) {
+                        let n = plane.len().min(dst_plane.len());
+                        dst_plane[..n].copy_from_slice(&plane[..n]);
                     }
                 }
-            } else {
-                // Copy single packed buffer
-                if !(*dst).data[0].is_null() {
-                    let size = src.planes()[0].len();
-                    ptr::copy_nonoverlapping(src.planes()[0].as_ptr(), (*dst).data[0], size);
-                }
+            } else if let Some(dst_plane) = dst.audio_plane_mut(0) {
+                let src_plane = &src.planes()[0];
+                let n = src_plane.len().min(dst_plane.len());
+                dst_plane[..n].copy_from_slice(&src_plane[..n]);
             }
         }
 
@@ -755,13 +725,10 @@ impl AudioEncoderInner {
             });
         }
 
-        let mut packet = av_packet_alloc();
-        if packet.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate packet".to_string(),
-            });
-        }
+        let mut packet = ff_sys::Packet::new().map_err(|_| EncodeError::Ffmpeg {
+            code: 0,
+            message: "Cannot allocate packet".to_string(),
+        })?;
 
         loop {
             let recv = self
@@ -770,7 +737,7 @@ impl AudioEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Audio codec not initialized".to_string(),
                 })?
-                .receive_packet(packet);
+                .receive_packet(packet.as_mut_ptr());
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -780,7 +747,6 @@ impl AudioEncoderInner {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -792,24 +758,24 @@ impl AudioEncoderInner {
             }
 
             // Set stream index
-            (*packet).stream_index = self.stream_index;
+            // SAFETY: `packet` is a valid owned packet; `stream_index` is a plain field.
+            (*packet.as_mut_ptr()).stream_index = self.stream_index;
 
             // Write packet
-            let write_ret = av_interleaved_write_frame(self.format_ctx, packet);
+            let write_ret = av_interleaved_write_frame(self.format_ctx, packet.as_mut_ptr());
             if write_ret < 0 {
-                av_packet_unref(packet);
-                av_packet_free(&raw mut packet);
+                packet.unref();
                 return Err(EncodeError::MuxingFailed {
                     reason: ff_sys::av_error_string(write_ret),
                 });
             }
 
-            self.bytes_written += (*packet).size as u64;
+            // SAFETY: `packet` is a valid owned packet; `size` is a plain field.
+            self.bytes_written += (*packet.as_ptr()).size as u64;
 
-            av_packet_unref(packet);
+            packet.unref();
         }
 
-        av_packet_free(&raw mut packet);
         Ok(())
     }
 

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -5,15 +5,14 @@
 //!
 //! ## Resource management
 //!
-//! [`ImageEncoderInner`] owns every FFmpeg pointer allocated during a single
-//! still-image encode. Its [`Drop`] implementation frees the raw handles
-//! (frame → packet → sws_ctx → format_ctx); `codec_ctx` is an owned
-//! [`ff_sys::CodecContext`] that frees itself when the struct drops, after the
-//! manual cleanup body has run. The encoder's `AVCodecContext` and the output
-//! `AVFormatContext` are independent allocations with no cross-reference, so
-//! this order is sound. Because `Drop` runs on every exit path — including
-//! panics and early `?` returns — no manual cleanup is needed at individual
-//! error sites.
+//! [`ImageEncoderInner`] owns every FFmpeg resource allocated during a single
+//! still-image encode. The destination frame, the packet, the codec context,
+//! and the scaling context are owned RAII values ([`ff_sys::Frame`],
+//! [`ff_sys::Packet`], [`ff_sys::CodecContext`], [`ff_sys::ScaleContext`]) that
+//! free themselves on drop. Only the output `AVFormatContext` remains a raw
+//! pointer; its [`Drop`] closes the IO context and frees the format context.
+//! Because `Drop` runs on every exit path — including panics and early `?`
+//! returns — no manual cleanup is needed at individual error sites.
 
 // Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
 #![allow(unsafe_code)]
@@ -37,8 +36,7 @@ use ff_sys::{
     AVCodecID, AVCodecID_AV_CODEC_ID_BMP, AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_PNG,
     AVCodecID_AV_CODEC_ID_TIFF, AVCodecID_AV_CODEC_ID_WEBP, AVColorRange_AVCOL_RANGE_JPEG,
     AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_BGR24, AVPixelFormat_AV_PIX_FMT_RGB24,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, av_frame_alloc, av_frame_free,
-    av_interleaved_write_frame, av_packet_alloc, av_packet_free, av_packet_unref, av_write_trailer,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, av_interleaved_write_frame, av_write_trailer,
     avformat, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
     avformat_write_header, swscale,
 };
@@ -66,30 +64,25 @@ pub(super) struct ImageEncodeOptions {
 
 /// Owns all FFmpeg resources for a single still-image encode operation.
 ///
-/// Every field is initialised to null/`None`. Resources are set as they are
-/// successfully allocated so that `Drop` only frees what actually exists.
+/// The destination frame, packet, codec context, and scaling context are owned
+/// RAII values that free themselves on drop. The output `AVFormatContext`
+/// starts null and is filled in as it is allocated, so the manual `Drop` only
+/// frees it when it actually exists.
 ///
 /// # Drop contract
 ///
-/// The manual `Drop` body releases the raw handles in this order:
-///
-/// 1. `dst_frame` — `av_frame_free`
-/// 2. `packet`    — `av_packet_free`
-/// 3. `sws_ctx`   — `sws_freeContext`
-/// 4. `format_ctx`— IO close (`avio_closep`) then `avformat_free_context`
-///
-/// `codec_ctx` is an owned [`ff_sys::CodecContext`]; it frees itself via field
-/// drop *after* the manual body, so the `AVCodecContext` is released last. That
-/// is sound because the encoder's `AVCodecContext` and the output
-/// `AVFormatContext` are independent allocations that do not reference each
-/// other. (The audio/video encoders hold their codec contexts as `Option` and
-/// take them to `None` before freeing `format_ctx`; here `codec_ctx` is a
-/// by-value field that is always present, so it is simply dropped last.)
+/// The manual `Drop` body only closes the IO context (`avio_closep`) and frees
+/// the output `AVFormatContext` (`avformat_free_context`). The owned
+/// [`ff_sys::Frame`], [`ff_sys::Packet`], [`ff_sys::ScaleContext`], and
+/// [`ff_sys::CodecContext`] fields free themselves via field drop after the
+/// manual body. That ordering is sound because the encoder's `AVCodecContext`
+/// and the output `AVFormatContext` are independent allocations that do not
+/// reference each other.
 struct ImageEncoderInner {
     format_ctx: *mut AVFormatContext,
     codec_ctx: ff_sys::CodecContext,
-    dst_frame: *mut ff_sys::AVFrame,
-    packet: *mut ff_sys::AVPacket,
+    dst_frame: ff_sys::Frame,
+    packet: ff_sys::Packet,
     sws_ctx: Option<ff_sys::ScaleContext>,
     dst_width: u32,
     dst_height: u32,
@@ -127,12 +120,16 @@ impl ImageEncoderInner {
         let codec_ctx = ff_sys::CodecContext::new(Some(codec))
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        // Start with the raw pointers null so Drop is safe from the very first field.
+        // Allocate the owned frame / packet up front; the format context starts
+        // null and is filled in as it is allocated.
+        let dst_frame =
+            ff_sys::Frame::new().map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
+        let packet = ff_sys::Packet::new().map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
         let mut inner = Self {
             format_ctx: ptr::null_mut(),
             codec_ctx,
-            dst_frame: ptr::null_mut(),
-            packet: ptr::null_mut(),
+            dst_frame,
+            packet,
             sws_ctx: None,
             dst_width,
             dst_height,
@@ -253,31 +250,15 @@ impl ImageEncoderInner {
             return Err(EncodeError::from_ffmpeg_error(ret));
         }
 
-        // ── Step 10: Allocate destination frame ───────────────────────────────
-        inner.dst_frame = av_frame_alloc();
-        if inner.dst_frame.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate destination frame".to_string(),
-            });
-        }
-        (*inner.dst_frame).format = pix_fmt;
-        (*inner.dst_frame).width = dst_width as i32;
-        (*inner.dst_frame).height = dst_height as i32;
+        // ── Step 10: Configure destination frame and allocate its buffer ──────
+        inner.dst_frame.set_format(pix_fmt);
+        inner.dst_frame.set_width(dst_width as i32);
+        inner.dst_frame.set_height(dst_height as i32);
 
-        let ret = ff_sys::av_frame_get_buffer(inner.dst_frame, 0);
-        if ret < 0 {
-            return Err(EncodeError::from_ffmpeg_error(ret));
-        }
-
-        // ── Step 11: Allocate packet ──────────────────────────────────────────
-        inner.packet = av_packet_alloc();
-        if inner.packet.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate packet".to_string(),
-            });
-        }
+        inner
+            .dst_frame
+            .get_buffer(0)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         Ok(inner)
     }
@@ -312,17 +293,9 @@ impl ImageEncoderInner {
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?,
             );
 
-            let mut src_data: [*const u8; MAX_PLANES] = [ptr::null(); MAX_PLANES];
-            let mut src_linesize: [i32; MAX_PLANES] = [0; MAX_PLANES];
-            for (i, plane) in src.planes().iter().enumerate() {
-                if i < MAX_PLANES {
-                    src_data[i] = plane.data().as_ptr();
-                    src_linesize[i] = src.strides()[i] as i32;
-                }
-            }
+            let src_planes: Vec<&[u8]> = src.planes().iter().map(|p| p.data()).collect();
+            let src_strides: Vec<i32> = src.strides().iter().map(|&s| s as i32).collect();
 
-            let dst_data = (*self.dst_frame).data.as_mut_ptr().cast_const();
-            let dst_linesize = (*self.dst_frame).linesize.as_mut_ptr();
             let scale_result = self
                 .sws_ctx
                 .as_mut()
@@ -330,13 +303,11 @@ impl ImageEncoderInner {
                     code: 0,
                     message: "Scaling context not initialized".to_string(),
                 })?
-                .scale(
-                    src_data.as_ptr(),
-                    src_linesize.as_ptr(),
-                    0,
+                .scale_planes(
+                    &src_planes,
+                    &src_strides,
                     src.height() as i32,
-                    dst_data,
-                    dst_linesize,
+                    &mut self.dst_frame,
                 );
 
             // Drop the context now — single use; the owned field frees it.
@@ -346,38 +317,42 @@ impl ImageEncoderInner {
         } else {
             // Direct plane copy — same format and dimensions.
             for (i, plane) in src.planes().iter().enumerate() {
-                if i >= MAX_PLANES || (*self.dst_frame).data[i].is_null() {
+                if i >= MAX_PLANES {
                     break;
                 }
                 let src_stride = src.strides()[i];
-                let dst_stride = (*self.dst_frame).linesize[i] as usize;
                 let plane_data = plane.data();
+                // The destination stride is the frame's own linesize for plane i.
+                // SAFETY: `dst_frame` is a valid get_buffer'd frame; `linesize` is
+                //         a plain field.
+                let dst_stride = (*self.dst_frame.as_ptr()).linesize[i] as usize;
+                // `video_plane_mut` yields `None` for an absent plane (null data),
+                // matching the previous null-plane break.
+                let Some(dst_plane) = self.dst_frame.video_plane_mut(i) else {
+                    break;
+                };
 
                 if src_stride == dst_stride {
-                    std::ptr::copy_nonoverlapping(
-                        plane_data.as_ptr(),
-                        (*self.dst_frame).data[i],
-                        plane_data.len(),
-                    );
+                    let n = plane_data.len().min(dst_plane.len());
+                    dst_plane[..n].copy_from_slice(&plane_data[..n]);
                 } else {
                     let row_bytes = src_stride.min(dst_stride);
                     let num_rows = plane_data.len() / src_stride;
                     for row in 0..num_rows {
-                        std::ptr::copy_nonoverlapping(
-                            plane_data[row * src_stride..].as_ptr(),
-                            (*self.dst_frame).data[i].add(row * dst_stride),
-                            row_bytes,
-                        );
+                        let src_off = row * src_stride;
+                        let dst_off = row * dst_stride;
+                        dst_plane[dst_off..dst_off + row_bytes]
+                            .copy_from_slice(&plane_data[src_off..src_off + row_bytes]);
                     }
                 }
             }
         }
 
-        (*self.dst_frame).pts = 0;
+        self.dst_frame.set_pts(0);
 
         // ── Send frame → encoder ──────────────────────────────────────────────
         self.codec_ctx
-            .send_frame(self.dst_frame)
+            .send_frame(self.dst_frame.as_ptr())
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Receive packets ───────────────────────────────────────────────────
@@ -411,13 +386,15 @@ impl ImageEncoderInner {
         loop {
             match self
                 .codec_ctx
-                .receive_packet(self.packet)
+                .receive_packet(self.packet.as_mut_ptr())
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?
             {
                 ff_sys::ReceiveOutcome::Frame => {
-                    (*self.packet).stream_index = 0;
-                    let ret = av_interleaved_write_frame(self.format_ctx, self.packet);
-                    av_packet_unref(self.packet);
+                    // SAFETY: `packet` is a valid owned packet; `stream_index` is a
+                    //         plain field.
+                    (*self.packet.as_mut_ptr()).stream_index = 0;
+                    let ret = av_interleaved_write_frame(self.format_ctx, self.packet.as_mut_ptr());
+                    self.packet.unref();
                     if ret < 0 {
                         return Err(EncodeError::from_ffmpeg_error(ret));
                     }
@@ -436,32 +413,14 @@ impl ImageEncoderInner {
 
 impl Drop for ImageEncoderInner {
     fn drop(&mut self) {
-        // SAFETY: Every pointer was allocated by the FFmpeg API and is either
-        // null (never allocated, or already freed) or a valid owned allocation.
-        // We check for null before each free to make Drop idempotent.
+        // The owned `dst_frame`, `packet`, `sws_ctx`, and `codec_ctx` fields free
+        // themselves via field drop after this body; only the raw output
+        // `AVFormatContext` needs manual cleanup here.
         //
-        // Release order for the raw handles (see the struct's Drop contract):
-        //   1. dst_frame  — av_frame_free  (sets pointer to null)
-        //   2. packet     — av_packet_free (sets pointer to null)
-        //   3. sws_ctx    — sws_freeContext
-        //   4. format_ctx — avio_closep (if pb still open) + avformat_free_context
-        // `codec_ctx` (owned CodecContext) frees itself last via field drop,
-        // after this body; sound as the two contexts are independent.
+        // SAFETY: `format_ctx` is either null (never allocated) or a valid owned
+        // allocation; the null check keeps Drop idempotent.
         unsafe {
-            if !self.dst_frame.is_null() {
-                // SAFETY: dst_frame is non-null and owned by this struct.
-                av_frame_free(&raw mut self.dst_frame);
-            }
-            if !self.packet.is_null() {
-                // SAFETY: packet is non-null and owned by this struct.
-                av_packet_free(&raw mut self.packet);
-            }
-            // sws_ctx is an owned Option<ff_sys::ScaleContext>; it frees itself
-            // via field drop (after this manual body), so no manual free here.
-            // codec_ctx is an owned ff_sys::CodecContext; it frees itself when the
-            // struct is dropped (after this manual cleanup runs).
             if !self.format_ctx.is_null() {
-                // SAFETY: format_ctx is non-null and owned by this struct.
                 // Close the IO context if it hasn't been closed yet (it is set
                 // to null by avio_closep, so this check prevents a double-close
                 // when encode_frame already closed it on success).
@@ -760,18 +719,18 @@ mod tests {
     }
 
     // Verify Drop does not panic on a partially-initialised inner struct whose
-    // raw pointers are all null. This guards the partial-allocation cleanup path
+    // format context is null. This guards the partial-allocation cleanup path
     // exercised when `open` returns early with an error before every field is set.
     #[test]
     fn drop_on_uninitialised_inner_should_not_panic() {
         // A `None` codec yields a generic owned context that frees itself on drop;
-        // the raw pointers are null, so the manual Drop checks skip them.
-        // SAFETY: all raw pointers are null; Drop checks for null before freeing.
+        // the owned frame / packet free themselves; `format_ctx` is null, so the
+        // manual Drop check skips it.
         let inner = ImageEncoderInner {
             format_ctx: ptr::null_mut(),
             codec_ctx: ff_sys::CodecContext::new(None).expect("generic context alloc"),
-            dst_frame: ptr::null_mut(),
-            packet: ptr::null_mut(),
+            dst_frame: ff_sys::Frame::new().expect("frame alloc"),
+            packet: ff_sys::Packet::new().expect("packet alloc"),
             sws_ctx: None,
             dst_width: 0,
             dst_height: 0,

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1630,6 +1630,24 @@ impl Frame {
         0
     }
 
+    #[must_use]
+    pub fn video_plane(&self, _i: usize) -> Option<&[u8]> {
+        None
+    }
+
+    pub fn video_plane_mut(&mut self, _i: usize) -> Option<&mut [u8]> {
+        None
+    }
+
+    #[must_use]
+    pub fn audio_plane(&self, _i: usize) -> Option<&[u8]> {
+        None
+    }
+
+    pub fn audio_plane_mut(&mut self, _i: usize) -> Option<&mut [u8]> {
+        None
+    }
+
     pub fn unref(&mut self) {}
 
     /// # Errors
@@ -1852,6 +1870,19 @@ impl ResampleContext {
         _dst: &mut [&mut [u8]],
         _dst_count: c_int,
         _src: &Frame,
+    ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn convert_into_frame(
+        &mut self,
+        _dst: &mut Frame,
+        _in_planes: &[&[u8]],
+        _in_count: c_int,
     ) -> Result<c_int, crate::AvError> {
         Err(crate::AvError::new(-1))
     }

--- a/crates/ff-sys/src/frame.rs
+++ b/crates/ff-sys/src/frame.rs
@@ -4,19 +4,21 @@
 //! manual `av_frame_alloc` + `av_frame_free` pair. Ownership is unique;
 //! [`try_clone`](Frame::try_clone) makes a ref-counted copy (`av_frame_ref`)
 //! rather than a deep copy. Scalar fields (width / height / format / pts / ...)
-//! are read and written through the typed accessors below; plane data
-//! (`data` / `linesize`) is not exposed as a raw-pointer accessor — it is handled
-//! by the swscale / swresample safe APIs ([`ScaleContext`](crate::ScaleContext),
-//! [`ResampleContext`](crate::ResampleContext)).
+//! are read and written through the typed accessors below. Plane data is never
+//! exposed as a raw pointer: the [`video_plane`](Frame::video_plane) /
+//! [`audio_plane`](Frame::audio_plane) accessors (and their `_mut` forms) return
+//! self-sizing safe slices, and the swscale / swresample APIs
+//! ([`ScaleContext`](crate::ScaleContext), [`ResampleContext`](crate::ResampleContext))
+//! consume the frames for scaling / resampling.
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 use crate::{
-    AVFrame, AVRational, AvError, av_frame_alloc as ffi_av_frame_alloc,
+    AV_NUM_DATA_POINTERS, AVFrame, AVRational, AvError, av_frame_alloc as ffi_av_frame_alloc,
     av_frame_free as ffi_av_frame_free, av_frame_get_buffer as ffi_av_frame_get_buffer,
     av_frame_move_ref as ffi_av_frame_move_ref, av_frame_ref as ffi_av_frame_ref,
-    av_frame_unref as ffi_av_frame_unref,
+    av_frame_unref as ffi_av_frame_unref, av_pix_fmt_desc_get as ffi_av_pix_fmt_desc_get,
 };
 
 /// An owned `AVFrame`.
@@ -179,6 +181,150 @@ impl Frame {
         unsafe { (*self.ptr.as_ptr()).ch_layout.nb_channels }
     }
 
+    // ── Plane data accessors ──────────────────────────────────────────────────
+    //
+    // Typed, self-sizing views over one image / audio plane. Each length is
+    // computed from the frame's own valid fields, so no raw pointer or size
+    // leaks to the caller. `None` is returned for any plane that is absent or
+    // whose format cannot be described (see per-method docs), which keeps these
+    // methods safe.
+    //
+    // Invariant: the length is derived from the frame's current `format` /
+    // dimensions / `nb_samples`, so these assume those were set before
+    // [`get_buffer`](Self::get_buffer) and not enlarged afterwards (the normal
+    // alloc -> set -> get_buffer -> use order). Growing a dimension after
+    // `get_buffer` without reallocating would desync the fields from the buffer.
+
+    /// Returns an immutable view of video plane `i`, sized to the plane's own
+    /// `linesize[i] * plane_height(i)` bytes.
+    ///
+    /// Returns `None` when the plane is absent or cannot be sized: `i` is out of
+    /// range, `data[i]` is null, the pixel format has no descriptor, or
+    /// `linesize[i]` / `height` is not positive.
+    #[must_use]
+    pub fn video_plane(&self, i: usize) -> Option<&[u8]> {
+        let len = self.video_plane_len(i)?;
+        // SAFETY: `video_plane_len` returned `Some`, so `i < AV_NUM_DATA_POINTERS`,
+        //         `data[i]` is non-null, and `len` is `linesize[i]` (> 0) times the
+        //         plane height, i.e. the byte count FFmpeg allocated for this plane.
+        //         The slice borrows `self` for its lifetime.
+        unsafe {
+            let data = (*self.ptr.as_ptr()).data[i];
+            Some(std::slice::from_raw_parts(data, len))
+        }
+    }
+
+    /// Returns a mutable view of video plane `i`, sized to the plane's own
+    /// `linesize[i] * plane_height(i)` bytes.
+    ///
+    /// Returns `None` under the same conditions as [`video_plane`](Self::video_plane).
+    pub fn video_plane_mut(&mut self, i: usize) -> Option<&mut [u8]> {
+        let len = self.video_plane_len(i)?;
+        // SAFETY: as in `video_plane`; `&mut self` guarantees exclusive access, so
+        //         the returned mutable slice is unique for its lifetime.
+        unsafe {
+            let data = (*self.ptr.as_ptr()).data[i];
+            Some(std::slice::from_raw_parts_mut(data, len))
+        }
+    }
+
+    /// Returns an immutable view of audio plane `i`, sized to the samples it
+    /// holds (one plane per channel for planar formats, a single interleaved
+    /// plane 0 for packed formats).
+    ///
+    /// Returns `None` when the plane is absent or cannot be sized: `i` is out of
+    /// range, `data[i]` is null, or the sample format is unusable.
+    #[must_use]
+    pub fn audio_plane(&self, i: usize) -> Option<&[u8]> {
+        let len = self.audio_plane_len(i)?;
+        // SAFETY: `audio_plane_len` returned `Some`, so `i` is in range, `data[i]`
+        //         is non-null, and `len` is the byte count for this plane derived
+        //         from `nb_samples`, the channel count, and the sample size. The
+        //         slice borrows `self` for its lifetime.
+        unsafe {
+            let data = (*self.ptr.as_ptr()).data[i];
+            Some(std::slice::from_raw_parts(data, len))
+        }
+    }
+
+    /// Returns a mutable view of audio plane `i`, sized as in
+    /// [`audio_plane`](Self::audio_plane).
+    ///
+    /// Returns `None` under the same conditions as [`audio_plane`](Self::audio_plane).
+    pub fn audio_plane_mut(&mut self, i: usize) -> Option<&mut [u8]> {
+        let len = self.audio_plane_len(i)?;
+        // SAFETY: as in `audio_plane`; `&mut self` guarantees exclusive access, so
+        //         the returned mutable slice is unique for its lifetime.
+        unsafe {
+            let data = (*self.ptr.as_ptr()).data[i];
+            Some(std::slice::from_raw_parts_mut(data, len))
+        }
+    }
+
+    /// Computes the byte length of video plane `i`, or `None` if the plane is
+    /// absent / cannot be sized. Shared by the video plane accessors.
+    fn video_plane_len(&self, i: usize) -> Option<usize> {
+        if i >= AV_NUM_DATA_POINTERS as usize {
+            return None;
+        }
+        // SAFETY: `self.ptr` is a valid owned frame; `data`, `linesize`, `format`,
+        //         and `height` are plain fields.
+        let (data, linesize, format, height) = unsafe {
+            let p = self.ptr.as_ptr();
+            ((*p).data[i], (*p).linesize[i], (*p).format, (*p).height)
+        };
+        // RK-008: a non-positive linesize would make the byte count wrap; guard it
+        // (a get_buffer'd encoder frame always has a positive linesize). A
+        // non-positive `height` would likewise wrap `plane_h as usize`, so guard it
+        // too (symmetric with the audio accessor's `nb_samples` / channel guards).
+        if data.is_null() || linesize <= 0 || height <= 0 {
+            return None;
+        }
+        let plane_h = plane_height(format, height, i)?;
+        Some(linesize as usize * plane_h as usize)
+    }
+
+    /// Computes the byte length of audio plane `i`, or `None` if the plane is
+    /// absent / cannot be sized. Shared by the audio plane accessors.
+    fn audio_plane_len(&self, i: usize) -> Option<usize> {
+        if i >= AV_NUM_DATA_POINTERS as usize {
+            return None;
+        }
+        // SAFETY: `self.ptr` is a valid owned frame; `data`, `format`,
+        //         `nb_samples`, and `ch_layout.nb_channels` are plain fields.
+        let (data, format, nb_samples, channels) = unsafe {
+            let p = self.ptr.as_ptr();
+            (
+                (*p).data[i],
+                (*p).format,
+                (*p).nb_samples,
+                (*p).ch_layout.nb_channels,
+            )
+        };
+        if data.is_null() {
+            return None;
+        }
+        let bytes = crate::swresample::sample_format::bytes_per_sample(format);
+        if bytes <= 0 || nb_samples < 0 || channels <= 0 {
+            return None;
+        }
+        let bytes = bytes as usize;
+        let nb_samples = nb_samples as usize;
+        if crate::swresample::sample_format::is_planar(format) {
+            // Planar: one plane per channel.
+            if i >= channels as usize {
+                return None;
+            }
+            Some(nb_samples * bytes)
+        } else {
+            // Packed: a single interleaved plane 0.
+            if i != 0 {
+                return None;
+            }
+            Some(nb_samples * channels as usize * bytes)
+        }
+    }
+
     /// Unreferences the frame's buffers, returning it to a blank state.
     pub fn unref(&mut self) {
         // SAFETY: `self.ptr` is a valid owned frame.
@@ -229,6 +375,28 @@ impl Frame {
             Ok(dst)
         }
     }
+}
+
+/// Returns the pixel height of video plane `plane` for `format`, or `None` if
+/// the format has no pixel descriptor.
+///
+/// Plane 0 spans the full frame height; subsequent (chroma) planes are
+/// subsampled vertically by `log2_chroma_h` from the format's descriptor.
+fn plane_height(format: c_int, height: c_int, plane: usize) -> Option<c_int> {
+    // SAFETY: `av_pix_fmt_desc_get` takes the format by value and returns a
+    //         pointer into FFmpeg's static descriptor table (or null for an
+    //         unknown format); the pointee is read only while valid here.
+    let desc = unsafe { ffi_av_pix_fmt_desc_get(format) };
+    if desc.is_null() {
+        return None;
+    }
+    if plane == 0 {
+        return Some(height);
+    }
+    // SAFETY: `desc` is non-null (checked); `log2_chroma_h` is a plain field.
+    let log2_chroma_h = unsafe { (*desc).log2_chroma_h };
+    let round = (1_i32 << log2_chroma_h) - 1;
+    Some((height + round) >> log2_chroma_h)
 }
 
 impl Drop for Frame {
@@ -343,5 +511,142 @@ mod tests {
             );
         }
         // Both drop cleanly: `dst` frees the moved buffer, `src` is blank.
+    }
+
+    #[test]
+    fn video_plane_mut_should_round_trip_through_video_plane() {
+        // A get_buffer'd RGB24 frame has a single packed plane whose slice length
+        // is `linesize[0] * height`; a pattern written via the mut accessor reads
+        // back identically through the shared accessor.
+        let mut frame = Frame::new().expect("frame allocation should succeed");
+        frame.set_format(crate::AVPixelFormat_AV_PIX_FMT_RGB24);
+        frame.set_width(16);
+        frame.set_height(16);
+        frame.get_buffer(0).expect("buffer alloc should succeed");
+
+        // SAFETY: `frame` is a valid get_buffer'd frame; `linesize[0]` is a field.
+        let expected_len = unsafe { (*frame.as_ptr()).linesize[0] as usize } * 16;
+
+        {
+            let plane = frame
+                .video_plane_mut(0)
+                .expect("plane 0 exists on a get_buffer'd RGB24 frame");
+            assert_eq!(plane.len(), expected_len, "len == linesize[0] * height");
+            for (i, b) in plane.iter_mut().enumerate() {
+                *b = (i % 251) as u8;
+            }
+        }
+
+        let plane = frame
+            .video_plane(0)
+            .expect("plane 0 exists on a get_buffer'd RGB24 frame");
+        assert_eq!(plane.len(), expected_len);
+        assert!(
+            plane.iter().enumerate().all(|(i, &b)| b == (i % 251) as u8),
+            "written pattern reads back unchanged"
+        );
+    }
+
+    #[test]
+    fn video_plane_should_size_chroma_planes_by_subsampling() {
+        // YUV420P chroma planes (1, 2) are vertically subsampled by 2, so their
+        // slice length is `linesize[i] * (height + 1) / 2`. Cover an even and an
+        // odd height to exercise the `(height + round) >> log2_chroma_h` rounding.
+        for height in [16i32, 17i32] {
+            let mut frame = Frame::new().expect("frame allocation should succeed");
+            frame.set_format(crate::AVPixelFormat_AV_PIX_FMT_YUV420P);
+            frame.set_width(16);
+            frame.set_height(height);
+            frame.get_buffer(0).expect("buffer alloc should succeed");
+
+            // SAFETY: `frame` is a valid get_buffer'd YUV420P frame; linesize is a field.
+            let (ls0, ls1) = unsafe {
+                let p = frame.as_ptr();
+                ((*p).linesize[0], (*p).linesize[1])
+            };
+            let chroma_h = (height + 1) / 2;
+
+            assert_eq!(
+                frame.video_plane(0).map(<[u8]>::len),
+                Some(ls0 as usize * height as usize),
+                "luma plane = linesize[0] * height (height={height})"
+            );
+            assert_eq!(
+                frame.video_plane(1).map(<[u8]>::len),
+                Some(ls1 as usize * chroma_h as usize),
+                "chroma plane = linesize[1] * (height+1)/2 (height={height})"
+            );
+        }
+    }
+
+    #[test]
+    fn video_plane_should_return_none_on_negative_linesize() {
+        // RK-008 guard: a non-positive linesize cannot size a slice, so the
+        // accessor must refuse it rather than compute a wrapped length.
+        let mut frame = Frame::new().expect("frame allocation should succeed");
+        frame.set_format(crate::AVPixelFormat_AV_PIX_FMT_RGB24);
+        frame.set_width(16);
+        frame.set_height(16);
+        frame.get_buffer(0).expect("buffer alloc should succeed");
+
+        // SAFETY: `frame` is a valid owned frame; force `linesize[0]` negative.
+        unsafe {
+            (*frame.as_mut_ptr()).linesize[0] = -1;
+        }
+        assert!(
+            frame.video_plane(0).is_none(),
+            "a negative linesize must yield None"
+        );
+    }
+
+    #[test]
+    fn audio_plane_len_should_match_planar_and_packed_layout() {
+        use crate::swresample::{channel_layout, sample_format};
+
+        let samples: c_int = 100;
+
+        // Planar S16P stereo: one plane per channel, each `samples * 2` bytes.
+        let mut planar = Frame::new().expect("frame allocation should succeed");
+        // SAFETY: set the audio fields on a fresh frame, then allocate its buffer.
+        unsafe {
+            let p = planar.as_mut_ptr();
+            (*p).format = sample_format::S16P;
+            (*p).nb_samples = samples;
+            (*p).sample_rate = 48000;
+            channel_layout::set_default(&raw mut (*p).ch_layout, 2);
+        }
+        planar.get_buffer(0).expect("planar buffer alloc");
+        assert_eq!(
+            planar.audio_plane(0).map(<[u8]>::len),
+            Some(samples as usize * 2)
+        );
+        assert_eq!(
+            planar.audio_plane(1).map(<[u8]>::len),
+            Some(samples as usize * 2)
+        );
+        assert!(
+            planar.audio_plane(2).is_none(),
+            "planar stereo has no third channel plane"
+        );
+
+        // Packed S16 stereo: a single interleaved plane 0 of `samples * 2ch * 2`.
+        let mut packed = Frame::new().expect("frame allocation should succeed");
+        // SAFETY: set the audio fields on a fresh frame, then allocate its buffer.
+        unsafe {
+            let p = packed.as_mut_ptr();
+            (*p).format = sample_format::S16;
+            (*p).nb_samples = samples;
+            (*p).sample_rate = 48000;
+            channel_layout::set_default(&raw mut (*p).ch_layout, 2);
+        }
+        packed.get_buffer(0).expect("packed buffer alloc");
+        assert_eq!(
+            packed.audio_plane(0).map(<[u8]>::len),
+            Some(samples as usize * 2 * 2)
+        );
+        assert!(
+            packed.audio_plane(1).is_none(),
+            "packed audio exposes only plane 0"
+        );
     }
 }

--- a/crates/ff-sys/src/resample_context.rs
+++ b/crates/ff-sys/src/resample_context.rs
@@ -4,12 +4,14 @@
 //! context, and frees it exactly once on drop, replacing the manual
 //! `swresample::alloc_set_opts2` + `swresample::init` + `swr_free`
 //! sequence. The value is always initialized once constructed (there is no
-//! un-initialized state), so the query methods are safe. The safe
-//! [`convert_into_planes`](ResampleContext::convert_into_planes) method resamples
-//! an owned [`Frame`]'s audio into caller-provided plane slices;
-//! [`convert`](ResampleContext::convert) stays `unsafe` for callers that still
-//! pass raw plane pointers, and [`new`](Self::new) is `unsafe` because it takes
-//! raw channel-layout pointers.
+//! un-initialized state), so the query methods are safe.
+//! [`convert_into_planes`](ResampleContext::convert_into_planes) resamples an
+//! owned [`Frame`]'s audio into caller-provided plane slices, and its mirror
+//! [`convert_into_frame`](ResampleContext::convert_into_frame) resamples caller
+//! plane slices into an owned output [`Frame`]; both take borrowed slices instead
+//! of raw pointers. [`convert`](ResampleContext::convert) stays `unsafe` for
+//! callers that still pass raw plane pointers, and [`new`](Self::new) is `unsafe`
+//! because it takes raw channel-layout pointers.
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
@@ -128,6 +130,67 @@ impl ResampleContext {
                 out_ptrs.as_mut_ptr(),
                 dst_count,
                 in_ptrs.as_ptr() as *const *const u8,
+                in_count,
+            )
+        }
+        .map_err(AvError::new)
+    }
+
+    /// Resamples / reformats caller-provided input plane slices into an owned
+    /// output [`Frame`]'s planes (safe-borrow wrapper, mirror of
+    /// [`convert_into_planes`](Self::convert_into_planes) with the roles swapped).
+    ///
+    /// `in_planes` holds one byte slice per input plane (one per channel for
+    /// planar formats, a single interleaved slice for packed formats) and
+    /// `in_count` is the number of samples per channel they hold. The output is
+    /// written into `dst`'s allocated planes, up to `dst.nb_samples` samples per
+    /// channel. Returns the number of samples produced per channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if conversion fails.
+    ///
+    /// # Safety
+    ///
+    /// `swr_convert` reads `in_count` samples from each input plane and writes up
+    /// to `dst.nb_samples` samples into each output plane, bounds the slice types
+    /// cannot express. The caller must ensure:
+    /// - `dst` is a get_buffer'd audio [`Frame`] whose planes hold at least
+    ///   `dst.nb_samples` samples per channel for the configured output format;
+    /// - each `in_planes[i]` is at least `in_count * bytes_per_sample` bytes;
+    /// - `in_planes` has one entry per input plane the configured format needs
+    ///   (planar formats need one plane per channel); at most
+    ///   [`AV_NUM_DATA_POINTERS`] planes are forwarded on each side.
+    /// An undersized or missing plane is an out-of-bounds / null access.
+    pub unsafe fn convert_into_frame(
+        &mut self,
+        dst: &mut Frame,
+        in_planes: &[&[u8]],
+        in_count: c_int,
+    ) -> Result<c_int, AvError> {
+        // Build fixed-size input pointer array from the borrowed slices; unused
+        // entries stay null, matching how FFmpeg treats absent planes.
+        const PLANES: usize = AV_NUM_DATA_POINTERS as usize;
+        let mut in_ptrs: [*const u8; PLANES] = [std::ptr::null(); PLANES];
+        for (i, plane) in in_planes.iter().enumerate().take(PLANES) {
+            in_ptrs[i] = plane.as_ptr();
+        }
+
+        let dst_ptr = dst.as_mut_ptr();
+        // SAFETY: `self.ptr` is a valid initialized context. `out_ptrs` is a local
+        //         copy of `dst`'s (get_buffer'd) output plane pointers and `in_ptrs`
+        //         a local copy of the caller's input plane pointers, both valid for
+        //         the duration of the call; `swr_convert` reads/writes only within
+        //         them for the sample counts given (upheld by the caller, see
+        //         # Safety).
+        unsafe {
+            let mut out_ptrs: [*mut u8; PLANES] = (*dst_ptr).data;
+            let out_count = (*dst_ptr).nb_samples;
+            crate::swresample::convert(
+                self.ptr.as_ptr(),
+                out_ptrs.as_mut_ptr(),
+                out_count,
+                in_ptrs.as_ptr(),
                 in_count,
             )
         }
@@ -276,6 +339,53 @@ mod tests {
         // SAFETY: `dst[0]` is sized for `samples` stereo S16 samples; `src` holds
         //         `samples` input samples.
         let produced = unsafe { ctx.convert_into_planes(&mut dst, samples, &src) }
+            .expect("conversion should succeed");
+        assert_eq!(
+            produced, samples,
+            "identity resample returns all input samples"
+        );
+    }
+
+    #[test]
+    fn convert_into_frame_should_write_resampled_samples() {
+        // Identity stereo S16 resample (48k -> 48k) into a get_buffer'd output
+        // frame: exercises the safe frame-output convert without a rate change.
+        let out_layout = channel_layout::stereo();
+        let in_layout = channel_layout::stereo();
+        // SAFETY: the two layouts are valid for the duration of the call.
+        let mut ctx = unsafe {
+            ResampleContext::new(
+                &out_layout,
+                sample_format::S16,
+                48000,
+                &in_layout,
+                sample_format::S16,
+                48000,
+            )
+        }
+        .expect("context creation should succeed");
+
+        let samples: c_int = 256;
+
+        // Source: packed S16 stereo input plane holding `samples` samples.
+        let in_plane = vec![0u8; samples as usize * 2 * 2];
+        let in_planes: [&[u8]; 1] = [in_plane.as_slice()];
+
+        // Destination: a get_buffer'd packed S16 stereo frame sized for `samples`.
+        let mut dst = crate::Frame::new().expect("frame allocation should succeed");
+        // SAFETY: set the audio fields on a fresh frame, then allocate its buffer.
+        unsafe {
+            let p = dst.as_mut_ptr();
+            (*p).format = sample_format::S16;
+            (*p).nb_samples = samples;
+            (*p).sample_rate = 48000;
+            channel_layout::set_default(&raw mut (*p).ch_layout, 2);
+        }
+        dst.get_buffer(0).expect("dst buffer alloc should succeed");
+
+        // SAFETY: `dst` is a get_buffer'd frame sized for `samples`; `in_planes[0]`
+        //         holds `samples` packed stereo S16 input samples.
+        let produced = unsafe { ctx.convert_into_frame(&mut dst, &in_planes, samples) }
             .expect("conversion should succeed");
         assert_eq!(
             produced, samples,


### PR DESCRIPTION
## Objective

- ff-encode still held raw `*mut AVFrame`/`*mut AVPacket` (including the image encoder's persistent fields with a manual Drop) and reached through `(*frame).data[i]` for its fill paths, because owned `Frame` deliberately exposed no plane accessor. This is the foundation + image + audio slice of #1512.

## Solution

- Add `Frame::{video_plane, video_plane_mut, audio_plane, audio_plane_mut}` — typed, self-sizing views returning safe slices (video sized by `linesize * plane_height` via the format's `log2_chroma_h`; audio by `nb_samples`); they return `None` and guard a non-positive `linesize`/`height`/`nb_samples` so the length can never wrap into an out-of-bounds slice. Add `ResampleContext::convert_into_frame` (the mirror of `convert_into_planes`).
- Migrate the image encoder's persistent `dst_frame`/`packet` to owned `Frame`/`Packet` (its manual Drop shrinks to the raw format context) and the audio encoder to `convert_into_frame` + `audio_plane_mut`, removing the manual frame/packet frees.
- The zero-pad path now silences every planar channel's tail (the old code only zeroed plane 0 — a latent-bug fix).
- Tests: plane round-trip, chroma-plane sizing (even/odd height), a negative-linesize guard, and an identity `convert_into_frame`.

The video encoder + preview (and the `buffersink_get_frame` wrapper) are relocated to #1514.

Closes #1512