### PR TITLE
refactor(ff-sys): seal the raw wrapper free-functions and add the seal guard

### DIFF
--- a/crates/ff-decode/src/audio/resample_inner.rs
+++ b/crates/ff-decode/src/audio/resample_inner.rs
@@ -353,10 +353,10 @@ unsafe fn convert_with_swr(
         // SAFETY: dst_ch_layout / src_ch_layout are valid for this call.
         let result = unsafe {
             ff_sys::ResampleContext::new(
-                &raw const dst_ch_layout,
+                &dst_ch_layout,
                 dst_format,
                 dst_sample_rate as i32,
-                &raw const src_ch_layout,
+                &src_ch_layout,
                 src_format,
                 src_sample_rate as i32,
             )

--- a/crates/ff-encode/examples/list_encoders.rs
+++ b/crates/ff-encode/examples/list_encoders.rs
@@ -2,47 +2,40 @@
 //!
 //! This example shows which video encoders are available in the current FFmpeg build.
 
-// Querying FFmpeg for available encoders requires unsafe FFI calls.
-#![allow(unsafe_code)]
-
 fn main() {
-    unsafe {
-        ff_sys::ensure_initialized();
+    ff_sys::ensure_initialized();
 
-        println!("Available video encoders:");
-        println!("{:-<60}", "");
+    println!("Available video encoders:");
+    println!("{:-<60}", "");
 
-        let encoders = [
-            // H.264 encoders
-            ("h264", "H.264 (built-in)"),
-            ("libx264", "H.264 (libx264)"),
-            ("h264_nvenc", "H.264 (NVENC)"),
-            ("h264_qsv", "H.264 (Quick Sync)"),
-            ("h264_amf", "H.264 (AMF)"),
-            ("h264_videotoolbox", "H.264 (VideoToolbox)"),
-            // H.265 encoders
-            ("hevc", "H.265 (built-in)"),
-            ("libx265", "H.265 (libx265)"),
-            ("hevc_nvenc", "H.265 (NVENC)"),
-            ("hevc_qsv", "H.265 (Quick Sync)"),
-            ("hevc_amf", "H.265 (AMF)"),
-            ("hevc_videotoolbox", "H.265 (VideoToolbox)"),
-            // Other codecs
-            ("libvpx-vp9", "VP9"),
-            ("libaom-av1", "AV1 (libaom)"),
-            ("libsvtav1", "AV1 (SVT)"),
-            ("mpeg4", "MPEG-4"),
-            ("prores_ks", "ProRes (Kostya)"),
-            ("prores", "ProRes"),
-            ("dnxhd", "DNxHD"),
-        ];
+    let encoders = [
+        // H.264 encoders
+        ("h264", "H.264 (built-in)"),
+        ("libx264", "H.264 (libx264)"),
+        ("h264_nvenc", "H.264 (NVENC)"),
+        ("h264_qsv", "H.264 (Quick Sync)"),
+        ("h264_amf", "H.264 (AMF)"),
+        ("h264_videotoolbox", "H.264 (VideoToolbox)"),
+        // H.265 encoders
+        ("hevc", "H.265 (built-in)"),
+        ("libx265", "H.265 (libx265)"),
+        ("hevc_nvenc", "H.265 (NVENC)"),
+        ("hevc_qsv", "H.265 (Quick Sync)"),
+        ("hevc_amf", "H.265 (AMF)"),
+        ("hevc_videotoolbox", "H.265 (VideoToolbox)"),
+        // Other codecs
+        ("libvpx-vp9", "VP9"),
+        ("libaom-av1", "AV1 (libaom)"),
+        ("libsvtav1", "AV1 (SVT)"),
+        ("mpeg4", "MPEG-4"),
+        ("prores_ks", "ProRes (Kostya)"),
+        ("prores", "ProRes"),
+        ("dnxhd", "DNxHD"),
+    ];
 
-        for (name, description) in encoders {
-            let c_name = std::ffi::CString::new(name).unwrap();
-            let available = ff_sys::avcodec::find_encoder_by_name(c_name.as_ptr()).is_some();
-
-            let status = if available { "✓" } else { "✗" };
-            println!("{} {:20} - {}", status, name, description);
-        }
+    for (name, description) in encoders {
+        let available = ff_sys::Codec::find_encoder_by_name(name).is_some();
+        let status = if available { "✓" } else { "✗" };
+        println!("{} {:20} - {}", status, name, description);
     }
 }

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -202,7 +202,7 @@ impl AudioEncoderInner {
 
         // Open codec
         codec_ctx
-            .open(codec, ptr::null_mut())
+            .open_codec(codec)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // After open2, frame_size is populated.  Allocate an AVAudioFifo when
@@ -565,7 +565,7 @@ impl AudioEncoderInner {
                         target_ch_layout,
                         target_format,
                         target_sample_rate,
-                        &raw const src_ch_layout,
+                        &src_ch_layout,
                         src_format,
                         src_sample_rate,
                     )

--- a/crates/ff-encode/src/image/encoder_inner.rs
+++ b/crates/ff-encode/src/image/encoder_inner.rs
@@ -28,7 +28,6 @@
 #![allow(clippy::unused_self)]
 
 use std::path::Path;
-use std::ptr;
 
 use ff_format::{PixelFormat, VideoFrame};
 use ff_sys::{
@@ -171,7 +170,7 @@ impl ImageEncoderInner {
         // ── Step 4: Open codec ────────────────────────────────────────────────
         inner
             .codec_ctx
-            .open(codec, ptr::null_mut())
+            .open_codec(codec)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // ── Step 5: Copy parameters to stream ─────────────────────────────────

--- a/crates/ff-encode/src/preview/preview_inner.rs
+++ b/crates/ff-encode/src/preview/preview_inner.rs
@@ -25,31 +25,23 @@ use std::time::Duration;
 
 use ff_sys::{
     AVCodecID_AV_CODEC_ID_GIF, AVCodecID_AV_CODEC_ID_PNG, AVPixelFormat_AV_PIX_FMT_RGB24,
-    AVRational, OutputFormatContext, avfilter_get_by_name, avfilter_graph_alloc,
-    avfilter_graph_config, avfilter_graph_create_filter, avfilter_graph_free, avfilter_link,
-    avformat,
+    AVRational, InputFormatContext, OutputFormatContext, avfilter_get_by_name,
+    avfilter_graph_alloc, avfilter_graph_config, avfilter_graph_create_filter, avfilter_graph_free,
+    avfilter_link,
 };
 
 use crate::PreviewImageError;
 
 /// Probes the video at `path` and returns its duration in seconds.
-///
-/// # Safety
-///
-/// All FFmpeg pointers are null-checked and freed on every exit path.
-unsafe fn probe_video_duration_secs(path: &Path) -> Result<f64, PreviewImageError> {
-    let fmt_ctx = avformat::open_input(path).map_err(PreviewImageError::from_ffmpeg_error)?;
+fn probe_video_duration_secs(path: &Path) -> Result<f64, PreviewImageError> {
+    let mut fmt_ctx = InputFormatContext::open(path)
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
+    fmt_ctx
+        .find_stream_info()
+        .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
-    if let Err(e) = avformat::find_stream_info(fmt_ctx) {
-        let mut p = fmt_ctx;
-        avformat::close_input(&raw mut p);
-        return Err(PreviewImageError::from_ffmpeg_error(e));
-    }
-
-    // SAFETY: fmt_ctx is non-null (open_input succeeded).
-    let duration_av = (*fmt_ctx).duration;
-    let mut p = fmt_ctx;
-    avformat::close_input(&raw mut p);
+    let duration_av = fmt_ctx.duration();
+    // `fmt_ctx` drops here, closing the input.
 
     if duration_av <= 0 {
         return Err(PreviewImageError::OperationFailed {
@@ -410,7 +402,7 @@ unsafe fn encode_frame_as_png_inner(
     codec_ctx.set_pix_fmt(pix_fmt);
 
     codec_ctx
-        .open(codec, ptr::null_mut())
+        .open_codec(codec)
         .map_err(|e| PreviewImageError::from_ffmpeg_error(e.code()))?;
 
     // Copy codec parameters to stream (includes width/height/format from the
@@ -1119,7 +1111,7 @@ unsafe fn encode_gif_unsafe(
     // Set GIF to loop infinitely (option "loop" = 0); unknown options are ignored.
     let _ = codec_ctx.set_opt("loop", "0");
 
-    if let Err(e) = codec_ctx.open(codec, ptr::null_mut()) {
+    if let Err(e) = codec_ctx.open_codec(codec) {
         let mut g = graph;
         avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(PreviewImageError::from_ffmpeg_error(e.code()));

--- a/crates/ff-encode/src/shared/hardware.rs
+++ b/crates/ff-encode/src/shared/hardware.rs
@@ -1,6 +1,5 @@
 //! Hardware encoder definitions.
 
-use std::ffi::CString;
 use std::sync::OnceLock;
 
 /// Hardware encoder type.
@@ -130,15 +129,8 @@ impl HardwareEncoder {
 ///
 /// Returns `true` if the encoder is available, `false` otherwise.
 fn is_encoder_available(name: &str) -> bool {
-    unsafe {
-        ff_sys::ensure_initialized();
-
-        let Ok(c_name) = CString::new(name) else {
-            return false;
-        };
-
-        ff_sys::avcodec::find_encoder_by_name(c_name.as_ptr()).is_some()
-    }
+    ff_sys::ensure_initialized();
+    ff_sys::Codec::find_encoder_by_name(name).is_some()
 }
 
 #[cfg(test)]

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -18,7 +18,7 @@ use super::options::audio_codec_to_id;
 use super::two_pass::AV_CODEC_FLAG_PASS1;
 use super::{
     AVMediaType_AVMEDIA_TYPE_SUBTITLE, AVPixelFormat_AV_PIX_FMT_YUV420P, AudioCodec, EncodeError,
-    VideoCodec, VideoEncoderInner, ptr,
+    VideoCodec, VideoEncoderInner,
 };
 
 impl VideoEncoderInner {
@@ -217,7 +217,7 @@ impl VideoEncoderInner {
 
         // Open codec
         codec_ctx
-            .open(selected_codec, ptr::null_mut())
+            .open_codec(selected_codec)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
         let actual_pix_fmt = from_av_pixel_format(codec_ctx.pix_fmt());
         log::info!(
@@ -330,7 +330,7 @@ impl VideoEncoderInner {
 
         // Open codec
         codec_ctx
-            .open(selected_codec, ptr::null_mut())
+            .open_codec(selected_codec)
             .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
         // Create stream. The owned codec_ctx frees itself if this returns.

--- a/crates/ff-encode/src/video/encoder_inner/encoding.rs
+++ b/crates/ff-encode/src/video/encoder_inner/encoding.rs
@@ -350,7 +350,7 @@ impl VideoEncoderInner {
                         target_ch_layout,
                         target_format,
                         target_sample_rate,
-                        &raw const src_ch_layout,
+                        &src_ch_layout,
                         src_format,
                         src_sample_rate,
                     )

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -39,10 +39,9 @@ use ff_sys::{
     AVCodecID_AV_CODEC_ID_VP9, AVMediaType_AVMEDIA_TYPE_SUBTITLE,
     AVPacketSideDataType_AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
     AVPacketSideDataType_AV_PKT_DATA_MASTERING_DISPLAY_METADATA, AVPixelFormat,
-    AVPixelFormat_AV_PIX_FMT_YUV420P, OutputFormatContext, avcodec, swresample,
+    AVPixelFormat_AV_PIX_FMT_YUV420P, OutputFormatContext, swresample,
 };
 use std::ffi::CString;
-use std::ptr;
 
 /// Internal encoder state with FFmpeg contexts.
 pub(super) struct VideoEncoderInner {

--- a/crates/ff-encode/src/video/encoder_inner/options.rs
+++ b/crates/ff-encode/src/video/encoder_inner/options.rs
@@ -19,7 +19,7 @@ use super::{
     AVCodecID_AV_CODEC_ID_NONE, AVCodecID_AV_CODEC_ID_OPUS, AVCodecID_AV_CODEC_ID_PCM_S16LE,
     AVCodecID_AV_CODEC_ID_PCM_S24LE, AVCodecID_AV_CODEC_ID_PNG, AVCodecID_AV_CODEC_ID_PRORES,
     AVCodecID_AV_CODEC_ID_VORBIS, AVCodecID_AV_CODEC_ID_VP8, AVCodecID_AV_CODEC_ID_VP9, AudioCodec,
-    CString, EncodeError, VideoCodec, VideoEncoderInner, avcodec,
+    EncodeError, VideoCodec, VideoEncoderInner,
 };
 
 /// Convert VideoCodec to FFmpeg AVCodecID.
@@ -405,11 +405,7 @@ impl VideoEncoderInner {
     ) -> Result<String, EncodeError> {
         // Early check: when Av1Svt is requested, verify that libsvtav1 is registered.
         if codec == VideoCodec::Av1Svt {
-            // SAFETY: find_encoder_by_name is always safe to call with a valid NUL-terminated
-            // C string literal; the returned pointer is owned by FFmpeg and must not be freed.
-            let has_svt = unsafe {
-                avcodec::find_encoder_by_name(b"libsvtav1\0".as_ptr() as *const i8).is_some()
-            };
+            let has_svt = ff_sys::Codec::find_encoder_by_name("libsvtav1").is_some();
             if !has_svt {
                 return Err(EncodeError::EncoderUnavailable {
                     codec: "av1/svt".to_string(),
@@ -421,9 +417,7 @@ impl VideoEncoderInner {
         // Early check: when H265 is requested, verify that at least one HEVC encoder
         // is registered in this FFmpeg build before attempting candidate selection.
         if codec == VideoCodec::H265 {
-            // SAFETY: avcodec::find_encoder is always safe to call with a valid codec ID;
-            // the returned pointer is owned by FFmpeg and must not be freed.
-            let has_hevc = unsafe { avcodec::find_encoder(AVCodecID_AV_CODEC_ID_HEVC).is_some() };
+            let has_hevc = ff_sys::Codec::find_encoder(AVCodecID_AV_CODEC_ID_HEVC).is_some();
             if !has_hevc {
                 return Err(EncodeError::EncoderUnavailable {
                     codec: "h265/hevc".to_string(),
@@ -454,14 +448,8 @@ impl VideoEncoderInner {
 
         // Try each candidate
         for &name in &candidates {
-            unsafe {
-                let c_name = CString::new(name).map_err(|_| EncodeError::Ffmpeg {
-                    code: 0,
-                    message: "Invalid encoder name".to_string(),
-                })?;
-                if avcodec::find_encoder_by_name(c_name.as_ptr()).is_some() {
-                    return Ok(name.to_string());
-                }
+            if ff_sys::Codec::find_encoder_by_name(name).is_some() {
+                return Ok(name.to_string());
             }
         }
 

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -16,7 +16,6 @@ use super::color::{
 use super::options::codec_to_id;
 use super::{
     AVPixelFormat_AV_PIX_FMT_YUV420P, CString, EncodeError, VideoEncoderConfig, VideoEncoderInner,
-    ptr,
 };
 
 /// FFmpeg pass-1 encoding flag: collect two-pass statistics, discard encoded output.
@@ -314,7 +313,7 @@ impl VideoEncoderInner {
         // native mpeg4 encoder without meaningful stats) do not support PASS2 and
         // return AVERROR(EPERM). In that case, fall back to opening without the
         // flag so the caller still gets a valid encoder and usable output.
-        if codec_ctx.open(selected_codec, ptr::null_mut()).is_err() {
+        if codec_ctx.open_codec(selected_codec).is_err() {
             log::warn!(
                 "two-pass pass-2 codec rejected AV_CODEC_FLAG_PASS2, \
                  falling back to single-pass mode codec={encoder_name}"
@@ -324,7 +323,7 @@ impl VideoEncoderInner {
             codec_ctx.set_flags(codec_ctx.flags() & !AV_CODEC_FLAG_PASS2);
             codec_ctx.clear_stats_in();
             codec_ctx
-                .open(selected_codec, ptr::null_mut())
+                .open_codec(selected_codec)
                 .map_err(|e| EncodeError::Ffmpeg {
                     code: e.code(),
                     message: format!(

--- a/crates/ff-encode/tests/advanced_codec_options_tests.rs
+++ b/crates/ff-encode/tests/advanced_codec_options_tests.rs
@@ -22,25 +22,17 @@ use std::time::Instant;
 
 /// Returns `true` when `libx265` is compiled into this FFmpeg build.
 fn is_libx265_available() -> bool {
-    let name = b"libx265\0";
-    // SAFETY: `name` is a valid null-terminated C string with static lifetime.
-    // The pointer is never stored beyond this call; FFmpeg does not take
-    // ownership of the name buffer.
-    unsafe { ff_sys::avcodec::find_encoder_by_name(name.as_ptr() as *const i8).is_some() }
+    ff_sys::Codec::find_encoder_by_name("libx265").is_some()
 }
 
 /// Returns `true` when `libaom-av1` is compiled into this FFmpeg build.
 fn is_libaom_av1_available() -> bool {
-    let name = b"libaom-av1\0";
-    // SAFETY: same invariants as above.
-    unsafe { ff_sys::avcodec::find_encoder_by_name(name.as_ptr() as *const i8).is_some() }
+    ff_sys::Codec::find_encoder_by_name("libaom-av1").is_some()
 }
 
 /// Returns `true` when `libvpx-vp9` is compiled into this FFmpeg build.
 fn is_libvpx_vp9_available() -> bool {
-    let name = b"libvpx-vp9\0";
-    // SAFETY: same invariants as above.
-    unsafe { ff_sys::avcodec::find_encoder_by_name(name.as_ptr() as *const i8).is_some() }
+    ff_sys::Codec::find_encoder_by_name("libvpx-vp9").is_some()
 }
 
 // ── H.265 ─────────────────────────────────────────────────────────────────────

--- a/crates/ff-encode/tests/h264_options_tests.rs
+++ b/crates/ff-encode/tests/h264_options_tests.rs
@@ -24,11 +24,7 @@ fn is_libx264_available() -> bool {
     if !cfg!(feature = "gpl") {
         return false;
     }
-    let name = b"libx264\0";
-    // SAFETY: `name` is a valid null-terminated C string with static lifetime.
-    // The pointer is never stored beyond this call; FFmpeg does not take
-    // ownership of the name buffer.
-    unsafe { ff_sys::avcodec::find_encoder_by_name(name.as_ptr() as *const i8).is_some() }
+    ff_sys::Codec::find_encoder_by_name("libx264").is_some()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/ff-encode/tests/professional_format_tests.rs
+++ b/crates/ff-encode/tests/professional_format_tests.rs
@@ -24,18 +24,12 @@ use std::path::Path;
 
 /// Returns `true` when `prores_ks` is compiled into this FFmpeg build.
 fn is_prores_ks_available() -> bool {
-    let name = b"prores_ks\0";
-    // SAFETY: `name` is a valid null-terminated C string with static lifetime.
-    // The pointer is never stored beyond this call; FFmpeg does not take
-    // ownership of the name buffer.
-    unsafe { ff_sys::avcodec::find_encoder_by_name(name.as_ptr() as *const i8).is_some() }
+    ff_sys::Codec::find_encoder_by_name("prores_ks").is_some()
 }
 
 /// Returns `true` when the `dnxhd` encoder is compiled into this FFmpeg build.
 fn is_dnxhd_available() -> bool {
-    let name = b"dnxhd\0";
-    // SAFETY: same invariants as above.
-    unsafe { ff_sys::avcodec::find_encoder_by_name(name.as_ptr() as *const i8).is_some() }
+    ff_sys::Codec::find_encoder_by_name("dnxhd").is_some()
 }
 
 // ── ffprobe CLI helpers ───────────────────────────────────────────────────────

--- a/crates/ff-filter/src/effects/effects_inner.rs
+++ b/crates/ff-filter/src/effects/effects_inner.rs
@@ -550,7 +550,7 @@ pub(super) unsafe fn transform_vidstab_unsafe(
     enc_ctx.set_pix_fmt(ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P);
     enc_ctx.set_time_base(filter_tb);
 
-    if let Err(e) = enc_ctx.open(enc_codec, std::ptr::null_mut()) {
+    if let Err(e) = enc_ctx.open_codec(enc_codec) {
         let mut g = graph;
         ff_sys::avfilter_graph_free(std::ptr::addr_of_mut!(g));
         return Err(FilterError::Ffmpeg {

--- a/crates/ff-stream/src/codec_utils.rs
+++ b/crates/ff-stream/src/codec_utils.rs
@@ -105,8 +105,7 @@ pub(crate) unsafe fn open_aac_encoder(
     enc.set_ch_layout_default(nb_channels);
 
     // On open failure `enc` drops (Drop = avcodec_free_context), so no manual free.
-    enc.open(codec, std::ptr::null_mut())
-        .map_err(|e| ffmpeg_err(e.code()))?;
+    enc.open_codec(codec).map_err(|e| ffmpeg_err(e.code()))?;
 
     log::info!(
         "{log_prefix} aac encoder opened \

--- a/crates/ff-stream/src/dash_inner/streams.rs
+++ b/crates/ff-stream/src/dash_inner/streams.rs
@@ -53,8 +53,7 @@ pub(super) unsafe fn open_aac_encoder(
     enc.set_ch_layout_default(nb_channels);
 
     // On open failure `enc` drops (Drop = avcodec_free_context), so no manual free.
-    enc.open(codec, std::ptr::null_mut())
-        .map_err(|e| ffmpeg_err(e.code()))?;
+    enc.open_codec(codec).map_err(|e| ffmpeg_err(e.code()))?;
 
     log::info!("dash aac encoder opened sample_rate={sample_rate} channels={nb_channels}");
     Ok(enc)

--- a/crates/ff-stream/src/dash_inner/write.rs
+++ b/crates/ff-stream/src/dash_inner/write.rs
@@ -1,7 +1,6 @@
 //! Packet writing loop and segment management for single-rendition and ABR DASH output.
 
 use std::ffi::CString;
-use std::ptr;
 
 use ff_sys::{
     AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE,
@@ -89,7 +88,7 @@ pub(super) unsafe fn write_dash_unsafe(
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
-        .open(vid_decoder, ptr::null_mut())
+        .open_codec(vid_decoder)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 5. Open input audio decoder (optional) ────────────────────────────────
@@ -106,9 +105,7 @@ pub(super) unsafe fn write_dash_unsafe(
 
         if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
             if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
-                if ctx.apply_parameters(&aud_par).is_ok()
-                    && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
-                {
+                if ctx.apply_parameters(&aud_par).is_ok() && ctx.open_codec(aud_decoder).is_ok() {
                     aud_sample_rate = ctx.sample_rate();
                     aud_nb_channels = ctx.ch_layout().nb_channels;
                     aud_dec_ctx = Some(ctx);
@@ -177,7 +174,7 @@ pub(super) unsafe fn write_dash_unsafe(
     // On error the owned `vid_enc_ctx` / decoders / `input_ctx` / `out_ctx` all
     // drop; no manual teardown is needed.
     vid_enc_ctx
-        .open(vid_enc_codec, ptr::null_mut())
+        .open_codec(vid_enc_codec)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────
@@ -626,7 +623,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
-        .open(vid_decoder, ptr::null_mut())
+        .open_codec(vid_decoder)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 5. Open input audio decoder (optional) ────────────────────────────────
@@ -643,9 +640,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
 
         if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
             if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
-                if ctx.apply_parameters(&aud_par).is_ok()
-                    && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
-                {
+                if ctx.apply_parameters(&aud_par).is_ok() && ctx.open_codec(aud_decoder).is_ok() {
                     aud_sample_rate = ctx.sample_rate();
                     aud_nb_channels = ctx.ch_layout().nb_channels;
                     aud_dec_ctx = Some(ctx);
@@ -724,7 +719,7 @@ pub(super) unsafe fn write_dash_abr_unsafe(
         enc_ctx.set_pix_fmt(AVPixelFormat_AV_PIX_FMT_YUV420P);
         enc_ctx.set_bit_rate(target_bitrate);
 
-        if let Err(e) = enc_ctx.open(vid_enc_codec, ptr::null_mut()) {
+        if let Err(e) = enc_ctx.open_codec(vid_enc_codec) {
             // `enc_ctx` and the prior renditions drop on return.
             return Err(ffmpeg_err(e.code()));
         }

--- a/crates/ff-stream/src/hls_inner.rs
+++ b/crates/ff-stream/src/hls_inner.rs
@@ -22,7 +22,6 @@
 
 use std::ffi::CString;
 use std::path::Path;
-use std::ptr;
 
 use ff_sys::{
     AVPictureType_AV_PICTURE_TYPE_I, AVPictureType_AV_PICTURE_TYPE_NONE, AVPixelFormat,
@@ -158,7 +157,7 @@ unsafe fn write_hls_unsafe(
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     vid_dec_ctx
-        .open(vid_decoder, ptr::null_mut())
+        .open_codec(vid_decoder)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 5. Open input audio decoder (optional) ────────────────────────────────
@@ -175,9 +174,7 @@ unsafe fn write_hls_unsafe(
 
         if let Some(aud_decoder) = ff_sys::Codec::find_decoder(aud_codec_id) {
             if let Ok(mut ctx) = ff_sys::CodecContext::new(Some(aud_decoder)) {
-                if ctx.apply_parameters(&aud_par).is_ok()
-                    && ctx.open(aud_decoder, ptr::null_mut()).is_ok()
-                {
+                if ctx.apply_parameters(&aud_par).is_ok() && ctx.open_codec(aud_decoder).is_ok() {
                     aud_sample_rate = ctx.sample_rate();
                     aud_nb_channels = ctx.ch_layout().nb_channels;
                     aud_dec_ctx = Some(ctx);
@@ -268,7 +265,7 @@ unsafe fn write_hls_unsafe(
     // On error the owned `vid_enc_ctx` / decoders / `input_ctx` / `out_ctx` all
     // drop; no manual teardown is needed.
     vid_enc_ctx
-        .open(vid_enc_codec, ptr::null_mut())
+        .open_codec(vid_enc_codec)
         .map_err(|e| ffmpeg_err(e.code()))?;
 
     // ── 9. Add video output stream ────────────────────────────────────────────

--- a/crates/ff-stream/src/live_dash_inner.rs
+++ b/crates/ff-stream/src/live_dash_inner.rs
@@ -19,7 +19,6 @@
 
 use std::ffi::CString;
 use std::path::Path;
-use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
@@ -188,7 +187,7 @@ impl LiveDashInner {
         // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
         // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
-            .open(vid_enc_codec, ptr::null_mut())
+            .open_codec(vid_enc_codec)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Add video output stream ────────────────────────────────────────

--- a/crates/ff-stream/src/live_hls_inner.rs
+++ b/crates/ff-stream/src/live_hls_inner.rs
@@ -19,7 +19,6 @@
 
 use std::ffi::CString;
 use std::path::Path;
-use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
@@ -208,7 +207,7 @@ impl LiveHlsInner {
         // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
         // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
-            .open(vid_enc_codec, ptr::null_mut())
+            .open_codec(vid_enc_codec)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 4. Add video output stream ────────────────────────────────────────

--- a/crates/ff-stream/src/rtmp_inner.rs
+++ b/crates/ff-stream/src/rtmp_inner.rs
@@ -19,7 +19,6 @@
 #![allow(clippy::too_many_lines)]
 
 use std::path::Path;
-use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
@@ -153,7 +152,7 @@ impl RtmpInner {
         // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
         // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
-            .open(vid_enc_codec, ptr::null_mut())
+            .open_codec(vid_enc_codec)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 3. Add video output stream ─────────────────────────────────────

--- a/crates/ff-stream/src/srt_output_inner.rs
+++ b/crates/ff-stream/src/srt_output_inner.rs
@@ -20,7 +20,6 @@
 #![allow(clippy::too_many_lines)]
 
 use std::path::Path;
-use std::ptr;
 
 use ff_format::{AudioFrame, VideoFrame};
 use ff_sys::AVPixelFormat_AV_PIX_FMT_YUV420P;
@@ -155,7 +154,7 @@ impl SrtInner {
         // On open failure `vid_enc_ctx` drops (frees the codec context); the owned
         // `out_ctx` frees on the `?` early return.
         vid_enc_ctx
-            .open(vid_enc_codec, ptr::null_mut())
+            .open_codec(vid_enc_codec)
             .map_err(|e| ffmpeg_err(e.code()))?;
 
         // ── 3. Add video output stream ─────────────────────────────────────

--- a/crates/ff-sys/benches/swresample_bench.rs
+++ b/crates/ff-sys/benches/swresample_bench.rs
@@ -6,9 +6,69 @@ use std::hint::black_box;
 use std::os::raw::c_int;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use ff_sys::swresample::{
-    alloc_set_opts2, channel_layout, convert, estimate_output_samples, init, sample_format,
-};
+use ff_sys::swresample::{channel_layout, estimate_output_samples, sample_format};
+use ff_sys::{AVChannelLayout, AVSampleFormat, SwrContext};
+
+// The hand-written `swresample::alloc_set_opts2` / `init` / `convert` wrappers are
+// sealed (`pub(crate)`), so this raw-FFI microbenchmark calls the bindgen entry
+// points directly through these thin shims, keeping the benchmark bodies unchanged.
+
+/// # Safety
+/// The channel-layout pointers must be valid for the duration of the call.
+unsafe fn alloc_set_opts2(
+    out_ch_layout: *const AVChannelLayout,
+    out_sample_fmt: AVSampleFormat,
+    out_sample_rate: c_int,
+    in_ch_layout: *const AVChannelLayout,
+    in_sample_fmt: AVSampleFormat,
+    in_sample_rate: c_int,
+) -> Result<*mut SwrContext, c_int> {
+    let mut ctx: *mut SwrContext = std::ptr::null_mut();
+    // SAFETY: `&mut ctx` is a valid out-pointer; the layout pointers are upheld
+    //         by the caller; null log_ctx and 0 log_offset are accepted.
+    let ret = unsafe {
+        ff_sys::swr_alloc_set_opts2(
+            &mut ctx,
+            out_ch_layout,
+            out_sample_fmt,
+            out_sample_rate,
+            in_ch_layout,
+            in_sample_fmt,
+            in_sample_rate,
+            0,
+            std::ptr::null_mut(),
+        )
+    };
+    if ret < 0 {
+        Err(ret)
+    } else if ctx.is_null() {
+        Err(-1)
+    } else {
+        Ok(ctx)
+    }
+}
+
+/// # Safety
+/// `ctx` must be an allocated, configured `SwrContext`.
+unsafe fn init(ctx: *mut SwrContext) -> Result<(), c_int> {
+    // SAFETY: the caller upholds `ctx`.
+    let ret = unsafe { ff_sys::swr_init(ctx) };
+    if ret < 0 { Err(ret) } else { Ok(()) }
+}
+
+/// # Safety
+/// `ctx` and the sample buffers must be valid for the configured formats.
+unsafe fn convert(
+    ctx: *mut SwrContext,
+    out: *mut *mut u8,
+    out_count: c_int,
+    in_: *const *const u8,
+    in_count: c_int,
+) -> Result<c_int, c_int> {
+    // SAFETY: the caller upholds the context and sample buffers.
+    let ret = unsafe { ff_sys::swr_convert(ctx, out, out_count, in_, in_count) };
+    if ret < 0 { Err(ret) } else { Ok(ret) }
+}
 
 /// Benchmark context creation for different configurations.
 fn bench_context_creation(c: &mut Criterion) {

--- a/crates/ff-sys/benches/swscale_bench.rs
+++ b/crates/ff-sys/benches/swscale_bench.rs
@@ -6,8 +6,69 @@ use std::hint::black_box;
 use std::os::raw::c_int;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use ff_sys::swscale::{get_context, scale, scale_flags};
-use ff_sys::{AVPixelFormat_AV_PIX_FMT_RGB24, AVPixelFormat_AV_PIX_FMT_RGBA};
+use ff_sys::swscale::scale_flags;
+use ff_sys::{
+    AVPixelFormat, AVPixelFormat_AV_PIX_FMT_RGB24, AVPixelFormat_AV_PIX_FMT_RGBA, SwsContext,
+};
+
+// The hand-written `swscale::get_context` / `scale` wrappers are sealed
+// (`pub(crate)`), so this raw-FFI microbenchmark calls the bindgen entry points
+// directly through these thin shims, keeping the benchmark bodies unchanged.
+
+/// # Safety
+/// The pixel-format/dimension arguments must be valid for `sws_getContext`.
+unsafe fn get_context(
+    src_w: c_int,
+    src_h: c_int,
+    src_fmt: AVPixelFormat,
+    dst_w: c_int,
+    dst_h: c_int,
+    dst_fmt: AVPixelFormat,
+    flags: c_int,
+) -> Result<*mut SwsContext, c_int> {
+    // SAFETY: null src/dst filters and param are accepted by `sws_getContext`.
+    let ctx = unsafe {
+        ff_sys::sws_getContext(
+            src_w,
+            src_h,
+            src_fmt,
+            dst_w,
+            dst_h,
+            dst_fmt,
+            flags,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null(),
+        )
+    };
+    if ctx.is_null() { Err(-1) } else { Ok(ctx) }
+}
+
+/// # Safety
+/// `ctx` and the plane/stride arrays must be valid for the configured formats.
+unsafe fn scale(
+    ctx: *mut SwsContext,
+    src: *const *const u8,
+    src_stride: *const c_int,
+    src_slice_y: c_int,
+    src_slice_h: c_int,
+    dst: *const *mut u8,
+    dst_stride: *const c_int,
+) -> Result<c_int, c_int> {
+    // SAFETY: the caller upholds the context and plane/stride arrays.
+    let ret = unsafe {
+        ff_sys::sws_scale(
+            ctx,
+            src,
+            src_stride,
+            src_slice_y,
+            src_slice_h,
+            dst,
+            dst_stride,
+        )
+    };
+    if ret < 0 { Err(ret) } else { Ok(ret) }
+}
 
 /// Load test image from assets directory.
 /// Returns (width, height, RGBA pixel data).

--- a/crates/ff-sys/src/avcodec.rs
+++ b/crates/ff-sys/src/avcodec.rs
@@ -17,7 +17,6 @@ use crate::{
     AVCodec, AVCodecContext, AVCodecID, AVCodecParameters, AVDictionary, AVFrame, AVPacket,
     avcodec_alloc_context3 as ffi_avcodec_alloc_context3,
     avcodec_find_decoder as ffi_avcodec_find_decoder,
-    avcodec_find_decoder_by_name as ffi_avcodec_find_decoder_by_name,
     avcodec_find_encoder as ffi_avcodec_find_encoder,
     avcodec_find_encoder_by_name as ffi_avcodec_find_encoder_by_name,
     avcodec_flush_buffers as ffi_avcodec_flush_buffers, avcodec_open2 as ffi_avcodec_open2,
@@ -28,6 +27,9 @@ use crate::{
     avcodec_send_frame as ffi_avcodec_send_frame, avcodec_send_packet as ffi_avcodec_send_packet,
     ensure_initialized,
 };
+// Only the test-only `find_decoder_by_name` wrapper uses this binding.
+#[cfg(test)]
+use crate::avcodec_find_decoder_by_name as ffi_avcodec_find_decoder_by_name;
 
 // ============================================================================
 // Codec lookup functions
@@ -48,7 +50,7 @@ use crate::{
 ///
 /// The returned pointer is owned by FFmpeg and must not be freed.
 /// It remains valid for the lifetime of the program.
-pub unsafe fn find_decoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
+pub(crate) unsafe fn find_decoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
     ensure_initialized();
 
     // SAFETY: `ffi_avcodec_find_decoder` is a pure table lookup that takes a codec
@@ -73,7 +75,8 @@ pub unsafe fn find_decoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
 ///
 /// - The name must be a valid null-terminated C string.
 /// - The returned pointer is owned by FFmpeg and must not be freed.
-pub unsafe fn find_decoder_by_name(name: *const i8) -> Option<*const AVCodec> {
+#[cfg(test)]
+pub(crate) unsafe fn find_decoder_by_name(name: *const i8) -> Option<*const AVCodec> {
     ensure_initialized();
 
     if name.is_null() {
@@ -102,7 +105,7 @@ pub unsafe fn find_decoder_by_name(name: *const i8) -> Option<*const AVCodec> {
 ///
 /// The returned pointer is owned by FFmpeg and must not be freed.
 /// It remains valid for the lifetime of the program.
-pub unsafe fn find_encoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
+pub(crate) unsafe fn find_encoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
     ensure_initialized();
 
     // SAFETY: `ffi_avcodec_find_encoder` is a pure table lookup that takes a codec
@@ -127,7 +130,7 @@ pub unsafe fn find_encoder(codec_id: AVCodecID) -> Option<*const AVCodec> {
 ///
 /// - The name must be a valid null-terminated C string.
 /// - The returned pointer is owned by FFmpeg and must not be freed.
-pub unsafe fn find_encoder_by_name(name: *const i8) -> Option<*const AVCodec> {
+pub(crate) unsafe fn find_encoder_by_name(name: *const i8) -> Option<*const AVCodec> {
     ensure_initialized();
 
     if name.is_null() {
@@ -160,7 +163,7 @@ pub unsafe fn find_encoder_by_name(name: *const i8) -> Option<*const AVCodec> {
 ///
 /// The returned context must be freed with `crate::avcodec_free_context` (or
 /// wrapped in [`CodecContext`](crate::CodecContext)) when no longer needed.
-pub unsafe fn alloc_context3(codec: *const AVCodec) -> Result<*mut AVCodecContext, c_int> {
+pub(crate) unsafe fn alloc_context3(codec: *const AVCodec) -> Result<*mut AVCodecContext, c_int> {
     ensure_initialized();
 
     // SAFETY: `codec` is either null (allowed, yields a generic context) or a valid
@@ -193,7 +196,7 @@ pub unsafe fn alloc_context3(codec: *const AVCodec) -> Result<*mut AVCodecContex
 /// # Safety
 ///
 /// Both pointers must be valid and non-null.
-pub unsafe fn parameters_from_context(
+pub(crate) unsafe fn parameters_from_context(
     par: *mut AVCodecParameters,
     ctx: *const AVCodecContext,
 ) -> Result<(), c_int> {
@@ -230,7 +233,7 @@ pub unsafe fn parameters_from_context(
 /// Returns a negative error code if:
 /// - Either pointer is null (`error_codes::EINVAL`)
 /// - Copying fails (e.g., unsupported codec parameters)
-pub unsafe fn parameters_to_context(
+pub(crate) unsafe fn parameters_to_context(
     ctx: *mut AVCodecContext,
     par: *const AVCodecParameters,
 ) -> Result<(), c_int> {
@@ -274,7 +277,7 @@ pub unsafe fn parameters_to_context(
 /// - Context is null (`error_codes::EINVAL`)
 /// - The codec is not found or incompatible
 /// - Required codec options are missing
-pub unsafe fn open2(
+pub(crate) unsafe fn open2(
     ctx: *mut AVCodecContext,
     codec: *const AVCodec,
     options: *mut *mut AVDictionary,
@@ -319,7 +322,10 @@ pub unsafe fn open2(
 ///
 /// - The context must be a valid, open decoder context.
 /// - The packet must contain valid encoded data or be null for flushing.
-pub unsafe fn send_packet(ctx: *mut AVCodecContext, pkt: *const AVPacket) -> Result<(), c_int> {
+pub(crate) unsafe fn send_packet(
+    ctx: *mut AVCodecContext,
+    pkt: *const AVPacket,
+) -> Result<(), c_int> {
     if ctx.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -356,7 +362,10 @@ pub unsafe fn send_packet(ctx: *mut AVCodecContext, pkt: *const AVPacket) -> Res
 ///
 /// - The context must be a valid, open decoder context.
 /// - The frame must be allocated.
-pub unsafe fn receive_frame(ctx: *mut AVCodecContext, frame: *mut AVFrame) -> Result<(), c_int> {
+pub(crate) unsafe fn receive_frame(
+    ctx: *mut AVCodecContext,
+    frame: *mut AVFrame,
+) -> Result<(), c_int> {
     if ctx.is_null() || frame.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -397,7 +406,10 @@ pub unsafe fn receive_frame(ctx: *mut AVCodecContext, frame: *mut AVFrame) -> Re
 ///
 /// - The context must be a valid, open encoder context.
 /// - The frame must contain valid raw data or be null for flushing.
-pub unsafe fn send_frame(ctx: *mut AVCodecContext, frame: *const AVFrame) -> Result<(), c_int> {
+pub(crate) unsafe fn send_frame(
+    ctx: *mut AVCodecContext,
+    frame: *const AVFrame,
+) -> Result<(), c_int> {
     if ctx.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -434,7 +446,10 @@ pub unsafe fn send_frame(ctx: *mut AVCodecContext, frame: *const AVFrame) -> Res
 ///
 /// - The context must be a valid, open encoder context.
 /// - The packet must be allocated.
-pub unsafe fn receive_packet(ctx: *mut AVCodecContext, pkt: *mut AVPacket) -> Result<(), c_int> {
+pub(crate) unsafe fn receive_packet(
+    ctx: *mut AVCodecContext,
+    pkt: *mut AVPacket,
+) -> Result<(), c_int> {
     if ctx.is_null() || pkt.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -469,7 +484,7 @@ pub unsafe fn receive_packet(ctx: *mut AVCodecContext, pkt: *mut AVPacket) -> Re
 ///
 /// This function does not return an error code as FFmpeg's `avcodec_flush_buffers()`
 /// returns void.
-pub unsafe fn flush_buffers(ctx: *mut AVCodecContext) {
+pub(crate) unsafe fn flush_buffers(ctx: *mut AVCodecContext) {
     // SAFETY: `ctx` is null-checked before use; when non-null the caller guarantees it
     // is a valid, open codec context. FFmpeg only resets the context's internal state.
     unsafe {

--- a/crates/ff-sys/src/avformat.rs
+++ b/crates/ff-sys/src/avformat.rs
@@ -18,11 +18,14 @@ use std::time::Duration;
 
 use crate::{
     AVFormatContext, AVIOContext, AVPacket, av_read_frame as ffi_av_read_frame,
-    av_seek_frame as ffi_av_seek_frame, av_write_frame as ffi_av_write_frame,
-    avformat_close_input as ffi_avformat_close_input,
-    avformat_find_stream_info as ffi_avformat_find_stream_info,
+    av_seek_frame as ffi_av_seek_frame, avformat_find_stream_info as ffi_avformat_find_stream_info,
     avformat_open_input as ffi_avformat_open_input, avformat_seek_file as ffi_avformat_seek_file,
     ensure_initialized,
+};
+// Only the test-only `close_input` / `write_frame` wrappers use these bindings.
+#[cfg(test)]
+use crate::{
+    av_write_frame as ffi_av_write_frame, avformat_close_input as ffi_avformat_close_input,
 };
 
 // FFmpeg I/O functions (declared here as they may not be in bindgen output)
@@ -131,7 +134,7 @@ pub mod seek_flags {
 /// - The path contains invalid UTF-8 or null bytes
 /// - The file cannot be opened
 /// - The file format is not recognized
-pub unsafe fn open_input(path: &Path) -> Result<*mut AVFormatContext, c_int> {
+pub(crate) unsafe fn open_input(path: &Path) -> Result<*mut AVFormatContext, c_int> {
     ensure_initialized();
 
     // Convert path to C string
@@ -167,7 +170,7 @@ pub unsafe fn open_input(path: &Path) -> Result<*mut AVFormatContext, c_int> {
 /// `avformat_open_input`. Both keys are freed via `av_dict_free` regardless of
 /// whether the open succeeds.
 ///
-/// The returned pointer must be freed using [`close_input()`].
+/// The returned pointer must be freed using `close_input()`.
 ///
 /// # Errors
 ///
@@ -177,7 +180,7 @@ pub unsafe fn open_input(path: &Path) -> Result<*mut AVFormatContext, c_int> {
 /// # Safety
 ///
 /// The caller must call `close_input()` on the returned context when done.
-pub unsafe fn open_input_url(
+pub(crate) unsafe fn open_input_url(
     url: &str,
     connect_timeout: Duration,
     read_timeout: Duration,
@@ -266,7 +269,7 @@ pub fn srt_available() -> bool {
 /// Open an image sequence using the `image2` demuxer.
 ///
 /// Sets `framerate` in the demuxer options so FFmpeg assigns the correct PTS
-/// to each frame. The returned pointer must be freed using [`close_input()`].
+/// to each frame. The returned pointer must be freed using `close_input()`.
 ///
 /// # Errors
 ///
@@ -276,7 +279,7 @@ pub fn srt_available() -> bool {
 /// # Safety
 ///
 /// The caller must call `close_input()` on the returned context when done.
-pub unsafe fn open_input_image_sequence(
+pub(crate) unsafe fn open_input_image_sequence(
     path: &Path,
     framerate: u32,
 ) -> Result<*mut AVFormatContext, c_int> {
@@ -355,7 +358,8 @@ pub unsafe fn open_input_image_sequence(
 /// This function safely handles:
 /// - `ctx` being null
 /// - `*ctx` being null
-pub unsafe fn close_input(ctx: *mut *mut AVFormatContext) {
+#[cfg(test)]
+pub(crate) unsafe fn close_input(ctx: *mut *mut AVFormatContext) {
     // SAFETY: The caller guarantees `ctx` is either null or a valid pointer to a
     //         context pointer allocated by `open_input`. Dereferencing `ctx` is
     //         guarded by the null check, and `avformat_close_input` tolerates a
@@ -387,7 +391,7 @@ pub unsafe fn close_input(ctx: *mut *mut AVFormatContext) {
 /// # Errors
 ///
 /// Returns a negative error code if stream information cannot be read.
-pub unsafe fn find_stream_info(ctx: *mut AVFormatContext) -> Result<(), c_int> {
+pub(crate) unsafe fn find_stream_info(ctx: *mut AVFormatContext) -> Result<(), c_int> {
     if ctx.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -418,7 +422,7 @@ pub unsafe fn find_stream_info(ctx: *mut AVFormatContext) -> Result<(), c_int> {
 /// # Errors
 ///
 /// Returns a negative error code if seeking fails.
-pub unsafe fn seek_frame(
+pub(crate) unsafe fn seek_frame(
     ctx: *mut AVFormatContext,
     stream_index: c_int,
     timestamp: i64,
@@ -459,7 +463,7 @@ pub unsafe fn seek_frame(
 /// # Errors
 ///
 /// Returns a negative error code if seeking fails.
-pub unsafe fn seek_file(
+pub(crate) unsafe fn seek_file(
     ctx: *mut AVFormatContext,
     stream_index: c_int,
     min_ts: i64,
@@ -502,7 +506,10 @@ pub unsafe fn seek_file(
 /// Returns a negative error code if:
 /// - Reading fails
 /// - End of file is reached (`error_codes::EOF`)
-pub unsafe fn read_frame(ctx: *mut AVFormatContext, pkt: *mut AVPacket) -> Result<(), c_int> {
+pub(crate) unsafe fn read_frame(
+    ctx: *mut AVFormatContext,
+    pkt: *mut AVPacket,
+) -> Result<(), c_int> {
     if ctx.is_null() || pkt.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -537,7 +544,11 @@ pub unsafe fn read_frame(ctx: *mut AVFormatContext, pkt: *mut AVPacket) -> Resul
 /// Returns a negative error code if:
 /// - Context or packet is null (`error_codes::EINVAL`)
 /// - Writing fails
-pub unsafe fn write_frame(ctx: *mut AVFormatContext, pkt: *mut AVPacket) -> Result<(), c_int> {
+#[cfg(test)]
+pub(crate) unsafe fn write_frame(
+    ctx: *mut AVFormatContext,
+    pkt: *mut AVPacket,
+) -> Result<(), c_int> {
     if ctx.is_null() || pkt.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -590,7 +601,7 @@ pub unsafe fn write_frame(ctx: *mut AVFormatContext, pkt: *mut AVPacket) -> Resu
 ///     close_output(pb);
 /// }
 /// ```
-pub unsafe fn open_output(path: &Path, flags: c_int) -> Result<*mut AVIOContext, c_int> {
+pub(crate) unsafe fn open_output(path: &Path, flags: c_int) -> Result<*mut AVIOContext, c_int> {
     ensure_initialized();
 
     // Convert path to C string
@@ -651,7 +662,7 @@ pub unsafe fn open_output(path: &Path, flags: c_int) -> Result<*mut AVIOContext,
 ///     assert!(pb.is_null());
 /// }
 /// ```
-pub unsafe fn close_output(pb: *mut *mut AVIOContext) {
+pub(crate) unsafe fn close_output(pb: *mut *mut AVIOContext) {
     // SAFETY: The caller guarantees `pb` is either null or a valid pointer to an
     //         AVIOContext pointer from `open_output`. Dereferencing `pb` is
     //         guarded by the null check, and `avio_closep` tolerates a null `*pb`.

--- a/crates/ff-sys/src/buffersink.rs
+++ b/crates/ff-sys/src/buffersink.rs
@@ -35,6 +35,9 @@ pub enum BufferSinkOutcome {
 /// # Safety
 ///
 /// `sink` must be a valid `*mut AVFilterContext` for a buffersink filter.
+// seal-allow-raw: the filter graph (AVFilterContext / buffersrc / buffersink) is
+// not yet a sealed owned type, so this drain wrapper still takes a raw sink
+// pointer. Tracked with the broader filter-graph RAII work, separate from #1506.
 pub unsafe fn buffersink_get_frame(
     sink: *mut AVFilterContext,
     dst: &mut Frame,

--- a/crates/ff-sys/src/codec.rs
+++ b/crates/ff-sys/src/codec.rs
@@ -54,6 +54,14 @@ impl Codec {
     }
 
     /// Returns the underlying codec pointer for FFI calls.
+    ///
+    /// [`Codec`] is a lightweight borrowed handle to a static FFmpeg codec, not a
+    /// sealed owned resource, so it deliberately exposes its raw pointer for
+    /// consumers that read codec-descriptor fields (`sample_fmts`, `capabilities`,
+    /// …) the safe API does not (yet) mirror.
+    // seal-allow-raw: Codec is a borrowed static handle, intentionally out of the
+    // #1506 owned-type seal (see #1566); consumers read AVCodec descriptor fields
+    // through this pointer.
     #[must_use]
     pub const fn as_ptr(&self) -> *const AVCodec {
         self.ptr.as_ptr()

--- a/crates/ff-sys/src/codec_context.rs
+++ b/crates/ff-sys/src/codec_context.rs
@@ -3,8 +3,8 @@
 //! [`CodecContext`] allocates a codec context and frees it exactly once on drop,
 //! replacing the manual `avcodec::alloc_context3` + `avcodec::free_context` pair.
 //! Its fallible methods return [`AvError`]. Packet / frame arguments are the owned
-//! [`Packet`] / [`Frame`] types, so `send_packet` / `receive_frame` are safe;
-//! `open` (raw options dictionary), `parameters_to_context` (raw parameters), and
+//! [`Packet`] / [`Frame`] types, so `send_packet` / `receive_frame` are safe, and
+//! `open_codec` / `apply_parameters` cover opening and parameter copies; only
 //! `send_eof` / `flush_buffers` (opened-context precondition) remain `unsafe`.
 
 use std::ffi::{CStr, CString};
@@ -13,9 +13,9 @@ use std::ptr::{self, NonNull};
 
 use crate::{
     AVCodecContext, AVCodecID, AVCodecParameters, AVColorPrimaries, AVColorRange, AVColorSpace,
-    AVColorTransferCharacteristic, AVDictionary, AVPixelFormat, AVRational, AVSampleFormat,
-    AvError, Codec, CodecParameters, Frame, HwDeviceContext, Packet,
-    av_buffer_replace as ffi_av_buffer_replace, avcodec_free_context as ffi_avcodec_free_context,
+    AVColorTransferCharacteristic, AVPixelFormat, AVRational, AVSampleFormat, AvError, Codec,
+    CodecParameters, Frame, HwDeviceContext, Packet, av_buffer_replace as ffi_av_buffer_replace,
+    avcodec_free_context as ffi_avcodec_free_context,
 };
 
 /// The outcome of a [`CodecContext::receive_frame`] call.
@@ -472,12 +472,11 @@ impl CodecContext {
         }
     }
 
-    /// Copies the parameters of `params` into the context (safe wrapper).
+    /// Copies the parameters of `params` into the context.
     ///
-    /// This is the borrowed-handle counterpart of the raw
-    /// [`parameters_to_context`](Self::parameters_to_context); it takes a
-    /// [`CodecParameters`] borrowed from an [`InputFormatContext`](crate::InputFormatContext)
-    /// stream, so no raw pointer is exposed.
+    /// Takes a [`CodecParameters`] borrowed from an
+    /// [`InputFormatContext`](crate::InputFormatContext) stream, so no raw pointer
+    /// is exposed.
     ///
     /// # Errors
     ///
@@ -489,24 +488,10 @@ impl CodecContext {
             .map_err(AvError::new)
     }
 
-    /// Copies stream parameters into the context.
+    /// Opens the context with `codec` using default options.
     ///
-    /// # Safety
-    ///
-    /// `par` must be a valid `*const AVCodecParameters`.
-    pub unsafe fn parameters_to_context(
-        &mut self,
-        par: *const AVCodecParameters,
-    ) -> Result<(), AvError> {
-        // SAFETY: `self.ptr` is a valid owned context; the caller upholds `par`.
-        unsafe { crate::avcodec::parameters_to_context(self.ptr.as_ptr(), par) }
-            .map_err(AvError::new)
-    }
-
-    /// Opens the context with `codec` using default options (safe wrapper).
-    ///
-    /// This is the safe counterpart of the raw [`open`](Self::open); it always
-    /// passes a null options dictionary, which every ff-decode call site uses.
+    /// Always passes a null options dictionary, which every consumer call site
+    /// uses.
     ///
     /// # Errors
     ///
@@ -518,19 +503,22 @@ impl CodecContext {
             .map_err(AvError::new)
     }
 
-    /// Opens the context with `codec` and optional dictionary `options`.
+    /// Copies raw stream parameters into the context.
+    ///
+    /// Test-only: the safe [`apply_parameters`](Self::apply_parameters) covers
+    /// every non-test caller; this raw variant is retained for ff-sys's own
+    /// raw-FFI decode test helper in `swresample`.
     ///
     /// # Safety
     ///
-    /// `options` must be null or a valid `*mut *mut AVDictionary`.
-    pub unsafe fn open(
+    /// `par` must be a valid `*const AVCodecParameters`.
+    #[cfg(test)]
+    pub(crate) unsafe fn parameters_to_context(
         &mut self,
-        codec: Codec,
-        options: *mut *mut AVDictionary,
+        par: *const AVCodecParameters,
     ) -> Result<(), AvError> {
-        // SAFETY: `self.ptr` is a valid owned context and `codec` is a valid static
-        //         codec; the caller upholds `options`.
-        unsafe { crate::avcodec::open2(self.ptr.as_ptr(), codec.as_ptr(), options) }
+        // SAFETY: `self.ptr` is a valid owned context; the caller upholds `par`.
+        unsafe { crate::avcodec::parameters_to_context(self.ptr.as_ptr(), par) }
             .map_err(AvError::new)
     }
 
@@ -554,7 +542,7 @@ impl CodecContext {
     ///
     /// # Safety
     ///
-    /// The context must have been opened via [`open`](Self::open) first.
+    /// The context must have been opened via [`open_codec`](Self::open_codec) first.
     pub unsafe fn send_eof(&mut self) -> Result<(), AvError> {
         // SAFETY: the caller guarantees the context is opened; a null packet is
         //         the documented end-of-stream signal for `avcodec_send_packet`.
@@ -583,7 +571,7 @@ impl CodecContext {
     ///
     /// # Safety
     ///
-    /// The context must have been opened via [`open`](Self::open) first:
+    /// The context must have been opened via [`open_codec`](Self::open_codec) first:
     /// `avcodec_flush_buffers` reads codec-internal state that `avcodec_open2`
     /// allocates, so calling it on an unopened context is undefined behaviour.
     pub unsafe fn flush_buffers(&mut self) {
@@ -659,7 +647,7 @@ impl CodecContext {
     /// # Safety
     ///
     /// `par` must be a valid `*mut AVCodecParameters`.
-    pub unsafe fn parameters_from_context(
+    pub(crate) unsafe fn parameters_from_context(
         &self,
         par: *mut AVCodecParameters,
     ) -> Result<(), AvError> {

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1287,25 +1287,6 @@ impl CodecContext {
         Err(crate::AvError::new(-1))
     }
 
-    /// # Safety
-    /// Stub; never executed on docs.rs.
-    pub unsafe fn parameters_to_context(
-        &mut self,
-        _par: *const AVCodecParameters,
-    ) -> Result<(), crate::AvError> {
-        Err(crate::AvError::new(-1))
-    }
-
-    /// # Safety
-    /// Stub; never executed on docs.rs.
-    pub unsafe fn open(
-        &mut self,
-        _codec: Codec,
-        _options: *mut *mut AVDictionary,
-    ) -> Result<(), crate::AvError> {
-        Err(crate::AvError::new(-1))
-    }
-
     /// # Errors
     /// Stub; never executed on docs.rs.
     pub fn send_packet(&mut self, _pkt: &Packet) -> Result<(), crate::AvError> {
@@ -1354,7 +1335,7 @@ impl CodecContext {
 
     /// # Safety
     /// Stub; never executed on docs.rs.
-    pub unsafe fn parameters_from_context(
+    pub(crate) unsafe fn parameters_from_context(
         &self,
         _par: *mut AVCodecParameters,
     ) -> Result<(), crate::AvError> {

--- a/crates/ff-sys/src/resample_context.rs
+++ b/crates/ff-sys/src/resample_context.rs
@@ -43,17 +43,20 @@ impl ResampleContext {
     ///
     /// # Safety
     ///
-    /// `out_ch_layout` and `in_ch_layout` must be valid `*const AVChannelLayout`
-    /// pointers for the duration of the call.
+    /// The borrowed `out_ch_layout` / `in_ch_layout` are always valid to read, but
+    /// they must hold well-formed, initialized `AVChannelLayout` values (e.g. from
+    /// [`channel_layout::stereo`](crate::swresample::channel_layout::stereo)); a
+    /// malformed layout is passed on to libswresample unchecked.
     pub unsafe fn new(
-        out_ch_layout: *const AVChannelLayout,
+        out_ch_layout: &AVChannelLayout,
         out_sample_fmt: AVSampleFormat,
         out_sample_rate: c_int,
-        in_ch_layout: *const AVChannelLayout,
+        in_ch_layout: &AVChannelLayout,
         in_sample_fmt: AVSampleFormat,
         in_sample_rate: c_int,
     ) -> Result<Self, AvError> {
-        // SAFETY: the caller upholds the channel-layout pointers; `alloc_set_opts2`
+        // SAFETY: the borrowed layouts are valid for the call (the caller upholds
+        //         that they are well-formed per # Safety); `alloc_set_opts2`
         //         validates the sample rates and returns a non-null context or an
         //         error code.
         let ptr = unsafe {

--- a/crates/ff-sys/src/swresample/context.rs
+++ b/crates/ff-sys/src/swresample/context.rs
@@ -3,10 +3,12 @@
 use std::os::raw::c_int;
 
 use crate::{
-    AVChannelLayout, AVSampleFormat, SwrContext, ensure_initialized, swr_alloc as ffi_swr_alloc,
+    AVChannelLayout, AVSampleFormat, SwrContext, ensure_initialized,
     swr_alloc_set_opts2 as ffi_swr_alloc_set_opts2, swr_init as ffi_swr_init,
-    swr_is_initialized as ffi_swr_is_initialized,
 };
+// Only the test-only `alloc` / `is_initialized` wrappers use these bindings.
+#[cfg(test)]
+use crate::{swr_alloc as ffi_swr_alloc, swr_is_initialized as ffi_swr_is_initialized};
 
 /// Allocate an empty SwrContext.
 ///
@@ -22,7 +24,8 @@ use crate::{
 ///
 /// The returned context must be freed with `crate::swr_free` (or wrapped in
 /// [`ResampleContext`](crate::ResampleContext)) when no longer needed.
-pub unsafe fn alloc() -> Result<*mut SwrContext, c_int> {
+#[cfg(test)]
+pub(crate) unsafe fn alloc() -> Result<*mut SwrContext, c_int> {
     ensure_initialized();
 
     // SAFETY: swr_alloc takes no arguments and allocates a fresh context;
@@ -60,7 +63,7 @@ pub unsafe fn alloc() -> Result<*mut SwrContext, c_int> {
 /// - The returned context must be freed with `crate::swr_free` (or wrapped in
 ///   [`ResampleContext`](crate::ResampleContext)) when no longer needed.
 /// - Channel layout pointers must be valid for the duration of this call.
-pub unsafe fn alloc_set_opts2(
+pub(crate) unsafe fn alloc_set_opts2(
     out_ch_layout: *const AVChannelLayout,
     out_sample_fmt: AVSampleFormat,
     out_sample_rate: c_int,
@@ -130,7 +133,7 @@ pub unsafe fn alloc_set_opts2(
 /// Returns a negative error code if:
 /// - Context is null (`error_codes::EINVAL`)
 /// - Initialization fails (e.g., invalid configuration)
-pub unsafe fn init(ctx: *mut SwrContext) -> Result<(), c_int> {
+pub(crate) unsafe fn init(ctx: *mut SwrContext) -> Result<(), c_int> {
     if ctx.is_null() {
         return Err(crate::error_codes::EINVAL);
     }
@@ -155,7 +158,8 @@ pub unsafe fn init(ctx: *mut SwrContext) -> Result<(), c_int> {
 /// # Safety
 ///
 /// The context pointer must be valid or null.
-pub unsafe fn is_initialized(ctx: *const SwrContext) -> bool {
+#[cfg(test)]
+pub(crate) unsafe fn is_initialized(ctx: *const SwrContext) -> bool {
     if ctx.is_null() {
         return false;
     }

--- a/crates/ff-sys/src/swresample/convert.rs
+++ b/crates/ff-sys/src/swresample/convert.rs
@@ -2,7 +2,10 @@
 
 use std::os::raw::c_int;
 
-use crate::{SwrContext, swr_convert as ffi_swr_convert, swr_get_delay as ffi_swr_get_delay};
+use crate::{SwrContext, swr_convert as ffi_swr_convert};
+// Only the test-only `get_delay` wrapper uses this binding.
+#[cfg(test)]
+use crate::swr_get_delay as ffi_swr_get_delay;
 
 /// Headroom samples added to output buffer estimates.
 ///
@@ -40,7 +43,7 @@ pub(super) const RESAMPLE_HEADROOM_SAMPLES: i32 = 256;
 ///
 /// To flush remaining samples after all input has been processed,
 /// call with `in_` set to null and `in_count` set to 0.
-pub unsafe fn convert(
+pub(crate) unsafe fn convert(
     ctx: *mut SwrContext,
     out: *mut *mut u8,
     out_count: c_int,
@@ -83,7 +86,8 @@ pub unsafe fn convert(
 /// # Safety
 ///
 /// The context pointer must be valid.
-pub unsafe fn get_delay(ctx: *mut SwrContext, base: i64) -> i64 {
+#[cfg(test)]
+pub(crate) unsafe fn get_delay(ctx: *mut SwrContext, base: i64) -> i64 {
     if ctx.is_null() {
         return 0;
     }

--- a/crates/ff-sys/src/swresample/mod.rs
+++ b/crates/ff-sys/src/swresample/mod.rs
@@ -3,9 +3,15 @@
 //! This module provides thin wrapper functions around FFmpeg's libswresample API
 //! for resampling audio data and converting between sample formats and channel layouts.
 //!
-//! # Safety
+//! The public surface is pointer-free (`estimate_output_samples`, the
+//! `channel_layout` / `sample_format` submodules); the raw pointer-taking wrappers
+//! (`alloc_set_opts2` / `init` / `convert` / …) are `pub(crate)`, driven only by
+//! the owned [`ResampleContext`](crate::ResampleContext). (`audio_fifo` remains a
+//! separate, still-raw public submodule.)
 //!
-//! Callers are responsible for:
+//! # Safety (crate-internal wrappers)
+//!
+//! For the `pub(crate)` wrappers, callers are responsible for:
 //! - Ensuring pointers are valid before passing to these functions
 //! - Properly freeing resources using the corresponding free functions
 //! - Not using pointers after they have been freed
@@ -18,8 +24,9 @@ pub mod audio_fifo;
 pub mod channel_layout;
 pub mod sample_format;
 
-pub use context::{alloc, alloc_set_opts2, init, is_initialized};
-pub use convert::{convert, estimate_output_samples, get_delay};
+pub(crate) use context::{alloc_set_opts2, init};
+pub(crate) use convert::convert;
+pub use convert::estimate_output_samples;
 
 #[cfg(test)]
 mod tests {
@@ -95,9 +102,7 @@ mod tests {
             codec_ctx
                 .parameters_to_context(codecpar)
                 .map_err(|e| e.code())?;
-            codec_ctx
-                .open(codec, std::ptr::null_mut())
-                .map_err(|e| e.code())?;
+            codec_ctx.open_codec(codec).map_err(|e| e.code())?;
 
             // Allocate frame and packet. On failure the owned `codec_ctx` drops (frees).
             let frame = av_frame_alloc();

--- a/crates/ff-sys/src/swscale.rs
+++ b/crates/ff-sys/src/swscale.rs
@@ -3,9 +3,13 @@
 //! This module provides thin wrapper functions around FFmpeg's libswscale API
 //! for scaling video frames and converting between pixel formats.
 //!
-//! # Safety
+//! The public surface is pointer-free (`scale_flags`, the `is_supported_*`
+//! queries); the raw pointer-taking wrappers (`get_context` / `scale`) are
+//! `pub(crate)`, driven only by the owned [`ScaleContext`](crate::ScaleContext).
 //!
-//! Callers are responsible for:
+//! # Safety (crate-internal wrappers)
+//!
+//! For the `pub(crate)` wrappers, callers are responsible for:
 //! - Ensuring pointers are valid before passing to these functions
 //! - Properly freeing resources using the corresponding free functions
 //! - Not using pointers after they have been freed
@@ -180,7 +184,7 @@ pub mod scale_flags {
 ///     crate::sws_freeContext(ctx);
 /// }
 /// ```
-pub unsafe fn get_context(
+pub(crate) unsafe fn get_context(
     src_w: c_int,
     src_h: c_int,
     src_fmt: AVPixelFormat,
@@ -274,7 +278,7 @@ pub unsafe fn get_context(
 ///     )?;
 /// }
 /// ```
-pub unsafe fn scale(
+pub(crate) unsafe fn scale(
     ctx: *mut SwsContext,
     src: *const *const u8,
     src_stride: *const c_int,

--- a/crates/ff-sys/tests/seal.rs
+++ b/crates/ff-sys/tests/seal.rs
@@ -1,0 +1,201 @@
+//! Regression guard for the ff-sys safe-layer seal (#1506 / #1473, ADR-0003).
+//!
+//! The sealed part of the hand-written safe layer must expose **no** raw pointer
+//! in a public signature: every `*const` / `*mut` lives behind an owned RAII type
+//! or a `pub(crate)` wrapper, and the only raw FFI a consumer may touch is the
+//! bindgen layer (`pub use raw::*`), which this guard does not scan (nor the
+//! `docsrs_stubs`, which mix that raw layer with the wrapper stubs).
+//!
+//! This test reads the sources as text (no FFmpeg needed at runtime) and fails if
+//! any `pub` (not `pub(crate)`) `fn` / `unsafe fn` / `const fn` signature names a
+//! raw pointer. A signature can opt out with a `seal-allow-raw` marker comment
+//! placed in the contiguous comment block directly above it (used for
+//! `buffersink_get_frame`'s `AVFilterContext` and `Codec::as_ptr`, deliberately
+//! outside the #1506 owned-type seal).
+//!
+//! Not everything is in scope: the `audio_fifo` (`*mut AVAudioFifo`) and
+//! `channel_layout` POD helpers (`*mut AVChannelLayout`) are separate unsealed raw
+//! surfaces, excluded below until their own RAII sealing lands.
+
+/// The hand-written safe-layer source files, embedded at compile time.
+const SAFE_LAYER: &[(&str, &str)] = &[
+    ("frame.rs", include_str!("../src/frame.rs")),
+    ("packet.rs", include_str!("../src/packet.rs")),
+    ("codec.rs", include_str!("../src/codec.rs")),
+    ("codec_context.rs", include_str!("../src/codec_context.rs")),
+    (
+        "format_context.rs",
+        include_str!("../src/format_context.rs"),
+    ),
+    ("scale_context.rs", include_str!("../src/scale_context.rs")),
+    (
+        "resample_context.rs",
+        include_str!("../src/resample_context.rs"),
+    ),
+    ("hwdevice.rs", include_str!("../src/hwdevice.rs")),
+    ("buffersink.rs", include_str!("../src/buffersink.rs")),
+    ("avcodec.rs", include_str!("../src/avcodec.rs")),
+    ("avformat.rs", include_str!("../src/avformat.rs")),
+    ("swscale.rs", include_str!("../src/swscale.rs")),
+    (
+        "swresample/mod.rs",
+        include_str!("../src/swresample/mod.rs"),
+    ),
+    (
+        "swresample/context.rs",
+        include_str!("../src/swresample/context.rs"),
+    ),
+    (
+        "swresample/convert.rs",
+        include_str!("../src/swresample/convert.rs"),
+    ),
+    // NOT scanned — `docsrs_stubs.rs` intentionally mixes the sealed wrapper stubs
+    // with the *bindgen-layer* stubs (`av_frame_alloc`, `av_dict_get`, …) that
+    // mirror the intentionally-unsealed `pub use raw::*`; a whole-file scan would
+    // wrongly flag that raw layer, so it is excluded here.
+    //
+    // NOT scanned — separate raw surfaces outside the #1506 seal, each operating on
+    // a non-owned FFmpeg type (like buffersink's `AVFilterContext`): the
+    // `audio_fifo` submodule (`*mut AVAudioFifo`) and the `channel_layout` POD
+    // helpers (`*mut AVChannelLayout`, an embedded frame/context field). They gain
+    // owned wrappers (and this guard) when their own sealing lands. `sample_format`
+    // is pointer-free but omitted with its siblings for a single, clear boundary.
+];
+
+/// Returns the public signatures in `src` that name a raw pointer type.
+///
+/// A signature starts at a line whose trimmed text begins with `pub fn` /
+/// `pub unsafe fn` / `pub const fn` / `pub async fn` (crucially NOT `pub(crate)`
+/// or `pub(super)`, which don't match) and runs until the line that opens the
+/// body (`{`) or ends the declaration (`;`). A signature is skipped when a
+/// `seal-allow-raw` marker appears in the contiguous comment/attribute block
+/// directly above it.
+fn raw_pointer_public_signatures(src: &str) -> Vec<String> {
+    const STARTS: [&str; 4] = [
+        "pub fn ",
+        "pub unsafe fn ",
+        "pub const fn ",
+        "pub async fn ",
+    ];
+    let lines: Vec<&str> = src.lines().collect();
+    let mut hits = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if STARTS.iter().any(|s| trimmed.starts_with(s)) {
+            // Accumulate the signature until the body `{` or a `;`.
+            let mut sig = String::new();
+            let mut j = i;
+            loop {
+                sig.push_str(lines[j]);
+                sig.push('\n');
+                if lines[j].contains('{') || lines[j].trim_end().ends_with(';') {
+                    break;
+                }
+                j += 1;
+                if j >= lines.len() {
+                    break;
+                }
+            }
+
+            // Exemption: a `seal-allow-raw` marker in the contiguous comment /
+            // attribute / blank block immediately above the signature.
+            let mut exempt = sig.contains("seal-allow-raw");
+            let mut k = i;
+            while !exempt && k > 0 {
+                k -= 1;
+                let above = lines[k].trim_start();
+                if above.starts_with("//") || above.starts_with("#[") || above.is_empty() {
+                    if lines[k].contains("seal-allow-raw") {
+                        exempt = true;
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            if !exempt && (sig.contains("*const") || sig.contains("*mut")) {
+                hits.push(sig.trim().to_string());
+            }
+            i = j + 1;
+        } else {
+            i += 1;
+        }
+    }
+    hits
+}
+
+#[test]
+fn seal_guard_should_reject_public_raw_pointer_signatures() {
+    let mut offenders = Vec::new();
+    for (name, src) in SAFE_LAYER {
+        for sig in raw_pointer_public_signatures(src) {
+            offenders.push(format!("{name}:\n{sig}"));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "the ff-sys safe layer must expose no raw pointer in a public signature; \
+         demote the offender(s) to `pub(crate)` (or add a `seal-allow-raw` marker if the \
+         raw surface is intentionally unsealed):\n\n{}",
+        offenders.join("\n\n")
+    );
+}
+
+#[test]
+fn seal_guard_scanner_should_flag_a_synthetic_raw_signature() {
+    // The scanner must actually detect a public raw-pointer signature (guards
+    // against a vacuous pass), across params, returns, and multi-line sigs.
+    assert_eq!(
+        raw_pointer_public_signatures("pub fn bad() -> *mut u8 { core::ptr::null_mut() }").len(),
+        1,
+        "a public raw-pointer return must be flagged"
+    );
+    assert_eq!(
+        raw_pointer_public_signatures("pub unsafe fn bad(p: *const u8) -> bool { p.is_null() }")
+            .len(),
+        1,
+        "a public raw-pointer parameter must be flagged"
+    );
+    assert_eq!(
+        raw_pointer_public_signatures("pub fn bad(\n    p: *mut u8,\n) -> i32 {\n    0\n}").len(),
+        1,
+        "a multi-line public raw-pointer signature must be flagged"
+    );
+    assert_eq!(
+        raw_pointer_public_signatures("pub const fn bad(&self) -> *const u8 { core::ptr::null() }")
+            .len(),
+        1,
+        "a public const-fn raw-pointer return must be flagged"
+    );
+
+    // And it must NOT flag the legitimate cases the seal permits.
+    assert!(
+        raw_pointer_public_signatures("pub(crate) unsafe fn ok(p: *mut u8) {}").is_empty(),
+        "a pub(crate) raw-pointer signature is sealed and must not be flagged"
+    );
+    assert!(
+        raw_pointer_public_signatures("pub fn ok(x: i32) -> bool { x > 0 }").is_empty(),
+        "a public non-pointer signature must not be flagged"
+    );
+    assert!(
+        raw_pointer_public_signatures(
+            "// seal-allow-raw: intentionally unsealed\npub unsafe fn ok(p: *mut u8) {}"
+        )
+        .is_empty(),
+        "a seal-allow-raw-marked signature must not be flagged"
+    );
+    assert!(
+        raw_pointer_public_signatures("pub(super) unsafe fn ok(p: *mut u8) {}").is_empty(),
+        "a pub(super) raw-pointer signature is sealed and must not be flagged"
+    );
+    // Mirrors the real `Codec::as_ptr`: the marker is separated from the signature
+    // by a continuation comment line and a `#[must_use]` attribute.
+    assert!(
+        raw_pointer_public_signatures(
+            "// seal-allow-raw: x\n// continued\n#[must_use]\npub const fn ok(&self) -> *const u8 { core::ptr::null() }"
+        )
+        .is_empty(),
+        "a seal-allow-raw exemption separated by an attribute/comment block must still apply"
+    );
+}


### PR DESCRIPTION
## Objective

- Final slice (S4b) of the ff-sys safe-layer seal (#1473 / ADR-0003): the hand-written safe layer must expose no raw pointer in a public signature, and that must be self-enforcing.

## Solution

- Demote every raw-pointer-naming public free-function in the `avcodec` / `avformat` / `swscale` / `swresample` wrapper modules to `pub(crate)` (const/enum/safe-helper submodules stay public); test-only wrappers are gated `#[cfg(test)]`.
- Seal the owned-type raw-pointer methods the guard surfaced: `CodecContext::parameters_from_context` -> `pub(crate)`, `parameters_to_context` -> `#[cfg(test)]`, delete the raw `open` (`open_codec` covers every caller), and change `ResampleContext::new` to take `&AVChannelLayout` (kept `unsafe`: a CUSTOM-order layout still carries an inner pointer libswresample dereferences).
- Migrate the remaining consumers to the safe API (broader than the two sites the issue named): encoder-availability probes use `Codec::find_encoder*`; the preview duration probe uses `InputFormatContext`; ~15 `CodecContext::open(codec, null)` sites across ff-encode / ff-stream / ff-filter become `open_codec(codec)`.
- Keep `Codec::as_ptr` (a borrowed static handle) and `buffersink_get_frame` (raw `AVFilterContext`, filter graph not yet an owned type) public, marked `seal-allow-raw`.
- Point the swscale/swresample benches at the bindgen entry points via thin local shims.
- Add `crates/ff-sys/tests/seal.rs`: a text scanner that fails if any public signature in the sealed sources names a raw pointer, with a non-vacuous self-test.

Closes #1567
Closes #1506