### PR TITLE
refactor(ff-encode/ff-filter): migrate the remaining raw demux consumers to InputFormatContext

### DIFF
--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -592,50 +592,46 @@ impl VideoEncoderInner {
         source_stream_index: usize,
     ) {
         let path = std::path::Path::new(source_path);
-        let src_ctx = match ff_sys::avformat::open_input(path) {
+        // The owned demux context frees itself (closing the input) on every early
+        // return below and at scope end, so no manual teardown is needed.
+        let mut src_ctx = match ff_sys::InputFormatContext::open(path) {
             Ok(ctx) => ctx,
             Err(e) => {
                 log::warn!(
                     "subtitle_passthrough: failed to open source file \
                      path={source_path} error={}",
-                    ff_sys::av_error_string(e)
+                    ff_sys::av_error_string(e.code())
                 );
                 return;
             }
         };
 
-        if let Err(e) = ff_sys::avformat::find_stream_info(src_ctx) {
+        if let Err(e) = src_ctx.find_stream_info() {
             log::warn!(
                 "subtitle_passthrough: failed to find stream info \
                  path={source_path} error={}",
-                ff_sys::av_error_string(e)
+                ff_sys::av_error_string(e.code())
             );
-            let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
-        let nb_streams = (*src_ctx).nb_streams as usize;
+        let nb_streams = src_ctx.nb_streams() as usize;
         if source_stream_index >= nb_streams {
             log::warn!(
                 "subtitle_passthrough: stream index out of range \
                  index={source_stream_index} nb_streams={nb_streams}"
             );
-            let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
         // SAFETY: source_stream_index < nb_streams; streams is a valid array.
-        let in_stream = *(*src_ctx).streams.add(source_stream_index);
+        let in_stream = *(*src_ctx.as_ptr()).streams.add(source_stream_index);
 
         if (*(*in_stream).codecpar).codec_type != AVMediaType_AVMEDIA_TYPE_SUBTITLE {
             log::warn!(
                 "subtitle_passthrough: stream at index {source_stream_index} \
                  is not a subtitle stream"
             );
-            let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
@@ -645,8 +641,6 @@ impl VideoEncoderInner {
         let out_stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), std::ptr::null());
         if out_stream.is_null() {
             log::warn!("subtitle_passthrough: avformat_new_stream failed");
-            let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
@@ -657,16 +651,11 @@ impl VideoEncoderInner {
                 "subtitle_passthrough: avcodec_parameters_copy failed error={}",
                 ff_sys::av_error_string(ret)
             );
-            let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return;
         }
 
         // Reset codec_tag so the muxer can pick the appropriate value for the container.
         (*(*out_stream).codecpar).codec_tag = 0;
-
-        let mut src_ctx_ptr = src_ctx;
-        ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
 
         self.subtitle_passthrough = Some((
             source_path.to_string(),
@@ -698,31 +687,31 @@ impl VideoEncoderInner {
         };
 
         let path = std::path::Path::new(&source_path);
-        let src_ctx = match ff_sys::avformat::open_input(path) {
+        // The owned demux context frees itself (closing the input) on every early
+        // return below and at scope end, so no manual teardown is needed.
+        let mut src_ctx = match ff_sys::InputFormatContext::open(path) {
             Ok(ctx) => ctx,
             Err(e) => {
                 log::warn!(
                     "subtitle_passthrough: failed to re-open source file \
                      path={source_path} error={}",
-                    ff_sys::av_error_string(e)
+                    ff_sys::av_error_string(e.code())
                 );
                 return Ok(());
             }
         };
 
-        if let Err(e) = ff_sys::avformat::find_stream_info(src_ctx) {
+        if let Err(e) = src_ctx.find_stream_info() {
             log::warn!(
                 "subtitle_passthrough: failed to find stream info on re-open \
                  path={source_path} error={}",
-                ff_sys::av_error_string(e)
+                ff_sys::av_error_string(e.code())
             );
-            let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return Ok(());
         }
 
         // SAFETY: source_stream_index was validated in init_subtitle_passthrough.
-        let in_stream = *(*src_ctx).streams.add(source_stream_index);
+        let in_stream = *(*src_ctx.as_ptr()).streams.add(source_stream_index);
         let in_time_base = (*in_stream).time_base;
 
         // SAFETY: out_stream_index was set by avformat_new_stream; format_ctx is valid.
@@ -732,8 +721,6 @@ impl VideoEncoderInner {
         let out_time_base = (*out_stream).time_base;
 
         let Ok(mut pkt) = ff_sys::Packet::new() else {
-            let mut src_ctx_ptr = src_ctx;
-            ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
             return Err(EncodeError::Ffmpeg {
                 code: 0,
                 message: "subtitle_passthrough: av_packet_alloc failed".to_string(),
@@ -741,13 +728,13 @@ impl VideoEncoderInner {
         };
 
         loop {
-            match ff_sys::avformat::read_frame(src_ctx, pkt.as_mut_ptr()) {
-                Err(e) if e == ff_sys::error_codes::EOF => break,
+            match src_ctx.read_frame(&mut pkt) {
+                Err(e) if e.is_eof() => break,
                 Err(e) => {
                     log::warn!(
                         "subtitle_passthrough: read_frame error, stopping \
                          path={source_path} error={}",
-                        ff_sys::av_error_string(e)
+                        ff_sys::av_error_string(e.code())
                     );
                     break;
                 }
@@ -787,10 +774,7 @@ impl VideoEncoderInner {
             pkt.unref();
         }
 
-        // `pkt` drops at end of scope, freeing it.
-        let mut src_ctx_ptr = src_ctx;
-        ff_sys::avformat::close_input(&raw mut src_ctx_ptr);
-
+        // `pkt` and the owned `src_ctx` drop at end of scope, freeing them.
         Ok(())
     }
 

--- a/crates/ff-filter/src/analysis/analysis_inner.rs
+++ b/crates/ff-filter/src/analysis/analysis_inner.rs
@@ -664,17 +664,18 @@ pub(super) unsafe fn compute_psnr_unsafe(
 /// - All `AVFormatContext` resources are released before returning.
 /// - Only the first video stream's metadata is accessed (no data read).
 unsafe fn probe_video_frame_count(path: &Path) -> Option<i64> {
-    let mut fmt_ctx = ff_sys::avformat::open_input(path).ok()?;
+    // The owned demux context frees itself (closing the input) on drop at fn end.
+    let mut fmt_ctx = ff_sys::InputFormatContext::open(path).ok()?;
 
     // Ignore find_stream_info errors; partial info is still usable.
-    let _ = ff_sys::avformat::find_stream_info(fmt_ctx);
+    let _ = fmt_ctx.find_stream_info();
 
-    let nb_streams = (*fmt_ctx).nb_streams;
+    let nb_streams = fmt_ctx.nb_streams();
     let mut result: Option<i64> = None;
 
     for i in 0..nb_streams {
         // SAFETY: streams is a valid array of `nb_streams` pointers.
-        let stream = *(*fmt_ctx).streams.add(i as usize);
+        let stream = *(*fmt_ctx.as_ptr()).streams.add(i as usize);
         if (*(*stream).codecpar).codec_type != ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO {
             continue;
         }
@@ -697,6 +698,5 @@ unsafe fn probe_video_frame_count(path: &Path) -> Option<i64> {
         break; // Only inspect the first video stream.
     }
 
-    ff_sys::avformat::close_input(std::ptr::addr_of_mut!(fmt_ctx));
     result
 }

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -2182,30 +2182,29 @@ pub(super) unsafe fn build_audio_concat(
 
 // ── Dissolve-join graph builder ────────────────────────────────────────────────
 
-/// Probe a clip's duration in seconds using `avformat_open_input` +
-/// `avformat_find_stream_info`.  Returns `CompositionFailed` if the file
-/// cannot be opened or has an unknown duration.
+/// Probe a clip's duration in seconds via an owned `ff_sys::InputFormatContext`
+/// (open + find stream info).  Returns `CompositionFailed` if the file cannot be
+/// opened or has an unknown duration.
 pub(super) unsafe fn probe_clip_duration_sec(path: &PathBuf) -> Result<f64, FilterError> {
-    let ctx = ff_sys::avformat::open_input(path.as_ref()).map_err(|code| {
+    // The owned demux context frees itself (closing the input) on every early
+    // return below and at scope end, so no manual teardown is needed.
+    let mut ctx = ff_sys::InputFormatContext::open(path.as_ref()).map_err(|e| {
         FilterError::CompositionFailed {
             reason: format!(
-                "failed to probe clip duration code={code} path={}",
+                "failed to probe clip duration code={} path={}",
+                e.code(),
                 path.display()
             ),
         }
     })?;
 
-    if let Err(code) = ff_sys::avformat::find_stream_info(ctx) {
-        let mut p = ctx;
-        ff_sys::avformat::close_input(&raw mut p);
+    if let Err(e) = ctx.find_stream_info() {
         return Err(FilterError::CompositionFailed {
-            reason: format!("avformat_find_stream_info failed code={code}"),
+            reason: format!("avformat_find_stream_info failed code={}", e.code()),
         });
     }
 
-    let duration_val = (*ctx).duration;
-    let mut p = ctx;
-    ff_sys::avformat::close_input(&raw mut p);
+    let duration_val = ctx.duration();
 
     if duration_val <= 0 {
         return Err(FilterError::CompositionFailed {


### PR DESCRIPTION
## Objective

- The closed #1505 claimed all consumers were migrated off the raw escape hatches, but three demux consumers still opened a raw `*mut AVFormatContext` via `avformat::open_input` — ff-encode's subtitle passthrough and two ff-filter probes — blocking #1506 from privatizing those wrappers.

## Solution

- Migrate all three to the owned `ff_sys::InputFormatContext`: `open_input` -> `InputFormatContext::open`, `find_stream_info`/`read_frame`/`duration` become owned methods, and every manual `close_input` is removed (the owned context frees itself, closing the input, on drop across all paths). Stream/codecpar reads stay raw via `as_ptr` (transitional, sealed later).
- This is slice **S1** of the #1506 decomposition and removes every raw `avformat` demux wrapper call from ff-encode and ff-filter.

Closes #1538