### PR TITLE
feat(ff-render): real ScaleNode (variable output dimensions) + CPU scaler

### DIFF
--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -26,6 +26,7 @@ ff-preview = { workspace = true }
 ff-format  = { workspace = true }
 log        = { workspace = true }
 thiserror  = { workspace = true }
+image      = { workspace = true }
 
 [dependencies.wgpu]
 version  = "30.0.0"

--- a/crates/ff-render/src/graph/graph_inner.rs
+++ b/crates/ff-render/src/graph/graph_inner.rs
@@ -38,14 +38,21 @@ fn execute_nodes<'a>(
     // final result into the last one, which becomes the next node's input[0].
     let mut scope = FrameScope::new(&ctx.pool, &ctx.device);
     let input_idx = scope.acquire(w, h, format, input_usage);
-    let output_idx: Vec<Vec<usize>> = nodes
-        .iter()
-        .map(|node| {
-            (0..node.pass_count().max(1))
-                .map(|_| scope.acquire(w, h, format, output_usage))
-                .collect()
-        })
-        .collect();
+    // A node may resize (e.g. ScaleNode); thread the running size so each node's
+    // output targets — and thus the next node's input — are the right size.
+    // input[1..] (the original source) stays at the initial `w` x `h`.
+    let mut cur_w = w;
+    let mut cur_h = h;
+    let mut output_idx: Vec<Vec<usize>> = Vec::with_capacity(nodes.len());
+    for node in nodes {
+        let (out_w, out_h) = node.output_dimensions(cur_w, cur_h);
+        let passes: Vec<usize> = (0..node.pass_count().max(1))
+            .map(|_| scope.acquire(out_w, out_h, format, output_usage))
+            .collect();
+        output_idx.push(passes);
+        cur_w = out_w;
+        cur_h = out_h;
+    }
 
     // Upload the 8-bit `rgba` frame to the initial GPU texture. Only valid for
     // an `Rgba8Unorm` working format: an HDR (`Rgba16Float`) graph is driven by a
@@ -123,9 +130,16 @@ pub(super) fn run_gpu(
     let (scope, current_idx) = execute_nodes(nodes, ctx, rgba, w, h, format);
     ctx.note_readback();
 
+    // Read back at the final texture's actual size — a node may have resized it
+    // (e.g. ScaleNode), so it can differ from the input `w` x `h`.
+    let (out_w, out_h) = {
+        let tex = scope.get(current_idx);
+        (tex.width(), tex.height())
+    };
+
     // Copy the final texture to a CPU-readable staging buffer.
-    let bytes_per_row_padded = align_up(w * bpp, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
-    let buffer_size = u64::from(bytes_per_row_padded) * u64::from(h);
+    let bytes_per_row_padded = align_up(out_w * bpp, wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    let buffer_size = u64::from(bytes_per_row_padded) * u64::from(out_h);
 
     let staging_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("ff-render staging"),
@@ -155,8 +169,8 @@ pub(super) fn run_gpu(
             },
         },
         wgpu::Extent3d {
-            width: w,
-            height: h,
+            width: out_w,
+            height: out_h,
             depth_or_array_layers: 1,
         },
     );
@@ -185,10 +199,10 @@ pub(super) fn run_gpu(
         .map_err(|e| RenderError::Composite {
             message: format!("staging buffer get_mapped_range failed: {e}"),
         })?;
-    let mut out = Vec::with_capacity((w * h * bpp) as usize);
-    for y in 0..h as usize {
+    let mut out = Vec::with_capacity((out_w * out_h * bpp) as usize);
+    for y in 0..out_h as usize {
         let row_start = y * bytes_per_row_padded as usize;
-        let row_end = row_start + (w * bpp) as usize;
+        let row_end = row_start + (out_w * bpp) as usize;
         out.extend_from_slice(&raw[row_start..row_end]);
     }
     drop(raw);
@@ -218,12 +232,15 @@ pub(super) fn run_gpu_to_texture(
         .ok_or_else(|| RenderError::Composite {
             message: "no composited texture to display".to_string(),
         })?;
+    // The final texture may have been resized by a node (e.g. ScaleNode), so the
+    // handle reports the texture's actual dimensions rather than the input size.
+    let (out_w, out_h) = (texture.width(), texture.height());
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
     Ok(TextureHandle {
         texture,
         view,
-        width: w,
-        height: h,
+        width: out_w,
+        height: out_h,
     })
 }
 

--- a/crates/ff-render/src/graph/mod.rs
+++ b/crates/ff-render/src/graph/mod.rs
@@ -468,6 +468,83 @@ mod gpu_tests {
         );
     }
 
+    #[test]
+    fn scale_gpu_should_produce_requested_dimensions() {
+        use crate::nodes::{ScaleAlgorithm, ScaleNode};
+
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (in_w, in_h) = (8u32, 8u32);
+        let (out_w, out_h) = (4u32, 2u32);
+        let graph = RenderGraph::new(Arc::clone(&ctx)).push(ScaleNode::new(
+            out_w,
+            out_h,
+            ScaleAlgorithm::Bilinear,
+        ));
+        let rgba = vec![128u8; (in_w * in_h * 4) as usize];
+
+        let handle = graph
+            .process_gpu_to_texture(&rgba, in_w, in_h)
+            .expect("scaled texture");
+        assert_eq!(
+            (handle.width, handle.height),
+            (out_w, out_h),
+            "handle must report the requested dimensions, not the input size"
+        );
+        assert_eq!(
+            (handle.texture.width(), handle.texture.height()),
+            (out_w, out_h),
+            "the GPU texture must be allocated at the requested dimensions"
+        );
+    }
+
+    #[test]
+    fn scale_gpu_downscale_solid_should_preserve_colour() {
+        use crate::nodes::{ScaleAlgorithm, ScaleNode};
+
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (in_w, in_h) = (8u32, 8u32);
+        let (out_w, out_h) = (2u32, 2u32);
+        let mut rgba = Vec::new();
+        for _ in 0..(in_w * in_h) {
+            rgba.extend_from_slice(&[200, 100, 50, 255]);
+        }
+        let graph = RenderGraph::new(Arc::clone(&ctx)).push(ScaleNode::new(
+            out_w,
+            out_h,
+            ScaleAlgorithm::Bilinear,
+        ));
+
+        let out = graph
+            .process_gpu(&rgba, in_w, in_h)
+            .expect("downscaled bytes");
+        assert_eq!(
+            out.len(),
+            (out_w * out_h * 4) as usize,
+            "readback must be at the scaled size (proves the resize happened)"
+        );
+        for px in out.chunks_exact(4) {
+            assert!(
+                (i32::from(px[0]) - 200).abs() <= 4,
+                "R must be preserved through downscale; got {}",
+                px[0]
+            );
+            assert!(
+                (i32::from(px[1]) - 100).abs() <= 4,
+                "G must be preserved; got {}",
+                px[1]
+            );
+            assert!(
+                (i32::from(px[2]) - 50).abs() <= 4,
+                "B must be preserved; got {}",
+                px[2]
+            );
+        }
+    }
+
     /// Decode an IEEE-754 half-float (as read back from an `Rgba16Float` target)
     /// to `f32`. Adequate for the [0, 1] RGB values these tests read.
     #[allow(clippy::cast_precision_loss)]

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -54,6 +54,16 @@ pub trait RenderNode: RenderNodeCpu {
         1
     }
 
+    /// Output dimensions this node produces given its input dimensions.
+    ///
+    /// Default: unchanged (`(in_w, in_h)`). A resampling node (e.g.
+    /// [`ScaleNode`]) overrides this so the executor allocates its output target
+    /// — and every following node's input — at the new size. All of a node's
+    /// `pass_count()` targets are allocated at this size.
+    fn output_dimensions(&self, in_w: u32, in_h: u32) -> (u32, u32) {
+        (in_w, in_h)
+    }
+
     /// Run the GPU render pass.
     ///
     /// `inputs` has `input_count()` textures: `inputs[0]` is the previous node's

--- a/crates/ff-render/src/nodes/scale.rs
+++ b/crates/ff-render/src/nodes/scale.rs
@@ -25,17 +25,20 @@ struct ScalePipeline {
 
 /// Resample a frame to a target resolution.
 ///
-/// In Phase 1 the GPU path renders into the output texture at whatever size
-/// it was allocated — the graph allocates same-size textures, so `ScaleNode`
-/// acts as a bilinear blit pass. Full dimension-changing support (variable
-/// output texture size) is a Phase 2 addition.
+/// The GPU path renders into a `width` x `height` output target (the executor
+/// allocates a differently sized target from [`output_dimensions`]) using the
+/// node's [`ScaleAlgorithm`] sampler, so it truly resizes rather than blitting
+/// same-size. The CPU path is exposed as [`scale_cpu`](Self::scale_cpu), which
+/// returns a new resized buffer (the in-place [`RenderNodeCpu::process_cpu`]
+/// cannot change dimensions, so it stays a no-op).
 ///
-/// The CPU path is a no-op; use an offline scaler (e.g. `image` crate) for
-/// CPU-side resizing.
+/// A `width` or `height` of `0` means "keep the input size" (passthrough).
+///
+/// [`output_dimensions`]: crate::nodes::RenderNode::output_dimensions
 pub struct ScaleNode {
-    /// Target width in pixels (used as metadata; output size depends on the graph).
+    /// Target width in pixels (`0` = keep input width).
     pub width: u32,
-    /// Target height in pixels.
+    /// Target height in pixels (`0` = keep input height).
     pub height: u32,
     /// Sampling algorithm.
     pub algorithm: ScaleAlgorithm,
@@ -54,6 +57,42 @@ impl ScaleNode {
             pipeline: std::sync::OnceLock::new(),
         }
     }
+
+    /// Output size for the given input size: the configured `width` x `height`,
+    /// or the input size when either is `0` (passthrough).
+    #[must_use]
+    pub fn target_size(&self, in_w: u32, in_h: u32) -> (u32, u32) {
+        if self.width == 0 || self.height == 0 {
+            (in_w, in_h)
+        } else {
+            (self.width, self.height)
+        }
+    }
+
+    /// Resize an RGBA frame on the CPU, returning `(pixels, out_w, out_h)`.
+    ///
+    /// `src` is `in_w` x `in_h` RGBA (`in_w * in_h * 4` bytes). The output is
+    /// [`target_size`](Self::target_size) at the node's [`ScaleAlgorithm`]
+    /// (Bilinear -> triangle, Bicubic -> Catmull-Rom, Lanczos -> Lanczos3). A
+    /// malformed `src` (wrong length) is returned unchanged.
+    #[must_use]
+    pub fn scale_cpu(&self, src: &[u8], in_w: u32, in_h: u32) -> (Vec<u8>, u32, u32) {
+        // A zero-dimension source has nothing to resample; return it as-is.
+        if in_w == 0 || in_h == 0 {
+            return (src.to_vec(), in_w, in_h);
+        }
+        let (out_w, out_h) = self.target_size(in_w, in_h);
+        let Some(img) = image::RgbaImage::from_raw(in_w, in_h, src.to_vec()) else {
+            return (src.to_vec(), in_w, in_h);
+        };
+        let filter = match self.algorithm {
+            ScaleAlgorithm::Bilinear => image::imageops::FilterType::Triangle,
+            ScaleAlgorithm::Bicubic => image::imageops::FilterType::CatmullRom,
+            ScaleAlgorithm::Lanczos => image::imageops::FilterType::Lanczos3,
+        };
+        let resized = image::imageops::resize(&img, out_w, out_h, filter);
+        (resized.into_raw(), out_w, out_h)
+    }
 }
 
 impl Default for ScaleNode {
@@ -66,8 +105,10 @@ impl Default for ScaleNode {
 
 impl RenderNodeCpu for ScaleNode {
     fn process_cpu(&self, _rgba: &mut [u8], _w: u32, _h: u32) {
-        // CPU-side resize is not implemented in Phase 1.
-        // Use an offline scaler (e.g. `image::imageops::resize`) for CPU paths.
+        // Resizing changes dimensions, which the in-place `process_cpu(&mut [u8])`
+        // signature cannot express (the buffer size is fixed). Use
+        // [`ScaleNode::scale_cpu`] for a real CPU resize; here it is a no-op so
+        // a ScaleNode in the CPU fallback chain passes the frame through.
     }
 }
 
@@ -166,6 +207,10 @@ impl ScaleNode {
 
 #[cfg(feature = "wgpu")]
 impl super::RenderNode for ScaleNode {
+    fn output_dimensions(&self, in_w: u32, in_h: u32) -> (u32, u32) {
+        self.target_size(in_w, in_h)
+    }
+
     fn process(
         &self,
         inputs: &[&wgpu::Texture],
@@ -247,5 +292,56 @@ mod tests {
     #[test]
     fn scale_algorithm_default_should_be_bilinear() {
         assert_eq!(ScaleAlgorithm::default(), ScaleAlgorithm::Bilinear);
+    }
+
+    #[test]
+    fn scale_cpu_should_resize_not_passthrough() {
+        // 4x2 frame: left half red, right half blue. Downscale to 2x2. A real
+        // resize yields a 2x2 buffer with a red-dominant left column and a
+        // blue-dominant right column; a no-op/passthrough would not change dims.
+        let node = ScaleNode::new(2, 2, ScaleAlgorithm::Bilinear);
+        let mut src = Vec::new();
+        for _y in 0..2 {
+            for x in 0..4 {
+                if x < 2 {
+                    src.extend_from_slice(&[255, 0, 0, 255]);
+                } else {
+                    src.extend_from_slice(&[0, 0, 255, 255]);
+                }
+            }
+        }
+
+        let (out, out_w, out_h) = node.scale_cpu(&src, 4, 2);
+        assert_eq!(
+            (out_w, out_h),
+            (2, 2),
+            "must resize to the requested dimensions"
+        );
+        assert_eq!(out.len(), 2 * 2 * 4, "output must be a 2x2 RGBA buffer");
+        assert_ne!(
+            out, src,
+            "output must differ from the input (not a passthrough)"
+        );
+        // Pixel (col, row) at index (row * 2 + col) * 4.
+        let left = &out[0..4]; // (0, 0)
+        let right = &out[4..8]; // (1, 0)
+        assert!(
+            left[0] > left[2],
+            "left column must stay red-dominant after resize; got {left:?}"
+        );
+        assert!(
+            right[2] > right[0],
+            "right column must stay blue-dominant after resize; got {right:?}"
+        );
+    }
+
+    #[test]
+    fn scale_cpu_zero_dimensions_should_passthrough() {
+        // A ScaleNode with width/height 0 keeps the input size.
+        let node = ScaleNode::new(0, 0, ScaleAlgorithm::Bilinear);
+        let src = vec![10u8, 20, 30, 255, 40, 50, 60, 255]; // 2x1 RGBA
+        let (out, out_w, out_h) = node.scale_cpu(&src, 2, 1);
+        assert_eq!((out_w, out_h), (2, 1), "0 dimensions keep the input size");
+        assert_eq!(out, src, "passthrough must return the input unchanged");
     }
 }


### PR DESCRIPTION
## Objective

- `ScaleNode`'s GPU path rendered into whatever size the graph allocated (the input size), so `width`/`height` were effectively metadata and it could not actually resize.
- Its CPU `process_cpu` was a no-op, so the CPU path did not resize either.

## Solution

- Add `RenderNode::output_dimensions` (default: unchanged). The executor threads the running size and allocates each node's output targets — and thus the next node's input — at the size the node requests, so `ScaleNode` renders into a `width` x `height` target and truly resamples.
- `run_gpu` and `run_gpu_to_texture` read back and report the final texture's actual dimensions, which a resizing node may have changed.
- Add `ScaleNode::scale_cpu`, a real CPU resize via the `image` crate (Bilinear -> triangle, Bicubic -> Catmull-Rom, Lanczos -> Lanczos3). The in-place `process_cpu` cannot change dimensions, so it stays a documented no-op and `scale_cpu` is the CPU resize primitive. A `width`/`height` of `0` keeps the input size.
- GPU tests assert the output texture has the requested dimensions and that a solid colour survives downscaling; a CPU test asserts a real resize (not a passthrough). GPU tests are gated behind `wgpu` and skip without an adapter.

The graph's in-place CPU fallback chain still cannot resize (dimension changes are incompatible with the in-place `process_cpu` signature); a size-aware CPU pipeline is left to the #1365 bridge.

Closes #1588