### PR TITLE
feat(ff-sys): add RAII OutputFormatContext and migrate ff-encode muxers

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -24,17 +24,16 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3,
     AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_NONE,
     AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE,
-    AVCodecID_AV_CODEC_ID_VORBIS, AVFormatContext, av_interleaved_write_frame, av_write_trailer,
-    avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header, swresample,
+    AVCodecID_AV_CODEC_ID_VORBIS, OutputFormatContext, av_interleaved_write_frame,
+    avformat_new_stream, swresample,
 };
-use std::ffi::{CString, c_void};
+use std::ffi::c_void;
 use std::ptr;
 
 /// Internal encoder state with FFmpeg contexts.
 pub(super) struct AudioEncoderInner {
-    /// Output format context
-    pub(super) format_ctx: *mut AVFormatContext,
+    /// Output format context (owned; frees itself and closes its IO on drop)
+    pub(super) format_ctx: OutputFormatContext,
 
     /// Audio codec context
     pub(super) codec_ctx: Option<ff_sys::CodecContext>,
@@ -80,33 +79,16 @@ impl AudioEncoderInner {
         unsafe {
             ff_sys::ensure_initialized();
 
-            // Allocate output format context
-            let c_path = CString::new(config.path.to_str().ok_or_else(|| {
-                EncodeError::CannotCreateFile {
-                    path: config.path.clone(),
-                }
-            })?)
-            .map_err(|_| EncodeError::CannotCreateFile {
-                path: config.path.clone(),
-            })?;
-
-            let mut format_ctx: *mut AVFormatContext = ptr::null_mut();
-            let ret = avformat_alloc_output_context2(
-                &raw mut format_ctx,
-                ptr::null_mut(),
-                ptr::null(),
-                c_path.as_ptr(),
-            );
-
-            if ret < 0 || format_ctx.is_null() {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
+            // Allocate output format context (owned; muxer guessed from the path).
+            // On any early return below, its `Drop` closes the IO and frees it.
+            let format_ctx =
+                OutputFormatContext::new(None, &config.path).map_err(|e| EncodeError::Ffmpeg {
+                    code: e.code(),
                     message: format!(
                         "Cannot create output context: {}",
-                        ff_sys::av_error_string(ret)
+                        ff_sys::av_error_string(e.code())
                     ),
-                });
-            }
+                })?;
 
             let mut encoder = Self {
                 format_ctx,
@@ -123,27 +105,21 @@ impl AudioEncoderInner {
             // Initialize audio encoder
             encoder.init_audio_encoder(config)?;
 
-            // Open output file
-            if let Ok(pb) =
-                ff_sys::avformat::open_output(&config.path, ff_sys::avformat::avio_flags::WRITE)
-            {
-                (*format_ctx).pb = pb;
-            } else {
-                encoder.cleanup();
-                return Err(EncodeError::CannotCreateFile {
+            // Open output file (the owned context closes it on drop).
+            encoder.format_ctx.open_io(&config.path).map_err(|_| {
+                EncodeError::CannotCreateFile {
                     path: config.path.clone(),
-                });
-            }
+                }
+            })?;
 
             // Write file header
-            let ret = avformat_write_header(format_ctx, ptr::null_mut());
-            if ret < 0 {
-                encoder.cleanup();
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!("Cannot write header: {}", ff_sys::av_error_string(ret)),
-                });
-            }
+            encoder
+                .format_ctx
+                .write_header()
+                .map_err(|e| EncodeError::Ffmpeg {
+                    code: e.code(),
+                    message: format!("Cannot write header: {}", ff_sys::av_error_string(e.code())),
+                })?;
 
             Ok(encoder)
         }
@@ -251,7 +227,7 @@ impl AudioEncoderInner {
         }
 
         // Create stream
-        let stream = avformat_new_stream(self.format_ctx, codec_ptr);
+        let stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), codec_ptr);
         if stream.is_null() {
             // The owned codec_ctx frees itself on return.
             return Err(EncodeError::Ffmpeg {
@@ -271,7 +247,7 @@ impl AudioEncoderInner {
             .parameters_from_context((*stream).codecpar)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        self.stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
+        self.stream_index = (self.format_ctx.nb_streams() - 1) as i32;
         self.codec_ctx = Some(codec_ctx);
 
         Ok(())
@@ -762,7 +738,8 @@ impl AudioEncoderInner {
             (*packet.as_mut_ptr()).stream_index = self.stream_index;
 
             // Write packet
-            let write_ret = av_interleaved_write_frame(self.format_ctx, packet.as_mut_ptr());
+            let write_ret =
+                av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), packet.as_mut_ptr());
             if write_ret < 0 {
                 packet.unref();
                 return Err(EncodeError::MuxingFailed {
@@ -803,13 +780,15 @@ impl AudioEncoderInner {
             }
 
             // Write trailer
-            let ret = av_write_trailer(self.format_ctx);
-            if ret < 0 {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
-                });
-            }
+            self.format_ctx
+                .write_trailer()
+                .map_err(|e| EncodeError::Ffmpeg {
+                    code: e.code(),
+                    message: format!(
+                        "Cannot write trailer: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
+                })?;
 
             Ok(())
         } // unsafe
@@ -829,14 +808,8 @@ impl AudioEncoderInner {
         // Free resampling context (owned ResampleContext drops on assignment).
         self.swr_ctx = None;
 
-        // Close output file
-        if !self.format_ctx.is_null() {
-            if !(*self.format_ctx).pb.is_null() {
-                ff_sys::avformat::close_output(&raw mut (*self.format_ctx).pb);
-            }
-            avformat_free_context(self.format_ctx);
-            self.format_ctx = ptr::null_mut();
-        }
+        // The owned `format_ctx` closes its IO and frees itself when the struct
+        // drops; nothing to close here.
     }
 }
 

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -7,12 +7,12 @@
 //!
 //! [`ImageEncoderInner`] owns every FFmpeg resource allocated during a single
 //! still-image encode. The destination frame, the packet, the codec context,
-//! and the scaling context are owned RAII values ([`ff_sys::Frame`],
-//! [`ff_sys::Packet`], [`ff_sys::CodecContext`], [`ff_sys::ScaleContext`]) that
-//! free themselves on drop. Only the output `AVFormatContext` remains a raw
-//! pointer; its [`Drop`] closes the IO context and frees the format context.
-//! Because `Drop` runs on every exit path — including panics and early `?`
-//! returns — no manual cleanup is needed at individual error sites.
+//! the scaling context, and the output format context are owned RAII values
+//! ([`ff_sys::Frame`], [`ff_sys::Packet`], [`ff_sys::CodecContext`],
+//! [`ff_sys::ScaleContext`], [`ff_sys::OutputFormatContext`]) that free
+//! themselves on drop; the format context also closes its IO on drop. Because
+//! drop runs on every exit path — including panics and early `?` returns — no
+//! manual cleanup is needed at individual error sites.
 
 // Rust 2024: Allow unsafe operations in unsafe functions for FFmpeg C API
 #![allow(unsafe_code)]
@@ -27,7 +27,6 @@
 #![allow(clippy::manual_c_str_literals)]
 #![allow(clippy::unused_self)]
 
-use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
@@ -35,10 +34,9 @@ use ff_format::{PixelFormat, VideoFrame};
 use ff_sys::{
     AVCodecID, AVCodecID_AV_CODEC_ID_BMP, AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_PNG,
     AVCodecID_AV_CODEC_ID_TIFF, AVCodecID_AV_CODEC_ID_WEBP, AVColorRange_AVCOL_RANGE_JPEG,
-    AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_BGR24, AVPixelFormat_AV_PIX_FMT_RGB24,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, av_interleaved_write_frame, av_write_trailer,
-    avformat, avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header, swscale,
+    AVPixelFormat, AVPixelFormat_AV_PIX_FMT_BGR24, AVPixelFormat_AV_PIX_FMT_RGB24,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, OutputFormatContext, av_interleaved_write_frame,
+    avformat_new_stream, swscale,
 };
 
 use crate::EncodeError;
@@ -64,22 +62,12 @@ pub(super) struct ImageEncodeOptions {
 
 /// Owns all FFmpeg resources for a single still-image encode operation.
 ///
-/// The destination frame, packet, codec context, and scaling context are owned
-/// RAII values that free themselves on drop. The output `AVFormatContext`
-/// starts null and is filled in as it is allocated, so the manual `Drop` only
-/// frees it when it actually exists.
-///
-/// # Drop contract
-///
-/// The manual `Drop` body only closes the IO context (`avio_closep`) and frees
-/// the output `AVFormatContext` (`avformat_free_context`). The owned
-/// [`ff_sys::Frame`], [`ff_sys::Packet`], [`ff_sys::ScaleContext`], and
-/// [`ff_sys::CodecContext`] fields free themselves via field drop after the
-/// manual body. That ordering is sound because the encoder's `AVCodecContext`
-/// and the output `AVFormatContext` are independent allocations that do not
-/// reference each other.
+/// The destination frame, packet, codec context, scaling context, and output
+/// format context are owned RAII values that free themselves on drop, so no
+/// early-return path leaks them.
 struct ImageEncoderInner {
-    format_ctx: *mut AVFormatContext,
+    /// Output format context (owned; frees itself and closes its IO on drop).
+    format_ctx: OutputFormatContext,
     codec_ctx: ff_sys::CodecContext,
     dst_frame: ff_sys::Frame,
     packet: ff_sys::Packet,
@@ -111,22 +99,41 @@ impl ImageEncoderInner {
             .pixel_format
             .map_or_else(|| preferred_pix_fmt(codec_id), pixel_format_to_av);
 
-        // Find the encoder and allocate the owned codec context up front so the
-        // struct can hold it by value; the remaining raw pointers start null and
-        // are filled in as they are allocated.
+        // Find the encoder and allocate the owned codec context, frame, packet,
+        // and (below) format context up front so the struct holds them by value.
         let codec = ff_sys::Codec::find_encoder(codec_id).ok_or(EncodeError::UnsupportedCodec {
             codec: format!("codec_id={codec_id}"),
         })?;
         let codec_ctx = ff_sys::CodecContext::new(Some(codec))
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        // Allocate the owned frame / packet up front; the format context starts
-        // null and is filled in as it is allocated.
         let dst_frame =
             ff_sys::Frame::new().map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
         let packet = ff_sys::Packet::new().map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
+        // ── Step 1: Output format context (owned) ─────────────────────────────
+        // Prefer an explicit single-image muxer when one is known. Auto-detection
+        // (NULL format name) resolves to the `image2` muxer for most still-image
+        // formats, which expects a `%d` sequence pattern in the filename and emits
+        // a cosmetic warning for ordinary names like "frame.jpg"; a dedicated
+        // single-image muxer ("mjpeg", "apng", …) avoids that. If no explicit
+        // muxer is known (e.g. BMP) or it is unavailable on a minimal FFmpeg
+        // build, fall back to auto-detection. The owned context frees itself and
+        // closes its IO on drop, so any early return below cannot leak it.
+        let format_ctx = match codec_fallback_format(codec_id) {
+            Some(fmt) => OutputFormatContext::new(Some(fmt), path)
+                .or_else(|_| OutputFormatContext::new(None, path)),
+            None => OutputFormatContext::new(None, path),
+        }
+        .map_err(|e| EncodeError::Ffmpeg {
+            code: e.code(),
+            message: format!(
+                "Cannot create output context: {}",
+                ff_sys::av_error_string(e.code())
+            ),
+        })?;
+
         let mut inner = Self {
-            format_ctx: ptr::null_mut(),
+            format_ctx,
             codec_ctx,
             dst_frame,
             packet,
@@ -136,67 +143,8 @@ impl ImageEncoderInner {
             pix_fmt,
         };
 
-        // ── Step 1: Output format context ─────────────────────────────────────
-        let c_path = CString::new(path.to_str().ok_or_else(|| EncodeError::CannotCreateFile {
-            path: path.to_path_buf(),
-        })?)
-        .map_err(|_| EncodeError::CannotCreateFile {
-            path: path.to_path_buf(),
-        })?;
-
-        // Prefer an explicit muxer name when one is available.
-        //
-        // The auto-detection path (NULL format name) resolves to the `image2`
-        // muxer for most still-image formats.  `image2` expects filenames that
-        // contain a `%d` sequence-number pattern and emits a cosmetic warning:
-        //   "[image2 @ …] The specified filename '…' does not contain an image
-        //    sequence pattern"
-        // for any ordinary name like "frame.jpg".  Using a dedicated single-image
-        // muxer ("mjpeg", "apng", …) avoids that warning entirely.
-        //
-        // If no explicit muxer is known (e.g. BMP), or if the explicit muxer
-        // fails for any reason, we fall back to auto-detection.
-        let explicit_fmt = codec_fallback_format(codec_id);
-
-        let mut ret = if let Some(fmt) = explicit_fmt {
-            avformat_alloc_output_context2(
-                &raw mut inner.format_ctx,
-                ptr::null_mut(),
-                fmt,
-                c_path.as_ptr(),
-            )
-        } else {
-            avformat_alloc_output_context2(
-                &raw mut inner.format_ctx,
-                ptr::null_mut(),
-                ptr::null(),
-                c_path.as_ptr(),
-            )
-        };
-
-        // Fallback to auto-detection if the explicit muxer was unavailable or
-        // failed (e.g. on a minimal FFmpeg build that omits the dedicated muxer).
-        if ret < 0 || inner.format_ctx.is_null() {
-            ret = avformat_alloc_output_context2(
-                &raw mut inner.format_ctx,
-                ptr::null_mut(),
-                ptr::null(),
-                c_path.as_ptr(),
-            );
-        }
-
-        if ret < 0 || inner.format_ctx.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!(
-                    "Cannot create output context: {}",
-                    ff_sys::av_error_string(ret)
-                ),
-            });
-        }
-
         // ── Step 2: Video stream ──────────────────────────────────────────────
-        let stream = avformat_new_stream(inner.format_ctx, ptr::null());
+        let stream = avformat_new_stream(inner.format_ctx.as_mut_ptr(), ptr::null());
         if stream.is_null() {
             return Err(EncodeError::Ffmpeg {
                 code: 0,
@@ -240,15 +188,16 @@ impl ImageEncoderInner {
         (*par).format = pix_fmt;
 
         // ── Step 8: Open output file ──────────────────────────────────────────
-        let io_ctx = avformat::open_output(path, avformat::avio_flags::WRITE)
-            .map_err(EncodeError::from_ffmpeg_error)?;
-        (*inner.format_ctx).pb = io_ctx;
+        inner
+            .format_ctx
+            .open_io(path)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Step 9: Write file header ─────────────────────────────────────────
-        let ret = avformat_write_header(inner.format_ctx, ptr::null_mut());
-        if ret < 0 {
-            return Err(EncodeError::from_ffmpeg_error(ret));
-        }
+        inner
+            .format_ctx
+            .write_header()
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Step 10: Configure destination frame and allocate its buffer ──────
         inner.dst_frame.set_format(pix_fmt);
@@ -367,9 +316,10 @@ impl ImageEncoderInner {
         self.drain_packets(true)?;
 
         // ── Finalise file ─────────────────────────────────────────────────────
-        av_write_trailer(self.format_ctx);
-        // SAFETY: format_ctx and pb are non-null at this point.
-        avformat::close_output(&raw mut (*self.format_ctx).pb);
+        // Preserve the prior behaviour of not surfacing a trailer error here.
+        let _ = self.format_ctx.write_trailer();
+        // Close the IO now (nulls `pb`) so the later drop does not double-close.
+        self.format_ctx.close_io();
 
         Ok(())
     }
@@ -393,7 +343,10 @@ impl ImageEncoderInner {
                     // SAFETY: `packet` is a valid owned packet; `stream_index` is a
                     //         plain field.
                     (*self.packet.as_mut_ptr()).stream_index = 0;
-                    let ret = av_interleaved_write_frame(self.format_ctx, self.packet.as_mut_ptr());
+                    let ret = av_interleaved_write_frame(
+                        self.format_ctx.as_mut_ptr(),
+                        self.packet.as_mut_ptr(),
+                    );
                     self.packet.unref();
                     if ret < 0 {
                         return Err(EncodeError::from_ffmpeg_error(ret));
@@ -408,29 +361,6 @@ impl ImageEncoderInner {
             }
         }
         Ok(())
-    }
-}
-
-impl Drop for ImageEncoderInner {
-    fn drop(&mut self) {
-        // The owned `dst_frame`, `packet`, `sws_ctx`, and `codec_ctx` fields free
-        // themselves via field drop after this body; only the raw output
-        // `AVFormatContext` needs manual cleanup here.
-        //
-        // SAFETY: `format_ctx` is either null (never allocated) or a valid owned
-        // allocation; the null check keeps Drop idempotent.
-        unsafe {
-            if !self.format_ctx.is_null() {
-                // Close the IO context if it hasn't been closed yet (it is set
-                // to null by avio_closep, so this check prevents a double-close
-                // when encode_frame already closed it on success).
-                if !(*self.format_ctx).pb.is_null() {
-                    avformat::close_output(&raw mut (*self.format_ctx).pb);
-                }
-                avformat_free_context(self.format_ctx);
-                self.format_ctx = ptr::null_mut();
-            }
-        }
     }
 }
 
@@ -468,17 +398,17 @@ pub(super) fn codec_from_extension(path: &Path) -> Result<AVCodecID, EncodeError
 /// perform image-sequence pattern validation and are present in all standard
 /// FFmpeg builds.  Returns `None` for codecs whose primary muxer is `image2`
 /// and for which no dedicated alternative is commonly available.
-fn codec_fallback_format(codec_id: AVCodecID) -> Option<*const std::os::raw::c_char> {
+fn codec_fallback_format(codec_id: AVCodecID) -> Option<&'static str> {
     // Use if/else rather than match to avoid the non_upper_case_globals lint
     // that fires when bindgen-generated constants appear in pattern position.
     if codec_id == AVCodecID_AV_CODEC_ID_MJPEG {
-        Some(c"mjpeg".as_ptr())
+        Some("mjpeg")
     } else if codec_id == AVCodecID_AV_CODEC_ID_PNG {
-        Some(c"apng".as_ptr())
+        Some("apng")
     } else if codec_id == AVCodecID_AV_CODEC_ID_TIFF {
-        Some(c"tiff".as_ptr())
+        Some("tiff")
     } else if codec_id == AVCodecID_AV_CODEC_ID_WEBP {
-        Some(c"webp".as_ptr())
+        Some("webp")
     } else {
         None
     }
@@ -718,16 +648,17 @@ mod tests {
         );
     }
 
-    // Verify Drop does not panic on a partially-initialised inner struct whose
-    // format context is null. This guards the partial-allocation cleanup path
-    // exercised when `open` returns early with an error before every field is set.
+    // Verify Drop does not panic on an inner struct whose output context was
+    // allocated but never opened (`open_io`) — the early-return path when `open`
+    // fails after allocating the context but before writing the header. The owned
+    // context must free itself with a null `pb` without closing anything.
     #[test]
-    fn drop_on_uninitialised_inner_should_not_panic() {
-        // A `None` codec yields a generic owned context that frees itself on drop;
-        // the owned frame / packet free themselves; `format_ctx` is null, so the
-        // manual Drop check skips it.
+    fn drop_with_unopened_context_should_not_panic() {
+        // All owned fields free themselves on drop; `format_ctx` has no `pb`
+        // opened, so its drop frees the context without closing an IO.
         let inner = ImageEncoderInner {
-            format_ctx: ptr::null_mut(),
+            format_ctx: OutputFormatContext::new(None, std::path::Path::new("dummy.png"))
+                .expect("output context alloc"),
             codec_ctx: ff_sys::CodecContext::new(None).expect("generic context alloc"),
             dst_frame: ff_sys::Frame::new().expect("frame alloc"),
             packet: ff_sys::Packet::new().expect("packet alloc"),

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -654,11 +654,16 @@ mod tests {
     // context must free itself with a null `pb` without closing anything.
     #[test]
     fn drop_with_unopened_context_should_not_panic() {
+        // Allocate the output context first; skip gracefully when no still-image
+        // muxer is available (CI's minimal FFmpeg is built without image2/png).
+        let Ok(format_ctx) = OutputFormatContext::new(None, std::path::Path::new("dummy.png"))
+        else {
+            return;
+        };
         // All owned fields free themselves on drop; `format_ctx` has no `pb`
         // opened, so its drop frees the context without closing an IO.
         let inner = ImageEncoderInner {
-            format_ctx: OutputFormatContext::new(None, std::path::Path::new("dummy.png"))
-                .expect("output context alloc"),
+            format_ctx,
             codec_ctx: ff_sys::CodecContext::new(None).expect("generic context alloc"),
             dst_frame: ff_sys::Frame::new().expect("frame alloc"),
             packet: ff_sys::Packet::new().expect("packet alloc"),

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -25,11 +25,10 @@ use std::time::Duration;
 
 use ff_sys::{
     AVCodecID_AV_CODEC_ID_GIF, AVCodecID_AV_CODEC_ID_PNG, AVPixelFormat_AV_PIX_FMT_RGB24,
-    AVRational, av_interleaved_write_frame, av_opt_set, av_packet_unref, av_write_trailer,
+    AVRational, OutputFormatContext, av_interleaved_write_frame, av_opt_set, av_packet_unref,
     avfilter_get_by_name, avfilter_graph_alloc, avfilter_graph_config,
     avfilter_graph_create_filter, avfilter_graph_free, avfilter_link, avformat,
-    avformat_alloc_output_context2, avformat_free_context, avformat_new_stream,
-    avformat_write_header,
+    avformat_new_stream,
 };
 
 use crate::PreviewImageError;
@@ -393,38 +392,18 @@ unsafe fn encode_frame_as_png_inner(
 ) -> Result<(), PreviewImageError> {
     let pix_fmt = AVPixelFormat_AV_PIX_FMT_RGB24;
 
-    // ── Allocate output format context ────────────────────────────────────────
-    let mut fmt_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
-    let c_path =
-        CString::new(
-            output
-                .to_str()
-                .ok_or_else(|| PreviewImageError::CannotCreateFile {
-                    path: output.to_path_buf(),
-                })?,
-        )
-        .map_err(|_| PreviewImageError::CannotCreateFile {
-            path: output.to_path_buf(),
-        })?;
-
+    // ── Allocate output format context (owned) ────────────────────────────────
     // Use the image2 muxer explicitly: it accepts the png encoder for single-
     // frame output, regardless of the file extension.  The "apng" muxer only
     // accepts the APNG (animated PNG) codec — not the plain PNG codec — and
-    // would fail at avformat_write_header.
-    let ret = avformat_alloc_output_context2(
-        &raw mut fmt_ctx,
-        ptr::null_mut(),
-        c"image2".as_ptr(),
-        c_path.as_ptr(),
-    );
-    if ret < 0 || fmt_ctx.is_null() {
-        return Err(PreviewImageError::from_ffmpeg_error(ret));
-    }
+    // would fail at the header write. The owned context frees itself and closes
+    // its IO on drop, so every early return below is leak-free.
+    let mut fmt_ctx = OutputFormatContext::new(Some("image2"), output)
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     // ── Create video stream ───────────────────────────────────────────────────
-    let stream = avformat_new_stream(fmt_ctx, ptr::null());
+    let stream = avformat_new_stream(fmt_ctx.as_mut_ptr(), ptr::null());
     if stream.is_null() {
-        avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::Ffmpeg {
             code: 0,
             message: "avformat_new_stream failed".to_string(),
@@ -433,30 +412,22 @@ unsafe fn encode_frame_as_png_inner(
 
     // ── Find and open PNG encoder ─────────────────────────────────────────────
     let Some(codec) = ff_sys::Codec::find_encoder(AVCodecID_AV_CODEC_ID_PNG) else {
-        avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::UnsupportedCodec {
             codec: "png".to_string(),
         });
     };
 
-    let mut codec_ctx = match ff_sys::CodecContext::new(Some(codec)) {
-        Ok(ctx) => ctx,
-        Err(e) => {
-            avformat_free_context(fmt_ctx);
-            return Err(PreviewImageError::from_ffmpeg_error(e.code()));
-        }
-    };
+    let mut codec_ctx = ff_sys::CodecContext::new(Some(codec))
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     codec_ctx.set_width(width);
     codec_ctx.set_height(height);
     codec_ctx.set_time_base(AVRational { num: 1, den: 1 });
     codec_ctx.set_pix_fmt(pix_fmt);
 
-    if let Err(e) = codec_ctx.open(codec, ptr::null_mut()) {
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
-        return Err(PreviewImageError::from_ffmpeg_error(e.code()));
-    }
+    codec_ctx
+        .open(codec, ptr::null_mut())
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     // Copy codec parameters to stream.
     // SAFETY: stream and codec_ctx are non-null.
@@ -468,30 +439,16 @@ unsafe fn encode_frame_as_png_inner(
     (*par).format = pix_fmt;
 
     // ── Open output IO and write header ───────────────────────────────────────
-    let io_ctx = match avformat::open_output(output, avformat::avio_flags::WRITE) {
-        Ok(ctx) => ctx,
-        Err(e) => {
-            drop(codec_ctx);
-            avformat_free_context(fmt_ctx);
-            return Err(PreviewImageError::from_ffmpeg_error(e));
-        }
-    };
-    (*fmt_ctx).pb = io_ctx;
+    fmt_ctx
+        .open_io(output)
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
-    let ret = avformat_write_header(fmt_ctx, ptr::null_mut());
-    if ret < 0 {
-        avformat::close_output(&raw mut (*fmt_ctx).pb);
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
-        return Err(PreviewImageError::from_ffmpeg_error(ret));
-    }
+    fmt_ctx
+        .write_header()
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     // ── Allocate packet ───────────────────────────────────────────────────────
     let Ok(mut packet) = ff_sys::Packet::new() else {
-        av_write_trailer(fmt_ctx);
-        avformat::close_output(&raw mut (*fmt_ctx).pb);
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
         return Err(PreviewImageError::Ffmpeg {
             code: 0,
             message: "av_packet_alloc failed".to_string(),
@@ -505,19 +462,28 @@ unsafe fn encode_frame_as_png_inner(
         codec_ctx
             .send_frame(frame)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(&mut codec_ctx, fmt_ctx, packet.as_mut_ptr(), false)?;
+        drain_packets(
+            &mut codec_ctx,
+            fmt_ctx.as_mut_ptr(),
+            packet.as_mut_ptr(),
+            false,
+        )?;
         codec_ctx
             .send_frame(ptr::null())
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(&mut codec_ctx, fmt_ctx, packet.as_mut_ptr(), true)?;
+        drain_packets(
+            &mut codec_ctx,
+            fmt_ctx.as_mut_ptr(),
+            packet.as_mut_ptr(),
+            true,
+        )?;
         Ok(())
     })();
 
-    av_write_trailer(fmt_ctx);
-    avformat::close_output(&raw mut (*fmt_ctx).pb);
-    // `packet` drops at end of scope, freeing it.
-    drop(codec_ctx);
-    avformat_free_context(fmt_ctx);
+    // Finalise the file, then let `packet`, `codec_ctx`, and `fmt_ctx` free
+    // themselves at end of scope (the owned context closes its IO on drop).
+    let _ = fmt_ctx.write_trailer();
+    fmt_ctx.close_io();
 
     encode_result
 }
@@ -1104,38 +1070,20 @@ unsafe fn encode_gif_unsafe(
         bail!(graph, format!("avfilter_graph_config failed code={ret}"));
     }
 
-    // ── Open GIF output ───────────────────────────────────────────────────────
-    let mut fmt_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
-    let Some(path_str) = output.to_str() else {
-        let mut g = graph;
-        avfilter_graph_free(std::ptr::addr_of_mut!(g));
-        return Err(PreviewImageError::CannotCreateFile {
-            path: output.to_path_buf(),
-        });
-    };
-    let Ok(c_path) = CString::new(path_str) else {
-        let mut g = graph;
-        avfilter_graph_free(std::ptr::addr_of_mut!(g));
-        return Err(PreviewImageError::CannotCreateFile {
-            path: output.to_path_buf(),
-        });
+    // ── Open GIF output (owned format context) ────────────────────────────────
+    // The owned context frees itself and closes its IO on drop; each early return
+    // below still frees the raw filter graph explicitly.
+    let mut fmt_ctx = match OutputFormatContext::new(Some("gif"), output) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            let mut g = graph;
+            avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(PreviewImageError::from_ffmpeg_error(e.code()));
+        }
     };
 
-    let ret = avformat_alloc_output_context2(
-        &raw mut fmt_ctx,
-        ptr::null_mut(),
-        c"gif".as_ptr(),
-        c_path.as_ptr(),
-    );
-    if ret < 0 || fmt_ctx.is_null() {
-        let mut g = graph;
-        avfilter_graph_free(std::ptr::addr_of_mut!(g));
-        return Err(PreviewImageError::from_ffmpeg_error(ret));
-    }
-
-    let stream = avformat_new_stream(fmt_ctx, ptr::null());
+    let stream = avformat_new_stream(fmt_ctx.as_mut_ptr(), ptr::null());
     if stream.is_null() {
-        avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(PreviewImageError::Ffmpeg {
@@ -1145,7 +1093,6 @@ unsafe fn encode_gif_unsafe(
     }
 
     let Some(codec) = ff_sys::Codec::find_encoder(AVCodecID_AV_CODEC_ID_GIF) else {
-        avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(PreviewImageError::UnsupportedCodec {
@@ -1156,7 +1103,6 @@ unsafe fn encode_gif_unsafe(
     let mut codec_ctx = match ff_sys::CodecContext::new(Some(codec)) {
         Ok(ctx) => ctx,
         Err(e) => {
-            avformat_free_context(fmt_ctx);
             let mut g = graph;
             avfilter_graph_free(std::ptr::addr_of_mut!(g));
             return Err(PreviewImageError::from_ffmpeg_error(e.code()));
@@ -1165,8 +1111,6 @@ unsafe fn encode_gif_unsafe(
 
     // Pull a first frame to discover width/height/pix_fmt from the filter output.
     let Ok(mut first_frame) = ff_sys::Frame::new() else {
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(PreviewImageError::Ffmpeg {
@@ -1178,8 +1122,6 @@ unsafe fn encode_gif_unsafe(
     // buffer outlives the filter graph, so graph-then-frame teardown is sound).
     let outcome = ff_sys::buffersink_get_frame(sink_ctx, &mut first_frame);
     if !matches!(&outcome, Ok(ff_sys::BufferSinkOutcome::Frame)) {
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
         let reason = match outcome {
@@ -1214,8 +1156,6 @@ unsafe fn encode_gif_unsafe(
     );
 
     if let Err(e) = codec_ctx.open(codec, ptr::null_mut()) {
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(PreviewImageError::from_ffmpeg_error(e.code()));
@@ -1231,33 +1171,19 @@ unsafe fn encode_gif_unsafe(
     (*par).format = out_pix_fmt;
 
     // Open output IO and write header.
-    let io_ctx = match avformat::open_output(output, avformat::avio_flags::WRITE) {
-        Ok(ctx) => ctx,
-        Err(e) => {
-            drop(codec_ctx);
-            avformat_free_context(fmt_ctx);
-            let mut g = graph;
-            avfilter_graph_free(std::ptr::addr_of_mut!(g));
-            return Err(PreviewImageError::from_ffmpeg_error(e));
-        }
-    };
-    (*fmt_ctx).pb = io_ctx;
-
-    let ret = avformat_write_header(fmt_ctx, ptr::null_mut());
-    if ret < 0 {
-        avformat::close_output(&raw mut (*fmt_ctx).pb);
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
+    if let Err(e) = fmt_ctx.open_io(output) {
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
-        return Err(PreviewImageError::from_ffmpeg_error(ret));
+        return Err(PreviewImageError::from_ffmpeg_error(e.code()));
+    }
+
+    if let Err(e) = fmt_ctx.write_header() {
+        let mut g = graph;
+        avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(PreviewImageError::from_ffmpeg_error(e.code()));
     }
 
     let Ok(mut packet) = ff_sys::Packet::new() else {
-        av_write_trailer(fmt_ctx);
-        avformat::close_output(&raw mut (*fmt_ctx).pb);
-        drop(codec_ctx);
-        avformat_free_context(fmt_ctx);
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(PreviewImageError::Ffmpeg {
@@ -1276,7 +1202,12 @@ unsafe fn encode_gif_unsafe(
         codec_ctx
             .send_frame(first_frame.as_ptr())
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(&mut codec_ctx, fmt_ctx, packet.as_mut_ptr(), false)?;
+        drain_packets(
+            &mut codec_ctx,
+            fmt_ctx.as_mut_ptr(),
+            packet.as_mut_ptr(),
+            false,
+        )?;
 
         // Pull and encode remaining frames.
         loop {
@@ -1296,22 +1227,32 @@ unsafe fn encode_gif_unsafe(
             codec_ctx
                 .send_frame(frame.as_ptr())
                 .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-            drain_packets(&mut codec_ctx, fmt_ctx, packet.as_mut_ptr(), false)?;
+            drain_packets(
+                &mut codec_ctx,
+                fmt_ctx.as_mut_ptr(),
+                packet.as_mut_ptr(),
+                false,
+            )?;
         }
 
         // Flush encoder.
         codec_ctx
             .send_frame(ptr::null())
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(&mut codec_ctx, fmt_ctx, packet.as_mut_ptr(), true)?;
+        drain_packets(
+            &mut codec_ctx,
+            fmt_ctx.as_mut_ptr(),
+            packet.as_mut_ptr(),
+            true,
+        )?;
         Ok(())
     })();
 
-    av_write_trailer(fmt_ctx);
-    avformat::close_output(&raw mut (*fmt_ctx).pb);
-    // `packet` and `first_frame` drop at end of scope, freeing them.
-    drop(codec_ctx);
-    avformat_free_context(fmt_ctx);
+    // Finalise the GIF, then free the raw filter graph. `packet`, `first_frame`,
+    // `codec_ctx`, and `fmt_ctx` free themselves at end of scope (the owned
+    // context closes its IO on drop).
+    let _ = fmt_ctx.write_trailer();
+    fmt_ctx.close_io();
     let mut g = graph;
     avfilter_graph_free(std::ptr::addr_of_mut!(g));
 

--- a/crates/ff-encode/src/video/builder/mod.rs
+++ b/crates/ff-encode/src/video/builder/mod.rs
@@ -820,7 +820,12 @@ mod tests {
     fn create_mock_encoder(video_codec_name: &str, audio_codec_name: &str) -> VideoEncoder {
         VideoEncoder {
             inner: Some(VideoEncoderInner {
-                format_ctx: std::ptr::null_mut(),
+                // A real (unopened) mux context; the mock never muxes and drops it untouched.
+                format_ctx: ff_sys::OutputFormatContext::new(
+                    None,
+                    std::path::Path::new("mock.mp4"),
+                )
+                .expect("mock output context allocation should succeed"),
                 video_codec_ctx: None,
                 audio_codec_ctx: None,
                 video_stream_index: -1,

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -19,7 +19,7 @@ use super::two_pass::AV_CODEC_FLAG_PASS1;
 use super::{
     AV_TIME_BASE, AVChapter, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P,
     AudioCodec, EncodeError, VideoCodec, VideoEncoderInner, av_interleaved_write_frame, av_mallocz,
-    avformat_free_context, avformat_new_stream, ptr,
+    avformat_new_stream, ptr,
 };
 
 impl VideoEncoderInner {
@@ -309,7 +309,7 @@ impl VideoEncoderInner {
         );
 
         // Create stream
-        let stream = avformat_new_stream(self.format_ctx, codec_ptr);
+        let stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), codec_ptr);
         if stream.is_null() {
             // The owned codec_ctx frees itself on return.
             return Err(EncodeError::Ffmpeg {
@@ -329,7 +329,7 @@ impl VideoEncoderInner {
             (*(*stream).codecpar).format = codec_ctx.pix_fmt();
         }
 
-        self.video_stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
+        self.video_stream_index = (self.format_ctx.nb_streams() - 1) as i32;
 
         // In two-pass mode the pass-1 context is stored separately; the real
         // (pass-2) video_codec_ctx is initialised later in run_pass2().
@@ -424,7 +424,7 @@ impl VideoEncoderInner {
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Create stream
-        let stream = avformat_new_stream(self.format_ctx, codec_ptr);
+        let stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), codec_ptr);
         if stream.is_null() {
             // The owned codec_ctx frees itself on return.
             return Err(EncodeError::Ffmpeg {
@@ -452,7 +452,7 @@ impl VideoEncoderInner {
         let fifo_sample_fmt = codec_ctx.sample_fmt();
         let fifo_nb_channels = codec_ctx.channels();
 
-        self.audio_stream_index = ((*self.format_ctx).nb_streams - 1) as i32;
+        self.audio_stream_index = (self.format_ctx.nb_streams() - 1) as i32;
         self.audio_codec_ctx = Some(codec_ctx);
 
         // Allocate sample FIFO for codecs that require a fixed frame_size (AAC, FLAC, ALAC …).
@@ -518,7 +518,7 @@ impl VideoEncoderInner {
         for (data, mime_type, filename) in attachments {
             // Create a new stream for the attachment.
             // SAFETY: format_ctx is valid; null codec means the muxer selects a default.
-            let out_stream = avformat_new_stream(self.format_ctx, std::ptr::null());
+            let out_stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), std::ptr::null());
             if out_stream.is_null() {
                 log::warn!("attachment: avformat_new_stream failed, skipping filename={filename}");
                 continue;
@@ -640,9 +640,9 @@ impl VideoEncoderInner {
         }
 
         // Record the output stream index before adding the new stream.
-        let out_stream_index = (*self.format_ctx).nb_streams as i32;
+        let out_stream_index = self.format_ctx.nb_streams() as i32;
         // SAFETY: format_ctx is valid; null codec means the muxer selects a default.
-        let out_stream = avformat_new_stream(self.format_ctx, std::ptr::null());
+        let out_stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), std::ptr::null());
         if out_stream.is_null() {
             log::warn!("subtitle_passthrough: avformat_new_stream failed");
             let mut src_ctx_ptr = src_ctx;
@@ -726,7 +726,9 @@ impl VideoEncoderInner {
         let in_time_base = (*in_stream).time_base;
 
         // SAFETY: out_stream_index was set by avformat_new_stream; format_ctx is valid.
-        let out_stream = *(*self.format_ctx).streams.add(out_stream_index as usize);
+        let out_stream = *(*self.format_ctx.as_mut_ptr())
+            .streams
+            .add(out_stream_index as usize);
         let out_time_base = (*out_stream).time_base;
 
         let Ok(mut pkt) = ff_sys::Packet::new() else {
@@ -774,7 +776,7 @@ impl VideoEncoderInner {
                 (*p).dts = (*p).pts;
             }
 
-            let write_ret = av_interleaved_write_frame(self.format_ctx, p);
+            let write_ret = av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), p);
             if write_ret < 0 {
                 log::warn!(
                     "subtitle_passthrough: av_interleaved_write_frame failed \
@@ -817,13 +819,7 @@ impl VideoEncoderInner {
             ff_sys::swresample::audio_fifo::free(fifo);
         }
 
-        // Close output file
-        if !self.format_ctx.is_null() {
-            if !(*self.format_ctx).pb.is_null() {
-                ff_sys::avformat::close_output(&raw mut (*self.format_ctx).pb);
-            }
-            avformat_free_context(self.format_ctx);
-            self.format_ctx = ptr::null_mut();
-        }
+        // The owned `format_ctx` closes its IO and frees itself when the struct
+        // drops; nothing to close here.
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -299,7 +299,7 @@ impl VideoEncoderInner {
             }
 
             // Write packet
-            let write_ret = av_interleaved_write_frame(self.format_ctx, pkt);
+            let write_ret = av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), pkt);
             if write_ret < 0 {
                 packet.unref();
                 return Err(EncodeError::MuxingFailed {
@@ -506,7 +506,8 @@ impl VideoEncoderInner {
             (*packet.as_mut_ptr()).stream_index = self.audio_stream_index;
 
             // Write packet
-            let write_ret = av_interleaved_write_frame(self.format_ctx, packet.as_mut_ptr());
+            let write_ret =
+                av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), packet.as_mut_ptr());
             if write_ret < 0 {
                 packet.unref();
                 return Err(EncodeError::MuxingFailed {

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -37,12 +37,11 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
     AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG, AVCodecID_AV_CODEC_ID_PRORES,
     AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9,
-    AVFormatContext, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
+    AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
     AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, av_interleaved_write_frame, av_mallocz,
-    av_packet_new_side_data, av_write_trailer, avcodec, avformat_alloc_output_context2,
-    avformat_free_context, avformat_new_stream, avformat_write_header, swresample,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, OutputFormatContext, av_interleaved_write_frame, av_mallocz,
+    av_packet_new_side_data, avcodec, avformat_new_stream, swresample,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -50,7 +49,7 @@ use std::ptr;
 /// Internal encoder state with FFmpeg contexts.
 pub(super) struct VideoEncoderInner {
     /// Output format context
-    pub(super) format_ctx: *mut AVFormatContext,
+    pub(super) format_ctx: OutputFormatContext,
 
     /// Video codec context
     pub(super) video_codec_ctx: Option<ff_sys::CodecContext>,
@@ -159,42 +158,22 @@ impl VideoEncoderInner {
         unsafe {
             ff_sys::ensure_initialized();
 
-            // Allocate output format context
-            let c_path = CString::new(config.path.to_str().ok_or_else(|| {
-                EncodeError::CannotCreateFile {
-                    path: config.path.clone(),
-                }
-            })?)
-            .map_err(|_| EncodeError::CannotCreateFile {
-                path: config.path.clone(),
-            })?;
-
             // For image-sequence outputs (path contains '%'), use the `image2`
             // muxer explicitly. The `image2` muxer manages I/O internally
             // (AVFMT_NOFILE), so we must not call avio_open on it.
             let is_image_sequence = config.path.to_str().is_some_and(|s| s.contains('%'));
 
-            let mut format_ctx: *mut AVFormatContext = ptr::null_mut();
-            let ret = avformat_alloc_output_context2(
-                &raw mut format_ctx,
-                ptr::null_mut(),
-                if is_image_sequence {
-                    b"image2\0".as_ptr() as *const i8
-                } else {
-                    ptr::null()
-                },
-                c_path.as_ptr(),
-            );
-
-            if ret < 0 || format_ctx.is_null() {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!(
-                        "Cannot create output context: {}",
-                        ff_sys::av_error_string(ret)
-                    ),
-                });
-            }
+            // Allocate output format context (owned; frees itself / closes its IO
+            // on drop, so any early return below cannot leak it).
+            let format_ctx =
+                OutputFormatContext::new(is_image_sequence.then_some("image2"), &config.path)
+                    .map_err(|e| EncodeError::Ffmpeg {
+                        code: e.code(),
+                        message: format!(
+                            "Cannot create output context: {}",
+                            ff_sys::av_error_string(e.code())
+                        ),
+                    })?;
 
             let mut encoder = Self {
                 format_ctx,
@@ -274,31 +253,30 @@ impl VideoEncoderInner {
             // Image-sequence output (path contains '%') uses the `image2` muxer which
             // manages I/O internally (AVFMT_NOFILE) — skip avio_open in that case.
             if !config.two_pass {
-                if !is_image_sequence {
-                    if let Ok(pb) = ff_sys::avformat::open_output(
-                        &config.path,
-                        ff_sys::avformat::avio_flags::WRITE,
-                    ) {
-                        (*format_ctx).pb = pb;
-                    } else {
-                        encoder.cleanup();
-                        return Err(EncodeError::CannotCreateFile {
+                // Muxers that manage their own IO (image2 sequences, AVFMT_NOFILE)
+                // must not have a `pb` opened for them.
+                if !encoder.format_ctx.is_nofile() {
+                    encoder.format_ctx.open_io(&config.path).map_err(|_| {
+                        EncodeError::CannotCreateFile {
                             path: config.path.clone(),
-                        });
-                    }
+                        }
+                    })?;
                 }
 
-                Self::apply_movflags(format_ctx, config.container);
-                Self::apply_metadata(format_ctx, &config.metadata);
-                Self::apply_chapters(format_ctx, &config.chapters);
-                let ret = avformat_write_header(format_ctx, ptr::null_mut());
-                if ret < 0 {
-                    encoder.cleanup();
-                    return Err(EncodeError::Ffmpeg {
-                        code: ret,
-                        message: format!("Cannot write header: {}", ff_sys::av_error_string(ret)),
-                    });
-                }
+                let fmt = encoder.format_ctx.as_mut_ptr();
+                Self::apply_movflags(fmt, config.container);
+                Self::apply_metadata(fmt, &config.metadata);
+                Self::apply_chapters(fmt, &config.chapters);
+                encoder
+                    .format_ctx
+                    .write_header()
+                    .map_err(|e| EncodeError::Ffmpeg {
+                        code: e.code(),
+                        message: format!(
+                            "Cannot write header: {}",
+                            ff_sys::av_error_string(e.code())
+                        ),
+                    })?;
             }
 
             Ok(encoder)
@@ -643,13 +621,15 @@ impl VideoEncoderInner {
             self.write_subtitle_packets()?;
 
             // Write trailer
-            let ret = av_write_trailer(self.format_ctx);
-            if ret < 0 {
-                return Err(EncodeError::Ffmpeg {
-                    code: ret,
-                    message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
-                });
-            }
+            self.format_ctx
+                .write_trailer()
+                .map_err(|e| EncodeError::Ffmpeg {
+                    code: e.code(),
+                    message: format!(
+                        "Cannot write trailer: {}",
+                        ff_sys::av_error_string(e.code())
+                    ),
+                })?;
 
             Ok(())
         } // unsafe
@@ -936,7 +916,10 @@ mod tests {
     /// Helper function to create a dummy encoder inner for testing.
     fn create_dummy_encoder_inner() -> VideoEncoderInner {
         VideoEncoderInner {
-            format_ctx: ptr::null_mut(),
+            // A real (unopened) mux context; the test only exercises the sws
+            // tracking fields and drops the context untouched.
+            format_ctx: OutputFormatContext::new(None, std::path::Path::new("dummy.mp4"))
+                .expect("dummy output context allocation should succeed"),
             video_codec_ctx: None,
             audio_codec_ctx: None,
             video_stream_index: -1,

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -16,7 +16,7 @@ use super::color::{
 use super::options::codec_to_id;
 use super::{
     AVPixelFormat_AV_PIX_FMT_YUV420P, CString, EncodeError, VideoEncoderConfig, VideoEncoderInner,
-    av_write_trailer, avformat_write_header, ptr,
+    ptr,
 };
 
 /// FFmpeg pass-1 encoding flag: collect two-pass statistics, discard encoded output.
@@ -124,26 +124,23 @@ impl VideoEncoderInner {
         self.init_pass2_codec_ctx(&config, &stats_str)?;
 
         // ── Step 5: Open output file and write header ────────────────────────
-        match ff_sys::avformat::open_output(&output_path, ff_sys::avformat::avio_flags::WRITE) {
-            Ok(pb) => (*self.format_ctx).pb = pb,
-            Err(_) => {
-                return Err(EncodeError::CannotCreateFile { path: output_path });
-            }
-        }
+        self.format_ctx
+            .open_io(&output_path)
+            .map_err(|_| EncodeError::CannotCreateFile { path: output_path })?;
 
-        Self::apply_movflags(self.format_ctx, config.container);
-        Self::apply_metadata(self.format_ctx, &config.metadata);
-        Self::apply_chapters(self.format_ctx, &config.chapters);
-        let ret = avformat_write_header(self.format_ctx, ptr::null_mut());
-        if ret < 0 {
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
+        let fmt = self.format_ctx.as_mut_ptr();
+        Self::apply_movflags(fmt, config.container);
+        Self::apply_metadata(fmt, &config.metadata);
+        Self::apply_chapters(fmt, &config.chapters);
+        self.format_ctx
+            .write_header()
+            .map_err(|e| EncodeError::Ffmpeg {
+                code: e.code(),
                 message: format!(
                     "Cannot write header in pass 2: {}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 ),
-            });
-        }
+            })?;
 
         // ── Step 6: Re-encode all buffered frames ────────────────────────────
         let frames = std::mem::take(&mut self.buffered_frames);
@@ -178,13 +175,15 @@ impl VideoEncoderInner {
         // Write subtitle passthrough packets before trailer.
         self.write_subtitle_packets()?;
 
-        let ret = av_write_trailer(self.format_ctx);
-        if ret < 0 {
-            return Err(EncodeError::Ffmpeg {
-                code: ret,
-                message: format!("Cannot write trailer: {}", ff_sys::av_error_string(ret)),
-            });
-        }
+        self.format_ctx
+            .write_trailer()
+            .map_err(|e| EncodeError::Ffmpeg {
+                code: e.code(),
+                message: format!(
+                    "Cannot write trailer: {}",
+                    ff_sys::av_error_string(e.code())
+                ),
+            })?;
 
         Ok(())
     }

--- a/crates/ff-sys/src/constants.rs
+++ b/crates/ff-sys/src/constants.rs
@@ -13,6 +13,15 @@ pub const AV_NOPTS_VALUE: i64 = i64::MIN;
 /// `avformat_find_stream_info` has been called.
 pub const AVFMT_TS_DISCONT: i32 = 0x0200;
 
+/// `AVFMT_NOFILE` — `AVOutputFormat` flag indicating the muxer manages its own
+/// I/O and has no `AVIOContext` (`pb`) opened by the caller.
+///
+/// Set for muxers such as `image2` (image sequences), `hls`, `dash`, and similar
+/// segment/directory formats. When set, the caller must not `avio_open` a `pb`,
+/// and the owned [`OutputFormatContext`](crate::OutputFormatContext) must not
+/// close one on drop.
+pub const AVFMT_NOFILE: i32 = 0x0001;
+
 /// `AV_BUFFERSRC_FLAG_KEEP_REF` normalized to `i32` for cross-platform use.
 ///
 /// bindgen generates `AV_BUFFERSRC_FLAG_KEEP_REF` as `u32` on Linux/macOS

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -33,7 +33,9 @@ pub struct SwsContext(());
 pub struct SwrContext(());
 pub struct AVBufferRef(());
 pub struct AVIOContext(());
-pub struct AVOutputFormat(());
+pub struct AVOutputFormat {
+    pub flags: c_int,
+}
 pub struct AVAudioFifo(());
 
 pub struct AVInputFormat {
@@ -131,6 +133,7 @@ pub struct AVFormatContext {
     pub nb_chapters: c_uint,
     pub chapters: *mut *mut AVChapter,
     pub iformat: *mut AVInputFormat,
+    pub oformat: *const AVOutputFormat,
     pub bit_rate: i64,
     pub pb: *mut AVIOContext,
     pub priv_data: *mut c_void,
@@ -1470,6 +1473,78 @@ impl Drop for InputFormatContext {
 
 // SAFETY: stub; never executed on docs.rs.
 unsafe impl Send for InputFormatContext {}
+
+// ── RAII owner stub (mirrors crate::format_context::OutputFormatContext) ──────
+// Keeps `ff_sys::OutputFormatContext` available so the mux consumers compile for
+// docs.rs while the real `format_context` module is cfg'd out.
+
+#[derive(Debug)]
+pub struct OutputFormatContext {
+    _ptr: std::ptr::NonNull<AVFormatContext>,
+}
+
+impl OutputFormatContext {
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn new(
+        _format_name: Option<&str>,
+        _filename: &std::path::Path,
+    ) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVFormatContext {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
+        self._ptr.as_ptr()
+    }
+
+    #[must_use]
+    pub fn nb_streams(&self) -> u32 {
+        0
+    }
+
+    #[must_use]
+    pub fn oformat_flags(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn is_nofile(&self) -> bool {
+        false
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn open_io(&mut self, _path: &std::path::Path) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn write_header(&mut self) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn write_trailer(&mut self) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    pub fn close_io(&mut self) {}
+}
+
+impl Drop for OutputFormatContext {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for OutputFormatContext {}
 
 // ── Borrowed stream / params stubs (mirror crate::format_context) ─────────────
 

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -1,4 +1,4 @@
-//! RAII owner for an input (demux) `AVFormatContext`.
+//! RAII owners for input (demux) and output (mux) `AVFormatContext`s.
 //!
 //! [`InputFormatContext`] opens a demuxing context and frees it exactly once on
 //! drop, replacing the manual `avformat::open_input*` + `avformat::close_input`
@@ -7,10 +7,15 @@
 //! (an owned Packet is a later step), so that method is `unsafe`: the caller
 //! upholds the usual FFmpeg preconditions.
 //!
-//! The mux (output) lifecycle is a separate owner (`OutputFormatContext`,
-//! tracked in #1493); this type covers demuxing only.
+//! [`OutputFormatContext`] owns the mux (output) lifecycle: it allocates a
+//! muxing context, opens/closes its IO (`pb`), writes the header/trailer, and
+//! frees the context exactly once on drop (closing a caller-opened `pb`),
+//! replacing the manual `avformat_alloc_output_context2` + `avio_open` +
+//! `avformat_free_context` teardown. Like `InputFormatContext`, it exposes a
+//! transitional `as_mut_ptr` for the write path (stream creation, packet
+//! writing) not yet wrapped.
 
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::path::Path;
@@ -264,6 +269,203 @@ impl Drop for InputFormatContext {
 //         guarantees exclusive access.
 unsafe impl Send for InputFormatContext {}
 
+/// An owned output (mux) `AVFormatContext`.
+///
+/// Allocates a muxing context and frees it exactly once on drop, closing the IO
+/// (`pb`) it opened unless the muxer manages its own IO (`AVFMT_NOFILE`). This
+/// replaces the manual `avformat_alloc_output_context2` + `avio_open` +
+/// `avformat_free_context` teardown scattered across every mux consumer, so no
+/// early-return path can leak the context.
+///
+/// Exactly-once free is guaranteed by construction: the value owns a
+/// [`NonNull`] and is neither `Copy` nor `Clone`.
+///
+/// The lifecycle (allocation, IO open/close, header/trailer) is wrapped as
+/// methods; the write path (`avformat_new_stream`, per-stream field setup,
+/// `av_interleaved_write_frame`) still goes through [`as_mut_ptr`] for now, so
+/// this type carries a transitional raw accessor like [`InputFormatContext`]
+/// (both are removed when the safe layer is sealed).
+///
+/// [`as_mut_ptr`]: OutputFormatContext::as_mut_ptr
+#[derive(Debug)]
+pub struct OutputFormatContext {
+    ptr: NonNull<AVFormatContext>,
+}
+
+impl OutputFormatContext {
+    /// Allocates a muxing context for `filename`, optionally forcing the muxer
+    /// named `format_name` (otherwise it is guessed from the filename).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the format cannot be resolved or the context
+    /// cannot be allocated.
+    pub fn new(format_name: Option<&str>, filename: &Path) -> Result<Self, AvError> {
+        crate::ensure_initialized();
+
+        let c_format = match format_name {
+            Some(name) => {
+                Some(CString::new(name).map_err(|_| AvError::new(crate::error_codes::EINVAL))?)
+            }
+            None => None,
+        };
+        let filename_str = filename
+            .to_str()
+            .ok_or_else(|| AvError::new(crate::error_codes::EINVAL))?;
+        let c_filename =
+            CString::new(filename_str).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+
+        let mut ctx: *mut AVFormatContext = std::ptr::null_mut();
+        // SAFETY: `ctx` is a valid out-pointer initialised to null; the two C
+        //         strings outlive the call; a null `oformat` lets FFmpeg pick the
+        //         muxer from `format_name` / `filename`.
+        let ret = unsafe {
+            crate::avformat_alloc_output_context2(
+                &mut ctx,
+                std::ptr::null_mut(),
+                c_format.as_ref().map_or(std::ptr::null(), |c| c.as_ptr()),
+                c_filename.as_ptr(),
+            )
+        };
+        if ret < 0 {
+            return Err(AvError::new(ret));
+        }
+        NonNull::new(ctx)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })
+    }
+
+    /// Returns the context pointer for read-only use.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AVFormatContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the context pointer for mutation and FFI calls (stream creation,
+    /// packet writing, and per-stream field setup during migration).
+    #[must_use]
+    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the number of streams registered on the context.
+    #[must_use]
+    pub fn nb_streams(&self) -> u32 {
+        // SAFETY: `self.ptr` is a valid owned mux context; `nb_streams` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).nb_streams }
+    }
+
+    /// Returns the `AVOutputFormat` flags, or `0` when the format is unset.
+    #[must_use]
+    pub fn oformat_flags(&self) -> c_int {
+        // SAFETY: `self.ptr` is a valid owned mux context. `oformat` is set for
+        //         every successfully allocated output, but we null-check it
+        //         defensively before reading `flags` (a plain field).
+        unsafe {
+            let oformat = (*self.ptr.as_ptr()).oformat;
+            if oformat.is_null() {
+                0
+            } else {
+                (*oformat).flags
+            }
+        }
+    }
+
+    /// Returns `true` when the muxer manages its own IO (`AVFMT_NOFILE`), so the
+    /// caller must not open or close a `pb`.
+    #[must_use]
+    pub fn is_nofile(&self) -> bool {
+        self.oformat_flags() & crate::constants::AVFMT_NOFILE != 0
+    }
+
+    /// Opens the output IO for `path` (write mode) and attaches it as the
+    /// context's `pb`.
+    ///
+    /// Callers must skip this for [`is_nofile`](Self::is_nofile) muxers, which
+    /// manage their own IO.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the output cannot be opened for writing.
+    pub fn open_io(&mut self, path: &Path) -> Result<(), AvError> {
+        // SAFETY: `open_output` validates the path and returns a freshly opened
+        //         AVIO context; we take ownership of it as this context's `pb`.
+        let pb = unsafe { crate::avformat::open_output(path, crate::avformat::avio_flags::WRITE) }
+            .map_err(AvError::new)?;
+        // SAFETY: `self.ptr` is a valid owned mux context; `pb` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pb = pb };
+        Ok(())
+    }
+
+    /// Writes the container header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the header cannot be written.
+    pub fn write_header(&mut self) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned mux context; no muxer options.
+        let ret = unsafe { crate::avformat_write_header(self.ptr.as_ptr(), std::ptr::null_mut()) };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Writes the container trailer, finalising the output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the trailer cannot be written.
+    pub fn write_trailer(&mut self) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned mux context whose header was written.
+        let ret = unsafe { crate::av_write_trailer(self.ptr.as_ptr()) };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Closes the output IO (`pb`) early, before drop.
+    ///
+    /// Used by segment muxers (HLS/DASH) that close the caller-opened `pb` right
+    /// after the header write so the muxer can manage its own segment files. The
+    /// close nulls `pb`, so a later drop does not double-close. This is a no-op
+    /// when `pb` is already null.
+    pub fn close_io(&mut self) {
+        // SAFETY: `self.ptr` is a valid owned mux context; `close_output`
+        //         null-checks `pb` and nulls it after closing.
+        unsafe { crate::avformat::close_output(&mut (*self.ptr.as_ptr()).pb) };
+    }
+}
+
+impl Drop for OutputFormatContext {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
+        //         runs exactly once. Close the caller-opened `pb` if one is still
+        //         open (it is null for `AVFMT_NOFILE` muxers, where the caller
+        //         opened none, and after `close_io`), then free the context. A
+        //         non-null `pb` is always one the caller opened and owns, so it
+        //         must be closed regardless of the muxer flags — mirroring the
+        //         manual `if pb != null { avio_closep }` teardown this replaces.
+        //         `close_output` null-checks and nulls `pb`; `avformat_free_context`
+        //         does not touch `pb`.
+        unsafe {
+            let ctx = self.ptr.as_ptr();
+            if !(*ctx).pb.is_null() {
+                crate::avformat::close_output(&mut (*ctx).pb);
+            }
+            crate::avformat_free_context(ctx);
+        }
+    }
+}
+
+// SAFETY: an `AVFormatContext` is not safe for concurrent access, but moving
+//         ownership between threads is sound because Rust's ownership model
+//         guarantees exclusive access.
+unsafe impl Send for OutputFormatContext {}
+
 /// A borrowed handle to one `AVStream` of an [`InputFormatContext`].
 ///
 /// The lifetime ties the handle to the owning format context borrow, so it
@@ -405,5 +607,28 @@ mod tests {
         // context (the error path returns before any owned value is built).
         let result = InputFormatContext::open(Path::new("/nonexistent/path/to/file.mp4"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn output_new_should_error_on_bogus_format() {
+        // A format name that matches no muxer makes allocation fail, returning
+        // before any owned context is built (nothing to leak).
+        let result =
+            OutputFormatContext::new(Some("definitely_not_a_real_muxer"), Path::new("out.bin"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn output_new_should_allocate_and_drop() {
+        // Allocate a normal file muxer (guessed from the `.mp4` extension) and
+        // drop it immediately. This exercises the success path, the
+        // `oformat`-flag read, and free-on-drop with a never-opened `pb`. Skip
+        // gracefully if the mp4 muxer is absent from a minimal FFmpeg build.
+        let Ok(ctx) = OutputFormatContext::new(None, Path::new("out.mp4")) else {
+            return;
+        };
+        // mp4 is a normal file muxer, not one that manages its own IO.
+        assert!(!ctx.is_nofile());
+        // `ctx` drops here: frees the context (its `pb` was never opened).
     }
 }

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -77,10 +77,10 @@ pub use buffersink::{BufferSinkOutcome, buffersink_get_frame};
 pub use codec::Codec;
 #[cfg(not(docsrs))]
 pub use codec_context::{CodecContext, ReceiveOutcome};
-pub use constants::{AV_NOPTS_VALUE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
+pub use constants::{AV_NOPTS_VALUE, AVFMT_NOFILE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
 #[cfg(not(docsrs))]
-pub use format_context::{CodecParameters, InputFormatContext, StreamRef};
+pub use format_context::{CodecParameters, InputFormatContext, OutputFormatContext, StreamRef};
 #[cfg(not(docsrs))]
 pub use frame::Frame;
 #[cfg(not(docsrs))]


### PR DESCRIPTION
## Objective

- The mux consumers each drove a raw `*mut AVFormatContext` with manual `avformat_alloc_output_context2` + `avio_open` + `avformat_free_context` teardown, leaking the context on some early-return paths.
- Add an owned output-context type and migrate the first consumer (ff-encode), mirroring the demux-side `InputFormatContext` (#1478).

## Solution

- Add `ff_sys::OutputFormatContext`: allocates a muxing `AVFormatContext`, opens/closes its IO (`pb`), writes the header/trailer, and frees the context exactly once on drop (closing a caller-opened `pb`). `Drop` closes `pb` whenever it is non-null and frees regardless of muxer flags, matching the existing if-pb-non-null teardown; `is_nofile()` only decides whether to open a `pb`. Transitional `as_mut_ptr` for the not-yet-wrapped write path (removed when the safe layer is sealed), plus a docs.rs stub and the `AVFMT_NOFILE` constant.
- Migrate ff-encode's audio / video / image / preview encoders to hold the owned type and drop their manual close/free paths; the image encoder keeps its explicit-then-auto muxer fallback, the video encoder skips opening a `pb` for `AVFMT_NOFILE` muxers (image2 sequences) and defers the pass-2 open, and the preview functions keep freeing their raw filter graph while the format context frees itself.
- This is the split core (ff-sys + ff-encode); the remaining mux consumers (#1526 ff-remux/ff-filter, #1527 ff-stream) and demux consumers (#1528 ff-probe/ff-analysis) are follow-ups.

Closes #1493