### PR TITLE
feat(ff-sys): add StreamRef frame-rate/nb_frames and CodecContext bit_rate accessors

### DIFF
--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -174,6 +174,13 @@ impl CodecContext {
         unsafe { (*self.ptr.as_ptr()).bit_rate = bit_rate };
     }
 
+    /// Returns the target bit rate in bits per second.
+    #[must_use]
+    pub fn bit_rate(&self) -> i64 {
+        // SAFETY: `self.ptr` is a valid owned context; `bit_rate` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).bit_rate }
+    }
+
     /// Sets the rate-control maximum bit rate.
     pub fn set_rc_max_rate(&mut self, rc_max_rate: i64) {
         // SAFETY: `self.ptr` is a valid owned context; `rc_max_rate` is a plain field.
@@ -734,6 +741,7 @@ mod tests {
         ctx.set_flags(ctx.flags() | 0x0400);
 
         assert_eq!(ctx.codec_id(), crate::AVCodecID_AV_CODEC_ID_H264);
+        assert_eq!(ctx.bit_rate(), 2_000_000);
         assert_eq!(ctx.sample_rate(), 48_000);
         assert_eq!(ctx.flags() & 0x0400, 0x0400);
     }

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1182,6 +1182,10 @@ impl CodecContext {
     pub fn set_codec_id(&mut self, _codec_id: AVCodecID) {}
     pub fn set_framerate(&mut self, _framerate: AVRational) {}
     pub fn set_bit_rate(&mut self, _bit_rate: i64) {}
+    #[must_use]
+    pub fn bit_rate(&self) -> i64 {
+        0
+    }
     pub fn set_rc_max_rate(&mut self, _rc_max_rate: i64) {}
     pub fn set_rc_buffer_size(&mut self, _rc_buffer_size: c_int) {}
     pub fn set_color_primaries(&mut self, _color_primaries: AVColorPrimaries) {}
@@ -1632,6 +1636,16 @@ impl<'a> StreamRef<'a> {
     #[must_use]
     pub fn avg_frame_rate(&self) -> AVRational {
         AVRational { num: 0, den: 1 }
+    }
+
+    #[must_use]
+    pub fn r_frame_rate(&self) -> AVRational {
+        AVRational { num: 0, den: 1 }
+    }
+
+    #[must_use]
+    pub fn nb_frames(&self) -> i64 {
+        0
     }
 
     #[must_use]

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -655,6 +655,24 @@ impl<'a> StreamRef<'a> {
         unsafe { (*self.ptr.as_ptr()).avg_frame_rate }
     }
 
+    /// Returns the stream's real base frame rate (may be `0/0` when unknown).
+    ///
+    /// This is the lowest frame rate with which all timestamps can be
+    /// represented accurately (the container's guessed constant frame rate),
+    /// distinct from [`avg_frame_rate`](Self::avg_frame_rate).
+    #[must_use]
+    pub fn r_frame_rate(&self) -> AVRational {
+        // SAFETY: `self.ptr` borrows a valid stream from a live format context.
+        unsafe { (*self.ptr.as_ptr()).r_frame_rate }
+    }
+
+    /// Returns the number of frames in the stream (0 when unknown).
+    #[must_use]
+    pub fn nb_frames(&self) -> i64 {
+        // SAFETY: `self.ptr` borrows a valid stream from a live format context.
+        unsafe { (*self.ptr.as_ptr()).nb_frames }
+    }
+
     /// Returns a borrowed handle to the stream's codec parameters.
     #[must_use]
     pub fn codecpar(&self) -> CodecParameters<'a> {


### PR DESCRIPTION
## Objective

- The ff-stream migration (#1543) reaches input-side field reads that the existing output-side accessors do not cover, blocking the last raw `as_ptr` field reads from moving to the safe API.

## Solution

- Add three additive, read-only accessors (each mirrors an existing one):
  - `StreamRef::r_frame_rate()` / `nb_frames()`, read by the fps detection.
  - `CodecContext::bit_rate()`, read by the HLS open-path log line.
- Include the matching docsrs stubs and a `bit_rate` round-trip assertion.

Closes #1549