### PR TITLE
feat(ff-filter): add rubberband pitch/time-stretch backend with fallback

### DIFF
--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use ff_filter::{
     AnimatedValue, AnimationTrack, AudioTrack, BlendMode, CompositeOp, FilterStep, LayerSource,
-    ProxySource, RealtimeLayerDescriptor, ScaleAlgorithm, VideoLayer,
+    PitchAlgo, ProxySource, RealtimeLayerDescriptor, ScaleAlgorithm, VideoLayer,
 };
 use ff_format::ChannelLayout;
 
@@ -355,6 +355,9 @@ pub(crate) fn audio_track(
         #[allow(clippy::cast_possible_truncation)]
         effects.push(FilterStep::PitchShift {
             semitones: pitch as f32,
+            // The model does not yet select a pitch backend; export uses the
+            // always-available signal path.
+            algo: PitchAlgo::Signal,
         });
     }
     if clip.fade_in > Duration::ZERO {
@@ -731,7 +734,7 @@ mod tests {
         let track = audio_track(&clip, 0, &no_anim(), None);
         assert!(track.effects.iter().any(|s| matches!(
             s,
-            FilterStep::PitchShift { semitones } if (semitones - 4.0).abs() < 1e-6
+            FilterStep::PitchShift { semitones, .. } if (semitones - 4.0).abs() < 1e-6
         )));
     }
 
@@ -745,7 +748,7 @@ mod tests {
         let track = audio_track(&clip, 0, &no_anim(), None);
         assert!(track.effects.iter().any(|s| matches!(
             s,
-            FilterStep::PitchShift { semitones } if (semitones - 5.0).abs() < 1e-6
+            FilterStep::PitchShift { semitones, .. } if (semitones - 5.0).abs() < 1e-6
         )));
     }
 

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -90,8 +90,8 @@ pub use ff_encode::{BitrateMode, EncodeError};
 // Clip::realtime_layer[_descriptor] returns, FilterError, and the EncoderConfig HwAccel setter.
 pub use ff_filter::{
     AnimatedValue, AnimationTrack, BlendMode, CompositeOp, DrawTextOptions, Easing, EqBand,
-    FilterError, FilterStep, HwAccel, Keyframe, RealtimeLayer, RealtimeLayerDescriptor, Rgb,
-    ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
+    FilterError, FilterStep, HwAccel, Keyframe, PitchAlgo, RealtimeLayer, RealtimeLayerDescriptor,
+    Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
 
 // editing model (unconditional)

--- a/crates/ff-filter/src/effects/audio_effects.rs
+++ b/crates/ff-filter/src/effects/audio_effects.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use crate::error::FilterError;
 use crate::graph::FilterGraph;
+use crate::graph::PitchAlgo;
 use crate::graph::filter_step::FilterStep;
 
 /// Noise type used as the initial spectral model for `afftdn`.
@@ -90,13 +91,38 @@ impl FilterGraph {
     ///
     /// Returns [`FilterError::Ffmpeg`] if `semitones` is outside −24.0..=24.0.
     pub fn pitch_shift(&mut self, semitones: f32) -> Result<&mut Self, FilterError> {
+        self.pitch_shift_with(semitones, PitchAlgo::Signal)
+    }
+
+    /// Shift audio pitch by `semitones` using the formant-preserving `rubberband`
+    /// backend when available.
+    ///
+    /// Identical range and semantics to [`pitch_shift`](Self::pitch_shift), but
+    /// selects [`PitchAlgo::Rubberband`]: the graph build uses `FFmpeg`'s
+    /// `rubberband` filter (formant-preserving) when the `FFmpeg` build provides it,
+    /// otherwise it falls back to the `asetrate`/`atempo` signal path with a
+    /// `log::warn!`. No error is returned when `rubberband` is unavailable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `semitones` is outside −24.0..=24.0.
+    pub fn pitch_shift_rubberband(&mut self, semitones: f32) -> Result<&mut Self, FilterError> {
+        self.pitch_shift_with(semitones, PitchAlgo::Rubberband)
+    }
+
+    fn pitch_shift_with(
+        &mut self,
+        semitones: f32,
+        algo: PitchAlgo,
+    ) -> Result<&mut Self, FilterError> {
         if !(-24.0..=24.0).contains(&semitones) {
             return Err(FilterError::Ffmpeg {
                 code: 0,
                 message: format!("semitones must be in -24..=24, got {semitones}"),
             });
         }
-        self.inner.push_step(FilterStep::PitchShift { semitones });
+        self.inner
+            .push_step(FilterStep::PitchShift { semitones, algo });
         Ok(self)
     }
 
@@ -112,13 +138,38 @@ impl FilterGraph {
     ///
     /// Returns [`FilterError::Ffmpeg`] if `factor` is outside 0.1–10.0.
     pub fn time_stretch(&mut self, factor: f32) -> Result<&mut Self, FilterError> {
+        self.time_stretch_with(factor, PitchAlgo::Signal)
+    }
+
+    /// Stretch or compress audio duration by `factor` using the higher-quality
+    /// `rubberband` backend when available.
+    ///
+    /// Identical range and semantics to [`time_stretch`](Self::time_stretch), but
+    /// selects [`PitchAlgo::Rubberband`]: the graph build uses `FFmpeg`'s
+    /// `rubberband` filter when the `FFmpeg` build provides it, otherwise it falls
+    /// back to the `atempo` signal path with a `log::warn!`. No error is returned
+    /// when `rubberband` is unavailable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Ffmpeg`] if `factor` is outside 0.1–10.0.
+    pub fn time_stretch_rubberband(&mut self, factor: f32) -> Result<&mut Self, FilterError> {
+        self.time_stretch_with(factor, PitchAlgo::Rubberband)
+    }
+
+    fn time_stretch_with(
+        &mut self,
+        factor: f32,
+        algo: PitchAlgo,
+    ) -> Result<&mut Self, FilterError> {
         if !(0.1..=10.0).contains(&factor) {
             return Err(FilterError::Ffmpeg {
                 code: 0,
                 message: format!("time_stretch factor must be 0.1–10.0, got {factor}"),
             });
         }
-        self.inner.push_step(FilterStep::TimeStretch { factor });
+        self.inner
+            .push_step(FilterStep::TimeStretch { factor, algo });
         Ok(self)
     }
 
@@ -260,6 +311,7 @@ impl FilterGraph {
 #[cfg(test)]
 mod tests {
     use crate::effects::audio_effects::NoiseType;
+    use crate::graph::PitchAlgo;
     use crate::graph::filter_step::FilterStep;
     use crate::{FilterError, FilterGraph};
     use std::path::Path;
@@ -383,7 +435,10 @@ mod tests {
 
     #[test]
     fn filter_step_time_stretch_should_have_atempo_filter_name() {
-        let step = FilterStep::TimeStretch { factor: 1.5 };
+        let step = FilterStep::TimeStretch {
+            factor: 1.5,
+            algo: PitchAlgo::Signal,
+        };
         assert_eq!(step.filter_name(), "atempo");
     }
 
@@ -443,8 +498,135 @@ mod tests {
 
     #[test]
     fn filter_step_pitch_shift_should_have_asetrate_filter_name() {
-        let step = FilterStep::PitchShift { semitones: 7.0 };
+        let step = FilterStep::PitchShift {
+            semitones: 7.0,
+            algo: PitchAlgo::Signal,
+        };
         assert_eq!(step.filter_name(), "asetrate");
+    }
+
+    #[test]
+    fn pitch_algo_should_default_to_signal() {
+        assert_eq!(PitchAlgo::default(), PitchAlgo::Signal);
+    }
+
+    #[test]
+    fn pitch_shift_should_push_signal_algo() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        graph.pitch_shift(7.0).unwrap();
+        assert!(
+            graph.inner.steps().iter().any(|s| matches!(
+                s,
+                FilterStep::PitchShift {
+                    algo: PitchAlgo::Signal,
+                    ..
+                }
+            )),
+            "pitch_shift must push a Signal-backed PitchShift step"
+        );
+    }
+
+    #[test]
+    fn pitch_shift_rubberband_should_push_rubberband_algo() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        graph.pitch_shift_rubberband(7.0).unwrap();
+        assert!(
+            graph.inner.steps().iter().any(|s| matches!(
+                s,
+                FilterStep::PitchShift {
+                    algo: PitchAlgo::Rubberband,
+                    ..
+                }
+            )),
+            "pitch_shift_rubberband must push a Rubberband-backed PitchShift step"
+        );
+    }
+
+    #[test]
+    fn time_stretch_should_push_signal_algo() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        graph.time_stretch(1.5).unwrap();
+        assert!(
+            graph.inner.steps().iter().any(|s| matches!(
+                s,
+                FilterStep::TimeStretch {
+                    algo: PitchAlgo::Signal,
+                    ..
+                }
+            )),
+            "time_stretch must push a Signal-backed TimeStretch step"
+        );
+    }
+
+    #[test]
+    fn time_stretch_rubberband_should_push_rubberband_algo() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        graph.time_stretch_rubberband(1.5).unwrap();
+        assert!(
+            graph.inner.steps().iter().any(|s| matches!(
+                s,
+                FilterStep::TimeStretch {
+                    algo: PitchAlgo::Rubberband,
+                    ..
+                }
+            )),
+            "time_stretch_rubberband must push a Rubberband-backed TimeStretch step"
+        );
+    }
+
+    #[test]
+    fn pitch_shift_rubberband_should_still_name_asetrate() {
+        // `filter_name` returns the always-available fallback filter so a
+        // `Rubberband` step validates on a build without the `rubberband` filter;
+        // the real filter choice happens at graph-build time.
+        let step = FilterStep::PitchShift {
+            semitones: 7.0,
+            algo: PitchAlgo::Rubberband,
+        };
+        assert_eq!(step.filter_name(), "asetrate");
+    }
+
+    #[test]
+    fn time_stretch_rubberband_should_still_name_atempo() {
+        let step = FilterStep::TimeStretch {
+            factor: 1.5,
+            algo: PitchAlgo::Rubberband,
+        };
+        assert_eq!(step.filter_name(), "atempo");
+    }
+
+    #[test]
+    fn pitch_shift_rubberband_should_accept_valid_range() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.pitch_shift_rubberband(12.0).is_ok());
+        assert!(graph.pitch_shift_rubberband(-24.0).is_ok());
+    }
+
+    #[test]
+    fn pitch_shift_rubberband_out_of_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.pitch_shift_rubberband(24.5);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "semitones=24.5 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn time_stretch_rubberband_should_accept_valid_range() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        assert!(graph.time_stretch_rubberband(0.5).is_ok());
+        assert!(graph.time_stretch_rubberband(2.0).is_ok());
+    }
+
+    #[test]
+    fn time_stretch_rubberband_out_of_range_should_return_ffmpeg_error() {
+        let mut graph = FilterGraph::builder().trim(0.0, 1.0).build().unwrap();
+        let result = graph.time_stretch_rubberband(11.0);
+        assert!(
+            matches!(result, Err(FilterError::Ffmpeg { .. })),
+            "factor=11.0 must return Err(FilterError::Ffmpeg {{ .. }}), got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -13,7 +13,7 @@ use crate::composite::CompositeOp;
 use crate::error::FilterError;
 use crate::graph::FfmpegToken;
 use crate::graph::filter_step::FilterStep;
-use crate::graph::types::{EqBand, HwAccel};
+use crate::graph::types::{EqBand, HwAccel, PitchAlgo};
 use ff_format::AlphaMode;
 
 // Hardware acceleration helpers
@@ -615,6 +615,32 @@ pub(super) fn decompose_atempo(factor: f64) -> Vec<f64> {
     chain
 }
 
+// Rubberband (high-quality, formant-preserving)
+
+/// `rubberband` filter args for a formant-preserving pitch shift of `semitones`.
+///
+/// The filter's `pitch` option is a frequency scale factor, so semitones map as
+/// `2^(semitones/12)`. `formant=preserved` keeps vocal formants in place (the
+/// point of the high-quality path).
+fn rubberband_pitch_args(semitones: f32) -> String {
+    let scale = 2f64.powf(f64::from(semitones) / 12.0);
+    format!("pitch={scale:.6}:formant=preserved")
+}
+
+/// `rubberband` filter args for a time-stretch by `factor` (duration only; the
+/// filter preserves pitch). The `tempo` option is the speed multiplier.
+fn rubberband_tempo_args(factor: f32) -> String {
+    format!("tempo={factor:.6}")
+}
+
+/// Whether the running `FFmpeg` build registered the `rubberband` filter
+/// (`--enable-librubberband`). Used to fall back to the signal path when absent.
+fn rubberband_available() -> bool {
+    // SAFETY: `avfilter_get_by_name` reads a valid static null-terminated C string
+    // and returns a borrowed pointer (or null); we only test it for null.
+    unsafe { !ff_sys::avfilter_get_by_name(c"rubberband".as_ptr()).is_null() }
+}
+
 /// Insert a chain of `atempo` filters for the audio path of a `Speed` step.
 ///
 /// Creates as many `atempo` instances as needed (see [`decompose_atempo`]) and
@@ -841,7 +867,33 @@ mod tests {
     use super::decompose_atempo;
     use super::escape_movie_path;
     use super::overlay_alpha_suffix;
+    use super::{rubberband_pitch_args, rubberband_tempo_args};
     use ff_format::AlphaMode;
+
+    #[test]
+    fn rubberband_pitch_args_should_convert_semitones_to_scale() {
+        // +12 semitones -> 2x frequency scale, formant preserved.
+        assert_eq!(
+            rubberband_pitch_args(12.0),
+            "pitch=2.000000:formant=preserved"
+        );
+        // -12 semitones -> half.
+        assert_eq!(
+            rubberband_pitch_args(-12.0),
+            "pitch=0.500000:formant=preserved"
+        );
+        // 0 semitones -> unity.
+        assert_eq!(
+            rubberband_pitch_args(0.0),
+            "pitch=1.000000:formant=preserved"
+        );
+    }
+
+    #[test]
+    fn rubberband_tempo_args_should_pass_factor() {
+        assert_eq!(rubberband_tempo_args(1.5), "tempo=1.500000");
+        assert_eq!(rubberband_tempo_args(0.5), "tempo=0.500000");
+    }
 
     #[test]
     fn escape_movie_path_escapes_windows_drive_and_backslashes() {
@@ -2923,8 +2975,24 @@ impl FilterGraphInner {
             }
 
             // TimeStretch — uses the same atempo chain as the audio path of Speed,
-            // but without any video setpts change.
-            if let FilterStep::TimeStretch { factor } = step {
+            // but without any video setpts change.  The Rubberband backend uses a
+            // single higher-quality `rubberband` filter when available, else falls
+            // back to the atempo chain.
+            if let FilterStep::TimeStretch { factor, algo } = step {
+                if *algo == PitchAlgo::Rubberband && rubberband_available() {
+                    prev_ctx = add_raw_filter_step(
+                        graph,
+                        prev_ctx,
+                        "rubberband",
+                        &rubberband_tempo_args(*factor),
+                        i,
+                        "stretch_rubberband",
+                    )?;
+                    continue;
+                }
+                if *algo == PitchAlgo::Rubberband {
+                    log::warn!("rubberband unavailable, falling back algo=signal");
+                }
                 prev_ctx = add_atempo_chain(graph, prev_ctx, f64::from(*factor), i)?;
                 continue;
             }
@@ -2955,7 +3023,23 @@ impl FilterGraphInner {
             // range, so add_atempo_chain decomposes it into linked instances.
             // The actual sample rate is resolved from buffersrc_args so the
             // integer value is substituted literally.
-            if let FilterStep::PitchShift { semitones } = step {
+            if let FilterStep::PitchShift { semitones, algo } = step {
+                // Rubberband backend: a single formant-preserving `rubberband`
+                // filter when available, else fall back to asetrate + atempo.
+                if *algo == PitchAlgo::Rubberband && rubberband_available() {
+                    prev_ctx = add_raw_filter_step(
+                        graph,
+                        prev_ctx,
+                        "rubberband",
+                        &rubberband_pitch_args(*semitones),
+                        i,
+                        "pitch_rubberband",
+                    )?;
+                    continue;
+                }
+                if *algo == PitchAlgo::Rubberband {
+                    log::warn!("rubberband unavailable, falling back algo=signal");
+                }
                 let rate = 2f64.powf(f64::from(*semitones) / 12.0);
                 let sr = parse_sample_rate_from_buffersrc(buffersrc_args);
                 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -192,6 +192,13 @@ impl FilterGraphInner {
         self.steps.push(step);
     }
 
+    /// The pending filter steps (test-only accessor for asserting what a builder
+    /// method pushed).
+    #[cfg(test)]
+    pub(crate) fn steps(&self) -> &[FilterStep] {
+        &self.steps
+    }
+
     /// Creates a pre-initialised inner for a source-only video composition graph.
     ///
     /// `graph` and `vsink_ctx` are owned by the returned struct and freed on drop

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use super::FfmpegToken;
 use super::builder::FilterGraphBuilder;
 use super::types::{
-    DrawTextOptions, EqBand, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
+    DrawTextOptions, EqBand, PitchAlgo, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
 };
 
 use crate::animation::{AnimatedValue, AnimationEntry, AnimationTrack, Keyframe};
@@ -846,6 +846,9 @@ pub enum FilterStep {
     PitchShift {
         /// Pitch shift in semitones. Range: [−24.0, 24.0].
         semitones: f32,
+        /// Backend algorithm. [`PitchAlgo::Rubberband`] uses the formant-preserving
+        /// `rubberband` filter when available (else falls back to the signal path).
+        algo: PitchAlgo,
     },
 
     /// Time-stretch audio without changing pitch via `FFmpeg`'s `atempo` filter.
@@ -858,6 +861,9 @@ pub enum FilterStep {
     TimeStretch {
         /// Speed / duration factor. 0.5 = 2× longer; 2.0 = 2× shorter. Range: [0.1, 10.0].
         factor: f32,
+        /// Backend algorithm. [`PitchAlgo::Rubberband`] uses the higher-quality
+        /// `rubberband` filter when available (else falls back to the signal path).
+        algo: PitchAlgo,
     },
 
     /// Simultaneously change audio speed and pitch by the same factor.
@@ -1758,14 +1764,14 @@ impl FilterStep {
             }
             // args() is not consumed by add_and_link_step (which is bypassed for
             // this compound step); provided here for completeness.
-            Self::PitchShift { semitones } => {
+            Self::PitchShift { semitones, .. } => {
                 let rate = 2f64.powf(f64::from(*semitones) / 12.0);
                 let atempo = 1.0 / rate;
                 format!("asetrate=sr*{rate:.6},atempo={atempo:.6}")
             }
             // args() is not consumed by add_and_link_step (bypassed in favour of
             // add_atempo_chain); provided here for single-instance completeness.
-            Self::TimeStretch { factor } => format!("{factor:.6}"),
+            Self::TimeStretch { factor, .. } => format!("{factor:.6}"),
             // args() is not consumed by add_and_link_step (bypassed; sample rate
             // is resolved from buffersrc_args at build time); provided for completeness.
             Self::SpeedChange { factor } => format!("asetrate=sr*{factor:.6}"),

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -18,5 +18,6 @@ pub use ffmpeg_token::FfmpegToken;
 pub use filter_step::FilterStep;
 pub use graph::FilterGraph;
 pub use types::{
-    DrawTextOptions, EqBand, HwAccel, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition, YadifMode,
+    DrawTextOptions, EqBand, HwAccel, PitchAlgo, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition,
+    YadifMode,
 };

--- a/crates/ff-filter/src/graph/types.rs
+++ b/crates/ff-filter/src/graph/types.rs
@@ -135,6 +135,23 @@ pub enum YadifMode {
     FieldNospatial = 3,
 }
 
+/// Backend algorithm for the [`PitchShift`](super::FilterStep::PitchShift) and
+/// [`TimeStretch`](super::FilterStep::TimeStretch) steps.
+///
+/// Used with [`super::FilterGraph::pitch_shift_rubberband`] and
+/// [`super::FilterGraph::time_stretch_rubberband`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PitchAlgo {
+    /// Signal-processing path: `asetrate` + `atempo` (pitch) or `atempo`
+    /// (time-stretch). Always available, but shifts formants.
+    #[default]
+    Signal,
+    /// `FFmpeg`'s `rubberband` filter: formant-preserving and higher quality.
+    /// Requires an `FFmpeg` built `--enable-librubberband`; when the filter is
+    /// absent the graph build falls back to [`Signal`](Self::Signal).
+    Rubberband,
+}
+
 /// Transition type for the `xfade` cross-dissolve filter.
 ///
 /// Used with [`super::FilterGraphBuilder::xfade`].

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -52,7 +52,7 @@ pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::{
     AudioConcatenator, AudioTrack, CrossfadeJoiner, DrawTextOptions, EqBand, FilterGraph,
     FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, LayerSource, MultiTrackAudioMixer,
-    MultiTrackComposer, ProxySource, RealtimeComposer, RealtimeLayer, RealtimeLayerDescriptor, Rgb,
-    ScaleAlgorithm, SolidSource, TextSource, ToneMap, VideoConcatenator, VideoLayer,
-    XfadeTransition, YadifMode,
+    MultiTrackComposer, PitchAlgo, ProxySource, RealtimeComposer, RealtimeLayer,
+    RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, SolidSource, TextSource, ToneMap,
+    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
 };

--- a/crates/ff-filter/tests/audio_effect_tests.rs
+++ b/crates/ff-filter/tests/audio_effect_tests.rs
@@ -503,6 +503,78 @@ fn pitch_shift_12_semitones_should_produce_audio_output() {
     );
 }
 
+/// Verifies the Rubberband pitch backend builds and runs, producing real audio.
+/// When the FFmpeg build provides the `rubberband` filter this exercises that
+/// path; otherwise the graph build falls back to `asetrate`/`atempo` (no error),
+/// which also produces output. Probe-gated via `drain_atempo` (RK-002/009):
+/// skips gracefully when no audio filters are available (CI). Formant
+/// preservation is spectral and not asserted here. Acceptance criterion for #1429.
+#[test]
+fn pitch_shift_rubberband_should_produce_audio_output() {
+    const SAMPLE_RATE: u32 = 48_000;
+    const SAMPLES: usize = 48_000;
+
+    let frame = make_sine_frame(440.0, SAMPLE_RATE, SAMPLES);
+
+    // Seed a transparent `volume(0.0)` step so `build()` succeeds (RK-009).
+    let mut graph = match FilterGraph::builder().volume(0.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: graph build failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = graph.pitch_shift_rubberband(12.0) {
+        println!("Skipping: pitch_shift_rubberband setup failed: {e}");
+        return;
+    }
+
+    let Some(mono) = drain_atempo(&mut graph, &frame) else {
+        return; // rubberband and atempo filters unavailable — already logged.
+    };
+
+    assert!(
+        rms(&mono) > 0.01,
+        "pitch_shift_rubberband(12) output must carry a real signal: rms={}",
+        rms(&mono)
+    );
+}
+
+/// Verifies the Rubberband time-stretch backend builds and runs, producing real
+/// audio. As with the pitch test, this exercises the `rubberband` filter when
+/// available and the `atempo` fallback otherwise, both without error.
+/// Probe-gated (RK-002/009). Acceptance criterion for #1429.
+#[test]
+fn time_stretch_rubberband_should_produce_audio_output() {
+    const SAMPLE_RATE: u32 = 48_000;
+    const SAMPLES: usize = 48_000;
+
+    let frame = make_sine_frame(440.0, SAMPLE_RATE, SAMPLES);
+
+    // Seed a transparent `volume(0.0)` step so `build()` succeeds (RK-009).
+    let mut graph = match FilterGraph::builder().volume(0.0).build() {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: graph build failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = graph.time_stretch_rubberband(0.5) {
+        println!("Skipping: time_stretch_rubberband setup failed: {e}");
+        return;
+    }
+
+    let Some(mono) = drain_atempo(&mut graph, &frame) else {
+        return; // rubberband and atempo filters unavailable — already logged.
+    };
+
+    assert!(
+        rms(&mono) > 0.01,
+        "time_stretch_rubberband(0.5) output must carry a real signal: rms={}",
+        rms(&mono)
+    );
+}
+
 /// Verifies that `FilterGraph::pitch_shift(24.0)` builds and runs. The +24
 /// semitone compensation factor (atempo = 0.25) falls outside a single atempo
 /// instance and must be realised as a chain. Acceptance criterion for #1091.


### PR DESCRIPTION
## Objective

- Provide a high-quality, formant-preserving pitch/time-stretch backend for musically usable voice pitch mapping (Oto-MAD), alongside the existing `asetrate`/`atempo` signal path.

## Solution

- Add a `PitchAlgo` backend selector (`Signal` or `Rubberband`, default `Signal`) as a field on `PitchShift` / `TimeStretch`. New `pitch_shift_rubberband` / `time_stretch_rubberband` builders emit `Rubberband`; the existing `pitch_shift` / `time_stretch` keep `Signal`.
- When a `Rubberband` step is built and the FFmpeg build provides the `rubberband` filter, the audio graph inserts a single formant-preserving `rubberband` node; otherwise it falls back to the `asetrate`/`atempo` signal path with a `log::warn` and no error. Availability is detected at graph-build time via `avfilter_get_by_name`, so there is no Cargo feature.
- `filter_name()` stays `asetrate`/`atempo`, so a `Rubberband` step validates on a build without the filter; the real choice happens at graph-build time.
- Add deterministic unit tests for the rubberband argument strings and the builder algorithm selection (via a test-only `FilterGraphInner::steps()` accessor), plus probe-gated integration tests that skip when the audio filters are unavailable.

Closes #1429