### PR TITLE
refactor(avio): make the editing model available without the pipeline feature

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -12,14 +12,25 @@ categories = ["multimedia::video", "multimedia::audio", "multimedia::encoding", 
 
 [features]
 default = ["probe", "decode", "encode", "analysis", "hwaccel"]
+# The editing model is now unconditional (ff-decode/encode/filter/pipeline are
+# non-optional), so `decode` / `filter` / `pipeline` no longer gate a dependency.
+# The names are retained: they still gate the not-yet-removed facade primitives in
+# lib.rs and the `required-features` of the primitive examples (#1484 retires them).
 probe    = ["dep:ff-probe"]
-decode   = ["dep:ff-decode"]
+decode   = []
+# `decode` is retained so the analysis examples that also use a facade decoder
+# (`required-features = ["analysis"]`) still activate the `decode`-gated re-exports.
 analysis = ["dep:ff-analysis", "decode"]
-encode   = ["dep:ff-encode", "dep:ff-remux", "ff-encode/preview-image"]
-filter   = ["dep:ff-filter"]
-pipeline = ["dep:ff-pipeline", "dep:thiserror", "dep:log", "decode", "encode", "filter", "ff-preview?/timeline"]
+encode   = ["dep:ff-remux", "ff-encode/preview-image"]
+filter   = []
+# `pipeline` no longer gates a dependency (ff-pipeline is non-optional). The name and
+# its decode/encode/filter implication are retained so the not-yet-migrated primitive
+# examples (`required-features = ["pipeline"]`) still activate those facade re-exports.
+pipeline = ["decode", "encode", "filter"]
 stream   = ["dep:ff-stream", "pipeline"]
-preview       = ["dep:ff-preview"]
+# `preview` supplies ff-preview's `timeline` feature: the model's `to_scene` /
+# `TimelinePlayer` (preview-gated) derive a `Scene` and hand it to `ScenePlayer`.
+preview       = ["dep:ff-preview", "ff-preview/timeline"]
 preview-proxy = ["preview", "ff-preview/proxy"]
 render        = ["dep:ff-render", "preview"]
 render-gpu    = ["render", "ff-render/wgpu"]
@@ -27,44 +38,46 @@ tokio         = ["decode", "encode", "ff-decode/tokio", "ff-encode/tokio", "ff-p
 gpl      = ["ff-encode/gpl"]
 hwaccel  = ["ff-encode/hwaccel"]
 srt      = ["ff-decode/srt", "ff-stream/srt"]
-serde    = ["pipeline", "dep:serde", "ff-filter/serde", "ff-format/serde"]
+serde    = ["dep:serde", "ff-filter/serde", "ff-format/serde"]
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+# Core engine: avio *is* the editing engine, so the crates its model
+# (Timeline / Clip / Editor / derive / render) needs are non-optional.
 ff-format = { workspace = true }
 ff-common = { workspace = true }
+ff-decode   = { workspace = true }
+ff-encode   = { workspace = true }
+ff-filter   = { workspace = true }
+ff-pipeline = { workspace = true }
+thiserror   = { workspace = true }
+log         = { workspace = true }
+# Opt-in capabilities (and the not-yet-removed facade primitives, see #1484).
 ff-probe    = { workspace = true, optional = true }
-ff-decode   = { workspace = true, optional = true }
 ff-analysis = { workspace = true, optional = true }
-ff-encode   = { workspace = true, optional = true }
 ff-remux    = { workspace = true, optional = true }
-ff-filter   = { workspace = true, optional = true }
-ff-pipeline = { workspace = true, optional = true }
 ff-stream   = { workspace = true, optional = true }
 ff-preview  = { workspace = true, optional = true }
 ff-render   = { workspace = true, optional = true }
-thiserror   = { workspace = true, optional = true }
-log         = { workspace = true, optional = true }
 serde       = { version = "1.0.228", features = ["derive"], optional = true }
 
 [[test]]
 name = "serde_persistence"
 required-features = ["serde"]
 
+# The editing model is unconditional, so its tests build by default (no feature gate).
 [[test]]
 name = "timeline_tests"
-required-features = ["pipeline"]
 
 [[test]]
 name = "composition_framerate"
-required-features = ["pipeline"]
 
 [[test]]
 name = "timeline_preview_tests"
-required-features = ["pipeline", "preview"]
+required-features = ["preview"]
 
 [[example]]
 name = "probe_info"
@@ -521,10 +534,10 @@ name = "multi_track_compose"
 path = "examples/filter/multi_track_compose.rs"
 required-features = ["filter", "pipeline", "encode"]
 
+# Engine demo — builds by default now that the model is unconditional.
 [[example]]
 name = "timeline_render"
 path = "examples/transcode/timeline_render.rs"
-required-features = ["filter", "pipeline", "encode"]
 
 [[example]]
 name = "scope_analyzer"

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -264,9 +264,6 @@ pub use ff_analysis::{
 // re-exported from avio without ambiguity.
 // VideoCodecEncodeExt provides encode-specific helpers (is_lgpl_compatible,
 // default_extension) on the shared VideoCodec type; import it to call them.
-// Engine surface: `BitrateMode` is an `EncoderConfig::builder()` setter dep and
-// `EncodeError` is named by `TimelineError::Encode(#[from] EncodeError)` — unconditional.
-pub use ff_encode::{BitrateMode, EncodeError};
 #[cfg(feature = "encode")]
 pub use ff_encode::{
     AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, AudioEncoderBuilder,
@@ -278,6 +275,9 @@ pub use ff_encode::{
     VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, VideoEncoderBuilder, VideoEncoderConfig,
     Vp9Options,
 };
+// Engine surface: `BitrateMode` is an `EncoderConfig::builder()` setter dep and
+// `EncodeError` is named by `TimelineError::Encode(#[from] EncodeError)` — unconditional.
+pub use ff_encode::{BitrateMode, EncodeError};
 
 // media-ops + trim moved to the `ff-remux` crate; re-exported here so `avio`'s
 // surface is unchanged (enabled by the `encode` feature, which pulls `ff-remux`).
@@ -301,6 +301,14 @@ pub use ff_decode::{
 pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 
 // ── filter feature ────────────────────────────────────────────────────────────
+#[cfg(feature = "filter")]
+pub use ff_filter::{
+    AnalyzeOptions, AnimationEntry, AudioConcatenator, AudioTrack, CrossfadeJoiner, FilterGraph,
+    FilterGraphBuilder, Interpolation, LavfiSource, LayerSource, LensProfile, Lerp, LoudnessMeter,
+    LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType, ProxySource,
+    QualityMetrics, RealtimeComposer, SolidSource, StabilizeOptions, Stabilizer, TextSource,
+    VideoConcatenator, VideoLayer,
+};
 // Engine surface: the ff-filter authoring set the model names via Clip / FilterStep /
 // animation (Clip fields, FilterStep variant payloads, animation authoring,
 // Clip::realtime_layer[_descriptor] returns, FilterError, and the EncoderConfig HwAccel
@@ -309,14 +317,6 @@ pub use ff_filter::{
     AnimatedValue, AnimationTrack, BlendMode, CompositeOp, DrawTextOptions, Easing, EqBand,
     FilterError, FilterStep, HwAccel, Keyframe, RealtimeLayer, RealtimeLayerDescriptor, Rgb,
     ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
-};
-#[cfg(feature = "filter")]
-pub use ff_filter::{
-    AnalyzeOptions, AnimationEntry, AudioConcatenator, AudioTrack, CrossfadeJoiner, FilterGraph,
-    FilterGraphBuilder, Interpolation, LavfiSource, LayerSource, LensProfile, Lerp, LoudnessMeter,
-    LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType, ProxySource,
-    QualityMetrics, RealtimeComposer, SolidSource, StabilizeOptions, Stabilizer, TextSource,
-    VideoConcatenator, VideoLayer,
 };
 
 // ── editing model (unconditional) ─────────────────────────────────────────────
@@ -347,15 +347,15 @@ pub use timeline::{Timeline, TimelineBuilder};
 pub use track::Track;
 pub use validate::TimelineIssue;
 
-// Engine surface: `Timeline::render(config: EncoderConfig)` and
-// `render_with_progress(_, _, impl Fn(&Progress) -> bool)` name these; the builder is
-// `EncoderConfig::builder()`'s constructor — unconditional.
-pub use ff_pipeline::{EncoderConfig, EncoderConfigBuilder, Progress};
 #[cfg(feature = "pipeline")]
 pub use ff_pipeline::{
     AudioPipeline, Pipeline, PipelineBuilder, PipelineError, ProgressCallback, ThumbnailPipeline,
     VideoPipeline,
 };
+// Engine surface: `Timeline::render(config: EncoderConfig)` and
+// `render_with_progress(_, _, impl Fn(&Progress) -> bool)` name these; the builder is
+// `EncoderConfig::builder()`'s constructor — unconditional.
+pub use ff_pipeline::{EncoderConfig, EncoderConfigBuilder, Progress};
 
 // ── stream feature ────────────────────────────────────────────────────────────
 //

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -239,11 +239,12 @@ pub use ff_probe::{ProbeError, open};
 // Arc<dyn FramePool> when you need to pass a pool through an abstraction boundary.
 #[cfg(feature = "decode")]
 pub use ff_common::{PooledBuffer, VecPool};
+// Engine surface: `TimelineError::Decode(#[from] DecodeError)` names it — unconditional.
+pub use ff_decode::DecodeError;
 #[cfg(feature = "decode")]
 pub use ff_decode::{
-    AudioDecoder, AudioDecoderBuilder, DecodeError, FrameExtractor, FramePool, HardwareAccel,
-    ImageDecoder, ImageDecoderBuilder, SeekMode, ThumbnailSelector, VideoDecoder,
-    VideoDecoderBuilder,
+    AudioDecoder, AudioDecoderBuilder, FrameExtractor, FramePool, HardwareAccel, ImageDecoder,
+    ImageDecoderBuilder, SeekMode, ThumbnailSelector, VideoDecoder, VideoDecoderBuilder,
 };
 
 // ── analysis feature ──────────────────────────────────────────────────────────
@@ -263,16 +264,19 @@ pub use ff_analysis::{
 // re-exported from avio without ambiguity.
 // VideoCodecEncodeExt provides encode-specific helpers (is_lgpl_compatible,
 // default_extension) on the shared VideoCodec type; import it to call them.
+// Engine surface: `BitrateMode` is an `EncoderConfig::builder()` setter dep and
+// `EncodeError` is named by `TimelineError::Encode(#[from] EncodeError)` — unconditional.
+pub use ff_encode::{BitrateMode, EncodeError};
 #[cfg(feature = "encode")]
 pub use ff_encode::{
     AacOptions, AacProfile, AudioCodecOptions, AudioEncoder, AudioEncoderBuilder,
-    AudioEncoderConfig, Av1Options, Av1Usage, BitrateMode, CRF_MAX, DnxhdOptions, DnxhdVariant,
-    EncodeError, EncodeProgress, EncodeProgressCallback, ExportPreset, FlacOptions, GifPreview,
-    H264Options, H264Preset, H264Profile, H264Tune, H265Options, H265Profile, H265Tier,
-    HardwareEncoder, ImageEncoder, ImageEncoderBuilder, Mp3Options, Mp3Quality, OpusApplication,
-    OpusOptions, OutputContainer, Preset, PreviewImageError, ProResOptions, ProResProfile,
-    SpriteSheet, SvtAv1Options, VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder,
-    VideoEncoderBuilder, VideoEncoderConfig, Vp9Options,
+    AudioEncoderConfig, Av1Options, Av1Usage, CRF_MAX, DnxhdOptions, DnxhdVariant, EncodeProgress,
+    EncodeProgressCallback, ExportPreset, FlacOptions, GifPreview, H264Options, H264Preset,
+    H264Profile, H264Tune, H265Options, H265Profile, H265Tier, HardwareEncoder, ImageEncoder,
+    ImageEncoderBuilder, Mp3Options, Mp3Quality, OpusApplication, OpusOptions, OutputContainer,
+    Preset, PreviewImageError, ProResOptions, ProResProfile, SpriteSheet, SvtAv1Options,
+    VideoCodecEncodeExt, VideoCodecOptions, VideoEncoder, VideoEncoderBuilder, VideoEncoderConfig,
+    Vp9Options,
 };
 
 // media-ops + trim moved to the `ff-remux` crate; re-exported here so `avio`'s
@@ -297,69 +301,60 @@ pub use ff_decode::{
 pub use ff_encode::{AsyncAudioEncoder, AsyncVideoEncoder};
 
 // ── filter feature ────────────────────────────────────────────────────────────
+// Engine surface: the ff-filter authoring set the model names via Clip / FilterStep /
+// animation (Clip fields, FilterStep variant payloads, animation authoring,
+// Clip::realtime_layer[_descriptor] returns, FilterError, and the EncoderConfig HwAccel
+// setter dep) — unconditional.
+pub use ff_filter::{
+    AnimatedValue, AnimationTrack, BlendMode, CompositeOp, DrawTextOptions, Easing, EqBand,
+    FilterError, FilterStep, HwAccel, Keyframe, RealtimeLayer, RealtimeLayerDescriptor, Rgb,
+    ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
+};
 #[cfg(feature = "filter")]
 pub use ff_filter::{
-    AnalyzeOptions, AnimatedValue, AnimationEntry, AnimationTrack, AudioConcatenator, AudioTrack,
-    BlendMode, CompositeOp, CrossfadeJoiner, DrawTextOptions, Easing, EqBand, FilterError,
-    FilterGraph, FilterGraphBuilder, FilterStep, HwAccel, Interpolation, Keyframe, LavfiSource,
-    LayerSource, LensProfile, Lerp, LoudnessMeter, LoudnessResult, MultiTrackAudioMixer,
-    MultiTrackComposer, NoiseType, ProxySource, QualityMetrics, RealtimeComposer, RealtimeLayer,
-    RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, SolidSource, StabilizeOptions, Stabilizer,
-    TextSource, ToneMap, VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    AnalyzeOptions, AnimationEntry, AudioConcatenator, AudioTrack, CrossfadeJoiner, FilterGraph,
+    FilterGraphBuilder, Interpolation, LavfiSource, LayerSource, LensProfile, Lerp, LoudnessMeter,
+    LoudnessResult, MultiTrackAudioMixer, MultiTrackComposer, NoiseType, ProxySource,
+    QualityMetrics, RealtimeComposer, SolidSource, StabilizeOptions, Stabilizer, TextSource,
+    VideoConcatenator, VideoLayer,
 };
 
-// ── pipeline feature ──────────────────────────────────────────────────────────
+// ── editing model (unconditional) ─────────────────────────────────────────────
 //
-// Enabling `pipeline` also enables `filter` (see Cargo.toml).
-// Progress / ProgressCallback are re-exported here as the canonical source.
-//
-// The editing model (`Timeline` / `Clip` / `render` / `TimelineError`) is defined
-// in `avio` itself — the engine owns the model. The execution pipelines stay in
-// `ff-pipeline` and are re-exported below.
-#[cfg(feature = "pipeline")]
+// The editing model (`Timeline` / `Clip` / `Editor` / `render` / `TimelineError`) is
+// defined in `avio` itself — the engine owns the model, and it is always compiled
+// (`ff-decode` / `ff-encode` / `ff-filter` / `ff-pipeline` are non-optional). The
+// standalone execution pipelines stay in `ff-pipeline`, re-exported below and still
+// gated behind the `pipeline` feature (removed in #1484).
 mod clip;
-#[cfg(feature = "pipeline")]
 mod derive;
-#[cfg(feature = "pipeline")]
 mod edit;
-#[cfg(feature = "pipeline")]
 mod editor;
-#[cfg(feature = "pipeline")]
 mod error;
-#[cfg(feature = "pipeline")]
 mod ids;
-#[cfg(feature = "pipeline")]
 mod marker;
-#[cfg(feature = "pipeline")]
 mod timeline;
-#[cfg(feature = "pipeline")]
 mod track;
-#[cfg(feature = "pipeline")]
 mod validate;
 
-#[cfg(feature = "pipeline")]
 pub use clip::{Clip, ClipSource, FitMode, VideoEffectRenderer};
-#[cfg(feature = "pipeline")]
 pub use edit::{ClipProperty, Command, EditError, apply};
-#[cfg(feature = "pipeline")]
 pub use editor::Editor;
-#[cfg(feature = "pipeline")]
 pub use error::TimelineError;
-#[cfg(feature = "pipeline")]
 pub use ids::{ClipId, GroupId, MarkerId, TrackId, TrackKind};
-#[cfg(feature = "pipeline")]
 pub use marker::Marker;
-#[cfg(feature = "pipeline")]
 pub use timeline::{Timeline, TimelineBuilder};
-#[cfg(feature = "pipeline")]
 pub use track::Track;
-#[cfg(feature = "pipeline")]
 pub use validate::TimelineIssue;
 
+// Engine surface: `Timeline::render(config: EncoderConfig)` and
+// `render_with_progress(_, _, impl Fn(&Progress) -> bool)` name these; the builder is
+// `EncoderConfig::builder()`'s constructor — unconditional.
+pub use ff_pipeline::{EncoderConfig, EncoderConfigBuilder, Progress};
 #[cfg(feature = "pipeline")]
 pub use ff_pipeline::{
-    AudioPipeline, EncoderConfig, EncoderConfigBuilder, Pipeline, PipelineBuilder, PipelineError,
-    Progress, ProgressCallback, ThumbnailPipeline, VideoPipeline,
+    AudioPipeline, Pipeline, PipelineBuilder, PipelineError, ProgressCallback, ThumbnailPipeline,
+    VideoPipeline,
 };
 
 // ── stream feature ────────────────────────────────────────────────────────────
@@ -399,17 +394,17 @@ pub use ff_preview::HardwareAccel;
 
 // The editing-model preview entry `TimelinePlayer` is defined in `avio` (the
 // `player` module) — it derives a `Scene` from a `Timeline` and hands it to
-// `ff-preview`'s `ScenePlayer`. `ScenePlayer` / `SceneRunner` / the `Scene`
-// types stay in `ff-preview` (model-agnostic). All require `preview` + `pipeline`;
-// the `pipeline` feature enables `ff-preview?/timeline` (see Cargo.toml).
-#[cfg(all(feature = "preview", feature = "pipeline"))]
+// `ff-preview`'s `ScenePlayer`. `ScenePlayer` / `SceneRunner` / the `Scene` types
+// stay in `ff-preview` (model-agnostic). The model is unconditional now, so these
+// require only `preview` (which supplies `ff-preview/timeline`).
+#[cfg(feature = "preview")]
 mod player;
-#[cfg(all(feature = "preview", feature = "pipeline"))]
+#[cfg(feature = "preview")]
 pub use ff_preview::{
     Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, ScenePlayer, SceneRunner,
     SceneVideoTrack,
 };
-#[cfg(all(feature = "preview", feature = "pipeline"))]
+#[cfg(feature = "preview")]
 pub use player::TimelinePlayer;
 
 #[cfg(all(feature = "preview", feature = "tokio"))]

--- a/crates/avio/tests/timeline_preview_tests.rs
+++ b/crates/avio/tests/timeline_preview_tests.rs
@@ -2,7 +2,7 @@
 //! (`avio::TimelinePlayer` -> `ff_preview` runner). Relocated from `ff-preview`
 //! when the model moved into `avio` (#1329). Asset-gated (`#[ignore]`).
 
-#![cfg(all(feature = "pipeline", feature = "preview"))]
+#![cfg(feature = "preview")]
 
 use std::path::PathBuf;
 use std::thread;


### PR DESCRIPTION
## Objective

- `avio` is the editing engine, but its model (`Timeline` / `Clip` / `Editor` / `render`) was gated behind `#[cfg(feature = "pipeline")]`, and `pipeline` is not a default feature — so a default build did not compile the engine at all.
- Make the model unconditional so `cargo add avio` (default, and even `--no-default-features`) exposes the engine.

## Solution

- Make the core-model crates non-optional (`ff-decode` / `ff-encode` / `ff-filter` / `ff-pipeline`, plus `thiserror` / `log`); un-gate the model modules.
- Split the mixed re-export blocks: the engine-named surface (`EncoderConfig` / `Progress`, `DecodeError`, `BitrateMode` / `EncodeError`, the `ff-filter` authoring set) becomes unconditional; the standalone facade primitives keep their existing feature gates.
- Retain all feature names (`decode` / `filter` / `pipeline` become no-op / implication features) so the not-yet-removed facade re-exports and the primitive examples' `required-features` stay valid; `preview` now supplies `ff-preview/timeline` since `to_scene` / `TimelinePlayer` are `preview`-only gated.
- Update the pure-model tests to build by default; relax `timeline_preview_tests`' file-level `cfg` to match its `required-features`.

Scope note: retiring the feature names, removing the dropped facade re-exports, migrating the primitive examples, and rewriting the crate docs engine-first are the follow-up (#1484). `ff-preview` / `ff-analysis` / `ff-probe` stay opt-in here; the core model does not need them.

Closes #1483