### PR TITLE
refactor(ff-sys): seal the owned-type raw-pointer surface

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -420,7 +420,7 @@ impl AudioEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame_ref(Some(&av_frame))
+                    .send_frame(Some(&av_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -510,7 +510,7 @@ impl AudioEncoderInner {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Audio codec not initialized".to_string(),
             })?
-            .send_frame_ref(Some(&av_frame))
+            .send_frame(Some(&av_frame))
             .map_err(|e| EncodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(
@@ -670,7 +670,7 @@ impl AudioEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Audio codec not initialized".to_string(),
                 })?
-                .receive_packet_into(&mut packet);
+                .receive_packet(&mut packet);
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -727,7 +727,7 @@ impl AudioEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame_ref(None)
+                    .send_frame(None)
                     .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_packets()?;
             }

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -292,7 +292,7 @@ impl ImageEncoderInner {
 
         // ── Send frame → encoder ──────────────────────────────────────────────
         self.codec_ctx
-            .send_frame_ref(Some(&self.dst_frame))
+            .send_frame(Some(&self.dst_frame))
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Receive packets ───────────────────────────────────────────────────
@@ -300,7 +300,7 @@ impl ImageEncoderInner {
 
         // ── Flush encoder ─────────────────────────────────────────────────────
         self.codec_ctx
-            .send_frame_ref(None)
+            .send_frame(None)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Drain remaining packets ───────────────────────────────────────────
@@ -327,7 +327,7 @@ impl ImageEncoderInner {
         loop {
             match self
                 .codec_ctx
-                .receive_packet_into(&mut self.packet)
+                .receive_packet(&mut self.packet)
                 .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?
             {
                 ff_sys::ReceiveOutcome::Frame => {

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -441,11 +441,11 @@ unsafe fn encode_frame_as_png_inner(
 
     let encode_result = (|| -> Result<(), PreviewImageError> {
         codec_ctx
-            .send_frame_ref(Some(&*frame))
+            .send_frame(Some(&*frame))
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
         drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, false)?;
         codec_ctx
-            .send_frame_ref(None)
+            .send_frame(None)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
         drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, true)?;
         Ok(())
@@ -475,7 +475,7 @@ unsafe fn drain_packets(
 ) -> Result<(), PreviewImageError> {
     loop {
         match codec_ctx
-            .receive_packet_into(packet)
+            .receive_packet(packet)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?
         {
             ff_sys::ReceiveOutcome::Frame => {
@@ -1163,7 +1163,7 @@ unsafe fn encode_gif_unsafe(
         first_frame.set_pts(frame_counter);
         frame_counter += 1;
         codec_ctx
-            .send_frame_ref(Some(&first_frame))
+            .send_frame(Some(&first_frame))
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
         drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, false)?;
 
@@ -1183,14 +1183,14 @@ unsafe fn encode_gif_unsafe(
             frame_counter += 1;
             // `frame` drops at end of iteration (or on the `?` below), freeing it.
             codec_ctx
-                .send_frame_ref(Some(&frame))
+                .send_frame(Some(&frame))
                 .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
             drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, false)?;
         }
 
         // Flush encoder.
         codec_ctx
-            .send_frame_ref(None)
+            .send_frame(None)
             .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
         drain_packets(&mut codec_ctx, &mut fmt_ctx, &mut packet, true)?;
         Ok(())

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -42,7 +42,7 @@ impl VideoEncoderInner {
         })?;
 
         loop {
-            match codec_ctx.receive_packet_into(&mut packet) {
+            match codec_ctx.receive_packet(&mut packet) {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Discard — do not write to the format context.
                     packet.unref();
@@ -265,7 +265,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
                 })?
-                .receive_packet_into(&mut packet);
+                .receive_packet(&mut packet);
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully
@@ -455,7 +455,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Audio codec not initialized".to_string(),
                 })?
-                .receive_packet_into(&mut packet);
+                .receive_packet(&mut packet);
             match recv {
                 Ok(ff_sys::ReceiveOutcome::Frame) => {
                     // Packet received successfully

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -349,7 +349,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Pass-1 codec context not initialized".to_string(),
                     })?
-                    .send_frame_ref(Some(&av_frame))
+                    .send_frame(Some(&av_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -406,7 +406,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
                 })?
-                .send_frame_ref(Some(&av_frame))
+                .send_frame(Some(&av_frame))
                 .map_err(|e| EncodeError::Ffmpeg {
                     code: e.code(),
                     message: format!(
@@ -459,7 +459,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame_ref(Some(&av_frame))
+                    .send_frame(Some(&av_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -522,7 +522,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame_ref(Some(&out_frame))
+                    .send_frame(Some(&out_frame))
                     .map_err(|e| EncodeError::Ffmpeg {
                         code: e.code(),
                         message: format!(
@@ -555,7 +555,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Video codec not initialized".to_string(),
                     })?
-                    .send_frame_ref(None)
+                    .send_frame(None)
                     .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_packets()?;
             }
@@ -597,7 +597,7 @@ impl VideoEncoderInner {
                             .ok_or_else(|| EncodeError::InvalidConfig {
                                 reason: "Audio codec not initialized".to_string(),
                             })?
-                            .send_frame_ref(Some(&out_frame));
+                            .send_frame(Some(&out_frame));
                         let _ = self.receive_audio_packets();
                         self.audio_sample_count += remaining as u64;
                     }
@@ -613,7 +613,7 @@ impl VideoEncoderInner {
                     .ok_or_else(|| EncodeError::InvalidConfig {
                         reason: "Audio codec not initialized".to_string(),
                     })?
-                    .send_frame_ref(None)
+                    .send_frame(None)
                     .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
                 self.receive_audio_packets()?;
             }

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -72,7 +72,7 @@ impl VideoEncoderInner {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Pass-1 codec context not initialized".to_string(),
             })?
-            .send_frame(ptr::null())
+            .send_frame(None)
             && e.code() != ff_sys::error_codes::EOF
         {
             return Err(EncodeError::Ffmpeg {
@@ -157,7 +157,7 @@ impl VideoEncoderInner {
                 .ok_or_else(|| EncodeError::InvalidConfig {
                     reason: "Video codec not initialized".to_string(),
                 })?
-                .send_frame(ptr::null())
+                .send_frame(None)
                 && e.code() != ff_sys::error_codes::EOF
             {
                 return Err(EncodeError::Ffmpeg {
@@ -411,7 +411,7 @@ impl VideoEncoderInner {
             .ok_or_else(|| EncodeError::InvalidConfig {
                 reason: "Video codec not initialized".to_string(),
             })?
-            .send_frame_ref(Some(&av_frame))
+            .send_frame(Some(&av_frame))
             .map_err(|e| EncodeError::Ffmpeg {
                 code: e.code(),
                 message: format!(

--- a/crates/ff-filter/src/effects/effects_inner.rs
+++ b/crates/ff-filter/src/effects/effects_inner.rs
@@ -235,7 +235,7 @@ fn drain_encoded_packets(
     stream_tb: ff_sys::AVRational,
 ) {
     while matches!(
-        enc_ctx.receive_packet_into(pkt),
+        enc_ctx.receive_packet(pkt),
         Ok(ff_sys::ReceiveOutcome::Frame)
     ) {
         // Read enc_tb at drain time — some encoders mutate time_base lazily.
@@ -630,7 +630,7 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     };
 
     // ── Encode first frame ────────────────────────────────────────────────────
-    let _ = enc_ctx.send_frame_ref(Some(&first_frame));
+    let _ = enc_ctx.send_frame(Some(&first_frame));
     drain_encoded_packets(&mut enc_ctx, &mut pkt, &mut out_ctx, stream_tb);
     drop(first_frame);
 
@@ -645,13 +645,13 @@ pub(super) unsafe fn transform_vidstab_unsafe(
         ) {
             break;
         }
-        let _ = enc_ctx.send_frame_ref(Some(&frame));
+        let _ = enc_ctx.send_frame(Some(&frame));
         drain_encoded_packets(&mut enc_ctx, &mut pkt, &mut out_ctx, stream_tb);
         // `frame` drops at end of iteration.
     }
 
     // ── Flush the encoder ─────────────────────────────────────────────────────
-    let _ = enc_ctx.send_frame_ref(None);
+    let _ = enc_ctx.send_frame(None);
     drain_encoded_packets(&mut enc_ctx, &mut pkt, &mut out_ctx, stream_tb);
 
     // ── Finalize output ───────────────────────────────────────────────────────

--- a/crates/ff-stream/src/codec_utils.rs
+++ b/crates/ff-stream/src/codec_utils.rs
@@ -213,7 +213,7 @@ pub(crate) fn drain_encoder(
     let frame_dur_enc_tb = unsafe { av_rescale_q(1, frame_period, enc_tb) };
 
     // NeedInput (EAGAIN) / Drained (EOF) / real error all end the drain.
-    while let Ok(ReceiveOutcome::Frame) = enc_ctx.receive_packet_into(&mut pkt) {
+    while let Ok(ReceiveOutcome::Frame) = enc_ctx.receive_packet(&mut pkt) {
         // Always override duration with the correct per-frame value BEFORE rescaling.
         if frame_dur_enc_tb > 0 {
             pkt.set_duration(frame_dur_enc_tb);

--- a/crates/ff-stream/src/dash_inner/write.rs
+++ b/crates/ff-stream/src/dash_inner/write.rs
@@ -400,7 +400,7 @@ pub(super) unsafe fn write_dash_unsafe(
                     false
                 };
 
-                if scaled && vid_enc_ctx.send_frame_ref(Some(&vid_enc_frame)).is_ok() {
+                if scaled && vid_enc_ctx.send_frame(Some(&vid_enc_frame)).is_ok() {
                     crate::codec_utils::drain_encoder(
                         &mut vid_enc_ctx,
                         &mut out_ctx,
@@ -458,7 +458,7 @@ pub(super) unsafe fn write_dash_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
+                    if aud_enc.send_frame(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc,
                             &mut out_ctx,
@@ -479,7 +479,7 @@ pub(super) unsafe fn write_dash_unsafe(
     }
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
-    let _ = vid_enc_ctx.send_frame_ref(None);
+    let _ = vid_enc_ctx.send_frame(None);
     crate::codec_utils::drain_encoder(
         &mut vid_enc_ctx,
         &mut out_ctx,
@@ -516,7 +516,7 @@ pub(super) unsafe fn write_dash_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
+                    if aud_enc.send_frame(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc,
                             &mut out_ctx,
@@ -529,7 +529,7 @@ pub(super) unsafe fn write_dash_unsafe(
                 aud_enc_frame.unref();
             }
         }
-        let _ = aud_enc.send_frame_ref(None);
+        let _ = aud_enc.send_frame(None);
         crate::codec_utils::drain_encoder(
             aud_enc,
             &mut out_ctx,
@@ -957,12 +957,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                         false
                     };
 
-                    if scaled
-                        && state
-                            .vid_enc_ctx
-                            .send_frame_ref(Some(&vid_enc_frame))
-                            .is_ok()
-                    {
+                    if scaled && state.vid_enc_ctx.send_frame(Some(&vid_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
                             &mut state.vid_enc_ctx,
                             &mut out_ctx,
@@ -1022,7 +1017,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
+                    if aud_enc.send_frame(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc,
                             &mut out_ctx,
@@ -1044,7 +1039,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
     for state in &mut rendition_states {
-        let _ = state.vid_enc_ctx.send_frame_ref(None);
+        let _ = state.vid_enc_ctx.send_frame(None);
         crate::codec_utils::drain_encoder(
             &mut state.vid_enc_ctx,
             &mut out_ctx,
@@ -1081,7 +1076,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
+                    if aud_enc.send_frame(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc,
                             &mut out_ctx,
@@ -1094,7 +1089,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
                 aud_enc_frame.unref();
             }
         }
-        let _ = aud_enc.send_frame_ref(None);
+        let _ = aud_enc.send_frame(None);
         crate::codec_utils::drain_encoder(
             aud_enc,
             &mut out_ctx,

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -495,7 +495,7 @@ unsafe fn write_hls_unsafe(
                     false
                 };
 
-                if scaled && vid_enc_ctx.send_frame_ref(Some(&vid_enc_frame)).is_ok() {
+                if scaled && vid_enc_ctx.send_frame(Some(&vid_enc_frame)).is_ok() {
                     crate::codec_utils::drain_encoder(
                         &mut vid_enc_ctx,
                         &mut out_ctx,
@@ -553,7 +553,7 @@ unsafe fn write_hls_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
+                    if aud_enc.send_frame(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc,
                             &mut out_ctx,
@@ -574,7 +574,7 @@ unsafe fn write_hls_unsafe(
     }
 
     // ── 14. Flush encoders ────────────────────────────────────────────────────
-    let _ = vid_enc_ctx.send_frame_ref(None);
+    let _ = vid_enc_ctx.send_frame(None);
     crate::codec_utils::drain_encoder(
         &mut vid_enc_ctx,
         &mut out_ctx,
@@ -611,7 +611,7 @@ unsafe fn write_hls_unsafe(
                 {
                     aud_enc_frame.set_nb_samples(n);
                     aud_enc_frame.set_pts(audio_sample_count);
-                    if aud_enc.send_frame_ref(Some(&aud_enc_frame)).is_ok() {
+                    if aud_enc.send_frame(Some(&aud_enc_frame)).is_ok() {
                         crate::codec_utils::drain_encoder(
                             aud_enc,
                             &mut out_ctx,
@@ -624,7 +624,7 @@ unsafe fn write_hls_unsafe(
                 aud_enc_frame.unref();
             }
         }
-        let _ = aud_enc.send_frame_ref(None);
+        let _ = aud_enc.send_frame(None);
         crate::codec_utils::drain_encoder(
             aud_enc,
             &mut out_ctx,

--- a/crates/ff-stream/src/muxer_core.rs
+++ b/crates/ff-stream/src/muxer_core.rs
@@ -238,7 +238,7 @@ impl MuxerCore {
 
         if self
             .vid_enc_ctx
-            .send_frame_ref(Some(&self.vid_enc_frame))
+            .send_frame(Some(&self.vid_enc_frame))
             .is_ok()
         {
             drain_encoder(
@@ -337,7 +337,7 @@ impl MuxerCore {
             self.aud_enc_frame.set_nb_samples(n);
             self.aud_enc_frame.set_pts(self.audio_pts);
             if let Some(aud_ctx) = self.aud_enc_ctx.as_mut()
-                && aud_ctx.send_frame_ref(Some(&self.aud_enc_frame)).is_ok()
+                && aud_ctx.send_frame(Some(&self.aud_enc_frame)).is_ok()
             {
                 let aud_frame_period = AVRational {
                     num: aud_ctx.frame_size(),
@@ -370,7 +370,7 @@ impl MuxerCore {
     /// `open_unsafe`. This method must be called at most once.
     pub(crate) unsafe fn flush_and_close_unsafe(&mut self) {
         // ── Flush video encoder ───────────────────────────────────────────────
-        let _ = self.vid_enc_ctx.send_frame_ref(None);
+        let _ = self.vid_enc_ctx.send_frame(None);
         drain_encoder(
             &mut self.vid_enc_ctx,
             &mut self.out_ctx,
@@ -411,7 +411,7 @@ impl MuxerCore {
                         self.aud_enc_frame.set_nb_samples(n);
                         self.aud_enc_frame.set_pts(self.audio_pts);
                         if let Some(aud_ctx) = self.aud_enc_ctx.as_mut()
-                            && aud_ctx.send_frame_ref(Some(&self.aud_enc_frame)).is_ok()
+                            && aud_ctx.send_frame(Some(&self.aud_enc_frame)).is_ok()
                         {
                             let aud_frame_period = AVRational {
                                 num: aud_ctx.frame_size(),
@@ -432,7 +432,7 @@ impl MuxerCore {
 
             // Flush the AAC encoder itself.
             if let Some(aud_ctx) = self.aud_enc_ctx.as_mut() {
-                let _ = aud_ctx.send_frame_ref(None);
+                let _ = aud_ctx.send_frame(None);
                 let aud_frame_period = AVRational {
                     num: aud_ctx.frame_size(),
                     den: aud_ctx.sample_rate(),

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -13,8 +13,8 @@ use std::ptr::{self, NonNull};
 
 use crate::{
     AVCodecContext, AVCodecID, AVCodecParameters, AVColorPrimaries, AVColorRange, AVColorSpace,
-    AVColorTransferCharacteristic, AVDictionary, AVFrame, AVPacket, AVPixelFormat, AVRational,
-    AVSampleFormat, AvError, Codec, CodecParameters, Frame, HwDeviceContext, Packet,
+    AVColorTransferCharacteristic, AVDictionary, AVPixelFormat, AVRational, AVSampleFormat,
+    AvError, Codec, CodecParameters, Frame, HwDeviceContext, Packet,
     av_buffer_replace as ffi_av_buffer_replace, avcodec_free_context as ffi_avcodec_free_context,
 };
 
@@ -87,14 +87,22 @@ impl CodecContext {
     }
 
     /// Returns the context pointer for read-only use.
+    ///
+    /// Test-only: retained solely for ff-sys's own unit tests (the raw-FFI audio
+    /// decoder helper in `swresample`). No public or non-test signature exposes
+    /// this raw pointer.
+    #[cfg(test)]
     #[must_use]
-    pub const fn as_ptr(&self) -> *const AVCodecContext {
+    pub(crate) const fn as_ptr(&self) -> *const AVCodecContext {
         self.ptr.as_ptr()
     }
 
     /// Returns the context pointer for mutation and FFI calls.
+    ///
+    /// Test-only: see `as_ptr`.
+    #[cfg(test)]
     #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVCodecContext {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut AVCodecContext {
         self.ptr.as_ptr()
     }
 
@@ -584,51 +592,20 @@ impl CodecContext {
         unsafe { crate::avcodec::flush_buffers(self.ptr.as_ptr()) };
     }
 
-    /// Sends a frame to the encoder (a null frame flushes it, entering draining).
-    ///
-    /// After sending a null frame, loop [`receive_packet`](Self::receive_packet)
-    /// until it returns [`ReceiveOutcome::Drained`] to collect the buffered packets.
-    ///
-    /// # Safety
-    ///
-    /// `frame` must be null or a valid `*const AVFrame`.
-    pub unsafe fn send_frame(&mut self, frame: *const AVFrame) -> Result<(), AvError> {
-        // SAFETY: `self.ptr` is a valid open encoder context; the caller upholds `frame`.
-        unsafe { crate::avcodec::send_frame(self.ptr.as_ptr(), frame) }.map_err(AvError::new)
-    }
-
-    /// Receives an encoded packet, returning a typed [`ReceiveOutcome`].
-    ///
-    /// `EAGAIN` (need input) and `EOF` (drained) are returned as
-    /// [`ReceiveOutcome::NeedInput`] / [`ReceiveOutcome::Drained`] rather than
-    /// errors; only other negative codes are `Err`.
-    ///
-    /// # Safety
-    ///
-    /// `pkt` must be a valid `*mut AVPacket`.
-    pub unsafe fn receive_packet(&mut self, pkt: *mut AVPacket) -> Result<ReceiveOutcome, AvError> {
-        // SAFETY: `self.ptr` is a valid open encoder context; the caller upholds `pkt`.
-        let result = unsafe { crate::avcodec::receive_packet(self.ptr.as_ptr(), pkt) };
-        classify_receive(result)
-    }
-
     /// Sends a frame to the encoder; `None` flushes it, entering draining.
     ///
-    /// The safe counterpart of [`send_frame`](Self::send_frame): after sending
-    /// `None`, loop [`receive_packet_into`](Self::receive_packet_into) until it
+    /// After sending `None`, loop [`receive_packet`](Self::receive_packet) until it
     /// returns [`ReceiveOutcome::Drained`] to collect the buffered packets.
-    ///
-    /// Transitional name: this is renamed to `send_frame` once the raw `unsafe`
-    /// [`send_frame`](Self::send_frame) is removed (#1506).
     ///
     /// # Errors
     ///
     /// Returns an [`AvError`] on a real encode error.
-    pub fn send_frame_ref(&mut self, frame: Option<&Frame>) -> Result<(), AvError> {
+    pub fn send_frame(&mut self, frame: Option<&Frame>) -> Result<(), AvError> {
         let ptr = frame.map_or(std::ptr::null(), Frame::as_ptr);
-        // SAFETY: `ptr` is null (flush) or a valid `*const AVFrame` borrowed from
-        //         `frame` for the duration of the call; `self.ptr` is a valid context.
-        unsafe { self.send_frame(ptr) }
+        // SAFETY: `self.ptr` is a valid owned encoder context; `ptr` is null (flush)
+        //         or a valid `*const AVFrame` borrowed from `frame` for the call. An
+        //         unopened context is rejected with EINVAL (no deref), so this is safe.
+        unsafe { crate::avcodec::send_frame(self.ptr.as_ptr(), ptr) }.map_err(AvError::new)
     }
 
     /// Attaches a hardware device context to this codec context (for hardware
@@ -662,20 +639,19 @@ impl CodecContext {
 
     /// Receives an encoded packet into `pkt`, returning a typed [`ReceiveOutcome`].
     ///
-    /// The safe counterpart of [`receive_packet`](Self::receive_packet), pairing
-    /// with [`receive_frame`](Self::receive_frame). `EAGAIN` / `EOF` are returned
-    /// as [`ReceiveOutcome::NeedInput`] / [`ReceiveOutcome::Drained`], not errors.
-    ///
-    /// Transitional name: this is renamed to `receive_packet` once the raw `unsafe`
-    /// [`receive_packet`](Self::receive_packet) is removed (#1506).
+    /// Pairs with [`receive_frame`](Self::receive_frame). `EAGAIN` / `EOF` are
+    /// returned as [`ReceiveOutcome::NeedInput`] / [`ReceiveOutcome::Drained`],
+    /// not errors.
     ///
     /// # Errors
     ///
     /// Returns an [`AvError`] on a real encode error.
-    pub fn receive_packet_into(&mut self, pkt: &mut Packet) -> Result<ReceiveOutcome, AvError> {
-        // SAFETY: `pkt` is a valid owned packet borrowed mutably for the call;
-        //         `self.ptr` is a valid context.
-        unsafe { self.receive_packet(pkt.as_mut_ptr()) }
+    pub fn receive_packet(&mut self, pkt: &mut Packet) -> Result<ReceiveOutcome, AvError> {
+        // SAFETY: `self.ptr` is a valid owned encoder context; `pkt` is a valid owned
+        //         packet borrowed mutably for the call. An unopened context is rejected
+        //         with EINVAL (no deref), so this is safe.
+        let result = unsafe { crate::avcodec::receive_packet(self.ptr.as_ptr(), pkt.as_mut_ptr()) };
+        classify_receive(result)
     }
 
     /// Copies this context's parameters into `par` (encoder → stream codecpar).
@@ -727,9 +703,8 @@ mod tests {
     fn codec_context_new_should_allocate_and_drop_cleanly() {
         // A `None` codec yields a generic context, so this does not depend on any
         // specific decoder being present in the linked FFmpeg build.
-        let ctx = CodecContext::new(None).expect("alloc should succeed");
-        assert!(!ctx.as_ptr().is_null());
-        // Dropping `ctx` here frees the context exactly once (no panic / double free).
+        let _ctx = CodecContext::new(None).expect("alloc should succeed");
+        // Dropping `_ctx` here frees the context exactly once (no panic / double free).
     }
 
     #[test]
@@ -827,17 +802,17 @@ mod tests {
     }
 
     #[test]
-    fn send_frame_ref_and_receive_packet_into_should_err_when_unopened() {
+    fn send_frame_and_receive_packet_should_err_when_unopened() {
         // On an unopened context avcodec_send_frame / avcodec_receive_packet return
         // EINVAL via the avcodec_is_open guard (no deref); the safe wrappers must
         // surface that as Err without panicking — for both the flush (None) and
         // frame (Some) send paths and the receive path.
         let mut ctx = CodecContext::new(None).expect("alloc should succeed");
-        assert!(ctx.send_frame_ref(None).is_err());
+        assert!(ctx.send_frame(None).is_err());
         let frame = Frame::new().expect("frame alloc should succeed");
-        assert!(ctx.send_frame_ref(Some(&frame)).is_err());
+        assert!(ctx.send_frame(Some(&frame)).is_err());
         let mut pkt = Packet::new().expect("packet alloc should succeed");
-        assert!(ctx.receive_packet_into(&mut pkt).is_err());
+        assert!(ctx.receive_packet(&mut pkt).is_err());
     }
 
     #[test]

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1161,16 +1161,6 @@ impl CodecContext {
         Err(crate::AvError::new(-1))
     }
 
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const AVCodecContext {
-        self._ptr.as_ptr()
-    }
-
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVCodecContext {
-        self._ptr.as_ptr()
-    }
-
     pub fn set_thread_count(&mut self, _thread_count: c_int) {}
 
     pub fn set_width(&mut self, _width: c_int) {}
@@ -1338,24 +1328,9 @@ impl CodecContext {
     /// Stub; never executed on docs.rs.
     pub unsafe fn flush_buffers(&mut self) {}
 
-    /// # Safety
-    /// Stub; never executed on docs.rs.
-    pub unsafe fn send_frame(&mut self, _frame: *const AVFrame) -> Result<(), crate::AvError> {
-        Err(crate::AvError::new(-1))
-    }
-
-    /// # Safety
-    /// Stub; never executed on docs.rs.
-    pub unsafe fn receive_packet(
-        &mut self,
-        _pkt: *mut AVPacket,
-    ) -> Result<ReceiveOutcome, crate::AvError> {
-        Err(crate::AvError::new(-1))
-    }
-
     /// # Errors
     /// Stub; never executed on docs.rs.
-    pub fn send_frame_ref(&mut self, _frame: Option<&Frame>) -> Result<(), crate::AvError> {
+    pub fn send_frame(&mut self, _frame: Option<&Frame>) -> Result<(), crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 
@@ -1370,7 +1345,7 @@ impl CodecContext {
 
     /// # Errors
     /// Stub; never executed on docs.rs.
-    pub fn receive_packet_into(
+    pub fn receive_packet(
         &mut self,
         _pkt: &mut Packet,
     ) -> Result<ReceiveOutcome, crate::AvError> {
@@ -1428,16 +1403,6 @@ impl InputFormatContext {
         _framerate: u32,
     ) -> Result<Self, crate::AvError> {
         Err(crate::AvError::new(-1))
-    }
-
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const AVFormatContext {
-        self._ptr.as_ptr()
-    }
-
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
-        self._ptr.as_ptr()
     }
 
     #[must_use]
@@ -1559,16 +1524,6 @@ impl OutputFormatContext {
         _filename: &std::path::Path,
     ) -> Result<Self, crate::AvError> {
         Err(crate::AvError::new(-1))
-    }
-
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const AVFormatContext {
-        self._ptr.as_ptr()
-    }
-
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
-        self._ptr.as_ptr()
     }
 
     #[must_use]
@@ -1868,12 +1823,12 @@ impl Frame {
     }
 
     #[must_use]
-    pub const fn as_ptr(&self) -> *const AVFrame {
+    pub(crate) const fn as_ptr(&self) -> *const AVFrame {
         self._ptr.as_ptr()
     }
 
     #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVFrame {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut AVFrame {
         self._ptr.as_ptr()
     }
 
@@ -2022,12 +1977,12 @@ impl Packet {
     }
 
     #[must_use]
-    pub const fn as_ptr(&self) -> *const AVPacket {
+    pub(crate) const fn as_ptr(&self) -> *const AVPacket {
         self._ptr.as_ptr()
     }
 
     #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVPacket {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut AVPacket {
         self._ptr.as_ptr()
     }
 
@@ -2211,21 +2166,6 @@ impl ScaleContext {
         Err(crate::AvError::new(-1))
     }
 
-    /// # Errors
-    /// Stub; never executed on docs.rs.
-    /// # Safety
-    /// Stub; never executed on docs.rs.
-    pub unsafe fn scale(
-        &mut self,
-        _src: *const *const u8,
-        _src_stride: *const c_int,
-        _src_slice_y: c_int,
-        _src_slice_h: c_int,
-        _dst: *const *mut u8,
-        _dst_stride: *const c_int,
-    ) -> Result<c_int, crate::AvError> {
-        Err(crate::AvError::new(-1))
-    }
 }
 
 impl Drop for ScaleContext {
@@ -2291,20 +2231,6 @@ impl ResampleContext {
     /// # Safety
     /// Stub; never executed on docs.rs.
     pub unsafe fn flush_into_frame(&mut self, _dst: &mut Frame) -> Result<c_int, crate::AvError> {
-        Err(crate::AvError::new(-1))
-    }
-
-    /// # Errors
-    /// Stub; never executed on docs.rs.
-    /// # Safety
-    /// Stub; never executed on docs.rs.
-    pub unsafe fn convert(
-        &mut self,
-        _out: *mut *mut u8,
-        _out_count: c_int,
-        _in_: *const *const u8,
-        _in_count: c_int,
-    ) -> Result<c_int, crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -3,18 +3,16 @@
 //! [`InputFormatContext`] opens a demuxing context and frees it exactly once on
 //! drop, replacing the manual `avformat::open_input*` + `avformat::close_input`
 //! pair. Its fallible methods return [`AvError`]. The packet argument of
-//! [`read_frame`](InputFormatContext::read_frame) stays a raw pointer for now
-//! (an owned Packet is a later step), so that method is `unsafe`: the caller
-//! upholds the usual FFmpeg preconditions.
+//! [`read_frame`](InputFormatContext::read_frame) is the owned [`Packet`], so no
+//! public signature exposes a raw pointer.
 //!
 //! [`OutputFormatContext`] owns the mux (output) lifecycle: it allocates a
 //! muxing context, opens/closes its IO (`pb`), writes the header/trailer, and
 //! frees the context exactly once on drop (closing a caller-opened `pb`),
 //! replacing the manual `avformat_alloc_output_context2` + `avio_open` +
 //! `avformat_free_context` teardown. The write path (stream creation, packet
-//! writing, metadata / attachments / chapters) is exposed through safe methods;
-//! a transitional `as_mut_ptr` remains for the few sites not yet wrapped and is
-//! removed once the safe layer is sealed.
+//! writing, metadata / attachments / chapters) is exposed entirely through safe
+//! methods.
 
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
@@ -143,18 +141,6 @@ impl InputFormatContext {
         NonNull::new(ptr)
             .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
             .map(|ptr| Self { ptr })
-    }
-
-    /// Returns the context pointer for read-only use.
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const AVFormatContext {
-        self.ptr.as_ptr()
-    }
-
-    /// Returns the context pointer for mutation and FFI calls.
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
-        self.ptr.as_ptr()
     }
 
     /// Returns the number of streams in the container.
@@ -393,13 +379,10 @@ unsafe impl Send for InputFormatContext {}
 /// Exactly-once free is guaranteed by construction: the value owns a
 /// [`NonNull`] and is neither `Copy` nor `Clone`.
 ///
-/// The lifecycle (allocation, IO open/close, header/trailer) is wrapped as
-/// methods; the write path (`avformat_new_stream`, per-stream field setup,
-/// `av_interleaved_write_frame`) still goes through [`as_mut_ptr`] for now, so
-/// this type carries a transitional raw accessor like [`InputFormatContext`]
-/// (both are removed when the safe layer is sealed).
-///
-/// [`as_mut_ptr`]: OutputFormatContext::as_mut_ptr
+/// The lifecycle (allocation, IO open/close, header/trailer) and the write path
+/// (`avformat_new_stream`, per-stream field setup, `av_interleaved_write_frame`)
+/// are exposed entirely through safe methods, so no public signature exposes the
+/// raw context pointer.
 #[derive(Debug)]
 pub struct OutputFormatContext {
     ptr: NonNull<AVFormatContext>,
@@ -446,19 +429,6 @@ impl OutputFormatContext {
         NonNull::new(ctx)
             .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
             .map(|ptr| Self { ptr })
-    }
-
-    /// Returns the context pointer for read-only use.
-    #[must_use]
-    pub const fn as_ptr(&self) -> *const AVFormatContext {
-        self.ptr.as_ptr()
-    }
-
-    /// Returns the context pointer for mutation and FFI calls (stream creation,
-    /// packet writing, and per-stream field setup during migration).
-    #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVFormatContext {
-        self.ptr.as_ptr()
     }
 
     /// Returns the number of streams registered on the context.

--- a/crates/ff-sys/src/frame.rs
+++ b/crates/ff-sys/src/frame.rs
@@ -48,14 +48,19 @@ impl Frame {
     }
 
     /// Returns the frame pointer for read-only use.
+    ///
+    /// Crate-internal: the safe swscale / swresample / codec APIs consume the
+    /// owned [`Frame`], so no public signature exposes this raw pointer.
     #[must_use]
-    pub const fn as_ptr(&self) -> *const AVFrame {
+    pub(crate) const fn as_ptr(&self) -> *const AVFrame {
         self.ptr.as_ptr()
     }
 
     /// Returns the frame pointer for mutation and FFI calls.
+    ///
+    /// Crate-internal: see [`as_ptr`](Self::as_ptr).
     #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVFrame {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut AVFrame {
         self.ptr.as_ptr()
     }
 

--- a/crates/ff-sys/src/packet.rs
+++ b/crates/ff-sys/src/packet.rs
@@ -41,14 +41,19 @@ impl Packet {
     }
 
     /// Returns the packet pointer for read-only use.
+    ///
+    /// Crate-internal: the safe codec / format APIs consume the owned [`Packet`],
+    /// so no public signature exposes this raw pointer.
     #[must_use]
-    pub const fn as_ptr(&self) -> *const AVPacket {
+    pub(crate) const fn as_ptr(&self) -> *const AVPacket {
         self.ptr.as_ptr()
     }
 
     /// Returns the packet pointer for mutation and FFI calls.
+    ///
+    /// Crate-internal: see [`as_ptr`](Self::as_ptr).
     #[must_use]
-    pub fn as_mut_ptr(&mut self) -> *mut AVPacket {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut AVPacket {
         self.ptr.as_ptr()
     }
 

--- a/crates/ff-sys/src/resample_context.rs
+++ b/crates/ff-sys/src/resample_context.rs
@@ -8,10 +8,11 @@
 //! [`convert_into_planes`](ResampleContext::convert_into_planes) resamples an
 //! owned [`Frame`]'s audio into caller-provided plane slices, and its mirror
 //! [`convert_into_frame`](ResampleContext::convert_into_frame) resamples caller
-//! plane slices into an owned output [`Frame`]; both take borrowed slices instead
-//! of raw pointers. [`convert`](ResampleContext::convert) stays `unsafe` for
-//! callers that still pass raw plane pointers, and [`new`](Self::new) is `unsafe`
-//! because it takes raw channel-layout pointers.
+//! plane slices into an owned output [`Frame`], and
+//! [`flush_into_frame`](ResampleContext::flush_into_frame) drains the buffered
+//! samples; all take borrowed slices instead of raw pointers, so no public
+//! signature exposes a raw plane pointer. [`new`](Self::new) is `unsafe` because
+//! it takes raw channel-layout pointers.
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
@@ -232,32 +233,6 @@ impl ResampleContext {
             )
         }
         .map_err(AvError::new)
-    }
-
-    /// Converts (resamples / reformats) audio samples into the output buffers.
-    ///
-    /// Returns the number of samples produced per channel. Passing a null `in_`
-    /// with `in_count` 0 flushes buffered samples.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`AvError`] if conversion fails.
-    ///
-    /// # Safety
-    ///
-    /// `out` / `in_` and their counts must describe buffers valid for this
-    /// context's configured formats (or a null `in_` with a zero count).
-    pub unsafe fn convert(
-        &mut self,
-        out: *mut *mut u8,
-        out_count: c_int,
-        in_: *const *const u8,
-        in_count: c_int,
-    ) -> Result<c_int, AvError> {
-        // SAFETY: `self.ptr` is a valid initialized context; the caller upholds
-        //         the sample buffers.
-        unsafe { crate::swresample::convert(self.ptr.as_ptr(), out, out_count, in_, in_count) }
-            .map_err(AvError::new)
     }
 
     /// Returns the number of output samples a `swr_convert` with `in_samples`

--- a/crates/ff-sys/src/scale_context.rs
+++ b/crates/ff-sys/src/scale_context.rs
@@ -4,10 +4,9 @@
 //! drop, replacing the manual `swscale::get_context` + `sws_freeContext`
 //! pair. Its constructor is safe (it takes only dimensions, pixel formats, and
 //! flags). The safe [`scale_frames`](ScaleContext::scale_frames) /
-//! [`scale_planes`](ScaleContext::scale_planes) methods drive the scaler from
-//! owned [`Frame`] / borrowed plane slices; the raw
-//! [`scale`](ScaleContext::scale) stays `unsafe` for callers that still pass raw
-//! plane pointers.
+//! [`scale_planes`](ScaleContext::scale_planes) / [`scale_slices`](ScaleContext::scale_slices)
+//! methods drive the scaler from owned [`Frame`] / borrowed plane slices, so no
+//! public signature exposes a raw plane pointer.
 
 use std::os::raw::c_int;
 use std::ptr::NonNull;
@@ -226,43 +225,6 @@ impl ScaleContext {
                 src_h,
                 dst_ptrs.as_ptr(),
                 dst_line.as_ptr(),
-            )
-        }
-        .map_err(AvError::new)
-    }
-
-    /// Scales / converts a slice of the source image into the destination.
-    ///
-    /// Returns the height of the output slice.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`AvError`] if scaling fails.
-    ///
-    /// # Safety
-    ///
-    /// The plane and stride arrays must be valid and sized for the formats and
-    /// dimensions this context was created for.
-    pub unsafe fn scale(
-        &mut self,
-        src: *const *const u8,
-        src_stride: *const c_int,
-        src_slice_y: c_int,
-        src_slice_h: c_int,
-        dst: *const *mut u8,
-        dst_stride: *const c_int,
-    ) -> Result<c_int, AvError> {
-        // SAFETY: `self.ptr` is a valid owned scaling context; the caller upholds
-        //         the plane / stride arrays.
-        unsafe {
-            crate::swscale::scale(
-                self.ptr.as_ptr(),
-                src,
-                src_stride,
-                src_slice_y,
-                src_slice_h,
-                dst,
-                dst_stride,
             )
         }
         .map_err(AvError::new)


### PR DESCRIPTION
## Objective

- Slice S4a of the ff-sys safe-layer seal (#1473 / ADR-0003): with consumer migration complete (#1545 + #1560), the owned RAII types must no longer expose a raw pointer in any public signature, and the safe encode/decode methods should carry clean names.

## Solution

- Demote `Frame`/`Packet` `as_ptr`/`as_mut_ptr` to `pub(crate)` (they have in-crate callers).
- Delete the now-unused raw surface: `Input`/`OutputFormatContext` `as_ptr`/`as_mut_ptr`, `ScaleContext::scale`, `ResampleContext::convert`, and the raw `CodecContext::send_frame`/`receive_packet` (inlined into their safe wrappers). Deleting (rather than demoting) seals the surface without leaving a `pub(crate)` method that would trip `dead_code` under the lib-only CI clippy.
- Keep `CodecContext::as_ptr`/`as_mut_ptr` as `#[cfg(test)] pub(crate)`: their only remaining callers are an in-crate unit-test helper, so they are present in the test build, absent in the lib build, and never public.
- Rename the safe methods `send_frame_ref` -> `send_frame` and `receive_packet_into` -> `receive_packet`, updating ~49 consumer call sites across ff-encode / ff-filter / ff-stream; the two-pass encoder's raw `send_frame(ptr::null())` flush becomes the safe `send_frame(None)`.
- Mirror the demotions/renames/deletions in the docs.rs stubs so the DOCS_RS build stays shape-compatible.
- No behavior change; the safe layer now names no raw pointer in a public signature.

Resolves #1566
Part of #1506