### PR TITLE
docs(rules): scope the unsafe deep-review trigger to logic changes

### DIFF
--- a/docs/rules/unsafe.md
+++ b/docs/rules/unsafe.md
@@ -11,7 +11,12 @@
 - Every `unsafe` block and `unsafe impl` has a `// SAFETY:` comment stating why it is sound. An
   `unsafe` block with no such comment must be flagged in review.
 - The pure-Rust crates (`ff-format`, `ff-common`) contain **no `unsafe`**.
-- A change that adds or alters `unsafe` triggers Tier-2 review (`/code-review-deep`).
+- A change that adds or alters `unsafe` **logic** — ownership, reference counting, lifetime, or
+  concurrency — triggers Tier-2 review (`/code-review-deep`). But when the added `unsafe` is only a
+  guarded null-check (e.g. `avfilter_get_by_name(...).is_null()`) or an additive mirror of an
+  already-verified wrapper, and changes none of that logic, Tier-1 (`/code-review`) plus `cargo doc`
+  and a push-introspection test is enough — reserve Tier-2 for genuine soundness-logic changes (RAII
+  `Drop`/refcount) or non-obvious cross-crate FFI call paths.
 
 ## Lints
 


### PR DESCRIPTION
## Objective

- Not every added `unsafe` warrants a deep review; a guarded null-check or an additive mirror of an already-verified wrapper changes no soundness-relevant logic.

## Solution

- Refine the unsafe review-tier guidance so the deep-review trigger keys off `unsafe` **logic** changes (ownership, reference counting, lifetime, concurrency) rather than the mere presence of `unsafe`.
- Note that a guarded null-check (e.g. `avfilter_get_by_name(...).is_null()`) or an additive wrapper mirror is adequately covered by the standard review plus `cargo doc` and a test; reserve deep review for genuine soundness-logic changes and non-obvious cross-crate FFI call paths.