### PR TITLE
feat(avio): persist per-clip and timeline effect chains via serde

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -293,9 +293,8 @@ pub struct Clip {
     /// [`FilterStep`] (e.g. `Lut3d`, `Curves`, `ChromaKey`, `GBlur`) to a
     /// single clip. An empty vec (the default) is a no-op.
     ///
-    /// Not persisted by the `serde` feature yet: `FilterStep` is not serializable,
-    /// so this field is skipped and deserializes to an empty vec (see #1426).
-    #[cfg_attr(feature = "serde", serde(skip))]
+    /// Persisted by the `serde` feature (#1452). Compositor-internal steps
+    /// (`Blend` / `Composite` / `AlphaMatte`) are not serialized.
     pub video_effects: Vec<FilterStep>,
     /// Ordered per-clip audio filter steps applied to the clip's audio track.
     ///
@@ -304,8 +303,7 @@ pub struct Clip {
     /// `ParametricEq`, `NoiseReduce`) to a single clip. An empty vec (the
     /// default) is a no-op.
     ///
-    /// Not persisted by the `serde` feature yet (see [`video_effects`](Self::video_effects)).
-    #[cfg_attr(feature = "serde", serde(skip))]
+    /// Persisted by the `serde` feature (#1452; see [`video_effects`](Self::video_effects)).
     pub audio_effects: Vec<FilterStep>,
 }
 

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -108,9 +108,8 @@ pub struct Timeline {
     /// ([`FilterStep::LoudnessNormalize`]). Per-track (pre-mix) effects are a
     /// separate feature (see issue #1446).
     ///
-    /// Not persisted by the `serde` feature yet: `FilterStep` is not serializable,
-    /// so this field is skipped and deserializes to an empty vec (see #1426).
-    #[cfg_attr(feature = "serde", serde(skip))]
+    /// Persisted by the `serde` feature (#1452). Compositor-internal steps
+    /// (`Blend` / `Composite` / `AlphaMatte`) are not serialized.
     pub(crate) audio_filter: Vec<FilterStep>,
 }
 

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -14,7 +14,7 @@ use avio::{
     AnimationTrack, BlendMode, Clip, ClipSource, Command, Easing, Keyframe, Marker, Timeline,
     XfadeTransition, apply,
 };
-use ff_filter::FilterStep;
+use ff_filter::{FilterStep, PitchAlgo};
 use ff_format::{Color, TextSpec};
 
 /// Builds a representative multi-track document exercising File/Text/Solid clips,
@@ -137,22 +137,84 @@ fn clip_source_should_round_trip_each_variant() {
 }
 
 #[test]
-fn clip_effects_should_be_omitted_from_serialization() {
-    // FilterStep is not serializable yet, so video_effects/audio_effects are
-    // skipped: they never appear in the JSON and deserialize to an empty vec.
-    let clip = Clip::new("v.mp4").with_video_effect(FilterStep::Hue { degrees: 30.0 });
-    assert_eq!(clip.video_effects.len(), 1);
+fn clip_effects_should_round_trip_through_serde() {
+    // #1452: FilterStep effect chains now persist. Exercise a video chain and an
+    // audio chain, including a PitchShift carrying its `algo` backend selector.
+    let clip = Clip::new("v.mp4")
+        .with_video_effect(FilterStep::Hue { degrees: 30.0 })
+        .with_video_effect(FilterStep::HFlip)
+        .with_audio_effect(FilterStep::Volume(-3.0))
+        .with_audio_effect(FilterStep::PitchShift {
+            semitones: 4.0,
+            algo: PitchAlgo::Rubberband,
+        });
 
     let json = serde_json::to_string(&clip).unwrap();
-    assert!(
-        !json.contains("video_effects"),
-        "skipped field must not be serialized: {json}"
-    );
-
     let back: Clip = serde_json::from_str(&json).unwrap();
+
+    // FilterStep has no PartialEq (its composition variants carry a builder), so
+    // compare the re-serialized Values rather than the structs.
+    let v1: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let v2: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&back).unwrap()).unwrap();
+    assert_eq!(v1, v2, "effect chains must round-trip through serde");
+
+    assert_eq!(
+        back.video_effects.len(),
+        2,
+        "video effects survive the load"
+    );
     assert!(
-        back.video_effects.is_empty(),
-        "skipped field must deserialize to an empty vec"
+        matches!(back.video_effects[0], FilterStep::Hue { degrees } if (degrees - 30.0).abs() < 1e-6)
+    );
+    assert!(matches!(back.video_effects[1], FilterStep::HFlip));
+    assert_eq!(
+        back.audio_effects.len(),
+        2,
+        "audio effects survive the load"
+    );
+    assert!(
+        matches!(
+            back.audio_effects[1],
+            FilterStep::PitchShift {
+                algo: PitchAlgo::Rubberband,
+                ..
+            }
+        ),
+        "the PitchShift algo backend survives the round-trip"
+    );
+}
+
+#[test]
+fn timeline_audio_filter_should_round_trip_through_serde() {
+    let original = Timeline::builder()
+        .canvas(1920, 1080)
+        .frame_rate(30.0)
+        .audio_track(vec![Clip::new("music.mp3")])
+        .audio_filter(vec![
+            FilterStep::Volume(-2.0),
+            FilterStep::PitchShift {
+                semitones: -3.0,
+                algo: PitchAlgo::Signal,
+            },
+        ])
+        .build()
+        .unwrap();
+
+    let json = serde_json::to_string(&original).unwrap();
+    assert!(
+        json.contains("audio_filter") && json.contains("PitchShift"),
+        "the audio_filter chain must be serialized: {json}"
+    );
+    let back: Timeline = serde_json::from_str(&json).unwrap();
+
+    // A dropped chain would make the re-serialized Value differ from the original.
+    let v1: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let v2: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&back).unwrap()).unwrap();
+    assert_eq!(
+        v1, v2,
+        "timeline audio_filter must round-trip through serde"
     );
 }
 

--- a/crates/ff-filter/Cargo.toml
+++ b/crates/ff-filter/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["video", "audio", "ffmpeg", "filter", "effect"]
 categories = ["multimedia::video", "multimedia::audio", "api-bindings"]
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "ff-format/serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -34,6 +34,7 @@ pub(crate) fn escape_filter_path(path: &str) -> String {
 // matches must carry a `_` arm.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FilterStep {
     /// Convert video to a suitable pixel format from the given options.
     Format {
@@ -543,6 +544,11 @@ pub enum FilterStep {
     ///
     /// `Box<FilterGraphBuilder>` is used to break the otherwise-recursive type:
     /// `FilterStep` → `FilterGraphBuilder` → `Vec<FilterStep>`.
+    ///
+    /// Not serialized: this compositor-internal variant carries a
+    /// `FilterGraphBuilder` (which cannot round-trip serde), and it never appears
+    /// in the editing model's persisted effect chains.
+    #[cfg_attr(feature = "serde", serde(skip))]
     Blend {
         /// Filter pipeline for the top (foreground) layer.
         top: Box<FilterGraphBuilder>,
@@ -564,6 +570,9 @@ pub enum FilterStep {
     ///
     /// `Box<FilterGraphBuilder>` breaks the otherwise-recursive type, following
     /// the same pattern as [`FilterStep::Blend`].
+    ///
+    /// Not serialized (compositor-internal; see [`FilterStep::Blend`]).
+    #[cfg_attr(feature = "serde", serde(skip))]
     Composite {
         /// The Porter-Duff operator combining the two layers.
         op: CompositeOp,
@@ -633,6 +642,9 @@ pub enum FilterStep {
     ///
     /// `Box<FilterGraphBuilder>` breaks the otherwise-recursive type, following
     /// the same pattern as [`FilterStep::Blend`].
+    ///
+    /// Not serialized (compositor-internal; see [`FilterStep::Blend`]).
+    #[cfg_attr(feature = "serde", serde(skip))]
     AlphaMatte {
         /// Pipeline for the grayscale matte stream (slot 1).
         matte: Box<FilterGraphBuilder>,

--- a/crates/ff-filter/src/graph/types.rs
+++ b/crates/ff-filter/src/graph/types.rs
@@ -16,6 +16,7 @@
 // Open catalog: `FFmpeg`'s `tonemap` supports more operators than are exposed here.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ToneMap {
     /// Hable (Uncharted 2) filmic tone mapping.
     ///
@@ -71,6 +72,7 @@ pub enum HwAccel {
 ///
 /// See [`super::FilterGraphBuilder::three_way_cc`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rgb {
     /// Red channel multiplier (neutral: `1.0`).
     pub r: f32,
@@ -95,6 +97,7 @@ impl Rgb {
 // Open catalog: `swscale` exposes more flags (neighbor, area, gauss, …) than these.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ScaleAlgorithm {
     /// Fast bilinear interpolation (default). Good balance of speed and quality.
     Fast,
@@ -124,6 +127,7 @@ impl ScaleAlgorithm {
 ///
 /// Used with [`super::FilterGraphBuilder::yadif`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum YadifMode {
     /// Output one frame per frame (progressive output).
     Frame = 0,
@@ -141,6 +145,7 @@ pub enum YadifMode {
 /// Used with [`super::FilterGraph::pitch_shift_rubberband`] and
 /// [`super::FilterGraph::time_stretch_rubberband`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PitchAlgo {
     /// Signal-processing path: `asetrate` + `atempo` (pitch) or `atempo`
     /// (time-stretch). Always available, but shifts formants.
@@ -218,6 +223,7 @@ impl XfadeTransition {
 // Open catalog: more biquad band types (lowpass, highpass, notch, …) can be added.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EqBand {
     /// Low-shelf EQ: boosts or cuts all frequencies below `freq_hz`.
     ///
@@ -290,6 +296,7 @@ impl EqBand {
 ///
 /// Used with [`super::FilterGraphBuilder::drawtext`].
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DrawTextOptions {
     /// Text string (UTF-8). Special characters (`:`, `'`, `\`) are escaped automatically.
     pub text: String,

--- a/crates/ff-format/src/color.rs
+++ b/crates/ff-format/src/color.rs
@@ -32,6 +32,7 @@ use std::fmt;
 /// - **RGB**: Identity matrix for RGB/GBR content
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ColorSpace {
     /// ITU-R BT.709 — HD television matrix (most common for HD video)
     #[default]
@@ -162,6 +163,7 @@ impl fmt::Display for ColorSpace {
 /// - **Full**: Computer graphics, screenshots, game capture
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ColorRange {
     /// Limited/TV range (16-235 for Y, 16-240 for UV in 8-bit)
     #[default]
@@ -293,6 +295,7 @@ impl fmt::Display for ColorRange {
 /// - **BT.2020**: Wide color gamut for UHD/HDR
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ColorPrimaries {
     /// ITU-R BT.709 primaries (same as sRGB, most common)
     #[default]
@@ -397,6 +400,7 @@ impl fmt::Display for ColorPrimaries {
 /// - **`Linear`**: Linear light, no gamma applied
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ColorTransfer {
     /// ITU-R BT.709 transfer characteristic (standard SDR)
     #[default]

--- a/crates/ff-format/src/pixel.rs
+++ b/crates/ff-format/src/pixel.rs
@@ -35,6 +35,7 @@ use std::fmt;
 /// - **High bit depth**: 10-bit formats for HDR content (Yuv420p10le, Yuv422p10le, Yuv444p10le, Yuva444p10le, P010le)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PixelFormat {
     // Packed RGB
     /// 24-bit RGB (8:8:8) - 3 bytes per pixel


### PR DESCRIPTION
## Objective

- #1426 serialized the editing document but left the effect chains `Clip.video_effects`, `Clip.audio_effects`, and `Timeline.audio_filter` (`Vec<FilterStep>`) as `#[serde(skip)]`, so they were dropped on save/load.

## Solution

- Derive `Serialize`/`Deserialize` (behind each crate's `serde` feature) on `FilterStep` and the payload types a persisted variant references, plus the `ff-format` color enums; remove the three `#[serde(skip)]` attributes so the chains round-trip. The exact derive set is closed by compiling.
- The three composition variants (`Blend`, `Composite`, `AlphaMatte`) carry a `Box<FilterGraphBuilder>`, which cannot round-trip serde (its `AnimationEntry` uses `&'static str` fields). They are compositor-internal and never appear in the editing model's effect chains, so they are `#[serde(skip)]` (documented).
- Wire `ff-filter/serde` to enable `ff-format/serde` (FilterStep references the color enums). Derives stay behind the `serde` feature; the default build pulls in no serde.
- Extend `serde_persistence.rs` with round-trip tests for a clip's video/audio effect chains (including a `PitchShift` carrying its `algo`) and a timeline `audio_filter` chain.

Closes #1452