### PR TITLE
feat(ff-render): multi-pass / multi-input graph executor

### DIFF
--- a/crates/ff-render/src/graph/graph_inner.rs
+++ b/crates/ff-render/src/graph/graph_inner.rs
@@ -24,18 +24,29 @@ pub(super) fn run_gpu(
 
     let format = wgpu::TextureFormat::Rgba8Unorm;
     let input_usage = wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING;
+    // Outputs double as general-purpose scratch: `COPY_DST` lets a node (or test)
+    // fill a pass target via `write_texture`, `COPY_SRC` allows readback, and
+    // `TEXTURE_BINDING` lets a later node sample it. Harmless to render-only nodes.
     let output_usage = wgpu::TextureUsages::RENDER_ATTACHMENT
         | wgpu::TextureUsages::COPY_SRC
+        | wgpu::TextureUsages::COPY_DST
         | wgpu::TextureUsages::TEXTURE_BINDING;
 
     // Acquire every texture for the frame up front, so the process loop below
     // holds only shared borrows of the scope (further acquires would need
     // `&mut`). The scope returns all of them to the pool when it drops.
+    //
+    // Per node we allocate `pass_count()` output textures; the node writes its
+    // final result into the last one, which becomes the next node's input[0].
     let mut scope = FrameScope::new(&ctx.pool, &ctx.device);
     let input_idx = scope.acquire(w, h, format, input_usage);
-    let output_idx: Vec<usize> = nodes
+    let output_idx: Vec<Vec<usize>> = nodes
         .iter()
-        .map(|_| scope.acquire(w, h, format, output_usage))
+        .map(|node| {
+            (0..node.pass_count().max(1))
+                .map(|_| scope.acquire(w, h, format, output_usage))
+                .collect()
+        })
         .collect();
 
     // Upload the input frame to the initial GPU texture.
@@ -59,11 +70,28 @@ pub(super) fn run_gpu(
         },
     );
 
-    // Run each node: output of one node is the input of the next.
+    // Run each node. input[0] is the chained texture (the source frame for the
+    // first node, the previous node's final pass otherwise); input[1..] are the
+    // original source frame. Outputs are the node's `pass_count()` targets; the
+    // node's final pass, output_idx[last], becomes the next input[0].
     let mut current_idx = input_idx;
-    for (node, &out_idx) in nodes.iter().zip(&output_idx) {
-        node.process(&[scope.get(current_idx)], &[scope.get(out_idx)], ctx);
-        current_idx = out_idx;
+    for (node, passes) in nodes.iter().zip(&output_idx) {
+        let inputs: Vec<&wgpu::Texture> = (0..node.input_count())
+            .map(|i| {
+                if i == 0 {
+                    scope.get(current_idx)
+                } else {
+                    scope.get(input_idx)
+                }
+            })
+            .collect();
+        let outputs: Vec<&wgpu::Texture> = passes.iter().map(|&idx| scope.get(idx)).collect();
+        node.process(&inputs, &outputs, ctx);
+        // `passes` is always non-empty (`pass_count().max(1) >= 1`); the final
+        // pass becomes the next node's input[0].
+        if let Some(&last) = passes.last() {
+            current_idx = last;
+        }
     }
 
     // Copy the final texture to a CPU-readable staging buffer.

--- a/crates/ff-render/src/graph/mod.rs
+++ b/crates/ff-render/src/graph/mod.rs
@@ -198,7 +198,7 @@ mod tests {
 #[cfg(all(test, feature = "wgpu"))]
 mod gpu_tests {
     use super::{Arc, RenderContext, RenderGraph};
-    use crate::nodes::ColorGradeNode;
+    use crate::nodes::{ColorGradeNode, RenderNode, RenderNodeCpu};
 
     /// A headless GPU context, or `None` when no adapter is available (CI).
     fn ctx() -> Option<Arc<RenderContext>> {
@@ -206,6 +206,124 @@ mod gpu_tests {
             Ok(ctx) => Some(Arc::new(ctx)),
             Err(_) => None,
         }
+    }
+
+    /// Fill a whole texture with a solid RGBA color via `write_texture`.
+    fn fill(ctx: &RenderContext, tex: &wgpu::Texture, color: [u8; 4]) {
+        let (w, h) = (tex.width(), tex.height());
+        let data: Vec<u8> = color
+            .iter()
+            .copied()
+            .cycle()
+            .take((w * h * 4) as usize)
+            .collect();
+        ctx.queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(w * 4),
+                rows_per_image: None,
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
+    const COLOR_A: [u8; 4] = [10, 20, 30, 255];
+    const COLOR_B: [u8; 4] = [200, 150, 100, 255];
+    const GREEN: [u8; 4] = [0, 255, 0, 255];
+    const RED: [u8; 4] = [255, 0, 0, 255];
+
+    /// Two-pass node: writes COLOR_A into the first pass and COLOR_B into the
+    /// second. If the executor allocated only one output (ignoring `pass_count`)
+    /// it writes COLOR_A instead, so a readback of COLOR_B proves both passes ran.
+    struct TwoPassNode;
+    impl RenderNodeCpu for TwoPassNode {
+        fn process_cpu(&self, _rgba: &mut [u8], _w: u32, _h: u32) {}
+    }
+    impl RenderNode for TwoPassNode {
+        fn pass_count(&self) -> usize {
+            2
+        }
+        fn process(
+            &self,
+            _inputs: &[&wgpu::Texture],
+            outputs: &[&wgpu::Texture],
+            ctx: &RenderContext,
+        ) {
+            if outputs.len() >= 2 {
+                fill(ctx, outputs[0], COLOR_A);
+                fill(ctx, outputs[1], COLOR_B);
+            } else {
+                fill(ctx, outputs[0], COLOR_A);
+            }
+        }
+    }
+
+    /// Two-input node: writes GREEN when it receives both inputs, RED otherwise.
+    /// A readback of GREEN proves the executor passed `input_count()` inputs.
+    struct TwoInputNode;
+    impl RenderNodeCpu for TwoInputNode {
+        fn process_cpu(&self, _rgba: &mut [u8], _w: u32, _h: u32) {}
+    }
+    impl RenderNode for TwoInputNode {
+        fn input_count(&self) -> usize {
+            2
+        }
+        fn process(
+            &self,
+            inputs: &[&wgpu::Texture],
+            outputs: &[&wgpu::Texture],
+            ctx: &RenderContext,
+        ) {
+            let color = if inputs.len() == 2 { GREEN } else { RED };
+            fill(ctx, outputs[0], color);
+        }
+    }
+
+    #[test]
+    fn executor_should_run_a_two_pass_node_and_read_back_the_final_pass() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let graph = RenderGraph::new(Arc::clone(&ctx)).push(TwoPassNode);
+        let (w, h) = (16u32, 16u32);
+        let rgba = vec![0u8; (w * h * 4) as usize];
+
+        let out = graph.process_gpu(&rgba, w, h).expect("two-pass frame");
+        assert_eq!(
+            &out[0..4],
+            &COLOR_B,
+            "the final pass (COLOR_B) must be read back; got {:?}",
+            &out[0..4]
+        );
+    }
+
+    #[test]
+    fn executor_should_feed_two_inputs_to_a_multi_input_node() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let graph = RenderGraph::new(Arc::clone(&ctx)).push(TwoInputNode);
+        let (w, h) = (16u32, 16u32);
+        let rgba = vec![0u8; (w * h * 4) as usize];
+
+        let out = graph.process_gpu(&rgba, w, h).expect("two-input frame");
+        assert_eq!(
+            &out[0..4],
+            &GREEN,
+            "receiving two inputs must produce GREEN; got {:?}",
+            &out[0..4]
+        );
     }
 
     fn alloc_count(ctx: &RenderContext) -> usize {

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -56,9 +56,11 @@ pub trait RenderNode: RenderNodeCpu {
 
     /// Run the GPU render pass.
     ///
-    /// `inputs[i]` are the source textures (`len == input_count()`).
-    /// `outputs[i]` are pre-allocated `Rgba8Unorm` target textures
-    /// (`len == pass_count()`). Write the final result into `outputs[pass_count()-1]`.
+    /// `inputs` has `input_count()` textures: `inputs[0]` is the previous node's
+    /// final-pass output (or the source frame for the first node), and
+    /// `inputs[1..]` are the original source frame. `outputs` has `pass_count()`
+    /// pre-allocated `Rgba8Unorm` targets; write the final result into
+    /// `outputs[pass_count()-1]`, which the executor feeds to the next node.
     fn process(
         &self,
         inputs: &[&wgpu::Texture],


### PR DESCRIPTION
## Objective

- `run_gpu` passed exactly one input and one output texture to every node, ignoring each node's declared `pass_count()` and `input_count()`.
- True multi-pass nodes could not run, and multi-input nodes had to carry their extra inputs through internal fields.

## Solution

- Allocate `pass_count()` output targets per node from the B1 texture pool and supply `input_count()` inputs.
- `input[0]` is the chained texture (the source frame for the first node, the previous node's final pass otherwise); `input[1..]` are the original source frame; the node writes its final result into the last pass, which becomes the next node's `input[0]`.
- A node declaring 1 input and 1 pass behaves exactly as before; output textures gain `COPY_DST` so a pass target can be filled directly, and the `RenderNode` contract doc is updated to match.
- Add two synthetic nodes and GPU tests (`wgpu`-gated, skip without an adapter) proving both passes of a two-pass node run and both inputs reach a multi-input node.

Closes #1586