### PR TITLE
feat(ff-sys): complete the seal API with Packet duration, Frame linesize, and swr flush

### DIFF
--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1791,6 +1791,11 @@ impl Frame {
     }
 
     #[must_use]
+    pub fn linesize(&self, _i: usize) -> c_int {
+        0
+    }
+
+    #[must_use]
     pub fn audio_plane(&self, _i: usize) -> Option<&[u8]> {
         None
     }
@@ -1860,11 +1865,18 @@ impl Packet {
         0
     }
 
+    #[must_use]
+    pub fn duration(&self) -> i64 {
+        0
+    }
+
     pub fn set_stream_index(&mut self, _stream_index: c_int) {}
 
     pub fn set_pts(&mut self, _pts: i64) {}
 
     pub fn set_dts(&mut self, _dts: i64) {}
+
+    pub fn set_duration(&mut self, _duration: i64) {}
 
     pub fn rescale_ts(&mut self, _src_tb: AVRational, _dst_tb: AVRational) {}
 
@@ -2048,6 +2060,14 @@ impl ResampleContext {
         _in_planes: &[&[u8]],
         _in_count: c_int,
     ) -> Result<c_int, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    /// # Safety
+    /// Stub; never executed on docs.rs.
+    pub unsafe fn flush_into_frame(&mut self, _dst: &mut Frame) -> Result<c_int, crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 

--- a/crates/ff-sys/src/frame.rs
+++ b/crates/ff-sys/src/frame.rs
@@ -62,9 +62,10 @@ impl Frame {
     //
     // Each getter reads one plain scalar field of the frame; each setter writes
     // one. They let downstream crates configure and inspect a frame without
-    // dereferencing the raw `AVFrame` pointer. Plane data (`data` / `linesize`)
-    // is deliberately not exposed here (that would leak a raw pointer type); the
-    // swscale / swresample safe APIs handle it.
+    // dereferencing the raw `AVFrame` pointer. The plane pointer array (`data`) is
+    // deliberately not exposed here (that would leak a raw pointer type) — the
+    // swscale / swresample safe APIs consume the frames instead — but the plane
+    // strides (`linesize`, plain integers) are available via `linesize`.
 
     /// Returns the frame width in pixels (video frames).
     #[must_use]
@@ -266,6 +267,21 @@ impl Frame {
             let data = (*self.ptr.as_ptr()).data[i];
             Some(std::slice::from_raw_parts_mut(data, len))
         }
+    }
+
+    /// Returns the byte stride (`linesize[i]`) of plane `i`, or `0` when `i` is
+    /// out of range.
+    ///
+    /// For video this is the row stride; for planar audio it is the plane's byte
+    /// size. Used to copy same-format planes row by row.
+    #[must_use]
+    pub fn linesize(&self, i: usize) -> c_int {
+        if i >= AV_NUM_DATA_POINTERS as usize {
+            return 0;
+        }
+        // SAFETY: `self.ptr` is a valid owned frame; `i` is bounds-checked against
+        //         `AV_NUM_DATA_POINTERS`; `linesize` is a plain fixed-size array field.
+        unsafe { (*self.ptr.as_ptr()).linesize[i] }
     }
 
     /// Returns an immutable view of audio plane `i`, sized to the samples it
@@ -667,6 +683,22 @@ mod tests {
             frame.video_plane(0).is_none(),
             "a negative linesize must yield None"
         );
+    }
+
+    #[test]
+    fn linesize_should_read_the_stride_and_bound_check() {
+        let mut frame = Frame::new().expect("frame allocation should succeed");
+        frame.set_format(crate::AVPixelFormat_AV_PIX_FMT_RGB24);
+        frame.set_width(16);
+        frame.set_height(16);
+        frame.get_buffer(0).expect("buffer alloc should succeed");
+        // RGB24 at width 16 has a positive row stride (>= 48 bytes).
+        assert!(
+            frame.linesize(0) >= 48,
+            "plane 0 should have a positive stride"
+        );
+        // Out-of-range plane index is a bounds-checked 0, not a panic / OOB read.
+        assert_eq!(frame.linesize(99), 0);
     }
 
     #[test]

--- a/crates/ff-sys/src/packet.rs
+++ b/crates/ff-sys/src/packet.rs
@@ -72,6 +72,13 @@ impl Packet {
         unsafe { (*self.ptr.as_ptr()).dts }
     }
 
+    /// Returns the packet's duration (in the stream's time base).
+    #[must_use]
+    pub fn duration(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned packet; `duration` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).duration }
+    }
+
     /// Sets the index of the stream this packet belongs to.
     pub fn set_stream_index(&mut self, stream_index: std::os::raw::c_int) {
         // SAFETY: `self.ptr` is a valid owned packet; `stream_index` is a plain field.
@@ -88,6 +95,12 @@ impl Packet {
     pub fn set_dts(&mut self, dts: i64) {
         // SAFETY: `self.ptr` is a valid owned packet; `dts` is a plain field.
         unsafe { (*self.ptr.as_ptr()).dts = dts };
+    }
+
+    /// Sets the packet's duration (in the stream's time base).
+    pub fn set_duration(&mut self, duration: i64) {
+        // SAFETY: `self.ptr` is a valid owned packet; `duration` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).duration = duration };
     }
 
     /// Rescales the packet's `pts` / `dts` / `duration` from `src_tb` to `dst_tb`.
@@ -164,9 +177,11 @@ mod tests {
         packet.set_stream_index(3);
         packet.set_pts(1_000);
         packet.set_dts(900);
+        packet.set_duration(512);
         assert_eq!(packet.stream_index(), 3);
         assert_eq!(packet.pts(), 1_000);
         assert_eq!(packet.dts(), 900);
+        assert_eq!(packet.duration(), 512);
     }
 
     #[test]

--- a/crates/ff-sys/src/resample_context.rs
+++ b/crates/ff-sys/src/resample_context.rs
@@ -197,6 +197,43 @@ impl ResampleContext {
         .map_err(AvError::new)
     }
 
+    /// Flushes the resampler's buffered samples into `dst` (a `swr_convert` with a
+    /// NULL input), returning the number of samples produced per channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if conversion fails.
+    ///
+    /// # Safety
+    ///
+    /// The NULL input needs no input buffer, but `swr_convert` still writes up to
+    /// `dst.nb_samples` samples into each output plane, a bound the slice types
+    /// cannot express. The caller must ensure `dst` is a get_buffer'd audio
+    /// [`Frame`] whose planes hold at least `dst.nb_samples` samples per channel
+    /// for the configured output format; otherwise the null output planes are an
+    /// out-of-bounds / null write.
+    pub unsafe fn flush_into_frame(&mut self, dst: &mut Frame) -> Result<c_int, AvError> {
+        let dst_ptr = dst.as_mut_ptr();
+        // SAFETY: `self.ptr` is a valid initialized context. `out_ptrs` is a local
+        //         copy of `dst`'s (get_buffer'd) output plane pointers, valid for the
+        //         duration of the call; the input is null with count 0 (the documented
+        //         flush signal), so no input buffer is read. `swr_convert` writes only
+        //         within the output planes for `out_count` samples (upheld by the
+        //         caller, see # Safety).
+        unsafe {
+            let mut out_ptrs: [*mut u8; AV_NUM_DATA_POINTERS as usize] = (*dst_ptr).data;
+            let out_count = (*dst_ptr).nb_samples;
+            crate::swresample::convert(
+                self.ptr.as_ptr(),
+                out_ptrs.as_mut_ptr(),
+                out_count,
+                std::ptr::null(),
+                0,
+            )
+        }
+        .map_err(AvError::new)
+    }
+
     /// Converts (resamples / reformats) audio samples into the output buffers.
     ///
     /// Returns the number of samples produced per channel. Passing a null `in_`


### PR DESCRIPTION
## Objective

- The ff-stream migration (#1543) surfaced three owned-type field/FFI sites the #1540 API did not yet cover, blocking that migration from being purely mechanical.

## Solution

- Add the three methods (additive; no consumer changes):
  - `Packet::set_duration` / `duration`, for `drain_encoder`'s `pkt->duration`.
  - `Frame::linesize(i)`, the bounds-checked plane stride (a plain integer, not a pointer) the same-format plane-copy reads.
  - `ResampleContext::flush_into_frame`, the NULL-input flush variant of `convert_into_frame`; it stays `unsafe` with the same get_buffer'd precondition.
- docsrs stubs and unit tests for the round-trips are included.
- Addendum to #1540 that lets #1543 be a purely mechanical migration.

Closes #1547