### PR TITLE
fix(ff-render): Compositor uses YuvUploadNode + resolve BT.601/BT.709 inconsistency

### DIFF
--- a/crates/ff-render/src/compositor/compositor_inner.rs
+++ b/crates/ff-render/src/compositor/compositor_inner.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use ff_format::{PixelFormat, VideoFrame};
@@ -8,7 +9,8 @@ use crate::nodes::composite::{
     fullscreen_pipeline, linear_sampler, submit_render_pass, two_tex_sampler_uniform_bgl,
     upload_rgba_texture,
 };
-use crate::nodes::{BlendMode, RenderNode, TransformNode};
+use crate::nodes::upload::chroma_dims;
+use crate::nodes::{BlendMode, RenderNode, TransformNode, YuvFormat, YuvUploadNode};
 
 use super::FrameLayer;
 
@@ -24,6 +26,10 @@ pub(super) struct CompositorGraph {
     blend_sampler: wgpu::Sampler,
     blend_uniform_buf: wgpu::Buffer,
     transform_node: TransformNode,
+    /// GPU YUV-upload nodes, one per distinct `(format, width, height)`. Cached
+    /// so the upload pipeline is built once per config and reused across frames
+    /// (creating a node per frame would recompile the shader every frame).
+    yuv_nodes: HashMap<(YuvFormat, u32, u32), YuvUploadNode>,
 }
 
 impl CompositorGraph {
@@ -56,6 +62,7 @@ impl CompositorGraph {
             blend_sampler,
             blend_uniform_buf,
             transform_node: TransformNode::default(),
+            yuv_nodes: HashMap::new(),
         }
     }
 
@@ -70,8 +77,7 @@ impl CompositorGraph {
 
         for layer in layers {
             let (fw, fh) = layer.frame.resolution();
-            let rgba = frame_to_rgba(&layer.frame)?;
-            let src_tex = upload_rgba_texture(ctx, &rgba, fw, fh, "Compositor src");
+            let src_tex = ingest_layer(&mut self.yuv_nodes, ctx, &layer.frame, fw, fh)?;
 
             let layer_tex = if layer.transform.is_identity() {
                 src_tex
@@ -104,12 +110,89 @@ impl CompositorGraph {
     }
 }
 
+// Layer ingest
+
+/// Produce a GPU RGBA texture for one layer's frame.
+///
+/// Planar 8-bit YUV is uploaded and converted on the GPU via a cached
+/// [`YuvUploadNode`] (the single YUV → RGB path, BT.601). Every other supported
+/// format is converted on the CPU by [`frame_to_rgba`] and uploaded.
+fn ingest_layer(
+    yuv_nodes: &mut HashMap<(YuvFormat, u32, u32), YuvUploadNode>,
+    ctx: &Arc<RenderContext>,
+    frame: &VideoFrame,
+    fw: u32,
+    fh: u32,
+) -> Result<wgpu::Texture, RenderError> {
+    if let Some(yuv_format) = yuv_format_of(frame.format()) {
+        let (y, cb, cr) = extract_dense_yuv(frame, yuv_format, fw, fh)?;
+        let node = yuv_nodes
+            .entry((yuv_format, fw, fh))
+            .or_insert_with(|| YuvUploadNode::new(yuv_format, fw, fh));
+        node.set_planes(y, cb, cr);
+        let out_tex = create_output_tex(ctx, fw, fh);
+        node.process(&[], &[&out_tex], ctx);
+        Ok(out_tex)
+    } else {
+        let rgba = frame_to_rgba(frame)?;
+        Ok(upload_rgba_texture(ctx, &rgba, fw, fh, "Compositor src"))
+    }
+}
+
+/// Map a planar 8-bit YUV [`PixelFormat`] to a [`YuvFormat`]; `None` for
+/// anything the GPU upload node does not handle.
+fn yuv_format_of(format: PixelFormat) -> Option<YuvFormat> {
+    match format {
+        PixelFormat::Yuv420p => Some(YuvFormat::Yuv420p),
+        PixelFormat::Yuv422p => Some(YuvFormat::Yuv422p),
+        PixelFormat::Yuv444p => Some(YuvFormat::Yuv444p),
+        _ => None,
+    }
+}
+
+/// Dense Y, Cb, Cr plane buffers.
+type YuvPlanes = (Vec<u8>, Vec<u8>, Vec<u8>);
+
+/// Extract dense (stride-free) Y, Cb, Cr planes sized as [`YuvUploadNode`]
+/// expects: Y is `fw × fh`, Cb/Cr are the sub-sampled chroma dimensions.
+fn extract_dense_yuv(
+    frame: &VideoFrame,
+    format: YuvFormat,
+    fw: u32,
+    fh: u32,
+) -> Result<YuvPlanes, RenderError> {
+    let (cw, ch) = chroma_dims(format, fw, fh);
+    let y = dense_plane(frame, 0, fw as usize, fh as usize)?;
+    let cb = dense_plane(frame, 1, cw as usize, ch as usize)?;
+    let cr = dense_plane(frame, 2, cw as usize, ch as usize)?;
+    Ok((y, cb, cr))
+}
+
+/// Copy plane `idx` into a tightly packed `w × h` buffer, stripping any stride
+/// padding.
+fn dense_plane(frame: &VideoFrame, idx: usize, w: usize, h: usize) -> Result<Vec<u8>, RenderError> {
+    let plane = frame.plane(idx).ok_or_else(|| RenderError::Composite {
+        message: format!("YUV frame: missing plane {idx}"),
+    })?;
+    let stride = frame.stride(idx).unwrap_or(w);
+    if stride == w {
+        Ok(plane[..w * h].to_vec())
+    } else {
+        let mut out = Vec::with_capacity(w * h);
+        for r in 0..h {
+            out.extend_from_slice(&plane[r * stride..r * stride + w]);
+        }
+        Ok(out)
+    }
+}
+
 // Frame → RGBA conversion
 
-/// Convert any supported `VideoFrame` to a dense RGBA byte buffer.
+/// Convert a supported non-YUV `VideoFrame` to a dense RGBA byte buffer.
 ///
-/// Uses BT.601 coefficients for YUV formats (matching `YuvUploadNode`).
-/// Returns `RenderError::UnsupportedFormat` for unrecognised formats.
+/// Planar YUV is handled on the GPU by [`ingest_layer`] (via [`YuvUploadNode`]),
+/// so it is rejected here with `RenderError::UnsupportedFormat`, as is any other
+/// unrecognised format.
 fn frame_to_rgba(frame: &VideoFrame) -> Result<Vec<u8>, RenderError> {
     let w = frame.width() as usize;
     let h = frame.height() as usize;
@@ -185,67 +268,10 @@ fn frame_to_rgba(frame: &VideoFrame) -> Result<Vec<u8>, RenderError> {
             }
             Ok(out)
         }
-        PixelFormat::Yuv420p => yuv_to_rgba(frame, 2, 2),
-        PixelFormat::Yuv422p => yuv_to_rgba(frame, 2, 1),
-        PixelFormat::Yuv444p => yuv_to_rgba(frame, 1, 1),
         other => Err(RenderError::UnsupportedFormat {
             format: format!("{other:?}"),
         }),
     }
-}
-
-/// Inline BT.601 YCbCr → RGBA conversion for planar 8-bit YUV formats.
-///
-/// `chroma_x_div` / `chroma_y_div` are the horizontal / vertical subsampling
-/// divisors (e.g. 2/2 for 4:2:0, 2/1 for 4:2:2, 1/1 for 4:4:4).
-#[allow(
-    clippy::many_single_char_names,
-    clippy::similar_names,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
-)]
-fn yuv_to_rgba(
-    frame: &VideoFrame,
-    chroma_x_div: usize,
-    chroma_y_div: usize,
-) -> Result<Vec<u8>, RenderError> {
-    let w = frame.width() as usize;
-    let h = frame.height() as usize;
-
-    let y_plane = frame.plane(0).ok_or_else(|| RenderError::Composite {
-        message: "YUV frame: missing Y plane".to_string(),
-    })?;
-    let u_plane = frame.plane(1).ok_or_else(|| RenderError::Composite {
-        message: "YUV frame: missing U plane".to_string(),
-    })?;
-    let v_plane = frame.plane(2).ok_or_else(|| RenderError::Composite {
-        message: "YUV frame: missing V plane".to_string(),
-    })?;
-
-    let y_stride = frame.stride(0).unwrap_or(w);
-    let u_stride = frame.stride(1).unwrap_or(w.div_ceil(chroma_x_div));
-    let v_stride = frame.stride(2).unwrap_or(w.div_ceil(chroma_x_div));
-
-    let mut out = Vec::with_capacity(w * h * 4);
-    for row in 0..h {
-        for col in 0..w {
-            let y = f32::from(y_plane[row * y_stride + col]) / 255.0;
-            let u = f32::from(u_plane[(row / chroma_y_div) * u_stride + col / chroma_x_div])
-                / 255.0
-                - 0.5;
-            let v = f32::from(v_plane[(row / chroma_y_div) * v_stride + col / chroma_x_div])
-                / 255.0
-                - 0.5;
-            let r = (y + 1.402 * v).clamp(0.0, 1.0);
-            let g = (y - 0.344_136 * u - 0.714_136 * v).clamp(0.0, 1.0);
-            let b = (y + 1.772 * u).clamp(0.0, 1.0);
-            out.push((r * 255.0 + 0.5) as u8);
-            out.push((g * 255.0 + 0.5) as u8);
-            out.push((b * 255.0 + 0.5) as u8);
-            out.push(255);
-        }
-    }
-    Ok(out)
 }
 
 // GPU helpers
@@ -413,14 +439,33 @@ mod tests {
     }
 
     #[test]
-    fn frame_to_rgba_yuv420p_should_produce_rgba_output() {
+    fn frame_to_rgba_yuv_should_be_unsupported() {
+        // YUV now goes through the GPU YuvUploadNode path (single YUV → RGB
+        // source of truth), so the CPU frame_to_rgba rejects it.
         let frame = yuv420_frame(4, 4);
-        let result = frame_to_rgba(&frame).expect("Yuv420p must succeed");
-        assert_eq!(result.len(), 4 * 4 * 4, "YUV output must be w*h*4 bytes");
-        // All pixels should have alpha=255.
-        for chunk in result.chunks_exact(4) {
-            assert_eq!(chunk[3], 255, "YUV output alpha must be 255");
-        }
+        let result = frame_to_rgba(&frame);
+        assert!(
+            matches!(result, Err(RenderError::UnsupportedFormat { .. })),
+            "YUV must be routed through the GPU node, not frame_to_rgba"
+        );
+    }
+
+    #[test]
+    fn yuv_format_of_should_map_planar_yuv_and_reject_others() {
+        assert_eq!(
+            yuv_format_of(PixelFormat::Yuv420p),
+            Some(YuvFormat::Yuv420p)
+        );
+        assert_eq!(
+            yuv_format_of(PixelFormat::Yuv422p),
+            Some(YuvFormat::Yuv422p)
+        );
+        assert_eq!(
+            yuv_format_of(PixelFormat::Yuv444p),
+            Some(YuvFormat::Yuv444p)
+        );
+        assert_eq!(yuv_format_of(PixelFormat::Rgba), None);
+        assert_eq!(yuv_format_of(PixelFormat::Yuv420p10le), None);
     }
 
     #[test]
@@ -445,5 +490,140 @@ mod tests {
         assert_eq!(result[1], 20, "G stays");
         assert_eq!(result[2], 10, "B must come from BGRA.b (index 0)");
         assert_eq!(result[3], 255, "A stays");
+    }
+
+    /// A headless GPU context, or `None` when no adapter is available (CI).
+    fn gpu_ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    /// Read an `Rgba8Unorm` texture back to a dense `w * h * 4` byte buffer.
+    fn readback(ctx: &RenderContext, tex: &wgpu::Texture, w: u32, h: u32) -> Vec<u8> {
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let bpr = (w * 4 + align - 1) & !(align - 1);
+        let staging = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("test readback"),
+            size: u64::from(bpr) * u64::from(h),
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut enc = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("test readback"),
+            });
+        enc.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(bpr),
+                    rows_per_image: None,
+                },
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+        ctx.queue.submit(std::iter::once(enc.finish()));
+        let slice = staging.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            tx.send(r).ok();
+        });
+        ctx.device.poll(wgpu::PollType::wait_indefinitely()).ok();
+        rx.recv().expect("map channel").expect("map result");
+        let raw = slice.get_mapped_range().expect("mapped range");
+        let mut out = Vec::with_capacity((w * h * 4) as usize);
+        for y in 0..h as usize {
+            let s = y * bpr as usize;
+            out.extend_from_slice(&raw[s..s + (w * 4) as usize]);
+        }
+        drop(raw);
+        staging.unmap();
+        out
+    }
+
+    /// A Yuv420p frame filled with constant Y, U, V (dense, no stride padding).
+    fn yuv420_solid(w: u32, h: u32, yv: u8, uv: u8, vv: u8) -> VideoFrame {
+        let (cw, ch) = chroma_dims(YuvFormat::Yuv420p, w, h);
+        let y = vec![yv; (w * h) as usize];
+        let u = vec![uv; (cw * ch) as usize];
+        let v = vec![vv; (cw * ch) as usize];
+        VideoFrame::new(
+            vec![
+                PooledBuffer::standalone(y),
+                PooledBuffer::standalone(u),
+                PooledBuffer::standalone(v),
+            ],
+            vec![w as usize, cw as usize, cw as usize],
+            w,
+            h,
+            PixelFormat::Yuv420p,
+            Timestamp::default(),
+            false,
+        )
+        .expect("yuv420 frame")
+    }
+
+    #[test]
+    fn compositor_yuv_ingest_should_match_node_path_within_tolerance() {
+        let Some(ctx) = gpu_ctx() else {
+            return;
+        };
+        let (w, h) = (4u32, 4u32);
+        let (yv, uv, vv) = (150u8, 100u8, 170u8);
+        let (cw, ch) = chroma_dims(YuvFormat::Yuv420p, w, h);
+
+        // Node path: the same planes straight through YuvUploadNode.
+        let mut node = YuvUploadNode::new(YuvFormat::Yuv420p, w, h);
+        node.set_planes(
+            vec![yv; (w * h) as usize],
+            vec![uv; (cw * ch) as usize],
+            vec![vv; (cw * ch) as usize],
+        );
+        let node_rgb = crate::graph::RenderGraph::new(Arc::clone(&ctx))
+            .push(node)
+            .process_gpu(&vec![0u8; (w * h * 4) as usize], w, h)
+            .expect("node path");
+
+        // Compositor path: one opaque YUV layer over the (black) canvas.
+        let mut compositor = crate::Compositor::new(Arc::clone(&ctx), w, h);
+        let mut layers = vec![crate::FrameLayer {
+            frame: yuv420_solid(w, h, yv, uv, vv),
+            transform: crate::LayerTransform::default(),
+            blend_mode: BlendMode::Normal,
+            opacity: 1.0,
+            z_order: 0,
+        }];
+        let tex = compositor.composite(&mut layers).expect("compositor path");
+        let comp_rgb = readback(&ctx, &tex, w, h);
+
+        assert_eq!(
+            comp_rgb.len(),
+            node_rgb.len(),
+            "both paths must produce w*h*4 bytes"
+        );
+        for (c, n) in comp_rgb.chunks_exact(4).zip(node_rgb.chunks_exact(4)) {
+            for ch in 0..3 {
+                assert!(
+                    (i32::from(c[ch]) - i32::from(n[ch])).abs() <= 6,
+                    "compositor and node RGB must match within tolerance; ch={ch} comp={} node={}",
+                    c[ch],
+                    n[ch]
+                );
+            }
+        }
     }
 }

--- a/crates/ff-render/src/nodes/upload.rs
+++ b/crates/ff-render/src/nodes/upload.rs
@@ -1,7 +1,7 @@
 use super::RenderNodeCpu;
 
 /// YUV sub-sampling format for [`YuvUploadNode`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum YuvFormat {
     /// Planar 4:2:0 — Y at full resolution; Cb/Cr at half width and height.
     #[default]


### PR DESCRIPTION
## Objective

- The `Compositor` converted every frame to RGBA on the CPU via `frame_to_rgba`, duplicating the YUV-to-RGB conversion that `YuvUploadNode` already performs on the GPU.
- The designed native-YUV GPU upload was unused in the compositor path, and two YUV-to-RGB implementations were a maintenance hazard.

## Solution

- Route planar 8-bit YUV ingest through a cached `YuvUploadNode` (the single YUV-to-RGB source of truth, BT.601) and remove the duplicate CPU `yuv_to_rgba`; `frame_to_rgba` now handles only non-YUV formats and rejects YUV.
- Cache upload nodes by `(format, width, height)` so the pipeline is compiled once per config and reused across frames rather than rebuilt every frame.
- A GPU test asserts the compositor and node paths agree within tolerance; a unit test documents that YUV no longer goes through `frame_to_rgba`.
- Both paths already used BT.601 (the "YuvUploadNode uses BT.709" premise was stale), so the inconsistency is resolved by unifying on one path.

Honouring a frame's signalled colour space is left out of scope: `VideoFrame` carries no colour-space field, so BT.601 remains the documented default (would need a cross-crate `VideoFrame` extension).

Closes #1589