### PR TITLE
feat(ff-sys): add the accessors and safe FFI methods to seal the safe layer

### DIFF
--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -605,6 +605,43 @@ impl CodecContext {
         classify_receive(result)
     }
 
+    /// Sends a frame to the encoder; `None` flushes it, entering draining.
+    ///
+    /// The safe counterpart of [`send_frame`](Self::send_frame): after sending
+    /// `None`, loop [`receive_packet_into`](Self::receive_packet_into) until it
+    /// returns [`ReceiveOutcome::Drained`] to collect the buffered packets.
+    ///
+    /// Transitional name: this is renamed to `send_frame` once the raw `unsafe`
+    /// [`send_frame`](Self::send_frame) is removed (#1506).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] on a real encode error.
+    pub fn send_frame_ref(&mut self, frame: Option<&Frame>) -> Result<(), AvError> {
+        let ptr = frame.map_or(std::ptr::null(), Frame::as_ptr);
+        // SAFETY: `ptr` is null (flush) or a valid `*const AVFrame` borrowed from
+        //         `frame` for the duration of the call; `self.ptr` is a valid context.
+        unsafe { self.send_frame(ptr) }
+    }
+
+    /// Receives an encoded packet into `pkt`, returning a typed [`ReceiveOutcome`].
+    ///
+    /// The safe counterpart of [`receive_packet`](Self::receive_packet), pairing
+    /// with [`receive_frame`](Self::receive_frame). `EAGAIN` / `EOF` are returned
+    /// as [`ReceiveOutcome::NeedInput`] / [`ReceiveOutcome::Drained`], not errors.
+    ///
+    /// Transitional name: this is renamed to `receive_packet` once the raw `unsafe`
+    /// [`receive_packet`](Self::receive_packet) is removed (#1506).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] on a real encode error.
+    pub fn receive_packet_into(&mut self, pkt: &mut Packet) -> Result<ReceiveOutcome, AvError> {
+        // SAFETY: `pkt` is a valid owned packet borrowed mutably for the call;
+        //         `self.ptr` is a valid context.
+        unsafe { self.receive_packet(pkt.as_mut_ptr()) }
+    }
+
     /// Copies this context's parameters into `par` (encoder → stream codecpar).
     ///
     /// # Safety
@@ -750,6 +787,20 @@ mod tests {
         // codec being opened; reading it must not panic.
         let ctx = CodecContext::new(None).expect("alloc should succeed");
         let _ = ctx.sample_fmt();
+    }
+
+    #[test]
+    fn send_frame_ref_and_receive_packet_into_should_err_when_unopened() {
+        // On an unopened context avcodec_send_frame / avcodec_receive_packet return
+        // EINVAL via the avcodec_is_open guard (no deref); the safe wrappers must
+        // surface that as Err without panicking — for both the flush (None) and
+        // frame (Some) send paths and the receive path.
+        let mut ctx = CodecContext::new(None).expect("alloc should succeed");
+        assert!(ctx.send_frame_ref(None).is_err());
+        let frame = Frame::new().expect("frame alloc should succeed");
+        assert!(ctx.send_frame_ref(Some(&frame)).is_err());
+        let mut pkt = Packet::new().expect("packet alloc should succeed");
+        assert!(ctx.receive_packet_into(&mut pkt).is_err());
     }
 
     #[test]

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1333,6 +1333,21 @@ impl CodecContext {
         Err(crate::AvError::new(-1))
     }
 
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn send_frame_ref(&mut self, _frame: Option<&Frame>) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn receive_packet_into(
+        &mut self,
+        _pkt: &mut Packet,
+    ) -> Result<ReceiveOutcome, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
     /// # Safety
     /// Stub; never executed on docs.rs.
     pub unsafe fn parameters_from_context(
@@ -1537,6 +1552,55 @@ impl OutputFormatContext {
     }
 
     pub fn close_io(&mut self) {}
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn new_stream(&mut self, _codec: Option<&Codec>) -> Result<usize, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    #[must_use]
+    pub fn stream_time_base(&self, _idx: usize) -> AVRational {
+        AVRational { num: 0, den: 0 }
+    }
+
+    pub fn set_stream_time_base(&mut self, _idx: usize, _time_base: AVRational) {}
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn apply_stream_params_from_context(
+        &mut self,
+        _idx: usize,
+        _ctx: &CodecContext,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn copy_stream_params(
+        &mut self,
+        _idx: usize,
+        _src: CodecParameters<'_>,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn set_opt(
+        &mut self,
+        _key: &std::ffi::CStr,
+        _value: &std::ffi::CStr,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn write_interleaved(&mut self, _pkt: &mut Packet) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
 }
 
 impl Drop for OutputFormatContext {
@@ -1790,6 +1854,19 @@ impl Packet {
     pub fn pts(&self) -> i64 {
         0
     }
+
+    #[must_use]
+    pub fn dts(&self) -> i64 {
+        0
+    }
+
+    pub fn set_stream_index(&mut self, _stream_index: c_int) {}
+
+    pub fn set_pts(&mut self, _pts: i64) {}
+
+    pub fn set_dts(&mut self, _dts: i64) {}
+
+    pub fn rescale_ts(&mut self, _src_tb: AVRational, _dst_tb: AVRational) {}
 
     pub fn unref(&mut self) {}
 

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -24,8 +24,11 @@ use std::time::Duration;
 
 use crate::{
     AVChannelLayout, AVCodecID, AVCodecParameters, AVColorPrimaries, AVColorRange, AVColorSpace,
-    AVFormatContext, AVMediaType, AVRational, AVStream, AvError, Packet,
+    AVFormatContext, AVMediaType, AVRational, AVStream, AvError, Codec, CodecContext, Packet,
+    av_interleaved_write_frame as ffi_av_interleaved_write_frame, av_opt_set as ffi_av_opt_set,
+    avcodec_parameters_copy as ffi_avcodec_parameters_copy,
     avformat_close_input as ffi_avformat_close_input,
+    avformat_new_stream as ffi_avformat_new_stream,
 };
 
 /// An owned input (demux) `AVFormatContext`.
@@ -438,6 +441,158 @@ impl OutputFormatContext {
         //         null-checks `pb` and nulls it after closing.
         unsafe { crate::avformat::close_output(&mut (*self.ptr.as_ptr()).pb) };
     }
+
+    /// Returns the raw `*mut AVStream` at `idx`, or null when out of range.
+    fn stream_ptr(&self, idx: usize) -> *mut AVStream {
+        // SAFETY: `self.ptr` is a valid owned mux context. We bound-check `idx`
+        //         against `nb_streams` before indexing the `streams` array.
+        unsafe {
+            let ctx = self.ptr.as_ptr();
+            if idx >= (*ctx).nb_streams as usize {
+                std::ptr::null_mut()
+            } else {
+                *(*ctx).streams.add(idx)
+            }
+        }
+    }
+
+    /// Adds a new output stream (optionally bound to `codec`) and returns its index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the stream cannot be allocated.
+    pub fn new_stream(&mut self, codec: Option<&Codec>) -> Result<usize, AvError> {
+        let codec_ptr = codec.map_or(std::ptr::null(), Codec::as_ptr);
+        // SAFETY: `self.ptr` is a valid owned mux context; `codec_ptr` is null or a
+        //         valid `*const AVCodec` borrowed from `codec` for the call.
+        let stream = unsafe { ffi_avformat_new_stream(self.ptr.as_ptr(), codec_ptr) };
+        if stream.is_null() {
+            return Err(AvError::new(crate::error_codes::ENOMEM));
+        }
+        // The stream is appended, so its index is the new `nb_streams - 1`.
+        Ok(self.nb_streams() as usize - 1)
+    }
+
+    /// Returns the time base of output stream `idx`, or `0/0` when out of range.
+    #[must_use]
+    pub fn stream_time_base(&self, idx: usize) -> AVRational {
+        let stream = self.stream_ptr(idx);
+        if stream.is_null() {
+            AVRational { num: 0, den: 0 }
+        } else {
+            // SAFETY: `stream` is a valid non-null stream from this context.
+            unsafe { (*stream).time_base }
+        }
+    }
+
+    /// Sets the time base of output stream `idx` (no-op when out of range).
+    pub fn set_stream_time_base(&mut self, idx: usize, time_base: AVRational) {
+        let stream = self.stream_ptr(idx);
+        if !stream.is_null() {
+            // SAFETY: `stream` is a valid non-null stream from this context.
+            unsafe { (*stream).time_base = time_base };
+        }
+    }
+
+    /// Copies `ctx`'s codec parameters into output stream `idx` (encoder → stream).
+    ///
+    /// The encoder-side counterpart of [`copy_stream_params`](Self::copy_stream_params)
+    /// (which copies from another stream's parameters for stream-copy remuxing).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if `idx` is out of range or the copy fails.
+    pub fn apply_stream_params_from_context(
+        &mut self,
+        idx: usize,
+        ctx: &CodecContext,
+    ) -> Result<(), AvError> {
+        let stream = self.stream_ptr(idx);
+        if stream.is_null() {
+            return Err(AvError::new(crate::error_codes::EINVAL));
+        }
+        // SAFETY: `stream` is valid; its `codecpar` is allocated with it and non-null.
+        //         `parameters_from_context` copies into that codecpar.
+        unsafe {
+            let par = (*stream).codecpar;
+            ctx.parameters_from_context(par)
+        }
+    }
+
+    /// Copies `src` codec parameters into output stream `idx` (stream copy) and
+    /// clears its `codec_tag` so the muxer assigns the container's value.
+    ///
+    /// The stream-copy counterpart of
+    /// [`apply_stream_params_from_context`](Self::apply_stream_params_from_context)
+    /// (which copies from an encoder context).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if `idx` is out of range or the copy fails.
+    pub fn copy_stream_params(
+        &mut self,
+        idx: usize,
+        src: CodecParameters<'_>,
+    ) -> Result<(), AvError> {
+        let stream = self.stream_ptr(idx);
+        if stream.is_null() {
+            return Err(AvError::new(crate::error_codes::EINVAL));
+        }
+        // SAFETY: `stream` is valid; `dst`/`src.as_raw()` are non-null codecpar
+        //         pointers (allocated with their streams); the copy is a deep copy.
+        unsafe {
+            let dst = (*stream).codecpar;
+            let ret = ffi_avcodec_parameters_copy(dst, src.as_raw());
+            if ret < 0 {
+                return Err(AvError::new(ret));
+            }
+            (*dst).codec_tag = 0;
+        }
+        Ok(())
+    }
+
+    /// Sets a private muxer option (`av_opt_set` on the muxer's `priv_data`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the option is unrecognised or cannot be set.
+    pub fn set_opt(&mut self, key: &CStr, value: &CStr) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned mux context. `priv_data` is the muxer's
+        //         option object, which is null for a muxer without private options;
+        //         `av_opt_set` (via `av_opt_find2`) null-checks `obj` first and then
+        //         returns `AVERROR_OPTION_NOT_FOUND` without dereferencing it, so a
+        //         null `priv_data` is a returned error, not a deref. `key`/`value`
+        //         outlive the call.
+        let ret = unsafe {
+            ffi_av_opt_set(
+                (*self.ptr.as_ptr()).priv_data,
+                key.as_ptr(),
+                value.as_ptr(),
+                0,
+            )
+        };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Writes `pkt` to the output, interleaving it into the muxer's queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the write fails.
+    pub fn write_interleaved(&mut self, pkt: &mut Packet) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned mux context whose header was written;
+        //         `pkt` is a valid owned packet borrowed mutably for the call.
+        let ret = unsafe { ffi_av_interleaved_write_frame(self.ptr.as_ptr(), pkt.as_mut_ptr()) };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl Drop for OutputFormatContext {
@@ -630,5 +785,36 @@ mod tests {
         // mp4 is a normal file muxer, not one that manages its own IO.
         assert!(!ctx.is_nofile());
         // `ctx` drops here: frees the context (its `pb` was never opened).
+    }
+
+    #[test]
+    fn output_stream_api_should_round_trip() {
+        // Exercises new_stream / stream_time_base / set_stream_time_base / set_opt.
+        // Needs a real muxer; skip gracefully if mp4 is absent (minimal FFmpeg build).
+        let Ok(mut ctx) = OutputFormatContext::new(None, Path::new("out.mp4")) else {
+            return;
+        };
+        let idx = ctx
+            .new_stream(None)
+            .expect("new_stream should allocate a stream");
+        assert_eq!(idx, 0);
+        assert_eq!(ctx.nb_streams(), 1);
+
+        ctx.set_stream_time_base(idx, AVRational { num: 1, den: 30 });
+        let tb = ctx.stream_time_base(idx);
+        assert_eq!((tb.num, tb.den), (1, 30));
+
+        // An out-of-range index is a safe no-op / zero, not a panic.
+        let oob = ctx.stream_time_base(99);
+        assert_eq!((oob.num, oob.den), (0, 0));
+
+        // An unrecognised muxer option surfaces as an error (no panic).
+        let key = std::ffi::CString::new("definitely_not_a_real_option").unwrap();
+        let value = std::ffi::CString::new("1").unwrap();
+        assert!(ctx.set_opt(&key, &value).is_err());
+
+        // The codec-parameter copy's out-of-range index guard returns Err, not a panic.
+        let cc = CodecContext::new(None).expect("codec context alloc should succeed");
+        assert!(ctx.apply_stream_params_from_context(99, &cc).is_err());
     }
 }

--- a/crates/ff-sys/src/packet.rs
+++ b/crates/ff-sys/src/packet.rs
@@ -9,9 +9,9 @@
 use std::ptr::NonNull;
 
 use crate::{
-    AVPacket, AvError, av_packet_alloc as ffi_av_packet_alloc,
+    AVPacket, AVRational, AvError, av_packet_alloc as ffi_av_packet_alloc,
     av_packet_free as ffi_av_packet_free, av_packet_ref as ffi_av_packet_ref,
-    av_packet_unref as ffi_av_packet_unref,
+    av_packet_rescale_ts as ffi_av_packet_rescale_ts, av_packet_unref as ffi_av_packet_unref,
 };
 
 /// An owned `AVPacket`.
@@ -63,6 +63,38 @@ impl Packet {
     pub fn pts(&self) -> i64 {
         // SAFETY: `self.ptr` is a valid owned packet; `pts` is a plain field.
         unsafe { (*self.ptr.as_ptr()).pts }
+    }
+
+    /// Returns the decompression timestamp (in the stream's time base).
+    #[must_use]
+    pub fn dts(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned packet; `dts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).dts }
+    }
+
+    /// Sets the index of the stream this packet belongs to.
+    pub fn set_stream_index(&mut self, stream_index: std::os::raw::c_int) {
+        // SAFETY: `self.ptr` is a valid owned packet; `stream_index` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).stream_index = stream_index };
+    }
+
+    /// Sets the presentation timestamp (in the stream's time base).
+    pub fn set_pts(&mut self, pts: i64) {
+        // SAFETY: `self.ptr` is a valid owned packet; `pts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pts = pts };
+    }
+
+    /// Sets the decompression timestamp (in the stream's time base).
+    pub fn set_dts(&mut self, dts: i64) {
+        // SAFETY: `self.ptr` is a valid owned packet; `dts` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).dts = dts };
+    }
+
+    /// Rescales the packet's `pts` / `dts` / `duration` from `src_tb` to `dst_tb`.
+    pub fn rescale_ts(&mut self, src_tb: AVRational, dst_tb: AVRational) {
+        // SAFETY: `self.ptr` is a valid owned packet; the time bases are plain
+        //         POD values.
+        unsafe { ffi_av_packet_rescale_ts(self.ptr.as_ptr(), src_tb, dst_tb) };
     }
 
     /// Unreferences the packet's buffer, returning it to a blank state.
@@ -124,5 +156,30 @@ mod tests {
         let clone = packet.try_clone().expect("ref-count clone should succeed");
         assert!(!clone.as_ptr().is_null());
         // Both `packet` and `clone` drop independently (ref-counted), no double free.
+    }
+
+    #[test]
+    fn scalar_setters_should_round_trip() {
+        let mut packet = Packet::new().expect("packet allocation should succeed");
+        packet.set_stream_index(3);
+        packet.set_pts(1_000);
+        packet.set_dts(900);
+        assert_eq!(packet.stream_index(), 3);
+        assert_eq!(packet.pts(), 1_000);
+        assert_eq!(packet.dts(), 900);
+    }
+
+    #[test]
+    fn rescale_ts_should_scale_pts_and_dts() {
+        let mut packet = Packet::new().expect("packet allocation should succeed");
+        packet.set_pts(100);
+        packet.set_dts(100);
+        // 1/1000 -> 1/2000 doubles the timestamps.
+        packet.rescale_ts(
+            AVRational { num: 1, den: 1000 },
+            AVRational { num: 1, den: 2000 },
+        );
+        assert_eq!(packet.pts(), 200);
+        assert_eq!(packet.dts(), 200);
     }
 }


### PR DESCRIPTION
## Objective

- ~144 consumer sites still use the owned types' transitional `as_ptr`/`as_mut_ptr` — split into field access (`(*x.as_ptr()).field`) and raw-ptr-to-FFI (`ffi(x.as_mut_ptr())`). Eliminating both is required before #1506 can remove `as_ptr`/`as_mut_ptr` and privatize the raw wrappers.

## Solution

- Add the additive ff-sys API those sites need (no consumer changes), so the per-crate migrations become mechanical:
  - **Packet**: `set_stream_index`/`set_pts`/`set_dts`/`dts` and `rescale_ts`.
  - **CodecContext**: safe `send_frame_ref(Option<&Frame>)` (`None` flushes) and `receive_packet_into(&mut Packet)`, alongside the transitional raw versions.
  - **OutputFormatContext**: an index-based stream API (`new_stream`, `stream_time_base`/`set_stream_time_base`, `apply_stream_params_from_context`, `copy_stream_params`), plus `set_opt` and `write_interleaved`.
- Add docsrs stubs for every new method and unit tests for the round-trips, index guards, and error paths.
- Slice **S3-api** of the #1506 decomposition; unblocks the per-crate migrations (#1543 ff-stream, #1544 ff-encode, #1545 rest).

Closes #1540