### PR TITLE
refactor(ff-encode): adopt owned Frame/Packet in the video encoder

### DIFF
--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -19,8 +19,7 @@ use super::two_pass::AV_CODEC_FLAG_PASS1;
 use super::{
     AV_TIME_BASE, AVChapter, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P,
     AudioCodec, EncodeError, VideoCodec, VideoEncoderInner, av_interleaved_write_frame, av_mallocz,
-    av_packet_alloc, av_packet_free, av_packet_unref, avformat_free_context, avformat_new_stream,
-    ptr,
+    avformat_free_context, avformat_new_stream, ptr,
 };
 
 impl VideoEncoderInner {
@@ -730,18 +729,17 @@ impl VideoEncoderInner {
         let out_stream = *(*self.format_ctx).streams.add(out_stream_index as usize);
         let out_time_base = (*out_stream).time_base;
 
-        let pkt = av_packet_alloc();
-        if pkt.is_null() {
+        let Ok(mut pkt) = ff_sys::Packet::new() else {
             let mut src_ctx_ptr = src_ctx;
             ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "subtitle_passthrough: av_packet_alloc failed".to_string(),
             });
-        }
+        };
 
         loop {
-            match ff_sys::avformat::read_frame(src_ctx, pkt) {
+            match ff_sys::avformat::read_frame(src_ctx, pkt.as_mut_ptr()) {
                 Err(e) if e == ff_sys::error_codes::EOF => break,
                 Err(e) => {
                     log::warn!(
@@ -754,25 +752,29 @@ impl VideoEncoderInner {
                 Ok(()) => {}
             }
 
+            // This is a demux-input packet; its fields have no typed accessor and
+            // are read/written through the packet pointer.
+            let p = pkt.as_mut_ptr();
+
             // Skip packets from other streams.
-            if (*pkt).stream_index != source_stream_index as i32 {
-                av_packet_unref(pkt);
+            if (*p).stream_index != source_stream_index as i32 {
+                pkt.unref();
                 continue;
             }
 
             // Rescale timestamps from the source stream's time base to the output stream's.
             // SAFETY: pkt is valid; time bases are plain value types.
-            ff_sys::av_packet_rescale_ts(pkt, in_time_base, out_time_base);
-            (*pkt).stream_index = out_stream_index;
+            ff_sys::av_packet_rescale_ts(p, in_time_base, out_time_base);
+            (*p).stream_index = out_stream_index;
 
             // SRT/subtitle packets typically carry only PTS (DTS is AV_NOPTS_VALUE).
             // The matroska muxer requires a valid DTS for av_interleaved_write_frame;
             // mirror PTS → DTS when DTS is absent so packets are not silently dropped.
-            if (*pkt).dts == i64::MIN {
-                (*pkt).dts = (*pkt).pts;
+            if (*p).dts == i64::MIN {
+                (*p).dts = (*p).pts;
             }
 
-            let write_ret = av_interleaved_write_frame(self.format_ctx, pkt);
+            let write_ret = av_interleaved_write_frame(self.format_ctx, p);
             if write_ret < 0 {
                 log::warn!(
                     "subtitle_passthrough: av_interleaved_write_frame failed \
@@ -780,10 +782,10 @@ impl VideoEncoderInner {
                     ff_sys::av_error_string(write_ret)
                 );
             }
-            av_packet_unref(pkt);
+            pkt.unref();
         }
 
-        av_packet_free(std::ptr::from_mut::<*mut _>(&mut (pkt as *mut _)));
+        // `pkt` drops at end of scope, freeing it.
         let mut src_ctx_ptr = src_ctx;
         ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
 

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -12,9 +12,8 @@
 
 use super::color::{pixel_format_to_av, sample_format_to_av};
 use super::{
-    AVChannelLayout, AVCodecContext, AVFrame, AVPixelFormat, AudioFrame, EncodeError,
-    VideoEncoderInner, VideoFrame, av_interleaved_write_frame, av_packet_alloc, av_packet_free,
-    av_packet_unref, ptr, swresample,
+    AVChannelLayout, AVCodecContext, AVPixelFormat, AudioFrame, EncodeError, VideoEncoderInner,
+    VideoFrame, av_interleaved_write_frame, swresample,
 };
 
 /// Maximum number of planes in AVFrame data/linesize arrays.
@@ -37,25 +36,21 @@ impl VideoEncoderInner {
     pub(super) unsafe fn drain_pass1_packets(
         codec_ctx: &mut ff_sys::CodecContext,
     ) -> Result<(), EncodeError> {
-        let mut packet = av_packet_alloc();
-        if packet.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate packet".to_string(),
-            });
-        }
+        let mut packet = ff_sys::Packet::new().map_err(|_| EncodeError::Ffmpeg {
+            code: 0,
+            message: "Cannot allocate packet".to_string(),
+        })?;
 
         loop {
-            match codec_ctx.receive_packet(packet) {
+            match codec_ctx.receive_packet(packet.as_mut_ptr()) {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Discard — do not write to the format context.
-                    av_packet_unref(packet);
+                    packet.unref();
                 }
                 Ok(ff_sys::ReceiveOutcome::NeedInput | ff_sys::ReceiveOutcome::Drained) => {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -67,7 +62,6 @@ impl VideoEncoderInner {
             }
         }
 
-        av_packet_free(&raw mut packet);
         Ok(())
     }
 
@@ -90,13 +84,12 @@ impl VideoEncoderInner {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it directly manipulates FFmpeg AVFrame pointers.
-    /// The caller must ensure that `dst` is a valid, properly allocated AVFrame pointer
-    /// and that `codec_ctx` is a valid, open `AVCodecContext`.
+    /// The caller must ensure `codec_ctx` is a valid, open `AVCodecContext`; its
+    /// fields are read through the raw pointer. `dst` is a safe owned frame.
     pub(super) unsafe fn convert_video_frame(
         &mut self,
         src: &VideoFrame,
-        dst: *mut AVFrame,
+        dst: &mut ff_sys::Frame,
         codec_ctx: *mut AVCodecContext,
     ) -> Result<(), EncodeError> {
         let target_fmt = (*codec_ctx).pix_fmt;
@@ -145,29 +138,26 @@ impl VideoEncoderInner {
     pub(super) unsafe fn copy_frame_direct(
         &self,
         src: &VideoFrame,
-        dst: *mut AVFrame,
+        dst: &mut ff_sys::Frame,
         target_fmt: AVPixelFormat,
     ) -> Result<(), EncodeError> {
         // Set frame properties
-        (*dst).format = target_fmt;
-        (*dst).width = src.width() as i32;
-        (*dst).height = src.height() as i32;
+        dst.set_format(target_fmt);
+        dst.set_width(src.width() as i32);
+        dst.set_height(src.height() as i32);
 
         // Allocate frame buffer
-        let ret = ff_sys::av_frame_get_buffer(dst, 0);
-        if ret < 0 {
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!(
-                    "Cannot allocate frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                ),
-            });
-        }
+        dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Cannot allocate frame buffer: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
         // Copy each plane directly
         for (i, plane) in src.planes().iter().enumerate() {
-            if i >= (*dst).data.len() || (*dst).data[i].is_null() {
+            if i >= MAX_PLANES {
                 break;
             }
 
@@ -181,31 +171,32 @@ impl VideoEncoderInner {
                     message: format!("Missing stride for plane {}", i),
                 })?;
 
-            let dst_stride = (*dst).linesize[i] as usize;
             let plane_data = plane.data();
-            let plane_height = self.get_plane_height(src.height(), i, src.format());
+            // The destination stride is the frame's own linesize for plane i.
+            // SAFETY: `dst` is a valid get_buffer'd frame; `linesize` is a plain field.
+            let dst_stride = (*dst.as_ptr()).linesize[i] as usize;
+            // `video_plane_mut` yields `None` for an absent plane (null data),
+            // matching the previous null-plane break; it self-sizes to the plane's
+            // `linesize * plane_height`, superseding the removed `get_plane_height`.
+            let Some(dst_plane) = dst.video_plane_mut(i) else {
+                break;
+            };
 
-            // Optimization: If strides match, copy entire plane at once
+            // Optimization: If strides match, copy the whole plane at once.
             if src_stride == dst_stride {
-                let total_size = src_stride * plane_height;
-                if total_size <= plane_data.len() {
-                    ptr::copy_nonoverlapping(plane_data.as_ptr(), (*dst).data[i], total_size);
-                    continue;
-                }
-            }
-
-            // Copy line by line to handle different strides
-            for y in 0..plane_height {
-                let src_offset = y * src_stride;
-                let dst_offset = y * dst_stride;
-                let line_size = src_stride.min(dst_stride);
-
-                if src_offset + line_size <= plane_data.len() {
-                    ptr::copy_nonoverlapping(
-                        plane_data.as_ptr().add(src_offset),
-                        (*dst).data[i].add(dst_offset),
-                        line_size,
-                    );
+                let n = plane_data.len().min(dst_plane.len());
+                dst_plane[..n].copy_from_slice(&plane_data[..n]);
+            } else {
+                // Copy line by line to handle different strides.
+                let row_bytes = src_stride.min(dst_stride);
+                let num_rows = dst_plane.len() / dst_stride;
+                for row in 0..num_rows {
+                    let src_off = row * src_stride;
+                    let dst_off = row * dst_stride;
+                    if src_off + row_bytes <= plane_data.len() {
+                        dst_plane[dst_off..dst_off + row_bytes]
+                            .copy_from_slice(&plane_data[src_off..src_off + row_bytes]);
+                    }
                 }
             }
         }
@@ -217,106 +208,41 @@ impl VideoEncoderInner {
     pub(super) unsafe fn scale_frame(
         &mut self,
         src: &VideoFrame,
-        dst: *mut AVFrame,
+        dst: &mut ff_sys::Frame,
         target_fmt: AVPixelFormat,
         target_width: u32,
         target_height: u32,
     ) -> Result<(), EncodeError> {
         // Set frame properties
-        (*dst).format = target_fmt;
-        (*dst).width = target_width as i32;
-        (*dst).height = target_height as i32;
+        dst.set_format(target_fmt);
+        dst.set_width(target_width as i32);
+        dst.set_height(target_height as i32);
 
         // Allocate frame buffer
-        let ret = ff_sys::av_frame_get_buffer(dst, 0);
-        if ret < 0 {
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!(
-                    "Cannot allocate frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                ),
-            });
-        }
+        dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Cannot allocate frame buffer: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
-        // Prepare source data pointers and strides
-        let mut src_data: [*const u8; MAX_PLANES] = [ptr::null(); MAX_PLANES];
-        let mut src_linesize: [i32; MAX_PLANES] = [0; MAX_PLANES];
+        // Prepare source plane slices and strides.
+        let src_planes: Vec<&[u8]> = src.planes().iter().map(|p| p.data()).collect();
+        let src_strides: Vec<i32> = src.strides().iter().map(|&s| s as i32).collect();
 
-        for (i, plane) in src.planes().iter().enumerate() {
-            if i < MAX_PLANES {
-                src_data[i] = plane.data().as_ptr();
-                src_linesize[i] = src.strides()[i] as i32;
-            }
-        }
-
-        // Perform scaling/conversion using the cached scaling context.
+        // Perform scaling/conversion using the cached scaling context (kept across
+        // frames — unlike the single-use image encoder, this context is reused).
         self.sws_ctx
             .as_mut()
             .ok_or_else(|| EncodeError::Ffmpeg {
                 code: 0,
                 message: "Scaling context not initialized".to_string(),
             })?
-            .scale(
-                src_data.as_ptr(),
-                src_linesize.as_ptr(),
-                0,
-                src.height() as i32,
-                (*dst).data.as_mut_ptr().cast_const(),
-                (*dst).linesize.as_mut_ptr(),
-            )
+            .scale_planes(&src_planes, &src_strides, src.height() as i32, dst)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         Ok(())
-    }
-
-    /// Calculate the height of a plane for a given frame height and pixel format.
-    ///
-    /// Different pixel formats have different plane heights. For YUV 4:2:0 formats,
-    /// the U/V planes are half the height of the Y plane.
-    ///
-    /// # Arguments
-    ///
-    /// * `frame_height` - The height of the entire frame
-    /// * `plane_index` - The plane index (0: Y/RGB, 1: U/UV, 2: V)
-    /// * `format` - The pixel format
-    ///
-    /// # Returns
-    ///
-    /// The height (number of rows) for the specified plane.
-    #[allow(clippy::manual_div_ceil)]
-    pub(super) fn get_plane_height(
-        &self,
-        frame_height: u32,
-        plane_index: usize,
-        format: ff_format::PixelFormat,
-    ) -> usize {
-        use ff_format::PixelFormat;
-
-        match format {
-            // YUV 4:2:0 - U and V planes are half height
-            PixelFormat::Yuv420p | PixelFormat::Yuv420p10le => {
-                if plane_index == 0 {
-                    frame_height as usize
-                } else {
-                    // Safe division with ceiling: (height + 1) / 2
-                    // Equivalent to div_ceil(2) but more explicit about avoiding overflow
-                    // Note: div_ceil() internally uses (n + d - 1) / d which could overflow
-                    ((frame_height as usize) + 1) / 2
-                }
-            }
-            // Semi-planar NV12/NV21/P010 - UV plane is half height
-            PixelFormat::Nv12 | PixelFormat::Nv21 | PixelFormat::P010le => {
-                if plane_index == 0 {
-                    frame_height as usize
-                } else {
-                    // Safe division with ceiling: (height + 1) / 2
-                    ((frame_height as usize) + 1) / 2
-                }
-            }
-            // All other formats - full height for all planes
-            _ => frame_height as usize,
-        }
     }
 
     /// Receive encoded packets from the encoder.
@@ -327,13 +253,10 @@ impl VideoEncoderInner {
             });
         }
 
-        let mut packet = av_packet_alloc();
-        if packet.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate packet".to_string(),
-            });
-        }
+        let mut packet = ff_sys::Packet::new().map_err(|_| EncodeError::Ffmpeg {
+            code: 0,
+            message: "Cannot allocate packet".to_string(),
+        })?;
 
         loop {
             let recv = self
@@ -342,7 +265,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
                 })?
-                .receive_packet(packet);
+                .receive_packet(packet.as_mut_ptr());
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -352,7 +275,6 @@ impl VideoEncoderInner {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -363,33 +285,33 @@ impl VideoEncoderInner {
                 }
             }
 
-            // Set stream index
-            (*packet).stream_index = self.video_stream_index;
+            // Set stream index and, for keyframes, attach HDR10 side data. These
+            // packet fields have no typed accessor, so they are read/written
+            // through the packet pointer.
+            let pkt = packet.as_mut_ptr();
+            (*pkt).stream_index = self.video_stream_index;
 
-            // Attach HDR10 side data to keyframe packets.
             if let Some(ref meta) = self.hdr10_metadata {
                 const AV_PKT_FLAG_KEY: i32 = 1;
-                if (*packet).flags & AV_PKT_FLAG_KEY != 0 {
-                    self.attach_hdr10_side_data(packet, meta);
+                if (*pkt).flags & AV_PKT_FLAG_KEY != 0 {
+                    self.attach_hdr10_side_data(pkt, meta);
                 }
             }
 
             // Write packet
-            let write_ret = av_interleaved_write_frame(self.format_ctx, packet);
+            let write_ret = av_interleaved_write_frame(self.format_ctx, pkt);
             if write_ret < 0 {
-                av_packet_unref(packet);
-                av_packet_free(&raw mut packet);
+                packet.unref();
                 return Err(EncodeError::MuxingFailed {
                     reason: ff_sys::av_error_string(write_ret),
                 });
             }
 
-            self.bytes_written += (*packet).size as u64;
+            self.bytes_written += (*pkt).size as u64;
 
-            av_packet_unref(packet);
+            packet.unref();
         }
 
-        av_packet_free(&raw mut packet);
         Ok(())
     }
 
@@ -397,7 +319,7 @@ impl VideoEncoderInner {
     pub(super) unsafe fn convert_audio_frame(
         &mut self,
         src: &AudioFrame,
-        dst: *mut AVFrame,
+        dst: &mut ff_sys::Frame,
     ) -> Result<(), EncodeError> {
         let codec_ctx = self
             .audio_codec_ctx
@@ -448,37 +370,40 @@ impl VideoEncoderInner {
                 src.samples() as i32,
             );
 
-            // Set frame properties
-            (*dst).format = target_format;
-            (*dst).sample_rate = target_sample_rate;
-            (*dst).nb_samples = out_samples;
-
-            // Copy target channel layout
-            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, target_ch_layout)
-                .map_err(EncodeError::from_ffmpeg_error)?;
-
-            // Allocate frame buffer
-            let ret = ff_sys::av_frame_get_buffer(dst, 0);
-            if ret < 0 {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!(
-                        "Cannot allocate audio frame buffer: {}",
-                        ff_sys::av_error_string(ret)
-                    ),
-                });
+            // Set frame properties. These audio scalar fields have no typed
+            // setter, so they are written through the frame pointer.
+            // SAFETY: `dst` is a valid owned frame; these are plain fields.
+            {
+                let p = dst.as_mut_ptr();
+                (*p).format = target_format;
+                (*p).sample_rate = target_sample_rate;
+                (*p).nb_samples = out_samples;
             }
 
-            // Prepare input pointers
-            let in_ptrs: Vec<*const u8> = if src.format().is_planar() {
-                // Planar: one pointer per channel
-                src.planes().iter().map(|p| p.as_ptr()).collect()
+            // Copy target channel layout
+            swresample::channel_layout::copy(
+                &raw mut (*dst.as_mut_ptr()).ch_layout,
+                target_ch_layout,
+            )
+            .map_err(EncodeError::from_ffmpeg_error)?;
+
+            // Allocate frame buffer
+            dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Cannot allocate audio frame buffer: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
+
+            // Prepare input plane slices (planar: one per channel; packed: one).
+            let in_planes: Vec<&[u8]> = if src.format().is_planar() {
+                src.planes().iter().map(Vec::as_slice).collect()
             } else {
-                // Packed: single pointer
-                vec![src.planes()[0].as_ptr()]
+                vec![src.planes()[0].as_slice()]
             };
 
-            // Convert
+            // Convert into the output frame's planes.
             let samples_out = self
                 .swr_ctx
                 .as_mut()
@@ -486,52 +411,50 @@ impl VideoEncoderInner {
                     code: 0,
                     message: "Resampling context not initialized".to_string(),
                 })?
-                .convert(
-                    (*dst).data.as_mut_ptr().cast(),
-                    out_samples,
-                    in_ptrs.as_ptr(),
-                    src.samples() as i32,
-                )
+                .convert_into_frame(dst, &in_planes, src.samples() as i32)
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-            (*dst).nb_samples = samples_out;
+            // SAFETY: `dst` is a valid owned frame; `nb_samples` is a plain field.
+            (*dst.as_mut_ptr()).nb_samples = samples_out;
         } else {
-            // No resampling needed, direct copy
-            (*dst).format = src_format;
-            (*dst).sample_rate = src_sample_rate;
-            (*dst).nb_samples = src.samples() as i32;
-
-            // Copy channel layout
-            swresample::channel_layout::copy(&raw mut (*dst).ch_layout, &raw const src_ch_layout)
-                .map_err(EncodeError::from_ffmpeg_error)?;
-
-            // Allocate frame buffer
-            let ret = ff_sys::av_frame_get_buffer(dst, 0);
-            if ret < 0 {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!(
-                        "Cannot allocate audio frame buffer: {}",
-                        ff_sys::av_error_string(ret)
-                    ),
-                });
+            // No resampling needed, direct copy. These audio scalar fields have no
+            // typed setter, so they are written through the frame pointer.
+            // SAFETY: `dst` is a valid owned frame; these are plain fields.
+            {
+                let p = dst.as_mut_ptr();
+                (*p).format = src_format;
+                (*p).sample_rate = src_sample_rate;
+                (*p).nb_samples = src.samples() as i32;
             }
 
-            // Copy audio data
+            // Copy channel layout
+            swresample::channel_layout::copy(
+                &raw mut (*dst.as_mut_ptr()).ch_layout,
+                &raw const src_ch_layout,
+            )
+            .map_err(EncodeError::from_ffmpeg_error)?;
+
+            // Allocate frame buffer
+            dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Cannot allocate audio frame buffer: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
+
+            // Copy audio data into the destination frame's planes.
             if src.format().is_planar() {
-                // Copy each plane
                 for (i, plane) in src.planes().iter().enumerate() {
-                    if i < (*dst).data.len() && !(*dst).data[i].is_null() {
-                        let size = plane.len();
-                        ptr::copy_nonoverlapping(plane.as_ptr(), (*dst).data[i], size);
+                    if let Some(dst_plane) = dst.audio_plane_mut(i) {
+                        let n = plane.len().min(dst_plane.len());
+                        dst_plane[..n].copy_from_slice(&plane[..n]);
                     }
                 }
-            } else {
-                // Copy single packed buffer
-                if !(*dst).data[0].is_null() {
-                    let size = src.planes()[0].len();
-                    ptr::copy_nonoverlapping(src.planes()[0].as_ptr(), (*dst).data[0], size);
-                }
+            } else if let Some(dst_plane) = dst.audio_plane_mut(0) {
+                let src_plane = &src.planes()[0];
+                let n = src_plane.len().min(dst_plane.len());
+                dst_plane[..n].copy_from_slice(&src_plane[..n]);
             }
         }
 
@@ -546,13 +469,10 @@ impl VideoEncoderInner {
             });
         }
 
-        let mut packet = av_packet_alloc();
-        if packet.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate packet".to_string(),
-            });
-        }
+        let mut packet = ff_sys::Packet::new().map_err(|_| EncodeError::Ffmpeg {
+            code: 0,
+            message: "Cannot allocate packet".to_string(),
+        })?;
 
         loop {
             let recv = self
@@ -561,7 +481,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Audio codec not initialized".to_string(),
                 })?
-                .receive_packet(packet);
+                .receive_packet(packet.as_mut_ptr());
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -571,7 +491,6 @@ impl VideoEncoderInner {
                     break;
                 }
                 Err(e) => {
-                    av_packet_free(&raw mut packet);
                     return Err(EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -582,25 +501,24 @@ impl VideoEncoderInner {
                 }
             }
 
-            // Set stream index
-            (*packet).stream_index = self.audio_stream_index;
+            // Set stream index. This packet field has no typed accessor, so it is
+            // written through the packet pointer.
+            (*packet.as_mut_ptr()).stream_index = self.audio_stream_index;
 
             // Write packet
-            let write_ret = av_interleaved_write_frame(self.format_ctx, packet);
+            let write_ret = av_interleaved_write_frame(self.format_ctx, packet.as_mut_ptr());
             if write_ret < 0 {
-                av_packet_unref(packet);
-                av_packet_free(&raw mut packet);
+                packet.unref();
                 return Err(EncodeError::MuxingFailed {
                     reason: ff_sys::av_error_string(write_ret),
                 });
             }
 
-            self.bytes_written += (*packet).size as u64;
+            self.bytes_written += (*packet.as_ptr()).size as u64;
 
-            av_packet_unref(packet);
+            packet.unref();
         }
 
-        av_packet_free(&raw mut packet);
         Ok(())
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -37,13 +37,12 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
     AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG, AVCodecID_AV_CODEC_ID_PRORES,
     AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9,
-    AVFormatContext, AVFrame, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
+    AVFormatContext, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
     AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, av_frame_alloc, av_frame_free, av_interleaved_write_frame,
-    av_mallocz, av_packet_alloc, av_packet_free, av_packet_new_side_data, av_packet_unref,
-    av_write_trailer, avcodec, avformat_alloc_output_context2, avformat_free_context,
-    avformat_new_stream, avformat_write_header, swresample,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, av_interleaved_write_frame, av_mallocz,
+    av_packet_new_side_data, av_write_trailer, avcodec, avformat_alloc_output_context2,
+    avformat_free_context, avformat_new_stream, avformat_write_header, swresample,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -325,40 +324,31 @@ impl VideoEncoderInner {
                     .as_mut_ptr();
 
                 // Convert the incoming frame to YUV420P (the pass-1 codec's format).
-                let mut av_frame = av_frame_alloc();
-                if av_frame.is_null() {
-                    return Err(EncodeError::Ffmpeg {
-                        code: 0,
-                        message: "Cannot allocate frame".to_string(),
-                    });
-                }
+                let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Cannot allocate frame".to_string(),
+                })?;
 
-                let convert_result = self.convert_video_frame(frame, av_frame, pass1_ctx);
-                if let Err(e) = convert_result {
-                    av_frame_free(&raw mut av_frame);
-                    return Err(e);
-                }
+                self.convert_video_frame(frame, &mut av_frame, pass1_ctx)?;
 
-                // Buffer the converted YUV420P data for pass-2 replay.
+                // Buffer the converted YUV420P data for pass-2 replay. `video_plane`
+                // self-sizes each plane (Y full height, U/V by chroma subsampling)
+                // and yields `None` (→ empty Vec) for an absent plane.
                 let width = (*pass1_ctx).width as u32;
                 let height = (*pass1_ctx).height as u32;
-                let uv_height = (height as usize).div_ceil(2);
 
                 let planes: Vec<Vec<u8>> = (0..3)
                     .map(|i| {
-                        if (*av_frame).data[i].is_null() {
-                            return Vec::new();
-                        }
-                        let stride = (*av_frame).linesize[i] as usize;
-                        let h = if i == 0 { height as usize } else { uv_height };
-                        // SAFETY: data[i] points to a valid buffer of stride * h bytes
-                        // allocated by av_frame_get_buffer inside convert_video_frame.
-                        std::slice::from_raw_parts((*av_frame).data[i], stride * h).to_vec()
+                        av_frame
+                            .video_plane(i)
+                            .map(<[u8]>::to_vec)
+                            .unwrap_or_default()
                     })
                     .collect();
 
-                let strides: Vec<usize> =
-                    (0..3).map(|i| (*av_frame).linesize[i] as usize).collect();
+                let strides: Vec<usize> = (0..3)
+                    .map(|i| (*av_frame.as_ptr()).linesize[i] as usize)
+                    .collect();
 
                 self.buffered_frames.push(TwoPassFrame {
                     planes,
@@ -371,33 +361,26 @@ impl VideoEncoderInner {
 
                 // Send to pass-1 encoder and discard the encoded output.
                 // time_base.den = fps * 1000, so one frame duration = 1000 ticks.
-                (*av_frame).pts = self.frame_count as i64 * 1000;
-                let send_result = self
-                    .pass1_codec_ctx
+                av_frame.set_pts(self.frame_count as i64 * 1000);
+                self.pass1_codec_ctx
                     .as_mut()
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Pass-1 codec context not initialized".to_string(),
                     })?
-                    .send_frame(av_frame);
-                if let Err(e) = send_result {
-                    av_frame_free(&raw mut av_frame);
-                    return Err(EncodeError::Ffmpeg {
+                    .send_frame(av_frame.as_ptr())
+                    .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
                             "Failed to send frame to pass-1 encoder: {}",
                             ff_sys::av_error_string(e.code())
                         ),
-                    });
-                }
+                    })?;
 
-                let drain_result =
-                    Self::drain_pass1_packets(self.pass1_codec_ctx.as_mut().ok_or_else(|| {
-                        EncodeError::InvalidConfig {
-                            reason: "Pass-1 codec context not initialized".to_string(),
-                        }
-                    })?);
-                av_frame_free(&raw mut av_frame);
-                drain_result?;
+                Self::drain_pass1_packets(self.pass1_codec_ctx.as_mut().ok_or_else(|| {
+                    EncodeError::InvalidConfig {
+                        reason: "Pass-1 codec context not initialized".to_string(),
+                    }
+                })?)?;
 
                 self.frame_count += 1;
                 return Ok(());
@@ -413,52 +396,35 @@ impl VideoEncoderInner {
                 .as_mut_ptr();
 
             // Allocate AVFrame
-            let mut av_frame = av_frame_alloc();
-            if av_frame.is_null() {
-                return Err(EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Cannot allocate frame".to_string(),
-                });
-            }
+            let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate frame".to_string(),
+            })?;
 
             // Convert VideoFrame to AVFrame
-            let convert_result = self.convert_video_frame(frame, av_frame, codec_ctx);
-            if let Err(e) = convert_result {
-                av_frame_free(&raw mut av_frame);
-                return Err(e);
-            }
+            self.convert_video_frame(frame, &mut av_frame, codec_ctx)?;
 
             // Set frame properties.
             // time_base.den = fps * 1000, so one frame duration = 1000 ticks.
-            (*av_frame).pts = self.frame_count as i64 * 1000;
+            av_frame.set_pts(self.frame_count as i64 * 1000);
 
             // Send frame to encoder
-            let send_result = self
-                .video_codec_ctx
+            self.video_codec_ctx
                 .as_mut()
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
                 })?
-                .send_frame(av_frame);
-            if let Err(e) = send_result {
-                av_frame_free(&raw mut av_frame);
-                return Err(EncodeError::Ffmpeg {
+                .send_frame(av_frame.as_ptr())
+                .map_err(|e| EncodeError::Ffmpeg {
                     code: e.code(),
                     message: format!(
                         "Failed to send frame: {}",
                         ff_sys::av_error_string(e.code())
                     ),
-                });
-            }
+                })?;
 
-            // Receive packets
-            let receive_result = self.receive_packets();
-
-            // Always cleanup the frame
-            av_frame_free(&raw mut av_frame);
-
-            // Check if receiving packets failed
-            receive_result?;
+            // Receive packets (the owned `av_frame` drops at end of scope).
+            self.receive_packets()?;
 
             self.frame_count += 1;
 
@@ -487,38 +453,28 @@ impl VideoEncoderInner {
             let frame_size = (*codec_ctx).frame_size;
 
             // Allocate and convert incoming frame.
-            let mut av_frame = av_frame_alloc();
-            if av_frame.is_null() {
-                return Err(EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Cannot allocate frame".to_string(),
-                });
-            }
-            if let Err(e) = self.convert_audio_frame(frame, av_frame) {
-                av_frame_free(&raw mut av_frame);
-                return Err(e);
-            }
+            let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+                code: 0,
+                message: "Cannot allocate frame".to_string(),
+            })?;
+            self.convert_audio_frame(frame, &mut av_frame)?;
 
             // ── Variable frame-size path (PCM, Vorbis …) ────────────────────
             if frame_size <= 0 || self.audio_fifo.is_none() {
-                (*av_frame).pts = self.audio_sample_count as i64;
-                let send_result = self
-                    .audio_codec_ctx
+                av_frame.set_pts(self.audio_sample_count as i64);
+                self.audio_codec_ctx
                     .as_mut()
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(av_frame);
-                av_frame_free(&raw mut av_frame);
-                if let Err(e) = send_result {
-                    return Err(EncodeError::Ffmpeg {
+                    .send_frame(av_frame.as_ptr())
+                    .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
                             "Failed to send audio frame: {}",
                             ff_sys::av_error_string(e.code())
                         ),
-                    });
-                }
+                    })?;
                 self.receive_audio_packets()?;
                 self.audio_sample_count += frame.samples() as u64;
                 return Ok(());
@@ -529,73 +485,67 @@ impl VideoEncoderInner {
                 reason: "Audio FIFO not initialized for fixed-frame-size codec".to_string(),
             })?;
 
-            // Write converted samples into the FIFO.
-            let nb_samples = (*av_frame).nb_samples;
-            let write_result = ff_sys::swresample::audio_fifo::write(
-                fifo,
-                (*av_frame).data.as_ptr() as *const *mut _,
-                nb_samples,
-            );
-            av_frame_free(&raw mut av_frame);
-            write_result.map_err(EncodeError::from_ffmpeg_error)?;
+            // Write converted samples into the FIFO, then let `av_frame` drop.
+            {
+                let nb_samples = (*av_frame.as_ptr()).nb_samples;
+                ff_sys::swresample::audio_fifo::write(
+                    fifo,
+                    (*av_frame.as_ptr()).data.as_ptr() as *const *mut _,
+                    nb_samples,
+                )
+                .map_err(EncodeError::from_ffmpeg_error)?;
+            }
+            drop(av_frame);
 
             // Drain full frame_size chunks.
             while ff_sys::swresample::audio_fifo::size(fifo) >= frame_size {
-                let mut out_frame = av_frame_alloc();
-                if out_frame.is_null() {
-                    return Err(EncodeError::Ffmpeg {
-                        code: 0,
-                        message: "Cannot allocate audio frame".to_string(),
-                    });
+                let mut out_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+                    code: 0,
+                    message: "Cannot allocate audio frame".to_string(),
+                })?;
+                // These audio scalar fields have no typed setter, so they are
+                // written through the frame pointer.
+                {
+                    let p = out_frame.as_mut_ptr();
+                    (*p).nb_samples = frame_size;
+                    (*p).format = (*codec_ctx).sample_fmt;
+                    (*p).sample_rate = (*codec_ctx).sample_rate;
                 }
-                (*out_frame).nb_samples = frame_size;
-                (*out_frame).format = (*codec_ctx).sample_fmt;
-                (*out_frame).sample_rate = (*codec_ctx).sample_rate;
                 swresample::channel_layout::copy(
-                    &raw mut (*out_frame).ch_layout,
+                    &raw mut (*out_frame.as_mut_ptr()).ch_layout,
                     &raw const (*codec_ctx).ch_layout,
                 )
                 .map_err(EncodeError::from_ffmpeg_error)?;
 
-                let ret = ff_sys::av_frame_get_buffer(out_frame, 0);
-                if ret < 0 {
-                    av_frame_free(&raw mut out_frame);
-                    return Err(EncodeError::Ffmpeg {
-                        code: ret,
-                        message: format!(
-                            "Cannot allocate audio frame buffer: {}",
-                            ff_sys::av_error_string(ret)
-                        ),
-                    });
-                }
+                out_frame.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+                    code: e.code(),
+                    message: format!(
+                        "Cannot allocate audio frame buffer: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
+                })?;
 
-                if let Err(e) = ff_sys::swresample::audio_fifo::read(
+                ff_sys::swresample::audio_fifo::read(
                     fifo,
-                    (*out_frame).data.as_mut_ptr().cast(),
+                    (*out_frame.as_mut_ptr()).data.as_mut_ptr().cast(),
                     frame_size,
-                ) {
-                    av_frame_free(&raw mut out_frame);
-                    return Err(EncodeError::from_ffmpeg_error(e));
-                }
+                )
+                .map_err(EncodeError::from_ffmpeg_error)?;
 
-                (*out_frame).pts = self.audio_sample_count as i64;
-                let send_result = self
-                    .audio_codec_ctx
+                out_frame.set_pts(self.audio_sample_count as i64);
+                self.audio_codec_ctx
                     .as_mut()
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(out_frame);
-                av_frame_free(&raw mut out_frame);
-                if let Err(e) = send_result {
-                    return Err(EncodeError::Ffmpeg {
+                    .send_frame(out_frame.as_ptr())
+                    .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
                             "Failed to send audio frame: {}",
                             ff_sys::av_error_string(e.code())
                         ),
-                    });
-                }
+                    })?;
                 self.receive_audio_packets()?;
                 self.audio_sample_count += frame_size as u64;
             }
@@ -640,35 +590,39 @@ impl VideoEncoderInner {
                     })?
                     .as_mut_ptr();
                 let remaining = ff_sys::swresample::audio_fifo::size(fifo);
-                if remaining > 0 {
-                    let mut out_frame = av_frame_alloc();
-                    if !out_frame.is_null() {
-                        (*out_frame).nb_samples = remaining;
-                        (*out_frame).format = (*codec_ctx).sample_fmt;
-                        (*out_frame).sample_rate = (*codec_ctx).sample_rate;
-                        let _ = swresample::channel_layout::copy(
-                            &raw mut (*out_frame).ch_layout,
-                            &raw const (*codec_ctx).ch_layout,
-                        );
-                        if ff_sys::av_frame_get_buffer(out_frame, 0) == 0 {
-                            let _ = ff_sys::swresample::audio_fifo::read(
-                                fifo,
-                                (*out_frame).data.as_mut_ptr().cast(),
-                                remaining,
-                            );
-                            (*out_frame).pts = self.audio_sample_count as i64;
-                            let _ = self
-                                .audio_codec_ctx
-                                .as_mut()
-                                .ok_or_else(|| EncodeError::InvalidConfig {
-                                    reason: "Audio codec not initialized".to_string(),
-                                })?
-                                .send_frame(out_frame);
-                            let _ = self.receive_audio_packets();
-                            self.audio_sample_count += remaining as u64;
-                        }
-                        av_frame_free(&raw mut out_frame);
+                if remaining > 0
+                    && let Ok(mut out_frame) = ff_sys::Frame::new()
+                {
+                    // These audio scalar fields have no typed setter, so they are
+                    // written through the frame pointer.
+                    {
+                        let p = out_frame.as_mut_ptr();
+                        (*p).nb_samples = remaining;
+                        (*p).format = (*codec_ctx).sample_fmt;
+                        (*p).sample_rate = (*codec_ctx).sample_rate;
                     }
+                    let _ = swresample::channel_layout::copy(
+                        &raw mut (*out_frame.as_mut_ptr()).ch_layout,
+                        &raw const (*codec_ctx).ch_layout,
+                    );
+                    if out_frame.get_buffer(0).is_ok() {
+                        let _ = ff_sys::swresample::audio_fifo::read(
+                            fifo,
+                            (*out_frame.as_mut_ptr()).data.as_mut_ptr().cast(),
+                            remaining,
+                        );
+                        out_frame.set_pts(self.audio_sample_count as i64);
+                        let _ = self
+                            .audio_codec_ctx
+                            .as_mut()
+                            .ok_or_else(|| EncodeError::InvalidConfig {
+                                reason: "Audio codec not initialized".to_string(),
+                            })?
+                            .send_frame(out_frame.as_ptr());
+                        let _ = self.receive_audio_packets();
+                        self.audio_sample_count += remaining as u64;
+                    }
+                    // `out_frame` drops here.
                 }
             }
 
@@ -819,80 +773,6 @@ mod tests {
             assert!(h265_candidates.contains(&"libaom-av1"));
             assert!(!h265_candidates.contains(&"libx265"));
         }
-    }
-
-    #[test]
-    fn test_get_plane_height_yuv420p() {
-        let inner = create_dummy_encoder_inner();
-
-        // Test YUV420P format - Y plane is full height, U/V planes are half height
-        // Even height (640x480)
-        assert_eq!(
-            inner.get_plane_height(480, 0, ff_format::PixelFormat::Yuv420p),
-            480
-        );
-        assert_eq!(
-            inner.get_plane_height(480, 1, ff_format::PixelFormat::Yuv420p),
-            240
-        );
-        assert_eq!(
-            inner.get_plane_height(480, 2, ff_format::PixelFormat::Yuv420p),
-            240
-        );
-
-        // Odd height (641x481) - test ceiling division
-        assert_eq!(
-            inner.get_plane_height(481, 0, ff_format::PixelFormat::Yuv420p),
-            481
-        );
-        assert_eq!(
-            inner.get_plane_height(481, 1, ff_format::PixelFormat::Yuv420p),
-            241
-        ); // (481 + 1) / 2 = 241
-        assert_eq!(
-            inner.get_plane_height(481, 2, ff_format::PixelFormat::Yuv420p),
-            241
-        );
-    }
-
-    #[test]
-    fn test_get_plane_height_nv12() {
-        let inner = create_dummy_encoder_inner();
-
-        // Test NV12 format - Y plane is full height, UV plane is half height
-        assert_eq!(
-            inner.get_plane_height(1080, 0, ff_format::PixelFormat::Nv12),
-            1080
-        );
-        assert_eq!(
-            inner.get_plane_height(1080, 1, ff_format::PixelFormat::Nv12),
-            540
-        );
-
-        // Odd height
-        assert_eq!(
-            inner.get_plane_height(1081, 0, ff_format::PixelFormat::Nv12),
-            1081
-        );
-        assert_eq!(
-            inner.get_plane_height(1081, 1, ff_format::PixelFormat::Nv12),
-            541
-        ); // (1081 + 1) / 2 = 541
-    }
-
-    #[test]
-    fn test_get_plane_height_rgba() {
-        let inner = create_dummy_encoder_inner();
-
-        // Test RGBA format - all planes are full height (only 1 plane)
-        assert_eq!(
-            inner.get_plane_height(720, 0, ff_format::PixelFormat::Rgba),
-            720
-        );
-        assert_eq!(
-            inner.get_plane_height(720, 1, ff_format::PixelFormat::Rgba),
-            720
-        );
     }
 
     #[test]

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -16,7 +16,7 @@ use super::color::{
 use super::options::codec_to_id;
 use super::{
     AVPixelFormat_AV_PIX_FMT_YUV420P, CString, EncodeError, VideoEncoderConfig, VideoEncoderInner,
-    av_frame_alloc, av_frame_free, av_write_trailer, avformat_write_header, ptr,
+    av_write_trailer, avformat_write_header, ptr,
 };
 
 /// FFmpeg pass-1 encoding flag: collect two-pass statistics, discard encoded output.
@@ -359,88 +359,72 @@ impl VideoEncoderInner {
             });
         }
 
-        let mut av_frame = av_frame_alloc();
-        if av_frame.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot allocate frame for pass 2".to_string(),
-            });
-        }
+        let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
+            code: 0,
+            message: "Cannot allocate frame for pass 2".to_string(),
+        })?;
 
         // Set frame format — always YUV420P (converted during pass 1).
-        (*av_frame).format = AVPixelFormat_AV_PIX_FMT_YUV420P;
-        (*av_frame).width = tf.width as i32;
-        (*av_frame).height = tf.height as i32;
+        av_frame.set_format(AVPixelFormat_AV_PIX_FMT_YUV420P);
+        av_frame.set_width(tf.width as i32);
+        av_frame.set_height(tf.height as i32);
 
         // Allocate the frame buffer.
-        let ret = ff_sys::av_frame_get_buffer(av_frame, 0);
-        if ret < 0 {
-            av_frame_free(&raw mut av_frame);
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!(
-                    "Cannot allocate pass-2 frame buffer: {}",
-                    ff_sys::av_error_string(ret)
-                ),
-            });
-        }
+        av_frame.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Cannot allocate pass-2 frame buffer: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
 
-        // Copy the buffered YUV420P data into the AVFrame.
-        let uv_height = (tf.height as usize).div_ceil(2);
+        // Copy the buffered YUV420P data into the AVFrame. `video_plane_mut`
+        // self-sizes each destination plane (Y full height, U/V by subsampling)
+        // and yields `None` for an absent plane.
         for (plane_idx, (plane_data, src_stride)) in
             tf.planes.iter().zip(tf.strides.iter()).enumerate()
         {
-            if plane_idx >= 3 || (*av_frame).data[plane_idx].is_null() || plane_data.is_empty() {
+            if plane_idx >= 3 || plane_data.is_empty() {
                 break;
             }
-            let dst_stride = (*av_frame).linesize[plane_idx] as usize;
-            let plane_height = if plane_idx == 0 {
-                tf.height as usize
-            } else {
-                uv_height
+            // SAFETY: `av_frame` is a valid get_buffer'd frame; `linesize` is a plain field.
+            let dst_stride = (*av_frame.as_ptr()).linesize[plane_idx] as usize;
+            let Some(dst_plane) = av_frame.video_plane_mut(plane_idx) else {
+                break;
             };
 
-            for row in 0..plane_height {
+            let num_rows = dst_plane.len() / dst_stride;
+            for row in 0..num_rows {
                 let src_off = row * src_stride;
                 let dst_off = row * dst_stride;
                 let copy_len = (*src_stride).min(dst_stride);
 
                 if src_off + copy_len <= plane_data.len() {
-                    // SAFETY: bounds checked above; both pointers are valid and
-                    // the regions do not overlap.
-                    ptr::copy_nonoverlapping(
-                        plane_data.as_ptr().add(src_off),
-                        (*av_frame).data[plane_idx].add(dst_off),
-                        copy_len,
-                    );
+                    dst_plane[dst_off..dst_off + copy_len]
+                        .copy_from_slice(&plane_data[src_off..src_off + copy_len]);
                 }
             }
         }
 
-        (*av_frame).pts = tf.pts;
+        av_frame.set_pts(tf.pts);
 
         // Send to pass-2 encoder.
-        let send_result = self
-            .video_codec_ctx
+        self.video_codec_ctx
             .as_mut()
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Video codec not initialized".to_string(),
             })?
-            .send_frame(av_frame);
-        if let Err(e) = send_result {
-            av_frame_free(&raw mut av_frame);
-            return Err(EncodeError::Ffmpeg {
+            .send_frame(av_frame.as_ptr())
+            .map_err(|e| EncodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(
                     "Failed to send frame to pass-2 encoder: {}",
                     ff_sys::av_error_string(e.code())
                 ),
-            });
-        }
+            })?;
 
-        let receive_result = self.receive_packets();
-        av_frame_free(&raw mut av_frame);
-        receive_result?;
+        // Receive packets (the owned `av_frame` drops at end of scope).
+        self.receive_packets()?;
 
         self.frame_count += 1;
         Ok(())


### PR DESCRIPTION
## Objective

- Continue the ff-sys RAII hardening (#1473, ADR-0003): the video encoder still held its frames and packets as raw `*mut AVFrame` / `*mut AVPacket` locals with manual `av_frame_free` / `av_packet_free`.
- Complete the #1514 split (PR-B); the preview half plus the buffersink wrapper landed in #1517.

## Solution

- Migrate every transient frame/packet local in the video encoder to owned `ff_sys::Frame` / `ff_sys::Packet`; the manual frees and their multi-exit cleanup are removed (the owned types free on drop).
- Route fill/scale/convert through the safe #1512 accessors: `copy_frame_direct` → `Frame::video_plane_mut`, `scale_frame` → `ScaleContext::scale_planes` (cached context kept), `convert_audio_frame` → `ResampleContext::convert_into_frame` / `Frame::audio_plane_mut`, two-pass read → `Frame::video_plane`; the convert helpers take `&mut Frame` instead of a raw dst pointer.
- Remove the hand-rolled `get_plane_height` and its tests; plane heights now come from the self-sizing accessors (correct for every subsampling layout). Audio scalar fields and packet fields that have no typed accessor stay as raw field access via `as_mut_ptr()`. Behavior-preserving; no new ff-sys API.

Closes #1516