### PR TITLE
perf(ff-render): TexturePool for GPU texture reuse

### DIFF
--- a/crates/ff-render/src/context.rs
+++ b/crates/ff-render/src/context.rs
@@ -1,4 +1,7 @@
+use std::sync::Mutex;
+
 use crate::error::RenderError;
+use crate::pool::TexturePool;
 
 /// Owns the wgpu device and queue used by the render pipeline.
 ///
@@ -7,13 +10,20 @@ use crate::error::RenderError;
 pub struct RenderContext {
     pub device: wgpu::Device,
     pub queue: wgpu::Queue,
+    /// Shared reuse pool for GPU textures, so the graph (and, later, the
+    /// compositor) avoid per-frame texture allocation.
+    pub(crate) pool: Mutex<TexturePool>,
 }
 
 impl RenderContext {
     /// Wrap an existing wgpu device (e.g. shared with the window renderer).
     #[must_use]
     pub fn new(device: wgpu::Device, queue: wgpu::Queue) -> Self {
-        Self { device, queue }
+        Self {
+            device,
+            queue,
+            pool: Mutex::new(TexturePool::new()),
+        }
     }
 
     /// Initialise wgpu using the default (best available) backend.
@@ -73,6 +83,10 @@ impl RenderContext {
                 message: e.to_string(),
             })?;
 
-        Ok(Self { device, queue })
+        Ok(Self {
+            device,
+            queue,
+            pool: Mutex::new(TexturePool::new()),
+        })
     }
 }

--- a/crates/ff-render/src/graph/graph_inner.rs
+++ b/crates/ff-render/src/graph/graph_inner.rs
@@ -3,10 +3,13 @@ use std::sync::Arc;
 use crate::context::RenderContext;
 use crate::error::RenderError;
 use crate::nodes::RenderNode;
+use crate::pool::FrameScope;
 
 /// Execute all `nodes` on the `rgba` input and return the processed RGBA bytes.
 ///
-/// Allocates one pair of GPU textures per node — no texture pooling in Phase 1.
+/// Textures are drawn from the context's [`TexturePool`](crate::pool) via a
+/// [`FrameScope`], so a warmed-up pipeline allocates no textures per frame; the
+/// scope returns them all to the pool when it drops.
 #[allow(clippy::too_many_lines)]
 pub(super) fn run_gpu(
     nodes: &[Box<dyn RenderNode>],
@@ -19,25 +22,26 @@ pub(super) fn run_gpu(
         return Ok(rgba.to_vec());
     }
 
-    // Upload the input frame to the initial GPU texture.
-    let input_tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
-        label: Some("ff-render input"),
-        size: wgpu::Extent3d {
-            width: w,
-            height: h,
-            depth_or_array_layers: 1,
-        },
-        mip_level_count: 1,
-        sample_count: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Rgba8Unorm,
-        usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
-        view_formats: &[],
-    });
+    let format = wgpu::TextureFormat::Rgba8Unorm;
+    let input_usage = wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING;
+    let output_usage = wgpu::TextureUsages::RENDER_ATTACHMENT
+        | wgpu::TextureUsages::COPY_SRC
+        | wgpu::TextureUsages::TEXTURE_BINDING;
 
+    // Acquire every texture for the frame up front, so the process loop below
+    // holds only shared borrows of the scope (further acquires would need
+    // `&mut`). The scope returns all of them to the pool when it drops.
+    let mut scope = FrameScope::new(&ctx.pool, &ctx.device);
+    let input_idx = scope.acquire(w, h, format, input_usage);
+    let output_idx: Vec<usize> = nodes
+        .iter()
+        .map(|_| scope.acquire(w, h, format, output_usage))
+        .collect();
+
+    // Upload the input frame to the initial GPU texture.
     ctx.queue.write_texture(
         wgpu::TexelCopyTextureInfo {
-            texture: &input_tex,
+            texture: scope.get(input_idx),
             mip_level: 0,
             origin: wgpu::Origin3d::ZERO,
             aspect: wgpu::TextureAspect::All,
@@ -56,28 +60,10 @@ pub(super) fn run_gpu(
     );
 
     // Run each node: output of one node is the input of the next.
-    let mut current_tex = input_tex;
-
-    for node in nodes {
-        let output_tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("ff-render node output"),
-            size: wgpu::Extent3d {
-                width: w,
-                height: h,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::COPY_SRC
-                | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        });
-
-        node.process(&[&current_tex], &[&output_tex], ctx);
-        current_tex = output_tex;
+    let mut current_idx = input_idx;
+    for (node, &out_idx) in nodes.iter().zip(&output_idx) {
+        node.process(&[scope.get(current_idx)], &[scope.get(out_idx)], ctx);
+        current_idx = out_idx;
     }
 
     // Copy the final texture to a CPU-readable staging buffer.
@@ -98,7 +84,7 @@ pub(super) fn run_gpu(
         });
     encoder.copy_texture_to_buffer(
         wgpu::TexelCopyTextureInfo {
-            texture: &current_tex,
+            texture: scope.get(current_idx),
             mip_level: 0,
             origin: wgpu::Origin3d::ZERO,
             aspect: wgpu::TextureAspect::All,

--- a/crates/ff-render/src/graph/mod.rs
+++ b/crates/ff-render/src/graph/mod.rs
@@ -194,3 +194,52 @@ mod tests {
         );
     }
 }
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::{Arc, RenderContext, RenderGraph};
+    use crate::nodes::ColorGradeNode;
+
+    /// A headless GPU context, or `None` when no adapter is available (CI).
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    fn alloc_count(ctx: &RenderContext) -> usize {
+        ctx.pool
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .alloc_count()
+    }
+
+    #[test]
+    fn render_graph_should_not_allocate_textures_after_the_first_frame() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        // Identity grade: a real GPU node so run_gpu acquires input + output.
+        let graph =
+            RenderGraph::new(Arc::clone(&ctx)).push(ColorGradeNode::new(0.0, 1.0, 1.0, 0.0, 0.0));
+        let (w, h) = (16u32, 16u32);
+        let rgba = vec![128u8; (w * h * 4) as usize];
+
+        graph.process_gpu(&rgba, w, h).expect("first frame");
+        let after_first = alloc_count(&ctx);
+        assert!(
+            after_first > 0,
+            "the first frame must allocate its textures; got {after_first}"
+        );
+
+        for _ in 0..3 {
+            graph.process_gpu(&rgba, w, h).expect("subsequent frame");
+        }
+        assert_eq!(
+            alloc_count(&ctx),
+            after_first,
+            "same-size frames must reuse pooled textures (steady state = 0 allocations/frame)"
+        );
+    }
+}

--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -68,6 +68,8 @@ pub mod sink;
 pub mod compositor;
 #[cfg(feature = "wgpu")]
 pub mod context;
+#[cfg(feature = "wgpu")]
+mod pool;
 
 // Top-level re-exports
 

--- a/crates/ff-render/src/pool.rs
+++ b/crates/ff-render/src/pool.rs
@@ -1,0 +1,198 @@
+//! Format-and-usage-keyed pool of reusable GPU textures.
+//!
+//! Allocating and dropping a `wgpu::Texture` every frame is a per-frame GPU API
+//! cost. [`TexturePool`] hands out textures keyed by
+//! `(width, height, format, usage)` and takes them back for reuse, so a running
+//! pipeline performs zero `create_texture` calls per frame once warmed up.
+//!
+//! A frame acquires its textures through a [`FrameScope`], which returns them all
+//! to the pool when it drops, so an early return still reclaims them.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, PoisonError};
+
+/// Pool key: textures are only interchangeable when their size, format, and
+/// usage all match.
+type TextureKey = (u32, u32, wgpu::TextureFormat, wgpu::TextureUsages);
+
+/// Reuse pool for GPU textures, keyed by size, format, and usage.
+pub(crate) struct TexturePool {
+    /// Free textures available for reuse, grouped by key.
+    free: HashMap<TextureKey, Vec<wgpu::Texture>>,
+    /// Number of textures actually created (pool misses). Read by tests to
+    /// assert steady-state zero allocation.
+    alloc_count: usize,
+}
+
+impl TexturePool {
+    pub(crate) fn new() -> Self {
+        Self {
+            free: HashMap::new(),
+            alloc_count: 0,
+        }
+    }
+
+    /// Return a texture matching the key: reuse a freed one, or create it on a
+    /// miss.
+    pub(crate) fn acquire(
+        &mut self,
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+        format: wgpu::TextureFormat,
+        usage: wgpu::TextureUsages,
+    ) -> wgpu::Texture {
+        if let Some(texture) = self
+            .free
+            .get_mut(&(width, height, format, usage))
+            .and_then(Vec::pop)
+        {
+            return texture;
+        }
+
+        self.alloc_count += 1;
+        device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("ffrender.pool.texture"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage,
+            view_formats: &[],
+        })
+    }
+
+    /// Return a texture to the pool for reuse under its key.
+    pub(crate) fn release(&mut self, key: TextureKey, texture: wgpu::Texture) {
+        self.free.entry(key).or_default().push(texture);
+    }
+
+    /// Number of textures created so far (pool misses).
+    #[cfg(test)]
+    pub(crate) fn alloc_count(&self) -> usize {
+        self.alloc_count
+    }
+}
+
+/// Lock the pool, recovering the guard if a previous holder panicked.
+///
+/// The pool never spans an `unwind`-capable operation while locked, so a
+/// poisoned lock is a non-event: recover the inner guard rather than panicking.
+fn lock(pool: &Mutex<TexturePool>) -> std::sync::MutexGuard<'_, TexturePool> {
+    pool.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Owns the textures acquired during one frame and returns them all to the pool
+/// on drop.
+///
+/// `acquire` returns an index rather than a reference so that further acquires
+/// (which need `&mut self`) do not conflict with references handed out earlier;
+/// resolve an index to a texture with [`get`](Self::get) once all acquires for
+/// the frame are done.
+pub(crate) struct FrameScope<'a> {
+    pool: &'a Mutex<TexturePool>,
+    device: &'a wgpu::Device,
+    /// Textures acquired this frame, with the key each must be released under.
+    items: Vec<(TextureKey, wgpu::Texture)>,
+}
+
+impl<'a> FrameScope<'a> {
+    pub(crate) fn new(pool: &'a Mutex<TexturePool>, device: &'a wgpu::Device) -> Self {
+        Self {
+            pool,
+            device,
+            items: Vec::new(),
+        }
+    }
+
+    /// Acquire a texture for this frame and return its index within the scope.
+    pub(crate) fn acquire(
+        &mut self,
+        width: u32,
+        height: u32,
+        format: wgpu::TextureFormat,
+        usage: wgpu::TextureUsages,
+    ) -> usize {
+        let texture = lock(self.pool).acquire(self.device, width, height, format, usage);
+        self.items.push(((width, height, format, usage), texture));
+        self.items.len() - 1
+    }
+
+    /// Resolve an index returned by [`acquire`](Self::acquire) to its texture.
+    pub(crate) fn get(&self, index: usize) -> &wgpu::Texture {
+        &self.items[index].1
+    }
+}
+
+impl Drop for FrameScope<'_> {
+    fn drop(&mut self) {
+        let mut pool = lock(self.pool);
+        for (key, texture) in self.items.drain(..) {
+            pool.release(key, texture);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod tests {
+    use super::TexturePool;
+
+    /// A headless GPU device, or `None` when no adapter is available (CI).
+    fn device() -> Option<wgpu::Device> {
+        match futures::executor::block_on(crate::context::RenderContext::init()) {
+            Ok(ctx) => Some(ctx.device),
+            Err(_) => None,
+        }
+    }
+
+    #[test]
+    fn texture_pool_should_reuse_a_released_texture_for_the_same_key() {
+        let Some(device) = device() else {
+            return;
+        };
+        let mut pool = TexturePool::new();
+        let key = (
+            16,
+            16,
+            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+        );
+
+        let texture = pool.acquire(&device, key.0, key.1, key.2, key.3);
+        assert_eq!(pool.alloc_count(), 1, "the first acquire is a pool miss");
+
+        pool.release(key, texture);
+        let _reused = pool.acquire(&device, key.0, key.1, key.2, key.3);
+        assert_eq!(
+            pool.alloc_count(),
+            1,
+            "releasing then re-acquiring the same key must reuse, not allocate"
+        );
+    }
+
+    #[test]
+    fn texture_pool_should_key_formats_distinctly() {
+        let Some(device) = device() else {
+            return;
+        };
+        let mut pool = TexturePool::new();
+        let usage = wgpu::TextureUsages::COPY_DST;
+
+        let rgba8 = pool.acquire(&device, 16, 16, wgpu::TextureFormat::Rgba8Unorm, usage);
+        pool.release((16, 16, wgpu::TextureFormat::Rgba8Unorm, usage), rgba8);
+
+        // A different format is a distinct key: it must not reuse the released
+        // Rgba8Unorm texture.
+        let _rgba16 = pool.acquire(&device, 16, 16, wgpu::TextureFormat::Rgba16Float, usage);
+        assert_eq!(
+            pool.alloc_count(),
+            2,
+            "a distinct format must allocate its own texture"
+        );
+    }
+}


### PR DESCRIPTION
## Objective

- `graph_inner::run_gpu` allocated one input texture plus one output texture per node every frame; the `TexturePool` the design doc describes did not exist.
- A running pipeline should perform no GPU texture allocations per frame in steady state (v0.18.0 axis B, B1).

## Solution

- Add `TexturePool` (new `crates/ff-render/src/pool.rs`) keyed by `(width, height, format, usage)`: `acquire` reuses a freed texture or creates one on a miss; `release` returns it.
- Add `FrameScope`, which acquires a frame's textures and returns them all to the pool on drop, so an early return still reclaims them.
- Store the pool on `RenderContext` so the graph (and, later, the compositor) share it; wire `run_gpu` to draw its input and per-node output textures from the pool.
- Tests (gated on the `wgpu` feature, skipped when no adapter): pool reuse for the same key, distinct keying per format, and no texture allocation after the first frame.
- Compositor and per-node internal texture pooling stay out of scope for follow-ups (B2/B6).

Closes #1585
