### PR TITLE
docs(readme): make README code examples copy-paste runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,32 +16,38 @@ A safe, high-level Rust API over FFmpeg: an editing engine on top of a family of
 - **Two layers**: an opinionated editing engine on top of model-free FFmpeg primitives, so you can adopt the whole engine or depend on a single `ff-*` crate (see [Design Philosophy](#design-philosophy)).
 - **Focused**: a foundation for video delivery services and video editing applications in Rust; it does not try to cover every FFmpeg feature.
 
+Re-encode a video to H.264, reusing the source resolution and frame rate:
+
 ```rust
 use ff_probe::open;
 use ff_decode::VideoDecoder;
-use ff_encode::{VideoEncoder, VideoCodec, AudioCodec, BitrateMode};
+use ff_encode::{VideoEncoder, VideoCodec, BitrateMode};
 
-// Inspect a media file
-let info = open("input.mp4")?;
-if let Some(v) = info.primary_video() {
-    println!("{}x{} @ {:.2} fps", v.width(), v.height(), v.fps());
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Inspect the input and reuse its resolution and frame rate.
+    let info = open("input.mp4")?;
+    let video = info
+        .primary_video()
+        .ok_or("input.mp4 has no video stream")?;
+    let (width, height, fps) = (video.width(), video.height(), video.fps());
+    println!("{width}x{height} @ {fps:.2} fps");
+
+    // A decoder for the input, an encoder for the output.
+    let mut decoder = VideoDecoder::open("input.mp4").build()?;
+    let mut encoder = VideoEncoder::create("output.mp4")
+        .video(width, height, fps)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23)) // 0-51, lower = higher quality
+        .build()?;
+
+    // Decode every frame and re-encode it.
+    while let Some(frame) = decoder.decode_one()? {
+        encoder.push_video(&frame)?;
+    }
+    encoder.finish()?; // flush buffered frames and finalize the file
+
+    Ok(())
 }
-
-// Decode frames
-let mut decoder = VideoDecoder::open("input.mp4").build()?;
-while let Some(frame) = decoder.decode_one()? {
-    // process frame.planes() ...
-}
-
-// Re-encode
-let mut encoder = VideoEncoder::create("output.mp4")
-    .video(1920, 1080, 30.0)
-    .video_codec(VideoCodec::H264)
-    .bitrate_mode(BitrateMode::Crf(23))
-    .audio(48000, 2)
-    .audio_codec(AudioCodec::Aac)
-    .build()?;
-encoder.finish()?;
 ```
 
 ## Design Philosophy

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -49,7 +49,7 @@ The **`pipeline`** feature unlocks the editing model (`Timeline` / `Clip` / `Edi
 | `encode`        | `ff-encode` + `ff-remux`, encoding and remux   | yes     |                     |
 | `hwaccel`       | hardware-accelerated encoders                  | yes     |                     |
 | `filter`        | `ff-filter`, filter graph operations           | no      |                     |
-| `pipeline`      | `ff-pipeline`, decode/filter/encode            | no      | `filter`            |
+| `pipeline`      | `ff-pipeline`, decode/filter/encode            | no      | `decode`, `encode`, `filter` |
 | `stream`        | `ff-stream`, HLS / DASH / live streaming       | no      | `pipeline`          |
 | `preview`       | `ff-preview`, real-time playback and seek      | no      |                     |
 | `preview-proxy` | proxy generation                               | no      | `preview`           |
@@ -58,7 +58,7 @@ The **`pipeline`** feature unlocks the editing model (`Timeline` / `Clip` / `Edi
 | `tokio`         | async wrappers for decode, encode, and preview | no      | `decode` + `encode` |
 | `gpl`           | GPL-licensed encoders                          | no      |                     |
 | `srt`           | SRT input/output                               | no      |                     |
-| `serde`         | `serde` derives for the model and filter types | no      |                     |
+| `serde`         | `serde` derives for the model and filter types | no      | `pipeline`          |
 
 ## Quick Start
 
@@ -67,15 +67,21 @@ The **`pipeline`** feature unlocks the editing model (`Timeline` / `Clip` / `Edi
 Place one clip on a video track, size the canvas, and render the timeline to a file.
 
 ```rust
-use avio::{Clip, Timeline, EncoderConfig};
+use avio::{Clip, EncoderConfig, Timeline};
 
-let timeline = Timeline::builder()
-    .canvas(1920, 1080)
-    .frame_rate(30.0)
-    .video_track(vec![Clip::new("input.mp4")])
-    .build()?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // One clip on a video track; canvas and frame rate set explicitly.
+    let timeline = Timeline::builder()
+        .canvas(1920, 1080)
+        .frame_rate(30.0)
+        .video_track(vec![Clip::new("input.mp4")])
+        .build()?;
 
-timeline.render("output.mp4", EncoderConfig::builder().build())?;
+    // Derive frames from the timeline (composite, encode) in one call.
+    timeline.render("output.mp4", EncoderConfig::builder().build())?;
+
+    Ok(())
+}
 ```
 
 ### Compose multiple clips and tracks

--- a/crates/ff-analysis/README.md
+++ b/crates/ff-analysis/README.md
@@ -34,19 +34,46 @@ FFmpeg 7.x or 8.x development libraries must be installed on your system.
 use ff_analysis::WaveformAnalyzer;
 use std::time::Duration;
 
-let samples = WaveformAnalyzer::new("clip.mp4")
-    .interval(Duration::from_millis(100))
-    .run()?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // One peak/RMS sample per 100 ms interval, both in dBFS.
+    let samples = WaveformAnalyzer::new("clip.mp4")
+        .interval(Duration::from_millis(100))
+        .run()?;
+
+    for s in &samples {
+        println!("{:?}: peak={:.1} dBFS  rms={:.1} dBFS", s.timestamp, s.peak_db, s.rms_db);
+    }
+
+    Ok(())
+}
 ```
 
 ## Video scopes
 
+The scope functions are pure pixel arithmetic over a decoded `ff_format::VideoFrame`, so
+this example pulls one frame from [`ff-decode`](https://crates.io/crates/ff-decode) (add
+`ff-decode` and `ff-format` to your `Cargo.toml`). Scopes support the `yuv420p`, `yuv422p`,
+and `yuv444p` pixel formats; requesting `Yuv420p` output keeps the result deterministic.
+
 ```rust
 use ff_analysis::ScopeAnalyzer;
+use ff_decode::VideoDecoder;
+use ff_format::PixelFormat;
 
-// `frame` is a decoded `ff_format::VideoFrame`.
-let hist = ScopeAnalyzer::histogram(&frame);
-let parade = ScopeAnalyzer::rgb_parade(&frame);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut decoder = VideoDecoder::open("clip.mp4")
+        .output_format(PixelFormat::Yuv420p)
+        .build()?;
+    let frame = decoder
+        .decode_one()?
+        .ok_or("clip.mp4 has no video frames")?;
+
+    let hist = ScopeAnalyzer::histogram(&frame);
+    let parade = ScopeAnalyzer::rgb_parade(&frame);
+    println!("luma[255]={}  parade columns={}", hist.luma[255], parade.r.len());
+
+    Ok(())
+}
 ```
 
 ## Error Handling

--- a/crates/ff-common/README.md
+++ b/crates/ff-common/README.md
@@ -12,13 +12,40 @@ Shared buffer-pooling abstractions for the ff-* crate family.
 
 ## Usage
 
-`ff-common` is an internal workspace crate, not intended for direct use in application code. The following example shows the `PooledBuffer::standalone` constructor, which allocates a buffer without a backing pool:
+`ff-common` is an internal workspace crate, not intended for direct use in application code. The following program shows `VecPool`, the ready-to-use pool: buffers released to it are reused by later `acquire` calls, and a `PooledBuffer` returns itself to its pool automatically when dropped.
+
+```rust
+use ff_common::{FramePool, VecPool};
+
+fn main() {
+    // A pool that retains up to 4 reusable buffers. `VecPool::new`
+    // returns an `Arc<VecPool>` so it can be shared across threads.
+    let pool = VecPool::new(4);
+    assert_eq!(pool.available(), 0); // starts empty
+
+    // Seed the pool with one buffer, then acquire it back out.
+    pool.release(vec![0u8; 2048]);
+    assert_eq!(pool.available(), 1);
+
+    {
+        // `acquire` hands back the smallest buffer that fits, resized to
+        // the requested length. When `buf` is dropped it returns to `pool`.
+        let buf = pool.acquire(1024).unwrap();
+        assert_eq!(buf.len(), 1024);
+        assert_eq!(pool.available(), 0);
+    }
+
+    // The buffer was automatically returned on drop.
+    assert_eq!(pool.available(), 1);
+    println!("pool now holds {} buffer(s)", pool.available());
+}
+```
+
+For a buffer with no backing pool, `PooledBuffer::standalone` wraps an existing `Vec<u8>`; its memory is simply freed when dropped:
 
 ```rust
 use ff_common::PooledBuffer;
 
-// Wrap a 4096-byte buffer with no pool backing.
-// Memory is freed normally when `buf` is dropped.
 let buf = PooledBuffer::standalone(vec![0u8; 4096]);
 assert_eq!(buf.len(), 4096);
 ```

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -20,16 +20,27 @@ ff-format = "0.16"
 use ff_decode::VideoDecoder;
 use ff_format::PixelFormat;
 
-let mut decoder = VideoDecoder::open("video.mp4")
-    .output_format(PixelFormat::Rgba)
-    .build()?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // `open` returns a builder; configure it, then `build()` to get the decoder.
+    let mut decoder = VideoDecoder::open("video.mp4")
+        .output_format(PixelFormat::Rgba)
+        .build()?;
 
-while let Some(frame) = decoder.decode_one()? {
-    // frame.data()      : raw pixel bytes in RGBA order
-    // frame.width()     : frame width in pixels
-    // frame.height()    : frame height in pixels
-    // frame.timestamp() : position as Timestamp
-    process(&frame);
+    let width = decoder.width();
+    let height = decoder.height();
+    println!("{width}x{height}, duration {:?}", decoder.duration());
+
+    let mut count = 0;
+    // `decode_one` yields `Ok(None)` at end of stream.
+    while let Some(frame) = decoder.decode_one()? {
+        let ts = frame.timestamp().as_duration();   // position as a Duration
+        let pixels = frame.data();                   // raw pixel bytes in RGBA order
+        println!("frame {count} @ {ts:?}: {} bytes", pixels.len());
+        count += 1;
+    }
+
+    println!("decoded {count} frames");
+    Ok(())
 }
 ```
 
@@ -57,8 +68,9 @@ let mut decoder = AudioDecoder::open("audio.flac")
     .build()?;
 
 while let Some(frame) = decoder.decode_one()? {
-    // frame.to_f32_interleaved() : interleaved f32 samples
-    process(&frame);
+    let samples = frame.to_f32_interleaved();   // interleaved f32 samples
+    println!("{} samples", frame.sample_count());
+    // ... consume `samples` ...
 }
 ```
 
@@ -77,7 +89,7 @@ let mut decoder = VideoDecoder::open("frames/frame%04d.png")
     .build()?;
 
 while let Some(frame) = decoder.decode_one()? {
-    process(&frame);
+    println!("{}x{}", frame.width(), frame.height());
 }
 ```
 
@@ -122,7 +134,7 @@ let mut decoder = VideoDecoder::open("hdr.mkv")
     .build()?;
 ```
 
-Common 10-bit formats: `Yuv420p10le`, `Yuv422p10le`, `Yuv444p10le`, `P010Le`.
+Common 10-bit formats: `Yuv420p10le`, `Yuv422p10le`, `Yuv444p10le`, `P010le`.
 
 ## Scaled Output
 

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -22,26 +22,37 @@ By default, only LGPL-compatible encoders are enabled.
 
 ## Quick Start
 
+Encoding needs frames from somewhere; the example below decodes `input.mp4`
+with [`ff-decode`](https://crates.io/crates/ff-decode) and re-encodes it as a
+video-only H.264 file. Add `ff-decode = "0.16"` to run it.
+
 ```rust
-use ff_encode::{VideoEncoder, VideoCodec, AudioCodec, BitrateMode};
+use ff_decode::VideoDecoder;
+use ff_encode::{VideoEncoder, VideoCodec, BitrateMode};
 
-let mut encoder = VideoEncoder::create("output.mp4")
-    .video(1920, 1080, 30.0)          // width, height, fps
-    .video_codec(VideoCodec::H264)
-    .bitrate_mode(BitrateMode::Cbr(4_000_000))
-    .audio(48_000, 2)                 // sample_rate, channels
-    .audio_codec(AudioCodec::Aac)
-    .audio_bitrate(192_000)
-    .build()?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Open the source; the decoder reports its resolution and frame rate.
+    let mut decoder = VideoDecoder::open("input.mp4").build()?;
+    let (width, height, fps) = (decoder.width(), decoder.height(), decoder.frame_rate());
 
-for frame in &video_frames {
-    encoder.push_video(frame)?;
+    let mut encoder = VideoEncoder::create("output.mp4")
+        .video(width, height, fps)           // width, height, fps
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23))  // 0-51, lower = better
+        .build()?;
+
+    while let Some(frame) = decoder.decode_one()? {
+        encoder.push_video(&frame)?;
+    }
+    encoder.finish()?; // required to finalize; Drop does not flush the muxer
+    Ok(())
 }
-for frame in &audio_frames {
-    encoder.push_audio(frame)?;
-}
-encoder.finish()?;
 ```
+
+To add an audio track, configure `.audio(sample_rate, channels)` /
+`.audio_codec(...)` and push decoded `AudioFrame`s with `encoder.push_audio(&frame)?`.
+A configured audio stream that never receives frames produces an invalid file,
+so only declare audio when you actually feed it.
 
 ## Quality Modes
 
@@ -217,9 +228,10 @@ let mut encoder = VideoEncoder::create("output.mxf")
 
 | DNxHD/HR Variant | Pixel Format | Notes |
 |---|---|---|
-| `Dnxhd115`, `Dnxhd145`, `Dnxhd220` | `yuv422p` | Fixed bitrate, 1080p only |
+| `Dnxhd115`, `Dnxhd145`, `Dnxhd220` | `yuv422p` | Fixed bitrate, 1080p/720p only |
 | `Dnxhd220x`, `DnxhrHqx` | `yuv422p10le` | 10-bit |
-| `DnxhrLb`, `DnxhrSq`, `DnxhrHq`, `DnxhrR444` | `yuv422p` | Any resolution |
+| `DnxhrLb`, `DnxhrSq`, `DnxhrHq` | `yuv422p` | Any resolution |
+| `DnxhrR444` | `yuv444p10le` | Any resolution, 4:4:4 10-bit |
 
 ## HDR Metadata
 

--- a/crates/ff-filter/README.md
+++ b/crates/ff-filter/README.md
@@ -15,15 +15,45 @@ ff-filter = "0.16"
 
 ## Building a Filter Chain
 
+Filtering needs input frames, so this example decodes them with
+[`ff-decode`](https://crates.io/crates/ff-decode), runs each through the graph,
+and encodes the results with [`ff-encode`](https://crates.io/crates/ff-encode)
+(add both as dependencies to run it):
+
 ```rust
+use ff_decode::VideoDecoder;
+use ff_encode::{BitrateMode, VideoCodec, VideoEncoder};
 use ff_filter::{FilterGraph, ScaleAlgorithm};
 
-let graph = FilterGraph::builder()
-    .trim(10.0, 30.0)                           // keep seconds 10-30
-    .scale(1280, 720, ScaleAlgorithm::Fast)     // resize to 720p
-    .fade_in(0.0, 0.5)                           // 0.5-second fade in at the start
-    .fade_out(19.5, 0.5)                         // 0.5-second fade out
-    .build()?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Build a chain; the graph description is generated and validated internally.
+    let mut graph = FilterGraph::builder()
+        .trim(10.0, 30.0)                           // keep seconds 10-30
+        .scale(1280, 720, ScaleAlgorithm::Fast)     // resize to 720p
+        .fade_in(0.0, 0.5)                          // 0.5-second fade in at the start
+        .fade_out(19.5, 0.5)                        // 0.5-second fade out
+        .build()?;
+
+    // A decoder for the input, an encoder for the graph's 1280×720 output.
+    let mut decoder = VideoDecoder::open("input.mp4").build()?;
+    let (width, height) = graph.output_resolution().unwrap_or((1280, 720));
+    let mut encoder = VideoEncoder::create("output.mp4")
+        .video(width, height, decoder.frame_rate())
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Crf(23)) // 0-51, lower = higher quality
+        .build()?;
+
+    // Push decoded frames into input slot 0 and pull transformed frames out.
+    while let Some(input_frame) = decoder.decode_one()? {
+        graph.push_video(0, &input_frame)?;
+        while let Some(output_frame) = graph.pull_video()? {
+            encoder.push_video(&output_frame)?;
+        }
+    }
+    encoder.finish()?; // flush buffered frames and finalize the file
+
+    Ok(())
+}
 ```
 
 `build()` checks the configured steps and returns an `Err` if a value is out of range or the step set is empty. The underlying `FFmpeg` graph is constructed lazily on the first `push_video` / `push_audio` call, using the first frame's format.
@@ -70,18 +100,22 @@ chain automatically.
 
 ## Using the Filter Graph
 
-```rust
-// Push decoded frames into input slot 0 and pull transformed frames out.
-while let Some(input_frame) = decoder.decode_frame()? {
-    graph.push_video(0, &input_frame)?;
-    while let Some(output_frame) = graph.pull_video()? {
-        encoder.push_video(&output_frame)?;
-    }
-}
-```
+The single-input loop is shown in [Building a Filter Chain](#building-a-filter-chain)
+above: push each decoded frame into slot 0 with `push_video`, then drain the
+graph with `pull_video`.
 
 Multi-input filters (such as `xfade` or `overlay`) read from additional slots:
 push clip A frames to slot 0 and clip B frames to slot 1.
+
+```rust
+// `graph` built with .overlay(x, y); `frame_a` / `frame_b` are VideoFrames
+// from two decoders.
+graph.push_video(0, &frame_a)?; // main stream → slot 0
+graph.push_video(1, &frame_b)?; // overlay stream → slot 1
+while let Some(output_frame) = graph.pull_video()? {
+    // encode or display `output_frame`
+}
+```
 
 ## Error Handling
 

--- a/crates/ff-format/README.md
+++ b/crates/ff-format/README.md
@@ -66,19 +66,29 @@ let meta = Hdr10Metadata {
 ## Example
 
 ```rust
-use ff_format::{Timestamp, Rational};
+use ff_format::{Rational, Timestamp};
 
-// A timestamp is a PTS value paired with a time base.
-// Here the time base is 1/1000 (milliseconds), so 2500 units = 2.5 seconds.
-let time_base = Rational::new(1, 1000);
-let ts = Timestamp::new(2500, time_base);
+fn main() {
+    // A timestamp is a PTS value paired with a time base.
+    // Here the time base is 1/1000 (milliseconds), so 2500 units = 2.5 seconds.
+    let time_base = Rational::new(1, 1000);
+    let ts = Timestamp::new(2500, time_base);
 
-// Timestamps add together (the result keeps the left operand's time base).
-let one_second = Timestamp::new(1000, time_base);
-let three_and_a_half = ts + one_second;
+    // Timestamps add together (the result keeps the left operand's time base).
+    let one_second = Timestamp::new(1000, time_base);
+    let three_and_a_half = ts + one_second;
 
-assert_eq!(ts.as_secs_f64(), 2.5);
-assert_eq!(three_and_a_half.as_secs_f64(), 3.5);
+    assert_eq!(ts.as_secs_f64(), 2.5);
+    assert_eq!(three_and_a_half.as_secs_f64(), 3.5);
+
+    // Rescale to the 90kHz time base and read back the frame index at 30 fps.
+    let rescaled = three_and_a_half.rescale(Rational::new(1, 90000));
+    println!(
+        "{three_and_a_half} = pts {} @ 90kHz, frame {}",
+        rescaled.pts(),
+        rescaled.as_frame_number(30.0)
+    );
+}
 ```
 
 ## MSRV

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -11,6 +11,8 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 ```toml
 [dependencies]
 ff-pipeline = "0.16"
+ff-format = "0.16"  # VideoCodec, AudioCodec
+ff-encode = "0.16"  # BitrateMode
 ```
 
 ## Building a Pipeline
@@ -20,23 +22,32 @@ use ff_pipeline::{Pipeline, EncoderConfig};
 use ff_format::{VideoCodec, AudioCodec};
 use ff_encode::BitrateMode;
 
-let config = EncoderConfig::builder()
-    .video_codec(VideoCodec::H264)
-    .audio_codec(AudioCodec::Aac)
-    .bitrate_mode(BitrateMode::Cbr(4_000_000))
-    .resolution(1280, 720)
-    .build();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Codec and quality settings for the output.
+    let config = EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .audio_codec(AudioCodec::Aac)
+        .bitrate_mode(BitrateMode::Cbr(4_000_000))
+        .resolution(1280, 720)
+        .build();
 
-let pipeline = Pipeline::builder()
-    .input("input.mp4")
-    .output("output.mp4", config)
-    .on_progress(|p| {
-        println!("frame={} elapsed={:.1}s", p.frames_processed, p.elapsed.as_secs_f64());
-        true // return false to cancel
-    })
-    .build()?;
+    // Wire input → encode with a progress callback, then run to completion.
+    Pipeline::builder()
+        .input("input.mp4")
+        .output("output.mp4", config)
+        .on_progress(|p| {
+            println!(
+                "frame={} elapsed={:.1}s",
+                p.frames_processed,
+                p.elapsed.as_secs_f64()
+            );
+            true // return false to cancel
+        })
+        .build()?
+        .run()?;
 
-pipeline.run()?;
+    Ok(())
+}
 ```
 
 ## Configuration Validation

--- a/crates/ff-preview/README.md
+++ b/crates/ff-preview/README.md
@@ -62,33 +62,43 @@ use std::path::Path;
 use std::time::Duration;
 use ff_preview::{DecodeBuffer, FrameResult};
 
-let mut buf = DecodeBuffer::open(Path::new("video.mp4")).build()?;
-buf.seek(Duration::from_secs(30))?;
+fn main() -> Result<(), ff_preview::PreviewError> {
+    let mut buf = DecodeBuffer::open(Path::new("video.mp4")).build()?;
+    buf.seek(Duration::from_secs(30))?;
 
-loop {
-    match buf.pop_frame() {
-        FrameResult::Frame(f) => {
-            println!("pts: {:?}", f.timestamp().as_duration());
-            break;
+    loop {
+        match buf.pop_frame() {
+            FrameResult::Frame(f) => {
+                println!("pts: {:?}", f.timestamp().as_duration());
+                break;
+            }
+            FrameResult::Seeking(_) => std::thread::sleep(Duration::from_millis(5)),
+            FrameResult::Eof => break,
         }
-        FrameResult::Seeking(_) => std::thread::sleep(Duration::from_millis(5)),
-        FrameResult::Eof => break,
     }
+
+    Ok(())
 }
 ```
 
 ### Proxy generation
 
+Requires the `proxy` feature (`--features proxy`). A file goes in, a
+lower-resolution proxy file comes out at `{output_dir}/{stem}_proxy_{res}.mp4`.
+
 ```rust
 use std::path::Path;
 use ff_preview::{ProxyGenerator, ProxyResolution};
 
-let proxy_path = ProxyGenerator::new(Path::new("original_1080p.mp4"))?
-    .resolution(ProxyResolution::Quarter)
-    .output_dir(Path::new("/tmp"))
-    .generate()?;
+fn main() -> Result<(), ff_preview::PreviewError> {
+    let proxy_path = ProxyGenerator::new(Path::new("original_1080p.mp4"))?
+        .resolution(ProxyResolution::Quarter)
+        .output_dir(&std::env::temp_dir())
+        .generate()?;
 
-println!("proxy at {}", proxy_path.display());
+    println!("proxy at {}", proxy_path.display());
+    Ok(())
+}
 ```
 
 ## Feature Flags

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -18,22 +18,28 @@ ff-probe = "0.16"
 ```rust
 use ff_probe::open;
 
-fn main() -> Result<(), ff_probe::ProbeError> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let info = open("video.mp4")?;
 
+    let format = info.format();
+    let duration = info.duration();
+    println!("format:   {format}");
+    println!("duration: {duration:?}");
+
     if let Some(video) = info.primary_video() {
-        println!("resolution: {}x{}", video.width(), video.height());
-        println!("frame rate: {}", video.frame_rate());
-        println!("codec:      {:?}", video.codec());
+        let (width, height, fps) = (video.width(), video.height(), video.fps());
+        let codec = video.codec();
+        println!("video:    {width}x{height} @ {fps:.2} fps");
+        println!("codec:    {codec:?}");
     }
 
     if let Some(audio) = info.primary_audio() {
-        println!("sample rate:  {} Hz", audio.sample_rate());
-        println!("channels:     {}", audio.channels());
-        println!("audio codec:  {:?}", audio.codec());
+        let (sample_rate, channels) = (audio.sample_rate(), audio.channels());
+        let codec = audio.codec();
+        println!("audio:    {sample_rate} Hz, {channels} channels");
+        println!("codec:    {codec:?}");
     }
 
-    println!("duration: {:?}", info.duration());
     Ok(())
 }
 ```

--- a/crates/ff-remux/README.md
+++ b/crates/ff-remux/README.md
@@ -23,14 +23,18 @@ FFmpeg 7.x or 8.x development libraries must be installed on your system.
 use ff_remux::StreamCopyTrim;
 use std::time::Duration;
 
-// new(input, start, end, output)
-StreamCopyTrim::new(
-    "input.mp4",
-    Duration::from_secs(10),
-    Duration::from_secs(25),
-    "clip.mp4",
-)
-.run()?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Copy the range [10s, 25s) from input.mp4 into clip.mp4 without re-encoding.
+    let start = Duration::from_secs(10);
+    let end = Duration::from_secs(25);
+
+    // new(input, start, end, output)
+    StreamCopyTrim::new("input.mp4", start, end, "clip.mp4").run()?;
+
+    let length = end - start;
+    println!("wrote clip.mp4 ({length:?})");
+    Ok(())
+}
 ```
 
 ## Audio replace / extract / add

--- a/crates/ff-render/README.md
+++ b/crates/ff-render/README.md
@@ -35,16 +35,21 @@ Without `wgpu` only the CPU fallback path is available via `RenderGraph::process
 All built-in nodes implement `RenderNodeCpu`, which processes raw RGBA bytes without any GPU dependency.
 
 ```rust
-use ff_render::{RenderGraph, ColorGradeNode, BlendMode, BlendModeNode};
+use ff_render::{BlendMode, BlendModeNode, ColorGradeNode, RenderGraph};
 
-// Build a pipeline: boost brightness then multiply-blend with an overlay.
-let overlay_rgba: Vec<u8> = /* ... */ vec![0u8; 4 * 4 * 4];
-let graph = RenderGraph::new_cpu()
-    .push_cpu(ColorGradeNode::new(0.2, 1.0, 1.0, 0.0, 0.0))
-    .push_cpu(BlendModeNode::new(BlendMode::Multiply, 0.8, overlay_rgba, 4, 4));
+fn main() {
+    // Build a pipeline: boost brightness then multiply-blend with an overlay.
+    let overlay_rgba: Vec<u8> = vec![0u8; 4 * 4 * 4];
+    let graph = RenderGraph::new_cpu()
+        .push_cpu(ColorGradeNode::new(0.2, 1.0, 1.0, 0.0, 0.0))
+        .push_cpu(BlendModeNode::new(BlendMode::Multiply, 0.8, overlay_rgba, 4, 4));
 
-let input_rgba: Vec<u8> = /* decoded frame */ vec![128u8; 4 * 4 * 4];
-let output: Vec<u8> = graph.process_cpu(&input_rgba, 4, 4);
+    // A decoded 4×4 RGBA frame (mid-grey stand-in).
+    let input_rgba: Vec<u8> = vec![128u8; 4 * 4 * 4];
+    let output: Vec<u8> = graph.process_cpu(&input_rgba, 4, 4);
+
+    println!("processed {} bytes", output.len());
+}
 ```
 
 ## GPU Path (wgpu feature)
@@ -121,6 +126,10 @@ async fn compositor_example() -> Result<(), ff_render::RenderError> {
     let ctx = Arc::new(RenderContext::init().await?);
     let mut comp = Compositor::new(Arc::clone(&ctx), 1920, 1080);
 
+    // Layer frames are decoded elsewhere (e.g. via ff-decode) as `ff_format::VideoFrame`.
+    let background_frame = /* a VideoFrame */ unimplemented!();
+    let overlay_frame = /* a VideoFrame */ unimplemented!();
+
     let mut layers = vec![
         FrameLayer {
             frame:      background_frame,
@@ -170,13 +179,21 @@ async fn compositor_example() -> Result<(), ff_render::RenderError> {
 `YuvUploadNode` accepts planar YUV data directly, bypassing `sws_scale`:
 
 ```rust
-use ff_render::{RenderGraph, YuvUploadNode, YuvFormat};
+use ff_render::{RenderGraph, YuvFormat, YuvUploadNode};
 
-let mut node = YuvUploadNode::new(YuvFormat::Yuv420p, 1920, 1080);
-node.set_planes(y_plane, cb_plane, cr_plane);
+fn main() {
+    // Y at full resolution; Cb/Cr sub-sampled to half width and height (4:2:0).
+    let y_plane = vec![0u8; 1920 * 1080];
+    let cb_plane = vec![128u8; 960 * 540];
+    let cr_plane = vec![128u8; 960 * 540];
 
-let graph = RenderGraph::new_cpu().push_cpu(node);
-let rgba = graph.process_cpu(&vec![0u8; 1920 * 1080 * 4], 1920, 1080);
+    let mut node = YuvUploadNode::new(YuvFormat::Yuv420p, 1920, 1080);
+    node.set_planes(y_plane, cb_plane, cr_plane);
+
+    let graph = RenderGraph::new_cpu().push_cpu(node);
+    let rgba = graph.process_cpu(&vec![0u8; 1920 * 1080 * 4], 1920, 1080);
+    println!("produced {} rgba bytes", rgba.len());
+}
 ```
 
 Supported formats: `Yuv420p`, `Yuv422p`, `Yuv444p`.

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -23,13 +23,16 @@ deferred to `build()`, and `write()` performs the encode-and-mux.
 use ff_stream::HlsOutput;
 use std::time::Duration;
 
-HlsOutput::new("hls_output/")
-    .input("source.mp4")
-    .segment_duration(Duration::from_secs(6))
-    .keyframe_interval(48)
-    .build()?
-    .write()?;
-// Writes hls_output/playlist.m3u8 and numbered segments (segment000.ts, …).
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    HlsOutput::new("hls_output/")
+        .input("source.mp4") // any file FFmpeg can demux
+        .segment_duration(Duration::from_secs(6))
+        .keyframe_interval(48)
+        .build()?
+        .write()?;
+    // Writes hls_output/playlist.m3u8 and numbered segments (segment000.ts, …).
+    Ok(())
+}
 ```
 
 ## DASH Output

--- a/crates/ff-sys/README.md
+++ b/crates/ff-sys/README.md
@@ -62,6 +62,26 @@ Alongside the raw bindgen output, `ff-sys` ships thin safe-wrapper modules that 
 
 These modules are public (`pub mod`) but are meant for use by the higher-level `ff-*` crates rather than for direct consumption.
 
+## Usage
+
+`ff-sys` is normally consumed transitively through the safe `ff-*` crates. A few of the thin wrappers are themselves safe, however, and can be called directly:
+
+```rust
+use ff_sys::{av_error_string, avformat, error_codes};
+
+fn main() {
+    // Convert an FFmpeg error code into a readable message.
+    let msg = av_error_string(error_codes::ENOMEM);
+    println!("ENOMEM: {msg}");
+
+    // Query the linked FFmpeg build for optional protocol support.
+    let has_srt = avformat::srt_available();
+    println!("libsrt available: {has_srt}");
+}
+```
+
+Most of the surface is raw FFI and therefore `unsafe`; the safe wrappers above and the `ff-*` crates exist so that application code never has to touch it directly.
+
 ## MSRV
 
 Rust 1.93.0 (edition 2024).


### PR DESCRIPTION
## Objective

- The root README and every crate README opened with a code example that could not be pasted and compiled: top-level `?` with no `fn main`, undefined variables (`video_frames`, `process(&frame)`, `background_frame`), or an encoder that was built and finished without ever encoding a frame.
- Verifying the examples against the implementation also revealed several outdated or wrong API references.

## Solution

- Rewrite each crate's primary / Quick Start example as a complete `fn main` program with a coherent flow and no undefined variables; wire an ff-decode input source for the cross-crate encode/filter/analysis examples and note the extra dependency. Smaller option-showcase snippets stay as fragments.
- Fix inaccuracies found during verification: `PixelFormat::P010Le` -> `P010le`, `decoder.decode_frame()` -> `decode_one()`, the `DnxhrR444` pixel-format row, the avio feature table's `pipeline`/`serde` implied features, and ff-pipeline's installation snippet missing `ff-format`/`ff-encode`.
- Add a runnable safe-wrapper example to the ff-sys README, which previously had none.
- README code blocks are not compiled by CI (#1210), so every example was verified against the crate source.