### PR TITLE
docs: publish crate design docs under docs/specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,6 @@ Desktop.ini
 
 /Cargo.lock
 
-# Internal design docs (not for public repo)
-/docs/crates/
-/docs/dev/
-/docs/roadmap/tasks/
 
 # Claude Code — personal use only, not shared with contributors
 /CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -28,18 +28,16 @@ Desktop.ini
 # Ignore build artifacts and lock files
 **/target/
 
-
 /Cargo.lock
 
-
-# Claude Code — personal use only, not shared with contributors
+# Claude Code
 /CLAUDE.md
 /.claude/
 
-# Personal working notes (not shared with contributors)
+# Personal working notes
 /TODO.md
 
-# Private local media — drop your own files here to run avio during development
+# Private local media: drop your own files here to run avio during development
 /assets/private/*
 !/assets/private/.gitkeep
 !/assets/private/README.md

--- a/docs/adr/0003-ff-sys-safe-wrapper-layer.md
+++ b/docs/adr/0003-ff-sys-safe-wrapper-layer.md
@@ -156,7 +156,7 @@ Implemented across the RAII hardening track (#1477–#1506) and enforced by:
 * Rules this rests on: `docs/rules/unsafe.md` (`*_inner.rs` isolation, `// SAFETY:`),
   `docs/rules/design.md` (primitive scope / litmus).
 * Call order this would let types enforce later: the per-crate
-  `docs/crates/*/design.md` FFmpeg call-order sections, where deviating from the
+  `docs/specs/crates/*/design.md` FFmpeg call-order sections, where deviating from the
   specified order is a bug.
 * Related: the `ff-*` hardening track (v0.17.0). Follow-on, out of scope here:
   call-order typestate.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
 # Architecture Decision Records
 
 A design decision's rationale lives here and nowhere else. `docs/specs/**` and the
-per-crate `docs/crates/*/design.md` state the *outcome* and link to the record;
+per-crate `docs/specs/crates/*/design.md` state the *outcome* and link to the record;
 they do not repeat the reasoning.
 
 These records are written in **English** (like `docs/rules/`), because they
@@ -28,7 +28,7 @@ Records are numbered consecutively from `0001`.
 | Location | Holds | Does not hold |
 |---|---|---|
 | `docs/specs/**` | what the design is (architecture of record) | why it was chosen; links here instead |
-| `docs/crates/*/design.md` | per-crate design and the FFmpeg call order | why a cross-cutting decision was made |
+| `docs/specs/crates/*/design.md` | per-crate design and the FFmpeg call order | why a cross-cutting decision was made |
 | `docs/adr/**` | why a decision was chosen, when, and what would reverse it | type or signature detail; links to the specs |
 | `docs/rules/**` | what to do while implementing | how a decision was reached |
 | `docs/roadmap/**` | what to build next (capabilities) | how a decision was reached |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -16,5 +16,4 @@ This directory collects the conventions to follow when writing code across the a
 
 Design specs live in [`../specs/`](../specs/), and the rationale behind significant design and
 architecture decisions in [`../adr/`](../adr/) (Architecture Decision Records; see
-[when to write one](../adr/README.md#when-to-write-one)). Internal review-knowledge and process docs
-live in `docs/dev/`.
+[when to write one](../adr/README.md#when-to-write-one)).

--- a/docs/rules/design.md
+++ b/docs/rules/design.md
@@ -66,7 +66,7 @@ avio is an **editing engine**; the `ff-*` family are **model-agnostic primitives
 
 ## 6. FFmpeg call order is part of the design
 
-The crate design docs (`docs/crates/{name}/design.md`) specify the exact FFmpeg call order.
+The crate design docs (`docs/specs/crates/{name}/design.md`) specify the exact FFmpeg call order.
 Deviating without a deliberate, documented reason is a bug, not a style choice.
 
 ---

--- a/docs/rules/unsafe.md
+++ b/docs/rules/unsafe.md
@@ -95,7 +95,7 @@ impl Drop for FilterGraphInner {
 
 ## FFmpeg call order
 
-The exact call order is specified per crate in `docs/crates/{name}/design.md` and is part of the
+The exact call order is specified per crate in `docs/specs/crates/{name}/design.md` and is part of the
 design (see [design.md](./design.md)). Deviating is a bug.
 
 ---

--- a/docs/specs/crates/avio/design.md
+++ b/docs/specs/crates/avio/design.md
@@ -1,0 +1,34 @@
+# avio
+
+The core of a video-editing application, handling everything end to end: arranging sources on a timeline, editing them, and going from preview through export.
+
+## Purpose
+
+Building a video-editing application requires not only the individual features of reading in, compositing, and writing out sources, but also a mechanism that binds them together and handles the editing itself: "which source is placed where, arranged how, and processed how." avio takes on this core as the **body of the editing engine**, representing the edit content as data and deriving video from it. Callers can achieve everything from editing to output simply by assembling a timeline, without delving into the details of each feature.
+
+## What it solves
+
+- **Representing edits as data** — the placement, trim, opacity, transitions, and more of sources can be described consistently in the form of a timeline.
+- **Non-destructive editing** — the original sources are not rewritten and only the edit content is manipulated, so it can be recomposed at any time.
+- **Undoable editing** — every editing operation can be undone and redone one step at a time, so you can experiment with confidence.
+- **Turning edits into video** — from the timeline, derive and export video that reflects compositing, transitions, and effects.
+- **Consistency of preview and output** — the preview during editing and the final export are obtained from the same edit content.
+- **Grasping source information** — the resolution, frame rate, codec, and so on of the sources to be read in can be checked in advance.
+
+## Capabilities
+
+- Placing and editing clips on the timeline (video and audio tracks)
+- Per-clip trim, placement position, opacity, and transition specification
+- Compositing by layering multiple tracks
+- Applying editing operations, with history management involving undo and redo
+- Exporting the edit result to a file
+- Real-time preview (on supported configurations)
+- Checking source metadata
+- A consistent entry point that binds together the various media features (decode, encode, analysis, compositing, and so on)
+
+## Out of scope
+
+- The internal implementation of individual processes such as decode, encode, and compositing (delegated to lower-level features)
+- Any specific screen UI or application operation scheme
+- Management and storage of the source files themselves
+- Low-level media processing used on its own (uses that call each feature directly are delegated to the lower levels)

--- a/docs/specs/crates/ff-analysis/design.md
+++ b/docs/specs/crates/ff-analysis/design.md
@@ -1,0 +1,33 @@
+# ff-analysis
+
+Analyzes the content of media and extracts information usable for editing and organizing decisions (scene boundaries, silent segments, waveforms, and the like).
+
+## Purpose
+
+To edit and organize sources, you first need to know content features such as "where the scene changes," "where it is silent," and "where the highlights are." Finding these by eye and by hand is laborious and prone to oversights. ff-analysis **automatically extracts such analysis information** from sources, so that tools and users can make accurate editing decisions based on it.
+
+## What it solves
+
+- **Detecting scene boundaries** — automatically find the positions where scenes switch, usable for cut candidates and chapter structuring.
+- **Detecting silent segments** — identify ranges where sound is absent, usable for removing unneeded parts and automatic splitting.
+- **Grasping black frames and keyframes** — surface nearly pitch-black segments and positions suited to seeking.
+- **Visualizing video and audio distributions** — extract distributions of brightness, color, and volume, usable as material for quality checks and color adjustment.
+- **Analysis that does not rely on guesswork** — obtain results as numbers based on the actual content, with failures returned in a form whose cause is clear.
+
+## Capabilities
+
+- Detection of scene boundaries (cuts)
+- Detection of silent segments
+- Detection of nearly black frames
+- Enumeration of keyframe positions
+- Extraction of brightness and RGB histograms
+- Extraction of audio amplitude waveforms (peak / RMS)
+- Video scopes (waveform, vectorscope, RGB parade, histogram)
+- Result representation of tempo (BPM)
+
+## Out of scope
+
+- Editing, processing, or converting sources (only reading and reporting)
+- Reading in (decoding) or writing out (encoding) sources themselves
+- The editing model such as timeline, editing, and history
+- How the analysis results are used (decisions such as applying cuts are delegated to the caller)

--- a/docs/specs/crates/ff-common/design.md
+++ b/docs/specs/crates/ff-common/design.md
@@ -1,0 +1,31 @@
+# ff-common
+
+Provides a shared foundation for reusing memory efficiently in media processing and keeping practical speed.
+
+## Purpose
+
+In video and audio processing, large frame buffers are repeatedly acquired and released every frame, which becomes a cause of slowdown and memory pressure. ff-common provides, as a shared foundation, a mechanism that reuses memory once finished with instead of discarding it, curbing wasteful acquisition and release. By sharing this foundation, each capability obtains practical performance without building memory management individually.
+
+## What it solves
+
+- **Memory reuse** — instead of letting go of a buffer once finished with, reuses it in later processing to reduce acquisition cost.
+- **Fewer acquisitions and releases** — avoids repeated allocation and prevents slowdown across the whole process.
+- **Automatic cleanup** — a buffer once finished with automatically returns to the reuse pool, requiring no manual release.
+- **Safe sharing** — the same reuse mechanism can be used safely from multiple processes.
+- **Commonization** — each capability shares a unified foundation rather than building memory management individually.
+
+## Capabilities
+
+- A reuse mechanism for the buffers used in media processing
+- A reuse framework that can adjust how much is kept on hand according to usage
+- Automatic return and re-acquisition of buffers once finished with
+- Consistent handling that works even for one-off use with no reuse pool
+- Safe shared use from multiple processes
+- A lightweight, independent foundation with no dependence on FFmpeg
+
+## Out of scope
+
+- Reading, writing, or processing video, audio, and images themselves
+- Dependence on or coupling to FFmpeg's features
+- Defining the common types that represent media
+- The editing model such as timeline, editing, and history

--- a/docs/specs/crates/ff-decode/design.md
+++ b/docs/specs/crates/ff-decode/design.md
@@ -1,0 +1,39 @@
+# ff-decode
+
+Provides the ability to read video, audio, and images of many formats into a form the
+application can work with.
+
+## Purpose
+
+Media files and streams come in countless containers, codecs, resolutions, and color
+systems, so they cannot be used for editing, playback, or analysis as they are. ff-decode
+absorbs these differences and lets input media be read out in a consistent form. Callers
+can read media without any knowledge of the individual formats.
+
+## What it solves
+
+- **Uniform ingestion of diverse inputs** — read supported video, audio, and image formats
+  without having to account for their differences.
+- **Access to any position** — not only sequential reading from the start, but seeking to a
+  specified time position.
+- **Practical performance** — hardware acceleration and buffer reuse keep reading fast
+  enough for real use.
+- **Robustness** — keep reading as far as possible even with corrupt data or network
+  interruptions.
+- **Preview material** — obtain representative frames for lists and thumbnails.
+
+## Capabilities
+
+- Decoding of video, audio, and images (extraction frame by frame / sample by sample)
+- Seeking to a specified time position
+- Hardware acceleration (auto-selected where available)
+- Ingestion of network inputs (URLs and streams)
+- Asynchronous reading
+- Representative-frame extraction and thumbnail generation
+
+## Out of scope
+
+- Writing out (encoding) or muxing
+- Effects, compositing, and other processing
+- Timeline, editing, and history (the editing model)
+- Playback (clock, audio output, screen display)

--- a/docs/specs/crates/ff-encode/design.md
+++ b/docs/specs/crates/ff-encode/design.md
@@ -1,0 +1,33 @@
+# ff-encode
+
+Provides the ability to "write out" edited and processed video, audio, and images in a format suited to their purpose.
+
+## Purpose
+
+The results of editing and conversion generate no value until they are assembled into a form that can finally be distributed, stored, or played back. Yet output targets serve diverse purposes, and the suitable codec and quality settings differ greatly depending on whether the destination is web delivery, archiving, professional use, or something else. ff-encode makes it possible to **reliably write out deliverables in a format that fits their purpose**, and to notice inconsistent settings at an early stage.
+
+## What it solves
+
+- **Writing out to diverse output formats** — produce deliverables by choosing the codec and container that suit the purpose.
+- **Control over quality and size** — adjust to the goal with constant bitrate, quality criteria, variable bitrate, and the like.
+- **Early detection of misconfiguration** — grasp combinations that cannot hold before writing begins.
+- **Support for specialized uses** — output across a broad range, from delivery to archiving, professional formats, and HDR.
+- **Insight into progress** — check how far a long write has advanced.
+
+## Capabilities
+
+- Writing out video, audio, and images
+- A broad choice of codecs and containers, with detailed per-codec quality and characteristic specification
+- A choice of quality modes such as constant bitrate, quality criteria, or variable bitrate
+- Support for professional formats (ProRes, DNxHD/HR, and so on) and HDR metadata
+- Use of hardware encoding, with automatic fallback to software when it is unavailable
+- Notification of write progress
+- Asynchronous writing
+
+## Out of scope
+
+- Reading materials (decoding) or extracting metadata
+- Processing such as effects and compositing
+- The editing model, such as timelines, edits, and history
+- Stream copy without re-encoding (mux-only processing)
+- Playback (clock, audio output, screen display)

--- a/docs/specs/crates/ff-filter/design.md
+++ b/docs/specs/crates/ff-filter/design.md
@@ -1,0 +1,32 @@
+# ff-filter
+
+Provides the ability to apply processing to video and audio (effects such as resizing, color adjustment, compositing, and fades).
+
+## Purpose
+
+Outputting a material as it is does not reach the intended look or sound. Processing such as size adjustment, color correction, overlaying multiple materials, and fades shapes the finished result. Applying such effects in combination normally requires specialized knowledge, but ff-filter makes it possible to **assemble the needed processing step by step and apply it to video and audio**, and to notice specifications that cannot hold before applying them.
+
+## What it solves
+
+- **Assembling effects** — compose processing such as resizing, color adjustment, compositing, and fades by layering it in order.
+- **Specification that does not rely on specialized knowledge** — specify the processing on a purpose basis, without having to be conscious of the fine internal description.
+- **Early detection of misspecification** — grasp out-of-range values and empty procedures before processing begins.
+- **Compositing multiple materials** — overlay or mix two or more videos or audios into one.
+- **Practical performance** — leverage hardware acceleration to process at a practical speed.
+
+## Capabilities
+
+- Video processing (resizing, cropping, rotation, trimming, aspect adjustment, and so on)
+- Color and appearance effects (color adjustment, blur, noise removal, keying, HDR-to-SDR conversion, and so on)
+- Temporal effects (fade in/out, transitions between clips)
+- Overlaying and compositing text or other materials
+- Audio processing (volume adjustment, parametric equalizer, mixing of multiple audios)
+- Use of hardware acceleration
+
+## Out of scope
+
+- Reading materials (decoding) or writing them out (encoding)
+- Extracting metadata
+- The editing model, such as timelines, edits, and history
+- GPU compositing (compositing as a rendering engine)
+- Playback (clock, audio output, screen display)

--- a/docs/specs/crates/ff-format/design.md
+++ b/docs/specs/crates/ff-format/design.md
@@ -1,0 +1,31 @@
+# ff-format
+
+Provides the common types shared across crates so that every capability can handle media in the same language.
+
+## Purpose
+
+When each capability such as reading, processing, and writing represents media in a different language, translation is needed every time capabilities are connected, and mismatches and omissions arise. ff-format defines the basic elements of media such as frames, color and audio formats, codecs, and time positions as a shared vocabulary, so that all capabilities can hand media over in the same language. This makes the cooperation between capabilities consistent and lets them be combined with confidence.
+
+## What it solves
+
+- **A shared vocabulary** — represents media formats and attributes in a unified language shared by all capabilities.
+- **Consistent handoff** — produces no translation or mismatch when passing media from capability to capability.
+- **Preserving color and HDR information** — conveys important attributes such as color space and HDR without dropping them.
+- **Consistent expression of time position** — handles positions within media in a common form that keeps precision.
+- **FFmpeg independence** — keeps the shared vocabulary in a pure form not tied to any particular implementation.
+
+## Capabilities
+
+- Common types that represent the formats and attributes of video, audio, and images
+- A representation of frames passed between capabilities as decode results and encode inputs
+- A representation of color-related information such as color space, color gamut, and HDR
+- A representation of time positions within media, and conversion of positions that keeps precision
+- A consistent foundation for each capability to handle media in the same vocabulary
+- An independent type system not tied to FFmpeg's internal structures
+
+## Out of scope
+
+- Reading, processing, or writing media itself
+- Dependence on or coupling to FFmpeg's features
+- Mechanisms for performance such as memory reuse
+- The editing model such as timeline, editing, and history

--- a/docs/specs/crates/ff-pipeline/design.md
+++ b/docs/specs/crates/ff-pipeline/design.md
@@ -1,0 +1,32 @@
+# ff-pipeline
+
+Provides the ability to run reading, processing, and writing out as a single connected operation, executed together.
+
+## Purpose
+
+Transforming media requires connecting several stages in sequence: reading the input, applying the necessary processing, and writing it out in a specified format. Assembling each stage individually invites configuration mismatches and rework. ff-pipeline lets these be **composed as a single validated flow and executed together**. Callers do not manage each stage individually; they simply specify the input, output, and processing content to run a consistent transformation.
+
+## What it solves
+
+- **One-shot execution of a connected operation** — run everything from reading through processing to writing out together, without assembling it piece by piece.
+- **Rework prevention through up-front validation** — detect configuration flaws before processing begins and avoid wasted runs.
+- **Progress visibility** — receive how far processing has advanced at any time and present it to the user.
+- **Mid-way cancellation** — safely stop even a long operation at any time at the user's discretion.
+- **Errors that identify the cause** — report failures in a form that traces what happened at which stage.
+
+## Capabilities
+
+- Composition of a transformation with specified input, output, quality settings, and processing content
+- Pre-execution validation of settings (processing does not start if there are flaws)
+- Specification of output format and quality (codec, bitrate, resolution, and so on)
+- Execution of a transformation with processing stages in between
+- Ongoing progress notification
+- Cancellation of processing at the user's discretion
+- Failure notification including which stage it originated from
+
+## Out of scope
+
+- The internal means of realizing each of reading, processing, and writing out (delegated to other foundational capabilities)
+- The editing model such as timeline, clips, editing, and history
+- Adaptive streaming output for distribution
+- Real-time preview or playback during editing

--- a/docs/specs/crates/ff-preview/design.md
+++ b/docs/specs/crates/ff-preview/design.md
@@ -1,0 +1,31 @@
+# ff-preview
+
+Provides the ability to check results instantly while editing and to keep working smoothly even with heavy material.
+
+## Purpose
+
+In editing work, being able to confirm the result of a change on the spot is indispensable. High-resolution material, however, is heavy to play back as-is, and waiting on every check stalls the work. ff-preview lets **the video being edited be played back and checked instantly, while heavy material is replaced with lightweight proxy data for comfortable handling**. Callers do not build their own playback and checking machinery; they can focus on confirming how the edit looks.
+
+## What it solves
+
+- **Instant result confirmation** — play back the video being edited on the spot and confirm the changes made.
+- **Confirmation at a targeted position** — move precisely to any time position and check the video at that moment.
+- **Audio-video synchronization** — during playback, keep audio and video from drifting so the result is checked close to how it will actually look.
+- **Smooth handling of heavy material** — replace high-resolution material with lightweight proxy data and work comfortably.
+- **Automatic switching from proxy to original** — check with lightweight data and switch to the original material where needed.
+
+## Capabilities
+
+- Instant playback of the video being edited (play, pause, and stop operations)
+- Precise movement to any time position and confirmation there
+- Audio-synchronized playback of audio and video
+- Handoff of video in a form suited to rendering, where the display target can be prepared by the caller
+- Generation of lightweight proxy data for high-resolution material
+- Automatic use of proxy data versus original material as appropriate
+
+## Out of scope
+
+- Writing out (encoding) the finished video or output for distribution
+- The editing model itself such as timeline, clips, editing, and history
+- The substance of video processing such as effects and compositing
+- Control of screen display, window management, and audio output devices

--- a/docs/specs/crates/ff-probe/design.md
+++ b/docs/specs/crates/ff-probe/design.md
@@ -1,0 +1,32 @@
+# ff-probe
+
+Provides the ability to quickly learn what a piece of media contains (duration, resolution, codec, stream layout, and so on) without decoding it.
+
+## Purpose
+
+Before editing, converting, or playing back, you first need to know "what this material is." Without knowing its duration, resolution, codec, or audio/video layout, you can neither judge whether it can be ingested nor choose the appropriate processing. ff-probe makes it possible to **accurately grasp a material's nature in a single query**, without actually playing back or converting the file.
+
+## What it solves
+
+- **Immediate insight into material information** — obtain duration, resolution, codec, and the like in a short time without decoding the contents.
+- **Judgment that does not rely on guesswork** — determine what a material contains based on its actual contents, not its extension or file name.
+- **Insight into stream layout** — check the layout of the tracks contained in a material, such as video and audio.
+- **Typed results** — receive information in a form you can work with directly, without interpreting strings.
+- **Clear failures** — when a file cannot be opened or is corrupted, the result comes back in a form from which the cause can be read.
+
+## Capabilities
+
+- Obtaining a material's total playback duration
+- Obtaining a video's resolution, frame rate, codec, and pixel format
+- Obtaining an audio's sample rate, channel count, codec, and sample format
+- Listing the video/audio streams contained in a material and identifying the representative stream
+- Identifying the container (the format of the enclosing file)
+- Distinguishing the reason a read failed (not found, invalid format, absent stream, and so on)
+
+## Out of scope
+
+- Decoding a material (extracting frames or samples)
+- Writing out (encoding) or muxing
+- Effects, compositing, or processing
+- The editing model, such as timelines, edits, and history
+- Rewriting metadata (read-only)

--- a/docs/specs/crates/ff-remux/design.md
+++ b/docs/specs/crates/ff-remux/design.md
@@ -1,0 +1,30 @@
+# ff-remux
+
+Cuts out clips and replaces, extracts, or adds audio without re-encoding, quickly and without quality loss.
+
+## Purpose
+
+Operations such as cutting out part of a source or replacing its audio can be achieved without rebuilding the content of the video and audio. Even so, performing a rebuild (re-encoding) takes time and also degrades picture and sound quality. ff-remux **copies the content as-is to perform** such container-level operations, so they can be finished **quickly and without quality loss**.
+
+## What it solves
+
+- **Lossless cutout** — copy the specified time range without rebuilding it, extracting it while preserving picture and sound quality.
+- **Replacing, extracting, and adding audio** — with the video left as-is, swap out, take out, or add the audio track.
+- **Fast processing** — because no re-encoding is involved, it completes in a short time even for long content.
+- **Preserving quality** — carry over the original video and audio as-is, producing no generational degradation.
+- **Understandable failures** — return unsupported combinations and invalid inputs in a form whose cause can be read.
+
+## Capabilities
+
+- Cutout of a time range (no re-encoding)
+- Replacing an audio track
+- Extracting an audio track
+- Adding an audio track
+- Performing all of the above without any rebuild of video or audio
+
+## Out of scope
+
+- Re-encoding or format conversion (export that involves a rebuild)
+- Processing such as effects and compositing
+- Analysis or metadata extraction of sources
+- The editing model such as timeline, editing, and history

--- a/docs/specs/crates/ff-render/design.md
+++ b/docs/specs/crates/ff-render/design.md
@@ -1,0 +1,33 @@
+# ff-render
+
+Composites multiple video layers, effects, and transitions into a single image used for preview and export.
+
+## Purpose
+
+An edited video only becomes a finished image once multiple sources are layered, colors are adjusted, and transition effects are added. Such compositing involves a large amount of computation per frame, and doing it naively tends to be slow. ff-render performs this compositing and processing quickly with the power of the GPU, taking on the role of **assembling the edit result into a video you can actually see**. So that the same result can be obtained even in environments where the GPU is unavailable, it also provides an alternative processing path.
+
+## What it solves
+
+- **Layering** — composite multiple videos such as background, foreground, and overlay into one according to stacking order, opacity, and position.
+- **Look adjustment** — apply color correction such as brightness, contrast, saturation, and color temperature to video.
+- **Compositing expression** — blend sources together with a variety of blend modes such as multiply, screen, and overlay.
+- **Cutout and masking** — keep only the needed parts with chroma key (green-screen removal) and various masks.
+- **Transition effects** — smoothly show the change between clips, such as crossfades.
+- **Runs in any environment** — fast where a GPU is available, and producing the same result even where one is not.
+
+## Capabilities
+
+- Compositing of multiple layers (reflecting stacking order, opacity, scaling, translation, and rotation)
+- Color correction (brightness, contrast, saturation, color temperature, tint)
+- Blending with a rich set of blend modes
+- Cutout via chroma key, luma mask, shape mask, and the like
+- Transitions between clips (crossfade)
+- Integration into preview playback (continuous handoff of processed frames)
+- Fast processing on GPU environments, with an alternative path on unsupported environments
+
+## Out of scope
+
+- Reading in (decoding) or writing out (encoding) sources themselves
+- The timeline or editing decisions of which source is placed when and how
+- Edit history management (Undo/Redo)
+- Audio processing

--- a/docs/specs/crates/ff-stream/design.md
+++ b/docs/specs/crates/ff-stream/design.md
@@ -1,0 +1,31 @@
+# ff-stream
+
+Provides the ability to write out media for web distribution in a form whose quality switches according to the viewer's connection conditions.
+
+## Purpose
+
+Delivering media over the internet calls not for a single file but for a distribution format whose quality can switch to match the viewer's connection speed and playback environment. Preparing such formats by hand is cumbersome and error-prone. ff-stream lets a **distribution package containing multiple qualities be generated in one pass from the input material and put on distribution as-is**. Callers need not be aware of the details of the distribution format; they only specify the arrangement of qualities they want to deliver.
+
+## What it solves
+
+- **Quality switching according to the connection** — output in a form where playback quality switches automatically to match the viewer's environment.
+- **One-shot generation of a distribution package** — build, from the input material, a complete set that can be put on distribution as-is, all at once.
+- **Simultaneous output of multiple qualities** — prepare multiple qualities, from high to low, with a single specification.
+- **Support for major distribution methods** — output in the widely used, representative streaming methods.
+- **Errors that identify the cause** — report configuration flaws and unsupported requests in a form that can be acted on.
+
+## Capabilities
+
+- Writing out in major adaptive streaming formats
+- Specification of a tiered quality arrangement (combinations of resolution and bitrate)
+- Generation of a multi-quality package from a single input
+- Specification of basic distribution-related parameters such as segment length
+- Generation of the playlists/manifests and split data required for distribution
+- Clear failure notification for configuration flaws and unsupported requests
+
+## Out of scope
+
+- Distribution of the generated package, placement on a CDN, or playback to viewers
+- The editing model such as timeline, clips, editing, and history
+- Real-time preview or playback during editing
+- Ordinary writing out to a single file (output not intended for distribution)

--- a/docs/specs/crates/ff-sys/design.md
+++ b/docs/specs/crates/ff-sys/design.md
@@ -1,0 +1,31 @@
+# ff-sys
+
+Provides the foundation that lets the application safely use FFmpeg's power for video and audio processing.
+
+## Purpose
+
+Actually processing video and audio depends on FFmpeg's capabilities, but its entry point is very hard to handle, and a small mistake can lead to incorrect behavior or memory corruption. ff-sys consolidates the contact surface with FFmpeg into a single place and confines dangerous handling inside this layer. This lets each higher-level capability move forward on a stable foundation without worrying about FFmpeg's details or pitfalls.
+
+## What it solves
+
+- **Making FFmpeg safe to use** — wraps easily misused operations into a safe form so higher levels never touch dangerous handling.
+- **Automatic cleanup** — releases acquired resources without ever missing one, preventing memory leaks and double frees.
+- **Clarity about supported versions** — absorbs FFmpeg's version differences and specification changes at this layer.
+- **Absorbing per-environment setup** — automatically locates FFmpeg, whose whereabouts differ per OS, and makes the build succeed.
+- **Centralizing the danger boundary** — confines risky processing to this layer alone and keeps higher levels in a safe world.
+
+## Capabilities
+
+- A foundation on which higher-level crates can safely call FFmpeg's features
+- Acquisition of the resources needed for video, audio, and image processing, and their automatic cleanup
+- Guaranteed behavior against the assumed FFmpeg version and absorption of its differences
+- FFmpeg detection and setup support on Windows, Linux, and macOS respectively
+- Confirmation of whether the linked FFmpeg provides a given feature
+- A means to handle FFmpeg-originated errors in a readable form
+
+## Out of scope
+
+- Providing concrete media processing such as decoding and encoding
+- High-level APIs intended for direct use by callers
+- The editing model such as timeline, editing, and history
+- Bundling or distributing FFmpeg itself (it uses the FFmpeg provided by the environment)


### PR DESCRIPTION
## Objective

- The per-crate design docs lived in the internal, gitignored `docs/crates/` and had drifted out of date, so they could not serve as reliable public documentation.

## Solution

- Relocate the design docs to the public `docs/specs/crates/` and rewrite each as a concise product-level document (purpose, what it solves, capabilities, out of scope) in English.
- Update the references in `docs/adr` and `docs/rules` to the new path.
- Remove the now-unused `docs/crates`, `docs/dev`, and `docs/roadmap/tasks` ignore rules.