### PR TITLE
refactor(ff-encode): migrate off as_ptr/as_mut_ptr to the safe accessors

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -24,10 +24,8 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3,
     AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_NONE,
     AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE,
-    AVCodecID_AV_CODEC_ID_VORBIS, OutputFormatContext, av_interleaved_write_frame,
-    avformat_new_stream, swresample,
+    AVCodecID_AV_CODEC_ID_VORBIS, OutputFormatContext, swresample,
 };
-use std::ffi::c_void;
 use std::ptr;
 
 /// Internal encoder state with FFmpeg contexts.
@@ -226,28 +224,25 @@ impl AudioEncoderInner {
             self.frame_size = required;
         }
 
-        // Create stream
-        let stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), codec_ptr);
-        if stream.is_null() {
-            // The owned codec_ctx frees itself on return.
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot create stream".to_string(),
-            });
-        }
+        // Create stream. The owned codec_ctx frees itself if this returns.
+        let stream_idx = self
+            .format_ctx
+            .new_stream(Some(&codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        (*stream).time_base = codec_ctx.time_base();
+        self.format_ctx
+            .set_stream_time_base(stream_idx, codec_ctx.time_base());
 
         // Copy ALL codec parameters (including extradata) from the open codec
         // context to the stream.  avcodec_parameters_from_context must be
         // called after avcodec_open2 because some codecs (e.g. FLAC, AAC)
         // populate extradata only after the codec is opened.  Manual field
         // copies would miss extradata, causing avformat_write_header to fail.
-        codec_ctx
-            .parameters_from_context((*stream).codecpar)
+        self.format_ctx
+            .apply_stream_params_from_context(stream_idx, &codec_ctx)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        self.stream_index = (self.format_ctx.nb_streams() - 1) as i32;
+        self.stream_index = stream_idx as i32;
         self.codec_ctx = Some(codec_ctx);
 
         Ok(())
@@ -393,11 +388,8 @@ impl AudioEncoderInner {
 
                 // Write converted samples into AVAudioFifo.
                 // SAFETY: av_frame data buffers were allocated by convert_audio_frame
-                let write_result = swresample::audio_fifo::write(
-                    self.fifo,
-                    (*av_frame.as_ptr()).data.as_ptr().cast::<*mut c_void>(),
-                    nb_samples,
-                );
+                let write_result =
+                    swresample::audio_fifo::write_frame(self.fifo, &av_frame, nb_samples);
 
                 write_result.map_err(|e| EncodeError::Ffmpeg {
                     code: e,
@@ -428,7 +420,7 @@ impl AudioEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(av_frame.as_ptr())
+                    .send_frame_ref(Some(&av_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -463,31 +455,21 @@ impl AudioEncoderInner {
             .as_mut()
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio codec not initialized".to_string(),
-            })?
-            .as_mut_ptr();
+            })?;
 
         let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
             code: 0,
             message: "Cannot allocate frame".to_string(),
         })?;
 
-        // Configure the audio scalar fields from the codec context. These have no
-        // typed setter, so they are written through the frame pointer.
-        // SAFETY: `av_frame` is a valid owned frame; `codec_ctx` is a valid codec
-        //         context; these are plain fields.
-        {
-            let p = av_frame.as_mut_ptr();
-            (*p).format = (*codec_ctx).sample_fmt;
-            (*p).sample_rate = (*codec_ctx).sample_rate;
-            (*p).nb_samples = frame_size;
-            (*p).pts = self.sample_count as i64;
-        }
-
-        swresample::channel_layout::copy(
-            &raw mut (*av_frame.as_mut_ptr()).ch_layout,
-            &raw const (*codec_ctx).ch_layout,
-        )
-        .map_err(EncodeError::from_ffmpeg_error)?;
+        // Configure the audio scalar fields from the codec context.
+        av_frame.set_format(codec_ctx.sample_fmt());
+        av_frame.set_sample_rate(codec_ctx.sample_rate());
+        av_frame.set_nb_samples(frame_size);
+        av_frame.set_pts(self.sample_count as i64);
+        av_frame
+            .set_ch_layout(codec_ctx.ch_layout())
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         av_frame.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
             code: e.code(),
@@ -512,17 +494,14 @@ impl AudioEncoderInner {
         // For zero_pad=true:  FIFO has < frame_size samples → returns < frame_size;
         //                     the zeroed tail provides silence padding.
         // SAFETY: get_buffer allocated the plane buffers; they are large enough
-        swresample::audio_fifo::read(
-            self.fifo,
-            (*av_frame.as_ptr()).data.as_ptr().cast::<*mut c_void>(),
-            frame_size,
-        )
-        .map_err(|e| EncodeError::Ffmpeg {
-            code: e,
-            message: format!(
-                "Failed to read from audio FIFO: {}",
-                ff_sys::av_error_string(e)
-            ),
+        swresample::audio_fifo::read_frame(self.fifo, &mut av_frame, frame_size).map_err(|e| {
+            EncodeError::Ffmpeg {
+                code: e,
+                message: format!(
+                    "Failed to read from audio FIFO: {}",
+                    ff_sys::av_error_string(e)
+                ),
+            }
         })?;
         // nb_samples stays as frame_size: the encoder always receives a full frame.
 
@@ -531,7 +510,7 @@ impl AudioEncoderInner {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio codec not initialized".to_string(),
             })?
-            .send_frame(av_frame.as_ptr())
+            .send_frame_ref(Some(&av_frame))
             .map_err(|e| EncodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(
@@ -558,12 +537,11 @@ impl AudioEncoderInner {
             .as_ref()
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio codec not initialized".to_string(),
-            })?
-            .as_ptr();
+            })?;
 
-        let target_sample_rate = (*codec_ctx).sample_rate;
-        let target_format = (*codec_ctx).sample_fmt;
-        let target_ch_layout = &(*codec_ctx).ch_layout;
+        let target_sample_rate = codec_ctx.sample_rate();
+        let target_format = codec_ctx.sample_fmt();
+        let target_ch_layout = codec_ctx.ch_layout();
 
         // Check if we need to resample
         let src_sample_rate = src.sample_rate() as i32;
@@ -602,22 +580,12 @@ impl AudioEncoderInner {
                 src.samples() as i32,
             );
 
-            // Set frame properties. These audio scalar fields have no typed
-            // setter, so they are written through the frame pointer.
-            // SAFETY: `dst` is a valid owned frame; these are plain fields.
-            {
-                let p = dst.as_mut_ptr();
-                (*p).format = target_format;
-                (*p).sample_rate = target_sample_rate;
-                (*p).nb_samples = out_samples;
-            }
-
-            // Copy target channel layout
-            swresample::channel_layout::copy(
-                &raw mut (*dst.as_mut_ptr()).ch_layout,
-                target_ch_layout,
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
+            // Set frame properties from the encoder's target audio format.
+            dst.set_format(target_format);
+            dst.set_sample_rate(target_sample_rate);
+            dst.set_nb_samples(out_samples);
+            dst.set_ch_layout(target_ch_layout)
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
             // Allocate frame buffer
             dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
@@ -646,25 +614,14 @@ impl AudioEncoderInner {
                 .convert_into_frame(dst, &in_planes, src.samples() as i32)
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-            // SAFETY: `dst` is a valid owned frame; `nb_samples` is a plain field.
-            (*dst.as_mut_ptr()).nb_samples = samples_out;
+            dst.set_nb_samples(samples_out);
         } else {
-            // No resampling needed, direct copy. These audio scalar fields have no
-            // typed setter, so they are written through the frame pointer.
-            // SAFETY: `dst` is a valid owned frame; these are plain fields.
-            {
-                let p = dst.as_mut_ptr();
-                (*p).format = src_format;
-                (*p).sample_rate = src_sample_rate;
-                (*p).nb_samples = src.samples() as i32;
-            }
-
-            // Copy channel layout
-            swresample::channel_layout::copy(
-                &raw mut (*dst.as_mut_ptr()).ch_layout,
-                &raw const src_ch_layout,
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
+            // No resampling needed, direct copy from the source's audio format.
+            dst.set_format(src_format);
+            dst.set_sample_rate(src_sample_rate);
+            dst.set_nb_samples(src.samples() as i32);
+            dst.set_ch_layout(&src_ch_layout)
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
             // Allocate frame buffer
             dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
@@ -713,7 +670,7 @@ impl AudioEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Audio codec not initialized".to_string(),
                 })?
-                .receive_packet(packet.as_mut_ptr());
+                .receive_packet_into(&mut packet);
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -734,21 +691,17 @@ impl AudioEncoderInner {
             }
 
             // Set stream index
-            // SAFETY: `packet` is a valid owned packet; `stream_index` is a plain field.
-            (*packet.as_mut_ptr()).stream_index = self.stream_index;
+            packet.set_stream_index(self.stream_index);
 
             // Write packet
-            let write_ret =
-                av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), packet.as_mut_ptr());
-            if write_ret < 0 {
+            if let Err(e) = self.format_ctx.write_interleaved(&mut packet) {
                 packet.unref();
                 return Err(EncodeError::MuxingFailed {
-                    reason: ff_sys::av_error_string(write_ret),
+                    reason: ff_sys::av_error_string(e.code()),
                 });
             }
 
-            // SAFETY: `packet` is a valid owned packet; `size` is a plain field.
-            self.bytes_written += (*packet.as_ptr()).size as u64;
+            self.bytes_written += packet.size() as u64;
 
             packet.unref();
         }
@@ -774,7 +727,7 @@ impl AudioEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(ptr::null())
+                    .send_frame_ref(None)
                     .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_packets()?;
             }

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -35,8 +35,7 @@ use ff_sys::{
     AVCodecID, AVCodecID_AV_CODEC_ID_BMP, AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_PNG,
     AVCodecID_AV_CODEC_ID_TIFF, AVCodecID_AV_CODEC_ID_WEBP, AVColorRange_AVCOL_RANGE_JPEG,
     AVPixelFormat, AVPixelFormat_AV_PIX_FMT_BGR24, AVPixelFormat_AV_PIX_FMT_RGB24,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, OutputFormatContext, av_interleaved_write_frame,
-    avformat_new_stream, swscale,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, AVRational, OutputFormatContext, swscale,
 };
 
 use crate::EncodeError;
@@ -144,13 +143,10 @@ impl ImageEncoderInner {
         };
 
         // ── Step 2: Video stream ──────────────────────────────────────────────
-        let stream = avformat_new_stream(inner.format_ctx.as_mut_ptr(), ptr::null());
-        if stream.is_null() {
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot create output stream".to_string(),
-            });
-        }
+        let stream_idx = inner
+            .format_ctx
+            .new_stream(None)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Step 3: Configure codec context ──────────────────────────────────
         inner.codec_ctx.set_width(dst_width as i32);
@@ -179,13 +175,10 @@ impl ImageEncoderInner {
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Step 5: Copy parameters to stream ─────────────────────────────────
-        // SAFETY: stream is non-null (checked above); codec_ctx is open.
-        let par = (*stream).codecpar;
-        (*par).codec_id = codec_id;
-        (*par).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-        (*par).width = inner.codec_ctx.width();
-        (*par).height = inner.codec_ctx.height();
-        (*par).format = pix_fmt;
+        inner
+            .format_ctx
+            .apply_stream_params_from_context(stream_idx, &inner.codec_ctx)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Step 8: Open output file ──────────────────────────────────────────
         inner
@@ -272,9 +265,7 @@ impl ImageEncoderInner {
                 let src_stride = src.strides()[i];
                 let plane_data = plane.data();
                 // The destination stride is the frame's own linesize for plane i.
-                // SAFETY: `dst_frame` is a valid get_buffer'd frame; `linesize` is
-                //         a plain field.
-                let dst_stride = (*self.dst_frame.as_ptr()).linesize[i] as usize;
+                let dst_stride = self.dst_frame.linesize(i) as usize;
                 // `video_plane_mut` yields `None` for an absent plane (null data),
                 // matching the previous null-plane break.
                 let Some(dst_plane) = self.dst_frame.video_plane_mut(i) else {
@@ -301,7 +292,7 @@ impl ImageEncoderInner {
 
         // ── Send frame → encoder ──────────────────────────────────────────────
         self.codec_ctx
-            .send_frame(self.dst_frame.as_ptr())
+            .send_frame_ref(Some(&self.dst_frame))
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Receive packets ───────────────────────────────────────────────────
@@ -309,7 +300,7 @@ impl ImageEncoderInner {
 
         // ── Flush encoder ─────────────────────────────────────────────────────
         self.codec_ctx
-            .send_frame(ptr::null())
+            .send_frame_ref(None)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Drain remaining packets ───────────────────────────────────────────
@@ -336,20 +327,15 @@ impl ImageEncoderInner {
         loop {
             match self
                 .codec_ctx
-                .receive_packet(self.packet.as_mut_ptr())
+                .receive_packet_into(&mut self.packet)
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?
             {
                 ff_sys::ReceiveOutcome::Frame => {
-                    // SAFETY: `packet` is a valid owned packet; `stream_index` is a
-                    //         plain field.
-                    (*self.packet.as_mut_ptr()).stream_index = 0;
-                    let ret = av_interleaved_write_frame(
-                        self.format_ctx.as_mut_ptr(),
-                        self.packet.as_mut_ptr(),
-                    );
+                    self.packet.set_stream_index(0);
+                    let ret = self.format_ctx.write_interleaved(&mut self.packet);
                     self.packet.unref();
-                    if ret < 0 {
-                        return Err(EncodeError::from_ffmpeg_error(ret));
+                    if let Err(e) = ret {
+                        return Err(EncodeError::from_ffmpeg_error(e.code()));
                     }
                 }
                 ff_sys::ReceiveOutcome::Drained => break,

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -25,10 +25,9 @@ use std::time::Duration;
 
 use ff_sys::{
     AVCodecID_AV_CODEC_ID_GIF, AVCodecID_AV_CODEC_ID_PNG, AVPixelFormat_AV_PIX_FMT_RGB24,
-    AVRational, OutputFormatContext, av_interleaved_write_frame, av_opt_set, av_packet_unref,
-    avfilter_get_by_name, avfilter_graph_alloc, avfilter_graph_config,
-    avfilter_graph_create_filter, avfilter_graph_free, avfilter_link, avformat,
-    avformat_new_stream,
+    AVRational, OutputFormatContext, avfilter_get_by_name, avfilter_graph_alloc,
+    avfilter_graph_config, avfilter_graph_create_filter, avfilter_graph_free, avfilter_link,
+    avformat,
 };
 
 use crate::PreviewImageError;
@@ -282,7 +281,7 @@ unsafe fn generate_sprite_sheet_unsafe(
 
     // ── Step 4: encode the tile frame as PNG ──────────────────────────────────
     let encode_result = encode_frame_as_png(
-        tile_frame.as_mut_ptr(),
+        &mut tile_frame,
         output,
         cols,
         rows,
@@ -304,14 +303,14 @@ unsafe fn generate_sprite_sheet_unsafe(
     Ok(())
 }
 
-/// Encodes a raw `*mut AVFrame` as a PNG file at `output`.
+/// Encodes an owned [`ff_sys::Frame`] as a PNG file at `output`.
 ///
 /// # Safety
 ///
-/// `frame` must be a valid, non-null frame produced by the tile filter.
+/// `frame` must be a valid frame produced by the tile filter.
 /// All allocations are freed on every exit path.
 unsafe fn encode_frame_as_png(
-    frame: *mut ff_sys::AVFrame,
+    frame: &mut ff_sys::Frame,
     output: &Path,
     cols: u32,
     rows: u32,
@@ -320,9 +319,9 @@ unsafe fn encode_frame_as_png(
 ) -> Result<(), PreviewImageError> {
     let _ = (cols, rows, frame_width, frame_height); // used via frame dimensions
 
-    let width = (*frame).width;
-    let height = (*frame).height;
-    let src_pix_fmt = (*frame).format;
+    let width = frame.width();
+    let height = frame.height();
+    let src_pix_fmt = frame.format();
 
     // ── Convert to rgb24 if the frame pixel format is not PNG-compatible ──────
     // PNG encoder only accepts: rgb24, rgba, rgb48be, rgba64be, pal8, gray, …
@@ -339,8 +338,7 @@ unsafe fn encode_frame_as_png(
         cf.set_format(AVPixelFormat_AV_PIX_FMT_RGB24);
         cf.get_buffer(0)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        // SAFETY: src_pix_fmt and AVPixelFormat_AV_PIX_FMT_RGB24 are valid;
-        // frame and cf buffers are allocated and large enough.
+        // `sws_ctx` and `cf` drop on any `?` below, freeing their resources.
         let mut sws_ctx = ff_sys::ScaleContext::new(
             width,
             height,
@@ -351,26 +349,16 @@ unsafe fn encode_frame_as_png(
             ff_sys::swscale::scale_flags::BILINEAR,
         )
         .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        let cf_ptr = cf.as_mut_ptr();
-        // sws_ctx drops at the end of this scope, freeing the context;
-        // `cf` drops on any `?` above/below, freeing the conversion frame.
         sws_ctx
-            .scale(
-                (*frame).data.as_ptr().cast::<*const u8>(),
-                (*frame).linesize.as_ptr(),
-                0,
-                height,
-                (*cf_ptr).data.as_mut_ptr().cast_const(),
-                (*cf_ptr).linesize.as_mut_ptr(),
-            )
+            .scale_frames(frame, &mut cf)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
         Some(cf)
     } else {
         None
     };
 
-    let converted_frame: *mut ff_sys::AVFrame = match cf_owned.as_mut() {
-        Some(cf) => cf.as_mut_ptr(),
+    let converted_frame: &mut ff_sys::Frame = match cf_owned.as_mut() {
+        Some(cf) => cf,
         None => frame,
     };
 
@@ -385,7 +373,7 @@ unsafe fn encode_frame_as_png(
 /// `frame` must be a valid, non-null rgb24 frame with matching `width`/`height`.
 /// All allocations are freed on every exit path.
 unsafe fn encode_frame_as_png_inner(
-    frame: *mut ff_sys::AVFrame,
+    frame: &mut ff_sys::Frame,
     output: &Path,
     width: i32,
     height: i32,
@@ -402,13 +390,9 @@ unsafe fn encode_frame_as_png_inner(
         .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     // ── Create video stream ───────────────────────────────────────────────────
-    let stream = avformat_new_stream(fmt_ctx.as_mut_ptr(), ptr::null());
-    if stream.is_null() {
-        return Err(PreviewImageError::Ffmpeg {
-            code: 0,
-            message: "avformat_new_stream failed".to_string(),
-        });
-    }
+    let stream_idx = fmt_ctx
+        .new_stream(None)
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     // ── Find and open PNG encoder ─────────────────────────────────────────────
     let Some(codec) = ff_sys::Codec::find_encoder(AVCodecID_AV_CODEC_ID_PNG) else {
@@ -429,14 +413,11 @@ unsafe fn encode_frame_as_png_inner(
         .open(codec, ptr::null_mut())
         .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
-    // Copy codec parameters to stream.
-    // SAFETY: stream and codec_ctx are non-null.
-    let par = (*stream).codecpar;
-    (*par).codec_id = AVCodecID_AV_CODEC_ID_PNG;
-    (*par).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-    (*par).width = width;
-    (*par).height = height;
-    (*par).format = pix_fmt;
+    // Copy codec parameters to stream (includes width/height/format from the
+    // opened PNG encoder context).
+    fmt_ctx
+        .apply_stream_params_from_context(stream_idx, &codec_ctx)
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     // ── Open output IO and write header ───────────────────────────────────────
     fmt_ctx
@@ -456,27 +437,17 @@ unsafe fn encode_frame_as_png_inner(
     };
 
     // ── Encode: send frame → flush → drain packets ────────────────────────────
-    (*frame).pts = 0;
+    frame.set_pts(0);
 
     let encode_result = (|| -> Result<(), PreviewImageError> {
         codec_ctx
-            .send_frame(frame)
+            .send_frame_ref(Some(&*frame))
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(
-            &mut codec_ctx,
-            fmt_ctx.as_mut_ptr(),
-            packet.as_mut_ptr(),
-            false,
-        )?;
+        drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, false)?;
         codec_ctx
-            .send_frame(ptr::null())
+            .send_frame_ref(None)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(
-            &mut codec_ctx,
-            fmt_ctx.as_mut_ptr(),
-            packet.as_mut_ptr(),
-            true,
-        )?;
+        drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, true)?;
         Ok(())
     })();
 
@@ -495,24 +466,24 @@ unsafe fn encode_frame_as_png_inner(
 ///
 /// # Safety
 ///
-/// `codec_ctx`, `fmt_ctx`, and `packet` must all be valid non-null pointers.
+/// `codec_ctx`, `fmt_ctx`, and `packet` must all be valid.
 unsafe fn drain_packets(
     codec_ctx: &mut ff_sys::CodecContext,
-    fmt_ctx: *mut ff_sys::AVFormatContext,
-    packet: *mut ff_sys::AVPacket,
+    fmt_ctx: &mut ff_sys::OutputFormatContext,
+    packet: &mut ff_sys::Packet,
     until_eof: bool,
 ) -> Result<(), PreviewImageError> {
     loop {
         match codec_ctx
-            .receive_packet(packet)
+            .receive_packet_into(packet)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?
         {
             ff_sys::ReceiveOutcome::Frame => {
-                (*packet).stream_index = 0;
-                let ret = av_interleaved_write_frame(fmt_ctx, packet);
-                av_packet_unref(packet);
-                if ret < 0 {
-                    return Err(PreviewImageError::from_ffmpeg_error(ret));
+                packet.set_stream_index(0);
+                let ret = fmt_ctx.write_interleaved(packet);
+                packet.unref();
+                if let Err(e) = ret {
+                    return Err(PreviewImageError::from_ffmpeg_error(e.code()));
                 }
             }
             ff_sys::ReceiveOutcome::Drained => break,
@@ -823,7 +794,7 @@ unsafe fn generate_palette_unsafe(
     };
 
     // Save the palette frame to disk as PNG; `palette_frame` drops at end of scope.
-    encode_frame_as_png(palette_frame.as_mut_ptr(), palette_path, 0, 0, 0, 0)
+    encode_frame_as_png(&mut palette_frame, palette_path, 0, 0, 0, 0)
 }
 
 /// Pass 2: composes the GIF from the video + palette and encodes it.
@@ -1082,15 +1053,14 @@ unsafe fn encode_gif_unsafe(
         }
     };
 
-    let stream = avformat_new_stream(fmt_ctx.as_mut_ptr(), ptr::null());
-    if stream.is_null() {
-        let mut g = graph;
-        avfilter_graph_free(std::ptr::addr_of_mut!(g));
-        return Err(PreviewImageError::Ffmpeg {
-            code: 0,
-            message: "avformat_new_stream failed".to_string(),
-        });
-    }
+    let stream_idx = match fmt_ctx.new_stream(None) {
+        Ok(idx) => idx,
+        Err(e) => {
+            let mut g = graph;
+            avfilter_graph_free(std::ptr::addr_of_mut!(g));
+            return Err(PreviewImageError::from_ffmpeg_error(e.code()));
+        }
+    };
 
     let Some(codec) = ff_sys::Codec::find_encoder(AVCodecID_AV_CODEC_ID_GIF) else {
         let mut g = graph;
@@ -1146,14 +1116,8 @@ unsafe fn encode_gif_unsafe(
     });
     codec_ctx.set_pix_fmt(out_pix_fmt);
 
-    // Set GIF to loop infinitely (option "loop" = 0).
-    // SAFETY: priv_data is valid after alloc_context3; av_opt_set handles unknown options gracefully.
-    let _ = av_opt_set(
-        (*codec_ctx.as_mut_ptr()).priv_data.cast(),
-        c"loop".as_ptr(),
-        c"0".as_ptr(),
-        0,
-    );
+    // Set GIF to loop infinitely (option "loop" = 0); unknown options are ignored.
+    let _ = codec_ctx.set_opt("loop", "0");
 
     if let Err(e) = codec_ctx.open(codec, ptr::null_mut()) {
         let mut g = graph;
@@ -1161,14 +1125,13 @@ unsafe fn encode_gif_unsafe(
         return Err(PreviewImageError::from_ffmpeg_error(e.code()));
     }
 
-    // Copy codec parameters to stream.
-    // SAFETY: stream, codec_ctx, codecpar are non-null.
-    let par = (*stream).codecpar;
-    (*par).codec_id = AVCodecID_AV_CODEC_ID_GIF;
-    (*par).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-    (*par).width = out_width;
-    (*par).height = out_height;
-    (*par).format = out_pix_fmt;
+    // Copy codec parameters to stream (width/height/format from the opened
+    // GIF encoder context).
+    if let Err(e) = fmt_ctx.apply_stream_params_from_context(stream_idx, &codec_ctx) {
+        let mut g = graph;
+        avfilter_graph_free(std::ptr::addr_of_mut!(g));
+        return Err(PreviewImageError::from_ffmpeg_error(e.code()));
+    }
 
     // Open output IO and write header.
     if let Err(e) = fmt_ctx.open_io(output) {
@@ -1200,14 +1163,9 @@ unsafe fn encode_gif_unsafe(
         first_frame.set_pts(frame_counter);
         frame_counter += 1;
         codec_ctx
-            .send_frame(first_frame.as_ptr())
+            .send_frame_ref(Some(&first_frame))
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(
-            &mut codec_ctx,
-            fmt_ctx.as_mut_ptr(),
-            packet.as_mut_ptr(),
-            false,
-        )?;
+        drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, false)?;
 
         // Pull and encode remaining frames.
         loop {
@@ -1225,26 +1183,16 @@ unsafe fn encode_gif_unsafe(
             frame_counter += 1;
             // `frame` drops at end of iteration (or on the `?` below), freeing it.
             codec_ctx
-                .send_frame(frame.as_ptr())
+                .send_frame_ref(Some(&frame))
                 .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-            drain_packets(
-                &mut codec_ctx,
-                fmt_ctx.as_mut_ptr(),
-                packet.as_mut_ptr(),
-                false,
-            )?;
+            drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, false)?;
         }
 
         // Flush encoder.
         codec_ctx
-            .send_frame(ptr::null())
+            .send_frame_ref(None)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
-        drain_packets(
-            &mut codec_ctx,
-            fmt_ctx.as_mut_ptr(),
-            packet.as_mut_ptr(),
-            true,
-        )?;
+        drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, true)?;
         Ok(())
     })();
 

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -18,8 +18,7 @@ use super::options::audio_codec_to_id;
 use super::two_pass::AV_CODEC_FLAG_PASS1;
 use super::{
     AV_TIME_BASE, AVChapter, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P,
-    AudioCodec, EncodeError, VideoCodec, VideoEncoderInner, av_interleaved_write_frame, av_mallocz,
-    avformat_new_stream, ptr,
+    AudioCodec, EncodeError, VideoCodec, VideoEncoderInner, av_mallocz, avformat_new_stream, ptr,
 };
 
 impl VideoEncoderInner {
@@ -308,28 +307,21 @@ impl VideoEncoderInner {
              pix_fmt={actual_pix_fmt}"
         );
 
-        // Create stream
-        let stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), codec_ptr);
-        if stream.is_null() {
-            // The owned codec_ctx frees itself on return.
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot create stream".to_string(),
-            });
-        }
+        // Create stream. The owned codec_ctx frees itself if this returns.
+        let stream_idx = self
+            .format_ctx
+            .new_stream(Some(&selected_codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        (*stream).time_base = codec_ctx.time_base();
+        self.format_ctx
+            .set_stream_time_base(stream_idx, codec_ctx.time_base());
 
-        // Copy codec parameters to stream
-        if !(*stream).codecpar.is_null() {
-            (*(*stream).codecpar).codec_id = codec_ctx.codec_id();
-            (*(*stream).codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO;
-            (*(*stream).codecpar).width = codec_ctx.width();
-            (*(*stream).codecpar).height = codec_ctx.height();
-            (*(*stream).codecpar).format = codec_ctx.pix_fmt();
-        }
+        // Copy all codec parameters (including extradata) to the stream.
+        self.format_ctx
+            .apply_stream_params_from_context(stream_idx, &codec_ctx)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        self.video_stream_index = (self.format_ctx.nb_streams() - 1) as i32;
+        self.video_stream_index = stream_idx as i32;
 
         // In two-pass mode the pass-1 context is stored separately; the real
         // (pass-2) video_codec_ctx is initialised later in run_pass2().
@@ -423,17 +415,14 @@ impl VideoEncoderInner {
             .open(selected_codec, ptr::null_mut())
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        // Create stream
-        let stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), codec_ptr);
-        if stream.is_null() {
-            // The owned codec_ctx frees itself on return.
-            return Err(EncodeError::Ffmpeg {
-                code: 0,
-                message: "Cannot create stream".to_string(),
-            });
-        }
+        // Create stream. The owned codec_ctx frees itself if this returns.
+        let stream_idx = self
+            .format_ctx
+            .new_stream(Some(&selected_codec))
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-        (*stream).time_base = codec_ctx.time_base();
+        self.format_ctx
+            .set_stream_time_base(stream_idx, codec_ctx.time_base());
 
         // Copy all codec parameters to the stream — including extradata (e.g. AAC
         // AudioSpecificConfig) that is only available after avcodec_open2.
@@ -441,18 +430,16 @@ impl VideoEncoderInner {
         // ensures extradata, frame_size, channel layout, and codec_tag are all
         // propagated correctly so container muxers and hardware decoders can
         // identify and decode the stream.
-        if !(*stream).codecpar.is_null() {
-            codec_ctx
-                .parameters_from_context((*stream).codecpar)
-                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
-        }
+        self.format_ctx
+            .apply_stream_params_from_context(stream_idx, &codec_ctx)
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Read the FIFO parameters before moving the owned context into `self`.
         let frame_size = codec_ctx.frame_size();
         let fifo_sample_fmt = codec_ctx.sample_fmt();
         let fifo_nb_channels = codec_ctx.channels();
 
-        self.audio_stream_index = (self.format_ctx.nb_streams() - 1) as i32;
+        self.audio_stream_index = stream_idx as i32;
         self.audio_codec_ctx = Some(codec_ctx);
 
         // Allocate sample FIFO for codecs that require a fixed frame_size (AAC, FLAC, ALAC …).
@@ -624,10 +611,11 @@ impl VideoEncoderInner {
             return;
         }
 
-        // SAFETY: source_stream_index < nb_streams; streams is a valid array.
-        let in_stream = *(*src_ctx.as_ptr()).streams.add(source_stream_index);
+        let Some(in_stream) = src_ctx.stream(source_stream_index) else {
+            return;
+        };
 
-        if (*(*in_stream).codecpar).codec_type != AVMediaType_AVMEDIA_TYPE_SUBTITLE {
+        if in_stream.codecpar().codec_type() != AVMediaType_AVMEDIA_TYPE_SUBTITLE {
             log::warn!(
                 "subtitle_passthrough: stream at index {source_stream_index} \
                  is not a subtitle stream"
@@ -637,25 +625,24 @@ impl VideoEncoderInner {
 
         // Record the output stream index before adding the new stream.
         let out_stream_index = self.format_ctx.nb_streams() as i32;
-        // SAFETY: format_ctx is valid; null codec means the muxer selects a default.
-        let out_stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), std::ptr::null());
-        if out_stream.is_null() {
+        // A null codec means the muxer selects a default for the copied stream.
+        let Ok(new_idx) = self.format_ctx.new_stream(None) else {
             log::warn!("subtitle_passthrough: avformat_new_stream failed");
             return;
-        }
+        };
 
-        // SAFETY: out_stream and in_stream->codecpar are valid non-null pointers.
-        let ret = ff_sys::avcodec_parameters_copy((*out_stream).codecpar, (*in_stream).codecpar);
-        if ret < 0 {
+        // Copy the source codec parameters into the new stream (also clears
+        // codec_tag so the muxer picks the container's value).
+        if let Err(e) = self
+            .format_ctx
+            .copy_stream_params(new_idx, in_stream.codecpar())
+        {
             log::warn!(
                 "subtitle_passthrough: avcodec_parameters_copy failed error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
             return;
         }
-
-        // Reset codec_tag so the muxer can pick the appropriate value for the container.
-        (*(*out_stream).codecpar).codec_tag = 0;
 
         self.subtitle_passthrough = Some((
             source_path.to_string(),
@@ -710,15 +697,13 @@ impl VideoEncoderInner {
             return Ok(());
         }
 
-        // SAFETY: source_stream_index was validated in init_subtitle_passthrough.
-        let in_stream = *(*src_ctx.as_ptr()).streams.add(source_stream_index);
-        let in_time_base = (*in_stream).time_base;
+        // source_stream_index was validated in init_subtitle_passthrough.
+        let Some(in_time_base) = src_ctx.stream(source_stream_index).map(|s| s.time_base()) else {
+            return Ok(());
+        };
 
-        // SAFETY: out_stream_index was set by avformat_new_stream; format_ctx is valid.
-        let out_stream = *(*self.format_ctx.as_mut_ptr())
-            .streams
-            .add(out_stream_index as usize);
-        let out_time_base = (*out_stream).time_base;
+        // out_stream_index was set by new_stream when the output stream was added.
+        let out_time_base = self.format_ctx.stream_time_base(out_stream_index as usize);
 
         let Ok(mut pkt) = ff_sys::Packet::new() else {
             return Err(EncodeError::Ffmpeg {
@@ -741,34 +726,28 @@ impl VideoEncoderInner {
                 Ok(()) => {}
             }
 
-            // This is a demux-input packet; its fields have no typed accessor and
-            // are read/written through the packet pointer.
-            let p = pkt.as_mut_ptr();
-
             // Skip packets from other streams.
-            if (*p).stream_index != source_stream_index as i32 {
+            if pkt.stream_index() != source_stream_index as i32 {
                 pkt.unref();
                 continue;
             }
 
             // Rescale timestamps from the source stream's time base to the output stream's.
-            // SAFETY: pkt is valid; time bases are plain value types.
-            ff_sys::av_packet_rescale_ts(p, in_time_base, out_time_base);
-            (*p).stream_index = out_stream_index;
+            pkt.rescale_ts(in_time_base, out_time_base);
+            pkt.set_stream_index(out_stream_index);
 
             // SRT/subtitle packets typically carry only PTS (DTS is AV_NOPTS_VALUE).
             // The matroska muxer requires a valid DTS for av_interleaved_write_frame;
             // mirror PTS → DTS when DTS is absent so packets are not silently dropped.
-            if (*p).dts == i64::MIN {
-                (*p).dts = (*p).pts;
+            if pkt.dts() == i64::MIN {
+                pkt.set_dts(pkt.pts());
             }
 
-            let write_ret = av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), p);
-            if write_ret < 0 {
+            if let Err(e) = self.format_ctx.write_interleaved(&mut pkt) {
                 log::warn!(
                     "subtitle_passthrough: av_interleaved_write_frame failed \
                      error={}",
-                    ff_sys::av_error_string(write_ret)
+                    ff_sys::av_error_string(e.code())
                 );
             }
             pkt.unref();

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -12,8 +12,8 @@
 
 use super::color::{pixel_format_to_av, sample_format_to_av};
 use super::{
-    AVChannelLayout, AVCodecContext, AVPixelFormat, AudioFrame, EncodeError, VideoEncoderInner,
-    VideoFrame, av_interleaved_write_frame, swresample,
+    AVChannelLayout, AVPixelFormat, AudioFrame, EncodeError, VideoEncoderInner, VideoFrame,
+    swresample,
 };
 
 /// Maximum number of planes in AVFrame data/linesize arrays.
@@ -42,7 +42,7 @@ impl VideoEncoderInner {
         })?;
 
         loop {
-            match codec_ctx.receive_packet(packet.as_mut_ptr()) {
+            match codec_ctx.receive_packet_into(&mut packet) {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Discard — do not write to the format context.
                     packet.unref();
@@ -84,17 +84,18 @@ impl VideoEncoderInner {
     ///
     /// # Safety
     ///
-    /// The caller must ensure `codec_ctx` is a valid, open `AVCodecContext`; its
-    /// fields are read through the raw pointer. `dst` is a safe owned frame.
+    /// `dst` is a safe owned frame; the target format scalars come from the
+    /// caller's open codec context via the safe accessors.
     pub(super) unsafe fn convert_video_frame(
         &mut self,
         src: &VideoFrame,
         dst: &mut ff_sys::Frame,
-        codec_ctx: *mut AVCodecContext,
+        target_fmt: ff_sys::AVPixelFormat,
+        target_width: std::os::raw::c_int,
+        target_height: std::os::raw::c_int,
     ) -> Result<(), EncodeError> {
-        let target_fmt = (*codec_ctx).pix_fmt;
-        let target_width = (*codec_ctx).width as u32;
-        let target_height = (*codec_ctx).height as u32;
+        let target_width = target_width as u32;
+        let target_height = target_height as u32;
 
         let src_fmt = pixel_format_to_av(src.format());
         let src_width = src.width();
@@ -173,8 +174,7 @@ impl VideoEncoderInner {
 
             let plane_data = plane.data();
             // The destination stride is the frame's own linesize for plane i.
-            // SAFETY: `dst` is a valid get_buffer'd frame; `linesize` is a plain field.
-            let dst_stride = (*dst.as_ptr()).linesize[i] as usize;
+            let dst_stride = dst.linesize(i) as usize;
             // `video_plane_mut` yields `None` for an absent plane (null data),
             // matching the previous null-plane break; it self-sizes to the plane's
             // `linesize * plane_height`, superseding the removed `get_plane_height`.
@@ -265,7 +265,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
                 })?
-                .receive_packet(packet.as_mut_ptr());
+                .receive_packet_into(&mut packet);
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -285,29 +285,29 @@ impl VideoEncoderInner {
                 }
             }
 
-            // Set stream index and, for keyframes, attach HDR10 side data. These
-            // packet fields have no typed accessor, so they are read/written
-            // through the packet pointer.
-            let pkt = packet.as_mut_ptr();
-            (*pkt).stream_index = self.video_stream_index;
+            // Set stream index and, for keyframes, attach HDR10 side data.
+            packet.set_stream_index(self.video_stream_index);
 
             if let Some(ref meta) = self.hdr10_metadata {
                 const AV_PKT_FLAG_KEY: i32 = 1;
-                if (*pkt).flags & AV_PKT_FLAG_KEY != 0 {
+                if packet.flags() & AV_PKT_FLAG_KEY != 0 {
+                    // NOTE(#1555): `attach_hdr10_side_data` still takes a raw
+                    // `*mut AVPacket` (it needs a Packet side-data API). Keep the
+                    // raw pointer for this one call until that API lands.
+                    let pkt = packet.as_mut_ptr();
                     self.attach_hdr10_side_data(pkt, meta);
                 }
             }
 
             // Write packet
-            let write_ret = av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), pkt);
-            if write_ret < 0 {
+            if let Err(e) = self.format_ctx.write_interleaved(&mut packet) {
                 packet.unref();
                 return Err(EncodeError::MuxingFailed {
-                    reason: ff_sys::av_error_string(write_ret),
+                    reason: ff_sys::av_error_string(e.code()),
                 });
             }
 
-            self.bytes_written += (*pkt).size as u64;
+            self.bytes_written += packet.size() as u64;
 
             packet.unref();
         }
@@ -321,17 +321,16 @@ impl VideoEncoderInner {
         src: &AudioFrame,
         dst: &mut ff_sys::Frame,
     ) -> Result<(), EncodeError> {
-        let codec_ctx = self
-            .audio_codec_ctx
-            .as_ref()
-            .ok_or_else(|| EncodeError::InvalidConfig {
-                reason: "Audio codec not initialized".to_string(),
-            })?
-            .as_ptr();
+        let codec_ctx =
+            self.audio_codec_ctx
+                .as_ref()
+                .ok_or_else(|| EncodeError::InvalidConfig {
+                    reason: "Audio codec not initialized".to_string(),
+                })?;
 
-        let target_sample_rate = (*codec_ctx).sample_rate;
-        let target_format = (*codec_ctx).sample_fmt;
-        let target_ch_layout = &(*codec_ctx).ch_layout;
+        let target_sample_rate = codec_ctx.sample_rate();
+        let target_format = codec_ctx.sample_fmt();
+        let target_ch_layout = codec_ctx.ch_layout();
 
         // Check if we need to resample
         let src_sample_rate = src.sample_rate() as i32;
@@ -370,22 +369,12 @@ impl VideoEncoderInner {
                 src.samples() as i32,
             );
 
-            // Set frame properties. These audio scalar fields have no typed
-            // setter, so they are written through the frame pointer.
-            // SAFETY: `dst` is a valid owned frame; these are plain fields.
-            {
-                let p = dst.as_mut_ptr();
-                (*p).format = target_format;
-                (*p).sample_rate = target_sample_rate;
-                (*p).nb_samples = out_samples;
-            }
-
-            // Copy target channel layout
-            swresample::channel_layout::copy(
-                &raw mut (*dst.as_mut_ptr()).ch_layout,
-                target_ch_layout,
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
+            // Set frame properties from the encoder's target audio format.
+            dst.set_format(target_format);
+            dst.set_sample_rate(target_sample_rate);
+            dst.set_nb_samples(out_samples);
+            dst.set_ch_layout(target_ch_layout)
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
             // Allocate frame buffer
             dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
@@ -414,25 +403,14 @@ impl VideoEncoderInner {
                 .convert_into_frame(dst, &in_planes, src.samples() as i32)
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
-            // SAFETY: `dst` is a valid owned frame; `nb_samples` is a plain field.
-            (*dst.as_mut_ptr()).nb_samples = samples_out;
+            dst.set_nb_samples(samples_out);
         } else {
-            // No resampling needed, direct copy. These audio scalar fields have no
-            // typed setter, so they are written through the frame pointer.
-            // SAFETY: `dst` is a valid owned frame; these are plain fields.
-            {
-                let p = dst.as_mut_ptr();
-                (*p).format = src_format;
-                (*p).sample_rate = src_sample_rate;
-                (*p).nb_samples = src.samples() as i32;
-            }
-
-            // Copy channel layout
-            swresample::channel_layout::copy(
-                &raw mut (*dst.as_mut_ptr()).ch_layout,
-                &raw const src_ch_layout,
-            )
-            .map_err(EncodeError::from_ffmpeg_error)?;
+            // No resampling needed, direct copy from the source's audio format.
+            dst.set_format(src_format);
+            dst.set_sample_rate(src_sample_rate);
+            dst.set_nb_samples(src.samples() as i32);
+            dst.set_ch_layout(&src_ch_layout)
+                .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
             // Allocate frame buffer
             dst.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
@@ -481,7 +459,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Audio codec not initialized".to_string(),
                 })?
-                .receive_packet(packet.as_mut_ptr());
+                .receive_packet_into(&mut packet);
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -501,21 +479,18 @@ impl VideoEncoderInner {
                 }
             }
 
-            // Set stream index. This packet field has no typed accessor, so it is
-            // written through the packet pointer.
-            (*packet.as_mut_ptr()).stream_index = self.audio_stream_index;
+            // Set stream index.
+            packet.set_stream_index(self.audio_stream_index);
 
             // Write packet
-            let write_ret =
-                av_interleaved_write_frame(self.format_ctx.as_mut_ptr(), packet.as_mut_ptr());
-            if write_ret < 0 {
+            if let Err(e) = self.format_ctx.write_interleaved(&mut packet) {
                 packet.unref();
                 return Err(EncodeError::MuxingFailed {
-                    reason: ff_sys::av_error_string(write_ret),
+                    reason: ff_sys::av_error_string(e.code()),
                 });
             }
 
-            self.bytes_written += (*packet.as_ptr()).size as u64;
+            self.bytes_written += packet.size() as u64;
 
             packet.unref();
         }

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -28,20 +28,19 @@ pub(super) use two_pass::TwoPassFrame;
 use crate::{AudioCodec, EncodeError, VideoCodec};
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AV_TIME_BASE, AVAudioFifo, AVChannelLayout, AVChapter, AVCodecContext, AVCodecID,
-    AVCodecID_AV_CODEC_ID_AAC, AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC,
-    AVCodecID_AV_CODEC_ID_AV1, AVCodecID_AV_CODEC_ID_DNXHD, AVCodecID_AV_CODEC_ID_DTS,
-    AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FFV1, AVCodecID_AV_CODEC_ID_FLAC,
-    AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC, AVCodecID_AV_CODEC_ID_MJPEG,
-    AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_MPEG2VIDEO, AVCodecID_AV_CODEC_ID_MPEG4,
-    AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
-    AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG, AVCodecID_AV_CODEC_ID_PRORES,
-    AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9,
-    AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPacket,
-    AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+    AV_TIME_BASE, AVAudioFifo, AVChannelLayout, AVChapter, AVCodecID, AVCodecID_AV_CODEC_ID_AAC,
+    AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_AV1,
+    AVCodecID_AV_CODEC_ID_DNXHD, AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3,
+    AVCodecID_AV_CODEC_ID_FFV1, AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_H264,
+    AVCodecID_AV_CODEC_ID_HEVC, AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_MP3,
+    AVCodecID_AV_CODEC_ID_MPEG2VIDEO, AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE,
+    AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE,
+    AVCodecID_AV_CODEC_ID_PNG, AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS,
+    AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9, AVMediaType_AVMEDIA_TYPE_SUBTITLE,
+    AVPacket, AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, OutputFormatContext, av_interleaved_write_frame, av_mallocz,
-    av_packet_new_side_data, avcodec, avformat_new_stream, swresample,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, OutputFormatContext, av_mallocz, av_packet_new_side_data,
+    avcodec, avformat_new_stream, swresample,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -293,13 +292,16 @@ impl VideoEncoderInner {
         unsafe {
             // ── Two-pass path ────────────────────────────────────────────────────
             if self.two_pass {
-                let pass1_ctx = self
-                    .pass1_codec_ctx
-                    .as_mut()
-                    .ok_or_else(|| EncodeError::InvalidConfig {
-                        reason: "Pass-1 codec context not initialized".to_string(),
-                    })?
-                    .as_mut_ptr();
+                // Read the pass-1 codec's target format up front (Copy scalars) so
+                // the `&mut self` convert call does not alias the codec context.
+                let (pass1_fmt, pass1_width, pass1_height) = {
+                    let cc = self.pass1_codec_ctx.as_ref().ok_or_else(|| {
+                        EncodeError::InvalidConfig {
+                            reason: "Pass-1 codec context not initialized".to_string(),
+                        }
+                    })?;
+                    (cc.pix_fmt(), cc.width(), cc.height())
+                };
 
                 // Convert the incoming frame to YUV420P (the pass-1 codec's format).
                 let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
@@ -307,13 +309,19 @@ impl VideoEncoderInner {
                     message: "Cannot allocate frame".to_string(),
                 })?;
 
-                self.convert_video_frame(frame, &mut av_frame, pass1_ctx)?;
+                self.convert_video_frame(
+                    frame,
+                    &mut av_frame,
+                    pass1_fmt,
+                    pass1_width,
+                    pass1_height,
+                )?;
 
                 // Buffer the converted YUV420P data for pass-2 replay. `video_plane`
                 // self-sizes each plane (Y full height, U/V by chroma subsampling)
                 // and yields `None` (→ empty Vec) for an absent plane.
-                let width = (*pass1_ctx).width as u32;
-                let height = (*pass1_ctx).height as u32;
+                let width = pass1_width as u32;
+                let height = pass1_height as u32;
 
                 let planes: Vec<Vec<u8>> = (0..3)
                     .map(|i| {
@@ -324,9 +332,7 @@ impl VideoEncoderInner {
                     })
                     .collect();
 
-                let strides: Vec<usize> = (0..3)
-                    .map(|i| (*av_frame.as_ptr()).linesize[i] as usize)
-                    .collect();
+                let strides: Vec<usize> = (0..3).map(|i| av_frame.linesize(i) as usize).collect();
 
                 self.buffered_frames.push(TwoPassFrame {
                     planes,
@@ -345,7 +351,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Pass-1 codec context not initialized".to_string(),
                     })?
-                    .send_frame(av_frame.as_ptr())
+                    .send_frame_ref(Some(&av_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -365,13 +371,17 @@ impl VideoEncoderInner {
             }
 
             // ── Single-pass path ─────────────────────────────────────────────────
-            let codec_ctx = self
-                .video_codec_ctx
-                .as_mut()
-                .ok_or_else(|| EncodeError::InvalidConfig {
-                    reason: "Video codec not initialized".to_string(),
-                })?
-                .as_mut_ptr();
+            // Read the codec's target format up front (Copy scalars) so the
+            // `&mut self` convert call does not alias the codec context.
+            let (target_fmt, target_width, target_height) = {
+                let cc =
+                    self.video_codec_ctx
+                        .as_ref()
+                        .ok_or_else(|| EncodeError::InvalidConfig {
+                            reason: "Video codec not initialized".to_string(),
+                        })?;
+                (cc.pix_fmt(), cc.width(), cc.height())
+            };
 
             // Allocate AVFrame
             let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
@@ -380,7 +390,13 @@ impl VideoEncoderInner {
             })?;
 
             // Convert VideoFrame to AVFrame
-            self.convert_video_frame(frame, &mut av_frame, codec_ctx)?;
+            self.convert_video_frame(
+                frame,
+                &mut av_frame,
+                target_fmt,
+                target_width,
+                target_height,
+            )?;
 
             // Set frame properties.
             // time_base.den = fps * 1000, so one frame duration = 1000 ticks.
@@ -392,7 +408,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
                 })?
-                .send_frame(av_frame.as_ptr())
+                .send_frame_ref(Some(&av_frame))
                 .map_err(|e| EncodeError::Ffmpeg {
                     code: e.code(),
                     message: format!(
@@ -420,15 +436,15 @@ impl VideoEncoderInner {
     pub(super) fn push_audio_frame(&mut self, frame: &AudioFrame) -> Result<(), EncodeError> {
         // SAFETY: self is properly initialised; all raw FFmpeg pointers are valid and exclusively owned.
         unsafe {
-            let codec_ctx = self
-                .audio_codec_ctx
-                .as_mut()
-                .ok_or_else(|| EncodeError::InvalidConfig {
-                    reason: "Audio codec not initialized".to_string(),
-                })?
-                .as_mut_ptr();
-
-            let frame_size = (*codec_ctx).frame_size;
+            let (frame_size, sample_fmt, sample_rate) = {
+                let cc =
+                    self.audio_codec_ctx
+                        .as_ref()
+                        .ok_or_else(|| EncodeError::InvalidConfig {
+                            reason: "Audio codec not initialized".to_string(),
+                        })?;
+                (cc.frame_size(), cc.sample_fmt(), cc.sample_rate())
+            };
 
             // Allocate and convert incoming frame.
             let mut av_frame = ff_sys::Frame::new().map_err(|_| EncodeError::Ffmpeg {
@@ -445,7 +461,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(av_frame.as_ptr())
+                    .send_frame_ref(Some(&av_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -465,13 +481,9 @@ impl VideoEncoderInner {
 
             // Write converted samples into the FIFO, then let `av_frame` drop.
             {
-                let nb_samples = (*av_frame.as_ptr()).nb_samples;
-                ff_sys::swresample::audio_fifo::write(
-                    fifo,
-                    (*av_frame.as_ptr()).data.as_ptr() as *const *mut _,
-                    nb_samples,
-                )
-                .map_err(EncodeError::from_ffmpeg_error)?;
+                let nb_samples = av_frame.nb_samples();
+                ff_sys::swresample::audio_fifo::write_frame(fifo, &av_frame, nb_samples)
+                    .map_err(EncodeError::from_ffmpeg_error)?;
             }
             drop(av_frame);
 
@@ -481,19 +493,19 @@ impl VideoEncoderInner {
                     code: 0,
                     message: "Cannot allocate audio frame".to_string(),
                 })?;
-                // These audio scalar fields have no typed setter, so they are
-                // written through the frame pointer.
+                out_frame.set_nb_samples(frame_size);
+                out_frame.set_format(sample_fmt);
+                out_frame.set_sample_rate(sample_rate);
                 {
-                    let p = out_frame.as_mut_ptr();
-                    (*p).nb_samples = frame_size;
-                    (*p).format = (*codec_ctx).sample_fmt;
-                    (*p).sample_rate = (*codec_ctx).sample_rate;
+                    let cc = self.audio_codec_ctx.as_ref().ok_or_else(|| {
+                        EncodeError::InvalidConfig {
+                            reason: "Audio codec not initialized".to_string(),
+                        }
+                    })?;
+                    out_frame
+                        .set_ch_layout(cc.ch_layout())
+                        .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 }
-                swresample::channel_layout::copy(
-                    &raw mut (*out_frame.as_mut_ptr()).ch_layout,
-                    &raw const (*codec_ctx).ch_layout,
-                )
-                .map_err(EncodeError::from_ffmpeg_error)?;
 
                 out_frame.get_buffer(0).map_err(|e| EncodeError::Ffmpeg {
                     code: e.code(),
@@ -503,12 +515,8 @@ impl VideoEncoderInner {
                     ),
                 })?;
 
-                ff_sys::swresample::audio_fifo::read(
-                    fifo,
-                    (*out_frame.as_mut_ptr()).data.as_mut_ptr().cast(),
-                    frame_size,
-                )
-                .map_err(EncodeError::from_ffmpeg_error)?;
+                ff_sys::swresample::audio_fifo::read_frame(fifo, &mut out_frame, frame_size)
+                    .map_err(EncodeError::from_ffmpeg_error)?;
 
                 out_frame.set_pts(self.audio_sample_count as i64);
                 self.audio_codec_ctx
@@ -516,7 +524,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(out_frame.as_ptr())
+                    .send_frame_ref(Some(&out_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -549,7 +557,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Video codec not initialized".to_string(),
                     })?
-                    .send_frame(ptr::null())
+                    .send_frame_ref(None)
                     .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_packets()?;
             }
@@ -560,33 +568,28 @@ impl VideoEncoderInner {
             if let Some(fifo) = self.audio_fifo
                 && self.audio_codec_ctx.is_some()
             {
-                let codec_ctx = self
-                    .audio_codec_ctx
-                    .as_mut()
-                    .ok_or_else(|| EncodeError::InvalidConfig {
-                        reason: "Audio codec not initialized".to_string(),
-                    })?
-                    .as_mut_ptr();
+                let (aud_sample_fmt, aud_sample_rate) = {
+                    let cc = self.audio_codec_ctx.as_ref().ok_or_else(|| {
+                        EncodeError::InvalidConfig {
+                            reason: "Audio codec not initialized".to_string(),
+                        }
+                    })?;
+                    (cc.sample_fmt(), cc.sample_rate())
+                };
                 let remaining = ff_sys::swresample::audio_fifo::size(fifo);
                 if remaining > 0
                     && let Ok(mut out_frame) = ff_sys::Frame::new()
                 {
-                    // These audio scalar fields have no typed setter, so they are
-                    // written through the frame pointer.
-                    {
-                        let p = out_frame.as_mut_ptr();
-                        (*p).nb_samples = remaining;
-                        (*p).format = (*codec_ctx).sample_fmt;
-                        (*p).sample_rate = (*codec_ctx).sample_rate;
+                    out_frame.set_nb_samples(remaining);
+                    out_frame.set_format(aud_sample_fmt);
+                    out_frame.set_sample_rate(aud_sample_rate);
+                    if let Some(cc) = self.audio_codec_ctx.as_ref() {
+                        let _ = out_frame.set_ch_layout(cc.ch_layout());
                     }
-                    let _ = swresample::channel_layout::copy(
-                        &raw mut (*out_frame.as_mut_ptr()).ch_layout,
-                        &raw const (*codec_ctx).ch_layout,
-                    );
                     if out_frame.get_buffer(0).is_ok() {
-                        let _ = ff_sys::swresample::audio_fifo::read(
+                        let _ = ff_sys::swresample::audio_fifo::read_frame(
                             fifo,
-                            (*out_frame.as_mut_ptr()).data.as_mut_ptr().cast(),
+                            &mut out_frame,
                             remaining,
                         );
                         out_frame.set_pts(self.audio_sample_count as i64);
@@ -596,7 +599,7 @@ impl VideoEncoderInner {
                             .ok_or_else(|| EncodeError::InvalidConfig {
                                 reason: "Audio codec not initialized".to_string(),
                             })?
-                            .send_frame(out_frame.as_ptr());
+                            .send_frame_ref(Some(&out_frame));
                         let _ = self.receive_audio_packets();
                         self.audio_sample_count += remaining as u64;
                     }
@@ -612,7 +615,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame(ptr::null())
+                    .send_frame_ref(None)
                     .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_audio_packets()?;
             }

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -386,8 +386,7 @@ impl VideoEncoderInner {
             if plane_idx >= 3 || plane_data.is_empty() {
                 break;
             }
-            // SAFETY: `av_frame` is a valid get_buffer'd frame; `linesize` is a plain field.
-            let dst_stride = (*av_frame.as_ptr()).linesize[plane_idx] as usize;
+            let dst_stride = av_frame.linesize(plane_idx) as usize;
             let Some(dst_plane) = av_frame.video_plane_mut(plane_idx) else {
                 break;
             };
@@ -413,7 +412,7 @@ impl VideoEncoderInner {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Video codec not initialized".to_string(),
             })?
-            .send_frame(av_frame.as_ptr())
+            .send_frame_ref(Some(&av_frame))
             .map_err(|e| EncodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(


### PR DESCRIPTION
## Objective

- ff-encode was a large consumer of raw `as_ptr`/`as_mut_ptr`, blocking the #1506 seal that removes the transitional raw escape hatches from the ff-sys RAII types (ADR-0003). This is the staged main body; the non-trivial tail is split out.

## Solution

- Move the audio, video, image and preview encoders off raw FFmpeg field access to the ff-sys safe accessors: `send_frame_ref` / `receive_packet_into` / `write_interleaved` / `new_stream` / `apply_stream_params_from_context` / `set_stream_time_base` / `set_opt`, `Packet::size`/`flags`, `audio_fifo::write_frame`/`read_frame`, the CodecContext getters and Frame setters, `InputFormatContext::stream`.
- Refactor the `drain_packets`, `convert_video_frame` and `encode_frame_as_png` helpers to take borrowed owned types instead of raw pointers.
- The primary image and video streams now copy full encoder parameters via `apply_stream_params_from_context` (including extradata), matching the audio path, instead of a manual codecpar subset.
- The HDR10 side-data, attachment codecpar, and container metadata/chapters helpers need new ff-sys API and stay on raw pointers here; they are completed in #1555, which finishes this issue's acceptance criteria.

Refs #1544
Blocked-by #1555