### PR TITLE
feat(ff-render): DisplaySink / zero-copy push_frame_gpu

### DIFF
--- a/crates/ff-preview/Cargo.toml
+++ b/crates/ff-preview/Cargo.toml
@@ -25,12 +25,16 @@ tokio       = { version = "1.50.0", features = ["rt", "sync"], optional = true }
 ff-encode   = { workspace = true, optional = true }
 ff-filter   = { workspace = true, optional = true }
 ff-pipeline = { workspace = true, optional = true }
+wgpu        = { version = "30.0.0", optional = true }
 
 [features]
 default  = []
 tokio    = ["dep:tokio"]
 proxy    = ["dep:ff-encode", "dep:ff-filter", "dep:ff-pipeline"]
 timeline = ["dep:ff-filter"]
+# GPU-resident frame delivery: extends FrameSink with a zero-copy texture path.
+# Pulls in wgpu (kept in lockstep with ff-render's pin).
+display  = ["dep:wgpu"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/ff-preview/src/playback/sink.rs
+++ b/crates/ff-preview/src/playback/sink.rs
@@ -32,6 +32,36 @@ pub trait FrameSink: Send {
     ///
     /// Implementations should flush any pending output here.
     fn flush(&mut self) {}
+
+    /// Whether this sink can receive a GPU-resident frame via
+    /// [`push_frame_gpu`](Self::push_frame_gpu). Default: `false` (CPU only).
+    ///
+    /// A GPU compositor queries this to decide whether it can hand off a
+    /// composited texture directly (no GPU-to-CPU readback) or must fall back to
+    /// the CPU [`push_frame`](Self::push_frame) path.
+    #[cfg(feature = "display")]
+    fn accepts_gpu_frame(&self) -> bool {
+        false
+    }
+
+    /// Receive a composited frame as a GPU texture, avoiding a GPU-to-CPU
+    /// readback. Only called when [`accepts_gpu_frame`](Self::accepts_gpu_frame)
+    /// returns `true`; the default ignores the frame.
+    ///
+    /// `texture` is a row-major RGBA texture (`view` is its default view) of
+    /// `width × height`. It is owned by the caller for the duration of the call;
+    /// a sink that needs it beyond the call must copy or clone it.
+    #[cfg(feature = "display")]
+    fn push_frame_gpu(
+        &mut self,
+        texture: &wgpu::Texture,
+        view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+        pts: Duration,
+    ) {
+        let _ = (texture, view, width, height, pts);
+    }
 }
 
 // RgbaFrame / RgbaSink

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -17,6 +17,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 wgpu    = ["dep:wgpu"]
+# GPU-resident preview: hand the composited texture to the sink without a
+# GPU-to-CPU readback. Implies wgpu and enables ff-preview's matching path.
+display = ["wgpu", "ff-preview/display"]
 
 [dependencies]
 ff-preview = { workspace = true }

--- a/crates/ff-render/src/context.rs
+++ b/crates/ff-render/src/context.rs
@@ -1,4 +1,5 @@
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::RenderError;
 use crate::pool::TexturePool;
@@ -13,6 +14,9 @@ pub struct RenderContext {
     /// Shared reuse pool for GPU textures, so the graph (and, later, the
     /// compositor) avoid per-frame texture allocation.
     pub(crate) pool: Mutex<TexturePool>,
+    /// Count of GPU-to-CPU readbacks performed (staging-buffer maps). The
+    /// zero-copy display path never increments this; tests assert it stays flat.
+    pub(crate) readback_count: AtomicU64,
 }
 
 impl RenderContext {
@@ -23,7 +27,19 @@ impl RenderContext {
             device,
             queue,
             pool: Mutex::new(TexturePool::new()),
+            readback_count: AtomicU64::new(0),
         }
+    }
+
+    /// Record one GPU-to-CPU readback (called from the staging-buffer path).
+    pub(crate) fn note_readback(&self) {
+        self.readback_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Number of GPU-to-CPU readbacks performed so far.
+    #[cfg(test)]
+    pub(crate) fn readback_count(&self) -> u64 {
+        self.readback_count.load(Ordering::Relaxed)
     }
 
     /// Initialise wgpu using the default (best available) backend.
@@ -87,6 +103,7 @@ impl RenderContext {
             device,
             queue,
             pool: Mutex::new(TexturePool::new()),
+            readback_count: AtomicU64::new(0),
         })
     }
 }

--- a/crates/ff-render/src/graph/graph_inner.rs
+++ b/crates/ff-render/src/graph/graph_inner.rs
@@ -4,28 +4,23 @@ use crate::context::RenderContext;
 use crate::error::RenderError;
 use crate::nodes::RenderNode;
 use crate::pool::FrameScope;
+use crate::sink::TextureHandle;
 
-/// Execute all `nodes` on the `rgba` input and return the processed RGBA bytes.
+/// Acquire textures, upload the input, and run every node. Returns the scope
+/// (holding all frame textures) and the index of the final composited texture.
 ///
-/// Textures are drawn from the context's [`TexturePool`](crate::pool) via a
-/// [`FrameScope`], so a warmed-up pipeline allocates no textures per frame; the
-/// scope returns them all to the pool when it drops.
+/// Textures are drawn from the context's [`TexturePool`](crate::pool) via the
+/// returned [`FrameScope`]; how the final texture is consumed (read back, or
+/// taken out for display) is up to the caller, which owns the scope.
 #[allow(clippy::too_many_lines)]
-pub(super) fn run_gpu(
+fn execute_nodes<'a>(
     nodes: &[Box<dyn RenderNode>],
-    ctx: &Arc<RenderContext>,
+    ctx: &'a Arc<RenderContext>,
     rgba: &[u8],
     w: u32,
     h: u32,
     format: wgpu::TextureFormat,
-) -> Result<Vec<u8>, RenderError> {
-    if nodes.is_empty() {
-        return Ok(rgba.to_vec());
-    }
-
-    // Bytes per pixel of the working format: 8 for Rgba16Float (HDR), 4 for the
-    // 4-channel 8-bit default. Drives the input upload and the readback stride.
-    let bpp = bytes_per_pixel(format);
+) -> (FrameScope<'a>, usize) {
     let input_usage = wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING;
     // Outputs double as general-purpose scratch: `COPY_DST` lets a node (or test)
     // fill a pass target via `write_texture`, `COPY_SRC` allows readback, and
@@ -103,6 +98,31 @@ pub(super) fn run_gpu(
         }
     }
 
+    (scope, current_idx)
+}
+
+/// Execute all `nodes` on the `rgba` input and return the processed RGBA bytes.
+///
+/// Reads the final texture back to system memory (a GPU-to-CPU copy per frame).
+/// For a zero-copy display path, use [`run_gpu_to_texture`] instead.
+pub(super) fn run_gpu(
+    nodes: &[Box<dyn RenderNode>],
+    ctx: &Arc<RenderContext>,
+    rgba: &[u8],
+    w: u32,
+    h: u32,
+    format: wgpu::TextureFormat,
+) -> Result<Vec<u8>, RenderError> {
+    if nodes.is_empty() {
+        return Ok(rgba.to_vec());
+    }
+
+    // Bytes per pixel of the working format: 8 for Rgba16Float (HDR), 4 for the
+    // 4-channel 8-bit default. Drives the readback stride.
+    let bpp = bytes_per_pixel(format);
+    let (scope, current_idx) = execute_nodes(nodes, ctx, rgba, w, h, format);
+    ctx.note_readback();
+
     // Copy the final texture to a CPU-readable staging buffer.
     let bytes_per_row_padded = align_up(w * bpp, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
     let buffer_size = u64::from(bytes_per_row_padded) * u64::from(h);
@@ -175,6 +195,36 @@ pub(super) fn run_gpu(
     staging_buf.unmap();
 
     Ok(out)
+}
+
+/// Execute all `nodes` and hand the final composited texture to the caller as a
+/// [`TextureHandle`], **without** any GPU-to-CPU readback.
+///
+/// The texture is taken out of the pool (ownership transfers to the caller), so
+/// it stays valid for direct display; the graph's intermediate textures are
+/// returned to the pool. No staging buffer is mapped, so [`RenderContext`]'s
+/// readback counter is not incremented.
+pub(super) fn run_gpu_to_texture(
+    nodes: &[Box<dyn RenderNode>],
+    ctx: &Arc<RenderContext>,
+    rgba: &[u8],
+    w: u32,
+    h: u32,
+    format: wgpu::TextureFormat,
+) -> Result<TextureHandle, RenderError> {
+    let (scope, current_idx) = execute_nodes(nodes, ctx, rgba, w, h, format);
+    let texture = scope
+        .take(current_idx)
+        .ok_or_else(|| RenderError::Composite {
+            message: "no composited texture to display".to_string(),
+        })?;
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    Ok(TextureHandle {
+        texture,
+        view,
+        width: w,
+        height: h,
+    })
 }
 
 fn align_up(value: u32, alignment: u32) -> u32 {

--- a/crates/ff-render/src/graph/mod.rs
+++ b/crates/ff-render/src/graph/mod.rs
@@ -182,6 +182,32 @@ impl RenderGraph {
         graph_inner::run_gpu(&self.gpu_nodes, ctx, rgba, w, h, self.internal_format)
     }
 
+    /// Run the GPU pipeline and return the composited frame as a GPU
+    /// [`TextureHandle`](crate::sink::TextureHandle), **without** a GPU-to-CPU
+    /// readback. Use this for zero-copy display; use [`process_gpu`](Self::process_gpu)
+    /// when the caller needs the pixels in system memory.
+    ///
+    /// The returned texture is owned by the caller (taken out of the pool) and
+    /// stays valid until dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RenderError::Composite`] if called on a CPU-only graph, or on
+    /// GPU device failure.
+    #[cfg(feature = "wgpu")]
+    pub fn process_gpu_to_texture(
+        &self,
+        rgba: &[u8],
+        w: u32,
+        h: u32,
+    ) -> Result<crate::sink::TextureHandle, RenderError> {
+        let ctx = self.ctx.as_ref().ok_or_else(|| RenderError::Composite {
+            message: "process_gpu_to_texture called on a CPU-only RenderGraph (no RenderContext)"
+                .to_string(),
+        })?;
+        graph_inner::run_gpu_to_texture(&self.gpu_nodes, ctx, rgba, w, h, self.internal_format)
+    }
+
     /// Run the CPU fallback pipeline: apply each node's `process_cpu` in order.
     ///
     /// Both CPU-only nodes (`push_cpu`) and GPU nodes (`push`, wgpu feature)
@@ -415,6 +441,30 @@ mod gpu_tests {
             alloc_count(&ctx),
             after_first,
             "same-size frames must reuse pooled textures (steady state = 0 allocations/frame)"
+        );
+    }
+
+    #[test]
+    fn process_gpu_to_texture_should_return_handle_of_input_dimensions() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let graph =
+            RenderGraph::new(Arc::clone(&ctx)).push(ColorGradeNode::new(0.0, 1.0, 1.0, 0.0, 0.0));
+        let (w, h) = (16u32, 16u32);
+        let rgba = vec![128u8; (w * h * 4) as usize];
+
+        let handle = graph
+            .process_gpu_to_texture(&rgba, w, h)
+            .expect("texture handle");
+        assert_eq!(handle.width, w, "handle width must match input");
+        assert_eq!(handle.height, h, "handle height must match input");
+        assert_eq!(handle.texture.width(), w, "GPU texture width must match");
+        assert_eq!(handle.texture.height(), h, "GPU texture height must match");
+        assert_eq!(
+            ctx.readback_count(),
+            0,
+            "the texture path must not read back to system memory"
         );
     }
 

--- a/crates/ff-render/src/pool.rs
+++ b/crates/ff-render/src/pool.rs
@@ -127,6 +127,27 @@ impl<'a> FrameScope<'a> {
     pub(crate) fn get(&self, index: usize) -> &wgpu::Texture {
         &self.items[index].1
     }
+
+    /// Consume the scope, returning the texture at `index` to the caller and
+    /// releasing every other acquired texture back to the pool.
+    ///
+    /// The returned texture is **not** pooled: ownership transfers to the caller
+    /// (e.g. for zero-copy display), so it will not be handed out again until the
+    /// caller drops it. Returns `None` if `index` is out of range.
+    pub(crate) fn take(mut self, index: usize) -> Option<wgpu::Texture> {
+        // Empty `items` so the `Drop` below releases nothing (no double-return).
+        let items = std::mem::take(&mut self.items);
+        let mut pool = lock(self.pool);
+        let mut taken = None;
+        for (i, (key, texture)) in items.into_iter().enumerate() {
+            if i == index {
+                taken = Some(texture);
+            } else {
+                pool.release(key, texture);
+            }
+        }
+        taken
+    }
 }
 
 impl Drop for FrameScope<'_> {
@@ -148,6 +169,50 @@ mod tests {
             Ok(ctx) => Some(ctx.device),
             Err(_) => None,
         }
+    }
+
+    #[test]
+    fn frame_scope_take_should_not_return_taken_texture_to_pool() {
+        use std::sync::{Mutex, PoisonError};
+
+        let Some(device) = device() else {
+            return;
+        };
+        let pool = Mutex::new(TexturePool::new());
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+        let usage = wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING;
+
+        // Acquire two textures via a scope, take the first, drop the scope. Only
+        // the second (untaken) texture is released back to the pool.
+        {
+            let mut scope = super::FrameScope::new(&pool, &device);
+            let a = scope.acquire(16, 16, format, usage);
+            let _b = scope.acquire(16, 16, format, usage);
+            let taken = scope.take(a);
+            assert!(
+                taken.is_some(),
+                "take must return the texture at a valid index"
+            );
+        }
+
+        let mut guard = pool.lock().unwrap_or_else(PoisonError::into_inner);
+        let allocs = guard.alloc_count();
+        assert_eq!(allocs, 2, "the two scope acquires were pool misses");
+        // One texture is pooled (the untaken one): first acquire reuses it.
+        let reused = guard.acquire(&device, 16, 16, format, usage);
+        assert_eq!(
+            guard.alloc_count(),
+            allocs,
+            "the released texture must be reused, not allocated"
+        );
+        // The taken texture was NOT pooled, so a second acquire must allocate.
+        let _fresh = guard.acquire(&device, 16, 16, format, usage);
+        assert_eq!(
+            guard.alloc_count(),
+            allocs + 1,
+            "the taken texture was not returned to the pool, so this acquire allocates"
+        );
+        drop(reused);
     }
 
     #[test]

--- a/crates/ff-render/src/sink/mod.rs
+++ b/crates/ff-render/src/sink/mod.rs
@@ -55,6 +55,29 @@ impl GpuFrameSink {
 
 impl FrameSink for GpuFrameSink {
     fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
+        // Zero-copy path: when the downstream accepts a GPU frame, hand it the
+        // composited texture directly (no GPU-to-CPU readback). On failure, fall
+        // through to the readback path.
+        #[cfg(feature = "display")]
+        {
+            if self.downstream.accepts_gpu_frame() {
+                match self.graph.process_gpu_to_texture(rgba, width, height) {
+                    Ok(handle) => {
+                        self.downstream.push_frame_gpu(
+                            &handle.texture,
+                            &handle.view,
+                            handle.width,
+                            handle.height,
+                            pts,
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        log::warn!("GpuFrameSink zero-copy path failed, using readback error={e}");
+                    }
+                }
+            }
+        }
         #[cfg(feature = "wgpu")]
         {
             match self.graph.process_gpu(rgba, width, height) {
@@ -151,5 +174,104 @@ mod tests {
     fn gpu_frame_sink_should_be_send() {
         fn assert_send<T: Send>() {}
         assert_send::<GpuFrameSink>();
+    }
+}
+
+#[cfg(all(test, feature = "display"))]
+mod display_tests {
+    use std::sync::{Arc, Mutex, PoisonError};
+    use std::time::Duration;
+
+    use ff_preview::FrameSink;
+
+    use super::GpuFrameSink;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use crate::nodes::ColorGradeNode;
+
+    /// A headless GPU context, or `None` when no adapter is available (CI).
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    /// Downstream that accepts a GPU frame and records its dimensions.
+    struct GpuCapture(Arc<Mutex<Option<(u32, u32)>>>);
+    impl FrameSink for GpuCapture {
+        fn push_frame(&mut self, _rgba: &[u8], _w: u32, _h: u32, _pts: Duration) {
+            unreachable!("the zero-copy path must not call the CPU push_frame");
+        }
+        fn accepts_gpu_frame(&self) -> bool {
+            true
+        }
+        fn push_frame_gpu(
+            &mut self,
+            _texture: &wgpu::Texture,
+            _view: &wgpu::TextureView,
+            width: u32,
+            height: u32,
+            _pts: Duration,
+        ) {
+            *self.0.lock().unwrap_or_else(PoisonError::into_inner) = Some((width, height));
+        }
+    }
+
+    /// CPU-only downstream (default `accepts_gpu_frame() == false`).
+    struct CpuCapture(Arc<Mutex<bool>>);
+    impl FrameSink for CpuCapture {
+        fn push_frame(&mut self, _rgba: &[u8], _w: u32, _h: u32, _pts: Duration) {
+            *self.0.lock().unwrap_or_else(PoisonError::into_inner) = true;
+        }
+    }
+
+    #[test]
+    fn gpu_sink_should_forward_a_texture_without_cpu_readback() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let graph =
+            RenderGraph::new(Arc::clone(&ctx)).push(ColorGradeNode::new(0.0, 1.0, 1.0, 0.0, 0.0));
+        let got = Arc::new(Mutex::new(None));
+        let mut sink = GpuFrameSink::new(graph, Box::new(GpuCapture(Arc::clone(&got))));
+
+        let (w, h) = (16u32, 16u32);
+        sink.push_frame(&vec![128u8; (w * h * 4) as usize], w, h, Duration::ZERO);
+
+        assert_eq!(
+            *got.lock().unwrap_or_else(PoisonError::into_inner),
+            Some((w, h)),
+            "the GPU downstream must receive the composited texture"
+        );
+        assert_eq!(
+            ctx.readback_count(),
+            0,
+            "the zero-copy display path must perform no GPU-to-CPU readback"
+        );
+    }
+
+    #[test]
+    fn gpu_sink_cpu_downstream_should_use_readback_path() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let graph =
+            RenderGraph::new(Arc::clone(&ctx)).push(ColorGradeNode::new(0.0, 1.0, 1.0, 0.0, 0.0));
+        let got = Arc::new(Mutex::new(false));
+        let mut sink = GpuFrameSink::new(graph, Box::new(CpuCapture(Arc::clone(&got))));
+
+        let (w, h) = (16u32, 16u32);
+        sink.push_frame(&vec![128u8; (w * h * 4) as usize], w, h, Duration::ZERO);
+
+        assert!(
+            *got.lock().unwrap_or_else(PoisonError::into_inner),
+            "a CPU-only downstream must receive a CPU frame"
+        );
+        assert_eq!(
+            ctx.readback_count(),
+            1,
+            "a CPU-only downstream falls back to the readback path (proves the counter moves)"
+        );
     }
 }


### PR DESCRIPTION
## Objective

- `GpuFrameSink` reads the composited texture back to a `Vec<u8>` every frame, and that per-frame GPU-to-CPU readback dominates preview latency.
- `TextureHandle` existed but was unused, and there was no GPU-resident display path.

## Solution

- A new `display` feature extends `ff_preview::FrameSink` with two gated default methods: `accepts_gpu_frame()` (capability query) and `push_frame_gpu()`, which receives a wgpu texture handle. ff-preview gains an optional wgpu dependency behind the feature (no dependency cycle: wgpu is external).
- `RenderGraph::process_gpu_to_texture` runs the graph and takes the final texture out of the pool (`FrameScope::take` transfers ownership), returning a `TextureHandle` with no staging-buffer readback.
- `GpuFrameSink` uses the zero-copy path when the downstream accepts GPU frames and falls back to the existing readback path otherwise (CPU downstream, GPU error, or feature/adapter absent).
- `run_gpu` and the new `run_gpu_to_texture` share an extracted `execute_nodes` helper, so the 8-bit readback path is unchanged. `RenderContext` gains a readback counter so tests assert the display path performs zero readbacks (a CPU-downstream contrast test proves the counter moves).

Closes #1587