### PR TITLE
docs(adr): accept ADR-0004 (avio is the editing engine, not a facade)

### DIFF
--- a/docs/adr/0004-avio-engine-not-facade.md
+++ b/docs/adr/0004-avio-engine-not-facade.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-21
 decision-makers: itsakeyfut
 ---
@@ -78,20 +78,25 @@ a role being removed.
 
 ### Confirmation
 
-`proposed`, so nothing enforces it yet. Once implemented, these guard it:
+Realized and `accepted`. What confirms it:
 
-* A public-API guard (a doc/`cargo public-api` snapshot, or a compile-time check)
-  that `avio`'s root exports name no standalone primitive-engine type
-  (`VideoDecoder` / `VideoEncoder` / `Pipeline` / `HlsOutput` / `PreviewPlayer` /
-  `RenderGraph` / …).
-* `avio-examples` and the docs build against the engine surface (`Timeline` /
-  `Clip` / `Editor` plus model-facing types) and import no primitive engine from
-  `avio`.
-* `avio-examples` builds after the re-exports are removed, importing the
-  primitives it needs from the `ff-*` crates directly.
+* The primitive-facade re-exports are gone from `crates/avio/src/lib.rs`: it exposes
+  only the editing engine (`Timeline` / `Clip` / `Editor` / `render`), the
+  `ff-format` / `ff-filter` value types the model speaks, `EncoderConfig` /
+  `Progress`, the preview `Scene` surface, and the `open` / analysis convenience
+  keeps. The `#[cfg(test)]` accessibility tests in `lib.rs` assert that kept surface,
+  so removing a kept type breaks them.
+* `avio-examples` and the docs build against the engine surface and import no
+  primitive engine from `avio`; a consumer that needs a primitive depends on the
+  `ff-*` crate directly (e.g. `avio-examples` reaches for `ff_decode` / `ff_encode` /
+  `ff_common` for the fixtures it synthesizes).
 
-Until the PRs land, this record is the only statement of the direction; the status
-is honest, not enforced.
+Delivered by #1482 (classified the re-exports), #1483 (made the model unconditional),
+and #1484 (relocated the primitive examples, then removed the facade). A dedicated
+public-API regression guard (#1485) was considered and declined: `avio` is still
+pre-1.0 and may legitimately re-export further `ff-*` types as it matures, so
+hard-enforcing "no primitive re-exports" is premature — reconsider once the public
+surface stabilizes.
 
 ### Consequences
 
@@ -142,13 +147,13 @@ is honest, not enforced.
 
 ## More Information
 
-* Code: `crates/avio/src/lib.rs` (the `pub use ff_*` re-export block across all
-  twelve primitives; the engine model exports `Clip` / `Timeline` / `Editor` /
-  `derive`; the `ff-format` re-exports the model API needs). `avio-examples`
-  exercises the facade today.
+* Code: `crates/avio/src/lib.rs` — after #1484 it re-exports only the engine surface
+  (the model `Clip` / `Timeline` / `Editor` / `derive`, the `ff-format` / `ff-filter`
+  value types the model speaks, `EncoderConfig` / `Progress`, the preview `Scene`
+  surface, and the `open` / analysis convenience keeps). `avio-examples` exercises
+  the engine surface.
 * Architecture: the engine/primitive separation (#1326) in
   `docs/specs/engine-and-primitives.md`.
 * Related: ADR-0003 (`ff-sys` curated safe layer) shares the "curated and
   opinionated, not general-purpose" philosophy. The re-export removal and the
-  engine-first README rewrite are the implementation, tracked separately (engine
-  maturity, v0.17.0+).
+  engine-first README rewrite landed across #1482-#1484 (v0.17.0).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,9 +17,9 @@ standard. Copy [`adr-template.md`](./adr-template.md) to start one.
 | [0001](./0001-clip-and-track-identity.md) | Address clips and tracks by a document-scoped, monotonic `u64` id | accepted | unit tests in `crates/avio/src/edit.rs` (id set/unique, stability, not-found) |
 | [0002](./0002-per-clip-animation-in-the-model.md) | Carry all per-clip animation in the model; a primitive may static-evaluate what it cannot yet animate | accepted | derive unit tests in `crates/avio/src/derive.rs` (scale/rotation, pitch tracks flow; export == preview) |
 | [0003](./0003-ff-sys-safe-wrapper-layer.md) | Give ff-sys a curated RAII safe layer (owned `NonNull` newtypes, typed errors, localized `unsafe`) over the raw bindings | accepted | per-owned-type drop-once tests, `#![deny(unsafe_op_in_unsafe_fn)]` + CI clippy, and the no-raw-pointer guard `crates/ff-sys/tests/seal.rs` |
-| [0004](./0004-avio-engine-not-facade.md) | `avio` exposes only the editing engine and its model-facing types; drop the primitive-facade re-exports | proposed | not yet enforced (proposed); once implemented: public-API guard that no standalone primitive engine is re-exported, `avio-examples`/docs build on the engine surface, a `#[deprecated]` window |
+| [0004](./0004-avio-engine-not-facade.md) | `avio` exposes only the editing engine and its model-facing types; drop the primitive-facade re-exports | accepted | the primitive-facade re-exports removed from `crates/avio/src/lib.rs` (#1482-#1484), the `lib.rs` accessibility tests assert the kept engine surface, and `avio-examples`/docs build on it (a dedicated regression guard #1485 was declined as premature for a pre-1.0 crate) |
 
-**By status** - accepted: 0001, 0002, 0003 · proposed: 0004 · superseded: none
+**By status** - accepted: 0001, 0002, 0003, 0004 · proposed: none · superseded: none
 
 Records are numbered consecutively from `0001`.
 


### PR DESCRIPTION
## Objective

- ADR-0004 (avio exposes only the editing engine, not a facade over the ff-* primitives) is realized but still marked `proposed`; promote it to `accepted` and make its Confirmation honest.

## Solution

- Promote ADR-0004 `proposed` -> `accepted`; rewrite the Confirmation to reflect what actually confirms it: the facade-free `lib.rs` surface, the `lib.rs` accessibility tests that assert the kept engine surface, and `avio-examples`/docs building on the engine surface.
- Record that the delivery landed across #1482 (classify) / #1483 (model unconditional) / #1484 (relocate examples + remove the facade), and that the dedicated public-API regression guard (#1485) was declined as premature for a pre-1.0 crate that may still re-export further ff-* types.
- Update the ADR index row and the by-status summary.

Refs #1474