### PR TITLE
feat(ff-sys): add Packet size/flags accessors and audio_fifo Frame write/read

### DIFF
--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1027,6 +1027,22 @@ pub mod swresample {
         pub unsafe fn size(_fifo: *mut AVAudioFifo) -> c_int {
             0
         }
+
+        pub unsafe fn write_frame(
+            _fifo: *mut AVAudioFifo,
+            _src: &super::super::Frame,
+            _nb_samples: c_int,
+        ) -> Result<c_int, c_int> {
+            Err(-1)
+        }
+
+        pub unsafe fn read_frame(
+            _fifo: *mut AVAudioFifo,
+            _dst: &mut super::super::Frame,
+            _nb_samples: c_int,
+        ) -> Result<c_int, c_int> {
+            Err(-1)
+        }
     }
 
     pub mod sample_format {
@@ -1876,6 +1892,16 @@ impl Packet {
 
     #[must_use]
     pub fn dts(&self) -> i64 {
+        0
+    }
+
+    #[must_use]
+    pub fn size(&self) -> c_int {
+        0
+    }
+
+    #[must_use]
+    pub fn flags(&self) -> c_int {
         0
     }
 

--- a/crates/ff-sys/src/packet.rs
+++ b/crates/ff-sys/src/packet.rs
@@ -79,6 +79,20 @@ impl Packet {
         unsafe { (*self.ptr.as_ptr()).duration }
     }
 
+    /// Returns the packet's payload size in bytes.
+    #[must_use]
+    pub fn size(&self) -> std::os::raw::c_int {
+        // SAFETY: `self.ptr` is a valid owned packet; `size` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).size }
+    }
+
+    /// Returns the packet's flags (a bitmask of `AV_PKT_FLAG_*`).
+    #[must_use]
+    pub fn flags(&self) -> std::os::raw::c_int {
+        // SAFETY: `self.ptr` is a valid owned packet; `flags` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).flags }
+    }
+
     /// Sets the index of the stream this packet belongs to.
     pub fn set_stream_index(&mut self, stream_index: std::os::raw::c_int) {
         // SAFETY: `self.ptr` is a valid owned packet; `stream_index` is a plain field.
@@ -182,6 +196,15 @@ mod tests {
         assert_eq!(packet.pts(), 1_000);
         assert_eq!(packet.dts(), 900);
         assert_eq!(packet.duration(), 512);
+    }
+
+    #[test]
+    fn size_and_flags_should_read_defaults() {
+        let packet = Packet::new().expect("packet allocation should succeed");
+        // A fresh packet carries no payload and no flags; the accessors read
+        // those plain fields (there is no public setter for either).
+        assert_eq!(packet.size(), 0);
+        assert_eq!(packet.flags(), 0);
     }
 
     #[test]

--- a/crates/ff-sys/src/swresample/audio_fifo.rs
+++ b/crates/ff-sys/src/swresample/audio_fifo.rs
@@ -92,3 +92,82 @@ pub unsafe fn size(fifo: *mut AVAudioFifo) -> c_int {
     // SAFETY: caller guarantees fifo is valid
     unsafe { crate::av_audio_fifo_size(fifo) }
 }
+
+/// Write `nb_samples` samples from `src`'s planes into the FIFO.
+///
+/// The frame's planar `data` pointer array is read internally, so callers
+/// never touch the raw pointers. Returns the number of samples written.
+///
+/// # Safety
+///
+/// `fifo` must be valid, and `src` must hold at least `nb_samples` samples
+/// worth of data in its allocated planes.
+pub unsafe fn write_frame(
+    fifo: *mut AVAudioFifo,
+    src: &crate::Frame,
+    nb_samples: c_int,
+) -> Result<c_int, c_int> {
+    // SAFETY: `src` is a valid frame; its `data` pointer array is read (not
+    //         retained), and the caller upholds `fifo` and the sample count.
+    let data = unsafe { (*src.as_ptr()).data.as_ptr().cast::<*mut c_void>() };
+    unsafe { write(fifo, data, nb_samples) }
+}
+
+/// Read up to `nb_samples` samples from the FIFO into `dst`'s planes.
+///
+/// The frame's planar `data` pointer array is read internally, so callers
+/// never touch the raw pointers. Returns the number of samples actually read.
+///
+/// # Safety
+///
+/// `fifo` must be valid, and `dst` must have `get_buffer`'d planes with room
+/// for at least `nb_samples` samples.
+pub unsafe fn read_frame(
+    fifo: *mut AVAudioFifo,
+    dst: &mut crate::Frame,
+    nb_samples: c_int,
+) -> Result<c_int, c_int> {
+    // SAFETY: `dst` is a valid get_buffer'd frame; its `data` pointer array is
+    //         read (not retained) while the FIFO writes into the planes it
+    //         points to, and the caller upholds `fifo` and the sample count.
+    let data = unsafe { (*dst.as_mut_ptr()).data.as_ptr().cast::<*mut c_void>() };
+    unsafe { read(fifo, data, nb_samples) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{alloc, free, read_frame, size, write_frame};
+    use crate::Frame;
+    use crate::swresample::{channel_layout, sample_format};
+
+    fn get_buffered_audio_frame(nb_samples: i32) -> Frame {
+        let mut f = Frame::new().expect("frame alloc");
+        f.set_format(sample_format::FLTP);
+        f.set_sample_rate(48_000);
+        f.set_nb_samples(nb_samples);
+        f.set_ch_layout(&channel_layout::with_channels(2))
+            .expect("set ch_layout");
+        f.get_buffer(0).expect("get_buffer");
+        f
+    }
+
+    #[test]
+    fn write_frame_then_read_frame_should_round_trip_the_sample_count() {
+        // SAFETY: the FIFO is allocated and freed within this test; both frames
+        //         are get_buffer'd with matching FLTP / 2-channel parameters, so
+        //         their planes hold the sample counts written / read.
+        unsafe {
+            let fifo = alloc(sample_format::FLTP, 2, 1024).expect("fifo alloc");
+
+            let src = get_buffered_audio_frame(256);
+            assert_eq!(write_frame(fifo, &src, 256).expect("write_frame"), 256);
+            assert_eq!(size(fifo), 256);
+
+            let mut dst = get_buffered_audio_frame(256);
+            assert_eq!(read_frame(fifo, &mut dst, 256).expect("read_frame"), 256);
+            assert_eq!(size(fifo), 0);
+
+            free(fifo);
+        }
+    }
+}


### PR DESCRIPTION
## Objective

- The ff-encode migration (#1544) reaches owned-type field reads and FIFO calls that the existing accessors do not cover; this is the first, trivial slice of the ff-sys API it needs (the non-trivial HDR10 side-data / attachment codecpar / container metadata+chapters gaps are handled separately).

## Solution

- Add `Packet::size()` and `Packet::flags()` (plain field reads, mirroring `pts`/`dts`), read by the encoders' `bytes_written` accounting and the keyframe check.
- Add `swresample::audio_fifo::write_frame(fifo, &Frame, nb_samples)` and `read_frame(fifo, &mut Frame, nb_samples)`, which read the frame's planar `data` pointer array internally so consumers never touch the raw array (the FIFO stays a raw pointer; `AVAudioFifo` is not a sealed type).
- Include the docsrs stubs and unit tests (Packet default reads and a FIFO write/read round-trip on `get_buffer`'d frames).

Closes #1553