### PR TITLE
refactor(ff-sys/ff-filter): migrate ff-filter frame/stream reads off owned as_ptr

### DIFF
--- a/crates/ff-filter/src/analysis/analysis_inner.rs
+++ b/crates/ff-filter/src/analysis/analysis_inner.rs
@@ -659,34 +659,27 @@ pub(super) unsafe fn compute_psnr_unsafe(
 /// `duration × r_frame_rate`.  Returns `None` when the file cannot be opened,
 /// no video stream is found, or the duration is unknown.
 ///
-/// # Safety
-///
-/// - All `AVFormatContext` resources are released before returning.
-/// - Only the first video stream's metadata is accessed (no data read).
-unsafe fn probe_video_frame_count(path: &Path) -> Option<i64> {
+fn probe_video_frame_count(path: &Path) -> Option<i64> {
     // The owned demux context frees itself (closing the input) on drop at fn end.
     let mut fmt_ctx = ff_sys::InputFormatContext::open(path).ok()?;
 
     // Ignore find_stream_info errors; partial info is still usable.
     let _ = fmt_ctx.find_stream_info();
 
-    let nb_streams = fmt_ctx.nb_streams();
     let mut result: Option<i64> = None;
 
-    for i in 0..nb_streams {
-        // SAFETY: streams is a valid array of `nb_streams` pointers.
-        let stream = *(*fmt_ctx.as_ptr()).streams.add(i as usize);
-        if (*(*stream).codecpar).codec_type != ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO {
+    for stream in fmt_ctx.streams() {
+        if stream.codecpar().codec_type() != ff_sys::AVMediaType_AVMEDIA_TYPE_VIDEO {
             continue;
         }
 
-        if (*stream).nb_frames > 0 {
-            result = Some((*stream).nb_frames);
+        if stream.nb_frames() > 0 {
+            result = Some(stream.nb_frames());
         } else {
             // Fall back to duration × frame_rate.
-            let dur = (*stream).duration;
-            let tb = (*stream).time_base;
-            let fps = (*stream).r_frame_rate;
+            let dur = stream.duration();
+            let tb = stream.time_base();
+            let fps = stream.r_frame_rate();
 
             #[allow(clippy::cast_precision_loss)]
             if dur != ff_sys::AV_NOPTS_VALUE && tb.den > 0 && fps.den > 0 {

--- a/crates/ff-filter/src/effects/effects_inner.rs
+++ b/crates/ff-filter/src/effects/effects_inner.rs
@@ -224,35 +224,30 @@ pub(super) unsafe fn analyze_vidstab_unsafe(
 // ── Pass 2 — transform ────────────────────────────────────────────────────────
 
 /// Drain all available encoded packets from `enc_ctx` into `out_ctx`, rescaling
-/// timestamps from `enc_tb` to the output stream's time base.
+/// timestamps from the encoder's time base to the output stream's time base.
 ///
-/// # Safety
-///
-/// - `out_ctx` must be a valid `AVFormatContext` whose header has been written.
-/// - `enc_ctx` should have had at least one `send_frame` call (functional
-///   precondition; this drains whatever the encoder has produced).
-unsafe fn drain_encoded_packets(
+/// `out_ctx`'s header must have been written; `enc_ctx` should have had at least
+/// one `send_frame` call (this drains whatever the encoder has produced).
+fn drain_encoded_packets(
     enc_ctx: &mut ff_sys::CodecContext,
     pkt: &mut ff_sys::Packet,
-    out_ctx: *mut ff_sys::AVFormatContext,
+    out_ctx: &mut ff_sys::OutputFormatContext,
     stream_tb: ff_sys::AVRational,
 ) {
     while matches!(
-        enc_ctx.receive_packet(pkt.as_mut_ptr()),
+        enc_ctx.receive_packet_into(pkt),
         Ok(ff_sys::ReceiveOutcome::Frame)
     ) {
         // Read enc_tb at drain time — some encoders mutate time_base lazily.
         let enc_tb = enc_ctx.time_base();
-        // The packet fields have no typed accessor; touch them through the pointer.
-        let p = pkt.as_mut_ptr();
-        ff_sys::av_packet_rescale_ts(p, enc_tb, stream_tb);
-        (*p).stream_index = 0;
-        let ret = ff_sys::av_interleaved_write_frame(out_ctx, p);
+        pkt.rescale_ts(enc_tb, stream_tb);
+        pkt.set_stream_index(0);
+        let write_res = out_ctx.write_interleaved(pkt);
         pkt.unref();
-        if ret < 0 {
+        if let Err(e) = write_res {
             log::warn!(
                 "av_interleaved_write_frame failed error={}",
-                ff_sys::av_error_string(ret)
+                ff_sys::av_error_string(e.code())
             );
             break;
         }
@@ -581,17 +576,16 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     };
 
     // ── Add video stream and copy codec parameters ────────────────────────────
-    let out_stream = ff_sys::avformat_new_stream(out_ctx.as_mut_ptr(), std::ptr::null());
-    if out_stream.is_null() {
+    let Ok(out_idx) = out_ctx.new_stream(None) else {
         let mut g = graph;
         ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(FilterError::Ffmpeg {
             code: 0,
             message: "avformat_new_stream failed".to_string(),
         });
-    }
+    };
 
-    if let Err(e) = enc_ctx.parameters_from_context((*out_stream).codecpar) {
+    if let Err(e) = out_ctx.apply_stream_params_from_context(out_idx, &enc_ctx) {
         let mut g = graph;
         ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(FilterError::Ffmpeg {
@@ -622,7 +616,7 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     }
 
     // Read stream time base AFTER write_header — the muxer may adjust it.
-    let stream_tb = (*out_stream).time_base;
+    let stream_tb = out_ctx.stream_time_base(out_idx);
 
     // ── Allocate encode packet ────────────────────────────────────────────────
     let Ok(mut pkt) = ff_sys::Packet::new() else {
@@ -636,8 +630,8 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     };
 
     // ── Encode first frame ────────────────────────────────────────────────────
-    let _ = enc_ctx.send_frame(first_frame.as_ptr());
-    drain_encoded_packets(&mut enc_ctx, &mut pkt, out_ctx.as_mut_ptr(), stream_tb);
+    let _ = enc_ctx.send_frame_ref(Some(&first_frame));
+    drain_encoded_packets(&mut enc_ctx, &mut pkt, &mut out_ctx, stream_tb);
     drop(first_frame);
 
     // ── Encode remaining frames from the filter graph ─────────────────────────
@@ -651,14 +645,14 @@ pub(super) unsafe fn transform_vidstab_unsafe(
         ) {
             break;
         }
-        let _ = enc_ctx.send_frame(frame.as_ptr());
-        drain_encoded_packets(&mut enc_ctx, &mut pkt, out_ctx.as_mut_ptr(), stream_tb);
+        let _ = enc_ctx.send_frame_ref(Some(&frame));
+        drain_encoded_packets(&mut enc_ctx, &mut pkt, &mut out_ctx, stream_tb);
         // `frame` drops at end of iteration.
     }
 
     // ── Flush the encoder ─────────────────────────────────────────────────────
-    let _ = enc_ctx.send_frame(std::ptr::null());
-    drain_encoded_packets(&mut enc_ctx, &mut pkt, out_ctx.as_mut_ptr(), stream_tb);
+    let _ = enc_ctx.send_frame_ref(None);
+    drain_encoded_packets(&mut enc_ctx, &mut pkt, &mut out_ctx, stream_tb);
 
     // ── Finalize output ───────────────────────────────────────────────────────
     // `pkt` drops at end of scope, freeing it. The owned `out_ctx` closes its IO

--- a/crates/ff-filter/src/filter_inner/convert.rs
+++ b/crates/ff-filter/src/filter_inner/convert.rs
@@ -233,49 +233,30 @@ pub(super) unsafe fn copy_video_planes_to_av(src: &VideoFrame, dst: *mut AVFrame
     }
 }
 
-/// Source pointer for row `y` of a plane, per `FFmpeg`'s `av_image_copy`
-/// invariant `row_y = data + y * linesize`.
-///
-/// The signed step is correct for both positive (top-down) and negative
-/// (bottom-up, e.g. from `vflip`) `linesize`, so the plane is never vertically
-/// flipped (issue #1306). Casting `linesize` to `usize` first would both wrap a
-/// negative value to a huge stride and reverse row order.
-///
-/// # Safety
-///
-/// `data` must be non-null and point to a plane whose row `y` is in bounds.
-unsafe fn plane_row_ptr(data: *const u8, linesize: c_int, y: usize) -> *const u8 {
-    data.offset(y as isize * linesize as isize)
-}
-
 /// Build a [`VideoFrame`] by copying data out of an `AVFrame`.
 ///
 /// # Safety
 ///
 /// `raw_frame` must point to a valid, populated `AVFrame`.
-pub(super) unsafe fn av_frame_to_video_frame(raw_frame: *const AVFrame) -> Result<VideoFrame, ()> {
-    let width = (*raw_frame).width as u32;
-    let height = (*raw_frame).height as u32;
-    let format = av_to_pixel_format((*raw_frame).format);
-    let pts_raw = (*raw_frame).pts;
+pub(super) unsafe fn av_frame_to_video_frame(frame: &ff_sys::Frame) -> Result<VideoFrame, ()> {
+    let width = frame.width() as u32;
+    let height = frame.height() as u32;
+    let format = av_to_pixel_format(frame.format());
+    let pts_raw = frame.pts();
     if pts_raw == ff_sys::AV_NOPTS_VALUE {
         log::warn!("pts invalid in output video frame from filter graph");
     }
     let timestamp = video_ticks_to_timestamp(pts_raw);
     // AV_PICTURE_TYPE_I = 1: I-frame (key frame).  `key_frame` was removed
     // from AVFrame in FFmpeg 6; use `pict_type` instead.
-    let key_frame = (*raw_frame).pict_type == 1;
+    let key_frame = frame.pict_type() == ff_sys::AVPictureType_AV_PICTURE_TYPE_I;
 
     let num_planes = format.num_planes();
     let mut planes: Vec<PooledBuffer> = Vec::with_capacity(num_planes);
     let mut strides: Vec<usize> = Vec::with_capacity(num_planes);
 
     for i in 0..num_planes {
-        let src_ptr = (*raw_frame).data[i];
-        if src_ptr.is_null() {
-            return Err(());
-        }
-        let linesize_raw = (*raw_frame).linesize[i];
+        let linesize_raw = frame.linesize(i);
         let stride = linesize_raw.unsigned_abs() as usize;
         let rows = plane_height(format, i, height as usize);
 
@@ -287,7 +268,7 @@ pub(super) unsafe fn av_frame_to_video_frame(raw_frame: *const AVFrame) -> Resul
         // last row within bounds. `stride` is preserved so downstream stride math is
         // unchanged; inter-row padding is left zeroed (never read).
         let row_bytes = {
-            let n = ff_sys::av_image_get_linesize((*raw_frame).format, width as i32, i as i32);
+            let n = ff_sys::av_image_get_linesize(frame.format(), width as i32, i as i32);
             if n > 0 {
                 (n as usize).min(stride)
             } else {
@@ -295,18 +276,16 @@ pub(super) unsafe fn av_frame_to_video_frame(raw_frame: *const AVFrame) -> Resul
             }
         };
         let mut buf = vec![0u8; stride * rows];
-        for row in 0..rows {
-            // SAFETY: `plane_row_ptr` returns `src_ptr + row * linesize_raw`. A
-            // negative linesize (bottom-up scan order, e.g. from `vflip`) steps to
-            // lower addresses, matching FFmpeg's `av_image_copy` invariant so rows
-            // are copied top-down and never vertically flipped (issue #1306). Each
-            // source row has at least `row_bytes` valid bytes; the dst slice is
-            // inside `buf`.
-            std::ptr::copy_nonoverlapping(
-                plane_row_ptr(src_ptr, linesize_raw, row),
-                buf.as_mut_ptr().add(row * stride),
-                row_bytes,
-            );
+        // `copy_plane_rows` honors the signed linesize: a negative one (bottom-up
+        // scan, e.g. from `vflip`) is copied top-down, never vertically flipped
+        // (RK-008 / #1306). A null plane yields `None`, which we map to `Err`.
+        // SAFETY: `rows` / `row_bytes` stay within plane `i` (derived from the
+        //         frame's own format and dimensions) and `buf` holds `stride * rows`.
+        if frame
+            .copy_plane_rows(i, &mut buf, stride, rows, row_bytes)
+            .is_none()
+        {
+            return Err(());
         }
 
         planes.push(PooledBuffer::standalone(buf));
@@ -337,17 +316,13 @@ pub(super) unsafe fn copy_audio_planes_to_av(src: &AudioFrame, dst: *mut AVFrame
     }
 }
 
-/// Build an [`AudioFrame`] by copying data out of an `AVFrame`.
-///
-/// # Safety
-///
-/// `raw_frame` must point to a valid, populated `AVFrame`.
-pub(super) unsafe fn av_frame_to_audio_frame(raw_frame: *const AVFrame) -> Result<AudioFrame, ()> {
-    let samples = (*raw_frame).nb_samples as usize;
-    let channels = (*raw_frame).ch_layout.nb_channels as u32;
-    let sample_rate = (*raw_frame).sample_rate as u32;
-    let format = av_to_sample_format((*raw_frame).format);
-    let pts_raw = (*raw_frame).pts;
+/// Build an [`AudioFrame`] by copying data out of a decoded [`ff_sys::Frame`].
+pub(super) fn av_frame_to_audio_frame(frame: &ff_sys::Frame) -> Result<AudioFrame, ()> {
+    let samples = frame.nb_samples() as usize;
+    let channels = frame.channels() as u32;
+    let sample_rate = frame.sample_rate() as u32;
+    let format = av_to_sample_format(frame.format());
+    let pts_raw = frame.pts();
     if pts_raw == ff_sys::AV_NOPTS_VALUE {
         log::warn!("pts invalid in output audio frame from filter graph sample_rate={sample_rate}");
     }
@@ -362,15 +337,15 @@ pub(super) unsafe fn av_frame_to_audio_frame(raw_frame: *const AVFrame) -> Resul
     let mut planes: Vec<Vec<u8>> = Vec::with_capacity(num_planes);
 
     for i in 0..num_planes {
-        let src_ptr = (*raw_frame).data[i];
-        if src_ptr.is_null() {
-            return Err(());
-        }
         let byte_count = samples * bytes_per_sample;
-        // SAFETY: `av_buffersink_get_frame` guarantees at least
-        // `nb_samples * bytes_per_sample` bytes per plane pointer.
-        let data = std::slice::from_raw_parts(src_ptr, byte_count).to_vec();
-        planes.push(data);
+        // `audio_plane` returns `None` for a null/absent plane, which maps to
+        // `Err`. Copy only the frame's sample bytes (`byte_count`), matching the
+        // previous behavior.
+        let plane = frame
+            .audio_plane(i)
+            .and_then(|p| p.get(..byte_count))
+            .ok_or(())?;
+        planes.push(plane.to_vec());
     }
 
     AudioFrame::new(planes, samples, channels, sample_rate, format, timestamp).map_err(|_| ())
@@ -383,43 +358,8 @@ mod tests {
     use super::*;
     use ff_format::time::Rational;
 
-    // ── plane_row_ptr (issue #1306: no vertical flip on negative linesize) ─────
-
-    /// Positive linesize walks rows top-down: row `y` is at `data + y*linesize`.
-    #[test]
-    fn plane_row_ptr_positive_linesize_should_walk_rows_top_down() {
-        let mem = [10u8, 20, 30];
-        let data = mem.as_ptr();
-        // SAFETY: rows 0..3 map to offsets 0,1,2 — all in bounds of `mem`.
-        let got: Vec<u8> = (0..3)
-            .map(|y| unsafe { *plane_row_ptr(data, 1, y) })
-            .collect();
-        assert_eq!(got, [10, 20, 30]);
-    }
-
-    /// Negative linesize (bottom-up, e.g. `vflip`): `data` points at the top row,
-    /// which sits at the highest address. Correct top-down order is
-    /// `mem[2], mem[1], mem[0]` == `[30, 20, 10]`, NOT the flipped `[10, 20, 30]`.
-    #[test]
-    fn plane_row_ptr_negative_linesize_should_not_flip_rows() {
-        let mem = [10u8, 20, 30];
-        // SAFETY: index 2 is the last element of `mem`.
-        let data = unsafe { mem.as_ptr().add(2) };
-        // SAFETY: rows 0..3 map to offsets 0,-1,-2 — all in bounds of `mem`.
-        let got: Vec<u8> = (0..3)
-            .map(|y| unsafe { *plane_row_ptr(data, -1, y) })
-            .collect();
-        assert_eq!(got, [30, 20, 10]);
-    }
-
-    /// Row 0 is the base pointer regardless of the linesize sign.
-    #[test]
-    fn plane_row_ptr_row_zero_should_return_base() {
-        let mem = [7u8; 4];
-        let data = mem.as_ptr();
-        // SAFETY: y=0 yields a zero offset.
-        assert_eq!(unsafe { plane_row_ptr(data, -13, 0) }, data);
-    }
+    // Negative-linesize (RK-008 / #1306) plane copying now lives in
+    // `ff_sys::Frame::copy_plane_rows`, which carries its own regression test.
 
     // ── PTS helpers ───────────────────────────────────────────────────────────
 

--- a/crates/ff-filter/src/filter_inner/normalize.rs
+++ b/crates/ff-filter/src/filter_inner/normalize.rs
@@ -293,24 +293,22 @@ pub(super) unsafe fn run_volume_graph(
     // Signal EOF
     ff_sys::av_buffersrc_close(src_ctx, ff_sys::AV_NOPTS_VALUE, 0u32);
 
-    // Drain all corrected output frames
+    // Drain all corrected output frames. The owned frame frees itself each
+    // iteration; NeedMore / Drained / Err all end the drain.
     let mut output = Vec::new();
     loop {
-        let raw_frame = ff_sys::av_frame_alloc();
-        if raw_frame.is_null() {
+        let Ok(mut frame) = ff_sys::Frame::new() else {
+            break;
+        };
+        if !matches!(
+            ff_sys::buffersink_get_frame(sink_ctx, &mut frame),
+            Ok(ff_sys::BufferSinkOutcome::Frame)
+        ) {
             break;
         }
-        let ret = ff_sys::av_buffersink_get_frame(sink_ctx, raw_frame);
-        if ret < 0 {
-            let mut ptr = raw_frame;
-            ff_sys::av_frame_free(std::ptr::addr_of_mut!(ptr));
-            break;
-        }
-        if let Ok(af) = convert::av_frame_to_audio_frame(raw_frame) {
+        if let Ok(af) = convert::av_frame_to_audio_frame(&frame) {
             output.push(af);
         }
-        let mut ptr = raw_frame;
-        ff_sys::av_frame_free(std::ptr::addr_of_mut!(ptr));
     }
 
     Ok(output)

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -228,7 +228,7 @@ impl FilterGraphInner {
             }
 
             // `frame` drops at end of scope after the conversion reads it.
-            match av_frame_to_video_frame(frame.as_ptr()) {
+            match av_frame_to_video_frame(&frame) {
                 Ok(vframe) => Ok(Some(vframe)),
                 Err(()) => Err(FilterError::ProcessFailed),
             }
@@ -484,7 +484,7 @@ impl FilterGraphInner {
             }
 
             // `frame` drops at end of scope after the conversion reads it.
-            match av_frame_to_audio_frame(frame.as_ptr()) {
+            match av_frame_to_audio_frame(&frame) {
                 Ok(aframe) => Ok(Some(aframe)),
                 Err(()) => Err(FilterError::ProcessFailed),
             }

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1884,6 +1884,11 @@ impl Frame {
     }
     pub fn set_format(&mut self, _format: c_int) {}
     pub fn set_pict_type(&mut self, _pict_type: AVPictureType) {}
+
+    #[must_use]
+    pub fn pict_type(&self) -> AVPictureType {
+        0
+    }
     #[must_use]
     pub fn pts(&self) -> i64 {
         0

--- a/crates/ff-sys/src/frame.rs
+++ b/crates/ff-sys/src/frame.rs
@@ -112,6 +112,14 @@ impl Frame {
         unsafe { (*self.ptr.as_ptr()).pict_type = pict_type };
     }
 
+    /// Returns the picture type (`AV_PICTURE_TYPE_I` marks a keyframe). Used to
+    /// derive `key_frame` after `key_frame` was removed from `AVFrame` in FFmpeg 6.
+    #[must_use]
+    pub fn pict_type(&self) -> crate::AVPictureType {
+        // SAFETY: `self.ptr` is a valid owned frame; `pict_type` is a plain field.
+        unsafe { (*self.ptr.as_ptr()).pict_type }
+    }
+
     /// Returns the presentation timestamp (in the frame's time base).
     #[must_use]
     pub fn pts(&self) -> i64 {
@@ -545,11 +553,9 @@ mod tests {
     fn set_pict_type_should_round_trip() {
         let mut frame = Frame::new().expect("frame allocation should succeed");
         frame.set_pict_type(crate::AVPictureType_AV_PICTURE_TYPE_I);
-        // SAFETY: `frame` is a valid owned frame; `pict_type` is a plain field.
-        assert_eq!(
-            unsafe { (*frame.as_ptr()).pict_type },
-            crate::AVPictureType_AV_PICTURE_TYPE_I
-        );
+        // The getter reads back what the setter wrote (a fresh frame defaults to
+        // AV_PICTURE_TYPE_NONE).
+        assert_eq!(frame.pict_type(), crate::AVPictureType_AV_PICTURE_TYPE_I);
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- Continue the ff-sys RAII sealing (ADR-0003, #1473) by removing ff-filter's use of the owned `Frame` / `Packet` / `CodecContext` / `InputFormatContext` / `OutputFormatContext` raw pointers.
- ff-filter is the last consumer crate in #1545; the raw filter-graph / buffersrc / buffersink handling and push-direction raw `av_frame_alloc` frames stay out of scope.

## Solution

- convert.rs: `av_frame_to_video_frame` / `av_frame_to_audio_frame` take `&Frame`, reading scalars through accessors, video planes through `Frame::copy_plane_rows` (which internalizes the signed-linesize copy) and audio planes through `Frame::audio_plane`. The crate-local `plane_row_ptr` and its tests are removed; the negative-linesize regression now lives in `ff-sys`.
- push_pull / normalize: pass owned frames by reference to the conversions; normalize's drain loop uses an owned `Frame` instead of a raw `av_frame_alloc`.
- effects: `drain_encoded_packets` takes `&mut OutputFormatContext`, and the transform path uses `new_stream` / `apply_stream_params_from_context` / `stream_time_base` / `send_frame_ref`; the raw filter-graph teardown is preserved.
- analysis: `probe_video_frame_count` iterates `streams()` via `StreamRef`.
- ff-sys: add a `Frame::pict_type` getter (with docs.rs stub) for the video `key_frame` derivation.

After this, ff-analysis / ff-probe / ff-remux / ff-filter have no owned-type `as_ptr` uses; ff-decode's hardware-accel sites remain (tracked in #1560), so #1545 stays open until then.

Refs #1545