### PR TITLE
refactor(ff-stream): migrate mux output contexts to OutputFormatContext

### DIFF
--- a/crates/ff-stream/src/dash_inner/context.rs
+++ b/crates/ff-stream/src/dash_inner/context.rs
@@ -1,9 +1,6 @@
-//! `AVFormatContext` DASH setup/cleanup helpers and the `RenditionState` type.
+//! Per-rendition encoder state for the ABR DASH mux loop.
 
-use std::ptr;
-
-use ff_sys::avformat_free_context;
-use ff_sys::{AVFormatContext, AVPixelFormat};
+use ff_sys::AVPixelFormat;
 
 // ============================================================================
 // Per-rendition encoder state for ABR
@@ -22,16 +19,4 @@ pub(super) struct RenditionState {
     pub(super) last_src_fmt: Option<AVPixelFormat>,
     pub(super) last_src_w: Option<i32>,
     pub(super) last_src_h: Option<i32>,
-}
-
-// ============================================================================
-// Cleanup helpers (safe to call with null pointers)
-// ============================================================================
-
-pub(super) unsafe fn cleanup_output_ctx(mut out_ctx: *mut AVFormatContext) {
-    if !out_ctx.is_null() {
-        avformat_free_context(out_ctx);
-        out_ctx = ptr::null_mut();
-        let _ = out_ctx; // suppress unused warning
-    }
 }

--- a/crates/ff-stream/src/dash_inner/write.rs
+++ b/crates/ff-stream/src/dash_inner/write.rs
@@ -4,14 +4,14 @@ use std::ffi::CString;
 use std::ptr;
 
 use ff_sys::{
-    AVFormatContext, AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
+    AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
     AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, ReceiveOutcome, av_opt_set, av_rescale_q,
-    av_write_trailer, avformat_alloc_output_context2, avformat_new_stream, avformat_write_header,
+    avformat_new_stream,
 };
 
 use crate::error::StreamError;
 
-use super::context::{RenditionState, cleanup_output_ctx};
+use super::context::RenditionState;
 use super::streams::{detect_fps, open_aac_encoder, select_h264_encoder};
 use super::{ffmpeg_err, ffmpeg_err_msg};
 
@@ -128,28 +128,26 @@ pub(super) unsafe fn write_dash_unsafe(
     }
 
     // ── 6. Allocate DASH output context ───────────────────────────────────────
+    // `out_ctx` is owned (frees on drop, closing its `pb`); `input_ctx` stays raw,
+    // so every error path below still closes the input explicitly before returning.
     let manifest_path = format!("{output_dir}/manifest.mpd");
-    let c_manifest = CString::new(manifest_path.as_str())
-        .map_err(|_| ffmpeg_err_msg("manifest path contains null byte"))?;
-    let c_dash = c"dash";
 
-    let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
-    let ret = avformat_alloc_output_context2(
-        &mut out_ctx,
-        ptr::null_mut(),
-        c_dash.as_ptr(),
-        c_manifest.as_ptr(),
-    );
-    if ret < 0 || out_ctx.is_null() {
-        ff_sys::avformat::close_input(&mut input_ctx);
-        return Err(ffmpeg_err(ret));
-    }
+    let mut out_ctx = match ff_sys::OutputFormatContext::new(
+        Some("dash"),
+        std::path::Path::new(&manifest_path),
+    ) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            return Err(ffmpeg_err(e.code()));
+        }
+    };
 
     // ── 7. Set DASH muxer options ──────────────────────────────────────────────
     let seg_duration_str = format!("{}", segment_duration_secs as u32);
     if let Ok(c_seg_dur) = CString::new(seg_duration_str.as_str()) {
         let ret = av_opt_set(
-            (*out_ctx).priv_data,
+            (*out_ctx.as_mut_ptr()).priv_data,
             c"seg_duration".as_ptr(),
             c_seg_dur.as_ptr(),
             0,
@@ -165,13 +163,11 @@ pub(super) unsafe fn write_dash_unsafe(
 
     // ── 8. Open H.264 video encoder ───────────────────────────────────────────
     let vid_enc_codec = select_h264_encoder().ok_or_else(|| {
-        cleanup_output_ctx(out_ctx);
         ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err_msg("no H.264 encoder available (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)")
     })?;
 
     let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
-        cleanup_output_ctx(out_ctx);
         ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err(e.code())
     })?;
@@ -191,26 +187,23 @@ pub(super) unsafe fn write_dash_unsafe(
     vid_enc_ctx
         .open(vid_enc_codec, ptr::null_mut())
         .map_err(|e| {
-            cleanup_output_ctx(out_ctx);
             ff_sys::avformat::close_input(&mut input_ctx);
             ffmpeg_err(e.code())
         })?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────
-    let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
+    let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
     if vid_out_stream.is_null() {
-        cleanup_output_ctx(out_ctx);
         ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot create video output stream"));
     }
     (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
-    let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+    let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
     // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
     vid_enc_ctx
         .parameters_from_context((*vid_out_stream).codecpar)
         .map_err(|e| {
-            cleanup_output_ctx(out_ctx);
             ff_sys::avformat::close_input(&mut input_ctx);
             ffmpeg_err(e.code())
         })?;
@@ -223,7 +216,7 @@ pub(super) unsafe fn write_dash_unsafe(
     if audio_stream_idx >= 0 {
         match open_aac_encoder(aud_sample_rate, aud_nb_channels) {
             Ok(ctx) => {
-                let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+                let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
                 if aud_out_stream.is_null() {
                     // `ctx` drops here (frees the codec context).
                     log::warn!("dash cannot create audio output stream, skipping audio");
@@ -231,7 +224,7 @@ pub(super) unsafe fn write_dash_unsafe(
                 } else {
                     (*aud_out_stream).time_base.num = 1;
                     (*aud_out_stream).time_base.den = aud_sample_rate;
-                    aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+                    aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
                     // SAFETY: aud_out_stream and ctx are valid; avcodec_open2 called.
                     if ctx
@@ -274,28 +267,21 @@ pub(super) unsafe fn write_dash_unsafe(
     }
 
     // ── 11. Open output file and write header ─────────────────────────────────
-    let pb = ff_sys::avformat::open_output(
-        std::path::Path::new(&manifest_path),
-        ff_sys::avformat::avio_flags::WRITE,
-    )
-    .map_err(|e| {
-        cleanup_output_ctx(out_ctx);
+    if let Err(e) = out_ctx.open_io(std::path::Path::new(&manifest_path)) {
         ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
-    (*out_ctx).pb = pb;
-
-    let ret = avformat_write_header(out_ctx, ptr::null_mut());
-    if ret < 0 {
-        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_output_ctx(out_ctx);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        return Err(ffmpeg_err(ret));
+        return Err(ffmpeg_err(e.code()));
     }
 
-    // Close pb now so the DASH muxer can manage its own avio handles for
-    // segment files without hitting a locked-file error on Windows.
-    ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+    if let Err(e) = out_ctx.write_header() {
+        // The owned `out_ctx` closes `pb` and frees on drop at this return.
+        ff_sys::avformat::close_input(&mut input_ctx);
+        return Err(ffmpeg_err(e.code()));
+    }
+
+    // Close pb now so the DASH muxer can manage its own avio handles for segment
+    // files without hitting a locked-file error on Windows. `close_io` nulls `pb`,
+    // so the later drop only frees the context.
+    out_ctx.close_io();
 
     log::info!(
         "dash output context ready width={enc_width} height={enc_height} fps={video_fps:.1} \
@@ -320,9 +306,8 @@ pub(super) unsafe fn write_dash_unsafe(
         ff_sys::Frame::new(),
     )
     else {
-        av_write_trailer(out_ctx);
-        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_output_ctx(out_ctx);
+        let _ = out_ctx.write_trailer();
+        // `out_ctx` frees on drop at this return (pb already closed via close_io).
         ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate frame or packet"));
     };
@@ -439,7 +424,7 @@ pub(super) unsafe fn write_dash_unsafe(
                 if scaled && vid_enc_ctx.send_frame(vid_enc_frame.as_ptr()).is_ok() {
                     crate::codec_utils::drain_encoder(
                         vid_enc_ctx.as_mut_ptr(),
-                        out_ctx,
+                        out_ctx.as_mut_ptr(),
                         vid_out_stream_idx,
                         "dash",
                         vid_frame_period,
@@ -497,7 +482,7 @@ pub(super) unsafe fn write_dash_unsafe(
                     if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc.as_mut_ptr(),
-                            out_ctx,
+                            out_ctx.as_mut_ptr(),
                             aud_out_stream_idx,
                             "dash",
                             aud_frame_period,
@@ -518,7 +503,7 @@ pub(super) unsafe fn write_dash_unsafe(
     let _ = vid_enc_ctx.send_frame(ptr::null());
     crate::codec_utils::drain_encoder(
         vid_enc_ctx.as_mut_ptr(),
-        out_ctx,
+        out_ctx.as_mut_ptr(),
         vid_out_stream_idx,
         "dash",
         vid_frame_period,
@@ -559,7 +544,7 @@ pub(super) unsafe fn write_dash_unsafe(
                     if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc.as_mut_ptr(),
-                            out_ctx,
+                            out_ctx.as_mut_ptr(),
                             aud_out_stream_idx,
                             "dash",
                             aud_frame_period,
@@ -572,7 +557,7 @@ pub(super) unsafe fn write_dash_unsafe(
         let _ = aud_enc.send_frame(ptr::null());
         crate::codec_utils::drain_encoder(
             aud_enc.as_mut_ptr(),
-            out_ctx,
+            out_ctx.as_mut_ptr(),
             aud_out_stream_idx,
             "dash",
             aud_frame_period,
@@ -580,13 +565,13 @@ pub(super) unsafe fn write_dash_unsafe(
     }
 
     // ── 15. Finalize ──────────────────────────────────────────────────────────
-    av_write_trailer(out_ctx);
-    // pb was already closed after avformat_write_header; skip double-close.
+    let _ = out_ctx.write_trailer();
+    // pb was already closed via close_io after the header; skip double-close.
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
-    // Owned frames/packet and encoder / decoder / resample / scale contexts drop
-    // on scope exit; only the raw format contexts need explicit teardown.
-    cleanup_output_ctx(out_ctx);
+    // Owned frames/packet, encoder / decoder / resample / scale contexts, and the
+    // owned `out_ctx` drop on scope exit; only the raw `input_ctx` needs an
+    // explicit close.
     ff_sys::avformat::close_input(&mut input_ctx);
 
     log::info!(
@@ -707,28 +692,26 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     }
 
     // ── 6. Allocate DASH output context ───────────────────────────────────────
+    // `out_ctx` is owned (frees on drop, closing its `pb`); `input_ctx` stays raw,
+    // so every error path below still closes the input explicitly before returning.
     let manifest_path = format!("{output_dir}/manifest.mpd");
-    let c_manifest = CString::new(manifest_path.as_str())
-        .map_err(|_| ffmpeg_err_msg("manifest path contains null byte"))?;
-    let c_dash = c"dash";
 
-    let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
-    let ret = avformat_alloc_output_context2(
-        &mut out_ctx,
-        ptr::null_mut(),
-        c_dash.as_ptr(),
-        c_manifest.as_ptr(),
-    );
-    if ret < 0 || out_ctx.is_null() {
-        ff_sys::avformat::close_input(&mut input_ctx);
-        return Err(ffmpeg_err(ret));
-    }
+    let mut out_ctx = match ff_sys::OutputFormatContext::new(
+        Some("dash"),
+        std::path::Path::new(&manifest_path),
+    ) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            return Err(ffmpeg_err(e.code()));
+        }
+    };
 
     // ── 7. Set DASH muxer options ──────────────────────────────────────────────
     let seg_duration_str = format!("{}", segment_duration_secs as u32);
     if let Ok(c_seg_dur) = CString::new(seg_duration_str.as_str()) {
         let ret = av_opt_set(
-            (*out_ctx).priv_data,
+            (*out_ctx.as_mut_ptr()).priv_data,
             c"seg_duration".as_ptr(),
             c_seg_dur.as_ptr(),
             0,
@@ -744,7 +727,6 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
     // ── 8. Select H.264 encoder (shared across all renditions) ────────────────
     let Some(vid_enc_codec) = select_h264_encoder() else {
-        cleanup_output_ctx(out_ctx);
         ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg(
             "no H.264 encoder available (tried h264_nvenc, h264_qsv, h264_amf, \
@@ -762,7 +744,6 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         let mut enc_ctx = match ff_sys::CodecContext::new(Some(vid_enc_codec)) {
             Ok(ctx) => ctx,
             Err(e) => {
-                cleanup_output_ctx(out_ctx);
                 ff_sys::avformat::close_input(&mut input_ctx);
                 return Err(ffmpeg_err(e.code()));
             }
@@ -780,25 +761,22 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
         if let Err(e) = enc_ctx.open(vid_enc_codec, ptr::null_mut()) {
             // `enc_ctx` and the prior renditions drop on return.
-            cleanup_output_ctx(out_ctx);
             ff_sys::avformat::close_input(&mut input_ctx);
             return Err(ffmpeg_err(e.code()));
         }
 
-        let out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
+        let out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
         if out_stream.is_null() {
-            cleanup_output_ctx(out_ctx);
             ff_sys::avformat::close_input(&mut input_ctx);
             return Err(ffmpeg_err_msg(
                 "cannot create video output stream for rendition",
             ));
         }
         (*out_stream).time_base = (*enc_ctx.as_ptr()).time_base;
-        let stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+        let stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
         // SAFETY: out_stream and enc_ctx are valid; avcodec_open2 has been called.
         if let Err(e) = enc_ctx.parameters_from_context((*out_stream).codecpar) {
-            cleanup_output_ctx(out_ctx);
             ff_sys::avformat::close_input(&mut input_ctx);
             return Err(ffmpeg_err(e.code()));
         }
@@ -828,7 +806,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     if audio_stream_idx >= 0 {
         match open_aac_encoder(aud_sample_rate, aud_nb_channels) {
             Ok(ctx) => {
-                let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+                let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
                 if aud_out_stream.is_null() {
                     // `ctx` drops here (frees the codec context).
                     log::warn!("dash abr cannot create audio output stream, skipping audio");
@@ -836,7 +814,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 } else {
                     (*aud_out_stream).time_base.num = 1;
                     (*aud_out_stream).time_base.den = aud_sample_rate;
-                    aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+                    aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
                     let enc_ptr = ctx.as_ptr();
                     if !(*aud_out_stream).codecpar.is_null() {
@@ -882,28 +860,21 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     }
 
     // ── 11. Open output file and write header ─────────────────────────────────
-    let pb = ff_sys::avformat::open_output(
-        std::path::Path::new(&manifest_path),
-        ff_sys::avformat::avio_flags::WRITE,
-    )
-    .map_err(|e| {
-        cleanup_output_ctx(out_ctx);
+    if let Err(e) = out_ctx.open_io(std::path::Path::new(&manifest_path)) {
         ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
-    (*out_ctx).pb = pb;
+        return Err(ffmpeg_err(e.code()));
+    }
 
-    let ret = avformat_write_header(out_ctx, ptr::null_mut());
-    if ret < 0 {
-        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_output_ctx(out_ctx);
+    if let Err(e) = out_ctx.write_header() {
+        // The owned `out_ctx` closes `pb` and frees on drop at this return.
         ff_sys::avformat::close_input(&mut input_ctx);
-        return Err(ffmpeg_err(ret));
+        return Err(ffmpeg_err(e.code()));
     }
 
     // Close pb so the DASH muxer can manage its own avio handles for segment
-    // files without hitting a locked-file error on Windows.
-    ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+    // files without hitting a locked-file error on Windows. `close_io` nulls `pb`,
+    // so the later drop only frees the context.
+    out_ctx.close_io();
 
     log::info!(
         "dash abr output ready renditions={} fps={video_fps:.1} audio={}",
@@ -928,8 +899,8 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         ff_sys::Frame::new(),
     )
     else {
-        av_write_trailer(out_ctx);
-        cleanup_output_ctx(out_ctx);
+        let _ = out_ctx.write_trailer();
+        // `out_ctx` frees on drop at this return (pb already closed via close_io).
         ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate frame or packet"));
     };
@@ -1036,7 +1007,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                     if scaled && state.vid_enc_ctx.send_frame(vid_enc_frame.as_ptr()).is_ok() {
                         crate::codec_utils::drain_encoder(
                             state.vid_enc_ctx.as_mut_ptr(),
-                            out_ctx,
+                            out_ctx.as_mut_ptr(),
                             state.vid_out_stream_idx,
                             "dash",
                             vid_frame_period,
@@ -1096,7 +1067,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                     if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc.as_mut_ptr(),
-                            out_ctx,
+                            out_ctx.as_mut_ptr(),
                             aud_out_stream_idx,
                             "dash",
                             aud_frame_period,
@@ -1118,7 +1089,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         let _ = state.vid_enc_ctx.send_frame(ptr::null());
         crate::codec_utils::drain_encoder(
             state.vid_enc_ctx.as_mut_ptr(),
-            out_ctx,
+            out_ctx.as_mut_ptr(),
             state.vid_out_stream_idx,
             "dash",
             vid_frame_period,
@@ -1159,7 +1130,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                     if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc.as_mut_ptr(),
-                            out_ctx,
+                            out_ctx.as_mut_ptr(),
                             aud_out_stream_idx,
                             "dash",
                             aud_frame_period,
@@ -1172,7 +1143,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         let _ = aud_enc.send_frame(ptr::null());
         crate::codec_utils::drain_encoder(
             aud_enc.as_mut_ptr(),
-            out_ctx,
+            out_ctx.as_mut_ptr(),
             aud_out_stream_idx,
             "dash",
             aud_frame_period,
@@ -1180,13 +1151,12 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     }
 
     // ── 15. Finalize ──────────────────────────────────────────────────────────
-    av_write_trailer(out_ctx);
+    let _ = out_ctx.write_trailer();
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
-    // Owned frames/packet and encoder / decoder / resample / scale contexts
-    // (including every rendition in the Vec) drop on scope exit; only the raw
-    // format contexts need explicit teardown.
-    cleanup_output_ctx(out_ctx);
+    // Owned frames/packet, encoder / decoder / resample / scale contexts (including
+    // every rendition in the Vec), and the owned `out_ctx` drop on scope exit; only
+    // the raw `input_ctx` needs an explicit close.
     ff_sys::avformat::close_input(&mut input_ctx);
 
     log::info!(

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -27,8 +27,7 @@ use std::ptr;
 use ff_sys::{
     AVFormatContext, AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
     AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, ReceiveOutcome, av_opt_set,
-    av_rescale_q, av_write_trailer, avformat_alloc_output_context2, avformat_free_context,
-    avformat_new_stream, avformat_write_header,
+    av_rescale_q, avformat_new_stream,
 };
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
@@ -197,22 +196,18 @@ unsafe fn write_hls_unsafe(
     }
 
     // ── 6. Allocate HLS output context ────────────────────────────────────────
+    // `out_ctx` is owned (frees on drop, closing its `pb`); `input_ctx` stays raw,
+    // so every error path below still closes the input explicitly before returning.
     let playlist_path = format!("{output_dir}/playlist.m3u8");
-    let c_playlist = CString::new(playlist_path.as_str())
-        .map_err(|_| ffmpeg_err_msg("playlist path contains null byte"))?;
-    let c_hls = c"hls";
 
-    let mut out_ctx: *mut AVFormatContext = ptr::null_mut();
-    let ret = avformat_alloc_output_context2(
-        &mut out_ctx,
-        ptr::null_mut(),
-        c_hls.as_ptr(),
-        c_playlist.as_ptr(),
-    );
-    if ret < 0 || out_ctx.is_null() {
-        ff_sys::avformat::close_input(&mut input_ctx);
-        return Err(ffmpeg_err(ret));
-    }
+    let mut out_ctx = match ff_sys::OutputFormatContext::new(Some("hls"), Path::new(&playlist_path))
+    {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            ff_sys::avformat::close_input(&mut input_ctx);
+            return Err(ffmpeg_err(e.code()));
+        }
+    };
 
     // ── 7. Set HLS muxer options ──────────────────────────────────────────────
     let seg_time_str = format!("{}", segment_duration_secs as u32);
@@ -224,7 +219,7 @@ unsafe fn write_hls_unsafe(
         CString::new(seg_filename.as_str()),
     ) {
         let ret = av_opt_set(
-            (*out_ctx).priv_data,
+            (*out_ctx.as_mut_ptr()).priv_data,
             c"hls_time".as_ptr(),
             c_seg_time.as_ptr(),
             0,
@@ -237,7 +232,7 @@ unsafe fn write_hls_unsafe(
             );
         }
         let ret = av_opt_set(
-            (*out_ctx).priv_data,
+            (*out_ctx.as_mut_ptr()).priv_data,
             c"hls_segment_filename".as_ptr(),
             c_seg_file.as_ptr(),
             0,
@@ -251,7 +246,7 @@ unsafe fn write_hls_unsafe(
         }
         if use_fmp4 {
             let ret = av_opt_set(
-                (*out_ctx).priv_data,
+                (*out_ctx.as_mut_ptr()).priv_data,
                 c"hls_segment_type".as_ptr(),
                 c"fmp4".as_ptr(),
                 0,
@@ -267,13 +262,11 @@ unsafe fn write_hls_unsafe(
 
     // ── 8. Open H.264 video encoder ───────────────────────────────────────────
     let vid_enc_codec = crate::codec_utils::select_h264_encoder("hls").ok_or_else(|| {
-        cleanup_output_ctx(out_ctx);
         ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err_msg("no H.264 encoder available (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)")
     })?;
 
     let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
-        cleanup_output_ctx(out_ctx);
         ff_sys::avformat::close_input(&mut input_ctx);
         ffmpeg_err(e.code())
     })?;
@@ -292,31 +285,28 @@ unsafe fn write_hls_unsafe(
         2_000_000
     };
 
-    // On error the owned `vid_enc_ctx` / decoders drop; only the raw format
-    // contexts need explicit teardown.
+    // On error the owned `vid_enc_ctx` / decoders / `out_ctx` drop; only the raw
+    // `input_ctx` needs an explicit close.
     vid_enc_ctx
         .open(vid_enc_codec, ptr::null_mut())
         .map_err(|e| {
-            cleanup_output_ctx(out_ctx);
             ff_sys::avformat::close_input(&mut input_ctx);
             ffmpeg_err(e.code())
         })?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────
-    let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
+    let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
     if vid_out_stream.is_null() {
-        cleanup_output_ctx(out_ctx);
         ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot create video output stream"));
     }
     (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
-    let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+    let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
     // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
     vid_enc_ctx
         .parameters_from_context((*vid_out_stream).codecpar)
         .map_err(|e| {
-            cleanup_output_ctx(out_ctx);
             ff_sys::avformat::close_input(&mut input_ctx);
             ffmpeg_err(e.code())
         })?;
@@ -330,7 +320,7 @@ unsafe fn write_hls_unsafe(
         match crate::codec_utils::open_aac_encoder(aud_sample_rate, aud_nb_channels, 192_000, "hls")
         {
             Ok(ctx) => {
-                let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+                let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
                 if aud_out_stream.is_null() {
                     // `ctx` drops here (frees the codec context).
                     log::warn!("hls cannot create audio output stream, skipping audio");
@@ -338,7 +328,7 @@ unsafe fn write_hls_unsafe(
                 } else {
                     (*aud_out_stream).time_base.num = 1;
                     (*aud_out_stream).time_base.den = aud_sample_rate;
-                    aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+                    aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
                     // SAFETY: aud_out_stream and ctx are valid; avcodec_open2 called.
                     if ctx
@@ -381,29 +371,22 @@ unsafe fn write_hls_unsafe(
     }
 
     // ── 11. Open output file and write header ─────────────────────────────────
-    let pb = ff_sys::avformat::open_output(
-        Path::new(&playlist_path),
-        ff_sys::avformat::avio_flags::WRITE,
-    )
-    .map_err(|e| {
-        cleanup_output_ctx(out_ctx);
+    if let Err(e) = out_ctx.open_io(Path::new(&playlist_path)) {
         ff_sys::avformat::close_input(&mut input_ctx);
-        ffmpeg_err(e)
-    })?;
-    (*out_ctx).pb = pb;
-
-    let ret = avformat_write_header(out_ctx, ptr::null_mut());
-    if ret < 0 {
-        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_output_ctx(out_ctx);
-        ff_sys::avformat::close_input(&mut input_ctx);
-        return Err(ffmpeg_err(ret));
+        return Err(ffmpeg_err(e.code()));
     }
 
-    // Close pb now so the HLS muxer can rename its .tmp playlist files
-    // without hitting a locked-file error on Windows.  The HLS muxer
-    // manages its own avio handles for all subsequent playlist writes.
-    ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+    if let Err(e) = out_ctx.write_header() {
+        // The owned `out_ctx` closes `pb` and frees on drop at this return.
+        ff_sys::avformat::close_input(&mut input_ctx);
+        return Err(ffmpeg_err(e.code()));
+    }
+
+    // Close pb now so the HLS muxer can rename its .tmp playlist files without
+    // hitting a locked-file error on Windows.  The HLS muxer manages its own avio
+    // handles for all subsequent playlist writes. `close_io` nulls `pb`, so the
+    // later drop only frees the context.
+    out_ctx.close_io();
 
     log::info!(
         "hls output context ready width={enc_width} height={enc_height} fps={video_fps:.1} \
@@ -429,9 +412,8 @@ unsafe fn write_hls_unsafe(
         ff_sys::Frame::new(),
     )
     else {
-        av_write_trailer(out_ctx);
-        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-        cleanup_output_ctx(out_ctx);
+        let _ = out_ctx.write_trailer();
+        // `out_ctx` frees on drop at this return (pb already closed via close_io).
         ff_sys::avformat::close_input(&mut input_ctx);
         return Err(ffmpeg_err_msg("cannot allocate frame or packet"));
     };
@@ -550,7 +532,7 @@ unsafe fn write_hls_unsafe(
                 if scaled && vid_enc_ctx.send_frame(vid_enc_frame.as_ptr()).is_ok() {
                     crate::codec_utils::drain_encoder(
                         vid_enc_ctx.as_mut_ptr(),
-                        out_ctx,
+                        out_ctx.as_mut_ptr(),
                         vid_out_stream_idx,
                         "hls",
                         vid_frame_period,
@@ -608,7 +590,7 @@ unsafe fn write_hls_unsafe(
                     if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc.as_mut_ptr(),
-                            out_ctx,
+                            out_ctx.as_mut_ptr(),
                             aud_out_stream_idx,
                             "hls",
                             aud_frame_period,
@@ -629,7 +611,7 @@ unsafe fn write_hls_unsafe(
     let _ = vid_enc_ctx.send_frame(ptr::null());
     crate::codec_utils::drain_encoder(
         vid_enc_ctx.as_mut_ptr(),
-        out_ctx,
+        out_ctx.as_mut_ptr(),
         vid_out_stream_idx,
         "hls",
         vid_frame_period,
@@ -670,7 +652,7 @@ unsafe fn write_hls_unsafe(
                     if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc.as_mut_ptr(),
-                            out_ctx,
+                            out_ctx.as_mut_ptr(),
                             aud_out_stream_idx,
                             "hls",
                             aud_frame_period,
@@ -683,7 +665,7 @@ unsafe fn write_hls_unsafe(
         let _ = aud_enc.send_frame(ptr::null());
         crate::codec_utils::drain_encoder(
             aud_enc.as_mut_ptr(),
-            out_ctx,
+            out_ctx.as_mut_ptr(),
             aud_out_stream_idx,
             "hls",
             aud_frame_period,
@@ -691,13 +673,13 @@ unsafe fn write_hls_unsafe(
     }
 
     // ── 15. Finalize ──────────────────────────────────────────────────────────
-    av_write_trailer(out_ctx);
-    // pb was already closed after avformat_write_header; skip double-close.
+    let _ = out_ctx.write_trailer();
+    // pb was already closed via close_io after the header; skip double-close.
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
-    // Owned frames/packet and encoder / decoder / resample / scale contexts drop
-    // on scope exit; only the raw format contexts need explicit teardown.
-    cleanup_output_ctx(out_ctx);
+    // Owned frames/packet, encoder / decoder / resample / scale contexts, and the
+    // owned `out_ctx` drop on scope exit; only the raw `input_ctx` needs an
+    // explicit close.
     ff_sys::avformat::close_input(&mut input_ctx);
 
     log::info!(
@@ -759,16 +741,4 @@ unsafe fn detect_fps(stream: *mut ff_sys::AVStream, fmt_ctx: *mut AVFormatContex
     }
 
     25.0 // sane default
-}
-
-// ============================================================================
-// Cleanup helpers (safe to call with null pointers)
-// ============================================================================
-
-unsafe fn cleanup_output_ctx(mut out_ctx: *mut AVFormatContext) {
-    if !out_ctx.is_null() {
-        avformat_free_context(out_ctx);
-        out_ctx = ptr::null_mut();
-        let _ = out_ctx; // suppress unused warning
-    }
 }

--- a/crates/ff-stream/src/live_dash_inner.rs
+++ b/crates/ff-stream/src/live_dash_inner.rs
@@ -22,10 +22,7 @@ use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{
-    AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
-    avformat_free_context, avformat_new_stream, avformat_write_header,
-};
+use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_new_stream};
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
 use crate::error::StreamError;
@@ -123,26 +120,18 @@ impl LiveDashInner {
 
         // ── 1. Allocate DASH output context ───────────────────────────────────
         let manifest_path = format!("{output_dir}/manifest.mpd");
-        let c_manifest = CString::new(manifest_path.as_str())
-            .map_err(|_| ffmpeg_err_msg("manifest path contains null byte"))?;
 
-        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
-        let ret = avformat_alloc_output_context2(
-            &mut out_ctx,
-            ptr::null_mut(),
-            c"dash".as_ptr(),
-            c_manifest.as_ptr(),
-        );
-        if ret < 0 || out_ctx.is_null() {
-            return Err(ffmpeg_err(ret));
-        }
+        // The owned context frees itself on every early return below, so no manual
+        // teardown is needed on error paths.
+        let mut out_ctx = ff_sys::OutputFormatContext::new(Some("dash"), Path::new(&manifest_path))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 2. Set DASH muxer options ─────────────────────────────────────────
         let seg_time_str = format!("{segment_secs}");
 
         if let Ok(c_seg_time) = CString::new(seg_time_str.as_str()) {
             let ret = av_opt_set(
-                (*out_ctx).priv_data,
+                (*out_ctx.as_mut_ptr()).priv_data,
                 c"seg_duration".as_ptr(),
                 c_seg_time.as_ptr(),
                 0,
@@ -157,7 +146,7 @@ impl LiveDashInner {
         }
 
         let ret = av_opt_set(
-            (*out_ctx).priv_data,
+            (*out_ctx.as_mut_ptr()).priv_data,
             c"use_template".as_ptr(),
             c"1".as_ptr(),
             0,
@@ -170,7 +159,7 @@ impl LiveDashInner {
         }
 
         let ret = av_opt_set(
-            (*out_ctx).priv_data,
+            (*out_ctx.as_mut_ptr()).priv_data,
             c"use_timeline".as_ptr(),
             c"1".as_ptr(),
             0,
@@ -183,7 +172,7 @@ impl LiveDashInner {
         }
 
         let ret = av_opt_set(
-            (*out_ctx).priv_data,
+            (*out_ctx.as_mut_ptr()).priv_data,
             c"remove_at_exit".as_ptr(),
             c"0".as_ptr(),
             0,
@@ -198,17 +187,14 @@ impl LiveDashInner {
         // ── 3. Open H.264 video encoder ───────────────────────────────────────
         let vid_enc_codec =
             crate::codec_utils::select_h264_encoder("live_dash").ok_or_else(|| {
-                avformat_free_context(out_ctx);
                 ffmpeg_err_msg(
                     "no H.264 encoder available \
                      (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)",
                 )
             })?;
 
-        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e.code())
-        })?;
+        let mut vid_enc_ctx =
+            ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| ffmpeg_err(e.code()))?;
         vid_enc_ctx.set_width(enc_width);
         vid_enc_ctx.set_height(enc_height);
         vid_enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
@@ -223,31 +209,24 @@ impl LiveDashInner {
         vid_enc_ctx.set_gop_size(fps_int * segment_secs as i32);
         vid_enc_ctx.set_bit_rate(video_bitrate as i64);
 
-        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
-        // raw format context needs an explicit free.
+        // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
+        // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
             .open(vid_enc_codec, ptr::null_mut())
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Add video output stream ────────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
+        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
         (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
         vid_enc_ctx
             .parameters_from_context((*vid_out_stream).codecpar)
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 5. Open AAC audio encoder and add audio stream (optional) ─────────
         let mut aud_enc_ctx: Option<ff_sys::CodecContext> = None;
@@ -266,14 +245,14 @@ impl LiveDashInner {
                         1024
                     };
 
-                    let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+                    let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
                     if aud_out_stream.is_null() {
                         // `ctx` drops here (frees the codec context).
                         log::warn!("live_dash cannot create audio output stream, skipping audio");
                     } else {
                         (*aud_out_stream).time_base.num = 1;
                         (*aud_out_stream).time_base.den = sr;
-                        aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+                        aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
                         // SAFETY: aud_out_stream and ctx are valid.
                         if ctx
@@ -292,26 +271,18 @@ impl LiveDashInner {
         }
 
         // ── 6. Open output file and write header ──────────────────────────────
-        let pb = ff_sys::avformat::open_output(
-            Path::new(&manifest_path),
-            ff_sys::avformat::avio_flags::WRITE,
-        )
-        .map_err(|e| {
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e)
-        })?;
-        (*out_ctx).pb = pb;
+        out_ctx
+            .open_io(Path::new(&manifest_path))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
-        let ret = avformat_write_header(out_ctx, ptr::null_mut());
-        if ret < 0 {
-            ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err(ret));
-        }
+        // On header-write failure the owned `out_ctx` drops here, closing `pb` and
+        // freeing the context.
+        out_ctx.write_header().map_err(|e| ffmpeg_err(e.code()))?;
 
-        // Close pb so the DASH muxer can manage its own avio handles for
-        // segment files without hitting a locked-file error on Windows.
-        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+        // Close pb so the DASH muxer can manage its own avio handles for segment
+        // files without hitting a locked-file error on Windows. `close_io` nulls
+        // `pb`, so the later drop only frees the context.
+        out_ctx.close_io();
 
         log::info!(
             "live_dash output opened \
@@ -333,13 +304,7 @@ impl LiveDashInner {
             aud_frame_size,
             aud_sample_rate,
             "live_dash",
-            false, // close_pb_after_trailer: pb already closed after header write
-        )
-        .inspect_err(|_| {
-            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
-            // error; only the raw format context needs an explicit free.
-            avformat_free_context(out_ctx);
-        })?;
+        )?;
 
         Ok(Self { core })
     }

--- a/crates/ff-stream/src/live_hls_inner.rs
+++ b/crates/ff-stream/src/live_hls_inner.rs
@@ -22,10 +22,7 @@ use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{
-    AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_alloc_output_context2,
-    avformat_free_context, avformat_new_stream, avformat_write_header,
-};
+use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_new_stream};
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
 use crate::error::StreamError;
@@ -130,19 +127,11 @@ impl LiveHlsInner {
 
         // ── 1. Allocate HLS output context ────────────────────────────────────
         let playlist_path = format!("{output_dir}/index.m3u8");
-        let c_playlist = CString::new(playlist_path.as_str())
-            .map_err(|_| ffmpeg_err_msg("playlist path contains null byte"))?;
 
-        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
-        let ret = avformat_alloc_output_context2(
-            &mut out_ctx,
-            ptr::null_mut(),
-            c"hls".as_ptr(),
-            c_playlist.as_ptr(),
-        );
-        if ret < 0 || out_ctx.is_null() {
-            return Err(ffmpeg_err(ret));
-        }
+        // The owned context frees itself on every early return below, so no manual
+        // teardown is needed on error paths.
+        let mut out_ctx = ff_sys::OutputFormatContext::new(Some("hls"), Path::new(&playlist_path))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 2. Set HLS muxer options ──────────────────────────────────────────
         let seg_time_str = format!("{segment_secs}");
@@ -157,7 +146,7 @@ impl LiveHlsInner {
             CString::new(seg_filename.as_str()),
         ) {
             let ret = av_opt_set(
-                (*out_ctx).priv_data,
+                (*out_ctx.as_mut_ptr()).priv_data,
                 c"hls_time".as_ptr(),
                 c_seg_time.as_ptr(),
                 0,
@@ -170,7 +159,7 @@ impl LiveHlsInner {
                 );
             }
             let ret = av_opt_set(
-                (*out_ctx).priv_data,
+                (*out_ctx.as_mut_ptr()).priv_data,
                 c"hls_list_size".as_ptr(),
                 c_list_size.as_ptr(),
                 0,
@@ -183,7 +172,7 @@ impl LiveHlsInner {
                 );
             }
             let ret = av_opt_set(
-                (*out_ctx).priv_data,
+                (*out_ctx.as_mut_ptr()).priv_data,
                 c"hls_flags".as_ptr(),
                 c"delete_segments".as_ptr(),
                 0,
@@ -195,7 +184,7 @@ impl LiveHlsInner {
                 );
             }
             let ret = av_opt_set(
-                (*out_ctx).priv_data,
+                (*out_ctx.as_mut_ptr()).priv_data,
                 c"hls_segment_filename".as_ptr(),
                 c_seg_file.as_ptr(),
                 0,
@@ -209,7 +198,7 @@ impl LiveHlsInner {
             }
             if use_fmp4 {
                 let ret = av_opt_set(
-                    (*out_ctx).priv_data,
+                    (*out_ctx.as_mut_ptr()).priv_data,
                     c"hls_segment_type".as_ptr(),
                     c"fmp4".as_ptr(),
                     0,
@@ -226,17 +215,14 @@ impl LiveHlsInner {
         // ── 3. Open H.264 video encoder ───────────────────────────────────────
         let vid_enc_codec =
             crate::codec_utils::select_h264_encoder("live_hls").ok_or_else(|| {
-                avformat_free_context(out_ctx);
                 ffmpeg_err_msg(
                     "no H.264 encoder available \
                      (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)",
                 )
             })?;
 
-        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e.code())
-        })?;
+        let mut vid_enc_ctx =
+            ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| ffmpeg_err(e.code()))?;
         vid_enc_ctx.set_width(enc_width);
         vid_enc_ctx.set_height(enc_height);
         vid_enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
@@ -251,31 +237,24 @@ impl LiveHlsInner {
         vid_enc_ctx.set_gop_size(fps_int * segment_secs as i32);
         vid_enc_ctx.set_bit_rate(video_bitrate as i64);
 
-        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
-        // raw format context needs an explicit free.
+        // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
+        // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
             .open(vid_enc_codec, ptr::null_mut())
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Add video output stream ────────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
+        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
         (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
         vid_enc_ctx
             .parameters_from_context((*vid_out_stream).codecpar)
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 5. Open AAC audio encoder and add audio stream (optional) ─────────
         let mut aud_enc_ctx: Option<ff_sys::CodecContext> = None;
@@ -294,14 +273,14 @@ impl LiveHlsInner {
                         1024
                     };
 
-                    let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+                    let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
                     if aud_out_stream.is_null() {
                         // `ctx` drops here (frees the codec context).
                         log::warn!("live_hls cannot create audio output stream, skipping audio");
                     } else {
                         (*aud_out_stream).time_base.num = 1;
                         (*aud_out_stream).time_base.den = sr;
-                        aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+                        aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
                         // SAFETY: aud_out_stream and ctx are valid.
                         if ctx
@@ -320,26 +299,18 @@ impl LiveHlsInner {
         }
 
         // ── 6. Open output file and write header ──────────────────────────────
-        let pb = ff_sys::avformat::open_output(
-            Path::new(&playlist_path),
-            ff_sys::avformat::avio_flags::WRITE,
-        )
-        .map_err(|e| {
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e)
-        })?;
-        (*out_ctx).pb = pb;
+        out_ctx
+            .open_io(Path::new(&playlist_path))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
-        let ret = avformat_write_header(out_ctx, ptr::null_mut());
-        if ret < 0 {
-            ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err(ret));
-        }
+        // On header-write failure the owned `out_ctx` drops here, closing `pb` and
+        // freeing the context.
+        out_ctx.write_header().map_err(|e| ffmpeg_err(e.code()))?;
 
         // Close pb so the HLS muxer can rename its .tmp playlist files without
-        // hitting a locked-file error on Windows.
-        ff_sys::avformat::close_output(&mut (*out_ctx).pb);
+        // hitting a locked-file error on Windows. `close_io` nulls `pb`, so the
+        // later drop only frees the context.
+        out_ctx.close_io();
 
         log::info!(
             "live_hls output opened \
@@ -362,13 +333,7 @@ impl LiveHlsInner {
             aud_frame_size,
             aud_sample_rate,
             "live_hls",
-            false, // close_pb_after_trailer: pb already closed after header write
-        )
-        .inspect_err(|_| {
-            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
-            // error; only the raw format context needs an explicit free.
-            avformat_free_context(out_ctx);
-        })?;
+        )?;
 
         Ok(Self { core })
     }

--- a/crates/ff-stream/src/muxer_core.rs
+++ b/crates/ff-stream/src/muxer_core.rs
@@ -1,7 +1,7 @@
 //! Shared `FFmpeg` muxer state for all streaming outputs.
 //!
 //! [`MuxerCore`] owns the `FFmpeg` encode/mux state: the encoder contexts,
-//! resampler, scaler, and encoder frames as RAII owners, plus the raw output
+//! resampler, scaler, and encoder frames as RAII owners, plus the owned output
 //! format context (`out_ctx`). The four protocol-specific inner types
 //! (`RtmpInner`, `SrtInner`, `LiveHlsInner`, `LiveDashInner`) each hold a
 //! `MuxerCore` and delegate every method except `open_unsafe` to it.
@@ -21,8 +21,7 @@ use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat,
-    av_rescale_q, av_write_trailer, avformat_free_context,
+    AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, av_rescale_q,
 };
 
 use crate::codec_utils::{
@@ -40,10 +39,12 @@ use crate::error::StreamError;
 /// format context, encoder contexts, and streams are fully configured.
 /// Consumed by [`MuxerCore::flush_and_close_unsafe`].
 ///
-/// After `flush_and_close_unsafe` returns all pointers are zeroed; subsequent
-/// calls to any method are safe no-ops (Drop will be a no-op too).
+/// The owned `out_ctx` closes its `pb` (if still open) and frees the context on
+/// drop, so the protocol-specific teardown is expressed by *when* `pb` is closed
+/// (RTMP/SRT keep it open until drop; HLS/DASH close it right after the header
+/// via `close_io`), not by a manual free.
 pub(crate) struct MuxerCore {
-    pub(crate) out_ctx: *mut AVFormatContext,
+    pub(crate) out_ctx: ff_sys::OutputFormatContext,
     pub(crate) vid_enc_ctx: ff_sys::CodecContext,
     /// `None` when audio is not configured (optional for HLS/DASH).
     pub(crate) aud_enc_ctx: Option<ff_sys::CodecContext>,
@@ -74,13 +75,6 @@ pub(crate) struct MuxerCore {
     pub(crate) last_swr_in_channels: Option<i32>,
     /// Human-readable protocol prefix used in log messages (e.g. `"rtmp"`, `"live_hls"`).
     pub(crate) log_prefix: &'static str,
-    /// When `true`, `flush_and_close_unsafe` and `free_all` close `out_ctx.pb`
-    /// before freeing the format context.
-    ///
-    /// Set to `true` for RTMP/SRT (pb is kept open for streaming after the header
-    /// write). Set to `false` for LiveHLS/LiveDASH (pb is closed immediately after
-    /// `avformat_write_header` so the muxer can manage its own avio handles).
-    pub(crate) close_pb_after_trailer: bool,
 }
 
 // SAFETY: MuxerCore exclusively owns its FFmpeg state (RAII owners plus the raw
@@ -92,17 +86,13 @@ impl MuxerCore {
     /// Allocate encoder frames and initialise tracking state.
     ///
     /// Called by each inner `open_unsafe` after the format context, encoder
-    /// contexts, and output streams are fully configured.
-    ///
-    /// # Safety
-    ///
-    /// - `out_ctx` must be non-null and valid.
-    /// - `aud_enc_ctx` may be `None` (audio is optional for HLS/DASH outputs).
-    /// - The `vid_enc_ctx` / `aud_enc_ctx` owned contexts are moved in; on `Err`
-    ///   they drop here, so the caller must not free them.
+    /// contexts, and output streams are fully configured. The owned `out_ctx`
+    /// and the `vid_enc_ctx` / `aud_enc_ctx` contexts are moved in; on `Err`
+    /// they drop here (freeing themselves), so the caller must not free them.
+    /// `aud_enc_ctx` may be `None` (audio is optional for HLS/DASH outputs).
     #[allow(clippy::too_many_arguments)]
-    pub(crate) unsafe fn new(
-        out_ctx: *mut AVFormatContext,
+    pub(crate) fn new(
+        out_ctx: ff_sys::OutputFormatContext,
         vid_enc_ctx: ff_sys::CodecContext,
         aud_enc_ctx: Option<ff_sys::CodecContext>,
         vid_out_stream_idx: i32,
@@ -113,7 +103,6 @@ impl MuxerCore {
         aud_frame_size: i32,
         aud_sample_rate: i32,
         log_prefix: &'static str,
-        close_pb_after_trailer: bool,
     ) -> Result<Self, StreamError> {
         // Owned frames: each frees exactly once on drop. On the error arm the
         // successfully-allocated one (if any) drops at the end of this statement.
@@ -146,7 +135,6 @@ impl MuxerCore {
             last_swr_in_rate: None,
             last_swr_in_channels: None,
             log_prefix,
-            close_pb_after_trailer,
         })
     }
 
@@ -259,7 +247,7 @@ impl MuxerCore {
             // SAFETY: out_ctx is valid; vid_out_stream_idx is valid.
             drain_encoder(
                 self.vid_enc_ctx.as_mut_ptr(),
-                self.out_ctx,
+                self.out_ctx.as_mut_ptr(),
                 self.vid_out_stream_idx,
                 self.log_prefix,
                 AVRational {
@@ -287,6 +275,11 @@ impl MuxerCore {
         if self.aud_enc_ctx.is_none() || self.aud_out_stream_idx < 0 {
             return; // audio not configured
         }
+
+        // Raw output-context pointer for `drain_encoder`; taking it up front frees
+        // the `&mut self.out_ctx` borrow so it does not overlap the `aud_enc_ctx`
+        // field borrow held during the drain call below.
+        let out_ctx = self.out_ctx.as_mut_ptr();
 
         let in_fmt = sample_format_to_av(frame.format());
         let in_rate = frame.sample_rate() as i32;
@@ -362,7 +355,7 @@ impl MuxerCore {
                 // SAFETY: out_ctx is valid; aud_out_stream_idx is valid.
                 drain_encoder(
                     aud_ctx.as_mut_ptr(),
-                    self.out_ctx,
+                    out_ctx,
                     self.aud_out_stream_idx,
                     self.log_prefix,
                     aud_frame_period,
@@ -374,25 +367,28 @@ impl MuxerCore {
         self.aud_enc_frame.unref();
     }
 
-    /// Flush both encoders, write the container trailer, and release all resources.
+    /// Flush both encoders and write the container trailer.
     ///
-    /// For RTMP/SRT (`close_pb_after_trailer = true`) the persistent network
-    /// connection (`out_ctx.pb`) is closed after `av_write_trailer`.
-    /// For HLS/DASH (`close_pb_after_trailer = false`) `pb` was already closed
-    /// after the header write, so this is skipped.
-    ///
-    /// All pointers are zeroed after this call so that [`Drop`] is a no-op.
+    /// The persistent connection (`out_ctx.pb`) is *not* closed here: for RTMP/SRT
+    /// it stays open until [`Drop`] closes it; for HLS/DASH it was already closed
+    /// after the header write (`close_io`). Freeing the context also happens on
+    /// drop, so this method only finalises the stream.
     ///
     /// # Safety
     ///
     /// `self` must have been initialised by the enclosing inner type's
     /// `open_unsafe`. This method must be called at most once.
     pub(crate) unsafe fn flush_and_close_unsafe(&mut self) {
+        // Raw output-context pointer for the `drain_encoder` calls below; taking
+        // it up front frees the `&mut self.out_ctx` borrow so it does not overlap
+        // the encoder-context field borrows.
+        let out_ctx = self.out_ctx.as_mut_ptr();
+
         // ── Flush video encoder ───────────────────────────────────────────────
         let _ = self.vid_enc_ctx.send_frame(ptr::null());
         drain_encoder(
             self.vid_enc_ctx.as_mut_ptr(),
-            self.out_ctx,
+            out_ctx,
             self.vid_out_stream_idx,
             self.log_prefix,
             AVRational {
@@ -443,7 +439,7 @@ impl MuxerCore {
                             };
                             drain_encoder(
                                 aud_ctx.as_mut_ptr(),
-                                self.out_ctx,
+                                out_ctx,
                                 self.aud_out_stream_idx,
                                 self.log_prefix,
                                 aud_frame_period,
@@ -463,7 +459,7 @@ impl MuxerCore {
                 };
                 drain_encoder(
                     aud_ctx.as_mut_ptr(),
-                    self.out_ctx,
+                    out_ctx,
                     self.aud_out_stream_idx,
                     self.log_prefix,
                     aud_frame_period,
@@ -472,20 +468,11 @@ impl MuxerCore {
         }
 
         // ── Write trailer ─────────────────────────────────────────────────────
-        av_write_trailer(self.out_ctx);
-
-        // For RTMP/SRT the connection (pb) was kept open throughout the session
-        // and must be closed now. For HLS/DASH pb was already closed after the
-        // header write, so closing it here would be a double-close.
-        if self.close_pb_after_trailer && !(*self.out_ctx).pb.is_null() {
-            ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
-        }
+        // The owned `out_ctx` closes its `pb` (if still open, i.e. RTMP/SRT) and
+        // frees the context on drop, so no manual close/free is needed here.
+        let _ = self.out_ctx.write_trailer();
 
         log::info!("{} output finished", self.log_prefix);
-
-        // Free the raw out_ctx and null it so Drop does not double-free; the owned
-        // frames/contexts drop with the struct.
-        self.free_all();
     }
 
     /// Set the PTS on `vid_enc_frame` from `video_frame_count` and `fps_int`.
@@ -503,49 +490,5 @@ impl MuxerCore {
             self.vid_enc_ctx.time_base(),
         );
         self.vid_enc_frame.set_pts(pts);
-    }
-
-    /// Release the raw output format context and drop the optional owned contexts.
-    ///
-    /// The owned encoder frames / codec / resampler / scaler contexts free on their
-    /// own `Drop`; this only needs to close `out_ctx.pb` (RTMP/SRT) and free the raw
-    /// `out_ctx`, nulling it so a second call (from `Drop`) is a no-op.
-    ///
-    /// For RTMP/SRT (`close_pb_after_trailer = true`) closes `out_ctx.pb`
-    /// before freeing `out_ctx` — handles the abnormal Drop path where
-    /// `flush_and_close_unsafe` was never called.
-    ///
-    /// # Safety
-    ///
-    /// Must only be called when no other reference to `out_ctx` exists.
-    unsafe fn free_all(&mut self) {
-        // Owned scale / resample / audio-codec contexts drop when set to `None`;
-        // a second call re-`None`s them, so this is idempotent. The `vid_enc_ctx`
-        // field is not an `Option` — it drops exactly once when the struct drops.
-        self.sws_ctx = None;
-        self.swr_ctx = None;
-        // `vid_enc_frame` / `aud_enc_frame` are owned `Frame`s: they free exactly
-        // once when the struct drops, so there is nothing to free here.
-        self.aud_enc_ctx = None;
-        if !self.out_ctx.is_null() {
-            // For RTMP/SRT: close pb if still open (Drop path where
-            // flush_and_close_unsafe was not called).
-            if self.close_pb_after_trailer && !(*self.out_ctx).pb.is_null() {
-                ff_sys::avformat::close_output(&mut (*self.out_ctx).pb);
-            }
-            avformat_free_context(self.out_ctx);
-            self.out_ctx = ptr::null_mut();
-        }
-    }
-}
-
-impl Drop for MuxerCore {
-    fn drop(&mut self) {
-        // SAFETY: free_all checks each pointer for null before freeing.
-        // flush_and_close_unsafe already zeroed all pointers on the success path,
-        // so this is a safe no-op in the normal case.
-        unsafe {
-            self.free_all();
-        }
     }
 }

--- a/crates/ff-stream/src/rtmp_inner.rs
+++ b/crates/ff-stream/src/rtmp_inner.rs
@@ -5,8 +5,8 @@
 //! [`crate::rtmp`].
 //!
 //! Unlike the HLS/DASH muxers, the RTMP connection (`out_ctx->pb`) is kept
-//! open for the entire session and is only closed after [`av_write_trailer`]
-//! in [`RtmpInner::flush_and_close`].
+//! open for the entire session; the owned `OutputFormatContext` closes it on
+//! drop, after the trailer is written in [`RtmpInner::flush_and_close`].
 
 // This module is intentionally unsafe — it drives the FFmpeg C API directly.
 #![allow(unsafe_code)]
@@ -18,15 +18,11 @@
 #![allow(clippy::ref_as_ptr)]
 #![allow(clippy::too_many_lines)]
 
-use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{
-    AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_alloc_output_context2, avformat_free_context,
-    avformat_new_stream, avformat_write_header,
-};
+use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_new_stream};
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
 use crate::error::StreamError;
@@ -124,32 +120,21 @@ impl RtmpInner {
         ff_sys::ensure_initialized();
 
         // ── 1. Allocate FLV output context with RTMP URL ───────────────────
-        let c_url = CString::new(url).map_err(|_| ffmpeg_err_msg("RTMP URL contains null byte"))?;
-
-        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
-        let ret = avformat_alloc_output_context2(
-            &mut out_ctx,
-            ptr::null_mut(),
-            c"flv".as_ptr(),
-            c_url.as_ptr(),
-        );
-        if ret < 0 || out_ctx.is_null() {
-            return Err(ffmpeg_err(ret));
-        }
+        // The owned context frees itself on every early return below (closing its
+        // `pb` if one was opened), so no manual teardown is needed on error paths.
+        let mut out_ctx = ff_sys::OutputFormatContext::new(Some("flv"), Path::new(url))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 2. Open H.264 video encoder ────────────────────────────────────
         let vid_enc_codec = crate::codec_utils::select_h264_encoder("rtmp").ok_or_else(|| {
-            avformat_free_context(out_ctx);
             ffmpeg_err_msg(
                 "no H.264 encoder available \
                      (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)",
             )
         })?;
 
-        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e.code())
-        })?;
+        let mut vid_enc_ctx =
+            ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| ffmpeg_err(e.code()))?;
         vid_enc_ctx.set_width(enc_width);
         vid_enc_ctx.set_height(enc_height);
         vid_enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
@@ -165,37 +150,27 @@ impl RtmpInner {
         vid_enc_ctx.set_gop_size(fps_int * 2);
         vid_enc_ctx.set_bit_rate(video_bitrate as i64);
 
-        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
-        // raw format context needs an explicit free.
+        // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
+        // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
             .open(vid_enc_codec, ptr::null_mut())
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 3. Add video output stream ─────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
+        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
         (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
         vid_enc_ctx
             .parameters_from_context((*vid_out_stream).codecpar)
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Open AAC audio encoder ──────────────────────────────────────
-        let aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "rtmp")
-            .inspect_err(|_| {
-                avformat_free_context(out_ctx);
-            })?;
+        let aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "rtmp")?;
 
         let aud_frame_size = if aud_enc_ctx.frame_size() > 0 {
             aud_enc_ctx.frame_size()
@@ -204,14 +179,13 @@ impl RtmpInner {
         };
 
         // ── 5. Add audio output stream ─────────────────────────────────────
-        let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+        let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
         if aud_out_stream.is_null() {
-            avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create audio output stream"));
         }
         (*aud_out_stream).time_base.num = 1;
         (*aud_out_stream).time_base.den = aud_sample_rate;
-        let aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+        let aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
         // SAFETY: aud_out_stream and aud_enc_ctx are valid.
         if aud_enc_ctx
@@ -222,25 +196,19 @@ impl RtmpInner {
         }
 
         // ── 6. Open RTMP connection and write FLV header ───────────────────
-        // Unlike HLS/DASH, RTMP uses a persistent network connection.
-        // We use avio_open via avformat::open_output with the URL as the path.
-        // SAFETY: url is a valid null-terminated C string (validated above).
-        let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e)
-            })?;
-        (*out_ctx).pb = pb;
+        // Unlike HLS/DASH, RTMP uses a persistent network connection. `open_io`
+        // opens the avio handle for the URL and attaches it as the context's `pb`.
+        out_ctx
+            .open_io(Path::new(url))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
-        let ret = avformat_write_header(out_ctx, ptr::null_mut());
-        if ret < 0 {
-            ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err(ret));
-        }
+        // On header-write failure the owned `out_ctx` drops here, closing `pb` and
+        // freeing the context.
+        out_ctx.write_header().map_err(|e| ffmpeg_err(e.code()))?;
 
         // NOTE: pb is intentionally kept open. RTMP is a persistent TCP connection;
-        // closing pb here would terminate the stream.
+        // closing pb here would terminate the stream. The owned `out_ctx` closes it
+        // on drop, after the trailer in `flush_and_close_unsafe`.
 
         log::info!(
             "rtmp output opened url={url} video={enc_width}x{enc_height}@{fps_int}fps \
@@ -260,13 +228,7 @@ impl RtmpInner {
             aud_frame_size,
             aud_sample_rate,
             "rtmp",
-            true, // close_pb_after_trailer: pb stays open for streaming
-        )
-        .inspect_err(|_| {
-            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
-            // error; only the raw format context needs an explicit free.
-            avformat_free_context(out_ctx);
-        })?;
+        )?;
 
         Ok(Self { core })
     }

--- a/crates/ff-stream/src/srt_output_inner.rs
+++ b/crates/ff-stream/src/srt_output_inner.rs
@@ -5,8 +5,9 @@
 //! [`crate::srt_output`].
 //!
 //! The MPEG-TS muxer writes to the SRT URL via `avio_open2`. The connection
-//! (`out_ctx->pb`) is kept open for the entire session and closed after
-//! [`av_write_trailer`] in [`SrtInner::flush_and_close`].
+//! (`out_ctx->pb`) is kept open for the entire session; the owned
+//! `OutputFormatContext` closes it on drop, after the trailer is written in
+//! [`SrtInner::flush_and_close`].
 
 // This module is intentionally unsafe — it drives the FFmpeg C API directly.
 #![allow(unsafe_code)]
@@ -18,15 +19,11 @@
 #![allow(clippy::ref_as_ptr)]
 #![allow(clippy::too_many_lines)]
 
-use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{
-    AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_alloc_output_context2, avformat_free_context,
-    avformat_new_stream, avformat_write_header,
-};
+use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_new_stream};
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
 use crate::error::StreamError;
@@ -125,32 +122,21 @@ impl SrtInner {
         ff_sys::ensure_initialized();
 
         // ── 1. Allocate MPEG-TS output context with SRT URL ────────────────
-        let c_url = CString::new(url).map_err(|_| ffmpeg_err_msg("SRT URL contains null byte"))?;
-
-        let mut out_ctx: *mut ff_sys::AVFormatContext = ptr::null_mut();
-        let ret = avformat_alloc_output_context2(
-            &mut out_ctx,
-            ptr::null_mut(),
-            c"mpegts".as_ptr(),
-            c_url.as_ptr(),
-        );
-        if ret < 0 || out_ctx.is_null() {
-            return Err(ffmpeg_err(ret));
-        }
+        // The owned context frees itself on every early return below (closing its
+        // `pb` if one was opened), so no manual teardown is needed on error paths.
+        let mut out_ctx = ff_sys::OutputFormatContext::new(Some("mpegts"), Path::new(url))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 2. Open H.264 video encoder ────────────────────────────────────
         let vid_enc_codec = crate::codec_utils::select_h264_encoder("srt").ok_or_else(|| {
-            avformat_free_context(out_ctx);
             ffmpeg_err_msg(
                 "no H.264 encoder available \
                  (tried h264_nvenc, h264_qsv, h264_amf, h264_videotoolbox, libx264, mpeg4)",
             )
         })?;
 
-        let mut vid_enc_ctx = ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| {
-            avformat_free_context(out_ctx);
-            ffmpeg_err(e.code())
-        })?;
+        let mut vid_enc_ctx =
+            ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| ffmpeg_err(e.code()))?;
         vid_enc_ctx.set_width(enc_width);
         vid_enc_ctx.set_height(enc_height);
         vid_enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
@@ -166,37 +152,27 @@ impl SrtInner {
         vid_enc_ctx.set_gop_size(fps_int * 2);
         vid_enc_ctx.set_bit_rate(video_bitrate as i64);
 
-        // On open failure `vid_enc_ctx` drops (frees the codec context); only the
-        // raw format context needs an explicit free.
+        // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
+        // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
             .open(vid_enc_codec, ptr::null_mut())
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 3. Add video output stream ─────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx, vid_enc_codec.as_ptr());
+        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
         if vid_out_stream.is_null() {
-            avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create video output stream"));
         }
         (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
         // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
         vid_enc_ctx
             .parameters_from_context((*vid_out_stream).codecpar)
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e.code())
-            })?;
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Open AAC audio encoder ──────────────────────────────────────
-        let aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "srt")
-            .inspect_err(|_| {
-                avformat_free_context(out_ctx);
-            })?;
+        let aud_enc_ctx = open_aac_encoder(aud_sample_rate, aud_channels, aud_bitrate, "srt")?;
 
         let aud_frame_size = if aud_enc_ctx.frame_size() > 0 {
             aud_enc_ctx.frame_size()
@@ -205,14 +181,13 @@ impl SrtInner {
         };
 
         // ── 5. Add audio output stream ─────────────────────────────────────
-        let aud_out_stream = avformat_new_stream(out_ctx, ptr::null());
+        let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
         if aud_out_stream.is_null() {
-            avformat_free_context(out_ctx);
             return Err(ffmpeg_err_msg("cannot create audio output stream"));
         }
         (*aud_out_stream).time_base.num = 1;
         (*aud_out_stream).time_base.den = aud_sample_rate;
-        let aud_out_stream_idx = ((*out_ctx).nb_streams - 1) as i32;
+        let aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
 
         // SAFETY: aud_out_stream and aud_enc_ctx are valid.
         if aud_enc_ctx
@@ -223,25 +198,19 @@ impl SrtInner {
         }
 
         // ── 6. Open SRT connection and write MPEG-TS header ────────────────
-        // SRT uses a persistent network connection like RTMP.
-        // We use avio_open via avformat::open_output with the URL as the path.
-        // SAFETY: url is a valid null-terminated C string (validated above).
-        let pb = ff_sys::avformat::open_output(Path::new(url), ff_sys::avformat::avio_flags::WRITE)
-            .map_err(|e| {
-                avformat_free_context(out_ctx);
-                ffmpeg_err(e)
-            })?;
-        (*out_ctx).pb = pb;
+        // SRT uses a persistent network connection like RTMP. `open_io` opens the
+        // avio handle for the URL and attaches it as the context's `pb`.
+        out_ctx
+            .open_io(Path::new(url))
+            .map_err(|e| ffmpeg_err(e.code()))?;
 
-        let ret = avformat_write_header(out_ctx, ptr::null_mut());
-        if ret < 0 {
-            ff_sys::avformat::close_output(&mut (*out_ctx).pb);
-            avformat_free_context(out_ctx);
-            return Err(ffmpeg_err(ret));
-        }
+        // On header-write failure the owned `out_ctx` drops here, closing `pb` and
+        // freeing the context.
+        out_ctx.write_header().map_err(|e| ffmpeg_err(e.code()))?;
 
         // NOTE: pb is intentionally kept open. SRT is a persistent connection;
-        // closing pb here would terminate the stream.
+        // closing pb here would terminate the stream. The owned `out_ctx` closes it
+        // on drop, after the trailer in `flush_and_close_unsafe`.
 
         log::info!(
             "srt output opened url={url} video={enc_width}x{enc_height}@{fps_int}fps \
@@ -261,13 +230,7 @@ impl SrtInner {
             aud_frame_size,
             aud_sample_rate,
             "srt",
-            true, // close_pb_after_trailer: pb stays open for streaming
-        )
-        .inspect_err(|_| {
-            // `vid_enc_ctx` / `aud_enc_ctx` were moved in and drop inside `new` on
-            // error; only the raw format context needs an explicit free.
-            avformat_free_context(out_ctx);
-        })?;
+        )?;
 
         Ok(Self { core })
     }


### PR DESCRIPTION
## Objective

- ff-stream held its mux output contexts as raw `*mut AVFormatContext` with a `close_pb_after_trailer` flag, a `free_all` helper, a `cleanup_output_ctx` helper, and a manual `MuxerCore` `Drop` to model the differing `pb` lifecycles. It was the last mux consumer in the RAII hardening epic.

## Solution

- Migrate all six mux paths (RTMP, SRT, live HLS, live DASH, HLS/DASH transcode) to the owned `ff_sys::OutputFormatContext`.
- Model the `pb` lifecycle with the owned type: RTMP/SRT keep `pb` open for the session and let `Drop` close it after the trailer; the HLS/DASH segment muxers close `pb` right after the header via `close_io`.
- Remove the `close_pb_after_trailer` flag, `free_all`, the manual `MuxerCore` `Drop`, and `cleanup_output_ctx`; the owned `Drop` closes any still-open `pb` and frees the context, so no early-return path leaks it.
- Make `MuxerCore::new` a safe `fn` (it takes the context by value, no UB precondition).
- In the HLS/DASH transcode paths the demux `input_ctx` stays raw, so every error arm there keeps its explicit `close_input` while the owned `out_ctx` frees on its own.

Closes #1527