### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.17.0] - 2026-08-28
+
+This release matures the `avio` editing model into a host-adoptable engine and hardens the `ff-*` primitive family. `avio` gains stable clip and track identity, a full command-based `Editor` with undo/redo, typed clip sources, markers, groups, and serde persistence, and it is now unconditionally the editing engine rather than a facade over the primitives (ADR-0004). Underneath, `ff-sys` grows a curated RAII safe layer of owned types and a typed error (ADR-0003), and the entire family migrates onto it, so no `ff-*` crate exposes raw FFmpeg pointers across its boundaries.
+
+### Added
+
+#### avio
+- Stable `ClipId` / `TrackId` and a first-class `Track` model; edit commands address clips and tracks by id ([#1416](https://github.com/itsakeyfut/avio/issues/1416))
+- Host-adoptable `Editor` with undo/redo, amend, grouping, and `Command::Batch` ([#1417](https://github.com/itsakeyfut/avio/issues/1417))
+- `SetClip` opaque patch command and wider command coverage ([#1418](https://github.com/itsakeyfut/avio/issues/1418))
+- `SplitClip` (razor) command ([#1419](https://github.com/itsakeyfut/avio/issues/1419))
+- `MoveClipToTrack` and atomic ripple-delete ([#1420](https://github.com/itsakeyfut/avio/issues/1420))
+- `RippleTrim` command (trim a clip and close the gap) ([#1454](https://github.com/itsakeyfut/avio/issues/1454))
+- Per-clip `scale` and `rotation` as first-class animatable fields ([#1421](https://github.com/itsakeyfut/avio/issues/1421))
+- Per-clip fit/fill framing mode against the canvas ([#1422](https://github.com/itsakeyfut/avio/issues/1422))
+- Per-clip audio pitch as an animatable field ([#1423](https://github.com/itsakeyfut/avio/issues/1423))
+- Track-level (pre-mix) audio effect chain and timeline-level loudness normalization ([#1424](https://github.com/itsakeyfut/avio/issues/1424), [#1446](https://github.com/itsakeyfut/avio/issues/1446))
+- Typed `ClipSource` with first-class text/title clips ([#1425](https://github.com/itsakeyfut/avio/issues/1425))
+- First-class timeline markers ([#1455](https://github.com/itsakeyfut/avio/issues/1455))
+- Clip linking / groups for audio-video sync ([#1456](https://github.com/itsakeyfut/avio/issues/1456))
+- `Timeline::validate()` structured diagnostics ([#1457](https://github.com/itsakeyfut/avio/issues/1457))
+- serde persistence of the editing document, including per-clip and timeline effect chains ([#1426](https://github.com/itsakeyfut/avio/issues/1426), [#1452](https://github.com/itsakeyfut/avio/issues/1452))
+
+#### ff-sys
+- Curated RAII safe layer (ADR-0003): owned `Frame` / `Packet`, RAII `CodecContext`, input and output `FormatContext`, `ResampleContext` / `ScaleContext`, and a hardware-acceleration device context, each holding a `NonNull` and freeing its resource once on `Drop` ([#1473](https://github.com/itsakeyfut/avio/issues/1473), [#1477](https://github.com/itsakeyfut/avio/issues/1477), [#1478](https://github.com/itsakeyfut/avio/issues/1478), [#1479](https://github.com/itsakeyfut/avio/issues/1479), [#1480](https://github.com/itsakeyfut/avio/issues/1480), [#1493](https://github.com/itsakeyfut/avio/issues/1493), [#1560](https://github.com/itsakeyfut/avio/issues/1560))
+- Typed `AvError` over FFmpeg's `c_int` return codes ([#1476](https://github.com/itsakeyfut/avio/issues/1476), [#1488](https://github.com/itsakeyfut/avio/issues/1488))
+- Safe send/receive drain-flush protocol on `CodecContext` ([#1486](https://github.com/itsakeyfut/avio/issues/1486))
+
+#### ff-filter
+- Text/title layer source primitive ([#1427](https://github.com/itsakeyfut/avio/issues/1427))
+- Solid/color source primitive ([#1428](https://github.com/itsakeyfut/avio/issues/1428))
+- High-quality rubberband pitch/time-stretch backend with graceful fallback ([#1429](https://github.com/itsakeyfut/avio/issues/1429))
+
+#### ff-preview
+- Apply per-clip audio pitch in the preview path ([#1443](https://github.com/itsakeyfut/avio/issues/1443))
+
+#### ff-render
+- GPU node test coverage ([#1432](https://github.com/itsakeyfut/avio/issues/1432))
+
+### Changed
+
+#### avio
+- `avio` is unconditionally the editing engine (ADR-0004): the editing model no longer sits behind a `pipeline` feature gate, and the standalone primitive-engine re-exports were removed so the public surface is the engine itself, not a facade over the primitives ([#1474](https://github.com/itsakeyfut/avio/issues/1474), [#1482](https://github.com/itsakeyfut/avio/issues/1482), [#1483](https://github.com/itsakeyfut/avio/issues/1483), [#1484](https://github.com/itsakeyfut/avio/issues/1484))
+
+#### ff-* family
+- The whole family migrated onto the `ff-sys` RAII safe layer and is now raw-pointer-free at its boundaries, retiring `free_context`-style manual teardown across ff-encode, ff-stream, ff-preview, ff-filter, ff-remux, ff-probe, ff-analysis, and ff-decode ([#1506](https://github.com/itsakeyfut/avio/issues/1506))
+- The owned types' `as_ptr` / `as_mut_ptr` accessors are sealed `pub(crate)`, guarded by drop-once and no-raw-pointer regression tests ([#1481](https://github.com/itsakeyfut/avio/issues/1481), [#1566](https://github.com/itsakeyfut/avio/issues/1566), [#1567](https://github.com/itsakeyfut/avio/issues/1567))
+
+#### ff-encode / ff-remux
+- Retire the crate-wide clippy-allow blocks ([#1430](https://github.com/itsakeyfut/avio/issues/1430))
+
+### Fixed
+
+#### ff-preview
+- Report a poisoned decode thread as a typed error instead of panicking ([#1431](https://github.com/itsakeyfut/avio/issues/1431))
+
+#### ff-filter
+- Atempo-based audio integration tests now run instead of always skipping ([#1312](https://github.com/itsakeyfut/avio/issues/1312))
+
+---
+
 ## [0.16.0] - 2026-08-18
 
 This release splits the project into an editing **engine** (`avio`) and a family of **model-free primitive libraries** (the `ff-*` crates). The editing model moves up into `avio`, the primitives are purified so they impose no editing vocabulary, all crates share one version (lockstep), and every crate is prepared for its first standalone crates.io publish. Two new primitive crates are carved out of the existing ones, and a shared error-classification contract is added across the family.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 # below. Per-crate independent versioning is revisited at the Organization /
 # multi-repo migration.
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -17,20 +17,20 @@ authors = ["itsakeyfut"]
 
 [workspace.dependencies]
 # Internal ff-* dependencies
-ff-sys      = { path = "crates/ff-sys",      version = "0.16.0" }
-ff-common   = { path = "crates/ff-common",   version = "0.16.0" }
-ff-format   = { path = "crates/ff-format",   version = "0.16.0" }
-ff-probe    = { path = "crates/ff-probe",    version = "0.16.0" }
-ff-decode   = { path = "crates/ff-decode",   version = "0.16.0" }
-ff-analysis = { path = "crates/ff-analysis", version = "0.16.0" }
-ff-encode   = { path = "crates/ff-encode",   version = "0.16.0" }
-ff-filter   = { path = "crates/ff-filter",   version = "0.16.0" }
-ff-remux    = { path = "crates/ff-remux",    version = "0.16.0" }
-ff-pipeline = { path = "crates/ff-pipeline", version = "0.16.0" }
-ff-stream   = { path = "crates/ff-stream",   version = "0.16.0" }
-ff-preview  = { path = "crates/ff-preview",  version = "0.16.0" }
-ff-render   = { path = "crates/ff-render",   version = "0.16.0" }
-avio        = { path = "crates/avio",         version = "0.16.0" }
+ff-sys      = { path = "crates/ff-sys",      version = "0.17.0" }
+ff-common   = { path = "crates/ff-common",   version = "0.17.0" }
+ff-format   = { path = "crates/ff-format",   version = "0.17.0" }
+ff-probe    = { path = "crates/ff-probe",    version = "0.17.0" }
+ff-decode   = { path = "crates/ff-decode",   version = "0.17.0" }
+ff-analysis = { path = "crates/ff-analysis", version = "0.17.0" }
+ff-encode   = { path = "crates/ff-encode",   version = "0.17.0" }
+ff-filter   = { path = "crates/ff-filter",   version = "0.17.0" }
+ff-remux    = { path = "crates/ff-remux",    version = "0.17.0" }
+ff-pipeline = { path = "crates/ff-pipeline", version = "0.17.0" }
+ff-stream   = { path = "crates/ff-stream",   version = "0.17.0" }
+ff-preview  = { path = "crates/ff-preview",  version = "0.17.0" }
+ff-render   = { path = "crates/ff-render",   version = "0.17.0" }
+avio        = { path = "crates/avio",         version = "0.17.0" }
 
 # Error handling
 thiserror = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Add the `avio` engine, or individual `ff-*` primitives:
 
 ```toml
 [dependencies]
-avio = "0.16"
+avio = "0.17"
 
 # Or pick individual primitives, without the engine
-ff-probe  = "0.16"
-ff-decode = "0.16"
-ff-encode = "0.16"
+ff-probe  = "0.17"
+ff-decode = "0.17"
+ff-encode = "0.17"
 ```
 
 All crates share a single workspace version and are released together in lockstep; see [Versioning](#versioning). FFmpeg 7.x or 8.x development libraries must be installed on your system.

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -22,10 +22,10 @@ avio is a **video editing engine**: you describe an edit as data and the engine 
 ```toml
 [dependencies]
 # The editing engine: Timeline, Clip, Editor, render (build, edit, export).
-avio = "0.16"
+avio = "0.17"
 
 # With real-time preview:
-avio = { version = "0.16", features = ["preview"] }
+avio = { version = "0.17", features = ["preview"] }
 ```
 
 The editing engine (`Timeline` / `Clip` / `Editor` / `render`), media probing (`open`), and analysis are always available — `cargo add avio` gives you the engine. For standalone primitive work (a raw decoder, encoder, pipeline, stream output, or the GPU compositor), depend on the `ff-*` crate directly (see [Working with the primitives directly](#working-with-the-primitives-directly)).

--- a/crates/ff-analysis/README.md
+++ b/crates/ff-analysis/README.md
@@ -10,7 +10,7 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-analysis = "0.16"
+ff-analysis = "0.17"
 ```
 
 FFmpeg 7.x or 8.x development libraries must be installed on your system.

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -10,8 +10,8 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-decode = "0.16"
-ff-format = "0.16"
+ff-decode = "0.17"
+ff-format = "0.17"
 ```
 
 ## Video Decoding
@@ -209,7 +209,7 @@ Every error carries context in its `Display` message, and `err.is_recoverable()`
 
 ```toml
 [dependencies]
-ff-decode = { version = "0.16", features = ["tokio"] }
+ff-decode = { version = "0.17", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoDecoder` and `AudioDecoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -10,12 +10,12 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-encode = "0.16"
-ff-format = "0.16"
+ff-encode = "0.17"
+ff-format = "0.17"
 
 # Enable GPL-licensed encoders (libx264, libx265).
 # Requires GPL compliance or MPEG LA licensing in your project.
-# ff-encode = { version = "0.16", features = ["gpl"] }
+# ff-encode = { version = "0.17", features = ["gpl"] }
 ```
 
 By default, only LGPL-compatible encoders are enabled.
@@ -24,7 +24,7 @@ By default, only LGPL-compatible encoders are enabled.
 
 Encoding needs frames from somewhere; the example below decodes `input.mp4`
 with [`ff-decode`](https://crates.io/crates/ff-decode) and re-encodes it as a
-video-only H.264 file. Add `ff-decode = "0.16"` to run it.
+video-only H.264 file. Add `ff-decode = "0.17"` to run it.
 
 ```rust
 use ff_decode::VideoDecoder;
@@ -344,7 +344,7 @@ Common variants (not exhaustive):
 
 ```toml
 [dependencies]
-ff-encode = { version = "0.16", features = ["tokio"] }
+ff-encode = { version = "0.17", features = ["tokio"] }
 ```
 
 When the `tokio` feature is disabled, only the synchronous `VideoEncoder`, `AudioEncoder`, and `ImageEncoder` APIs are compiled. No tokio dependency is pulled in.

--- a/crates/ff-filter/README.md
+++ b/crates/ff-filter/README.md
@@ -10,7 +10,7 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-filter = "0.16"
+ff-filter = "0.17"
 ```
 
 ## Building a Filter Chain

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -10,9 +10,9 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-pipeline = "0.16"
-ff-format = "0.16"  # VideoCodec, AudioCodec
-ff-encode = "0.16"  # BitrateMode
+ff-pipeline = "0.17"
+ff-format = "0.17"  # VideoCodec, AudioCodec
+ff-encode = "0.17"  # BitrateMode
 ```
 
 ## Building a Pipeline

--- a/crates/ff-preview/README.md
+++ b/crates/ff-preview/README.md
@@ -10,13 +10,13 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-preview = "0.16"
+ff-preview = "0.17"
 
 # Enable async support
-ff-preview = { version = "0.16", features = ["tokio"] }
+ff-preview = { version = "0.17", features = ["tokio"] }
 
 # Enable proxy generation
-ff-preview = { version = "0.16", features = ["proxy"] }
+ff-preview = { version = "0.17", features = ["proxy"] }
 ```
 
 ## Quick Start

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -10,7 +10,7 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-probe = "0.16"
+ff-probe = "0.17"
 ```
 
 ## Quick Start

--- a/crates/ff-remux/README.md
+++ b/crates/ff-remux/README.md
@@ -10,7 +10,7 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-remux = "0.16"
+ff-remux = "0.17"
 ```
 
 FFmpeg 7.x or 8.x development libraries must be installed on your system.

--- a/crates/ff-render/README.md
+++ b/crates/ff-render/README.md
@@ -16,10 +16,10 @@ Implemented today: the CPU and GPU render graph (`RenderGraph`), all built-in no
 
 ```toml
 [dependencies]
-ff-render = "0.16"
+ff-render = "0.17"
 
 # Enable GPU processing (requires wgpu-compatible hardware)
-ff-render = { version = "0.16", features = ["wgpu"] }
+ff-render = { version = "0.17", features = ["wgpu"] }
 ```
 
 ## Feature Flags

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -11,7 +11,7 @@ It is an independent crate: use it on its own, or combine it with the other `ff-
 
 ```toml
 [dependencies]
-ff-stream = "0.16"
+ff-stream = "0.17"
 ```
 
 ## HLS Output


### PR DESCRIPTION
## Objective

- Cut the v0.17.0 release: publish the 14 crates and tag the workspace at 0.17.0.

## Solution

- Bump `[workspace.package].version` 0.16.0 to 0.17.0 and the matching internal version pins in `[workspace.dependencies]`.
- Move the CHANGELOG's `[Unreleased]` section to `[0.17.0]`, summarizing the editing-model maturity work (stable clip/track ids, command-based `Editor` with undo/redo, typed clip sources, markers, groups, serde persistence, engine-not-facade via ADR-0004) and the library hardening (ff-sys RAII safe layer with a typed error, whole-family migration to a raw-pointer-free API via ADR-0003).
- Update the README install pins from 0.16 to 0.17.

Merging this (with the `crates-io` environment approval) triggers `release.yml`: it publishes each crate whose version is not yet on crates.io in dependency order, then cuts the single `v0.17.0` tag and GitHub Release from the CHANGELOG section. Publishing is irreversible.