### PR TITLE
feat(ff-render): HDR Rgba16Float auto-detect from high-bit-depth input

### DIFF
--- a/crates/ff-render/src/graph/graph_inner.rs
+++ b/crates/ff-render/src/graph/graph_inner.rs
@@ -17,12 +17,15 @@ pub(super) fn run_gpu(
     rgba: &[u8],
     w: u32,
     h: u32,
+    format: wgpu::TextureFormat,
 ) -> Result<Vec<u8>, RenderError> {
     if nodes.is_empty() {
         return Ok(rgba.to_vec());
     }
 
-    let format = wgpu::TextureFormat::Rgba8Unorm;
+    // Bytes per pixel of the working format: 8 for Rgba16Float (HDR), 4 for the
+    // 4-channel 8-bit default. Drives the input upload and the readback stride.
+    let bpp = bytes_per_pixel(format);
     let input_usage = wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING;
     // Outputs double as general-purpose scratch: `COPY_DST` lets a node (or test)
     // fill a pass target via `write_texture`, `COPY_SRC` allows readback, and
@@ -49,26 +52,32 @@ pub(super) fn run_gpu(
         })
         .collect();
 
-    // Upload the input frame to the initial GPU texture.
-    ctx.queue.write_texture(
-        wgpu::TexelCopyTextureInfo {
-            texture: scope.get(input_idx),
-            mip_level: 0,
-            origin: wgpu::Origin3d::ZERO,
-            aspect: wgpu::TextureAspect::All,
-        },
-        rgba,
-        wgpu::TexelCopyBufferLayout {
-            offset: 0,
-            bytes_per_row: Some(w * 4),
-            rows_per_image: None,
-        },
-        wgpu::Extent3d {
-            width: w,
-            height: h,
-            depth_or_array_layers: 1,
-        },
-    );
+    // Upload the 8-bit `rgba` frame to the initial GPU texture. Only valid for
+    // an `Rgba8Unorm` working format: an HDR (`Rgba16Float`) graph is driven by a
+    // source node (e.g. `YuvUploadNode`, `input_count() == 0`) that supplies its
+    // own high-bit-depth pixels and ignores this seed, so the 8-bit upload — which
+    // would not fit an 8-bytes-per-pixel texture — is skipped.
+    if format == wgpu::TextureFormat::Rgba8Unorm {
+        ctx.queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: scope.get(input_idx),
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            rgba,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(w * 4),
+                rows_per_image: None,
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
 
     // Run each node. input[0] is the chained texture (the source frame for the
     // first node, the previous node's final pass otherwise); input[1..] are the
@@ -95,7 +104,7 @@ pub(super) fn run_gpu(
     }
 
     // Copy the final texture to a CPU-readable staging buffer.
-    let bytes_per_row_padded = align_up(w * 4, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    let bytes_per_row_padded = align_up(w * bpp, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
     let buffer_size = u64::from(bytes_per_row_padded) * u64::from(h);
 
     let staging_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
@@ -156,10 +165,10 @@ pub(super) fn run_gpu(
         .map_err(|e| RenderError::Composite {
             message: format!("staging buffer get_mapped_range failed: {e}"),
         })?;
-    let mut out = Vec::with_capacity((w * h * 4) as usize);
+    let mut out = Vec::with_capacity((w * h * bpp) as usize);
     for y in 0..h as usize {
         let row_start = y * bytes_per_row_padded as usize;
-        let row_end = row_start + (w * 4) as usize;
+        let row_end = row_start + (w * bpp) as usize;
         out.extend_from_slice(&raw[row_start..row_end]);
     }
     drop(raw);
@@ -170,4 +179,13 @@ pub(super) fn run_gpu(
 
 fn align_up(value: u32, alignment: u32) -> u32 {
     (value + alignment - 1) & !(alignment - 1)
+}
+
+/// Bytes per pixel of a working texture format. `Rgba16Float` is 8 (four 16-bit
+/// half-floats); every other format the graph uses is 4-channel 8-bit (4 bytes).
+fn bytes_per_pixel(format: wgpu::TextureFormat) -> u32 {
+    match format {
+        wgpu::TextureFormat::Rgba16Float => 8,
+        _ => 4,
+    }
 }

--- a/crates/ff-render/src/graph/mod.rs
+++ b/crates/ff-render/src/graph/mod.rs
@@ -41,6 +41,23 @@ pub struct RenderGraph {
     /// `None` when constructed via `new_cpu` — `process_gpu` will return an error.
     #[cfg(feature = "wgpu")]
     ctx: Option<Arc<RenderContext>>,
+    /// Working texture format for the GPU pipeline. `Rgba8Unorm` by default;
+    /// [`with_pixel_format`](Self::with_pixel_format) promotes it to `Rgba16Float`
+    /// for high-bit-depth input so precision is not lost before any node runs.
+    #[cfg(feature = "wgpu")]
+    internal_format: wgpu::TextureFormat,
+}
+
+/// Select the working GPU texture format for a source pixel format: `Rgba16Float`
+/// for high-bit-depth (10/12-bit) input, `Rgba8Unorm` otherwise.
+#[cfg(feature = "wgpu")]
+#[must_use]
+pub(crate) fn select_texture_format(pf: ff_format::PixelFormat) -> wgpu::TextureFormat {
+    if pf.is_high_bit_depth() {
+        wgpu::TextureFormat::Rgba16Float
+    } else {
+        wgpu::TextureFormat::Rgba8Unorm
+    }
 }
 
 impl RenderGraph {
@@ -56,6 +73,7 @@ impl RenderGraph {
             cpu_nodes: Vec::new(),
             gpu_nodes: Vec::new(),
             ctx: Some(ctx),
+            internal_format: wgpu::TextureFormat::Rgba8Unorm,
         }
     }
 
@@ -72,7 +90,40 @@ impl RenderGraph {
             gpu_nodes: Vec::new(),
             #[cfg(feature = "wgpu")]
             ctx: None,
+            #[cfg(feature = "wgpu")]
+            internal_format: wgpu::TextureFormat::Rgba8Unorm,
         }
+    }
+
+    /// Set the source pixel format so the GPU pipeline runs at the matching
+    /// working precision: high-bit-depth (10/12-bit) input promotes every
+    /// internal texture to `Rgba16Float`; 8-bit input stays `Rgba8Unorm`.
+    ///
+    /// The chosen format flows through the texture-pool key and every
+    /// intermediate target. For `Rgba16Float`, drive the graph with a
+    /// high-bit-depth source node (e.g. [`YuvUploadNode::new_high_bit_depth`]);
+    /// [`process_gpu`](Self::process_gpu) then returns raw `Rgba16Float` texels
+    /// (8 bytes/pixel) rather than 8-bit RGBA.
+    ///
+    /// [`YuvUploadNode::new_high_bit_depth`]: crate::nodes::YuvUploadNode::new_high_bit_depth
+    #[cfg(feature = "wgpu")]
+    #[must_use]
+    pub fn with_pixel_format(mut self, pf: ff_format::PixelFormat) -> Self {
+        self.internal_format = select_texture_format(pf);
+        self
+    }
+
+    /// The working GPU texture format ([`Rgba8Unorm`] by default,
+    /// [`Rgba16Float`] after [`with_pixel_format`](Self::with_pixel_format) with a
+    /// high-bit-depth format). Lets a caller interpret the byte layout of the
+    /// buffer [`process_gpu`](Self::process_gpu) returns.
+    ///
+    /// [`Rgba8Unorm`]: wgpu::TextureFormat::Rgba8Unorm
+    /// [`Rgba16Float`]: wgpu::TextureFormat::Rgba16Float
+    #[cfg(feature = "wgpu")]
+    #[must_use]
+    pub fn internal_format(&self) -> wgpu::TextureFormat {
+        self.internal_format
     }
 
     /// Append a GPU+CPU node to the chain.
@@ -114,6 +165,12 @@ impl RenderGraph {
     /// Requires the `wgpu` feature and a GPU context (created via [`new`](Self::new)).
     /// Returns [`RenderError::Composite`] if called on a CPU-only graph.
     ///
+    /// `rgba` is the 8-bit source frame and the returned buffer is 8-bit RGBA by
+    /// default. After [`with_pixel_format`](Self::with_pixel_format) selects an
+    /// `Rgba16Float` working format, `rgba` is ignored (the graph is driven by a
+    /// high-bit-depth source node) and the returned buffer is raw `Rgba16Float`
+    /// texels (8 bytes/pixel); see [`internal_format`](Self::internal_format).
+    ///
     /// # Errors
     ///
     /// Returns an error on GPU device failure or staging-buffer readback failure.
@@ -122,7 +179,7 @@ impl RenderGraph {
         let ctx = self.ctx.as_ref().ok_or_else(|| RenderError::Composite {
             message: "process_gpu called on a CPU-only RenderGraph (no RenderContext)".to_string(),
         })?;
-        graph_inner::run_gpu(&self.gpu_nodes, ctx, rgba, w, h)
+        graph_inner::run_gpu(&self.gpu_nodes, ctx, rgba, w, h, self.internal_format)
     }
 
     /// Run the CPU fallback pipeline: apply each node's `process_cpu` in order.
@@ -358,6 +415,122 @@ mod gpu_tests {
             alloc_count(&ctx),
             after_first,
             "same-size frames must reuse pooled textures (steady state = 0 allocations/frame)"
+        );
+    }
+
+    /// Decode an IEEE-754 half-float (as read back from an `Rgba16Float` target)
+    /// to `f32`. Adequate for the [0, 1] RGB values these tests read.
+    #[allow(clippy::cast_precision_loss)]
+    fn f16_to_f32(bits: u16) -> f32 {
+        let sign = if bits & 0x8000 != 0 { -1.0 } else { 1.0 };
+        let exp = i32::from((bits >> 10) & 0x1f);
+        let frac = f32::from(bits & 0x3ff);
+        if exp == 0 {
+            sign * frac * 2f32.powi(-24)
+        } else if exp == 0x1f {
+            sign * f32::INFINITY
+        } else {
+            sign * (1.0 + frac / 1024.0) * 2f32.powi(exp - 15)
+        }
+    }
+
+    /// A plane of `count` little-endian `u16` samples all equal to `value`.
+    fn plane10(value: u16, count: usize) -> Vec<u8> {
+        value
+            .to_le_bytes()
+            .iter()
+            .copied()
+            .cycle()
+            .take(count * 2)
+            .collect()
+    }
+
+    #[test]
+    fn pipeline_should_select_rgba16float_for_10bit_input() {
+        use super::select_texture_format;
+        use ff_format::PixelFormat;
+
+        assert_eq!(
+            select_texture_format(PixelFormat::Yuv420p10le),
+            wgpu::TextureFormat::Rgba16Float,
+            "10-bit planar input must select Rgba16Float"
+        );
+        assert_eq!(
+            select_texture_format(PixelFormat::P010le),
+            wgpu::TextureFormat::Rgba16Float,
+            "10-bit semi-planar input must select Rgba16Float"
+        );
+        assert_eq!(
+            select_texture_format(PixelFormat::Yuv420p),
+            wgpu::TextureFormat::Rgba8Unorm,
+            "8-bit input must stay Rgba8Unorm"
+        );
+        assert_eq!(
+            select_texture_format(PixelFormat::Rgba),
+            wgpu::TextureFormat::Rgba8Unorm,
+            "8-bit RGBA input must stay Rgba8Unorm"
+        );
+        // The builder reflects the same choice (no adapter required).
+        assert_eq!(
+            RenderGraph::new_cpu()
+                .with_pixel_format(PixelFormat::Yuv420p10le)
+                .internal_format(),
+            wgpu::TextureFormat::Rgba16Float
+        );
+        assert_eq!(
+            RenderGraph::new_cpu()
+                .with_pixel_format(PixelFormat::Yuv420p)
+                .internal_format(),
+            wgpu::TextureFormat::Rgba8Unorm
+        );
+    }
+
+    #[test]
+    fn yuv_upload_should_preserve_10bit_precision_into_rgba16float() {
+        use ff_format::PixelFormat;
+
+        use crate::nodes::{YuvFormat, YuvUploadNode};
+
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (w, h) = (2u32, 2u32);
+
+        // Render one 10-bit luma value (neutral chroma) at Rgba16Float and return
+        // the read-back R channel as f32.
+        let render = |y10: u16| -> f32 {
+            let mut node = YuvUploadNode::new_high_bit_depth(YuvFormat::Yuv420p, w, h);
+            // 2×2 420p: 4 luma samples, 1 chroma sample; neutral chroma = 512.
+            node.set_planes(plane10(y10, 4), plane10(512, 1), plane10(512, 1));
+            let graph = RenderGraph::new(Arc::clone(&ctx))
+                .with_pixel_format(PixelFormat::Yuv420p10le)
+                .push(node);
+            // The 8-bit `rgba` arg is ignored for an Rgba16Float graph.
+            let out = graph.process_gpu(&[], w, h).expect("hdr frame");
+            assert_eq!(
+                out.len(),
+                (w * h * 8) as usize,
+                "Rgba16Float readback must be 8 bytes/pixel"
+            );
+            f16_to_f32(u16::from_le_bytes([out[0], out[1]]))
+        };
+
+        // Y = 512 and Y = 515 both round to 128 (0.502) in 8-bit, but differ by
+        // 3/1023 ≈ 0.0029 in 10-bit. Preserving that proves the pipeline ran at
+        // >8-bit precision (non-vacuous: an 8-bit path would make them identical).
+        let a = render(512);
+        let b = render(515);
+        assert!(
+            (a - 512.0 / 1023.0).abs() < 0.01,
+            "Y=512 must decode to ~0.5005; got {a}"
+        );
+        assert!(
+            (b - 515.0 / 1023.0).abs() < 0.01,
+            "Y=515 must decode to ~0.5034; got {b}"
+        );
+        assert!(
+            (b - a).abs() > 0.0015,
+            "10-bit precision must distinguish Y=512 from Y=515; got a={a} b={b}"
         );
     }
 }

--- a/crates/ff-render/src/nodes/upload.rs
+++ b/crates/ff-render/src/nodes/upload.rs
@@ -39,6 +39,9 @@ pub struct YuvUploadNode {
     pub width: u32,
     /// Frame height in pixels.
     pub height: u32,
+    /// `true` for 10-bit planar input (planes are little-endian `u16`, values in
+    /// `0..=1023`) rendered to an `Rgba16Float` target; `false` for 8-bit.
+    high_bit_depth: bool,
     y_plane: Vec<u8>,
     cb_plane: Vec<u8>,
     cr_plane: Vec<u8>,
@@ -46,8 +49,13 @@ pub struct YuvUploadNode {
     pipeline: std::sync::OnceLock<YuvPipeline>,
 }
 
+/// Neutral chroma value for 10-bit YUV (mid of the `0..=1023` range).
+const TEN_BIT_NEUTRAL_CHROMA: u16 = 512;
+/// Maximum 10-bit sample value.
+const TEN_BIT_MAX: f32 = 1023.0;
+
 impl YuvUploadNode {
-    /// Create a new node. Plane buffers are initialised to neutral values (Y = 0, Cb = Cr = 128).
+    /// Create a new 8-bit node. Plane buffers are initialised to neutral values (Y = 0, Cb = Cr = 128).
     #[must_use]
     pub fn new(format: YuvFormat, width: u32, height: u32) -> Self {
         let (cw, ch) = chroma_dims(format, width, height);
@@ -55,6 +63,7 @@ impl YuvUploadNode {
             format,
             width,
             height,
+            high_bit_depth: false,
             y_plane: vec![0u8; (width * height) as usize],
             cb_plane: vec![128u8; (cw * ch) as usize],
             cr_plane: vec![128u8; (cw * ch) as usize],
@@ -63,16 +72,47 @@ impl YuvUploadNode {
         }
     }
 
+    /// Create a new 10-bit planar node. Plane buffers hold little-endian `u16`
+    /// samples (values `0..=1023`) and render to an `Rgba16Float` target, so
+    /// 10-bit precision survives the upload. Neutral init: Y = 0, Cb = Cr = 512.
+    #[must_use]
+    pub fn new_high_bit_depth(format: YuvFormat, width: u32, height: u32) -> Self {
+        let (cw, ch) = chroma_dims(format, width, height);
+        Self {
+            format,
+            width,
+            height,
+            high_bit_depth: true,
+            y_plane: vec![0u8; (width * height * 2) as usize],
+            cb_plane: u16_le_plane(TEN_BIT_NEUTRAL_CHROMA, (cw * ch) as usize),
+            cr_plane: u16_le_plane(TEN_BIT_NEUTRAL_CHROMA, (cw * ch) as usize),
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+
     /// Replace the stored plane buffers.
     ///
-    /// Expected sizes for `width × height` at `format`:
-    /// - `y`:       `width × height` bytes
-    /// - `cb`, `cr`: `chroma_w × chroma_h` bytes (sub-sampled per [`YuvFormat`])
+    /// Expected sizes for `width × height` at `format`, per sample:
+    /// - 8-bit: 1 byte; 10-bit ([`new_high_bit_depth`](Self::new_high_bit_depth)): 2 bytes (little-endian `u16`)
+    /// - `y`:       `width × height` samples
+    /// - `cb`, `cr`: `chroma_w × chroma_h` samples (sub-sampled per [`YuvFormat`])
     pub fn set_planes(&mut self, y: Vec<u8>, cb: Vec<u8>, cr: Vec<u8>) {
         self.y_plane = y;
         self.cb_plane = cb;
         self.cr_plane = cr;
     }
+}
+
+/// Build a plane of `count` little-endian `u16` samples all equal to `value`.
+fn u16_le_plane(value: u16, count: usize) -> Vec<u8> {
+    value
+        .to_le_bytes()
+        .iter()
+        .copied()
+        .cycle()
+        .take(count * 2)
+        .collect()
 }
 
 impl Default for YuvUploadNode {
@@ -101,15 +141,26 @@ fn chroma_divs(format: YuvFormat) -> (u32, u32) {
 // CPU path
 
 impl RenderNodeCpu for YuvUploadNode {
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
+        if self.y_plane.is_empty() || self.width == 0 || self.height == 0 {
+            return;
+        }
+        if self.high_bit_depth {
+            self.process_cpu_10bit(rgba, w, h);
+        } else {
+            self.process_cpu_8bit(rgba, w, h);
+        }
+    }
+}
+
+impl YuvUploadNode {
+    /// CPU YCbCr→RGBA for 8-bit planar input (1 byte per sample).
     #[allow(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         clippy::many_single_char_names
     )]
-    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
-        if self.y_plane.is_empty() || self.width == 0 || self.height == 0 {
-            return;
-        }
+    fn process_cpu_8bit(&self, rgba: &mut [u8], w: u32, h: u32) {
         let (cw, _) = chroma_dims(self.format, self.width, self.height);
         let (x_div, y_div) = chroma_divs(self.format);
         let rows = h.min(self.height) as usize;
@@ -122,18 +173,56 @@ impl RenderNodeCpu for YuvUploadNode {
                 let ci = cy * cw as usize + cx;
                 let cb = f32::from(self.cb_plane[ci]) / 255.0 - 0.5;
                 let cr = f32::from(self.cr_plane[ci]) / 255.0 - 0.5;
-                // BT.601 full-range YCbCr → linear RGB.
-                let r = (y_val + 1.402 * cr).clamp(0.0, 1.0);
-                let g = (y_val - 0.344 * cb - 0.714 * cr).clamp(0.0, 1.0);
-                let b = (y_val + 1.772 * cb).clamp(0.0, 1.0);
-                let idx = (row * w as usize + col) * 4;
-                rgba[idx] = (r * 255.0 + 0.5) as u8;
-                rgba[idx + 1] = (g * 255.0 + 0.5) as u8;
-                rgba[idx + 2] = (b * 255.0 + 0.5) as u8;
-                rgba[idx + 3] = 255;
+                write_ycbcr_rgba(rgba, (row * w as usize + col) * 4, y_val, cb, cr);
             }
         }
     }
+
+    /// CPU YCbCr→RGBA for 10-bit planar input (little-endian `u16` samples,
+    /// values `0..=1023`). The CPU fallback still writes 8-bit RGBA, so it loses
+    /// precision the GPU `Rgba16Float` path preserves.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::many_single_char_names
+    )]
+    fn process_cpu_10bit(&self, rgba: &mut [u8], w: u32, h: u32) {
+        let (cw, _) = chroma_dims(self.format, self.width, self.height);
+        let (x_div, y_div) = chroma_divs(self.format);
+        let rows = h.min(self.height) as usize;
+        let cols = w.min(self.width) as usize;
+        for row in 0..rows {
+            for col in 0..cols {
+                let y_val =
+                    sample_u16_le(&self.y_plane, row * self.width as usize + col) / TEN_BIT_MAX;
+                let cx = col / x_div as usize;
+                let cy = row / y_div as usize;
+                let ci = cy * cw as usize + cx;
+                let cb = sample_u16_le(&self.cb_plane, ci) / TEN_BIT_MAX - 0.5;
+                let cr = sample_u16_le(&self.cr_plane, ci) / TEN_BIT_MAX - 0.5;
+                write_ycbcr_rgba(rgba, (row * w as usize + col) * 4, y_val, cb, cr);
+            }
+        }
+    }
+}
+
+/// Read the `i`-th little-endian `u16` sample of a plane as `f32`.
+fn sample_u16_le(plane: &[u8], i: usize) -> f32 {
+    let lo = plane[i * 2];
+    let hi = plane[i * 2 + 1];
+    f32::from(u16::from_le_bytes([lo, hi]))
+}
+
+/// BT.601 full-range YCbCr → RGBA, writing 4 bytes at `idx` (alpha = 255).
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn write_ycbcr_rgba(rgba: &mut [u8], idx: usize, y_val: f32, cb: f32, cr: f32) {
+    let r = (y_val + 1.402 * cr).clamp(0.0, 1.0);
+    let g = (y_val - 0.344 * cb - 0.714 * cr).clamp(0.0, 1.0);
+    let b = (y_val + 1.772 * cb).clamp(0.0, 1.0);
+    rgba[idx] = (r * 255.0 + 0.5) as u8;
+    rgba[idx + 1] = (g * 255.0 + 0.5) as u8;
+    rgba[idx + 2] = (b * 255.0 + 0.5) as u8;
+    rgba[idx + 3] = 255;
 }
 
 // GPU path
@@ -146,9 +235,30 @@ impl YuvUploadNode {
             let device = &ctx.device;
             let (cw, ch) = chroma_dims(self.format, self.width, self.height);
 
+            // 10-bit planes are R16Uint (raw 0..1023) sampled as integers and
+            // divided by max_value in the shader, rendering to Rgba16Float so
+            // precision survives. R16Uint is a core format (unlike R16Unorm,
+            // which needs an optional device feature). 8-bit planes stay R8Unorm
+            // sampled as normalised floats, rendering to Rgba8Unorm.
+            let (plane_format, target_format, sample_type, shader_src) = if self.high_bit_depth {
+                (
+                    wgpu::TextureFormat::R16Uint,
+                    wgpu::TextureFormat::Rgba16Float,
+                    wgpu::TextureSampleType::Uint,
+                    include_str!("../shaders/yuv_upload_10bit.wgsl"),
+                )
+            } else {
+                (
+                    wgpu::TextureFormat::R8Unorm,
+                    wgpu::TextureFormat::Rgba8Unorm,
+                    wgpu::TextureSampleType::Float { filterable: false },
+                    include_str!("../shaders/yuv_upload.wgsl"),
+                )
+            };
+
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("YuvUpload shader"),
-                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/yuv_upload.wgsl").into()),
+                source: wgpu::ShaderSource::Wgsl(shader_src.into()),
             });
 
             let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -158,7 +268,7 @@ impl YuvUploadNode {
                         binding: 0,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                            sample_type,
                             view_dimension: wgpu::TextureViewDimension::D2,
                             multisampled: false,
                         },
@@ -168,7 +278,7 @@ impl YuvUploadNode {
                         binding: 1,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                            sample_type,
                             view_dimension: wgpu::TextureViewDimension::D2,
                             multisampled: false,
                         },
@@ -178,7 +288,7 @@ impl YuvUploadNode {
                         binding: 2,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                            sample_type,
                             view_dimension: wgpu::TextureViewDimension::D2,
                             multisampled: false,
                         },
@@ -216,7 +326,7 @@ impl YuvUploadNode {
                     module: &shader,
                     entry_point: Some("fs_main"),
                     targets: &[Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        format: target_format,
                         blend: None,
                         write_mask: wgpu::ColorWrites::ALL,
                     })],
@@ -229,7 +339,7 @@ impl YuvUploadNode {
                 cache: None,
             });
 
-            // Y luma plane (R8Unorm, full resolution).
+            // Y luma plane (full resolution).
             let y_tex = device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("YuvUpload Y"),
                 size: wgpu::Extent3d {
@@ -240,12 +350,12 @@ impl YuvUploadNode {
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::R8Unorm,
+                format: plane_format,
                 usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             });
 
-            // Cb chroma plane (R8Unorm, sub-sampled).
+            // Cb chroma plane (sub-sampled).
             let cb_tex = device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("YuvUpload Cb"),
                 size: wgpu::Extent3d {
@@ -256,12 +366,12 @@ impl YuvUploadNode {
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::R8Unorm,
+                format: plane_format,
                 usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             });
 
-            // Cr chroma plane (R8Unorm, sub-sampled).
+            // Cr chroma plane (sub-sampled).
             let cr_tex = device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("YuvUpload Cr"),
                 size: wgpu::Extent3d {
@@ -272,7 +382,7 @@ impl YuvUploadNode {
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::R8Unorm,
+                format: plane_format,
                 usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             });
@@ -322,6 +432,8 @@ impl super::RenderNode for YuvUploadNode {
         let pd = self.get_or_create_pipeline(ctx);
         let (cw, ch) = chroma_dims(self.format, self.width, self.height);
         let (x_div, y_div) = chroma_divs(self.format);
+        // Bytes per sample: 8-bit R8Unorm = 1, 10-bit R16Unorm = 2.
+        let bps = if self.high_bit_depth { 2 } else { 1 };
 
         // Upload Y luma plane.
         ctx.queue.write_texture(
@@ -334,7 +446,7 @@ impl super::RenderNode for YuvUploadNode {
             &self.y_plane,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(self.width),
+                bytes_per_row: Some(self.width * bps),
                 rows_per_image: None,
             },
             wgpu::Extent3d {
@@ -355,7 +467,7 @@ impl super::RenderNode for YuvUploadNode {
             &self.cb_plane,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(cw),
+                bytes_per_row: Some(cw * bps),
                 rows_per_image: None,
             },
             wgpu::Extent3d {
@@ -376,7 +488,7 @@ impl super::RenderNode for YuvUploadNode {
             &self.cr_plane,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(cw),
+                bytes_per_row: Some(cw * bps),
                 rows_per_image: None,
             },
             wgpu::Extent3d {
@@ -386,9 +498,14 @@ impl super::RenderNode for YuvUploadNode {
             },
         );
 
-        // Write chroma sub-sampling divisors to the uniform buffer.
-        ctx.queue
-            .write_buffer(&pd.uniform_buf, 0, &pack_u32(&[x_div, y_div, 0, 0]));
+        // Uniforms: [chroma_x_div: u32, chroma_y_div: u32, max_value: f32, pad].
+        // max_value is the 10-bit shader's normalisation divisor (1023); the
+        // 8-bit shader ignores this slot (its plane samples are pre-normalised).
+        let mut uniforms = [0u8; 16];
+        uniforms[0..4].copy_from_slice(&x_div.to_le_bytes());
+        uniforms[4..8].copy_from_slice(&y_div.to_le_bytes());
+        uniforms[8..12].copy_from_slice(&TEN_BIT_MAX.to_le_bytes());
+        ctx.queue.write_buffer(&pd.uniform_buf, 0, &uniforms);
 
         let y_view = pd
             .y_tex
@@ -596,6 +713,29 @@ mod tests {
     }
 
     #[test]
+    fn yuv_upload_cpu_10bit_should_decode_u16_planes() {
+        // Y = 768 (10-bit) → 768/1023 ≈ 0.751 → grey ≈ 191. Neutral chroma 512.
+        // A byte-truncating misread of the little-endian u16 (low byte 0x00)
+        // would yield 0, so asserting ~191 proves the u16 decode (non-vacuous).
+        let mut node = YuvUploadNode::new_high_bit_depth(YuvFormat::Yuv420p, 2, 2);
+        node.set_planes(
+            u16_le_plane(768, 4),
+            u16_le_plane(512, 1),
+            u16_le_plane(512, 1),
+        );
+        let mut rgba = vec![0u8; 16];
+        node.process_cpu(&mut rgba, 2, 2);
+        for pixel in rgba.chunks_exact(4) {
+            let r = i32::from(pixel[0]);
+            assert!(
+                (r - 191).abs() <= 3,
+                "10-bit Y=768 must decode to ~191; got {r}"
+            );
+            assert_eq!(pixel[3], 255, "alpha must be opaque");
+        }
+    }
+
+    #[test]
     fn yuv_upload_node_variant_and_error_types_should_compile() {
         let _ = YuvFormat::Yuv420p;
         let _ = YuvFormat::Yuv422p;
@@ -603,11 +743,4 @@ mod tests {
         let _ = YuvUploadNode::new(YuvFormat::Yuv420p, 320, 240);
         let _ = YuvUploadNode::default();
     }
-}
-
-// helpers
-
-#[cfg(feature = "wgpu")]
-fn pack_u32(values: &[u32]) -> Vec<u8> {
-    values.iter().flat_map(|v| v.to_le_bytes()).collect()
 }

--- a/crates/ff-render/src/shaders/yuv_upload_10bit.wgsl
+++ b/crates/ff-render/src/shaders/yuv_upload_10bit.wgsl
@@ -1,0 +1,63 @@
+// 10-bit planar YUV upload → RGBA. Planes are R16Uint (raw values 0..=1023, not
+// normalised), so this samples unsigned integers and divides by `max_value` to
+// reach [0, 1]. The render target is Rgba16Float, so 10-bit precision survives.
+// Kept separate from the 8-bit shader because the plane textures differ in sample
+// type (u32 here vs normalised f32 there).
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var y_tex:  texture_2d<u32>;
+@group(0) @binding(1) var cb_tex: texture_2d<u32>;
+@group(0) @binding(2) var cr_tex: texture_2d<u32>;
+@group(0) @binding(3) var<uniform> u: YuvUniforms;
+
+struct YuvUniforms {
+    chroma_x_div: u32,
+    chroma_y_div: u32,
+    // Divisor that maps a raw sample to [0, 1] (1023 for 10-bit).
+    max_value: f32,
+    _pad1: u32,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let luma_size = textureDimensions(y_tex);
+    let px = min(
+        vec2<i32>(in.uv * vec2<f32>(f32(luma_size.x), f32(luma_size.y))),
+        vec2<i32>(i32(luma_size.x) - 1, i32(luma_size.y) - 1),
+    );
+    let y_val = f32(textureLoad(y_tex, px, 0).r) / u.max_value;
+
+    let chroma_size = textureDimensions(cb_tex);
+    let cpx = min(
+        vec2<i32>(px.x / i32(u.chroma_x_div), px.y / i32(u.chroma_y_div)),
+        vec2<i32>(i32(chroma_size.x) - 1, i32(chroma_size.y) - 1),
+    );
+    let cb = f32(textureLoad(cb_tex, cpx, 0).r) / u.max_value - 0.5;
+    let cr = f32(textureLoad(cr_tex, cpx, 0).r) / u.max_value - 0.5;
+
+    // BT.601 full-range YCbCr → linear RGB.
+    let r = clamp(y_val + 1.402  * cr,              0.0, 1.0);
+    let g = clamp(y_val - 0.344  * cb - 0.714 * cr, 0.0, 1.0);
+    let b = clamp(y_val + 1.772  * cb,              0.0, 1.0);
+    return vec4<f32>(r, g, b, 1.0);
+}


### PR DESCRIPTION
## Objective

- The GPU pipeline always ran at `Rgba8Unorm`, so 10-bit input lost precision before any node executed.
- The v0.20.0 colour-science nodes (#1052 / #1053) need the graph to preserve 10/12-bit precision end to end.

## Solution

- `RenderGraph::with_pixel_format(PixelFormat)` selects the working format via `PixelFormat::is_high_bit_depth()` (`Rgba16Float` for 10/12-bit, `Rgba8Unorm` otherwise); `internal_format()` exposes the choice so a caller can interpret the returned texels.
- `run_gpu` threads that format through the texture pool and every intermediate target, sizes the readback by bytes-per-pixel, and skips the 8-bit input upload for an HDR graph (which is driven by a source node).
- `YuvUploadNode::new_high_bit_depth` adds a planar 10-bit path: little-endian `u16` planes upload to `R16Uint` textures and render through a dedicated integer-sampling shader to an `Rgba16Float` target. `R16Uint` is a core format (unlike `R16Unorm`, which needs an optional device feature); the 8-bit `R8Unorm` path is unchanged.
- Tests (gated behind `wgpu`, skipped without an adapter): format selection, and a non-vacuous precision test asserting two 10-bit values that collapse to one 8-bit level stay distinguishable at `Rgba16Float`.

P010 semi-planar upload is deferred to #1607.

Closes #1054