### PR TITLE
refactor(ff-sys): return AvError from the public safe wrappers

### DIFF
--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -215,10 +215,10 @@ impl AudioEncoderInner {
             self.fifo =
                 swresample::audio_fifo::alloc(target_fmt, config.channels as i32, required as i32)
                     .map_err(|e| EncodeError::Ffmpeg {
-                        code: e,
+                        code: e.code(),
                         message: format!(
                             "Cannot allocate audio FIFO: {}",
-                            ff_sys::av_error_string(e)
+                            ff_sys::av_error_string(e.code())
                         ),
                     })?;
             self.frame_size = required;
@@ -392,10 +392,10 @@ impl AudioEncoderInner {
                     swresample::audio_fifo::write_frame(self.fifo, &av_frame, nb_samples);
 
                 write_result.map_err(|e| EncodeError::Ffmpeg {
-                    code: e,
+                    code: e.code(),
                     message: format!(
                         "Failed to write to audio FIFO: {}",
-                        ff_sys::av_error_string(e)
+                        ff_sys::av_error_string(e.code())
                     ),
                 })?;
 
@@ -496,10 +496,10 @@ impl AudioEncoderInner {
         // SAFETY: get_buffer allocated the plane buffers; they are large enough
         swresample::audio_fifo::read_frame(self.fifo, &mut av_frame, frame_size).map_err(|e| {
             EncodeError::Ffmpeg {
-                code: e,
+                code: e.code(),
                 message: format!(
                     "Failed to read from audio FIFO: {}",
-                    ff_sys::av_error_string(e)
+                    ff_sys::av_error_string(e.code())
                 ),
             }
         })?;

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -368,7 +368,7 @@ impl VideoEncoderInner {
                 fifo_nb_channels,
                 frame_size * 2,
             )
-            .map_err(EncodeError::from_ffmpeg_error)?;
+            .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
             self.audio_fifo = Some(fifo);
         }
 

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -480,7 +480,7 @@ impl VideoEncoderInner {
             {
                 let nb_samples = av_frame.nb_samples();
                 ff_sys::swresample::audio_fifo::write_frame(fifo, &av_frame, nb_samples)
-                    .map_err(EncodeError::from_ffmpeg_error)?;
+                    .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
             }
             drop(av_frame);
 
@@ -513,7 +513,7 @@ impl VideoEncoderInner {
                 })?;
 
                 ff_sys::swresample::audio_fifo::read_frame(fifo, &mut out_frame, frame_size)
-                    .map_err(EncodeError::from_ffmpeg_error)?;
+                    .map_err(|e| EncodeError::from_ffmpeg_error(e.code()))?;
 
                 out_frame.set_pts(self.audio_sample_count as i64);
                 self.audio_codec_ctx

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -72,7 +72,7 @@ impl VideoEncoderInner {
                 reason: "Pass-1 codec context not initialized".to_string(),
             })?
             .send_frame(None)
-            && e.code() != ff_sys::error_codes::EOF
+            && !e.is_eof()
         {
             return Err(EncodeError::Ffmpeg {
                 code: e.code(),
@@ -157,7 +157,7 @@ impl VideoEncoderInner {
                     reason: "Video codec not initialized".to_string(),
                 })?
                 .send_frame(None)
-                && e.code() != ff_sys::error_codes::EOF
+                && !e.is_eof()
             {
                 return Err(EncodeError::Ffmpeg {
                     code: e.code(),

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -963,8 +963,8 @@ pub mod swresample {
         pub unsafe fn copy(
             _dst: *mut AVChannelLayout,
             _src: *const AVChannelLayout,
-        ) -> Result<(), i32> {
-            Err(-1)
+        ) -> Result<(), crate::AvError> {
+            Err(crate::AvError::new(-1))
         }
         pub unsafe fn is_equal(
             _chl: *const AVChannelLayout,
@@ -1002,8 +1002,8 @@ pub mod swresample {
             _sample_fmt: AVSampleFormat,
             _channels: c_int,
             _nb_samples: c_int,
-        ) -> Result<*mut AVAudioFifo, c_int> {
-            Err(-1)
+        ) -> Result<*mut AVAudioFifo, crate::AvError> {
+            Err(crate::AvError::new(-1))
         }
 
         pub unsafe fn free(_fifo: *mut AVAudioFifo) {}
@@ -1012,16 +1012,16 @@ pub mod swresample {
             _fifo: *mut AVAudioFifo,
             _data: *const *mut c_void,
             _nb_samples: c_int,
-        ) -> Result<c_int, c_int> {
-            Err(-1)
+        ) -> Result<c_int, crate::AvError> {
+            Err(crate::AvError::new(-1))
         }
 
         pub unsafe fn read(
             _fifo: *mut AVAudioFifo,
             _data: *const *mut c_void,
             _nb_samples: c_int,
-        ) -> Result<c_int, c_int> {
-            Err(-1)
+        ) -> Result<c_int, crate::AvError> {
+            Err(crate::AvError::new(-1))
         }
 
         pub unsafe fn size(_fifo: *mut AVAudioFifo) -> c_int {
@@ -1032,16 +1032,16 @@ pub mod swresample {
             _fifo: *mut AVAudioFifo,
             _src: &super::super::Frame,
             _nb_samples: c_int,
-        ) -> Result<c_int, c_int> {
-            Err(-1)
+        ) -> Result<c_int, crate::AvError> {
+            Err(crate::AvError::new(-1))
         }
 
         pub unsafe fn read_frame(
             _fifo: *mut AVAudioFifo,
             _dst: &mut super::super::Frame,
             _nb_samples: c_int,
-        ) -> Result<c_int, c_int> {
-            Err(-1)
+        ) -> Result<c_int, crate::AvError> {
+            Err(crate::AvError::new(-1))
         }
     }
 

--- a/crates/ff-sys/src/swresample/audio_fifo.rs
+++ b/crates/ff-sys/src/swresample/audio_fifo.rs
@@ -8,12 +8,12 @@
 use std::ffi::c_void;
 use std::os::raw::c_int;
 
-use crate::{AVAudioFifo, AVSampleFormat};
+use crate::{AVAudioFifo, AVSampleFormat, AvError};
 
 /// Allocate an `AVAudioFifo` for the given sample format, channel count,
 /// and initial capacity (in samples).
 ///
-/// Returns `Ok(fifo)` on success, `Err(-1)` on allocation failure.
+/// Returns `Ok(fifo)` on success, or an [`AvError`] on allocation failure.
 ///
 /// # Safety
 ///
@@ -23,10 +23,14 @@ pub unsafe fn alloc(
     sample_fmt: AVSampleFormat,
     channels: c_int,
     nb_samples: c_int,
-) -> Result<*mut AVAudioFifo, c_int> {
+) -> Result<*mut AVAudioFifo, AvError> {
     // SAFETY: caller guarantees parameters are valid
     let fifo = unsafe { crate::av_audio_fifo_alloc(sample_fmt, channels, nb_samples) };
-    if fifo.is_null() { Err(-1) } else { Ok(fifo) }
+    if fifo.is_null() {
+        Err(AvError::new(-1))
+    } else {
+        Ok(fifo)
+    }
 }
 
 /// Free an `AVAudioFifo` created by [`alloc`].
@@ -54,10 +58,14 @@ pub unsafe fn write(
     fifo: *mut AVAudioFifo,
     data: *const *mut c_void,
     nb_samples: c_int,
-) -> Result<c_int, c_int> {
+) -> Result<c_int, AvError> {
     // SAFETY: caller guarantees all pointers are valid
     let ret = unsafe { crate::av_audio_fifo_write(fifo, data, nb_samples) };
-    if ret < 0 { Err(ret) } else { Ok(ret) }
+    if ret < 0 {
+        Err(AvError::new(ret))
+    } else {
+        Ok(ret)
+    }
 }
 
 /// Read up to `nb_samples` samples from the FIFO into pre-allocated
@@ -77,10 +85,14 @@ pub unsafe fn read(
     fifo: *mut AVAudioFifo,
     data: *const *mut c_void,
     nb_samples: c_int,
-) -> Result<c_int, c_int> {
+) -> Result<c_int, AvError> {
     // SAFETY: caller guarantees all pointers are valid
     let ret = unsafe { crate::av_audio_fifo_read(fifo, data, nb_samples) };
-    if ret < 0 { Err(ret) } else { Ok(ret) }
+    if ret < 0 {
+        Err(AvError::new(ret))
+    } else {
+        Ok(ret)
+    }
 }
 
 /// Return the number of samples currently stored in the FIFO.
@@ -106,7 +118,7 @@ pub unsafe fn write_frame(
     fifo: *mut AVAudioFifo,
     src: &crate::Frame,
     nb_samples: c_int,
-) -> Result<c_int, c_int> {
+) -> Result<c_int, AvError> {
     // SAFETY: `src` is a valid frame; its `data` pointer array is read (not
     //         retained), and the caller upholds `fifo` and the sample count.
     let data = unsafe { (*src.as_ptr()).data.as_ptr().cast::<*mut c_void>() };
@@ -126,7 +138,7 @@ pub unsafe fn read_frame(
     fifo: *mut AVAudioFifo,
     dst: &mut crate::Frame,
     nb_samples: c_int,
-) -> Result<c_int, c_int> {
+) -> Result<c_int, AvError> {
     // SAFETY: `dst` is a valid get_buffer'd frame; its `data` pointer array is
     //         read (not retained) while the FIFO writes into the planes it
     //         points to, and the caller upholds `fifo` and the sample count.

--- a/crates/ff-sys/src/swresample/channel_layout.rs
+++ b/crates/ff-sys/src/swresample/channel_layout.rs
@@ -1,7 +1,7 @@
 //! Channel layout helpers for audio configuration.
 
 use crate::{
-    AVChannelLayout, AVChannelOrder_AV_CHANNEL_ORDER_NATIVE, av_channel_layout_compare,
+    AVChannelLayout, AVChannelOrder_AV_CHANNEL_ORDER_NATIVE, AvError, av_channel_layout_compare,
     av_channel_layout_copy, av_channel_layout_default, av_channel_layout_uninit,
 };
 
@@ -51,20 +51,24 @@ pub unsafe fn uninit(ch_layout: *mut AVChannelLayout) {
 ///
 /// # Returns
 ///
-/// Returns `Ok(())` on success, or an error code on failure.
+/// Returns `Ok(())` on success, or an [`AvError`] on failure.
 ///
 /// # Safety
 ///
 /// Both pointers must be valid.
-pub unsafe fn copy(dst: *mut AVChannelLayout, src: *const AVChannelLayout) -> Result<(), i32> {
+pub unsafe fn copy(dst: *mut AVChannelLayout, src: *const AVChannelLayout) -> Result<(), AvError> {
     if dst.is_null() || src.is_null() {
-        return Err(crate::error_codes::EINVAL);
+        return Err(AvError::new(crate::error_codes::EINVAL));
     }
 
     // SAFETY: `dst` and `src` are both non-null (checked above) and point to
     // valid channel layouts.
     let ret = unsafe { av_channel_layout_copy(dst, src) };
-    if ret < 0 { Err(ret) } else { Ok(()) }
+    if ret < 0 {
+        Err(AvError::new(ret))
+    } else {
+        Ok(())
+    }
 }
 
 /// Compare two channel layouts.


### PR DESCRIPTION
## Objective

- Complete the ADR-0003 typed-error migration: the RAII owned types already return `Result<_, AvError>`, but the remaining public safe-layer helpers (`audio_fifo`, `channel_layout::copy`) still returned a bare `c_int`.

## Solution

- `audio_fifo` (`alloc`/`write`/`read`/`write_frame`/`read_frame`) and `channel_layout::copy` now return `Result<_, AvError>` instead of a bare `c_int`. The pointers stay raw (these are still-unsealed surfaces); only the error type is unified.
- Migrate the ff-encode `audio_fifo` consumers to read `AvError::code()` while keeping the `Ffmpeg { code, message }` variant shape, and switch the two-pass flush sites to `!e.is_eof()` instead of comparing the raw `EOF` code.
- Mirror the two wrapper signatures in the docs.rs stubs.
- Behaviour is unchanged (`AvError` wraps the same code; `is_eof()` is exactly the prior comparison). The internal `pub(crate)` wrappers keep their `c_int` returns — they are not public API.

Closes #1488