### PR TITLE
refactor(ff-sys/ff-decode): add a hardware-accel RAII API and seal ff-decode

### DIFF
--- a/crates/ff-decode/src/video/decoder_inner/hardware.rs
+++ b/crates/ff-decode/src/video/decoder_inner/hardware.rs
@@ -1,7 +1,6 @@
-use super::{
-    AVBufferRef, AVCodecContext, AVHWDeviceType, AVPixelFormat, DecodeError, HardwareAccel,
-    VideoDecoderInner, ptr,
-};
+use ff_sys::{CodecContext, HwDeviceContext};
+
+use super::{AVHWDeviceType, AVPixelFormat, DecodeError, HardwareAccel, VideoDecoderInner};
 
 impl VideoDecoderInner {
     /// Maps our `HardwareAccel` enum to the corresponding FFmpeg `AVHWDeviceType`.
@@ -42,25 +41,26 @@ impl VideoDecoderInner {
     ///
     /// # Returns
     ///
-    /// Returns `Ok((hw_device_ctx, active_accel))` if hardware acceleration was initialized,
-    /// or `Ok((None, HardwareAccel::None))` if software decoding should be used.
+    /// Returns `Ok((Some(device), active_accel))` if hardware acceleration was
+    /// initialized (the owned [`HwDeviceContext`] must be kept alive as long as
+    /// the codec context uses it), or `Ok((None, HardwareAccel::None))` if
+    /// software decoding should be used.
     ///
     /// # Errors
     ///
     /// Returns an error only if a specific hardware accelerator was requested but failed to initialize.
-    pub(super) unsafe fn init_hardware_accel(
-        codec_ctx: *mut AVCodecContext,
+    pub(super) fn init_hardware_accel(
+        codec_ctx: &mut CodecContext,
         accel: HardwareAccel,
-    ) -> Result<(Option<*mut AVBufferRef>, HardwareAccel), DecodeError> {
+    ) -> Result<(Option<HwDeviceContext>, HardwareAccel), DecodeError> {
         match accel {
             HardwareAccel::Auto => {
                 // Try hardware accelerators in priority order
                 for &hw_type in Self::hw_accel_auto_priority() {
-                    // SAFETY: Caller ensures codec_ctx is valid and not yet configured with hardware
-                    match unsafe { Self::try_init_hw_device(codec_ctx, hw_type) } {
-                        Ok((Some(ctx), active)) => {
+                    match Self::try_init_hw_device(codec_ctx, hw_type) {
+                        Ok((Some(device), active)) => {
                             log::info!("hwaccel selected backend={}", active.name());
-                            return Ok((Some(ctx), active));
+                            return Ok((Some(device), active));
                         }
                         _ => {
                             log::debug!(
@@ -79,61 +79,33 @@ impl VideoDecoderInner {
             }
             _ => {
                 // Specific hardware accelerator requested
-                // SAFETY: Caller ensures codec_ctx is valid and not yet configured with hardware
-                unsafe { Self::try_init_hw_device(codec_ctx, accel) }
+                Self::try_init_hw_device(codec_ctx, accel)
             }
         }
     }
 
-    /// Tries to initialize a specific hardware device.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure `codec_ctx` is valid and not yet configured with a hardware device.
-    unsafe fn try_init_hw_device(
-        codec_ctx: *mut AVCodecContext,
+    /// Tries to initialize a specific hardware device and attach it to `codec_ctx`.
+    fn try_init_hw_device(
+        codec_ctx: &mut CodecContext,
         accel: HardwareAccel,
-    ) -> Result<(Option<*mut AVBufferRef>, HardwareAccel), DecodeError> {
+    ) -> Result<(Option<HwDeviceContext>, HardwareAccel), DecodeError> {
         // Get the FFmpeg device type
         let Some(device_type) = Self::hw_accel_to_device_type(accel) else {
             return Ok((None, HardwareAccel::None));
         };
 
-        // Create hardware device context
-        // SAFETY: FFmpeg is initialized, device_type is valid
-        let mut hw_device_ctx: *mut AVBufferRef = ptr::null_mut();
-        let ret = unsafe {
-            ff_sys::av_hwdevice_ctx_create(
-                ptr::addr_of_mut!(hw_device_ctx),
-                device_type,
-                ptr::null(),     // device: null for default device
-                ptr::null_mut(), // opts: null for default options
-                0,               // flags: currently unused by FFmpeg
-            )
-        };
+        // Create the hardware device context (owned; freed on drop). Failure here
+        // means the backend is unavailable on this system.
+        let device = HwDeviceContext::new(device_type)
+            .map_err(|_| DecodeError::HwAccelUnavailable { accel })?;
 
-        if ret < 0 {
-            // Hardware device creation failed
-            return Err(DecodeError::HwAccelUnavailable { accel });
-        }
+        // Attach it to the codec context, which takes its own reference. `device`
+        // keeps ours for the caller to hold alongside the decoder.
+        codec_ctx
+            .set_hw_device_ctx(&device)
+            .map_err(|_| DecodeError::HwAccelUnavailable { accel })?;
 
-        // Assign hardware device context to codec context
-        // We transfer ownership of the reference to codec_ctx
-        // SAFETY: codec_ctx and hw_device_ctx are valid
-        unsafe {
-            (*codec_ctx).hw_device_ctx = hw_device_ctx;
-        }
-
-        // We keep our own reference for cleanup in Drop
-        // SAFETY: hw_device_ctx is valid
-        let our_ref = unsafe { ff_sys::av_buffer_ref(hw_device_ctx) };
-        if our_ref.is_null() {
-            // Failed to create our reference
-            // codec_ctx still owns the original, so we don't need to clean it up here
-            return Err(DecodeError::HwAccelUnavailable { accel });
-        }
-
-        Ok((Some(our_ref), accel))
+        Ok((Some(device), accel))
     }
 
     /// Returns the currently active hardware acceleration mode.
@@ -164,11 +136,7 @@ impl VideoDecoderInner {
     ///
     /// If `self.frame` is a hardware frame, creates a new software frame
     /// and transfers the data from GPU to CPU memory.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure `self.frame` contains a valid decoded frame.
-    pub(super) unsafe fn transfer_hardware_frame_if_needed(&mut self) -> Result<(), DecodeError> {
+    pub(super) fn transfer_hardware_frame_if_needed(&mut self) -> Result<(), DecodeError> {
         let frame_format = self.frame.format();
 
         if !Self::is_hardware_format(frame_format) {
@@ -185,28 +153,16 @@ impl VideoDecoderInner {
             ),
         })?;
 
-        // Transfer data from the hardware frame to the software frame. This FFI
-        // call takes raw `AVFrame` pointers; a safe hw-frame-transfer wrapper is
-        // retained for the ff-sys RAII follow-up (the hw-accel API surface).
-        // SAFETY: self.frame and sw_frame are valid owned frames.
-        let ret = unsafe {
-            ff_sys::av_hwframe_transfer_data(
-                sw_frame.as_mut_ptr(),
-                self.frame.as_ptr(),
-                0, // flags: currently unused
-            )
-        };
-
-        if ret < 0 {
-            // Transfer failed; sw_frame frees itself on return.
-            return Err(DecodeError::Ffmpeg {
-                code: ret,
+        // Transfer GPU-side data from the hardware frame into the software frame.
+        sw_frame
+            .hwframe_transfer_data(&self.frame, 0)
+            .map_err(|e| DecodeError::Ffmpeg {
+                code: e.code(),
                 message: format!(
                     "Failed to transfer hardware frame to CPU memory: {}",
-                    ff_sys::av_error_string(ret)
+                    ff_sys::av_error_string(e.code())
                 ),
-            });
-        }
+            })?;
 
         // Copy metadata (pts, duration, etc.) from hardware frame to software frame
         sw_frame.set_pts(self.frame.pts());

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -24,7 +24,6 @@
 
 use std::ffi::CStr;
 use std::path::Path;
-use std::ptr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -37,8 +36,8 @@ use ff_format::container::ContainerInfo;
 use ff_format::time::{Rational, Timestamp};
 use ff_format::{PixelFormat, VideoFrame, VideoStreamInfo};
 use ff_sys::{
-    AVBufferRef, AVCodecContext, AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace,
-    AVHWDeviceType, AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame, InputFormatContext,
+    AVCodecID, AVColorPrimaries, AVColorRange, AVColorSpace, AVHWDeviceType,
+    AVMediaType_AVMEDIA_TYPE_VIDEO, AVPixelFormat, Frame, HwDeviceContext, InputFormatContext,
     Packet,
 };
 
@@ -94,8 +93,11 @@ pub(crate) struct VideoDecoderInner {
     pub(super) thumbnail_sws_ctx: Option<ff_sys::ScaleContext>,
     /// Last thumbnail dimensions (for cache invalidation)
     pub(super) thumbnail_cache_key: Option<(u32, u32, u32, u32, AVPixelFormat)>,
-    /// Hardware device context (if hardware acceleration is active)
-    pub(super) hw_device_ctx: Option<*mut AVBufferRef>,
+    /// Owned hardware device reference kept alive for as long as the codec
+    /// context uses it. Held only for its `Drop` (the codec keeps its own
+    /// reference), so it is never read after construction.
+    #[expect(dead_code, reason = "RAII drop-guard: released when the decoder drops")]
+    pub(super) hw_device_ctx: Option<HwDeviceContext>,
     /// Active hardware acceleration mode
     pub(super) active_hw_accel: HardwareAccel,
     /// Optional frame pool for memory reuse
@@ -245,31 +247,25 @@ impl VideoDecoderInner {
             codec_ctx.set_thread_count(thread_count as i32);
         }
 
-        // Initialize hardware acceleration if requested. The hw device / frames
-        // wiring stays on the raw `AVCodecContext` pointer (retained for the ff-sys
-        // RAII follow-up, which adds a dedicated hw-accel API).
-        // SAFETY: codec_ctx is valid and not yet opened
+        // Initialize hardware acceleration if requested. The owned
+        // `HwDeviceContext` (when Some) holds our reference to the hw device; the
+        // codec context takes its own via `set_hw_device_ctx`, so both are freed
+        // independently on drop.
         let (hw_device_ctx, active_hw_accel) =
-            unsafe { Self::init_hardware_accel(codec_ctx.as_mut_ptr(), hardware_accel)? };
+            Self::init_hardware_accel(&mut codec_ctx, hardware_accel)?;
 
-        // Open the codec
-        codec_ctx.open_codec(codec).map_err(|e| {
-            // If codec opening failed, we still own our reference to hw_device_ctx
-            // but it will be cleaned up when codec_ctx is freed (which happens
-            // when codec_ctx is dropped)
-            // Our reference in hw_device_ctx will be cleaned up here
-            if let Some(hw_ctx) = hw_device_ctx {
-                // SAFETY: hw_ctx is a valid buffer reference we own.
-                unsafe { ff_sys::av_buffer_unref(&mut (hw_ctx as *mut _)) };
-            }
-            DecodeError::Ffmpeg {
+        // Open the codec. On failure, `hw_device_ctx` (owned) drops with the rest
+        // of this constructor's locals, releasing our reference; `codec_ctx` drops
+        // too, releasing its own — no manual cleanup needed.
+        codec_ctx
+            .open_codec(codec)
+            .map_err(|e| DecodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(
                     "Failed to open codec: {}",
                     ff_sys::av_error_string(e.code())
                 ),
-            }
-        })?;
+            })?;
 
         // Extract stream and container information through the borrowed
         // stream / codec-context accessors.
@@ -332,24 +328,11 @@ impl VideoDecoderInner {
     }
 }
 
-impl Drop for VideoDecoderInner {
-    fn drop(&mut self) {
-        // The `sws_ctx` and `thumbnail_sws_ctx` (owned `ScaleContext`) free
-        // themselves when this struct drops.
-
-        // Free hardware device context if allocated
-        if let Some(hw_ctx) = self.hw_device_ctx {
-            // SAFETY: hw_ctx is valid and owned by this instance
-            unsafe {
-                ff_sys::av_buffer_unref(&mut (hw_ctx as *mut _));
-            }
-        }
-
-        // The owned `frame` (Frame) and `packet` (Packet) free themselves when
-        // this struct drops. The `format_ctx` (InputFormatContext) drops
-        // automatically after this Drop body, closing the demux context last.
-    }
-}
+// No manual `Drop` is needed: every field owns its FFmpeg resource and frees
+// itself when the struct drops (fields drop in declaration order). The hw device
+// reference (`HwDeviceContext`) is reference-counted and the `CodecContext` holds
+// its own reference, so the order in which the two release relative to each other
+// does not matter.
 
 // SAFETY: VideoDecoderInner manages FFmpeg contexts which are thread-safe when not shared.
 // We don't expose mutable access across threads, so Send is safe.

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -14,8 +14,8 @@ use std::ptr::{self, NonNull};
 use crate::{
     AVCodecContext, AVCodecID, AVCodecParameters, AVColorPrimaries, AVColorRange, AVColorSpace,
     AVColorTransferCharacteristic, AVDictionary, AVFrame, AVPacket, AVPixelFormat, AVRational,
-    AVSampleFormat, AvError, Codec, CodecParameters, Frame, Packet,
-    avcodec_free_context as ffi_avcodec_free_context,
+    AVSampleFormat, AvError, Codec, CodecParameters, Frame, HwDeviceContext, Packet,
+    av_buffer_replace as ffi_av_buffer_replace, avcodec_free_context as ffi_avcodec_free_context,
 };
 
 /// The outcome of a [`CodecContext::receive_frame`] call.
@@ -629,6 +629,35 @@ impl CodecContext {
         // SAFETY: `ptr` is null (flush) or a valid `*const AVFrame` borrowed from
         //         `frame` for the duration of the call; `self.ptr` is a valid context.
         unsafe { self.send_frame(ptr) }
+    }
+
+    /// Attaches a hardware device context to this codec context (for hardware
+    /// decoding / encoding), taking its own reference to `device`.
+    ///
+    /// Must be called before [`open_codec`](Self::open_codec); the codec reads
+    /// `hw_device_ctx` while opening. Any previously attached device reference is
+    /// released. `device` keeps its reference (both are freed independently: this
+    /// context's when it is freed, `device`'s when it drops).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if a new reference cannot be allocated.
+    pub fn set_hw_device_ctx(&mut self, device: &HwDeviceContext) -> Result<(), AvError> {
+        // SAFETY: `self.ptr` is a valid owned codec context; `hw_device_ctx` is a
+        //         plain `*mut AVBufferRef` field. `av_buffer_replace` unreferences
+        //         any prior value and stores a new reference to `device` (which
+        //         stays valid: it is borrowed for the call and owns its own ref).
+        let ret = unsafe {
+            ffi_av_buffer_replace(
+                std::ptr::addr_of_mut!((*self.ptr.as_ptr()).hw_device_ctx),
+                device.as_raw(),
+            )
+        };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
     }
 
     /// Receives an encoded packet into `pkt`, returning a typed [`ReceiveOutcome`].

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1361,6 +1361,15 @@ impl CodecContext {
 
     /// # Errors
     /// Stub; never executed on docs.rs.
+    pub fn set_hw_device_ctx(
+        &mut self,
+        _device: &HwDeviceContext,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
     pub fn receive_packet_into(
         &mut self,
         _pkt: &mut Packet,
@@ -1978,6 +1987,16 @@ impl Frame {
 
     /// # Errors
     /// Stub; never executed on docs.rs.
+    pub fn hwframe_transfer_data(
+        &mut self,
+        _src: &Frame,
+        _flags: c_int,
+    ) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
     pub fn try_clone(&self) -> Result<Self, crate::AvError> {
         Err(crate::AvError::new(-1))
     }
@@ -2102,6 +2121,30 @@ impl Codec {
         self._ptr.as_ptr()
     }
 }
+
+// ── RAII owner stub (mirrors crate::hwdevice::HwDeviceContext) ────────────────
+// Under DOCS_RS the real `hwdevice` module is cfg'd out; this shape-compatible
+// stub keeps `ff_sys::HwDeviceContext` available for docs.rs.
+
+#[derive(Debug)]
+pub struct HwDeviceContext {
+    _ptr: std::ptr::NonNull<AVBufferRef>,
+}
+
+impl HwDeviceContext {
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn new(_device_type: AVHWDeviceType) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+}
+
+impl Drop for HwDeviceContext {
+    fn drop(&mut self) {}
+}
+
+// SAFETY: stub; never executed on docs.rs.
+unsafe impl Send for HwDeviceContext {}
 
 // ── RAII owner stub (mirrors crate::scale_context::ScaleContext) ──────────────
 // Under DOCS_RS the real `scale_context` module is cfg'd out; this

--- a/crates/ff-sys/src/frame.rs
+++ b/crates/ff-sys/src/frame.rs
@@ -18,7 +18,8 @@ use crate::{
     AV_NUM_DATA_POINTERS, AVFrame, AVRational, AvError, av_frame_alloc as ffi_av_frame_alloc,
     av_frame_free as ffi_av_frame_free, av_frame_get_buffer as ffi_av_frame_get_buffer,
     av_frame_move_ref as ffi_av_frame_move_ref, av_frame_ref as ffi_av_frame_ref,
-    av_frame_unref as ffi_av_frame_unref, av_pix_fmt_desc_get as ffi_av_pix_fmt_desc_get,
+    av_frame_unref as ffi_av_frame_unref, av_hwframe_transfer_data as ffi_av_hwframe_transfer_data,
+    av_pix_fmt_desc_get as ffi_av_pix_fmt_desc_get,
 };
 
 /// An owned `AVFrame`.
@@ -480,6 +481,34 @@ impl Frame {
         unsafe { ffi_av_frame_move_ref(self.ptr.as_ptr(), src.ptr.as_ptr()) };
     }
 
+    /// Transfers data between `self` (destination) and a hardware frame `src`
+    /// (`av_hwframe_transfer_data`): copies `src`'s GPU-side data into `self`'s
+    /// CPU-side buffers (or vice versa), allocating `self`'s buffers as needed.
+    ///
+    /// This is safe because both frames are valid owned `AVFrame`s and the
+    /// `&mut self` / `&src` borrows preclude aliasing. When `src` is not actually
+    /// a hardware frame (no `hw_frames_ctx`), FFmpeg returns `AVERROR(EINVAL)`
+    /// rather than dereferencing anything invalid — a functional error, not UB
+    /// (RK-017); a safe caller cannot construct a frame with a bogus non-null
+    /// `hw_frames_ctx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the transfer fails (including `EINVAL` when
+    /// neither frame carries a hardware frames context).
+    pub fn hwframe_transfer_data(&mut self, src: &Frame, flags: c_int) -> Result<(), AvError> {
+        // SAFETY: `self` and `src` are valid owned frames (`&mut self` / `&src`
+        //         guarantee they are distinct); `av_hwframe_transfer_data` reads
+        //         `src` and writes `self`, guarding invalid inputs with `EINVAL`.
+        let ret =
+            unsafe { ffi_av_hwframe_transfer_data(self.ptr.as_ptr(), src.ptr.as_ptr(), flags) };
+        if ret < 0 {
+            Err(AvError::new(ret))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Makes a ref-counted copy of this frame (`av_frame_ref`), sharing the
     /// underlying buffers rather than deep-copying.
     ///
@@ -547,6 +576,21 @@ mod tests {
         let frame = Frame::new().expect("frame allocation should succeed");
         assert!(!frame.as_ptr().is_null());
         // Dropping `frame` frees it exactly once (no panic / double free).
+    }
+
+    #[test]
+    fn hwframe_transfer_data_should_error_for_non_hardware_frames() {
+        // Two plain software frames carry no `hw_frames_ctx`, so FFmpeg's
+        // `av_hwframe_transfer_data` returns an error (EINVAL) rather than
+        // transferring. This exercises the safe wrapper's error conversion with no
+        // GPU, confirming a non-hardware `src` is a functional error (not UB): the
+        // basis for `hwframe_transfer_data` being a safe `fn` (RK-017).
+        let src = Frame::new().expect("frame allocation should succeed");
+        let mut dst = Frame::new().expect("frame allocation should succeed");
+        assert!(
+            dst.hwframe_transfer_data(&src, 0).is_err(),
+            "transferring between two software frames must return Err, not panic"
+        );
     }
 
     #[test]

--- a/crates/ff-sys/src/hwdevice.rs
+++ b/crates/ff-sys/src/hwdevice.rs
@@ -1,0 +1,106 @@
+//! RAII owner for a hardware device context (`AVBufferRef` from
+//! `av_hwdevice_ctx_create`).
+//!
+//! [`HwDeviceContext`] creates a hardware device (CUDA / QSV / VAAPI / ...) and
+//! unreferences it exactly once on drop, replacing the manual
+//! `av_hwdevice_ctx_create` + `av_buffer_unref` pair. Its constructor is safe (it
+//! takes only an [`AVHWDeviceType`] and creates the default device). Hand it to a
+//! codec with [`CodecContext::set_hw_device_ctx`](crate::CodecContext::set_hw_device_ctx),
+//! which keeps its own reference; the two references are released independently.
+
+use std::ptr::NonNull;
+
+use crate::{
+    AVBufferRef, AVHWDeviceType, AvError, av_buffer_unref as ffi_av_buffer_unref,
+    av_hwdevice_ctx_create as ffi_av_hwdevice_ctx_create,
+};
+
+/// An owned hardware device context.
+///
+/// The reference is released exactly once on drop. This is guaranteed by
+/// construction: the value owns a [`NonNull`] and is neither `Copy` nor `Clone`,
+/// so it drops exactly once and cannot be duplicated.
+#[derive(Debug)]
+pub struct HwDeviceContext {
+    ptr: NonNull<AVBufferRef>,
+}
+
+impl HwDeviceContext {
+    /// Creates the default hardware device of the given type (e.g.
+    /// `AV_HWDEVICE_TYPE_CUDA`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] when the backend is unavailable on this system
+    /// (no driver / device), so callers can fall back to software decoding.
+    pub fn new(device_type: AVHWDeviceType) -> Result<Self, AvError> {
+        let mut ptr: *mut AVBufferRef = std::ptr::null_mut();
+        // SAFETY: `av_hwdevice_ctx_create` writes a new device reference into
+        //         `ptr` (or leaves it null and returns < 0). The default device is
+        //         requested with null `device` / `opts` and `flags = 0`.
+        let ret = unsafe {
+            ffi_av_hwdevice_ctx_create(
+                std::ptr::addr_of_mut!(ptr),
+                device_type,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if ret < 0 {
+            return Err(AvError::new(ret));
+        }
+        NonNull::new(ptr)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr })
+    }
+
+    /// Returns the underlying device reference for FFI calls within the crate.
+    ///
+    /// Not part of the public API: callers hand a `&HwDeviceContext` to
+    /// [`CodecContext::set_hw_device_ctx`](crate::CodecContext::set_hw_device_ctx),
+    /// which takes its own reference.
+    pub(crate) fn as_raw(&self) -> *mut AVBufferRef {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for HwDeviceContext {
+    fn drop(&mut self) {
+        // SAFETY: we uniquely own this reference (NonNull, not Copy/Clone), so
+        //         this runs exactly once. `av_buffer_unref` drops our reference
+        //         (freeing the device when the last reference goes) and writes
+        //         null into our local copy of the pointer, which is discarded.
+        unsafe {
+            let mut raw = self.ptr.as_ptr();
+            ffi_av_buffer_unref(std::ptr::addr_of_mut!(raw));
+        }
+    }
+}
+
+// SAFETY: an `AVBufferRef` device context is reference-counted and safe to move
+//         between threads; Rust's ownership model guarantees exclusive access to
+//         this owner, and we expose no shared mutation.
+unsafe impl Send for HwDeviceContext {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_should_return_a_result_without_panicking() {
+        // Creating a CUDA device either succeeds (a GPU / driver is present) or
+        // returns an error (CI has no backend). Either way the constructor must
+        // not panic, and a successful context must drop cleanly (no double free).
+        match HwDeviceContext::new(crate::AVHWDeviceType_AV_HWDEVICE_TYPE_CUDA) {
+            Ok(ctx) => {
+                assert!(!ctx.as_raw().is_null());
+                // `ctx` drops here, unreferencing exactly once.
+            }
+            Err(e) => {
+                // A well-formed error code, not a panic.
+                assert!(e.code() < 0);
+            }
+        }
+    }
+}

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -63,6 +63,8 @@ mod format_context;
 #[cfg(not(docsrs))]
 mod frame;
 #[cfg(not(docsrs))]
+mod hwdevice;
+#[cfg(not(docsrs))]
 mod packet;
 #[cfg(not(docsrs))]
 mod resample_context;
@@ -85,6 +87,8 @@ pub use format_context::{
 };
 #[cfg(not(docsrs))]
 pub use frame::Frame;
+#[cfg(not(docsrs))]
+pub use hwdevice::HwDeviceContext;
 #[cfg(not(docsrs))]
 pub use packet::Packet;
 #[cfg(not(docsrs))]


### PR DESCRIPTION
## Objective

- Finish the ff-sys RAII sealing (ADR-0003, #1473): ff-decode's hardware-acceleration path was the last place still using owned-type raw pointers (`av_hwframe_transfer_data`, the raw `hw_device_ctx` field write, and a manual `av_buffer_unref` in `Drop`).
- Completing it brings every consumer crate to zero owned-type `as_ptr`/`as_mut_ptr` uses, which #1545 requires and which unblocks the #1506 seal.

## Solution

- Add a hardware-accel RAII surface to ff-sys: `HwDeviceContext` (an owned `AVBufferRef` device from `av_hwdevice_ctx_create`, unreferenced once on drop), `CodecContext::set_hw_device_ctx` (attaches a device via `av_buffer_replace`, so the codec takes its own reference), and `Frame::hwframe_transfer_data` (a safe wrapper over `av_hwframe_transfer_data` — a non-hardware `src` is a functional `EINVAL`, not UB, so it stays a safe `fn`).
- Migrate ff-decode's `init_hardware_accel` / `try_init_hw_device` / `transfer_hardware_frame_if_needed` onto these. The decoder holds an `Option<HwDeviceContext>` whose `Drop` releases the device reference, so the manual `Drop` impl and the codec-open-failure manual unref are removed. The reference count is balanced across the success, codec-open-failure, and auto-fallback paths (this also removes a latent leak in the old auto path).
- Add a backend-independent test that transferring between two software frames returns `Err` (validating the safe wrapper's error path without a GPU); the device/transfer paths that need a real backend stay graceful-skipped as before.

With this, ff-analysis, ff-probe, ff-remux, ff-filter, and ff-decode all have zero owned-type `as_ptr`/`as_mut_ptr` uses.

Closes #1560
Closes #1545