### PR TITLE
feat(ff-encode/ff-sys): seal the HDR10, attachment, and metadata/chapters paths

### DIFF
--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -17,42 +17,21 @@ use super::color::{
 use super::options::audio_codec_to_id;
 use super::two_pass::AV_CODEC_FLAG_PASS1;
 use super::{
-    AV_TIME_BASE, AVChapter, AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P,
-    AudioCodec, EncodeError, VideoCodec, VideoEncoderInner, av_mallocz, avformat_new_stream, ptr,
+    AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P, AudioCodec, EncodeError,
+    VideoCodec, VideoEncoderInner, ptr,
 };
 
 impl VideoEncoderInner {
-    /// Call `av_dict_set` for each metadata entry before `avformat_write_header`.
-    ///
-    /// # Safety
-    /// `format_ctx` must be a valid non-null pointer to an allocated `AVFormatContext`.
-    /// Must be called before `avformat_write_header`.
-    pub(super) unsafe fn apply_metadata(
-        format_ctx: *mut ff_sys::AVFormatContext,
+    /// Set each container metadata entry before `avformat_write_header`.
+    pub(super) fn apply_metadata(
+        format_ctx: &mut ff_sys::OutputFormatContext,
         metadata: &[(String, String)],
     ) {
         for (key, value) in metadata {
-            let Ok(c_key) = std::ffi::CString::new(key.as_str()) else {
-                log::warn!("metadata key contains null byte, skipping key={key}");
-                continue;
-            };
-            let Ok(c_value) = std::ffi::CString::new(value.as_str()) else {
-                log::warn!("metadata value contains null byte, skipping key={key}");
-                continue;
-            };
-            // SAFETY: format_ctx is valid and non-null. c_key/c_value are valid
-            // CStrings covering this call. av_dict_set copies both strings.
-            let ret = ff_sys::av_dict_set(
-                &raw mut (*format_ctx).metadata,
-                c_key.as_ptr(),
-                c_value.as_ptr(),
-                0,
-            );
-            if ret < 0 {
+            if let Err(e) = format_ctx.set_metadata(key, value) {
                 log::warn!(
-                    "av_dict_set failed for metadata entry, skipping \
-                     key={key} error={}",
-                    ff_sys::av_error_string(ret)
+                    "metadata entry skipped key={key} error={}",
+                    ff_sys::av_error_string(e.code())
                 );
             }
         }
@@ -65,104 +44,43 @@ impl VideoEncoderInner {
     /// on the format context's `priv_data`. This enables CMAF-compatible
     /// fragmented output required for HLS fMP4 segments and MPEG-DASH.
     ///
-    /// # Safety
-    /// `format_ctx` must be a valid non-null pointer to an allocated `AVFormatContext`
-    /// whose `priv_data` is non-null. Must be called before `avformat_write_header`.
-    pub(super) unsafe fn apply_movflags(
-        format_ctx: *mut ff_sys::AVFormatContext,
+    pub(super) fn apply_movflags(
+        format_ctx: &mut ff_sys::OutputFormatContext,
         container: Option<crate::OutputContainer>,
     ) {
-        if container.is_some_and(|c| c.is_fragmented()) {
-            // SAFETY: format_ctx and priv_data are non-null; string literals are
-            // static and NUL-terminated. av_opt_set does not retain the pointers.
-            let ret = ff_sys::av_opt_set(
-                (*format_ctx).priv_data,
-                c"movflags".as_ptr(),
-                c"+frag_keyframe+empty_moov+default_base_moof".as_ptr(),
-                0,
+        if container.is_some_and(|c| c.is_fragmented())
+            && let Err(e) =
+                format_ctx.set_opt(c"movflags", c"+frag_keyframe+empty_moov+default_base_moof")
+        {
+            log::warn!(
+                "av_opt_set movflags failed for fMP4 container error={}",
+                ff_sys::av_error_string(e.code())
             );
-            if ret < 0 {
-                log::warn!(
-                    "av_opt_set movflags failed for fMP4 container error={}",
-                    ff_sys::av_error_string(ret)
-                );
-            }
         }
     }
 
-    /// Allocate `AVChapter` entries on the format context before `avformat_write_header`.
-    ///
-    /// # Safety
-    /// `format_ctx` must be a valid non-null pointer to an allocated `AVFormatContext`.
-    /// Must be called before `avformat_write_header`.
-    pub(super) unsafe fn apply_chapters(
-        format_ctx: *mut ff_sys::AVFormatContext,
+    /// Set the container chapters before `avformat_write_header`.
+    pub(super) fn apply_chapters(
+        format_ctx: &mut ff_sys::OutputFormatContext,
         chapters: &[ff_format::chapter::ChapterInfo],
     ) {
         if chapters.is_empty() {
             return;
         }
-        let n = chapters.len();
-        // SAFETY: allocating an array of n pointers for the chapters field.
-        let chapters_arr =
-            av_mallocz(std::mem::size_of::<*mut AVChapter>() * n) as *mut *mut AVChapter;
-        if chapters_arr.is_null() {
-            log::warn!("av_mallocz failed for chapters array, skipping chapters");
-            return;
-        }
-        (*format_ctx).chapters = chapters_arr;
-        (*format_ctx).nb_chapters = 0;
-
-        for (i, chapter) in chapters.iter().enumerate() {
-            // SAFETY: allocating a zeroed AVChapter struct.
-            let chap = av_mallocz(std::mem::size_of::<AVChapter>()) as *mut AVChapter;
-            if chap.is_null() {
-                log::warn!(
-                    "av_mallocz failed for AVChapter, skipping chapter id={}",
-                    chapter.id()
-                );
-                continue;
-            }
-            // SAFETY: chap is freshly allocated, non-null, and zeroed.
-            (*chap).id = chapter.id();
-            (*chap).time_base = ff_sys::AVRational {
-                num: 1,
-                den: AV_TIME_BASE as i32,
-            };
-            (*chap).start = chapter.start().as_micros() as i64;
-            (*chap).end = chapter.end().as_micros() as i64;
-            (*chap).metadata = std::ptr::null_mut();
-
-            if let Some(title) = chapter.title() {
-                let Ok(c_title) = std::ffi::CString::new(title) else {
-                    log::warn!(
-                        "chapter title contains null byte, skipping title id={}",
-                        chapter.id()
-                    );
-                    // SAFETY: chapters_arr is valid with capacity n.
-                    *chapters_arr.add(i) = chap;
-                    (*format_ctx).nb_chapters += 1;
-                    continue;
-                };
-                // SAFETY: chap->metadata is null; av_dict_set allocates and copies.
-                let ret = ff_sys::av_dict_set(
-                    &raw mut (*chap).metadata,
-                    b"title\0".as_ptr() as *const _,
-                    c_title.as_ptr(),
-                    0,
-                );
-                if ret < 0 {
-                    log::warn!(
-                        "av_dict_set failed for chapter title, skipping title \
-                         id={} error={}",
-                        chapter.id(),
-                        ff_sys::av_error_string(ret)
-                    );
-                }
-            }
-            // SAFETY: i < n so the write is in bounds.
-            *chapters_arr.add(i) = chap;
-            (*format_ctx).nb_chapters += 1;
+        let specs: Vec<ff_sys::ChapterSpec> = chapters
+            .iter()
+            .map(|c| ff_sys::ChapterSpec {
+                id: c.id(),
+                start_us: c.start().as_micros() as i64,
+                end_us: c.end().as_micros() as i64,
+                title: c.title(),
+            })
+            .collect();
+        if let Err(e) = format_ctx.set_chapters(&specs) {
+            log::warn!(
+                "set_chapters failed, skipping chapters error={}",
+                ff_sys::av_error_string(e.code())
+            );
         }
     }
 
@@ -496,69 +414,21 @@ impl VideoEncoderInner {
     ///
     /// Failures per entry are non-fatal: a warning is logged and the entry is
     /// skipped so the rest of encoding can continue.
-    ///
-    /// # Safety
-    ///
-    /// `self.format_ctx` must be a valid, non-null `AVFormatContext` pointer.
-    /// Must be called before `avformat_write_header`.
-    pub(super) unsafe fn init_attachments(&mut self, attachments: &[(Vec<u8>, String, String)]) {
+    pub(super) fn init_attachments(&mut self, attachments: &[(Vec<u8>, String, String)]) {
         for (data, mime_type, filename) in attachments {
-            // Create a new stream for the attachment.
-            // SAFETY: format_ctx is valid; null codec means the muxer selects a default.
-            let out_stream = avformat_new_stream(self.format_ctx.as_mut_ptr(), std::ptr::null());
-            if out_stream.is_null() {
-                log::warn!("attachment: avformat_new_stream failed, skipping filename={filename}");
-                continue;
+            match self
+                .format_ctx
+                .add_attachment_stream(data, mime_type, filename)
+            {
+                Ok(_) => log::info!(
+                    "attachment: registered filename={filename} mime={mime_type} size={}",
+                    data.len()
+                ),
+                Err(e) => log::warn!(
+                    "attachment: registration failed, skipping filename={filename} error={}",
+                    ff_sys::av_error_string(e.code())
+                ),
             }
-
-            let codecpar = (*out_stream).codecpar;
-            (*codecpar).codec_type = ff_sys::AVMediaType_AVMEDIA_TYPE_ATTACHMENT;
-            (*codecpar).codec_id = ff_sys::AVCodecID_AV_CODEC_ID_BIN_DATA;
-
-            // Allocate extradata with FFmpeg's allocator so it can be freed by
-            // avcodec_parameters_free. The padding bytes are zeroed by av_mallocz.
-            let alloc_size = data.len() + ff_sys::AV_INPUT_BUFFER_PADDING_SIZE as usize;
-            let extradata = ff_sys::av_mallocz(alloc_size) as *mut u8;
-            if extradata.is_null() {
-                log::warn!(
-                    "attachment: av_mallocz failed for extradata, skipping filename={filename}"
-                );
-                continue;
-            }
-            // SAFETY: extradata has at least `data.len()` bytes; data slice is valid.
-            std::ptr::copy_nonoverlapping(data.as_ptr(), extradata, data.len());
-            (*codecpar).extradata = extradata;
-            (*codecpar).extradata_size = data.len() as i32;
-
-            // Set stream metadata so the muxer records the filename and MIME type.
-            let Ok(c_filename) = std::ffi::CString::new(filename.as_str()) else {
-                log::warn!("attachment: filename contains null byte, skipping filename={filename}");
-                continue;
-            };
-            let Ok(c_mime) = std::ffi::CString::new(mime_type.as_str()) else {
-                log::warn!(
-                    "attachment: mime_type contains null byte, skipping filename={filename}"
-                );
-                continue;
-            };
-            // SAFETY: out_stream->metadata pointer is valid (initialized by avformat_new_stream).
-            ff_sys::av_dict_set(
-                &raw mut (*out_stream).metadata,
-                b"filename\0".as_ptr() as *const i8,
-                c_filename.as_ptr(),
-                0,
-            );
-            ff_sys::av_dict_set(
-                &raw mut (*out_stream).metadata,
-                b"mimetype\0".as_ptr() as *const i8,
-                c_mime.as_ptr(),
-                0,
-            );
-
-            log::info!(
-                "attachment: registered filename={filename} mime={mime_type} size={}",
-                data.len()
-            );
         }
     }
 

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -291,11 +291,7 @@ impl VideoEncoderInner {
             if let Some(ref meta) = self.hdr10_metadata {
                 const AV_PKT_FLAG_KEY: i32 = 1;
                 if packet.flags() & AV_PKT_FLAG_KEY != 0 {
-                    // NOTE(#1555): `attach_hdr10_side_data` still takes a raw
-                    // `*mut AVPacket` (it needs a Packet side-data API). Keep the
-                    // raw pointer for this one call until that API lands.
-                    let pkt = packet.as_mut_ptr();
-                    self.attach_hdr10_side_data(pkt, meta);
+                    self.attach_hdr10_side_data(&mut packet, meta);
                 }
             }
 

--- a/crates/ff-encode/src/video/encoder_inner/hdr.rs
+++ b/crates/ff-encode/src/video/encoder_inner/hdr.rs
@@ -11,9 +11,8 @@
 #![allow(clippy::unused_self)]
 
 use super::{
-    AVPacket, AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+    AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, VideoEncoderInner,
-    av_packet_new_side_data,
 };
 
 /// FFmpeg `AVContentLightMetadata` — matches the C struct layout.
@@ -56,83 +55,79 @@ impl VideoEncoderInner {
     /// `AV_PKT_DATA_MASTERING_DISPLAY_METADATA` to `pkt`.  Called from
     /// `receive_packets` for every keyframe when `hdr10_metadata` is set.
     ///
-    /// # Safety
-    ///
-    /// `pkt` must be a valid, non-null pointer to an allocated `AVPacket`.
-    pub(super) unsafe fn attach_hdr10_side_data(
+    pub(super) fn attach_hdr10_side_data(
         &self,
-        pkt: *mut AVPacket,
+        pkt: &mut ff_sys::Packet,
         meta: &ff_format::Hdr10Metadata,
     ) {
         // ── Content light level (MaxCLL / MaxFALL) ──────────────────────────
-        let cll_ptr = av_packet_new_side_data(
-            pkt,
+        match pkt.new_side_data(
             AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
             std::mem::size_of::<AvContentLightMetadata>(),
-        );
-        if cll_ptr.is_null() {
-            log::warn!(
+        ) {
+            None => log::warn!(
                 "hdr10 side_data allocation failed, skipping MaxCLL/MaxFALL type=content_light_level"
-            );
-        } else {
-            // SAFETY: av_packet_new_side_data returns memory allocated for exactly
-            // sizeof(AvContentLightMetadata) bytes with alignment suitable for the
-            // data type. We use ptr::write to avoid creating a reference to
-            // potentially-unaligned memory (ptr::write handles any alignment).
-            let cll_value = AvContentLightMetadata {
-                max_cll: u32::from(meta.max_cll),
-                max_fall: u32::from(meta.max_fall),
-            };
-            // SAFETY: write_unaligned does not require the pointer to be aligned;
-            // it copies bytes. FFmpeg's av_packet_new_side_data returns
-            // malloc-aligned memory in practice, but write_unaligned is correct
-            // regardless of alignment.
-            std::ptr::write_unaligned(cll_ptr.cast::<AvContentLightMetadata>(), cll_value);
+            ),
+            Some(buf) => {
+                let cll_value = AvContentLightMetadata {
+                    max_cll: u32::from(meta.max_cll),
+                    max_fall: u32::from(meta.max_fall),
+                };
+                // SAFETY: `buf` is exactly sizeof(AvContentLightMetadata) writable
+                //         bytes; write_unaligned copies the struct with no
+                //         alignment requirement.
+                unsafe {
+                    std::ptr::write_unaligned(
+                        buf.as_mut_ptr().cast::<AvContentLightMetadata>(),
+                        cll_value,
+                    );
+                }
+            }
         }
 
         // ── Mastering display colour volume ─────────────────────────────────
-        let md_ptr = av_packet_new_side_data(
-            pkt,
+        match pkt.new_side_data(
             AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
             std::mem::size_of::<AvMasteringDisplayMetadata>(),
-        );
-        if md_ptr.is_null() {
-            log::warn!(
+        ) {
+            None => log::warn!(
                 "hdr10 side_data allocation failed, skipping mastering display type=mastering_display_metadata"
-            );
-        } else {
-            let d = &meta.mastering_display;
-            let r = |n: u16| ff_sys::AVRational {
-                num: i32::from(n),
-                den: 50000,
-            };
-            let lum = |n: u32| ff_sys::AVRational {
-                num: i32::try_from(n).unwrap_or(i32::MAX),
-                den: 10000,
-            };
-            // SAFETY: av_packet_new_side_data returns memory allocated for exactly
-            // sizeof(AvMasteringDisplayMetadata) bytes. We use ptr::write to safely
-            // write the struct without creating a potentially-unaligned reference.
-            let md_value = AvMasteringDisplayMetadata {
-                // Chromaticity coordinates: denominator = 50000 (CIE 1931 xy).
-                // Order: [R, G, B][x, y]
-                display_primaries: [
-                    [r(d.red_x), r(d.red_y)],
-                    [r(d.green_x), r(d.green_y)],
-                    [r(d.blue_x), r(d.blue_y)],
-                ],
-                white_point: [r(d.white_x), r(d.white_y)],
-                // Luminance: denominator = 10000.
-                min_luminance: lum(d.min_luminance),
-                max_luminance: lum(d.max_luminance),
-                has_primaries: 1,
-                has_luminance: 1,
-            };
-            // SAFETY: write_unaligned does not require the pointer to be aligned;
-            // it copies bytes. FFmpeg's av_packet_new_side_data returns
-            // malloc-aligned memory in practice, but write_unaligned is correct
-            // regardless of alignment.
-            std::ptr::write_unaligned(md_ptr.cast::<AvMasteringDisplayMetadata>(), md_value);
+            ),
+            Some(buf) => {
+                let d = &meta.mastering_display;
+                let r = |n: u16| ff_sys::AVRational {
+                    num: i32::from(n),
+                    den: 50000,
+                };
+                let lum = |n: u32| ff_sys::AVRational {
+                    num: i32::try_from(n).unwrap_or(i32::MAX),
+                    den: 10000,
+                };
+                let md_value = AvMasteringDisplayMetadata {
+                    // Chromaticity coordinates: denominator = 50000 (CIE 1931 xy).
+                    // Order: [R, G, B][x, y]
+                    display_primaries: [
+                        [r(d.red_x), r(d.red_y)],
+                        [r(d.green_x), r(d.green_y)],
+                        [r(d.blue_x), r(d.blue_y)],
+                    ],
+                    white_point: [r(d.white_x), r(d.white_y)],
+                    // Luminance: denominator = 10000.
+                    min_luminance: lum(d.min_luminance),
+                    max_luminance: lum(d.max_luminance),
+                    has_primaries: 1,
+                    has_luminance: 1,
+                };
+                // SAFETY: `buf` is exactly sizeof(AvMasteringDisplayMetadata)
+                //         writable bytes; write_unaligned copies the struct with
+                //         no alignment requirement.
+                unsafe {
+                    std::ptr::write_unaligned(
+                        buf.as_mut_ptr().cast::<AvMasteringDisplayMetadata>(),
+                        md_value,
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -28,19 +28,18 @@ pub(super) use two_pass::TwoPassFrame;
 use crate::{AudioCodec, EncodeError, VideoCodec};
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::{
-    AV_TIME_BASE, AVAudioFifo, AVChannelLayout, AVChapter, AVCodecID, AVCodecID_AV_CODEC_ID_AAC,
-    AVCodecID_AV_CODEC_ID_AC3, AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_AV1,
-    AVCodecID_AV_CODEC_ID_DNXHD, AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3,
-    AVCodecID_AV_CODEC_ID_FFV1, AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_H264,
-    AVCodecID_AV_CODEC_ID_HEVC, AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_MP3,
-    AVCodecID_AV_CODEC_ID_MPEG2VIDEO, AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE,
-    AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE,
-    AVCodecID_AV_CODEC_ID_PNG, AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS,
-    AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9, AVMediaType_AVMEDIA_TYPE_SUBTITLE,
-    AVPacket, AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+    AVAudioFifo, AVChannelLayout, AVCodecID, AVCodecID_AV_CODEC_ID_AAC, AVCodecID_AV_CODEC_ID_AC3,
+    AVCodecID_AV_CODEC_ID_ALAC, AVCodecID_AV_CODEC_ID_AV1, AVCodecID_AV_CODEC_ID_DNXHD,
+    AVCodecID_AV_CODEC_ID_DTS, AVCodecID_AV_CODEC_ID_EAC3, AVCodecID_AV_CODEC_ID_FFV1,
+    AVCodecID_AV_CODEC_ID_FLAC, AVCodecID_AV_CODEC_ID_H264, AVCodecID_AV_CODEC_ID_HEVC,
+    AVCodecID_AV_CODEC_ID_MJPEG, AVCodecID_AV_CODEC_ID_MP3, AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
+    AVCodecID_AV_CODEC_ID_MPEG4, AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS,
+    AVCodecID_AV_CODEC_ID_PCM_S16LE, AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG,
+    AVCodecID_AV_CODEC_ID_PRORES, AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8,
+    AVCodecID_AV_CODEC_ID_VP9, AVMediaType_AVMEDIA_TYPE_SUBTITLE,
+    AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, OutputFormatContext, av_mallocz, av_packet_new_side_data,
-    avcodec, avformat_new_stream, swresample,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, OutputFormatContext, avcodec, swresample,
 };
 use std::ffi::CString;
 use std::ptr;
@@ -262,10 +261,9 @@ impl VideoEncoderInner {
                     })?;
                 }
 
-                let fmt = encoder.format_ctx.as_mut_ptr();
-                Self::apply_movflags(fmt, config.container);
-                Self::apply_metadata(fmt, &config.metadata);
-                Self::apply_chapters(fmt, &config.chapters);
+                Self::apply_movflags(&mut encoder.format_ctx, config.container);
+                Self::apply_metadata(&mut encoder.format_ctx, &config.metadata);
+                Self::apply_chapters(&mut encoder.format_ctx, &config.chapters);
                 encoder
                     .format_ctx
                     .write_header()

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -128,10 +128,9 @@ impl VideoEncoderInner {
             .open_io(&output_path)
             .map_err(|_| EncodeError::CannotCreateFile { path: output_path })?;
 
-        let fmt = self.format_ctx.as_mut_ptr();
-        Self::apply_movflags(fmt, config.container);
-        Self::apply_metadata(fmt, &config.metadata);
-        Self::apply_chapters(fmt, &config.chapters);
+        Self::apply_movflags(&mut self.format_ctx, config.container);
+        Self::apply_metadata(&mut self.format_ctx, &config.metadata);
+        Self::apply_chapters(&mut self.format_ctx, &config.chapters);
         self.format_ctx
             .write_header()
             .map_err(|e| EncodeError::Ffmpeg {

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1621,6 +1621,29 @@ impl OutputFormatContext {
     pub fn write_interleaved(&mut self, _pkt: &mut Packet) -> Result<(), crate::AvError> {
         Err(crate::AvError::new(-1))
     }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn set_metadata(&mut self, _key: &str, _value: &str) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn add_attachment_stream(
+        &mut self,
+        _data: &[u8],
+        _mime_type: &str,
+        _filename: &str,
+    ) -> Result<usize, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn set_chapters(&mut self, _chapters: &[ChapterSpec<'_>]) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
 }
 
 impl Drop for OutputFormatContext {
@@ -1629,6 +1652,14 @@ impl Drop for OutputFormatContext {
 
 // SAFETY: stub; never executed on docs.rs.
 unsafe impl Send for OutputFormatContext {}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ChapterSpec<'a> {
+    pub id: i64,
+    pub start_us: i64,
+    pub end_us: i64,
+    pub title: Option<&'a str>,
+}
 
 // ── Borrowed stream / params stubs (mirror crate::format_context) ─────────────
 
@@ -1919,6 +1950,14 @@ impl Packet {
     pub fn set_duration(&mut self, _duration: i64) {}
 
     pub fn rescale_ts(&mut self, _src_tb: AVRational, _dst_tb: AVRational) {}
+
+    pub fn new_side_data(
+        &mut self,
+        _kind: AVPacketSideDataType,
+        _size: usize,
+    ) -> Option<&mut [u8]> {
+        None
+    }
 
     pub fn unref(&mut self) {}
 

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -11,9 +11,10 @@
 //! muxing context, opens/closes its IO (`pb`), writes the header/trailer, and
 //! frees the context exactly once on drop (closing a caller-opened `pb`),
 //! replacing the manual `avformat_alloc_output_context2` + `avio_open` +
-//! `avformat_free_context` teardown. Like `InputFormatContext`, it exposes a
-//! transitional `as_mut_ptr` for the write path (stream creation, packet
-//! writing) not yet wrapped.
+//! `avformat_free_context` teardown. The write path (stream creation, packet
+//! writing, metadata / attachments / chapters) is exposed through safe methods;
+//! a transitional `as_mut_ptr` remains for the few sites not yet wrapped and is
+//! removed once the safe layer is sealed.
 
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
@@ -23,10 +24,12 @@ use std::ptr::NonNull;
 use std::time::Duration;
 
 use crate::{
-    AVChannelLayout, AVCodecID, AVCodecParameters, AVColorPrimaries, AVColorRange, AVColorSpace,
-    AVFormatContext, AVMediaType, AVRational, AVStream, AvError, Codec, CodecContext, Packet,
-    av_interleaved_write_frame as ffi_av_interleaved_write_frame, av_opt_set as ffi_av_opt_set,
-    avcodec_parameters_copy as ffi_avcodec_parameters_copy,
+    AV_INPUT_BUFFER_PADDING_SIZE, AV_TIME_BASE, AVChannelLayout, AVChapter, AVCodecID,
+    AVCodecID_AV_CODEC_ID_BIN_DATA, AVCodecParameters, AVColorPrimaries, AVColorRange,
+    AVColorSpace, AVDictionary, AVFormatContext, AVMediaType, AVMediaType_AVMEDIA_TYPE_ATTACHMENT,
+    AVRational, AVStream, AvError, Codec, CodecContext, Packet, av_dict_set as ffi_av_dict_set,
+    av_interleaved_write_frame as ffi_av_interleaved_write_frame, av_mallocz as ffi_av_mallocz,
+    av_opt_set as ffi_av_opt_set, avcodec_parameters_copy as ffi_avcodec_parameters_copy,
     avformat_close_input as ffi_avformat_close_input,
     avformat_new_stream as ffi_avformat_new_stream,
 };
@@ -593,6 +596,178 @@ impl OutputFormatContext {
             Ok(())
         }
     }
+
+    /// Sets a container-level metadata entry (`av_dict_set` on the muxer's
+    /// `metadata` dictionary). Call before writing the header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if `key` / `value` contain a NUL byte or the set fails.
+    pub fn set_metadata(&mut self, key: &str, value: &str) -> Result<(), AvError> {
+        let key_c = CString::new(key).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        let value_c = CString::new(value).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        // SAFETY: `self.ptr` is a valid owned mux context; `av_dict_set` copies
+        //         both strings into the context's `metadata` dictionary.
+        let ret = unsafe {
+            ffi_av_dict_set(
+                &raw mut (*self.ptr.as_ptr()).metadata,
+                key_c.as_ptr(),
+                value_c.as_ptr(),
+                0,
+            )
+        };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Adds a binary attachment stream (`AVMEDIA_TYPE_ATTACHMENT` /
+    /// `AV_CODEC_ID_BIN_DATA`), storing `data` in the stream's `extradata` and
+    /// recording `filename` / `mime_type` in its metadata. Returns the new
+    /// stream's index. Call before writing the header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the stream or its `extradata` cannot be
+    /// allocated, or `filename` / `mime_type` contain a NUL byte.
+    pub fn add_attachment_stream(
+        &mut self,
+        data: &[u8],
+        mime_type: &str,
+        filename: &str,
+    ) -> Result<usize, AvError> {
+        // Reject attachments too large for `extradata_size` (a `c_int`) before
+        // allocating anything, so the field never wraps to a negative value.
+        let extradata_size =
+            c_int::try_from(data.len()).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        let filename_c =
+            CString::new(filename).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        let mime_c =
+            CString::new(mime_type).map_err(|_| AvError::new(crate::error_codes::EINVAL))?;
+        // SAFETY: `self.ptr` is a valid owned mux context. A null codec lets the
+        //         muxer pick a default; the returned stream and its `codecpar`
+        //         are owned by the context. `extradata` is `av_mallocz`'d (owned
+        //         by the codecpar, freed with it) with the required trailing
+        //         padding, and `data` is copied into its leading bytes.
+        unsafe {
+            let stream = ffi_avformat_new_stream(self.ptr.as_ptr(), std::ptr::null());
+            if stream.is_null() {
+                return Err(AvError::new(crate::error_codes::ENOMEM));
+            }
+            let codecpar = (*stream).codecpar;
+            (*codecpar).codec_type = AVMediaType_AVMEDIA_TYPE_ATTACHMENT;
+            (*codecpar).codec_id = AVCodecID_AV_CODEC_ID_BIN_DATA;
+
+            let alloc_size = data.len() + AV_INPUT_BUFFER_PADDING_SIZE as usize;
+            let extradata = ffi_av_mallocz(alloc_size).cast::<u8>();
+            if extradata.is_null() {
+                return Err(AvError::new(crate::error_codes::ENOMEM));
+            }
+            std::ptr::copy_nonoverlapping(data.as_ptr(), extradata, data.len());
+            (*codecpar).extradata = extradata;
+            (*codecpar).extradata_size = extradata_size;
+
+            ffi_av_dict_set(
+                &raw mut (*stream).metadata,
+                c"filename".as_ptr(),
+                filename_c.as_ptr(),
+                0,
+            );
+            ffi_av_dict_set(
+                &raw mut (*stream).metadata,
+                c"mimetype".as_ptr(),
+                mime_c.as_ptr(),
+                0,
+            );
+        }
+        Ok(self.nb_streams() as usize - 1)
+    }
+
+    /// Sets the container's chapters, allocating the `AVChapter` array with
+    /// FFmpeg's allocator (owned by the context, freed on drop). Chapter times
+    /// are in microseconds (`AV_TIME_BASE` units). Call before writing the header.
+    ///
+    /// Per-chapter allocation / NUL-byte-title failures are logged and skipped;
+    /// the array is compacted so it holds exactly `nb_chapters` entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the top-level chapter array cannot be allocated.
+    pub fn set_chapters(&mut self, chapters: &[ChapterSpec<'_>]) -> Result<(), AvError> {
+        if chapters.is_empty() {
+            return Ok(());
+        }
+        // SAFETY: `self.ptr` is a valid owned mux context. The chapter pointer
+        //         array and each `AVChapter` are `av_mallocz`'d (owned by the
+        //         context, freed by `avformat_free_context` on drop). We write
+        //         each successful chapter at the running `nb_chapters` index so
+        //         the array is compact (no null gaps).
+        unsafe {
+            let ctx = self.ptr.as_ptr();
+            let arr = ffi_av_mallocz(std::mem::size_of::<*mut AVChapter>() * chapters.len())
+                .cast::<*mut AVChapter>();
+            if arr.is_null() {
+                return Err(AvError::new(crate::error_codes::ENOMEM));
+            }
+            (*ctx).chapters = arr;
+            (*ctx).nb_chapters = 0;
+
+            for spec in chapters {
+                let chap = ffi_av_mallocz(std::mem::size_of::<AVChapter>()).cast::<AVChapter>();
+                if chap.is_null() {
+                    log::warn!(
+                        "av_mallocz failed for AVChapter, skipping chapter id={}",
+                        spec.id
+                    );
+                    continue;
+                }
+                (*chap).id = spec.id;
+                (*chap).time_base = AVRational {
+                    num: 1,
+                    den: AV_TIME_BASE as c_int,
+                };
+                (*chap).start = spec.start_us;
+                (*chap).end = spec.end_us;
+                (*chap).metadata = std::ptr::null_mut::<AVDictionary>();
+
+                if let Some(title) = spec.title {
+                    if let Ok(title_c) = CString::new(title) {
+                        ffi_av_dict_set(
+                            &raw mut (*chap).metadata,
+                            c"title".as_ptr(),
+                            title_c.as_ptr(),
+                            0,
+                        );
+                    } else {
+                        log::warn!(
+                            "chapter title contains a NUL byte, skipping title id={}",
+                            spec.id
+                        );
+                    }
+                }
+                *arr.add((*ctx).nb_chapters as usize) = chap;
+                (*ctx).nb_chapters += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A chapter to write into an [`OutputFormatContext`] via
+/// [`set_chapters`](OutputFormatContext::set_chapters). Times are in
+/// microseconds (`AV_TIME_BASE` units).
+#[derive(Clone, Copy, Debug)]
+pub struct ChapterSpec<'a> {
+    /// Chapter id.
+    pub id: i64,
+    /// Start time in microseconds.
+    pub start_us: i64,
+    /// End time in microseconds.
+    pub end_us: i64,
+    /// Optional chapter title.
+    pub title: Option<&'a str>,
 }
 
 impl Drop for OutputFormatContext {
@@ -834,5 +1009,45 @@ mod tests {
         // The codec-parameter copy's out-of-range index guard returns Err, not a panic.
         let cc = CodecContext::new(None).expect("codec context alloc should succeed");
         assert!(ctx.apply_stream_params_from_context(99, &cc).is_err());
+    }
+
+    #[test]
+    fn metadata_attachment_and_chapters_should_apply() {
+        // Exercises set_metadata / add_attachment_stream / set_chapters. These set
+        // context/stream fields (no header write), so any file muxer works; skip
+        // gracefully if mp4 is absent from a minimal FFmpeg build.
+        let Ok(mut ctx) = OutputFormatContext::new(None, Path::new("out.mp4")) else {
+            return;
+        };
+
+        ctx.set_metadata("title", "test")
+            .expect("set_metadata should succeed");
+        // A NUL byte in the key is rejected without panicking.
+        assert!(ctx.set_metadata("k\0", "v").is_err());
+
+        let idx = ctx
+            .add_attachment_stream(b"font-bytes", "application/x-font", "font.ttf")
+            .expect("add_attachment_stream should allocate a stream");
+        assert_eq!(ctx.nb_streams(), idx as u32 + 1);
+        // A NUL byte in the filename is rejected without panicking.
+        assert!(ctx.add_attachment_stream(b"x", "m", "f\0").is_err());
+
+        // Empty chapters is a no-op Ok; a non-empty set allocates and compacts.
+        ctx.set_chapters(&[]).expect("empty chapters is Ok");
+        ctx.set_chapters(&[
+            ChapterSpec {
+                id: 0,
+                start_us: 0,
+                end_us: 1_000_000,
+                title: Some("Intro"),
+            },
+            ChapterSpec {
+                id: 1,
+                start_us: 1_000_000,
+                end_us: 2_000_000,
+                title: None,
+            },
+        ])
+        .expect("set_chapters should allocate");
     }
 }

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -80,7 +80,9 @@ pub use codec_context::{CodecContext, ReceiveOutcome};
 pub use constants::{AV_NOPTS_VALUE, AVFMT_NOFILE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
 pub use error::AvError;
 #[cfg(not(docsrs))]
-pub use format_context::{CodecParameters, InputFormatContext, OutputFormatContext, StreamRef};
+pub use format_context::{
+    ChapterSpec, CodecParameters, InputFormatContext, OutputFormatContext, StreamRef,
+};
 #[cfg(not(docsrs))]
 pub use frame::Frame;
 #[cfg(not(docsrs))]

--- a/crates/ff-sys/src/packet.rs
+++ b/crates/ff-sys/src/packet.rs
@@ -9,9 +9,10 @@
 use std::ptr::NonNull;
 
 use crate::{
-    AVPacket, AVRational, AvError, av_packet_alloc as ffi_av_packet_alloc,
-    av_packet_free as ffi_av_packet_free, av_packet_ref as ffi_av_packet_ref,
-    av_packet_rescale_ts as ffi_av_packet_rescale_ts, av_packet_unref as ffi_av_packet_unref,
+    AVPacket, AVPacketSideDataType, AVRational, AvError, av_packet_alloc as ffi_av_packet_alloc,
+    av_packet_free as ffi_av_packet_free, av_packet_new_side_data as ffi_av_packet_new_side_data,
+    av_packet_ref as ffi_av_packet_ref, av_packet_rescale_ts as ffi_av_packet_rescale_ts,
+    av_packet_unref as ffi_av_packet_unref,
 };
 
 /// An owned `AVPacket`.
@@ -117,6 +118,24 @@ impl Packet {
         unsafe { (*self.ptr.as_ptr()).duration = duration };
     }
 
+    /// Allocates `size` bytes of side data of the given `kind` on this packet
+    /// and returns a mutable slice over it, or `None` on allocation failure.
+    ///
+    /// The side data is owned by the packet and freed with it. The caller
+    /// writes the payload (e.g. an HDR metadata struct) into the returned slice.
+    pub fn new_side_data(&mut self, kind: AVPacketSideDataType, size: usize) -> Option<&mut [u8]> {
+        // SAFETY: `self.ptr` is a valid owned packet; `av_packet_new_side_data`
+        //         allocates `size` bytes (or returns null on OOM) attached to it.
+        let ptr = unsafe { ffi_av_packet_new_side_data(self.ptr.as_ptr(), kind, size) };
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFETY: `ptr` is non-null and points to `size` writable bytes owned
+            //         by the packet's side-data buffer.
+            Some(unsafe { std::slice::from_raw_parts_mut(ptr, size) })
+        }
+    }
+
     /// Rescales the packet's `pts` / `dts` / `duration` from `src_tb` to `dst_tb`.
     pub fn rescale_ts(&mut self, src_tb: AVRational, dst_tb: AVRational) {
         // SAFETY: `self.ptr` is a valid owned packet; the time bases are plain
@@ -205,6 +224,20 @@ mod tests {
         // those plain fields (there is no public setter for either).
         assert_eq!(packet.size(), 0);
         assert_eq!(packet.flags(), 0);
+    }
+
+    #[test]
+    fn new_side_data_should_return_a_writable_slice() {
+        let mut packet = Packet::new().expect("packet allocation should succeed");
+        let buf = packet
+            .new_side_data(
+                crate::AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+                8,
+            )
+            .expect("side data allocation should succeed");
+        assert_eq!(buf.len(), 8);
+        // The returned slice is writable and owned by the packet (freed on drop).
+        buf.copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- ff-encode's HDR10 side-data, binary attachment, and container metadata/chapters paths still reached FFmpeg through raw pointers because they needed non-trivial ff-sys API. This completes the ff-encode migration for the #1506 seal, leaving no `as_ptr`/`as_mut_ptr` in the crate.

## Solution

- Add the ff-sys API (additive): `Packet::new_side_data(kind, size) -> Option<&mut [u8]>`; `OutputFormatContext::set_metadata` / `add_attachment_stream` / `set_chapters` (with a `ChapterSpec` value type). The `av_packet_new_side_data` / `av_dict_set` / `av_mallocz` / extradata and AVChapter allocation stay inside ff-sys.
- Migrate the last ff-encode sites: `attach_hdr10_side_data` takes `&mut Packet`; `init_attachments`, `apply_metadata`, `apply_chapters` and `apply_movflags` take `&mut OutputFormatContext`.
- `set_chapters` writes each chapter at the running `nb_chapters` index, so a per-chapter allocation failure no longer leaves a null gap in the array (a latent bug in the previous inline code), and rejects an attachment whose length overflows `extradata_size`.

Closes #1555
Closes #1544