### PR TITLE
refactor(ff-stream): migrate off as_ptr/as_mut_ptr to the safe accessors

### DIFF
--- a/crates/ff-stream/src/codec_utils.rs
+++ b/crates/ff-stream/src/codec_utils.rs
@@ -12,13 +12,14 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::ptr_as_ptr)]
 #![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
 #![allow(clippy::borrow_as_ptr)]
 #![allow(clippy::ref_as_ptr)]
 
 use ff_sys::{
-    AVCodecContext, AVFormatContext, AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE, AVRational,
-    AVSampleFormat, av_interleaved_write_frame, av_packet_rescale_ts, av_rescale_q,
+    AVPixelFormat, AVPixelFormat_AV_PIX_FMT_NONE, AVRational, AVSampleFormat, ReceiveOutcome,
+    av_rescale_q,
 };
 
 use ff_format::{PixelFormat, SampleFormat};
@@ -183,20 +184,17 @@ pub(crate) fn sample_format_to_av(fmt: SampleFormat) -> AVSampleFormat {
 ///   for audio).  Converted to `enc_ctx->time_base` units inside this function so
 ///   it is immune to lazy time-base mutations.
 ///
-/// # Safety
+/// # Preconditions
 ///
-/// - `enc_ctx` must be a valid, fully-opened `AVCodecContext` with at least
-///   one call to `avcodec_send_frame` preceding this call.
-/// - `out_ctx` must be a valid `AVFormatContext` whose header has been written.
-/// - `stream_idx` must be a valid index into `out_ctx`'s stream array.
-// `enc_ctx` stays a raw `*mut AVCodecContext` (issue carve-out): this helper is
-// shared by the MuxerCore/live family and the HLS/DASH transcode paths, so its
-// signature is kept stable; the internal packet is owned (`Packet`) so there is
-// no manual `av_packet_free`.
-pub(crate) unsafe fn drain_encoder(
-    enc_ctx: *mut AVCodecContext,
-    out_ctx: *mut AVFormatContext,
-    stream_idx: i32,
+/// - `enc_ctx` must be fully opened with at least one `send_frame` preceding this
+///   call, and `out_ctx`'s header must already have been written. Both are
+///   borrowed mutably, so their lifecycle stays owned by the caller.
+/// - `stream_idx` must be a valid index into `out_ctx`'s stream array (an
+///   out-of-range index yields a `0/0` time base and the write fails).
+pub(crate) fn drain_encoder(
+    enc_ctx: &mut ff_sys::CodecContext,
+    out_ctx: &mut ff_sys::OutputFormatContext,
+    stream_idx: usize,
     log_prefix: &str,
     frame_period: AVRational,
 ) {
@@ -204,46 +202,34 @@ pub(crate) unsafe fn drain_encoder(
         return;
     };
 
-    // SAFETY: out_ctx is valid and stream_idx is a valid stream index.
-    let stream_tb = (*(*(*out_ctx).streams.add(stream_idx as usize))).time_base;
-    // SAFETY: enc_ctx is a valid, open codec context.
+    let stream_tb = out_ctx.stream_time_base(stream_idx);
     // Read enc_tb HERE — some encoders (mpeg4) mutate time_base lazily on first
     // send_frame, so the value may differ from what the caller observed earlier.
-    let enc_tb = (*enc_ctx).time_base;
+    let enc_tb = enc_ctx.time_base();
 
     // Compute the correct per-frame duration in enc_tb units using the live enc_tb.
     // av_rescale_q converts 1 unit of `frame_period` (e.g. 1/fps second) into enc_tb ticks.
-    let frame_dur_enc_tb = av_rescale_q(1, frame_period, enc_tb);
+    // SAFETY: `av_rescale_q` is a pure integer rescale with no pointer arguments.
+    let frame_dur_enc_tb = unsafe { av_rescale_q(1, frame_period, enc_tb) };
 
-    loop {
-        match ff_sys::avcodec::receive_packet(enc_ctx, pkt.as_mut_ptr()) {
-            Err(e) if e == ff_sys::error_codes::EAGAIN || e == ff_sys::error_codes::EOF => {
-                break;
-            }
-            Err(_) => break,
-            Ok(()) => {}
-        }
-
-        // The packet fields have no typed accessor; touch them through the pointer.
-        let p = pkt.as_mut_ptr();
-
+    // NeedInput (EAGAIN) / Drained (EOF) / real error all end the drain.
+    while let Ok(ReceiveOutcome::Frame) = enc_ctx.receive_packet_into(&mut pkt) {
         // Always override duration with the correct per-frame value BEFORE rescaling.
         if frame_dur_enc_tb > 0 {
-            (*p).duration = frame_dur_enc_tb;
+            pkt.set_duration(frame_dur_enc_tb);
         }
 
         // Rescale pts/dts/duration from encoder time_base to stream time_base.
-        // SAFETY: p is valid; enc_tb and stream_tb are valid AVRational values.
-        av_packet_rescale_ts(p, enc_tb, stream_tb);
+        pkt.rescale_ts(enc_tb, stream_tb);
 
-        (*p).stream_index = stream_idx;
-        let ret = av_interleaved_write_frame(out_ctx, p);
+        pkt.set_stream_index(stream_idx as i32);
+        let ret = out_ctx.write_interleaved(&mut pkt);
         pkt.unref();
-        if ret < 0 {
+        if let Err(e) = ret {
             log::warn!(
                 "{log_prefix} av_interleaved_write_frame failed \
                  stream_index={stream_idx} error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
             break;
         }

--- a/crates/ff-stream/src/dash_inner/streams.rs
+++ b/crates/ff-stream/src/dash_inner/streams.rs
@@ -1,6 +1,6 @@
 //! Video/audio stream helpers: encoder selection, AAC encoder open, FPS detection.
 
-use ff_sys::AVFormatContext;
+use ff_sys::AVRational;
 
 use crate::error::StreamError;
 
@@ -65,10 +65,7 @@ pub(super) unsafe fn open_aac_encoder(
 // ============================================================================
 
 #[allow(clippy::cast_precision_loss)]
-pub(super) unsafe fn detect_fps(
-    stream: *mut ff_sys::AVStream,
-    fmt_ctx: *mut AVFormatContext,
-) -> f64 {
+pub(super) fn detect_fps(avg: AVRational, rfr: AVRational, nb_frames: i64, duration: i64) -> f64 {
     const MIN_FPS: f64 = 1.0;
     const MAX_FPS: f64 = 240.0;
 
@@ -85,26 +82,55 @@ pub(super) unsafe fn detect_fps(
     };
 
     // 1. avg_frame_rate — reliable for most containers
-    let avg = (*stream).avg_frame_rate;
     if let Some(fps) = try_rational(avg.num, avg.den) {
         return fps;
     }
 
     // 2. r_frame_rate — constant-framerate indicator
-    let rfr = (*stream).r_frame_rate;
     if let Some(fps) = try_rational(rfr.num, rfr.den) {
         return fps;
     }
 
     // 3. Derive from nb_frames and total duration (robust for MPEG-4 Part 2)
-    let nb = (*stream).nb_frames;
-    let dur = (*fmt_ctx).duration; // in AV_TIME_BASE (1 000 000) microseconds
-    if nb > 0 && dur > 0 {
-        let fps = nb as f64 / (dur as f64 / 1_000_000.0);
+    // `duration` is in AV_TIME_BASE (1 000 000) microseconds.
+    if nb_frames > 0 && duration > 0 {
+        let fps = nb_frames as f64 / (duration as f64 / 1_000_000.0);
         if (MIN_FPS..=MAX_FPS).contains(&fps) {
             return fps;
         }
     }
 
     25.0 // sane default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detect_fps;
+    use ff_sys::AVRational;
+
+    fn r(num: i32, den: i32) -> AVRational {
+        AVRational { num, den }
+    }
+
+    #[test]
+    fn detect_fps_should_prefer_avg_frame_rate() {
+        assert_eq!(detect_fps(r(30, 1), r(60, 1), 0, 0), 30.0);
+    }
+
+    #[test]
+    fn detect_fps_should_fall_back_to_r_frame_rate_when_avg_out_of_range() {
+        // avg = 1_250_000/49 ≈ 25510 fps is outside [1, 240] and is rejected.
+        assert_eq!(detect_fps(r(1_250_000, 49), r(24, 1), 0, 0), 24.0);
+    }
+
+    #[test]
+    fn detect_fps_should_derive_from_nb_frames_and_duration() {
+        // 300 frames over 10 s (10_000_000 µs) = 30 fps, distinct from the 25.0 default.
+        assert_eq!(detect_fps(r(0, 0), r(0, 0), 300, 10_000_000), 30.0);
+    }
+
+    #[test]
+    fn detect_fps_should_default_to_25_when_all_sources_unknown() {
+        assert_eq!(detect_fps(r(0, 0), r(0, 0), 0, 0), 25.0);
+    }
 }

--- a/crates/ff-stream/src/dash_inner/write.rs
+++ b/crates/ff-stream/src/dash_inner/write.rs
@@ -5,8 +5,7 @@ use std::ptr;
 
 use ff_sys::{
     AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, ReceiveOutcome, av_opt_set, av_rescale_q,
-    avformat_new_stream,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, ReceiveOutcome, av_rescale_q,
 };
 
 use crate::error::StreamError;
@@ -42,8 +41,10 @@ pub(super) unsafe fn write_dash_unsafe(
     let mut audio_stream_idx: i32 = -1;
 
     for i in 0..nb_streams {
-        let stream = *(*input_ctx.as_ptr()).streams.add(i);
-        let codec_type = (*(*stream).codecpar).codec_type;
+        let Some(stream) = input_ctx.stream(i) else {
+            continue;
+        };
+        let codec_type = stream.codecpar().codec_type();
         if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO && video_stream_idx < 0 {
             video_stream_idx = i as i32;
         } else if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO && audio_stream_idx < 0 {
@@ -58,18 +59,25 @@ pub(super) unsafe fn write_dash_unsafe(
     }
 
     // ── 3. Read video stream properties ──────────────────────────────────────
-    let video_stream = *(*input_ctx.as_ptr()).streams.add(video_stream_idx as usize);
-    let video_codecpar = (*video_stream).codecpar;
-    let enc_width = (*video_codecpar).width;
-    let enc_height = (*video_codecpar).height;
-    let video_fps = detect_fps(video_stream, input_ctx.as_mut_ptr());
+    let vid_stream = input_ctx
+        .stream(video_stream_idx as usize)
+        .ok_or_else(|| ffmpeg_err_msg("video stream not found"))?;
+    let vid_par = vid_stream.codecpar();
+    let enc_width = vid_par.width();
+    let enc_height = vid_par.height();
+    let video_fps = detect_fps(
+        vid_stream.avg_frame_rate(),
+        vid_stream.r_frame_rate(),
+        vid_stream.nb_frames(),
+        input_ctx.duration(),
+    );
     let fps_int = video_fps.round().max(1.0) as i32;
 
     // Compute keyframe interval from segment duration and fps
     let keyframe_interval = (segment_duration_secs * fps_int as f64).round().max(1.0) as u32;
 
     // ── 4. Open input video decoder ────────────────────────────────────────────
-    let vid_codec_id = (*video_codecpar).codec_id;
+    let vid_codec_id = vid_par.codec_id();
     let vid_decoder = ff_sys::Codec::find_decoder(vid_codec_id)
         .ok_or_else(|| ffmpeg_err_msg("no video decoder available for input stream"))?;
 
@@ -77,7 +85,7 @@ pub(super) unsafe fn write_dash_unsafe(
         ff_sys::CodecContext::new(Some(vid_decoder)).map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
-        .parameters_to_context(video_codecpar)
+        .apply_parameters(&vid_par)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
@@ -89,18 +97,20 @@ pub(super) unsafe fn write_dash_unsafe(
     let mut aud_sample_rate: i32 = 44100;
     let mut aud_nb_channels: i32 = 2;
 
-    if audio_stream_idx >= 0 {
-        let audio_stream = *(*input_ctx.as_ptr()).streams.add(audio_stream_idx as usize);
-        let audio_codecpar = (*audio_stream).codecpar;
-        let aud_codec_id = (*audio_codecpar).codec_id;
+    if audio_stream_idx >= 0
+        && let Some(aud_par) = input_ctx
+            .stream(audio_stream_idx as usize)
+            .map(|s| s.codecpar())
+    {
+        let aud_codec_id = aud_par.codec_id();
 
         if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
             if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
-                if ctx.parameters_to_context(audio_codecpar).is_ok()
+                if ctx.apply_parameters(&aud_par).is_ok()
                     && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
                 {
-                    aud_sample_rate = (*ctx.as_ptr()).sample_rate;
-                    aud_nb_channels = (*ctx.as_ptr()).ch_layout.nb_channels;
+                    aud_sample_rate = ctx.sample_rate();
+                    aud_nb_channels = ctx.ch_layout().nb_channels;
                     aud_dec_ctx = Some(ctx);
                     log::info!(
                         "dash audio decoder opened sample_rate={aud_sample_rate} \
@@ -133,20 +143,14 @@ pub(super) unsafe fn write_dash_unsafe(
 
     // ── 7. Set DASH muxer options ──────────────────────────────────────────────
     let seg_duration_str = format!("{}", segment_duration_secs as u32);
-    if let Ok(c_seg_dur) = CString::new(seg_duration_str.as_str()) {
-        let ret = av_opt_set(
-            (*out_ctx.as_mut_ptr()).priv_data,
-            c"seg_duration".as_ptr(),
-            c_seg_dur.as_ptr(),
-            0,
+    if let Ok(c_seg_dur) = CString::new(seg_duration_str.as_str())
+        && let Err(e) = out_ctx.set_opt(c"seg_duration", &c_seg_dur)
+    {
+        log::warn!(
+            "dash seg_duration option not supported, using default \
+             requested={seg_duration_str} error={}",
+            ff_sys::av_error_string(e.code())
         );
-        if ret < 0 {
-            log::warn!(
-                "dash seg_duration option not supported, using default \
-                 requested={seg_duration_str} error={}",
-                ff_sys::av_error_string(ret)
-            );
-        }
     }
 
     // ── 8. Open H.264 video encoder ───────────────────────────────────────────
@@ -156,16 +160,19 @@ pub(super) unsafe fn write_dash_unsafe(
 
     let mut vid_enc_ctx =
         ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| ffmpeg_err(e.code()))?;
-    let venc = vid_enc_ctx.as_mut_ptr();
 
-    (*venc).width = enc_width;
-    (*venc).height = enc_height;
-    (*venc).time_base.num = 1;
-    (*venc).time_base.den = fps_int;
-    (*venc).framerate.num = fps_int;
-    (*venc).framerate.den = 1;
-    (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-    (*venc).bit_rate = 2_000_000;
+    vid_enc_ctx.set_width(enc_width);
+    vid_enc_ctx.set_height(enc_height);
+    vid_enc_ctx.set_time_base(AVRational {
+        num: 1,
+        den: fps_int,
+    });
+    vid_enc_ctx.set_framerate(AVRational {
+        num: fps_int,
+        den: 1,
+    });
+    vid_enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
+    vid_enc_ctx.set_bit_rate(2_000_000);
 
     // On error the owned `vid_enc_ctx` / decoders / `input_ctx` / `out_ctx` all
     // drop; no manual teardown is needed.
@@ -174,16 +181,12 @@ pub(super) unsafe fn write_dash_unsafe(
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────
-    let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
-    if vid_out_stream.is_null() {
-        return Err(ffmpeg_err_msg("cannot create video output stream"));
-    }
-    (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
-    let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-    // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-    vid_enc_ctx
-        .parameters_from_context((*vid_out_stream).codecpar)
+    let vid_out_stream_idx = out_ctx
+        .new_stream(Some(&vid_enc_codec))
+        .map_err(|e| ffmpeg_err(e.code()))? as i32;
+    out_ctx.set_stream_time_base(vid_out_stream_idx as usize, vid_enc_ctx.time_base());
+    out_ctx
+        .apply_stream_params_from_context(vid_out_stream_idx as usize, &vid_enc_ctx)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
@@ -194,19 +197,18 @@ pub(super) unsafe fn write_dash_unsafe(
     if audio_stream_idx >= 0 {
         match open_aac_encoder(aud_sample_rate, aud_nb_channels) {
             Ok(ctx) => {
-                let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
-                if aud_out_stream.is_null() {
-                    // `ctx` drops here (frees the codec context).
-                    log::warn!("dash cannot create audio output stream, skipping audio");
-                    audio_stream_idx = -1;
-                } else {
-                    (*aud_out_stream).time_base.num = 1;
-                    (*aud_out_stream).time_base.den = aud_sample_rate;
-                    aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-                    // SAFETY: aud_out_stream and ctx are valid; avcodec_open2 called.
-                    if ctx
-                        .parameters_from_context((*aud_out_stream).codecpar)
+                if let Ok(aud_idx) = out_ctx.new_stream(None) {
+                    let aud_idx = aud_idx as i32;
+                    aud_out_stream_idx = aud_idx;
+                    out_ctx.set_stream_time_base(
+                        aud_idx as usize,
+                        AVRational {
+                            num: 1,
+                            den: aud_sample_rate,
+                        },
+                    );
+                    if out_ctx
+                        .apply_stream_params_from_context(aud_idx as usize, &ctx)
                         .is_err()
                     {
                         log::warn!("dash audio stream codecpar copy failed");
@@ -214,15 +216,13 @@ pub(super) unsafe fn write_dash_unsafe(
 
                     // Set up resampler: decoded audio → FLTP at aud_sample_rate.
                     if let Some(dec) = aud_dec_ctx.as_ref() {
-                        let enc_ptr = ctx.as_ptr();
-                        let dec_ptr = dec.as_ptr();
                         if let Ok(swr) = ff_sys::ResampleContext::new(
-                            &(*enc_ptr).ch_layout,
-                            (*enc_ptr).sample_fmt,
-                            (*enc_ptr).sample_rate,
-                            &(*dec_ptr).ch_layout,
-                            (*dec_ptr).sample_fmt,
-                            (*dec_ptr).sample_rate,
+                            ctx.ch_layout(),
+                            ctx.sample_fmt(),
+                            ctx.sample_rate(),
+                            dec.ch_layout(),
+                            dec.sample_fmt(),
+                            dec.sample_rate(),
                         ) {
                             swr_ctx = Some(swr);
                             aud_enc_ctx = Some(ctx);
@@ -235,6 +235,10 @@ pub(super) unsafe fn write_dash_unsafe(
                         log::warn!("dash audio decoder missing, skipping audio");
                         audio_stream_idx = -1;
                     }
+                } else {
+                    // `ctx` drops here (frees the codec context).
+                    log::warn!("dash cannot create audio output stream, skipping audio");
+                    audio_stream_idx = -1;
                 }
             }
             Err(e) => {
@@ -396,11 +400,11 @@ pub(super) unsafe fn write_dash_unsafe(
                     false
                 };
 
-                if scaled && vid_enc_ctx.send_frame(vid_enc_frame.as_ptr()).is_ok() {
+                if scaled && vid_enc_ctx.send_frame_ref(Some(&vid_enc_frame)).is_ok() {
                     crate::codec_utils::drain_encoder(
-                        vid_enc_ctx.as_mut_ptr(),
-                        out_ctx.as_mut_ptr(),
-                        vid_out_stream_idx,
+                        &mut vid_enc_ctx,
+                        &mut out_ctx,
+                        vid_out_stream_idx as usize,
                         "dash",
                         vid_frame_period,
                     );
@@ -454,11 +458,11 @@ pub(super) unsafe fn write_dash_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
+                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc.as_mut_ptr(),
-                            out_ctx.as_mut_ptr(),
-                            aud_out_stream_idx,
+                            aud_enc,
+                            &mut out_ctx,
+                            aud_out_stream_idx as usize,
                             "dash",
                             aud_frame_period,
                         );
@@ -475,11 +479,11 @@ pub(super) unsafe fn write_dash_unsafe(
     }
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
-    let _ = vid_enc_ctx.send_frame(ptr::null());
+    let _ = vid_enc_ctx.send_frame_ref(None);
     crate::codec_utils::drain_encoder(
-        vid_enc_ctx.as_mut_ptr(),
-        out_ctx.as_mut_ptr(),
-        vid_out_stream_idx,
+        &mut vid_enc_ctx,
+        &mut out_ctx,
+        vid_out_stream_idx as usize,
         "dash",
         vid_frame_period,
     );
@@ -497,17 +501,13 @@ pub(super) unsafe fn write_dash_unsafe(
             aud_enc_frame.set_nb_samples(enc_frame_size);
             let _ = aud_enc_frame.set_ch_layout(aud_enc.ch_layout());
             if aud_enc_frame.get_buffer(0).is_ok() {
-                // Flush the resampler with a NULL input. `convert_into_frame`
-                // models the normal-input case; the flush needs a NULL input
-                // pointer, so the raw `convert` is used here.
+                // Flush the resampler with a NULL input; `flush_into_frame`
+                // drains the buffered samples into the frame's `nb_samples`
+                // (set to `enc_frame_size` above).
                 let flushed = if let Some(swr) = swr_ctx.as_mut() {
-                    swr.convert(
-                        (*aud_enc_frame.as_mut_ptr()).data.as_mut_ptr(),
-                        enc_frame_size,
-                        ptr::null(),
-                        0,
-                    )
-                    .ok()
+                    // SAFETY: `aud_enc_frame` was just `get_buffer`'d, so its
+                    //         output planes are allocated for the flush.
+                    swr.flush_into_frame(&mut aud_enc_frame).ok()
                 } else {
                     None
                 };
@@ -516,11 +516,11 @@ pub(super) unsafe fn write_dash_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
+                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc.as_mut_ptr(),
-                            out_ctx.as_mut_ptr(),
-                            aud_out_stream_idx,
+                            aud_enc,
+                            &mut out_ctx,
+                            aud_out_stream_idx as usize,
                             "dash",
                             aud_frame_period,
                         );
@@ -529,11 +529,11 @@ pub(super) unsafe fn write_dash_unsafe(
                 aud_enc_frame.unref();
             }
         }
-        let _ = aud_enc.send_frame(ptr::null());
+        let _ = aud_enc.send_frame_ref(None);
         crate::codec_utils::drain_encoder(
-            aud_enc.as_mut_ptr(),
-            out_ctx.as_mut_ptr(),
-            aud_out_stream_idx,
+            aud_enc,
+            &mut out_ctx,
+            aud_out_stream_idx as usize,
             "dash",
             aud_frame_period,
         );
@@ -582,8 +582,10 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     let mut audio_stream_idx: i32 = -1;
 
     for i in 0..nb_streams {
-        let stream = *(*input_ctx.as_ptr()).streams.add(i);
-        let codec_type = (*(*stream).codecpar).codec_type;
+        let Some(stream) = input_ctx.stream(i) else {
+            continue;
+        };
+        let codec_type = stream.codecpar().codec_type();
         if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO && video_stream_idx < 0 {
             video_stream_idx = i as i32;
         } else if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO && audio_stream_idx < 0 {
@@ -598,14 +600,21 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     }
 
     // ── 3. Read video stream properties ──────────────────────────────────────
-    let video_stream = *(*input_ctx.as_ptr()).streams.add(video_stream_idx as usize);
-    let video_codecpar = (*video_stream).codecpar;
-    let video_fps = detect_fps(video_stream, input_ctx.as_mut_ptr());
+    let vid_stream = input_ctx
+        .stream(video_stream_idx as usize)
+        .ok_or_else(|| ffmpeg_err_msg("video stream not found"))?;
+    let vid_par = vid_stream.codecpar();
+    let video_fps = detect_fps(
+        vid_stream.avg_frame_rate(),
+        vid_stream.r_frame_rate(),
+        vid_stream.nb_frames(),
+        input_ctx.duration(),
+    );
     let fps_int = video_fps.round().max(1.0) as i32;
     let keyframe_interval = (segment_duration_secs * fps_int as f64).round().max(1.0) as u32;
 
     // ── 4. Open input video decoder ────────────────────────────────────────────
-    let vid_codec_id = (*video_codecpar).codec_id;
+    let vid_codec_id = vid_par.codec_id();
     let vid_decoder = ff_sys::Codec::find_decoder(vid_codec_id)
         .ok_or_else(|| ffmpeg_err_msg("no video decoder available for input stream"))?;
 
@@ -613,7 +622,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         ff_sys::CodecContext::new(Some(vid_decoder)).map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
-        .parameters_to_context(video_codecpar)
+        .apply_parameters(&vid_par)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
@@ -625,18 +634,20 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     let mut aud_sample_rate: i32 = 44100;
     let mut aud_nb_channels: i32 = 2;
 
-    if audio_stream_idx >= 0 {
-        let audio_stream = *(*input_ctx.as_ptr()).streams.add(audio_stream_idx as usize);
-        let audio_codecpar = (*audio_stream).codecpar;
-        let aud_codec_id = (*audio_codecpar).codec_id;
+    if audio_stream_idx >= 0
+        && let Some(aud_par) = input_ctx
+            .stream(audio_stream_idx as usize)
+            .map(|s| s.codecpar())
+    {
+        let aud_codec_id = aud_par.codec_id();
 
         if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
             if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
-                if ctx.parameters_to_context(audio_codecpar).is_ok()
+                if ctx.apply_parameters(&aud_par).is_ok()
                     && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
                 {
-                    aud_sample_rate = (*ctx.as_ptr()).sample_rate;
-                    aud_nb_channels = (*ctx.as_ptr()).ch_layout.nb_channels;
+                    aud_sample_rate = ctx.sample_rate();
+                    aud_nb_channels = ctx.ch_layout().nb_channels;
                     aud_dec_ctx = Some(ctx);
                     log::info!(
                         "dash abr audio decoder opened sample_rate={aud_sample_rate} \
@@ -669,20 +680,14 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
     // ── 7. Set DASH muxer options ──────────────────────────────────────────────
     let seg_duration_str = format!("{}", segment_duration_secs as u32);
-    if let Ok(c_seg_dur) = CString::new(seg_duration_str.as_str()) {
-        let ret = av_opt_set(
-            (*out_ctx.as_mut_ptr()).priv_data,
-            c"seg_duration".as_ptr(),
-            c_seg_dur.as_ptr(),
-            0,
+    if let Ok(c_seg_dur) = CString::new(seg_duration_str.as_str())
+        && let Err(e) = out_ctx.set_opt(c"seg_duration", &c_seg_dur)
+    {
+        log::warn!(
+            "dash abr seg_duration option not supported, using default \
+             requested={seg_duration_str} error={}",
+            ff_sys::av_error_string(e.code())
         );
-        if ret < 0 {
-            log::warn!(
-                "dash abr seg_duration option not supported, using default \
-                 requested={seg_duration_str} error={}",
-                ff_sys::av_error_string(ret)
-            );
-        }
     }
 
     // ── 8. Select H.264 encoder (shared across all renditions) ────────────────
@@ -706,33 +711,29 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 return Err(ffmpeg_err(e.code()));
             }
         };
-        let ecptr = enc_ctx.as_mut_ptr();
-
-        (*ecptr).width = target_width;
-        (*ecptr).height = target_height;
-        (*ecptr).time_base.num = 1;
-        (*ecptr).time_base.den = fps_int;
-        (*ecptr).framerate.num = fps_int;
-        (*ecptr).framerate.den = 1;
-        (*ecptr).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-        (*ecptr).bit_rate = target_bitrate;
+        enc_ctx.set_width(target_width);
+        enc_ctx.set_height(target_height);
+        enc_ctx.set_time_base(AVRational {
+            num: 1,
+            den: fps_int,
+        });
+        enc_ctx.set_framerate(AVRational {
+            num: fps_int,
+            den: 1,
+        });
+        enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
+        enc_ctx.set_bit_rate(target_bitrate);
 
         if let Err(e) = enc_ctx.open(vid_enc_codec, ptr::null_mut()) {
             // `enc_ctx` and the prior renditions drop on return.
             return Err(ffmpeg_err(e.code()));
         }
 
-        let out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
-        if out_stream.is_null() {
-            return Err(ffmpeg_err_msg(
-                "cannot create video output stream for rendition",
-            ));
-        }
-        (*out_stream).time_base = (*enc_ctx.as_ptr()).time_base;
-        let stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-        // SAFETY: out_stream and enc_ctx are valid; avcodec_open2 has been called.
-        if let Err(e) = enc_ctx.parameters_from_context((*out_stream).codecpar) {
+        let stream_idx = out_ctx
+            .new_stream(Some(&vid_enc_codec))
+            .map_err(|e| ffmpeg_err(e.code()))? as i32;
+        out_ctx.set_stream_time_base(stream_idx as usize, enc_ctx.time_base());
+        if let Err(e) = out_ctx.apply_stream_params_from_context(stream_idx as usize, &enc_ctx) {
             return Err(ffmpeg_err(e.code()));
         }
 
@@ -761,38 +762,34 @@ pub(super) unsafe fn write_dash_abr_unsafe(
     if audio_stream_idx >= 0 {
         match open_aac_encoder(aud_sample_rate, aud_nb_channels) {
             Ok(ctx) => {
-                let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
-                if aud_out_stream.is_null() {
-                    // `ctx` drops here (frees the codec context).
-                    log::warn!("dash abr cannot create audio output stream, skipping audio");
-                    audio_stream_idx = -1;
-                } else {
-                    (*aud_out_stream).time_base.num = 1;
-                    (*aud_out_stream).time_base.den = aud_sample_rate;
-                    aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-                    let enc_ptr = ctx.as_ptr();
-                    if !(*aud_out_stream).codecpar.is_null() {
-                        (*(*aud_out_stream).codecpar).codec_id = (*enc_ptr).codec_id;
-                        (*(*aud_out_stream).codecpar).codec_type =
-                            ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO;
-                        (*(*aud_out_stream).codecpar).sample_rate = (*enc_ptr).sample_rate;
-                        (*(*aud_out_stream).codecpar).format = (*enc_ptr).sample_fmt;
-                        let _ = ff_sys::swresample::channel_layout::copy(
-                            &mut (*(*aud_out_stream).codecpar).ch_layout,
-                            &(*enc_ptr).ch_layout,
-                        );
+                if let Ok(aud_idx) = out_ctx.new_stream(None) {
+                    let aud_idx = aud_idx as i32;
+                    aud_out_stream_idx = aud_idx;
+                    out_ctx.set_stream_time_base(
+                        aud_idx as usize,
+                        AVRational {
+                            num: 1,
+                            den: aud_sample_rate,
+                        },
+                    );
+                    // Copy the full encoder parameters (codec id/type, sample
+                    // format, rate, channel layout, and the AAC extradata) into
+                    // the stream, matching the single-rendition and HLS paths.
+                    if out_ctx
+                        .apply_stream_params_from_context(aud_idx as usize, &ctx)
+                        .is_err()
+                    {
+                        log::warn!("dash abr audio stream codecpar copy failed");
                     }
 
                     if let Some(dec) = aud_dec_ctx.as_ref() {
-                        let dec_ptr = dec.as_ptr();
                         if let Ok(swr) = ff_sys::ResampleContext::new(
-                            &(*enc_ptr).ch_layout,
-                            (*enc_ptr).sample_fmt,
-                            (*enc_ptr).sample_rate,
-                            &(*dec_ptr).ch_layout,
-                            (*dec_ptr).sample_fmt,
-                            (*dec_ptr).sample_rate,
+                            ctx.ch_layout(),
+                            ctx.sample_fmt(),
+                            ctx.sample_rate(),
+                            dec.ch_layout(),
+                            dec.sample_fmt(),
+                            dec.sample_rate(),
                         ) {
                             swr_ctx = Some(swr);
                             aud_enc_ctx = Some(ctx);
@@ -805,6 +802,10 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                         log::warn!("dash abr audio decoder missing, skipping audio");
                         audio_stream_idx = -1;
                     }
+                } else {
+                    // `ctx` drops here (frees the codec context).
+                    log::warn!("dash abr cannot create audio output stream, skipping audio");
+                    audio_stream_idx = -1;
                 }
             }
             Err(e) => {
@@ -956,11 +957,16 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                         false
                     };
 
-                    if scaled && state.vid_enc_ctx.send_frame(vid_enc_frame.as_ptr()).is_ok() {
+                    if scaled
+                        && state
+                            .vid_enc_ctx
+                            .send_frame_ref(Some(&vid_enc_frame))
+                            .is_ok()
+                    {
                         crate::codec_utils::drain_encoder(
-                            state.vid_enc_ctx.as_mut_ptr(),
-                            out_ctx.as_mut_ptr(),
-                            state.vid_out_stream_idx,
+                            &mut state.vid_enc_ctx,
+                            &mut out_ctx,
+                            state.vid_out_stream_idx as usize,
                             "dash",
                             vid_frame_period,
                         );
@@ -1016,11 +1022,11 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
+                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc.as_mut_ptr(),
-                            out_ctx.as_mut_ptr(),
-                            aud_out_stream_idx,
+                            aud_enc,
+                            &mut out_ctx,
+                            aud_out_stream_idx as usize,
                             "dash",
                             aud_frame_period,
                         );
@@ -1038,11 +1044,11 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
     for state in &mut rendition_states {
-        let _ = state.vid_enc_ctx.send_frame(ptr::null());
+        let _ = state.vid_enc_ctx.send_frame_ref(None);
         crate::codec_utils::drain_encoder(
-            state.vid_enc_ctx.as_mut_ptr(),
-            out_ctx.as_mut_ptr(),
-            state.vid_out_stream_idx,
+            &mut state.vid_enc_ctx,
+            &mut out_ctx,
+            state.vid_out_stream_idx as usize,
             "dash",
             vid_frame_period,
         );
@@ -1060,17 +1066,13 @@ pub(super) unsafe fn write_dash_abr_unsafe(
             aud_enc_frame.set_nb_samples(enc_frame_size);
             let _ = aud_enc_frame.set_ch_layout(aud_enc.ch_layout());
             if aud_enc_frame.get_buffer(0).is_ok() {
-                // Flush the resampler with a NULL input. `convert_into_frame`
-                // models the normal-input case; the flush needs a NULL input
-                // pointer, so the raw `convert` is used here.
+                // Flush the resampler with a NULL input; `flush_into_frame`
+                // drains the buffered samples into the frame's `nb_samples`
+                // (set to `enc_frame_size` above).
                 let flushed = if let Some(swr) = swr_ctx.as_mut() {
-                    swr.convert(
-                        (*aud_enc_frame.as_mut_ptr()).data.as_mut_ptr(),
-                        enc_frame_size,
-                        ptr::null(),
-                        0,
-                    )
-                    .ok()
+                    // SAFETY: `aud_enc_frame` was just `get_buffer`'d, so its
+                    //         output planes are allocated for the flush.
+                    swr.flush_into_frame(&mut aud_enc_frame).ok()
                 } else {
                     None
                 };
@@ -1079,11 +1081,11 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
+                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc.as_mut_ptr(),
-                            out_ctx.as_mut_ptr(),
-                            aud_out_stream_idx,
+                            aud_enc,
+                            &mut out_ctx,
+                            aud_out_stream_idx as usize,
                             "dash",
                             aud_frame_period,
                         );
@@ -1092,11 +1094,11 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 aud_enc_frame.unref();
             }
         }
-        let _ = aud_enc.send_frame(ptr::null());
+        let _ = aud_enc.send_frame_ref(None);
         crate::codec_utils::drain_encoder(
-            aud_enc.as_mut_ptr(),
-            out_ctx.as_mut_ptr(),
-            aud_out_stream_idx,
+            aud_enc,
+            &mut out_ctx,
+            aud_out_stream_idx as usize,
             "dash",
             aud_frame_period,
         );

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -25,9 +25,8 @@ use std::path::Path;
 use std::ptr;
 
 use ff_sys::{
-    AVFormatContext, AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
-    AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, ReceiveOutcome, av_opt_set,
-    av_rescale_q, avformat_new_stream,
+    AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE, AVPixelFormat,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, ReceiveOutcome, av_rescale_q,
 };
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
@@ -106,8 +105,10 @@ unsafe fn write_hls_unsafe(
     let mut audio_stream_idx: i32 = -1;
 
     for i in 0..nb_streams {
-        let stream = *(*input_ctx.as_ptr()).streams.add(i);
-        let codec_type = (*(*stream).codecpar).codec_type;
+        let Some(stream) = input_ctx.stream(i) else {
+            continue;
+        };
+        let codec_type = stream.codecpar().codec_type();
         if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO && video_stream_idx < 0 {
             video_stream_idx = i as i32;
         } else if codec_type == ff_sys::AVMediaType_AVMEDIA_TYPE_AUDIO && audio_stream_idx < 0 {
@@ -122,23 +123,30 @@ unsafe fn write_hls_unsafe(
     }
 
     // ── 3. Read video stream properties ──────────────────────────────────────
-    let video_stream = *(*input_ctx.as_ptr()).streams.add(video_stream_idx as usize);
-    let video_codecpar = (*video_stream).codecpar;
+    let vid_stream = input_ctx
+        .stream(video_stream_idx as usize)
+        .ok_or_else(|| ffmpeg_err_msg("video stream not found"))?;
+    let vid_par = vid_stream.codecpar();
     let enc_width = if target_width > 0 {
         target_width
     } else {
-        (*video_codecpar).width
+        vid_par.width()
     };
     let enc_height = if target_height > 0 {
         target_height
     } else {
-        (*video_codecpar).height
+        vid_par.height()
     };
-    let video_fps = detect_fps(video_stream, input_ctx.as_mut_ptr());
+    let video_fps = detect_fps(
+        vid_stream.avg_frame_rate(),
+        vid_stream.r_frame_rate(),
+        vid_stream.nb_frames(),
+        input_ctx.duration(),
+    );
     let fps_int = video_fps.round().max(1.0) as i32;
 
     // ── 4. Open input video decoder ────────────────────────────────────────────
-    let vid_codec_id = (*video_codecpar).codec_id;
+    let vid_codec_id = vid_par.codec_id();
     let vid_decoder = ff_sys::Codec::find_decoder(vid_codec_id)
         .ok_or_else(|| ffmpeg_err_msg("no video decoder available for input stream"))?;
 
@@ -146,7 +154,7 @@ unsafe fn write_hls_unsafe(
         ff_sys::CodecContext::new(Some(vid_decoder)).map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
-        .parameters_to_context(video_codecpar)
+        .apply_parameters(&vid_par)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
@@ -158,18 +166,20 @@ unsafe fn write_hls_unsafe(
     let mut aud_sample_rate: i32 = 44100;
     let mut aud_nb_channels: i32 = 2;
 
-    if audio_stream_idx >= 0 {
-        let audio_stream = *(*input_ctx.as_ptr()).streams.add(audio_stream_idx as usize);
-        let audio_codecpar = (*audio_stream).codecpar;
-        let aud_codec_id = (*audio_codecpar).codec_id;
+    if audio_stream_idx >= 0
+        && let Some(aud_par) = input_ctx
+            .stream(audio_stream_idx as usize)
+            .map(|s| s.codecpar())
+    {
+        let aud_codec_id = aud_par.codec_id();
 
         if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
             if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
-                if ctx.parameters_to_context(audio_codecpar).is_ok()
+                if ctx.apply_parameters(&aud_par).is_ok()
                     && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
                 {
-                    aud_sample_rate = (*ctx.as_ptr()).sample_rate;
-                    aud_nb_channels = (*ctx.as_ptr()).ch_layout.nb_channels;
+                    aud_sample_rate = ctx.sample_rate();
+                    aud_nb_channels = ctx.ch_layout().nb_channels;
                     aud_dec_ctx = Some(ctx);
                     log::info!(
                         "hls audio decoder opened sample_rate={aud_sample_rate} \
@@ -208,45 +218,25 @@ unsafe fn write_hls_unsafe(
         CString::new(seg_time_str.as_str()),
         CString::new(seg_filename.as_str()),
     ) {
-        let ret = av_opt_set(
-            (*out_ctx.as_mut_ptr()).priv_data,
-            c"hls_time".as_ptr(),
-            c_seg_time.as_ptr(),
-            0,
-        );
-        if ret < 0 {
+        if let Err(e) = out_ctx.set_opt(c"hls_time", &c_seg_time) {
             log::warn!(
                 "hls_time option not supported, using default \
                  requested={seg_time_str} error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
         }
-        let ret = av_opt_set(
-            (*out_ctx.as_mut_ptr()).priv_data,
-            c"hls_segment_filename".as_ptr(),
-            c_seg_file.as_ptr(),
-            0,
-        );
-        if ret < 0 {
+        if let Err(e) = out_ctx.set_opt(c"hls_segment_filename", &c_seg_file) {
             log::warn!(
                 "hls_segment_filename option not supported, using default \
                  requested={seg_filename} error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
         }
-        if use_fmp4 {
-            let ret = av_opt_set(
-                (*out_ctx.as_mut_ptr()).priv_data,
-                c"hls_segment_type".as_ptr(),
-                c"fmp4".as_ptr(),
-                0,
+        if use_fmp4 && let Err(e) = out_ctx.set_opt(c"hls_segment_type", c"fmp4") {
+            log::warn!(
+                "hls_segment_type fmp4 option not supported error={}",
+                ff_sys::av_error_string(e.code())
             );
-            if ret < 0 {
-                log::warn!(
-                    "hls_segment_type fmp4 option not supported error={}",
-                    ff_sys::av_error_string(ret)
-                );
-            }
         }
     }
 
@@ -257,20 +247,23 @@ unsafe fn write_hls_unsafe(
 
     let mut vid_enc_ctx =
         ff_sys::CodecContext::new(Some(vid_enc_codec)).map_err(|e| ffmpeg_err(e.code()))?;
-    let venc = vid_enc_ctx.as_mut_ptr();
 
-    (*venc).width = enc_width;
-    (*venc).height = enc_height;
-    (*venc).time_base.num = 1;
-    (*venc).time_base.den = fps_int;
-    (*venc).framerate.num = fps_int;
-    (*venc).framerate.den = 1;
-    (*venc).pix_fmt = AVPixelFormat_AV_PIX_FMT_YUV420P;
-    (*venc).bit_rate = if target_bitrate > 0 {
+    vid_enc_ctx.set_width(enc_width);
+    vid_enc_ctx.set_height(enc_height);
+    vid_enc_ctx.set_time_base(AVRational {
+        num: 1,
+        den: fps_int,
+    });
+    vid_enc_ctx.set_framerate(AVRational {
+        num: fps_int,
+        den: 1,
+    });
+    vid_enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
+    vid_enc_ctx.set_bit_rate(if target_bitrate > 0 {
         target_bitrate
     } else {
         2_000_000
-    };
+    });
 
     // On error the owned `vid_enc_ctx` / decoders / `input_ctx` / `out_ctx` all
     // drop; no manual teardown is needed.
@@ -279,16 +272,12 @@ unsafe fn write_hls_unsafe(
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────
-    let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
-    if vid_out_stream.is_null() {
-        return Err(ffmpeg_err_msg("cannot create video output stream"));
-    }
-    (*vid_out_stream).time_base = (*vid_enc_ctx.as_ptr()).time_base;
-    let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-    // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-    vid_enc_ctx
-        .parameters_from_context((*vid_out_stream).codecpar)
+    let vid_out_stream_idx = out_ctx
+        .new_stream(Some(&vid_enc_codec))
+        .map_err(|e| ffmpeg_err(e.code()))? as i32;
+    out_ctx.set_stream_time_base(vid_out_stream_idx as usize, vid_enc_ctx.time_base());
+    out_ctx
+        .apply_stream_params_from_context(vid_out_stream_idx as usize, &vid_enc_ctx)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 10. Open AAC audio encoder and add audio stream (optional) ────────────
@@ -300,19 +289,18 @@ unsafe fn write_hls_unsafe(
         match crate::codec_utils::open_aac_encoder(aud_sample_rate, aud_nb_channels, 192_000, "hls")
         {
             Ok(ctx) => {
-                let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
-                if aud_out_stream.is_null() {
-                    // `ctx` drops here (frees the codec context).
-                    log::warn!("hls cannot create audio output stream, skipping audio");
-                    audio_stream_idx = -1;
-                } else {
-                    (*aud_out_stream).time_base.num = 1;
-                    (*aud_out_stream).time_base.den = aud_sample_rate;
-                    aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-                    // SAFETY: aud_out_stream and ctx are valid; avcodec_open2 called.
-                    if ctx
-                        .parameters_from_context((*aud_out_stream).codecpar)
+                if let Ok(aud_idx) = out_ctx.new_stream(None) {
+                    let aud_idx = aud_idx as i32;
+                    aud_out_stream_idx = aud_idx;
+                    out_ctx.set_stream_time_base(
+                        aud_idx as usize,
+                        AVRational {
+                            num: 1,
+                            den: aud_sample_rate,
+                        },
+                    );
+                    if out_ctx
+                        .apply_stream_params_from_context(aud_idx as usize, &ctx)
                         .is_err()
                     {
                         log::warn!("hls audio stream codecpar copy failed");
@@ -320,15 +308,13 @@ unsafe fn write_hls_unsafe(
 
                     // Set up resampler: decoded audio → FLTP at aud_sample_rate.
                     if let Some(dec) = aud_dec_ctx.as_ref() {
-                        let enc_ptr = ctx.as_ptr();
-                        let dec_ptr = dec.as_ptr();
                         if let Ok(swr) = ff_sys::ResampleContext::new(
-                            &(*enc_ptr).ch_layout,
-                            (*enc_ptr).sample_fmt,
-                            (*enc_ptr).sample_rate,
-                            &(*dec_ptr).ch_layout,
-                            (*dec_ptr).sample_fmt,
-                            (*dec_ptr).sample_rate,
+                            ctx.ch_layout(),
+                            ctx.sample_fmt(),
+                            ctx.sample_rate(),
+                            dec.ch_layout(),
+                            dec.sample_fmt(),
+                            dec.sample_rate(),
                         ) {
                             swr_ctx = Some(swr);
                             aud_enc_ctx = Some(ctx);
@@ -341,6 +327,10 @@ unsafe fn write_hls_unsafe(
                         log::warn!("hls audio decoder missing, skipping audio");
                         audio_stream_idx = -1;
                     }
+                } else {
+                    // `ctx` drops here (frees the codec context).
+                    log::warn!("hls cannot create audio output stream, skipping audio");
+                    audio_stream_idx = -1;
                 }
             }
             Err(e) => {
@@ -368,7 +358,7 @@ unsafe fn write_hls_unsafe(
     log::info!(
         "hls output context ready width={enc_width} height={enc_height} fps={video_fps:.1} \
          bit_rate={} audio={}",
-        (*vid_enc_ctx.as_ptr()).bit_rate,
+        vid_enc_ctx.bit_rate(),
         audio_stream_idx >= 0,
     );
 
@@ -505,11 +495,11 @@ unsafe fn write_hls_unsafe(
                     false
                 };
 
-                if scaled && vid_enc_ctx.send_frame(vid_enc_frame.as_ptr()).is_ok() {
+                if scaled && vid_enc_ctx.send_frame_ref(Some(&vid_enc_frame)).is_ok() {
                     crate::codec_utils::drain_encoder(
-                        vid_enc_ctx.as_mut_ptr(),
-                        out_ctx.as_mut_ptr(),
-                        vid_out_stream_idx,
+                        &mut vid_enc_ctx,
+                        &mut out_ctx,
+                        vid_out_stream_idx as usize,
                         "hls",
                         vid_frame_period,
                     );
@@ -563,11 +553,11 @@ unsafe fn write_hls_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
+                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc.as_mut_ptr(),
-                            out_ctx.as_mut_ptr(),
-                            aud_out_stream_idx,
+                            aud_enc,
+                            &mut out_ctx,
+                            aud_out_stream_idx as usize,
                             "hls",
                             aud_frame_period,
                         );
@@ -584,11 +574,11 @@ unsafe fn write_hls_unsafe(
     }
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
-    let _ = vid_enc_ctx.send_frame(ptr::null());
+    let _ = vid_enc_ctx.send_frame_ref(None);
     crate::codec_utils::drain_encoder(
-        vid_enc_ctx.as_mut_ptr(),
-        out_ctx.as_mut_ptr(),
-        vid_out_stream_idx,
+        &mut vid_enc_ctx,
+        &mut out_ctx,
+        vid_out_stream_idx as usize,
         "hls",
         vid_frame_period,
     );
@@ -606,17 +596,13 @@ unsafe fn write_hls_unsafe(
             aud_enc_frame.set_nb_samples(enc_frame_size);
             let _ = aud_enc_frame.set_ch_layout(aud_enc.ch_layout());
             if aud_enc_frame.get_buffer(0).is_ok() {
-                // Flush the resampler with a NULL input. `convert_into_frame`
-                // models the normal-input case; the flush needs a NULL input
-                // pointer, so the raw `convert` is used here.
+                // Flush the resampler with a NULL input; `flush_into_frame`
+                // drains the buffered samples into the frame's `nb_samples`
+                // (set to `enc_frame_size` above).
                 let flushed = if let Some(swr) = swr_ctx.as_mut() {
-                    swr.convert(
-                        (*aud_enc_frame.as_mut_ptr()).data.as_mut_ptr(),
-                        enc_frame_size,
-                        ptr::null(),
-                        0,
-                    )
-                    .ok()
+                    // SAFETY: `aud_enc_frame` was just `get_buffer`'d, so its
+                    //         output planes are allocated for the flush.
+                    swr.flush_into_frame(&mut aud_enc_frame).ok()
                 } else {
                     None
                 };
@@ -625,11 +611,11 @@ unsafe fn write_hls_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame(aud_enc_frame.as_ptr()).is_ok() {
+                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
-                            aud_enc.as_mut_ptr(),
-                            out_ctx.as_mut_ptr(),
-                            aud_out_stream_idx,
+                            aud_enc,
+                            &mut out_ctx,
+                            aud_out_stream_idx as usize,
                             "hls",
                             aud_frame_period,
                         );
@@ -638,11 +624,11 @@ unsafe fn write_hls_unsafe(
                 aud_enc_frame.unref();
             }
         }
-        let _ = aud_enc.send_frame(ptr::null());
+        let _ = aud_enc.send_frame_ref(None);
         crate::codec_utils::drain_encoder(
-            aud_enc.as_mut_ptr(),
-            out_ctx.as_mut_ptr(),
-            aud_out_stream_idx,
+            aud_enc,
+            &mut out_ctx,
+            aud_out_stream_idx as usize,
             "hls",
             aud_frame_period,
         );
@@ -675,7 +661,7 @@ unsafe fn write_hls_unsafe(
 /// in order and rejects values outside the sane range [1, 240] fps.
 /// Falls back to `nb_frames/duration` and finally to 25 fps.
 #[allow(clippy::cast_precision_loss)]
-unsafe fn detect_fps(stream: *mut ff_sys::AVStream, fmt_ctx: *mut AVFormatContext) -> f64 {
+fn detect_fps(avg: AVRational, rfr: AVRational, nb_frames: i64, duration: i64) -> f64 {
     const MIN_FPS: f64 = 1.0;
     const MAX_FPS: f64 = 240.0;
 
@@ -692,26 +678,55 @@ unsafe fn detect_fps(stream: *mut ff_sys::AVStream, fmt_ctx: *mut AVFormatContex
     };
 
     // 1. avg_frame_rate — reliable for most containers
-    let avg = (*stream).avg_frame_rate;
     if let Some(fps) = try_rational(avg.num, avg.den) {
         return fps;
     }
 
     // 2. r_frame_rate — constant-framerate indicator
-    let rfr = (*stream).r_frame_rate;
     if let Some(fps) = try_rational(rfr.num, rfr.den) {
         return fps;
     }
 
     // 3. Derive from nb_frames and total duration (robust for MPEG-4 Part 2)
-    let nb = (*stream).nb_frames;
-    let dur = (*fmt_ctx).duration; // in AV_TIME_BASE (1 000 000) microseconds
-    if nb > 0 && dur > 0 {
-        let fps = nb as f64 / (dur as f64 / 1_000_000.0);
+    // `duration` is in AV_TIME_BASE (1 000 000) microseconds.
+    if nb_frames > 0 && duration > 0 {
+        let fps = nb_frames as f64 / (duration as f64 / 1_000_000.0);
         if (MIN_FPS..=MAX_FPS).contains(&fps) {
             return fps;
         }
     }
 
     25.0 // sane default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detect_fps;
+    use ff_sys::AVRational;
+
+    fn r(num: i32, den: i32) -> AVRational {
+        AVRational { num, den }
+    }
+
+    #[test]
+    fn detect_fps_should_prefer_avg_frame_rate() {
+        assert_eq!(detect_fps(r(30, 1), r(60, 1), 0, 0), 30.0);
+    }
+
+    #[test]
+    fn detect_fps_should_fall_back_to_r_frame_rate_when_avg_out_of_range() {
+        // avg = 1_250_000/49 ≈ 25510 fps is outside [1, 240] and is rejected.
+        assert_eq!(detect_fps(r(1_250_000, 49), r(24, 1), 0, 0), 24.0);
+    }
+
+    #[test]
+    fn detect_fps_should_derive_from_nb_frames_and_duration() {
+        // 300 frames over 10 s (10_000_000 µs) = 30 fps, distinct from the 25.0 default.
+        assert_eq!(detect_fps(r(0, 0), r(0, 0), 300, 10_000_000), 30.0);
+    }
+
+    #[test]
+    fn detect_fps_should_default_to_25_when_all_sources_unknown() {
+        assert_eq!(detect_fps(r(0, 0), r(0, 0), 0, 0), 25.0);
+    }
 }

--- a/crates/ff-stream/src/live_dash_inner.rs
+++ b/crates/ff-stream/src/live_dash_inner.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_new_stream};
+use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
 use crate::error::StreamError;
@@ -129,58 +129,34 @@ impl LiveDashInner {
         // ── 2. Set DASH muxer options ─────────────────────────────────────────
         let seg_time_str = format!("{segment_secs}");
 
-        if let Ok(c_seg_time) = CString::new(seg_time_str.as_str()) {
-            let ret = av_opt_set(
-                (*out_ctx.as_mut_ptr()).priv_data,
-                c"seg_duration".as_ptr(),
-                c_seg_time.as_ptr(),
-                0,
+        if let Ok(c_seg_time) = CString::new(seg_time_str.as_str())
+            && let Err(e) = out_ctx.set_opt(c"seg_duration", &c_seg_time)
+        {
+            log::warn!(
+                "live_dash seg_duration option not supported, using default \
+                 requested={seg_time_str} error={}",
+                ff_sys::av_error_string(e.code())
             );
-            if ret < 0 {
-                log::warn!(
-                    "live_dash seg_duration option not supported, using default \
-                     requested={seg_time_str} error={}",
-                    ff_sys::av_error_string(ret)
-                );
-            }
         }
 
-        let ret = av_opt_set(
-            (*out_ctx.as_mut_ptr()).priv_data,
-            c"use_template".as_ptr(),
-            c"1".as_ptr(),
-            0,
-        );
-        if ret < 0 {
+        if let Err(e) = out_ctx.set_opt(c"use_template", c"1") {
             log::warn!(
                 "live_dash use_template option not supported error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
         }
 
-        let ret = av_opt_set(
-            (*out_ctx.as_mut_ptr()).priv_data,
-            c"use_timeline".as_ptr(),
-            c"1".as_ptr(),
-            0,
-        );
-        if ret < 0 {
+        if let Err(e) = out_ctx.set_opt(c"use_timeline", c"1") {
             log::warn!(
                 "live_dash use_timeline option not supported error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
         }
 
-        let ret = av_opt_set(
-            (*out_ctx.as_mut_ptr()).priv_data,
-            c"remove_at_exit".as_ptr(),
-            c"0".as_ptr(),
-            0,
-        );
-        if ret < 0 {
+        if let Err(e) = out_ctx.set_opt(c"remove_at_exit", c"0") {
             log::warn!(
                 "live_dash remove_at_exit option not supported error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
         }
 
@@ -216,16 +192,12 @@ impl LiveDashInner {
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Add video output stream ────────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
-        if vid_out_stream.is_null() {
-            return Err(ffmpeg_err_msg("cannot create video output stream"));
-        }
-        (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-        // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        vid_enc_ctx
-            .parameters_from_context((*vid_out_stream).codecpar)
+        let vid_out_stream_idx = out_ctx
+            .new_stream(Some(&vid_enc_codec))
+            .map_err(|e| ffmpeg_err(e.code()))? as i32;
+        out_ctx.set_stream_time_base(vid_out_stream_idx as usize, vid_enc_ctx.time_base());
+        out_ctx
+            .apply_stream_params_from_context(vid_out_stream_idx as usize, &vid_enc_ctx)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 5. Open AAC audio encoder and add audio stream (optional) ─────────
@@ -245,23 +217,28 @@ impl LiveDashInner {
                         1024
                     };
 
-                    let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
-                    if aud_out_stream.is_null() {
-                        // `ctx` drops here (frees the codec context).
-                        log::warn!("live_dash cannot create audio output stream, skipping audio");
-                    } else {
-                        (*aud_out_stream).time_base.num = 1;
-                        (*aud_out_stream).time_base.den = sr;
-                        aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-                        // SAFETY: aud_out_stream and ctx are valid.
-                        if ctx
-                            .parameters_from_context((*aud_out_stream).codecpar)
-                            .is_err()
-                        {
-                            log::warn!("live_dash audio stream codecpar copy failed");
+                    match out_ctx.new_stream(None) {
+                        Ok(idx) => {
+                            let idx = idx as i32;
+                            aud_out_stream_idx = idx;
+                            out_ctx.set_stream_time_base(
+                                idx as usize,
+                                ff_sys::AVRational { num: 1, den: sr },
+                            );
+                            if out_ctx
+                                .apply_stream_params_from_context(idx as usize, &ctx)
+                                .is_err()
+                            {
+                                log::warn!("live_dash audio stream codecpar copy failed");
+                            }
+                            aud_enc_ctx = Some(ctx);
                         }
-                        aud_enc_ctx = Some(ctx);
+                        // `ctx` drops here (frees the codec context).
+                        Err(_) => {
+                            log::warn!(
+                                "live_dash cannot create audio output stream, skipping audio"
+                            );
+                        }
                     }
                 }
                 Err(e) => {

--- a/crates/ff-stream/src/live_hls_inner.rs
+++ b/crates/ff-stream/src/live_hls_inner.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, av_opt_set, avformat_new_stream};
+use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg};
 use crate::error::StreamError;
@@ -145,70 +145,38 @@ impl LiveHlsInner {
             CString::new(list_size_str.as_str()),
             CString::new(seg_filename.as_str()),
         ) {
-            let ret = av_opt_set(
-                (*out_ctx.as_mut_ptr()).priv_data,
-                c"hls_time".as_ptr(),
-                c_seg_time.as_ptr(),
-                0,
-            );
-            if ret < 0 {
+            if let Err(e) = out_ctx.set_opt(c"hls_time", &c_seg_time) {
                 log::warn!(
                     "live_hls hls_time option not supported, using default \
                      requested={seg_time_str} error={}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 );
             }
-            let ret = av_opt_set(
-                (*out_ctx.as_mut_ptr()).priv_data,
-                c"hls_list_size".as_ptr(),
-                c_list_size.as_ptr(),
-                0,
-            );
-            if ret < 0 {
+            if let Err(e) = out_ctx.set_opt(c"hls_list_size", &c_list_size) {
                 log::warn!(
                     "live_hls hls_list_size option not supported, using default \
                      requested={list_size_str} error={}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 );
             }
-            let ret = av_opt_set(
-                (*out_ctx.as_mut_ptr()).priv_data,
-                c"hls_flags".as_ptr(),
-                c"delete_segments".as_ptr(),
-                0,
-            );
-            if ret < 0 {
+            if let Err(e) = out_ctx.set_opt(c"hls_flags", c"delete_segments") {
                 log::warn!(
                     "live_hls hls_flags option not supported error={}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 );
             }
-            let ret = av_opt_set(
-                (*out_ctx.as_mut_ptr()).priv_data,
-                c"hls_segment_filename".as_ptr(),
-                c_seg_file.as_ptr(),
-                0,
-            );
-            if ret < 0 {
+            if let Err(e) = out_ctx.set_opt(c"hls_segment_filename", &c_seg_file) {
                 log::warn!(
                     "live_hls hls_segment_filename option not supported, using default \
                      requested={seg_filename} error={}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 );
             }
-            if use_fmp4 {
-                let ret = av_opt_set(
-                    (*out_ctx.as_mut_ptr()).priv_data,
-                    c"hls_segment_type".as_ptr(),
-                    c"fmp4".as_ptr(),
-                    0,
+            if use_fmp4 && let Err(e) = out_ctx.set_opt(c"hls_segment_type", c"fmp4") {
+                log::warn!(
+                    "live_hls hls_segment_type fmp4 option not supported error={}",
+                    ff_sys::av_error_string(e.code())
                 );
-                if ret < 0 {
-                    log::warn!(
-                        "live_hls hls_segment_type fmp4 option not supported error={}",
-                        ff_sys::av_error_string(ret)
-                    );
-                }
             }
         }
 
@@ -244,16 +212,12 @@ impl LiveHlsInner {
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Add video output stream ────────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
-        if vid_out_stream.is_null() {
-            return Err(ffmpeg_err_msg("cannot create video output stream"));
-        }
-        (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-        // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        vid_enc_ctx
-            .parameters_from_context((*vid_out_stream).codecpar)
+        let vid_out_stream_idx = out_ctx
+            .new_stream(Some(&vid_enc_codec))
+            .map_err(|e| ffmpeg_err(e.code()))? as i32;
+        out_ctx.set_stream_time_base(vid_out_stream_idx as usize, vid_enc_ctx.time_base());
+        out_ctx
+            .apply_stream_params_from_context(vid_out_stream_idx as usize, &vid_enc_ctx)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 5. Open AAC audio encoder and add audio stream (optional) ─────────
@@ -273,23 +237,28 @@ impl LiveHlsInner {
                         1024
                     };
 
-                    let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
-                    if aud_out_stream.is_null() {
-                        // `ctx` drops here (frees the codec context).
-                        log::warn!("live_hls cannot create audio output stream, skipping audio");
-                    } else {
-                        (*aud_out_stream).time_base.num = 1;
-                        (*aud_out_stream).time_base.den = sr;
-                        aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-                        // SAFETY: aud_out_stream and ctx are valid.
-                        if ctx
-                            .parameters_from_context((*aud_out_stream).codecpar)
-                            .is_err()
-                        {
-                            log::warn!("live_hls audio stream codecpar copy failed");
+                    match out_ctx.new_stream(None) {
+                        Ok(idx) => {
+                            let idx = idx as i32;
+                            aud_out_stream_idx = idx;
+                            out_ctx.set_stream_time_base(
+                                idx as usize,
+                                ff_sys::AVRational { num: 1, den: sr },
+                            );
+                            if out_ctx
+                                .apply_stream_params_from_context(idx as usize, &ctx)
+                                .is_err()
+                            {
+                                log::warn!("live_hls audio stream codecpar copy failed");
+                            }
+                            aud_enc_ctx = Some(ctx);
                         }
-                        aud_enc_ctx = Some(ctx);
+                        // `ctx` drops here (frees the codec context).
+                        Err(_) => {
+                            log::warn!(
+                                "live_hls cannot create audio output stream, skipping audio"
+                            );
+                        }
                     }
                 }
                 Err(e) => {

--- a/crates/ff-stream/src/muxer_core.rs
+++ b/crates/ff-stream/src/muxer_core.rs
@@ -17,8 +17,6 @@
 #![allow(clippy::borrow_as_ptr)]
 #![allow(clippy::ref_as_ptr)]
 
-use std::ptr;
-
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
     AVPixelFormat, AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, AVSampleFormat, av_rescale_q,
@@ -219,8 +217,7 @@ impl MuxerCore {
             for (plane_idx, (src_plane, &src_stride)) in
                 planes.iter().zip(strides.iter()).enumerate().take(3)
             {
-                // SAFETY: vid_enc_frame is a get_buffer'd frame; linesize is a plain field.
-                let dst_stride = (*self.vid_enc_frame.as_ptr()).linesize[plane_idx] as usize;
+                let dst_stride = self.vid_enc_frame.linesize(plane_idx) as usize;
                 let Some(dst_plane) = self.vid_enc_frame.video_plane_mut(plane_idx) else {
                     continue;
                 };
@@ -241,14 +238,13 @@ impl MuxerCore {
 
         if self
             .vid_enc_ctx
-            .send_frame(self.vid_enc_frame.as_ptr())
+            .send_frame_ref(Some(&self.vid_enc_frame))
             .is_ok()
         {
-            // SAFETY: out_ctx is valid; vid_out_stream_idx is valid.
             drain_encoder(
-                self.vid_enc_ctx.as_mut_ptr(),
-                self.out_ctx.as_mut_ptr(),
-                self.vid_out_stream_idx,
+                &mut self.vid_enc_ctx,
+                &mut self.out_ctx,
+                self.vid_out_stream_idx as usize,
                 self.log_prefix,
                 AVRational {
                     num: 1,
@@ -275,11 +271,6 @@ impl MuxerCore {
         if self.aud_enc_ctx.is_none() || self.aud_out_stream_idx < 0 {
             return; // audio not configured
         }
-
-        // Raw output-context pointer for `drain_encoder`; taking it up front frees
-        // the `&mut self.out_ctx` borrow so it does not overlap the `aud_enc_ctx`
-        // field borrow held during the drain call below.
-        let out_ctx = self.out_ctx.as_mut_ptr();
 
         let in_fmt = sample_format_to_av(frame.format());
         let in_rate = frame.sample_rate() as i32;
@@ -346,17 +337,16 @@ impl MuxerCore {
             self.aud_enc_frame.set_nb_samples(n);
             self.aud_enc_frame.set_pts(self.audio_pts);
             if let Some(aud_ctx) = self.aud_enc_ctx.as_mut()
-                && aud_ctx.send_frame(self.aud_enc_frame.as_ptr()).is_ok()
+                && aud_ctx.send_frame_ref(Some(&self.aud_enc_frame)).is_ok()
             {
                 let aud_frame_period = AVRational {
                     num: aud_ctx.frame_size(),
                     den: aud_ctx.sample_rate(),
                 };
-                // SAFETY: out_ctx is valid; aud_out_stream_idx is valid.
                 drain_encoder(
-                    aud_ctx.as_mut_ptr(),
-                    out_ctx,
-                    self.aud_out_stream_idx,
+                    aud_ctx,
+                    &mut self.out_ctx,
+                    self.aud_out_stream_idx as usize,
                     self.log_prefix,
                     aud_frame_period,
                 );
@@ -379,17 +369,12 @@ impl MuxerCore {
     /// `self` must have been initialised by the enclosing inner type's
     /// `open_unsafe`. This method must be called at most once.
     pub(crate) unsafe fn flush_and_close_unsafe(&mut self) {
-        // Raw output-context pointer for the `drain_encoder` calls below; taking
-        // it up front frees the `&mut self.out_ctx` borrow so it does not overlap
-        // the encoder-context field borrows.
-        let out_ctx = self.out_ctx.as_mut_ptr();
-
         // ── Flush video encoder ───────────────────────────────────────────────
-        let _ = self.vid_enc_ctx.send_frame(ptr::null());
+        let _ = self.vid_enc_ctx.send_frame_ref(None);
         drain_encoder(
-            self.vid_enc_ctx.as_mut_ptr(),
-            out_ctx,
-            self.vid_out_stream_idx,
+            &mut self.vid_enc_ctx,
+            &mut self.out_ctx,
+            self.vid_out_stream_idx as usize,
             self.log_prefix,
             AVRational {
                 num: 1,
@@ -410,18 +395,13 @@ impl MuxerCore {
                 }
 
                 if self.aud_enc_frame.get_buffer(0).is_ok() {
-                    let out_count = self.aud_frame_size;
-                    // Flush the resampler with a NULL input. `convert_into_frame`
-                    // models the normal-input case; the flush needs a NULL input
-                    // pointer, so the raw `convert` is used here.
+                    // Flush the resampler with a NULL input; `flush_into_frame`
+                    // writes the drained samples into the frame's `nb_samples`
+                    // (set to `aud_frame_size` above).
                     let flushed = if let Some(swr) = self.swr_ctx.as_mut() {
-                        swr.convert(
-                            (*self.aud_enc_frame.as_mut_ptr()).data.as_mut_ptr(),
-                            out_count,
-                            ptr::null(),
-                            0,
-                        )
-                        .ok()
+                        // SAFETY: `aud_enc_frame` was just `get_buffer`'d, so its
+                        //         output planes are allocated for the flush.
+                        swr.flush_into_frame(&mut self.aud_enc_frame).ok()
                     } else {
                         None
                     };
@@ -431,16 +411,16 @@ impl MuxerCore {
                         self.aud_enc_frame.set_nb_samples(n);
                         self.aud_enc_frame.set_pts(self.audio_pts);
                         if let Some(aud_ctx) = self.aud_enc_ctx.as_mut()
-                            && aud_ctx.send_frame(self.aud_enc_frame.as_ptr()).is_ok()
+                            && aud_ctx.send_frame_ref(Some(&self.aud_enc_frame)).is_ok()
                         {
                             let aud_frame_period = AVRational {
                                 num: aud_ctx.frame_size(),
                                 den: aud_ctx.sample_rate(),
                             };
                             drain_encoder(
-                                aud_ctx.as_mut_ptr(),
-                                out_ctx,
-                                self.aud_out_stream_idx,
+                                aud_ctx,
+                                &mut self.out_ctx,
+                                self.aud_out_stream_idx as usize,
                                 self.log_prefix,
                                 aud_frame_period,
                             );
@@ -452,15 +432,15 @@ impl MuxerCore {
 
             // Flush the AAC encoder itself.
             if let Some(aud_ctx) = self.aud_enc_ctx.as_mut() {
-                let _ = aud_ctx.send_frame(ptr::null());
+                let _ = aud_ctx.send_frame_ref(None);
                 let aud_frame_period = AVRational {
                     num: aud_ctx.frame_size(),
                     den: aud_ctx.sample_rate(),
                 };
                 drain_encoder(
-                    aud_ctx.as_mut_ptr(),
-                    out_ctx,
-                    self.aud_out_stream_idx,
+                    aud_ctx,
+                    &mut self.out_ctx,
+                    self.aud_out_stream_idx as usize,
                     self.log_prefix,
                     aud_frame_period,
                 );

--- a/crates/ff-stream/src/rtmp_inner.rs
+++ b/crates/ff-stream/src/rtmp_inner.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_new_stream};
+use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
 use crate::error::StreamError;
@@ -157,16 +157,12 @@ impl RtmpInner {
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 3. Add video output stream ─────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
-        if vid_out_stream.is_null() {
-            return Err(ffmpeg_err_msg("cannot create video output stream"));
-        }
-        (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-        // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        vid_enc_ctx
-            .parameters_from_context((*vid_out_stream).codecpar)
+        let vid_out_stream_idx = out_ctx
+            .new_stream(Some(&vid_enc_codec))
+            .map_err(|e| ffmpeg_err(e.code()))? as i32;
+        out_ctx.set_stream_time_base(vid_out_stream_idx as usize, vid_enc_ctx.time_base());
+        out_ctx
+            .apply_stream_params_from_context(vid_out_stream_idx as usize, &vid_enc_ctx)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Open AAC audio encoder ──────────────────────────────────────
@@ -179,17 +175,16 @@ impl RtmpInner {
         };
 
         // ── 5. Add audio output stream ─────────────────────────────────────
-        let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
-        if aud_out_stream.is_null() {
-            return Err(ffmpeg_err_msg("cannot create audio output stream"));
-        }
-        (*aud_out_stream).time_base.num = 1;
-        (*aud_out_stream).time_base.den = aud_sample_rate;
-        let aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-        // SAFETY: aud_out_stream and aud_enc_ctx are valid.
-        if aud_enc_ctx
-            .parameters_from_context((*aud_out_stream).codecpar)
+        let aud_out_stream_idx = out_ctx.new_stream(None).map_err(|e| ffmpeg_err(e.code()))? as i32;
+        out_ctx.set_stream_time_base(
+            aud_out_stream_idx as usize,
+            ff_sys::AVRational {
+                num: 1,
+                den: aud_sample_rate,
+            },
+        );
+        if out_ctx
+            .apply_stream_params_from_context(aud_out_stream_idx as usize, &aud_enc_ctx)
             .is_err()
         {
             log::warn!("rtmp audio stream codecpar copy failed");

--- a/crates/ff-stream/src/srt_output_inner.rs
+++ b/crates/ff-stream/src/srt_output_inner.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
-use ff_sys::{AVPixelFormat_AV_PIX_FMT_YUV420P, avformat_new_stream};
+use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
 
 use crate::codec_utils::{ffmpeg_err, ffmpeg_err_msg, open_aac_encoder};
 use crate::error::StreamError;
@@ -159,16 +159,12 @@ impl SrtInner {
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 3. Add video output stream ─────────────────────────────────────
-        let vid_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), vid_enc_codec.as_ptr());
-        if vid_out_stream.is_null() {
-            return Err(ffmpeg_err_msg("cannot create video output stream"));
-        }
-        (*vid_out_stream).time_base = vid_enc_ctx.time_base();
-        let vid_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-        // SAFETY: vid_out_stream and vid_enc_ctx are valid; avcodec_open2 has been called.
-        vid_enc_ctx
-            .parameters_from_context((*vid_out_stream).codecpar)
+        let vid_out_stream_idx = out_ctx
+            .new_stream(Some(&vid_enc_codec))
+            .map_err(|e| ffmpeg_err(e.code()))? as i32;
+        out_ctx.set_stream_time_base(vid_out_stream_idx as usize, vid_enc_ctx.time_base());
+        out_ctx
+            .apply_stream_params_from_context(vid_out_stream_idx as usize, &vid_enc_ctx)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Open AAC audio encoder ──────────────────────────────────────
@@ -181,17 +177,16 @@ impl SrtInner {
         };
 
         // ── 5. Add audio output stream ─────────────────────────────────────
-        let aud_out_stream = avformat_new_stream(out_ctx.as_mut_ptr(), ptr::null());
-        if aud_out_stream.is_null() {
-            return Err(ffmpeg_err_msg("cannot create audio output stream"));
-        }
-        (*aud_out_stream).time_base.num = 1;
-        (*aud_out_stream).time_base.den = aud_sample_rate;
-        let aud_out_stream_idx = (out_ctx.nb_streams() - 1) as i32;
-
-        // SAFETY: aud_out_stream and aud_enc_ctx are valid.
-        if aud_enc_ctx
-            .parameters_from_context((*aud_out_stream).codecpar)
+        let aud_out_stream_idx = out_ctx.new_stream(None).map_err(|e| ffmpeg_err(e.code()))? as i32;
+        out_ctx.set_stream_time_base(
+            aud_out_stream_idx as usize,
+            ff_sys::AVRational {
+                num: 1,
+                den: aud_sample_rate,
+            },
+        );
+        if out_ctx
+            .apply_stream_params_from_context(aud_out_stream_idx as usize, &aud_enc_ctx)
             .is_err()
         {
             log::warn!("srt audio stream codecpar copy failed");


### PR DESCRIPTION
## Objective

- ff-stream was the largest consumer of raw `as_ptr`/`as_mut_ptr` (~104 sites), blocking the #1506 seal that removes the transitional raw escape hatches from the ff-sys RAII types (ADR-0003).

## Solution

- Remove every ff-stream `as_ptr`/`as_mut_ptr` field read/write and every owned-pointer-to-FFI call; all FFmpeg contexts, frames and packets are now owned RAII types.
- `drain_encoder` takes `&mut CodecContext` / `&mut OutputFormatContext` and a `usize` stream index (now a safe fn), using `receive_packet_into` / `write_interleaved` / `stream_time_base` / `set_duration` / `rescale_ts`; `MuxerCore` uses disjoint-field `&mut` borrows instead of a hoisted raw pointer.
- Stream setup moves to `new_stream` / `set_stream_time_base` / `apply_stream_params_from_context` / `set_opt`; input-side reads move to `InputFormatContext::stream` (`StreamRef` / `CodecParameters`) and `CodecContext::apply_parameters`; `detect_fps` becomes a pure function with deterministic unit tests.
- Behavior is preserved except the DASH ABR audio stream, which now copies the full encoder parameters (matching the single-rendition and HLS paths) instead of a manual codecpar subset.

Closes #1543