### PR TITLE
feat(ff-preview): apply per-clip audio pitch in the preview path

### DIFF
--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -298,6 +298,17 @@ pub(crate) fn audio_volume(
     }
 }
 
+/// The per-clip pitch (semitones): a set `pitch_track` evaluated at its `t=0`
+/// value, else the static `Clip.pitch`. Per-sample pitch automation is a deferred
+/// primitive capability (see ADR-0002). Shared by the export [`audio_track`] and
+/// the preview projection ([`Timeline::to_scene`](crate::Timeline::to_scene)) so
+/// they cannot diverge.
+pub(crate) fn audio_pitch(clip: &Clip) -> f64 {
+    clip.pitch_track
+        .as_ref()
+        .map_or(clip.pitch, |t| t.value_at(Duration::ZERO))
+}
+
 /// Derives the export [`AudioTrack`] for one clip.
 ///
 /// `fade_out_eff_dur` is the caller-resolved effective clip duration, used only
@@ -337,13 +348,9 @@ pub(crate) fn audio_track(
     if (clip.speed - 1.0).abs() > 1e-9 {
         effects.push(FilterStep::Speed { factor: clip.speed });
     }
-    // Per-clip pitch shift (semitones). A set `pitch_track` is evaluated at its
-    // `t=0` value: the mixer applies a static `PitchShift` (per-sample pitch
-    // automation is a deferred primitive capability; see ADR-0002).
-    let pitch = clip
-        .pitch_track
-        .as_ref()
-        .map_or(clip.pitch, |t| t.value_at(Duration::ZERO));
+    // Per-clip pitch shift (semitones), via the shared `audio_pitch` so export and
+    // preview cannot diverge on the value.
+    let pitch = audio_pitch(clip);
     if pitch.abs() > 1e-9 {
         #[allow(clippy::cast_possible_truncation)]
         effects.push(FilterStep::PitchShift {

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -1051,6 +1051,8 @@ fn video_placement(
         // V1 clip audio has no dedicated audio-track counterpart in export (which
         // mixes only `audio_tracks`), so its volume is the per-clip merge only.
         volume: crate::derive::audio_volume(clip, 0, &HashMap::new()),
+        // The same shared derive as export, so preview pitch matches export.
+        pitch: crate::derive::audio_pitch(clip),
     }
 }
 
@@ -1076,6 +1078,8 @@ fn audio_placement(
         // The single derive: the volume 3-way merge (incl. the timeline
         // `audio_{idx}_volume` automation) reaches preview, matching export.
         volume: crate::derive::audio_volume(clip, track_idx, animations),
+        // The same shared derive as export, so preview pitch matches export.
+        pitch: crate::derive::audio_pitch(clip),
     }
 }
 
@@ -1333,6 +1337,27 @@ mod tests {
         assert!((audio.speed - 2.0).abs() < f64::EPSILON);
         // The neutral clip volume falls back to the timeline `audio_0_volume` automation.
         assert!(matches!(audio.volume, AnimatedValue::Track(_)));
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_carry_pitch() {
+        use ff_filter::{Easing, Keyframe};
+
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("v.mp4").with_pitch(3.0)])
+            .audio_track(vec![Clip::new("a.mp3").with_pitch(1.0).with_pitch_track(
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 5.0, Easing::Linear)),
+            )])
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        // Video-clip audio carries the static per-clip pitch.
+        assert!((scene.video_tracks[0].placements[0].pitch - 3.0).abs() < f64::EPSILON);
+        // Audio-only clip: a set pitch_track wins over the static pitch, at t=0.
+        assert!((scene.audio_tracks[0].placements[0].pitch - 5.0).abs() < f64::EPSILON);
     }
 
     #[cfg(feature = "preview")]

--- a/crates/ff-preview/src/scene/audio_resampling.rs
+++ b/crates/ff-preview/src/scene/audio_resampling.rs
@@ -1,9 +1,12 @@
-//! Audio decode-thread spawning and linear resampling for timeline playback.
+//! Audio decode-thread spawning, pitch shifting, and linear resampling for
+//! timeline playback.
 //!
 //! [`spawn_audio_track_thread`] runs one [`AudioDecoder`] per audio-bearing clip,
-//! applies the per-clip fade envelope and speed resampling, and pushes mono
-//! samples into the mixer track. [`resample_linear`] is the preview-quality
-//! (no pitch correction) resampler it uses for non-1.0 speeds.
+//! applies the per-clip pitch shift, fade envelope, and speed resampling, and
+//! pushes mono samples into the mixer track. [`resample_linear`] is the
+//! preview-quality resampler used for non-1.0 speeds; [`PitchShifter`] is the
+//! duration-preserving pitch shifter (preview quality, hand-rolled so the audio
+//! thread stays pure-Rust).
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -59,6 +62,132 @@ fn resample_linear(input: &[f32], speed: f64, phase: &mut f64) -> Vec<f32> {
     out
 }
 
+/// Grain (analysis/synthesis window) length for the OLA pitch shifter.
+const PITCH_GRAIN: usize = 1024;
+/// Synthesis hop = 50% overlap. Hann at this hop is constant-overlap-add
+/// (adjacent windows sum to unity), so synthesis has unity gain.
+const PITCH_HOP: usize = PITCH_GRAIN / 2;
+
+/// Pitch-shift ratio for `semitones`, clamped to the export range (+/-24).
+/// `2^(semitones/12)`: `+12` -> `2.0` (octave up), `-12` -> `0.5` (octave down).
+fn pitch_ratio(semitones: f64) -> f64 {
+    2f64.powf(semitones.clamp(-24.0, 24.0) / 12.0)
+}
+
+/// Preview-quality, duration-preserving pitch shifter for one mono `f32` stream.
+///
+/// Pitch shift = OLA time-stretch by the pitch ratio `r`, then linear resample by
+/// `r`. The stretch changes duration (not pitch), the resample changes both, and
+/// the two compose to `pitch x r` at the original duration. Preview quality only
+/// (plain overlap-add, no phase-locking); artifacts are acceptable here — this is
+/// deliberately not the export `asetrate`/`atempo` path (which needs libavfilter
+/// and an EOF flush) so the audio thread stays pure-Rust and CI-testable.
+///
+/// State is carried across [`process`](Self::process) calls so output is seamless
+/// across the decoder's successive chunks (like [`resample_linear`]'s `phase`).
+///
+/// Introduces ~one grain of onset latency and drops the final partial grain at
+/// stream end; both are inaudible and acceptable at preview quality (audio is not
+/// sample-accurate against video for a pitched clip, only model-accurate).
+struct PitchShifter {
+    ratio: f64,
+    /// Analysis hop = synthesis hop / ratio (fractional). `r > 1` reads grains
+    /// closer together (more overlap-add repeats -> longer stretch).
+    analysis_hop: f64,
+    /// Hann window, precomputed once.
+    window: Vec<f32>,
+    /// Unconsumed input; a grain reads `PITCH_GRAIN` samples from `in_pos`.
+    in_buf: Vec<f32>,
+    /// Fractional start of the next grain, relative to the front of `in_buf`.
+    in_pos: f64,
+    /// Overlap-add carry: the second half of the last grain, awaiting the next.
+    ola_tail: Vec<f32>,
+    /// Fractional phase for the resample stage, carried across calls.
+    resample_phase: f64,
+}
+
+impl PitchShifter {
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    fn new(semitones: f64) -> Self {
+        let clamped = semitones.clamp(-24.0, 24.0);
+        if (clamped - semitones).abs() > f64::EPSILON {
+            log::warn!("preview pitch clamped to +/-24 semitones from={semitones}");
+        }
+        let ratio = pitch_ratio(clamped);
+        // Hann window: sin^2(pi n / N) == 0.5 (1 - cos(2 pi n / N)).
+        let window = (0..PITCH_GRAIN)
+            .map(|n| {
+                let s = (std::f64::consts::PI * n as f64 / PITCH_GRAIN as f64).sin();
+                (s * s) as f32
+            })
+            .collect();
+        Self {
+            ratio,
+            analysis_hop: PITCH_HOP as f64 / ratio,
+            window,
+            in_buf: Vec::new(),
+            in_pos: 0.0,
+            ola_tail: vec![0.0; PITCH_HOP],
+            resample_phase: 0.0,
+        }
+    }
+
+    /// Pitch-shift one chunk, returning ~`input.len()` samples (duration preserved).
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    fn process(&mut self, input: &[f32]) -> Vec<f32> {
+        self.in_buf.extend_from_slice(input);
+
+        // OLA time-stretch by `ratio`: emit HOP finalized samples per grain (the
+        // previous grain's windowed second half overlap-added with this grain's
+        // windowed first half), carry this grain's second half for the next.
+        let mut stretched: Vec<f32> = Vec::new();
+        while self.in_pos as usize + PITCH_GRAIN < self.in_buf.len() {
+            let base = self.in_pos;
+            for k in 0..PITCH_HOP {
+                let g_a = self.grain_sample(base, k);
+                let g_b = self.grain_sample(base, k + PITCH_HOP);
+                stretched.push(self.ola_tail[k] + g_a);
+                self.ola_tail[k] = g_b;
+            }
+            self.in_pos += self.analysis_hop;
+        }
+
+        // Drop the consumed input prefix; the next grain starts at floor(in_pos).
+        let consumed = self.in_pos as usize;
+        if consumed > 0 {
+            self.in_buf.drain(0..consumed);
+            self.in_pos -= consumed as f64;
+        }
+
+        // Resample by `ratio` -> net pitch x ratio at the original duration.
+        resample_linear(&stretched, self.ratio, &mut self.resample_phase)
+    }
+
+    /// Windowed, linearly-interpolated sample at fractional `base + k` of `in_buf`.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    fn grain_sample(&self, base: f64, k: usize) -> f32 {
+        let pos = base + k as f64;
+        let idx = pos as usize;
+        let frac = (pos - idx as f64) as f32;
+        let s = if idx + 1 < self.in_buf.len() {
+            self.in_buf[idx] * (1.0 - frac) + self.in_buf[idx + 1] * frac
+        } else if idx < self.in_buf.len() {
+            self.in_buf[idx]
+        } else {
+            0.0
+        };
+        s * self.window[k]
+    }
+}
+
 pub(super) fn spawn_audio_track_thread(
     path: PathBuf,
     start_pts: Duration,
@@ -90,6 +219,10 @@ pub(super) fn spawn_audio_track_thread(
         let apply_speed = (speed - 1.0).abs() > 1e-6;
         // Fractional position within the current source chunk carried across iterations.
         let mut speed_phase: f64 = 0.0;
+        // Per-clip pitch shift (semitones), applied duration-preserving before the
+        // speed resample so the fade envelope (computed from output samples) is
+        // unaffected. `None` = no pitch.
+        let mut pitch_shifter = (fades.pitch.abs() > 1e-9).then(|| PitchShifter::new(fades.pitch));
 
         // All fade/total timings are expressed in TIMELINE time (= source time / speed)
         // so that `samples_pushed / AUDIO_SAMPLE_RATE` (output time) lines up correctly.
@@ -118,6 +251,15 @@ pub(super) fn spawn_audio_track_thread(
                     if let Some(raw) = frame.as_f32()
                         && !raw.is_empty()
                     {
+                        // Pitch shift (duration-preserving), then speed resampling.
+                        let pitched: Vec<f32>;
+                        let pre_speed: &[f32] = if let Some(ps) = pitch_shifter.as_mut() {
+                            pitched = ps.process(raw);
+                            &pitched
+                        } else {
+                            raw
+                        };
+
                         // Speed resampling (linear interpolation)
                         // For speed > 1.0: fewer output samples (fast motion, pitch up).
                         // For speed < 1.0: more output samples (slow motion, pitch down).
@@ -125,10 +267,10 @@ pub(super) fn spawn_audio_track_thread(
 
                         let resampled: Vec<f32>;
                         let samples: &[f32] = if apply_speed {
-                            resampled = resample_linear(raw, speed, &mut speed_phase);
+                            resampled = resample_linear(pre_speed, speed, &mut speed_phase);
                             &resampled
                         } else {
-                            raw
+                            pre_speed
                         };
 
                         if apply_fades {
@@ -180,4 +322,78 @@ pub(super) fn spawn_audio_track_thread(
             }
         }
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+mod tests {
+    use super::*;
+
+    fn sine(freq: f64, rate: f64, n: usize) -> Vec<f32> {
+        (0..n)
+            .map(|i| (2.0 * std::f64::consts::PI * freq * i as f64 / rate).sin() as f32)
+            .collect()
+    }
+
+    /// Estimate frequency (Hz) from positive-going zero crossings.
+    fn estimate_freq(samples: &[f32], rate: f64) -> f64 {
+        let crossings = samples
+            .windows(2)
+            .filter(|w| w[0] <= 0.0 && w[1] > 0.0)
+            .count();
+        crossings as f64 / (samples.len() as f64 / rate)
+    }
+
+    #[test]
+    fn pitch_ratio_should_be_2_at_12_semitones() {
+        assert!((pitch_ratio(12.0) - 2.0).abs() < 1e-9);
+        assert!((pitch_ratio(-12.0) - 0.5).abs() < 1e-9);
+        assert!((pitch_ratio(0.0) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn pitch_ratio_should_clamp_to_24_semitones() {
+        assert!((pitch_ratio(100.0) - pitch_ratio(24.0)).abs() < 1e-12);
+        assert!((pitch_ratio(-100.0) - pitch_ratio(-24.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn pitch_shift_should_raise_fundamental_frequency() {
+        let rate = 48_000.0;
+        let f0 = 1000.0;
+        let input = sine(f0, rate, 48_000); // 1 s
+        let mut ps = PitchShifter::new(12.0); // +1 octave -> x2
+        let out = ps.process(&input);
+        // Skip the onset/tail grains where the window ramps up/down.
+        let mid = &out[PITCH_GRAIN..out.len().saturating_sub(PITCH_GRAIN)];
+        let f = estimate_freq(mid, rate);
+        assert!(
+            (f - 2.0 * f0).abs() < 0.1 * 2.0 * f0,
+            "expected ~{} Hz, got {f} Hz",
+            2.0 * f0
+        );
+    }
+
+    #[test]
+    fn pitch_shift_should_preserve_sample_count() {
+        let input = sine(440.0, 48_000.0, 24_000);
+        let mut ps = PitchShifter::new(7.0);
+        let out = ps.process(&input);
+        let ratio = out.len() as f64 / input.len() as f64;
+        assert!(
+            (0.85..=1.15).contains(&ratio),
+            "duration should be preserved; out/in = {ratio}"
+        );
+    }
+
+    #[test]
+    fn pitch_shift_zero_semitones_should_preserve_fundamental_frequency() {
+        let rate = 48_000.0;
+        let input = sine(440.0, rate, 24_000);
+        let mut ps = PitchShifter::new(0.0);
+        let out = ps.process(&input);
+        let mid = &out[PITCH_GRAIN..out.len().saturating_sub(PITCH_GRAIN)];
+        let f = estimate_freq(mid, rate);
+        assert!((f - 440.0).abs() < 44.0, "expected ~440 Hz, got {f} Hz");
+    }
 }

--- a/crates/ff-preview/src/scene/mod.rs
+++ b/crates/ff-preview/src/scene/mod.rs
@@ -214,6 +214,7 @@ impl ScenePlayer {
                 volume: clip_list[i].volume.clone(),
                 fade_in: clip_list[i].fade_in,
                 fade_out: clip_list[i].fade_out,
+                pitch: clip_list[i].pitch,
             });
         }
 
@@ -263,6 +264,7 @@ impl ScenePlayer {
                         fade_out: p.fade_out,
                         clip_dur,
                         speed: p.speed,
+                        pitch: p.pitch,
                         handle,
                         volume: p.volume.clone(),
                         cancel: None,
@@ -285,6 +287,7 @@ impl ScenePlayer {
                     volume: p.volume.clone(),
                     fade_in: p.fade_in,
                     fade_out: p.fade_out,
+                    pitch: p.pitch,
                 });
             }
             overlay_layers.push(OverlayLayer {
@@ -335,6 +338,7 @@ impl ScenePlayer {
                     fade_out: p.fade_out,
                     clip_dur,
                     speed: p.speed,
+                    pitch: p.pitch,
                     handle,
                     volume: p.volume.clone(),
                     cancel: None,
@@ -371,6 +375,7 @@ impl ScenePlayer {
                 let source = clip_states[0].source.clone();
                 let in_pt = clip_states[0].in_point;
                 let clip0_speed = clip_states[0].speed;
+                let clip0_pitch = clip_states[0].pitch;
                 let cancel = Arc::new(AtomicBool::new(false));
                 let thread = spawn_audio_track_thread(
                     source,
@@ -379,6 +384,7 @@ impl ScenePlayer {
                     Arc::clone(&cancel),
                     AudioFadeConfig {
                         speed: clip0_speed,
+                        pitch: clip0_pitch,
                         ..AudioFadeConfig::NONE
                     },
                 );

--- a/crates/ff-preview/src/scene/runner.rs
+++ b/crates/ff-preview/src/scene/runner.rs
@@ -1135,6 +1135,7 @@ impl SceneRunner {
                 .mul_f64(c.speed),
             in_point: c.in_point,
             speed: c.speed,
+            pitch: c.pitch,
         };
         let cancel = Arc::new(AtomicBool::new(false));
         let thread =

--- a/crates/ff-preview/src/scene/state.rs
+++ b/crates/ff-preview/src/scene/state.rs
@@ -64,6 +64,9 @@ pub(super) struct ClipState {
     /// = none). Forwarded to the audio decode thread's fade envelope.
     pub(super) fade_in: Duration,
     pub(super) fade_out: Duration,
+    /// Per-clip audio pitch shift in semitones (`0.0` = none). Forwarded to the
+    /// audio decode thread.
+    pub(super) pitch: f64,
 }
 
 // TransitionState
@@ -201,6 +204,9 @@ pub(super) struct AudioFadeConfig {
     /// Playback speed multiplier (`1.0` = normal). When != 1.0, decoded samples are
     /// linearly resampled to compress/expand playback time without pitch preservation.
     pub(super) speed: f64,
+    /// Per-clip pitch shift in semitones (`0.0` = none). Applied duration-preserving
+    /// by the audio thread, before the speed resample.
+    pub(super) pitch: f64,
 }
 
 impl AudioFadeConfig {
@@ -210,6 +216,7 @@ impl AudioFadeConfig {
         clip_dur: Duration::ZERO,
         in_point: Duration::ZERO,
         speed: 1.0,
+        pitch: 0.0,
     };
 }
 
@@ -230,6 +237,8 @@ pub(super) struct AudioOnlyTrack {
     pub(super) clip_dur: Duration,
     /// Playback speed multiplier (`1.0` = normal), applied by resampling.
     pub(super) speed: f64,
+    /// Per-clip pitch shift in semitones (`0.0` = none), forwarded to the thread.
+    pub(super) pitch: f64,
     pub(super) handle: AudioTrackHandle,
     /// Audio gain (dB), static or automated (the 3-way-merged value). Applied to
     /// `handle`: a static value once at open, an animated one per-tick.
@@ -258,6 +267,7 @@ impl AudioOnlyTrack {
                 clip_dur: self.clip_dur,
                 in_point: self.in_point,
                 speed: self.speed,
+                pitch: self.pitch,
             },
         );
         self.cancel = Some(cancel);

--- a/crates/ff-preview/src/scene/types.rs
+++ b/crates/ff-preview/src/scene/types.rs
@@ -82,6 +82,10 @@ pub struct ScenePlacement {
     /// Resolved audio gain (dB), static or animated. A static value is applied once at
     /// open; an animated one is evaluated per tick.
     pub volume: AnimatedValue<f64>,
+    /// Per-clip audio pitch shift in semitones (`0.0` = none). A set `pitch_track`
+    /// is evaluated at its `t=0` value (static, per ADR-0002); the preview applies
+    /// it duration-preserving, matching the export shift at the model level.
+    pub pitch: f64,
 }
 
 // SceneAudioTrack
@@ -116,4 +120,8 @@ pub struct SceneAudioPlacement {
     /// Resolved audio gain (dB), static or animated. A static value is applied once at
     /// open; an animated one is evaluated per tick.
     pub volume: AnimatedValue<f64>,
+    /// Per-clip audio pitch shift in semitones (`0.0` = none). A set `pitch_track`
+    /// is evaluated at its `t=0` value (static, per ADR-0002); the preview applies
+    /// it duration-preserving, matching the export shift at the model level.
+    pub pitch: f64,
 }


### PR DESCRIPTION
## Objective

- The model carries a per-clip audio pitch (`Clip.pitch` / `pitch_track`) and the export path renders it, but the preview audio thread ignored it, so preview and export diverged on pitch.

## Solution

- Add a preview-quality `PitchShifter` (overlap-add time-stretch by the pitch ratio, then linear resample by the same ratio) to the preview audio thread. The path is a pure-Rust decode -> resample -> fade -> mixer thread with no time-stretch, so a duration-preserving pitch shift needs a new stage; a hand-rolled Rust shifter keeps the thread pure-Rust and CI-testable rather than wiring an `asetrate`/`atempo` libavfilter graph into a real-time thread.
- Project the pitch onto both `ScenePlacement` and `SceneAudioPlacement` via a shared `derive::audio_pitch` helper (the export `audio_track` now uses the same helper), so preview and export cannot diverge on the value.
- Apply the pitch before the speed resample; it preserves the sample count, so the fade envelope timing is unaffected. Semitones are clamped to +/-24 and the audio thread never errors on pitch.
- Add deterministic unit tests (pitch ratio, a sine shifted up one octave, duration preservation) and a projection test.

Closes #1443