### PR TITLE
docs(examples): fix relocated examples' usage-doc feature flags

### DIFF
--- a/crates/ff-analysis/examples/black_frames.rs
+++ b/crates/ff-analysis/examples/black_frames.rs
@@ -8,8 +8,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example black_frames --features decode -- --input video.mp4
-//! cargo run --example black_frames --features decode -- --input video.mp4 --threshold 0.2
+//! cargo run --example black_frames -- --input video.mp4
+//! cargo run --example black_frames -- --input video.mp4 --threshold 0.2
 //! ```
 
 use std::process;

--- a/crates/ff-analysis/examples/histogram.rs
+++ b/crates/ff-analysis/examples/histogram.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example histogram --features decode -- --input video.mp4
-//! cargo run --example histogram --features decode -- --input video.mp4 --interval 30
+//! cargo run --example histogram -- --input video.mp4
+//! cargo run --example histogram -- --input video.mp4 --interval 30
 //! ```
 
 use std::process;

--- a/crates/ff-analysis/examples/keyframes.rs
+++ b/crates/ff-analysis/examples/keyframes.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example keyframes --features decode -- --input video.mp4
-//! cargo run --example keyframes --features decode -- --input video.mp4 --stream 0
+//! cargo run --example keyframes -- --input video.mp4
+//! cargo run --example keyframes -- --input video.mp4 --stream 0
 //! ```
 
 use std::process;

--- a/crates/ff-analysis/examples/scene_detection.rs
+++ b/crates/ff-analysis/examples/scene_detection.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example scene_detection --features decode -- --input video.mp4
-//! cargo run --example scene_detection --features decode -- --input video.mp4 --threshold 0.3
+//! cargo run --example scene_detection -- --input video.mp4
+//! cargo run --example scene_detection -- --input video.mp4 --threshold 0.3
 //! ```
 
 use std::process;

--- a/crates/ff-analysis/examples/scope_analyzer.rs
+++ b/crates/ff-analysis/examples/scope_analyzer.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example scope_analyzer --features decode -- --input video.mp4
-//! cargo run --example scope_analyzer --features decode -- --input video.mp4 --interval 60
+//! cargo run --example scope_analyzer -- --input video.mp4
+//! cargo run --example scope_analyzer -- --input video.mp4 --interval 60
 //! ```
 
 use std::process;

--- a/crates/ff-analysis/examples/silence_detection.rs
+++ b/crates/ff-analysis/examples/silence_detection.rs
@@ -6,8 +6,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example silence_detection --features decode -- --input audio.mp3
-//! cargo run --example silence_detection --features decode -- \
+//! cargo run --example silence_detection -- --input audio.mp3
+//! cargo run --example silence_detection -- \
 //!     --input audio.mp3 --threshold-db -50 --min-duration-ms 300
 //! ```
 

--- a/crates/ff-analysis/examples/waveform.rs
+++ b/crates/ff-analysis/examples/waveform.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example waveform --features decode -- --input audio.mp3
-//! cargo run --example waveform --features decode -- --input audio.mp3 --interval-ms 50
+//! cargo run --example waveform -- --input audio.mp3
+//! cargo run --example waveform -- --input audio.mp3 --interval-ms 50
 //! ```
 
 use std::process;

--- a/crates/ff-decode/examples/audio_raw_dump.rs
+++ b/crates/ff-decode/examples/audio_raw_dump.rs
@@ -17,7 +17,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_raw_dump --features decode -- \
+//! cargo run --example audio_raw_dump -- \
 //!   --input  audio.mp3        \
 //!   --output output.raw       \
 //!   [--frames 100]            # max frames to dump (default: all)

--- a/crates/ff-decode/examples/decode_format_convert.rs
+++ b/crates/ff-decode/examples/decode_format_convert.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example decode_format_convert --features decode -- \
+//! cargo run --example decode_format_convert -- \
 //!   --input input.mp4
 //! ```
 

--- a/crates/ff-decode/examples/decode_from_url.rs
+++ b/crates/ff-decode/examples/decode_from_url.rs
@@ -12,7 +12,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example decode_from_url --features decode -- \
+//! cargo run --example decode_from_url -- \
 //!   --url   http://example.com/video.mp4   \
 //!   [--max-frames 30]                      \
 //!   [--connect-timeout 10]                 \

--- a/crates/ff-decode/examples/decode_iterator.rs
+++ b/crates/ff-decode/examples/decode_iterator.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example decode_iterator --features decode -- \
+//! cargo run --example decode_iterator -- \
 //!   --input input.mp4   \
 //!   [--image photo.png]  # optional: also decode a still image
 //! ```

--- a/crates/ff-decode/examples/decode_metadata.rs
+++ b/crates/ff-decode/examples/decode_metadata.rs
@@ -8,10 +8,10 @@
 //!
 //! ```bash
 //! # Video file
-//! cargo run --example decode_metadata --features decode -- --input video.mp4
+//! cargo run --example decode_metadata -- --input video.mp4
 //!
 //! # Audio-only file
-//! cargo run --example decode_metadata --features decode -- --input audio.mp3
+//! cargo run --example decode_metadata -- --input audio.mp3
 //! ```
 
 use std::process;

--- a/crates/ff-decode/examples/decode_scaled.rs
+++ b/crates/ff-decode/examples/decode_scaled.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example decode_scaled --features decode -- --input input.mp4
+//! cargo run --example decode_scaled -- --input input.mp4
 //! ```
 
 use std::{path::Path, process};

--- a/crates/ff-decode/examples/decode_to_pcm.rs
+++ b/crates/ff-decode/examples/decode_to_pcm.rs
@@ -10,7 +10,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example decode_to_pcm --features decode -- \
+//! cargo run --example decode_to_pcm -- \
 //!   --input  audio.mp3       \
 //!   [--format f32|i16]       # output format (default: f32)
 //!   [--frames 5]             # number of frames to inspect (default: 5)

--- a/crates/ff-decode/examples/frame_extraction.rs
+++ b/crates/ff-decode/examples/frame_extraction.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example frame_extraction --features decode -- --input video.mp4
-//! cargo run --example frame_extraction --features decode -- --input video.mp4 --interval-secs 5
+//! cargo run --example frame_extraction -- --input video.mp4
+//! cargo run --example frame_extraction -- --input video.mp4 --interval-secs 5
 //! ```
 
 use std::process;

--- a/crates/ff-decode/examples/frame_pool_usage.rs
+++ b/crates/ff-decode/examples/frame_pool_usage.rs
@@ -14,7 +14,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example frame_pool_usage --features decode -- \
+//! cargo run --example frame_pool_usage -- \
 //!   --input      input.mp4  \
 //!   [--pool-size 8]         # number of frame buffers to retain (default: 8)
 //! ```

--- a/crates/ff-decode/examples/hardware_decode.rs
+++ b/crates/ff-decode/examples/hardware_decode.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example hardware_decode --features decode -- \
+//! cargo run --example hardware_decode -- \
 //!   --input  input.mp4                                     \
 //!   [--accel nvdec|qsv|amf|videotoolbox|vaapi|auto|none]
 //! ```

--- a/crates/ff-decode/examples/openexr_sequence.rs
+++ b/crates/ff-decode/examples/openexr_sequence.rs
@@ -17,7 +17,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example openexr_sequence --features "decode" -- \
+//! cargo run --example openexr_sequence -- \
 //!   --input "frames/frame%04d.exr"  \
 //!   [--fps 24]
 //! ```

--- a/crates/ff-decode/examples/thumbnail_selector.rs
+++ b/crates/ff-decode/examples/thumbnail_selector.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example thumbnail_selector --features decode -- --input video.mp4
-//! cargo run --example thumbnail_selector --features decode -- \
+//! cargo run --example thumbnail_selector -- --input video.mp4
+//! cargo run --example thumbnail_selector -- \
 //!     --input video.mp4 --interval-secs 10
 //! ```
 

--- a/crates/ff-encode/examples/audio_codec_options.rs
+++ b/crates/ff-encode/examples/audio_codec_options.rs
@@ -18,7 +18,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_codec_options --features "decode encode" -- \
+//! cargo run --example audio_codec_options -- \
 //!   --input   input.mp3   \
 //!   --output  output.opus  \
 //!   --codec   opus          # opus | aac | mp3 | flac  (default: opus)

--- a/crates/ff-encode/examples/codec_options.rs
+++ b/crates/ff-encode/examples/codec_options.rs
@@ -18,7 +18,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example codec_options --features "decode encode" -- \
+//! cargo run --example codec_options -- \
 //!   --input   input.mp4   \
 //!   --output  output.mp4  \
 //!   --codec   h264        # h264 | h265 | av1 | svt-av1 | vp9  (default: h264)

--- a/crates/ff-encode/examples/container_format.rs
+++ b/crates/ff-encode/examples/container_format.rs
@@ -21,7 +21,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example container_format --features "decode encode" -- \
+//! cargo run --example container_format -- \
 //!   --input     input.mp4    \
 //!   --output    output.mkv   \
 //!   [--container mp4|mkv|webm|avi|mov]  # default: infer from extension

--- a/crates/ff-encode/examples/encode_audio_direct.rs
+++ b/crates/ff-encode/examples/encode_audio_direct.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example encode_audio_direct --features "decode encode" -- \
+//! cargo run --example encode_audio_direct -- \
 //!   --input   input.mp3   \
 //!   --output  output.aac  \
 //!   [--codec  aac]        # aac | mp3 | opus | flac (default: aac)

--- a/crates/ff-encode/examples/encode_video_direct.rs
+++ b/crates/ff-encode/examples/encode_video_direct.rs
@@ -15,7 +15,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example encode_video_direct --features "decode encode" -- \
+//! cargo run --example encode_video_direct -- \
 //!   --input   input.mp4   \
 //!   --output  output.mp4  \
 //!   [--preset medium]     # ultrafast | faster | fast | medium | slow | slower | veryslow

--- a/crates/ff-encode/examples/encode_with_progress.rs
+++ b/crates/ff-encode/examples/encode_with_progress.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example encode_with_progress --features "decode encode" -- \
+//! cargo run --example encode_with_progress -- \
 //!   --input       input.mp4   \
 //!   --output      output.mp4  \
 //!   [--max-frames 100]        # stop after N frames (default: encode all)

--- a/crates/ff-encode/examples/export_preset.rs
+++ b/crates/ff-encode/examples/export_preset.rs
@@ -13,11 +13,11 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example export_preset --features "decode encode" -- \
+//! cargo run --example export_preset -- \
 //!     --input  input.mp4     \
 //!     --output output.mp4
 //!
-//! cargo run --example export_preset --features "decode encode" -- \
+//! cargo run --example export_preset -- \
 //!     --input  input.mp4     \
 //!     --output output.mp4    \
 //!     --preset twitter

--- a/crates/ff-encode/examples/gif_preview.rs
+++ b/crates/ff-encode/examples/gif_preview.rs
@@ -8,12 +8,12 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example gif_preview --features encode -- \
+//! cargo run --example gif_preview --features preview-image -- \
 //!     --input  video.mp4   \
 //!     --output preview.gif
 //!
 //! # Custom range, frame rate, and width:
-//! cargo run --example gif_preview --features encode -- \
+//! cargo run --example gif_preview --features preview-image -- \
 //!     --input    video.mp4   \
 //!     --output   preview.gif \
 //!     --start    5           \

--- a/crates/ff-encode/examples/gpl_encode.rs
+++ b/crates/ff-encode/examples/gpl_encode.rs
@@ -24,11 +24,11 @@
 //!
 //! ```bash
 //! # Default build — H.264 falls back to VP9 (LGPL)
-//! cargo run --example gpl_encode --features "decode encode" -- \
+//! cargo run --example gpl_encode -- \
 //!   --input input.mp4 --output output.mp4 --codec h264
 //!
 //! # GPL build — uses libx264 (GPL)
-//! cargo run --example gpl_encode --features "decode encode gpl" -- \
+//! cargo run --example gpl_encode --features gpl -- \
 //!   --input input.mp4 --output output.mp4 --codec h264
 //! ```
 

--- a/crates/ff-encode/examples/hdr10_encode.rs
+++ b/crates/ff-encode/examples/hdr10_encode.rs
@@ -19,7 +19,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example hdr10_encode --features "decode encode" -- \
+//! cargo run --example hdr10_encode -- \
 //!   --input    input.mp4     \
 //!   --output   output.mkv    \
 //!   [--max-cll  1000]        # MaxCLL in nits  (default: 1000)

--- a/crates/ff-encode/examples/hwaccel_encode.rs
+++ b/crates/ff-encode/examples/hwaccel_encode.rs
@@ -23,13 +23,13 @@
 //!
 //! ```bash
 //! cargo run --example hwaccel_encode --no-default-features \
-//!   --features "decode encode" -- --input input.mp4 --output output.mp4
+//!   -- --input input.mp4 --output output.mp4
 //! ```
 //!
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example hwaccel_encode --features "decode encode" -- \
+//! cargo run --example hwaccel_encode -- \
 //!   --input  input.mp4   \
 //!   --output output.mp4  \
 //!   [--hw    auto|nvenc|qsv|amf|videotoolbox|vaapi|none]  \

--- a/crates/ff-encode/examples/image_sequence.rs
+++ b/crates/ff-encode/examples/image_sequence.rs
@@ -19,13 +19,13 @@
 //!
 //! ```bash
 //! # Assemble PNGs into a video
-//! cargo run --example image_sequence --features "decode encode" -- \
+//! cargo run --example image_sequence -- \
 //!   --decode "frames/frame%04d.png" \
 //!   --output output.mp4 \
 //!   [--fps 25]
 //!
 //! # Extract video frames to PNGs
-//! cargo run --example image_sequence --features "decode encode" -- \
+//! cargo run --example image_sequence -- \
 //!   --encode input.mp4 \
 //!   --output "frames/frame%04d.png"
 //! ```

--- a/crates/ff-encode/examples/professional_formats.rs
+++ b/crates/ff-encode/examples/professional_formats.rs
@@ -16,7 +16,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example professional_formats --features "decode encode" -- \
+//! cargo run --example professional_formats -- \
 //!   --input   input.mp4       \
 //!   --output  output.mov      \
 //!   --codec   prores          # prores | dnxhd  (default: prores)

--- a/crates/ff-encode/examples/sprite_sheet.rs
+++ b/crates/ff-encode/examples/sprite_sheet.rs
@@ -9,12 +9,12 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example sprite_sheet --features encode -- \
+//! cargo run --example sprite_sheet --features preview-image -- \
 //!     --input  video.mp4        \
 //!     --output preview.png
 //!
 //! # Custom grid (5 columns × 4 rows, 160×90 px per frame):
-//! cargo run --example sprite_sheet --features encode -- \
+//! cargo run --example sprite_sheet --features preview-image -- \
 //!     --input       video.mp4   \
 //!     --output      preview.png \
 //!     --cols        5           \

--- a/crates/ff-filter/examples/advanced_audio_effects.rs
+++ b/crates/ff-filter/examples/advanced_audio_effects.rs
@@ -11,7 +11,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example advanced_audio_effects --features "decode encode filter" -- \
+//! cargo run --example advanced_audio_effects -- \
 //!   --input   input.mp4  \
 //!   --output  out.mp4    \
 //!   --effect  pitch-up

--- a/crates/ff-filter/examples/advanced_video_effects.rs
+++ b/crates/ff-filter/examples/advanced_video_effects.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example advanced_video_effects --features "decode encode filter" -- \
+//! cargo run --example advanced_video_effects -- \
 //!   --input   input.mp4  \
 //!   --output  out.mp4    \
 //!   --effect  film-grain

--- a/crates/ff-filter/examples/alpha_matte_external.rs
+++ b/crates/ff-filter/examples/alpha_matte_external.rs
@@ -19,7 +19,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example alpha_matte_external --features "decode encode filter" -- \
+//! cargo run --example alpha_matte_external -- \
 //!   --fg foreground.mp4 --matte matte.mp4 --bg background.mp4 --output result.mp4
 //! ```
 

--- a/crates/ff-filter/examples/blend_modes_demo.rs
+++ b/crates/ff-filter/examples/blend_modes_demo.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example blend_modes_demo --features "decode encode filter" -- \
+//! cargo run --example blend_modes_demo -- \
 //!   --base base.mp4 --top overlay.mp4 --mode multiply --opacity 1.0 \
 //!   --output result.mp4
 //! ```

--- a/crates/ff-filter/examples/chroma_key_green_screen.rs
+++ b/crates/ff-filter/examples/chroma_key_green_screen.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example chroma_key_green_screen --features "decode encode filter" -- \
+//! cargo run --example chroma_key_green_screen -- \
 //!   --fg foreground.mp4 --bg background.mp4 --output composited.mp4 \
 //!   [--color 0x00FF00] [--similarity 0.3] [--blend-factor 0.0]
 //! ```

--- a/crates/ff-filter/examples/filter_direct.rs
+++ b/crates/ff-filter/examples/filter_direct.rs
@@ -11,7 +11,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example filter_direct --features "decode encode filter" -- \
+//! cargo run --example filter_direct -- \
 //!   --input  input.mp4  \
 //!   --output output.mp4
 //! ```

--- a/crates/ff-filter/examples/loudness.rs
+++ b/crates/ff-filter/examples/loudness.rs
@@ -7,8 +7,8 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example loudness --features decode,filter -- --input audio.mp3
-//! cargo run --example loudness --features decode,filter -- --input video.mp4
+//! cargo run --example loudness -- --input audio.mp3
+//! cargo run --example loudness -- --input video.mp4
 //! ```
 
 use std::process;

--- a/crates/ff-filter/examples/luma_key_title_card.rs
+++ b/crates/ff-filter/examples/luma_key_title_card.rs
@@ -15,7 +15,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example luma_key_title_card --features "decode encode filter" -- \
+//! cargo run --example luma_key_title_card -- \
 //!   --title title.mp4 --bg background.mp4 --output result.mp4 \
 //!   [--threshold 0.9] [--tolerance 0.1] [--softness 0.0] [--invert]
 //! ```

--- a/crates/ff-filter/examples/mask_feathering.rs
+++ b/crates/ff-filter/examples/mask_feathering.rs
@@ -12,7 +12,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example mask_feathering --features "decode encode filter" -- \
+//! cargo run --example mask_feathering -- \
 //!   --input video.mp4 --radius 15 --output feathered.mp4 [--invert]
 //! ```
 //!

--- a/crates/ff-filter/examples/multi_track_compose.rs
+++ b/crates/ff-filter/examples/multi_track_compose.rs
@@ -10,7 +10,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example multi_track_compose --features filter,pipeline -- \
+//! cargo run --example multi_track_compose -- \
 //!   --base    base.mp4       \
 //!   --overlay overlay.mp4   \
 //!   --output  composed.mp4  \

--- a/crates/ff-filter/examples/polygon_garbage_matte.rs
+++ b/crates/ff-filter/examples/polygon_garbage_matte.rs
@@ -10,7 +10,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example polygon_garbage_matte --features "decode encode filter" -- \
+//! cargo run --example polygon_garbage_matte -- \
 //!   --input video.mp4 --output masked.mp4 [--feather 8] [--invert]
 //! ```
 

--- a/crates/ff-filter/examples/quality_metrics.rs
+++ b/crates/ff-filter/examples/quality_metrics.rs
@@ -7,11 +7,11 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example quality_metrics --features decode,filter -- \
+//! cargo run --example quality_metrics -- \
 //!     --reference original.mp4 --distorted compressed.mp4
 //!
 //! # Compare a video against itself — should give SSIM ≈ 1.0 and PSNR = ∞
-//! cargo run --example quality_metrics --features decode,filter -- \
+//! cargo run --example quality_metrics -- \
 //!     --reference video.mp4 --distorted video.mp4
 //! ```
 

--- a/crates/ff-pipeline/examples/add_watermark.rs
+++ b/crates/ff-pipeline/examples/add_watermark.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example add_watermark --features pipeline -- \
+//! cargo run --example add_watermark -- \
 //!   --input     input.mp4   \
 //!   --watermark logo.png    \
 //!   --output    branded.mp4 \

--- a/crates/ff-pipeline/examples/audio_channel.rs
+++ b/crates/ff-pipeline/examples/audio_channel.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_channel --features pipeline -- \
+//! cargo run --example audio_channel -- \
 //!   --input   input.mp4   \
 //!   --output  out.mp4     \
 //!   --effect  mono        \

--- a/crates/ff-pipeline/examples/audio_dynamics.rs
+++ b/crates/ff-pipeline/examples/audio_dynamics.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_dynamics --features pipeline -- \
+//! cargo run --example audio_dynamics -- \
 //!   --input   input.mp4      \
 //!   --output  processed.mp4  \
 //!   --effect  gate           \

--- a/crates/ff-pipeline/examples/audio_filters.rs
+++ b/crates/ff-pipeline/examples/audio_filters.rs
@@ -11,7 +11,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_filters --features pipeline -- \
+//! cargo run --example audio_filters -- \
 //!   --input   input.mp4     \
 //!   --output  filtered.mp4  \
 //!   --effect  volume        \

--- a/crates/ff-pipeline/examples/audio_normalize.rs
+++ b/crates/ff-pipeline/examples/audio_normalize.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_normalize --features pipeline -- \
+//! cargo run --example audio_normalize -- \
 //!   --input   input.mp4      \
 //!   --output  normalized.mp4 \
 //!   --effect  loudness       \

--- a/crates/ff-pipeline/examples/audio_sync.rs
+++ b/crates/ff-pipeline/examples/audio_sync.rs
@@ -6,7 +6,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_sync --features pipeline -- \
+//! cargo run --example audio_sync -- \
 //!   --input   input.mp4  \
 //!   --output  synced.mp4 \
 //!   --delay   250.0      # ms to shift audio: positive = delay, negative = advance

--- a/crates/ff-pipeline/examples/clip_concat.rs
+++ b/crates/ff-pipeline/examples/clip_concat.rs
@@ -9,7 +9,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example clip_concat --features pipeline -- \
+//! cargo run --example clip_concat -- \
 //!   --input-a  clip1.mp4  \
 //!   --input-b  clip2.mp4  \
 //!   --output   joined.mp4 \

--- a/crates/ff-pipeline/examples/color_grade.rs
+++ b/crates/ff-pipeline/examples/color_grade.rs
@@ -12,7 +12,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example color_grade --features pipeline -- \
+//! cargo run --example color_grade -- \
 //!   --input   input.mp4   \
 //!   --output  graded.mp4  \
 //!   --effect  eq          \

--- a/crates/ff-pipeline/examples/concat_clips.rs
+++ b/crates/ff-pipeline/examples/concat_clips.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example concat_clips --features pipeline -- \
+//! cargo run --example concat_clips -- \
 //!   --output joined.mp4 \
 //!   clip1.mp4 clip2.mp4 clip3.mp4
 //! ```

--- a/crates/ff-pipeline/examples/extract_thumbnails.rs
+++ b/crates/ff-pipeline/examples/extract_thumbnails.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example extract_thumbnails --features pipeline -- \
+//! cargo run --example extract_thumbnails -- \
 //!   --input  video.mp4 \
 //!   --output thumbs/   \
 //!   --times  0,30,60,90 \

--- a/crates/ff-pipeline/examples/hw_transcode.rs
+++ b/crates/ff-pipeline/examples/hw_transcode.rs
@@ -15,7 +15,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example hw_transcode --features pipeline -- \
+//! cargo run --example hw_transcode -- \
 //!   --input   input.mp4   \
 //!   --output  output.mp4  \
 //!   --hw      cuda         \  # cuda | videotoolbox | vaapi | none

--- a/crates/ff-pipeline/examples/subtitles.rs
+++ b/crates/ff-pipeline/examples/subtitles.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example subtitles --features pipeline -- \
+//! cargo run --example subtitles -- \
 //!   --input   input.mp4        \
 //!   --output  subtitled.mp4    \
 //!   --effect  srt              \

--- a/crates/ff-pipeline/examples/text_overlay.rs
+++ b/crates/ff-pipeline/examples/text_overlay.rs
@@ -8,7 +8,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example text_overlay --features pipeline -- \
+//! cargo run --example text_overlay -- \
 //!   --input   input.mp4   \
 //!   --output  out.mp4     \
 //!   --effect  drawtext    \

--- a/crates/ff-pipeline/examples/tone_map_hdr.rs
+++ b/crates/ff-pipeline/examples/tone_map_hdr.rs
@@ -16,7 +16,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example tone_map_hdr --features "pipeline probe" -- \
+//! cargo run --example tone_map_hdr -- \
 //!   --input   input_hdr.mp4   \
 //!   --output  output_sdr.mp4  \
 //!   [--method hable|reinhard|mobius]

--- a/crates/ff-pipeline/examples/transcode.rs
+++ b/crates/ff-pipeline/examples/transcode.rs
@@ -6,7 +6,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example transcode --features pipeline -- \
+//! cargo run --example transcode -- \
 //!   --input        input.mp4 \
 //!   --output       output.mp4 \
 //!   [--codec       h265]        # video codec: h264 | h265 | vp9 | av1 (default: h264)

--- a/crates/ff-pipeline/examples/transitions.rs
+++ b/crates/ff-pipeline/examples/transitions.rs
@@ -10,7 +10,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example transitions --features pipeline -- \
+//! cargo run --example transitions -- \
 //!   --input    clip_a.mp4   \
 //!   [--input-b clip_b.mp4]  \   # required for xfade
 //!   --output   out.mp4      \

--- a/crates/ff-pipeline/examples/trim_and_scale.rs
+++ b/crates/ff-pipeline/examples/trim_and_scale.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example trim_and_scale --features pipeline -- \
+//! cargo run --example trim_and_scale -- \
 //!   --input   input.mp4 \
 //!   --output  clip.mp4  \
 //!   --start   00:00:10  \

--- a/crates/ff-pipeline/examples/video_effects.rs
+++ b/crates/ff-pipeline/examples/video_effects.rs
@@ -9,7 +9,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example video_effects --features pipeline -- \
+//! cargo run --example video_effects -- \
 //!   --input   input.mp4  \
 //!   --output  effect.mp4 \
 //!   --effect  fade-in    \

--- a/crates/ff-pipeline/examples/video_enhance.rs
+++ b/crates/ff-pipeline/examples/video_enhance.rs
@@ -10,7 +10,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example video_enhance --features pipeline -- \
+//! cargo run --example video_enhance -- \
 //!   --input    input.mp4    \
 //!   --output   enhanced.mp4 \
 //!   --effect   blur         \

--- a/crates/ff-pipeline/examples/video_geometry.rs
+++ b/crates/ff-pipeline/examples/video_geometry.rs
@@ -10,7 +10,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example video_geometry --features pipeline -- \
+//! cargo run --example video_geometry -- \
 //!   --input   input.mp4  \
 //!   --output  out.mp4    \
 //!   --effect  vignette   \

--- a/crates/ff-pipeline/examples/video_speed.rs
+++ b/crates/ff-pipeline/examples/video_speed.rs
@@ -9,7 +9,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example video_speed --features pipeline -- \
+//! cargo run --example video_speed -- \
 //!   --input   input.mp4   \
 //!   --output  out.mp4     \
 //!   --effect  speed       \

--- a/crates/ff-remux/examples/audio_addition.rs
+++ b/crates/ff-remux/examples/audio_addition.rs
@@ -7,13 +7,13 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_addition --features encode -- \
+//! cargo run --example audio_addition -- \
 //!     --video  silent.mp4    \
 //!     --audio  music.mp3     \
 //!     --output with_audio.mp4
 //!
 //! # Loop short audio to cover the full video duration:
-//! cargo run --example audio_addition --features encode -- \
+//! cargo run --example audio_addition -- \
 //!     --video  silent.mp4    \
 //!     --audio  short.mp3     \
 //!     --output with_audio.mp4 \

--- a/crates/ff-remux/examples/audio_extraction.rs
+++ b/crates/ff-remux/examples/audio_extraction.rs
@@ -7,12 +7,12 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_extraction --features encode -- \
+//! cargo run --example audio_extraction -- \
 //!     --input  video.mp4     \
 //!     --output audio.m4a
 //!
 //! # Extract a specific audio stream (0-based index):
-//! cargo run --example audio_extraction --features encode -- \
+//! cargo run --example audio_extraction -- \
 //!     --input  video.mp4     \
 //!     --output audio.m4a     \
 //!     --stream 1

--- a/crates/ff-remux/examples/audio_replacement.rs
+++ b/crates/ff-remux/examples/audio_replacement.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example audio_replacement --features encode -- \
+//! cargo run --example audio_replacement -- \
 //!     --video  original.mp4  \
 //!     --audio  new_audio.mp3 \
 //!     --output replaced.mp4

--- a/crates/ff-remux/examples/clip_trim.rs
+++ b/crates/ff-remux/examples/clip_trim.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example clip_trim --features encode -- \
+//! cargo run --example clip_trim -- \
 //!   --input   input.mp4  \
 //!   --output  trimmed.mp4 \
 //!   --start   10.0        \   # start time in seconds (default: 0.0)

--- a/crates/ff-remux/examples/stream_copy_trim.rs
+++ b/crates/ff-remux/examples/stream_copy_trim.rs
@@ -9,7 +9,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example stream_copy_trim --features encode -- \
+//! cargo run --example stream_copy_trim -- \
 //!     --input  input.mp4  \
 //!     --start  10.0       \
 //!     --end    30.0       \

--- a/crates/ff-stream/examples/abr_ladder.rs
+++ b/crates/ff-stream/examples/abr_ladder.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example abr_ladder --features stream -- \
+//! cargo run --example abr_ladder -- \
 //!   --input   input.mp4 \
 //!   --output  ./abr/    \
 //!   [--format hls]      \

--- a/crates/ff-stream/examples/dash_output.rs
+++ b/crates/ff-stream/examples/dash_output.rs
@@ -6,7 +6,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example dash_output --features stream -- \
+//! cargo run --example dash_output -- \
 //!   --input    input.mp4  \
 //!   --output   ./dash/    \
 //!   [--segment 4]          # segment duration in seconds (default: 4)

--- a/crates/ff-stream/examples/fanout_output.rs
+++ b/crates/ff-stream/examples/fanout_output.rs
@@ -9,7 +9,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example fanout_output --features stream -- \
+//! cargo run --example fanout_output -- \
 //!   --input     input.mp4    \
 //!   --hls-dir   ./fanout-hls/ \
 //!   --dash-dir  ./fanout-dash/ \

--- a/crates/ff-stream/examples/hls_output.rs
+++ b/crates/ff-stream/examples/hls_output.rs
@@ -15,7 +15,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example hls_output --features stream -- \
+//! cargo run --example hls_output -- \
 //!   --input              input.mp4  \
 //!   --output             ./hls/     \
 //!   [--segment           6]         \

--- a/crates/ff-stream/examples/live_abr_ladder.rs
+++ b/crates/ff-stream/examples/live_abr_ladder.rs
@@ -15,7 +15,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example live_abr_ladder --features stream -- \
+//! cargo run --example live_abr_ladder -- \
 //!   --input   input.mp4  \
 //!   --output  ./abr-live/ \
 //!   [--format hls]        \

--- a/crates/ff-stream/examples/live_dash_output.rs
+++ b/crates/ff-stream/examples/live_dash_output.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example live_dash_output --features stream -- \
+//! cargo run --example live_dash_output -- \
 //!   --input    input.mp4    \
 //!   --output   ./live-dash/ \
 //!   [--segment 4]           \

--- a/crates/ff-stream/examples/live_hls_output.rs
+++ b/crates/ff-stream/examples/live_hls_output.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example live_hls_output --features stream -- \
+//! cargo run --example live_hls_output -- \
 //!   --input    input.mp4   \
 //!   --output   ./live-hls/ \
 //!   [--segment 6]          \

--- a/crates/ff-stream/examples/rtmp_output.rs
+++ b/crates/ff-stream/examples/rtmp_output.rs
@@ -12,7 +12,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example rtmp_output --features stream -- \
+//! cargo run --example rtmp_output -- \
 //!   --input   input.mp4                              \
 //!   --url     rtmp://ingest.example.com/live/key     \
 //!   [--bitrate 4000000]
@@ -22,7 +22,7 @@
 //!
 //! ```bash
 //! # nginx-rtmp on localhost:1935, application "live"
-//! cargo run --example rtmp_output --features stream -- \
+//! cargo run --example rtmp_output -- \
 //!   --input input.mp4  --url rtmp://127.0.0.1/live/test
 //! ```
 

--- a/crates/ff-stream/examples/srt_output.rs
+++ b/crates/ff-stream/examples/srt_output.rs
@@ -14,7 +14,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example srt_output --features "stream,srt" -- \
+//! cargo run --example srt_output --features srt -- \
 //!   --input   input.mp4                \
 //!   --url     srt://192.168.1.100:9000  \
 //!   [--bitrate 4000000]
@@ -28,7 +28,7 @@
 //! srt-live-transmit srt://:9000 file://con > /tmp/output.ts
 //!
 //! # In another terminal, push the stream:
-//! cargo run --example srt_output --features "stream,srt" -- \
+//! cargo run --example srt_output --features srt -- \
 //!   --input input.mp4  --url srt://127.0.0.1:9000
 //! ```
 


### PR DESCRIPTION
## Objective

- When the primitive examples moved from `avio` to their `ff-*` crates (#1573), their `//! cargo run --example ...` usage strings kept avio's old feature names (`decode` / `encode` / `filter` / `pipeline` / `stream`), which do not exist in the destination crates — the printed command fails with an unknown-feature error.

## Solution

- Drop the stale avio features (the examples build by default in their crate) and keep only the features that genuinely exist there: `tokio` for the async examples, `preview-image` for `gif_preview` / `sprite_sheet`, `srt` for `srt_output`, and `gpl` for the GPL-codec encode example.
- Doc-comment only across 80 relocated example files; no code changes.

Refs #1484