### PR TITLE
fix(avio): id-key track automation (TrackId, not track index)

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -530,13 +530,13 @@ impl Clip {
     #[must_use]
     pub fn realtime_layer_descriptor(&self) -> RealtimeLayerDescriptor {
         // One code path: the per-clip descriptor is the shared derive with no
-        // timeline-level animations (track index 0, empty map) — so a per-clip
+        // track-level automation (an empty `TrackAutomation`) — so a per-clip
         // keyframe or static value still applies, and the shape matches the export
         // `VideoLayer`.
         // No timeline canvas here, so `fit` is not applied (the derive skips the
         // framing step for a zero canvas); a canvas-aware descriptor comes from
         // `Timeline::to_scene`.
-        crate::derive::realtime_descriptor(self, 0, &std::collections::HashMap::new(), 0, 0)
+        crate::derive::realtime_descriptor(self, &crate::track::TrackAutomation::default(), 0, 0)
     }
 
     /// Attaches an audio [`FilterStep`] to this clip and returns the updated clip.

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -14,7 +14,6 @@
 //! preview does not yet honour are the `derive(model, t)` unification target of
 //! #1351 (see `docs/specs/engine-and-primitives.md` §2.1).
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
@@ -25,21 +24,14 @@ use ff_filter::{
 use ff_format::ChannelLayout;
 
 use crate::clip::{Clip, ClipSource, FitMode};
+use crate::track::TrackAutomation;
 
-/// Resolves a track-level animation: `AnimatedValue::Track` when the map holds a
-/// track for `"{prefix}_{track_idx}_{prop}"`, else `Static(default)`.
-fn track_animation(
-    animations: &HashMap<String, AnimationTrack<f64>>,
-    prefix: &str,
-    track_idx: usize,
-    prop: &str,
-    default: f64,
-) -> AnimatedValue<f64> {
-    animations
-        .get(&format!("{prefix}_{track_idx}_{prop}"))
-        .map_or(AnimatedValue::Static(default), |t| {
-            AnimatedValue::Track(t.clone())
-        })
+/// Resolves a track-level automation slot: `AnimatedValue::Track` when the track
+/// carries an animation for the property, else `Static(default)`.
+fn track_anim(slot: Option<&AnimationTrack<f64>>, default: f64) -> AnimatedValue<f64> {
+    slot.map_or(AnimatedValue::Static(default), |t| {
+        AnimatedValue::Track(t.clone())
+    })
 }
 
 /// The per-clip video transform shared by the export [`VideoLayer`] and the
@@ -60,18 +52,14 @@ struct VideoTransform {
 
 /// Computes the shared [`VideoTransform`]: a per-clip keyframe track wins, then a
 /// static non-neutral value, then any timeline track-level animation.
-fn video_transform(
-    clip: &Clip,
-    track_idx: usize,
-    animations: &HashMap<String, AnimationTrack<f64>>,
-) -> VideoTransform {
+fn video_transform(clip: &Clip, automation: &TrackAutomation) -> VideoTransform {
     #[allow(clippy::float_cmp)]
     let opacity = if let Some(track) = &clip.opacity_track {
         AnimatedValue::Track(track.clone())
     } else if clip.opacity != 1.0 {
         AnimatedValue::Static(f64::from(clip.opacity))
     } else {
-        track_animation(animations, "video", track_idx, "opacity", 1.0)
+        track_anim(automation.opacity.as_ref(), 1.0)
     };
     #[allow(clippy::float_cmp)]
     let x = if let Some(track) = &clip.x_track {
@@ -79,7 +67,7 @@ fn video_transform(
     } else if clip.x != 0.0 {
         AnimatedValue::Static(clip.x)
     } else {
-        track_animation(animations, "video", track_idx, "x", 0.0)
+        track_anim(automation.x.as_ref(), 0.0)
     };
     #[allow(clippy::float_cmp)]
     let y = if let Some(track) = &clip.y_track {
@@ -87,7 +75,7 @@ fn video_transform(
     } else if clip.y != 0.0 {
         AnimatedValue::Static(clip.y)
     } else {
-        track_animation(animations, "video", track_idx, "y", 0.0)
+        track_anim(automation.y.as_ref(), 0.0)
     };
     // The uniform per-clip `scale` drives both axes; a per-clip track wins, then a
     // static non-neutral value, then the per-axis timeline animation (kept
@@ -98,7 +86,7 @@ fn video_transform(
     } else if clip.scale != 1.0 {
         AnimatedValue::Static(clip.scale)
     } else {
-        track_animation(animations, "video", track_idx, "scale_x", 1.0)
+        track_anim(automation.scale_x.as_ref(), 1.0)
     };
     #[allow(clippy::float_cmp)]
     let scale_y = if let Some(track) = &clip.scale_track {
@@ -106,7 +94,7 @@ fn video_transform(
     } else if clip.scale != 1.0 {
         AnimatedValue::Static(clip.scale)
     } else {
-        track_animation(animations, "video", track_idx, "scale_y", 1.0)
+        track_anim(automation.scale_y.as_ref(), 1.0)
     };
     #[allow(clippy::float_cmp)]
     let rotation = if let Some(track) = &clip.rotation_track {
@@ -114,7 +102,7 @@ fn video_transform(
     } else if clip.rotation != 0.0 {
         AnimatedValue::Static(clip.rotation)
     } else {
-        track_animation(animations, "video", track_idx, "rotation", 0.0)
+        track_anim(automation.rotation.as_ref(), 0.0)
     };
     VideoTransform {
         opacity,
@@ -165,7 +153,7 @@ fn fit_step(clip: &Clip, cw: u32, ch: u32) -> Option<FilterStep> {
 pub(crate) fn video_layer(
     clip: &Clip,
     track_idx: usize,
-    animations: &HashMap<String, AnimationTrack<f64>>,
+    automation: &TrackAutomation,
     canvas_width: u32,
     canvas_height: u32,
     prev_end: Option<f64>,
@@ -225,7 +213,7 @@ pub(crate) fn video_layer(
         ClipSource::Text(spec) => LayerSource::Text(spec.clone()),
         ClipSource::Solid(color) => LayerSource::Solid(*color),
     };
-    let transform = video_transform(clip, track_idx, animations);
+    let transform = video_transform(clip, automation);
     VideoLayer {
         source,
         proxy,
@@ -255,12 +243,11 @@ pub(crate) fn video_layer(
 /// backbone.
 pub(crate) fn realtime_descriptor(
     clip: &Clip,
-    track_idx: usize,
-    animations: &HashMap<String, AnimationTrack<f64>>,
+    automation: &TrackAutomation,
     canvas_width: u32,
     canvas_height: u32,
 ) -> RealtimeLayerDescriptor {
-    let transform = video_transform(clip, track_idx, animations);
+    let transform = video_transform(clip, automation);
     // Frame to the canvas (same step as the export path) before the colour chain,
     // so preview and export share one framing interpretation.
     let mut effects = Vec::new();
@@ -282,19 +269,15 @@ pub(crate) fn realtime_descriptor(
 }
 
 /// The 3-way-merged audio volume (dB): a per-clip volume track wins, then a static
-/// non-zero `volume_db`, then the timeline `audio_{idx}_volume` automation. This is
+/// non-zero `volume_db`, then the track-level `volume` automation. This is
 /// the single interpretation the export [`audio_track`] and the preview audio
 /// projection ([`Timeline::to_scene`](crate::Timeline::to_scene)) share.
 #[allow(clippy::float_cmp)]
-pub(crate) fn audio_volume(
-    clip: &Clip,
-    track_idx: usize,
-    animations: &HashMap<String, AnimationTrack<f64>>,
-) -> AnimatedValue<f64> {
+pub(crate) fn audio_volume(clip: &Clip, automation: &TrackAutomation) -> AnimatedValue<f64> {
     match &clip.volume_track {
         Some(track) => AnimatedValue::Track(track.clone()),
         None if clip.volume_db != 0.0 => AnimatedValue::Static(clip.volume_db),
-        None => track_animation(animations, "audio", track_idx, "volume", 0.0),
+        None => track_anim(automation.volume.as_ref(), 0.0),
     }
 }
 
@@ -315,11 +298,10 @@ pub(crate) fn audio_pitch(clip: &Clip) -> f64 {
 /// to compute the fade-out start offset (`None` = could not be determined).
 pub(crate) fn audio_track(
     clip: &Clip,
-    track_idx: usize,
-    animations: &HashMap<String, AnimationTrack<f64>>,
+    automation: &TrackAutomation,
     fade_out_eff_dur: Option<Duration>,
 ) -> AudioTrack {
-    let volume = audio_volume(clip, track_idx, animations);
+    let volume = audio_volume(clip, automation);
     // Generated (Text/Solid) clips carry no audio and are skipped by the render's
     // audio loop before reaching here, so a File source is expected; the fallback
     // to an empty path is defensive only.
@@ -397,7 +379,7 @@ pub(crate) fn audio_track(
     AudioTrack {
         source: source_path,
         volume,
-        pan: track_animation(animations, "audio", track_idx, "pan", 0.0),
+        pan: track_anim(automation.pan.as_ref(), 0.0),
         effects,
         sample_rate: 48_000,
         channel_layout: ChannelLayout::Stereo,
@@ -411,8 +393,8 @@ mod tests {
 
     use super::*;
 
-    fn no_anim() -> HashMap<String, AnimationTrack<f64>> {
-        HashMap::new()
+    fn no_anim() -> TrackAutomation {
+        TrackAutomation::default()
     }
 
     // video_layer
@@ -528,13 +510,16 @@ mod tests {
 
     #[test]
     fn video_layer_neutral_opacity_should_fall_back_to_track_animation() {
-        let mut anims = HashMap::new();
-        anims.insert(
-            "video_0_opacity".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 1.0, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            opacity: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                1.0,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp4"); // opacity defaults to 1.0 (neutral)
-        let layer = video_layer(&clip, 0, &anims, 1920, 1080, None, None);
+        let layer = video_layer(&clip, 0, &automation, 1920, 1080, None, None);
         assert!(matches!(layer.opacity, AnimatedValue::Track(_)));
     }
 
@@ -633,7 +618,7 @@ mod tests {
     fn realtime_descriptor_fit_fill_should_share_step_with_export() {
         // export == preview parity: both emit the same framing step.
         let clip = Clip::new("a.mp4").with_fit(FitMode::Fill);
-        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        let d = realtime_descriptor(&clip, &no_anim(), 1920, 1080);
         assert!(matches!(
             d.effects.first(),
             Some(FilterStep::FillToAspect {
@@ -646,7 +631,7 @@ mod tests {
     #[test]
     fn realtime_descriptor_fit_none_should_emit_no_framing_step() {
         let clip = Clip::new("a.mp4"); // fit defaults to None
-        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        let d = realtime_descriptor(&clip, &no_anim(), 1920, 1080);
         assert!(!d.effects.iter().any(|s| matches!(
             s,
             FilterStep::FillToAspect { .. }
@@ -659,7 +644,7 @@ mod tests {
     fn fit_step_should_be_skipped_when_canvas_is_zero() {
         // The canvas-less `Clip::realtime_layer_descriptor` passes 0×0.
         let clip = Clip::new("a.mp4").with_fit(FitMode::Fill);
-        let d = realtime_descriptor(&clip, 0, &no_anim(), 0, 0);
+        let d = realtime_descriptor(&clip, &no_anim(), 0, 0);
         assert!(
             !d.effects
                 .iter()
@@ -674,14 +659,14 @@ mod tests {
         let mut clip = Clip::new("a.mp3").volume(-6.0);
         clip.volume_track =
             Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear)));
-        let track = audio_track(&clip, 0, &no_anim(), None);
+        let track = audio_track(&clip, &no_anim(), None);
         assert!(matches!(track.volume, AnimatedValue::Track(_)));
     }
 
     #[test]
     fn audio_track_static_volume_db_should_be_static() {
         let clip = Clip::new("a.mp3").volume(-6.0);
-        let track = audio_track(&clip, 0, &no_anim(), None);
+        let track = audio_track(&clip, &no_anim(), None);
         assert!(matches!(track.volume, AnimatedValue::Static(v) if (v + 6.0).abs() < 1e-9));
     }
 
@@ -693,7 +678,7 @@ mod tests {
             .with_speed(2.0)
             .with_fade_in(Duration::from_millis(200))
             .with_fade_out(Duration::from_millis(300));
-        let track = audio_track(&clip, 0, &no_anim(), Some(Duration::from_secs(4)));
+        let track = audio_track(&clip, &no_anim(), Some(Duration::from_secs(4)));
         let kinds: Vec<&FilterStep> = track.effects.iter().collect();
         assert!(matches!(kinds[0], FilterStep::ATrim { .. }));
         assert!(matches!(kinds[1], FilterStep::AResetPts));
@@ -707,7 +692,7 @@ mod tests {
     fn audio_track_fade_out_should_skip_when_duration_not_greater() {
         let clip = Clip::new("a.mp3").with_fade_out(Duration::from_secs(5));
         // eff_dur (3s) <= fade_out (5s) -> skipped
-        let track = audio_track(&clip, 0, &no_anim(), Some(Duration::from_secs(3)));
+        let track = audio_track(&clip, &no_anim(), Some(Duration::from_secs(3)));
         assert!(
             !track
                 .effects
@@ -718,20 +703,23 @@ mod tests {
 
     #[test]
     fn audio_track_pan_should_come_from_track_animation() {
-        let mut anims = HashMap::new();
-        anims.insert(
-            "audio_0_pan".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            pan: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                0.5,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp3");
-        let track = audio_track(&clip, 0, &anims, None);
+        let track = audio_track(&clip, &automation, None);
         assert!(matches!(track.pan, AnimatedValue::Track(_)));
     }
 
     #[test]
     fn audio_track_static_pitch_should_emit_pitch_shift() {
         let clip = Clip::new("a.mp3").with_pitch(4.0);
-        let track = audio_track(&clip, 0, &no_anim(), None);
+        let track = audio_track(&clip, &no_anim(), None);
         assert!(track.effects.iter().any(|s| matches!(
             s,
             FilterStep::PitchShift { semitones, .. } if (semitones - 4.0).abs() < 1e-6
@@ -745,7 +733,7 @@ mod tests {
         let clip = Clip::new("a.mp3").with_pitch(1.0).with_pitch_track(
             AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 5.0, Easing::Linear)),
         );
-        let track = audio_track(&clip, 0, &no_anim(), None);
+        let track = audio_track(&clip, &no_anim(), None);
         assert!(track.effects.iter().any(|s| matches!(
             s,
             FilterStep::PitchShift { semitones, .. } if (semitones - 5.0).abs() < 1e-6
@@ -755,7 +743,7 @@ mod tests {
     #[test]
     fn audio_track_zero_pitch_should_emit_no_pitch_shift() {
         let clip = Clip::new("a.mp3"); // pitch defaults to 0.0
-        let track = audio_track(&clip, 0, &no_anim(), None);
+        let track = audio_track(&clip, &no_anim(), None);
         assert!(
             !track
                 .effects
@@ -768,28 +756,34 @@ mod tests {
 
     #[test]
     fn audio_volume_should_fall_back_to_timeline_animation() {
-        let mut anims = HashMap::new();
-        anims.insert(
-            "audio_0_volume".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, -3.0, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            volume: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                -3.0,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp3"); // neutral volume_db, no volume_track
         assert!(matches!(
-            audio_volume(&clip, 0, &anims),
+            audio_volume(&clip, &automation),
             AnimatedValue::Track(_)
         ));
     }
 
     #[test]
     fn audio_volume_static_should_win_over_timeline() {
-        let mut anims = HashMap::new();
-        anims.insert(
-            "audio_0_volume".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, -3.0, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            volume: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                -3.0,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp3").volume(-6.0);
         assert!(matches!(
-            audio_volume(&clip, 0, &anims),
+            audio_volume(&clip, &automation),
             AnimatedValue::Static(x) if (x + 6.0).abs() < 1e-9
         ));
     }
@@ -805,7 +799,7 @@ mod tests {
             .offset(Duration::from_secs(2))
             .with_speed(2.0)
             .with_transition(XfadeTransition::Fade, Duration::from_millis(500));
-        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        let d = realtime_descriptor(&clip, &no_anim(), 1920, 1080);
         assert!(!d.effects.iter().any(|s| matches!(
             s,
             FilterStep::Trim { .. }
@@ -820,23 +814,27 @@ mod tests {
     fn realtime_descriptor_should_carry_effect_chain() {
         let mut clip = Clip::new("a.mp4");
         clip.brightness = 0.5; // forces an Eq step in `video_effect_chain`
-        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        let d = realtime_descriptor(&clip, &no_anim(), 1920, 1080);
         assert!(d.effects.iter().any(|s| matches!(s, FilterStep::Eq { .. })));
     }
 
     #[test]
     fn realtime_descriptor_should_pick_up_timeline_scale_and_rotation() {
-        let mut anims = HashMap::new();
-        anims.insert(
-            "video_1_scale_x".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
-        );
-        anims.insert(
-            "video_1_rotation".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 90.0, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            scale_x: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                0.5,
+                Easing::Linear,
+            ))),
+            rotation: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                90.0,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp4");
-        let d = realtime_descriptor(&clip, 1, &anims, 1920, 1080);
+        let d = realtime_descriptor(&clip, &automation, 1920, 1080);
         assert!(matches!(d.scale_x, AnimatedValue::Track(_)));
         assert!(matches!(d.rotation, AnimatedValue::Track(_)));
         assert!(matches!(d.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
@@ -844,27 +842,33 @@ mod tests {
 
     #[test]
     fn realtime_descriptor_opacity_should_fall_back_to_timeline_animation() {
-        // A neutral per-clip opacity (1.0) falls through to the timeline track.
-        let mut anims = HashMap::new();
-        anims.insert(
-            "video_0_opacity".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 1.0, Easing::Linear)),
-        );
+        // A neutral per-clip opacity (1.0) falls through to the track automation.
+        let automation = TrackAutomation {
+            opacity: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                1.0,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp4");
-        let d = realtime_descriptor(&clip, 0, &anims, 1920, 1080);
+        let d = realtime_descriptor(&clip, &automation, 1920, 1080);
         assert!(matches!(d.opacity, AnimatedValue::Track(_)));
     }
 
     #[test]
     fn realtime_descriptor_static_opacity_should_win_over_timeline() {
         // A per-clip static non-neutral opacity wins the 3-way merge.
-        let mut anims = HashMap::new();
-        anims.insert(
-            "video_0_opacity".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.2, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            opacity: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                0.2,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp4").with_opacity(0.5);
-        let d = realtime_descriptor(&clip, 0, &anims, 1920, 1080);
+        let d = realtime_descriptor(&clip, &automation, 1920, 1080);
         assert!(matches!(d.opacity, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
 
@@ -872,7 +876,7 @@ mod tests {
     fn realtime_descriptor_should_carry_composite_op() {
         let mut clip = Clip::new("a.mp4");
         clip.composite_op = CompositeOp::Under;
-        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        let d = realtime_descriptor(&clip, &no_anim(), 1920, 1080);
         assert!(matches!(d.composite_op, CompositeOp::Under));
     }
 
@@ -898,29 +902,35 @@ mod tests {
 
     #[test]
     fn video_layer_neutral_scale_should_fall_back_to_timeline_animation() {
-        let mut anims = HashMap::new();
-        anims.insert(
-            "video_0_scale_x".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            scale_x: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                0.5,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         let clip = Clip::new("a.mp4"); // scale defaults to 1.0 (neutral)
-        let layer = video_layer(&clip, 0, &anims, 1920, 1080, None, None);
+        let layer = video_layer(&clip, 0, &automation, 1920, 1080, None, None);
         assert!(matches!(layer.scale_x, AnimatedValue::Track(_)));
-        // scale_y has no timeline animation -> the default static 1.0.
+        // scale_y has no track animation -> the default static 1.0.
         assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
     }
 
     #[test]
     fn video_layer_static_scale_should_win_over_timeline_animation() {
-        let mut anims = HashMap::new();
-        anims.insert(
-            "video_0_scale_x".to_string(),
-            AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.25, Easing::Linear)),
-        );
+        let automation = TrackAutomation {
+            scale_x: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                0.25,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
         // A per-clip static non-neutral scale wins the 3-way merge over the
-        // timeline `scale_x` animation.
+        // track-level `scale_x` animation.
         let clip = Clip::new("a.mp4").with_scale(0.5);
-        let layer = video_layer(&clip, 0, &anims, 1920, 1080, None, None);
+        let layer = video_layer(&clip, 0, &automation, 1920, 1080, None, None);
         assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
         assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
     }
@@ -946,7 +956,7 @@ mod tests {
         // Preview uses the same `video_transform`, so per-clip scale/rotation reach
         // preview identically to export.
         let clip = Clip::new("a.mp4").with_scale(0.5).with_rotation(45.0);
-        let d = realtime_descriptor(&clip, 0, &no_anim(), 1920, 1080);
+        let d = realtime_descriptor(&clip, &no_anim(), 1920, 1080);
         assert!(matches!(d.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
         assert!(matches!(d.scale_y, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
         assert!(matches!(d.rotation, AnimatedValue::Static(v) if (v - 45.0).abs() < 1e-9));

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -117,7 +117,7 @@ pub use error::TimelineError;
 pub use ids::{ClipId, GroupId, MarkerId, TrackId, TrackKind};
 pub use marker::Marker;
 pub use timeline::{Timeline, TimelineBuilder};
-pub use track::Track;
+pub use track::{AudioProperty, Track, TrackAutomation, VideoProperty};
 pub use validate::TimelineIssue;
 
 // `Timeline::render` takes an `EncoderConfig` and reports `Progress`.

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -22,7 +22,7 @@ use crate::derive;
 use crate::error::TimelineError;
 use crate::ids::{ClipId, TrackId};
 use crate::marker::Marker;
-use crate::track::Track;
+use crate::track::{AudioProperty, Track, VideoProperty};
 use ff_pipeline::EncoderConfig;
 use ff_pipeline::Progress;
 use ff_pipeline::pipeline::hwaccel_to_hardware_encoder;
@@ -78,18 +78,6 @@ pub struct Timeline {
     /// Editorial markers on the timeline. Metadata only — they do not affect
     /// derivation, render, or preview. Addressed by [`MarkerId`](crate::MarkerId).
     pub(crate) markers: Vec<Marker>,
-    /// Animation tracks for video layer properties.
-    ///
-    /// Key format: `"video_{track_index}_{property}"`, e.g. `"video_0_opacity"`.
-    ///
-    /// Supported properties: `x`, `y`, `scale_x`, `scale_y`, `rotation`, `opacity`.
-    pub(crate) video_animations: HashMap<String, AnimationTrack<f64>>,
-    /// Animation tracks for audio track properties.
-    ///
-    /// Key format: `"audio_{track_index}_{property}"`, e.g. `"audio_1_volume"`.
-    ///
-    /// Supported properties: `volume`, `pan`.
-    pub(crate) audio_animations: HashMap<String, AnimationTrack<f64>>,
     /// Optional `lavfi` filtergraph string composited as the topmost video layer.
     ///
     /// When set, a [`VideoLayer`] whose source is
@@ -183,10 +171,10 @@ impl Timeline {
     /// Renders the timeline to an output file, invoking `on_progress` after
     /// each encoded video frame.
     ///
-    /// Animation tracks registered via [`TimelineBuilder::video_animation`] and
-    /// [`TimelineBuilder::audio_animation`] are forwarded to the corresponding
+    /// Track-level automation (see [`Track::automation`](crate::Track::automation),
+    /// set via [`TimelineBuilder::video_animation`] / [`TimelineBuilder::audio_animation`])
+    /// is forwarded to the corresponding
     /// [`VideoLayer`] / [`AudioTrack`](ff_filter::AudioTrack) fields before the filter graphs are built.
-    /// Unrecognised animation keys are ignored and logged as `warn!`.
     ///
     /// `on_progress` receives a [`Progress`] reference after every video frame.
     /// Returning `false` cancels the render and returns
@@ -251,8 +239,6 @@ impl Timeline {
             next_marker_id: _,
             next_group_id: _,
             markers: _,
-            video_animations,
-            audio_animations,
             lavfi_overlay,
             audio_filter,
         } = self;
@@ -299,32 +285,7 @@ impl Timeline {
             }
         }
 
-        // 2. Warn on unrecognised animation keys.
-        let valid_video_props = ["x", "y", "scale_x", "scale_y", "rotation", "opacity"];
-        for key in video_animations.keys() {
-            let parts: Vec<&str> = key.splitn(3, '_').collect();
-            let ok = parts.len() == 3
-                && parts[0] == "video"
-                && parts[1].parse::<usize>().is_ok()
-                && valid_video_props.contains(&parts[2]);
-            if !ok {
-                log::warn!("unknown animation key key={key}");
-            }
-        }
-
-        let valid_audio_props = ["volume", "pan"];
-        for key in audio_animations.keys() {
-            let parts: Vec<&str> = key.splitn(3, '_').collect();
-            let ok = parts.len() == 3
-                && parts[0] == "audio"
-                && parts[1].parse::<usize>().is_ok()
-                && valid_audio_props.contains(&parts[2]);
-            if !ok {
-                log::warn!("unknown animation key key={key}");
-            }
-        }
-
-        // 3. Build video composition graph.
+        // 2. Build video composition graph.
         let mut video_graph = None;
         if !video_tracks.is_empty() {
             // Per-track end-offset (seconds) of the last clip, used to compute
@@ -338,7 +299,8 @@ impl Timeline {
                 MultiTrackComposer::new(canvas_width, canvas_height).frame_rate(frame_rate);
             // Inactive tracks (disabled, muted, or shadowed by a solo elsewhere in
             // this list) contribute no layers. The enumerate index is preserved so
-            // the timeline animation keys (`video_{idx}_*`) still line up.
+            // the per-track cross-fade offset bookkeeping (`prev_end_by_track`)
+            // stays aligned; track-level automation now lives on the track itself.
             for (track_idx, track) in video_tracks.iter().enumerate() {
                 if !track.is_active(any_video_solo) {
                     continue;
@@ -373,7 +335,7 @@ impl Timeline {
                     composer = composer.add_layer(derive::video_layer(
                         clip,
                         track_idx,
-                        &video_animations,
+                        &track.automation,
                         canvas_width,
                         canvas_height,
                         prev_end,
@@ -437,7 +399,7 @@ impl Timeline {
         if has_audio && !has_track_effects {
             let mut mixer = MultiTrackAudioMixer::new(48_000, ChannelLayout::Stereo);
             // Honor mute/solo/enabled: an inactive audio track is silent.
-            for (track_idx, track) in audio_tracks.iter().enumerate() {
+            for track in &audio_tracks {
                 if !track.is_active(any_audio_solo) {
                     continue;
                 }
@@ -449,8 +411,7 @@ impl Timeline {
                     }
                     mixer = mixer.add_track(derive::audio_track(
                         clip,
-                        track_idx,
-                        &audio_animations,
+                        &track.automation,
                         audio_fade_out_eff_dur(clip),
                     ));
                 }
@@ -566,7 +527,7 @@ impl Timeline {
         } else if has_track_effects {
             // Per-track path: each track's audio is sub-mixed and run through its
             // own push/pull effect graph (so a two-pass step fires), then summed.
-            let mixed = mix_tracks_with_effects(&audio_tracks, any_audio_solo, &audio_animations)?;
+            let mixed = mix_tracks_with_effects(&audio_tracks, any_audio_solo)?;
             // Consume `mixed` by value so each frame drops right after it is pushed
             // downstream, freeing the mix buffer as we go (the master bus keeps its
             // own copy for a two-pass step, so holding `mixed` too would double it).
@@ -645,10 +606,9 @@ fn drain_source_audio(graph: &mut FilterGraph) -> Result<Vec<AudioFrame>, Timeli
 fn mix_tracks_with_effects(
     audio_tracks: &[Track],
     any_audio_solo: bool,
-    audio_animations: &HashMap<String, AnimationTrack<f64>>,
 ) -> Result<Vec<AudioFrame>, TimelineError> {
     let mut track_buffers: Vec<Vec<AudioFrame>> = Vec::new();
-    for (track_idx, track) in audio_tracks.iter().enumerate() {
+    for track in audio_tracks {
         if !track.is_active(any_audio_solo) {
             continue;
         }
@@ -661,8 +621,7 @@ fn mix_tracks_with_effects(
             }
             sub = sub.add_track(derive::audio_track(
                 clip,
-                track_idx,
-                audio_animations,
+                &track.automation,
                 audio_fade_out_eff_dur(clip),
             ));
             has_clip = true;
@@ -747,8 +706,6 @@ pub struct TimelineBuilder {
     frame_rate: Option<f64>,
     video_tracks: Vec<Track>,
     audio_tracks: Vec<Track>,
-    video_animations: HashMap<String, AnimationTrack<f64>>,
-    audio_animations: HashMap<String, AnimationTrack<f64>>,
     /// See [`TimelineBuilder::lavfi_overlay`].
     lavfi_overlay: Option<String>,
     /// See [`TimelineBuilder::audio_filter`].
@@ -770,8 +727,6 @@ impl TimelineBuilder {
             frame_rate: None,
             video_tracks: Vec::new(),
             audio_tracks: Vec::new(),
-            video_animations: HashMap::new(),
-            audio_animations: HashMap::new(),
             lavfi_overlay: None,
             audio_filter: Vec::new(),
         }
@@ -834,36 +789,48 @@ impl TimelineBuilder {
         }
     }
 
-    /// Registers a video-layer animation track.
+    /// Sets a video-layer animation on the video track at `track_index` (its
+    /// position among the video tracks added so far).
     ///
-    /// Key format: `"video_{track_index}_{property}"`, e.g. `"video_0_opacity"`.
-    ///
-    /// Supported properties: `x`, `y`, `scale_x`, `scale_y`, `rotation`, `opacity`.
-    /// Unrecognised keys are stored but emit `log::warn!` during [`Timeline::render()`].
+    /// The animation is stored on the [`Track`] itself (see
+    /// [`TrackAutomation`](crate::TrackAutomation)), so it stays with that track
+    /// through reordering or removal. Add the video track first; an out-of-range
+    /// `track_index` is ignored with a `log::warn!`.
     #[must_use]
-    pub fn video_animation(self, key: impl Into<String>, track: AnimationTrack<f64>) -> Self {
-        let mut video_animations = self.video_animations;
-        video_animations.insert(key.into(), track);
-        Self {
-            video_animations,
-            ..self
+    pub fn video_animation(
+        mut self,
+        track_index: usize,
+        property: VideoProperty,
+        animation: AnimationTrack<f64>,
+    ) -> Self {
+        if let Some(track) = self.video_tracks.get_mut(track_index) {
+            track.automation.set_video(property, animation);
+        } else {
+            log::warn!("video_animation ignored: no video track at index={track_index}");
         }
+        self
     }
 
-    /// Registers an audio-track animation track.
+    /// Sets an audio-track animation on the audio track at `track_index` (its
+    /// position among the audio tracks added so far).
     ///
-    /// Key format: `"audio_{track_index}_{property}"`, e.g. `"audio_0_volume"`.
-    ///
-    /// Supported properties: `volume`, `pan`.
-    /// Unrecognised keys are stored but emit `log::warn!` during [`Timeline::render()`].
+    /// The animation is stored on the [`Track`] itself (see
+    /// [`TrackAutomation`](crate::TrackAutomation)), so it stays with that track
+    /// through reordering or removal. Add the audio track first; an out-of-range
+    /// `track_index` is ignored with a `log::warn!`.
     #[must_use]
-    pub fn audio_animation(self, key: impl Into<String>, track: AnimationTrack<f64>) -> Self {
-        let mut audio_animations = self.audio_animations;
-        audio_animations.insert(key.into(), track);
-        Self {
-            audio_animations,
-            ..self
+    pub fn audio_animation(
+        mut self,
+        track_index: usize,
+        property: AudioProperty,
+        animation: AnimationTrack<f64>,
+    ) -> Self {
+        if let Some(track) = self.audio_tracks.get_mut(track_index) {
+            track.automation.set_audio(property, animation);
+        } else {
+            log::warn!("audio_animation ignored: no audio track at index={track_index}");
         }
+        self
     }
 
     /// Sets an `FFmpeg` `lavfi` filtergraph string that is composited as the topmost
@@ -950,8 +917,6 @@ impl TimelineBuilder {
             next_marker_id: 1,
             next_group_id: 1,
             markers: Vec::new(),
-            video_animations: self.video_animations,
-            audio_animations: self.audio_animations,
             lavfi_overlay: self.lavfi_overlay,
             audio_filter: self.audio_filter,
         })
@@ -1007,9 +972,8 @@ impl TimelineBuilder {
 #[cfg(feature = "preview")]
 fn video_placement(
     clip: &Clip,
-    track_idx: usize,
     is_base: bool,
-    animations: &HashMap<String, AnimationTrack<f64>>,
+    automation: &crate::track::TrackAutomation,
     canvas_width: u32,
     canvas_height: u32,
 ) -> ff_preview::ScenePlacement {
@@ -1038,30 +1002,23 @@ fn video_placement(
         // The single derive: preview and export build their video layers from the
         // same `avio::derive`, so the timeline-level animations (scale/rotation and
         // the opacity/x/y track-level fallbacks) reach the preview too.
-        layer: crate::derive::realtime_descriptor(
-            clip,
-            track_idx,
-            animations,
-            canvas_width,
-            canvas_height,
-        ),
+        layer: crate::derive::realtime_descriptor(clip, automation, canvas_width, canvas_height),
         fade_in: clip.fade_in,
         fade_out: clip.fade_out,
         // V1 clip audio has no dedicated audio-track counterpart in export (which
         // mixes only `audio_tracks`), so its volume is the per-clip merge only.
-        volume: crate::derive::audio_volume(clip, 0, &HashMap::new()),
+        volume: crate::derive::audio_volume(clip, &crate::track::TrackAutomation::default()),
         // The same shared derive as export, so preview pitch matches export.
         pitch: crate::derive::audio_pitch(clip),
     }
 }
 
 /// Projects one audio-only clip into a [`SceneAudioPlacement`](ff_preview::SceneAudioPlacement).
-/// `track_idx` is the audio track index; `animations` the timeline `audio_animations`.
+/// `automation` is the audio track's [`TrackAutomation`](crate::track::TrackAutomation).
 #[cfg(feature = "preview")]
 fn audio_placement(
     clip: &Clip,
-    track_idx: usize,
-    animations: &HashMap<String, AnimationTrack<f64>>,
+    automation: &crate::track::TrackAutomation,
 ) -> ff_preview::SceneAudioPlacement {
     ff_preview::SceneAudioPlacement {
         source: clip
@@ -1074,9 +1031,9 @@ fn audio_placement(
         speed: clip.speed.max(0.01),
         fade_in: clip.fade_in,
         fade_out: clip.fade_out,
-        // The single derive: the volume 3-way merge (incl. the timeline
-        // `audio_{idx}_volume` automation) reaches preview, matching export.
-        volume: crate::derive::audio_volume(clip, track_idx, animations),
+        // The single derive: the volume 3-way merge (incl. the track-level
+        // `volume` automation) reaches preview, matching export.
+        volume: crate::derive::audio_volume(clip, automation),
         // The same shared derive as export, so preview pitch matches export.
         pitch: crate::derive::audio_pitch(clip),
     }
@@ -1095,7 +1052,7 @@ impl Timeline {
     pub fn to_scene(&self) -> ff_preview::Scene {
         // Inactive tracks (disabled, muted, or shadowed by a solo elsewhere in the
         // list) project no placements, but keep their slot so the base-track
-        // (index 0) rule and the `video_{idx}_*` animation keys stay aligned.
+        // (index 0) rule stays aligned; track-level automation lives on the track.
         let any_video_solo = self.video_tracks.iter().any(|t| t.solo);
         let video_tracks = self
             .video_tracks
@@ -1109,9 +1066,8 @@ impl Timeline {
                         .map(|clip| {
                             video_placement(
                                 clip,
-                                track_idx,
                                 track_idx == 0,
-                                &self.video_animations,
+                                &track.automation,
                                 self.canvas_width,
                                 self.canvas_height,
                             )
@@ -1127,13 +1083,12 @@ impl Timeline {
         let audio_tracks = self
             .audio_tracks
             .iter()
-            .enumerate()
-            .map(|(track_idx, track)| ff_preview::SceneAudioTrack {
+            .map(|track| ff_preview::SceneAudioTrack {
                 placements: if track.is_active(any_audio_solo) {
                     track
                         .clips
                         .iter()
-                        .map(|clip| audio_placement(clip, track_idx, &self.audio_animations))
+                        .map(|clip| audio_placement(clip, &track.automation))
                         .collect()
                 } else {
                     Vec::new()
@@ -1250,15 +1205,18 @@ mod tests {
             .video_track(vec![Clip::new("base.mp4")])
             .video_track(vec![Clip::new("overlay.mp4")])
             .video_animation(
-                "video_1_scale_x",
+                1,
+                VideoProperty::ScaleX,
                 AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
             )
             .video_animation(
-                "video_1_rotation",
+                1,
+                VideoProperty::Rotation,
                 AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 45.0, Easing::Linear)),
             )
             .video_animation(
-                "video_1_opacity",
+                1,
+                VideoProperty::Opacity,
                 AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 1.0, Easing::Linear)),
             )
             .build()
@@ -1326,7 +1284,8 @@ mod tests {
             .video_track(vec![Clip::new("v.mp4")])
             .audio_track(vec![Clip::new("a.mp3").with_speed(2.0)]) // neutral volume
             .audio_animation(
-                "audio_0_volume",
+                0,
+                AudioProperty::Volume,
                 AnimationTrack::new().push(Keyframe::new(Duration::ZERO, -3.0, Easing::Linear)),
             )
             .build()
@@ -1334,7 +1293,7 @@ mod tests {
         let scene = timeline.to_scene();
         let audio = &scene.audio_tracks[0].placements[0];
         assert!((audio.speed - 2.0).abs() < f64::EPSILON);
-        // The neutral clip volume falls back to the timeline `audio_0_volume` automation.
+        // The neutral clip volume falls back to the audio track's `volume` automation.
         assert!(matches!(audio.volume, AnimatedValue::Track(_)));
     }
 
@@ -1555,12 +1514,14 @@ mod tests {
             .canvas(1920, 1080)
             .frame_rate(30.0)
             .video_track(vec![Clip::new("video.mp4")])
-            .video_animation("video_0_opacity", track)
+            .video_animation(0, VideoProperty::Opacity, track)
             .build()
             .unwrap();
 
-        assert_eq!(timeline.video_animations.len(), 1);
-        assert!(timeline.video_animations.contains_key("video_0_opacity"));
+        assert!(
+            timeline.video_tracks[0].automation.opacity.is_some(),
+            "the opacity animation lives on the track"
+        );
     }
 
     #[test]
@@ -1580,11 +1541,131 @@ mod tests {
             .canvas(1920, 1080)
             .frame_rate(30.0)
             .audio_track(vec![Clip::new("audio.mp4")])
-            .audio_animation("audio_0_volume", track)
+            .audio_animation(0, AudioProperty::Volume, track)
             .build()
             .unwrap();
 
-        assert_eq!(timeline.audio_animations.len(), 1);
-        assert!(timeline.audio_animations.contains_key("audio_0_volume"));
+        assert!(
+            timeline.audio_tracks[0].automation.volume.is_some(),
+            "the volume animation lives on the track"
+        );
+    }
+
+    #[test]
+    fn reordering_tracks_should_not_misalign_automation() {
+        use ff_filter::{Easing, Keyframe};
+
+        // Track 0 carries an opacity animation; track 1 does not.
+        let mut timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .video_track(vec![Clip::new("b.mp4")])
+            .video_animation(
+                0,
+                VideoProperty::Opacity,
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+            )
+            .build()
+            .unwrap();
+
+        // Reorder the two tracks. With index-keyed automation this would misalign;
+        // with on-track automation the animation moves with its track.
+        timeline.video_tracks.swap(0, 1);
+
+        assert!(
+            timeline.video_tracks[1].automation.opacity.is_some(),
+            "the animated track keeps its automation after reordering"
+        );
+        assert!(
+            timeline.video_tracks[0].automation.opacity.is_none(),
+            "the un-animated track gains no automation after reordering"
+        );
+    }
+
+    #[test]
+    fn removing_a_track_should_drop_only_its_automation() {
+        use crate::{Command, apply};
+        use ff_filter::{Easing, Keyframe};
+
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .video_track(vec![Clip::new("b.mp4")])
+            .video_animation(
+                0,
+                VideoProperty::Opacity,
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+            )
+            .video_animation(
+                1,
+                VideoProperty::Rotation,
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 45.0, Easing::Linear)),
+            )
+            .build()
+            .unwrap();
+
+        let removed = timeline.video_tracks[0].id;
+        let kept_rotation_present = timeline.video_tracks[1].automation.rotation.is_some();
+        let out = apply(&timeline, &Command::RemoveTrack { track: removed }).unwrap();
+
+        assert_eq!(out.video_tracks.len(), 1, "one track removed");
+        assert!(
+            out.video_tracks[0].automation.rotation.is_some() && kept_rotation_present,
+            "the surviving track keeps its own automation"
+        );
+        assert!(
+            out.video_tracks[0].automation.opacity.is_none(),
+            "the removed track's automation is gone (only its automation dropped)"
+        );
+    }
+
+    #[test]
+    fn video_animation_out_of_range_index_should_be_ignored() {
+        use ff_filter::{Easing, Keyframe};
+
+        // Only one video track exists; addressing index 5 must be ignored (a
+        // warn, not a panic) and leave no automation behind.
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .video_animation(
+                5,
+                VideoProperty::Opacity,
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+            )
+            .build()
+            .unwrap();
+        assert!(
+            timeline.video_tracks[0].automation.opacity.is_none(),
+            "an out-of-range track_index sets no automation"
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn track_automation_should_round_trip_through_serde() {
+        use ff_filter::{Easing, Keyframe};
+
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .video_animation(
+                0,
+                VideoProperty::Opacity,
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
+            )
+            .build()
+            .unwrap();
+
+        let json = serde_json::to_string(&timeline).unwrap();
+        let back: Timeline = serde_json::from_str(&json).unwrap();
+        assert!(
+            back.video_tracks[0].automation.opacity.is_some(),
+            "track automation must survive a serde round-trip"
+        );
     }
 }

--- a/crates/avio/src/track.rs
+++ b/crates/avio/src/track.rs
@@ -9,10 +9,91 @@
 //! output (see [`Track::is_active`]); `lock` and `name` are authoring metadata the
 //! derivation ignores.
 
-use ff_filter::FilterStep;
+use ff_filter::{AnimationTrack, FilterStep};
 
 use crate::clip::Clip;
 use crate::ids::TrackId;
+
+/// A video-layer property that a [`TrackAutomation`] can animate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoProperty {
+    /// Horizontal position.
+    X,
+    /// Vertical position.
+    Y,
+    /// Horizontal scale.
+    ScaleX,
+    /// Vertical scale.
+    ScaleY,
+    /// Rotation.
+    Rotation,
+    /// Opacity.
+    Opacity,
+}
+
+/// An audio-track property that a [`TrackAutomation`] can animate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioProperty {
+    /// Volume in dB.
+    Volume,
+    /// Stereo pan.
+    Pan,
+}
+
+/// Typed, per-property track-level automation.
+///
+/// Held by [`Track::automation`], it re-keys the old `"{video|audio}_{index}_{prop}"`
+/// string map by track *identity*: because the automation lives on the track,
+/// reordering or removing a track carries or drops its automation with it.
+/// This mirrors the per-property clip-level tracks on [`Clip`](crate::Clip)
+/// (`opacity_track`, `x_track`, …) so clip and track automation share one model.
+///
+/// Video tracks use the video properties (`opacity`/`x`/`y`/`scale_x`/`scale_y`/
+/// `rotation`); audio tracks use `volume`/`pan`. Unused properties stay `None`.
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TrackAutomation {
+    /// Opacity animation (video).
+    pub opacity: Option<AnimationTrack<f64>>,
+    /// Horizontal-position animation (video).
+    pub x: Option<AnimationTrack<f64>>,
+    /// Vertical-position animation (video).
+    pub y: Option<AnimationTrack<f64>>,
+    /// Horizontal-scale animation (video).
+    pub scale_x: Option<AnimationTrack<f64>>,
+    /// Vertical-scale animation (video).
+    pub scale_y: Option<AnimationTrack<f64>>,
+    /// Rotation animation (video).
+    pub rotation: Option<AnimationTrack<f64>>,
+    /// Volume animation (audio, dB).
+    pub volume: Option<AnimationTrack<f64>>,
+    /// Pan animation (audio).
+    pub pan: Option<AnimationTrack<f64>>,
+}
+
+impl TrackAutomation {
+    /// Sets the animation for a video property.
+    pub fn set_video(&mut self, property: VideoProperty, animation: AnimationTrack<f64>) {
+        let slot = match property {
+            VideoProperty::X => &mut self.x,
+            VideoProperty::Y => &mut self.y,
+            VideoProperty::ScaleX => &mut self.scale_x,
+            VideoProperty::ScaleY => &mut self.scale_y,
+            VideoProperty::Rotation => &mut self.rotation,
+            VideoProperty::Opacity => &mut self.opacity,
+        };
+        *slot = Some(animation);
+    }
+
+    /// Sets the animation for an audio property.
+    pub fn set_audio(&mut self, property: AudioProperty, animation: AnimationTrack<f64>) {
+        let slot = match property {
+            AudioProperty::Volume => &mut self.volume,
+            AudioProperty::Pan => &mut self.pan,
+        };
+        *slot = Some(animation);
+    }
+}
 
 /// An ordered list of [`Clip`]s and its editorial state.
 ///
@@ -55,6 +136,11 @@ pub struct Track {
     /// (mirroring [`Clip::audio_effects`](crate::Clip::audio_effects)).
     #[cfg_attr(feature = "serde", serde(skip))]
     pub audio_effects: Vec<FilterStep>,
+    /// Typed, id-addressed track-level automation (see [`TrackAutomation`]).
+    /// Empty by default; set via the `with_*_animation` builders or
+    /// [`TimelineBuilder`](crate::TimelineBuilder)'s `video_animation` /
+    /// `audio_animation`. Persisted by the `serde` feature.
+    pub automation: TrackAutomation,
 }
 
 impl Track {
@@ -73,6 +159,7 @@ impl Track {
             lock: false,
             clips,
             audio_effects: Vec::new(),
+            automation: TrackAutomation::default(),
         }
     }
 
@@ -116,6 +203,62 @@ impl Track {
     #[must_use]
     pub fn audio_effects(mut self, steps: Vec<FilterStep>) -> Self {
         self.audio_effects = steps;
+        self
+    }
+
+    /// Sets the track-level opacity animation (video).
+    #[must_use]
+    pub fn with_opacity_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.opacity = Some(animation);
+        self
+    }
+
+    /// Sets the track-level horizontal-position animation (video).
+    #[must_use]
+    pub fn with_x_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.x = Some(animation);
+        self
+    }
+
+    /// Sets the track-level vertical-position animation (video).
+    #[must_use]
+    pub fn with_y_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.y = Some(animation);
+        self
+    }
+
+    /// Sets the track-level horizontal-scale animation (video).
+    #[must_use]
+    pub fn with_scale_x_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.scale_x = Some(animation);
+        self
+    }
+
+    /// Sets the track-level vertical-scale animation (video).
+    #[must_use]
+    pub fn with_scale_y_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.scale_y = Some(animation);
+        self
+    }
+
+    /// Sets the track-level rotation animation (video).
+    #[must_use]
+    pub fn with_rotation_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.rotation = Some(animation);
+        self
+    }
+
+    /// Sets the track-level volume animation (audio, dB).
+    #[must_use]
+    pub fn with_volume_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.volume = Some(animation);
+        self
+    }
+
+    /// Sets the track-level pan animation (audio).
+    #[must_use]
+    pub fn with_pan_animation(mut self, animation: AnimationTrack<f64>) -> Self {
+        self.automation.pan = Some(animation);
         self
     }
 
@@ -168,5 +311,43 @@ mod tests {
             track.audio_effects[0],
             FilterStep::Volume(v) if (v - (-6.0)).abs() < 1e-9
         ));
+    }
+
+    #[test]
+    fn new_track_should_have_empty_automation() {
+        let a = TrackAutomation::default();
+        assert!(a.opacity.is_none() && a.x.is_none() && a.volume.is_none() && a.pan.is_none());
+    }
+
+    #[test]
+    fn with_animation_builders_should_set_each_property() {
+        let track = Track::new(vec![])
+            .with_opacity_animation(AnimationTrack::new())
+            .with_x_animation(AnimationTrack::new())
+            .with_y_animation(AnimationTrack::new())
+            .with_scale_x_animation(AnimationTrack::new())
+            .with_scale_y_animation(AnimationTrack::new())
+            .with_rotation_animation(AnimationTrack::new())
+            .with_volume_animation(AnimationTrack::new())
+            .with_pan_animation(AnimationTrack::new());
+        let a = &track.automation;
+        assert!(a.opacity.is_some(), "opacity set");
+        assert!(a.x.is_some() && a.y.is_some(), "position set");
+        assert!(a.scale_x.is_some() && a.scale_y.is_some(), "scale set");
+        assert!(a.rotation.is_some(), "rotation set");
+        assert!(a.volume.is_some() && a.pan.is_some(), "audio set");
+    }
+
+    #[test]
+    fn set_video_and_set_audio_should_target_the_right_slot() {
+        let mut a = TrackAutomation::default();
+        a.set_video(VideoProperty::ScaleY, AnimationTrack::new());
+        a.set_audio(AudioProperty::Pan, AnimationTrack::new());
+        assert!(a.scale_y.is_some(), "set_video hits scale_y");
+        assert!(a.pan.is_some(), "set_audio hits pan");
+        assert!(
+            a.scale_x.is_none() && a.volume.is_none(),
+            "no other slot touched"
+        );
     }
 }

--- a/crates/avio/src/validate.rs
+++ b/crates/avio/src/validate.rs
@@ -5,10 +5,6 @@
 //! references) before rendering. It is purely informational: it performs no I/O,
 //! never opens source files, and does not block [`Timeline::render`] on its own.
 
-use std::collections::HashMap;
-
-use ff_filter::AnimationTrack;
-
 use crate::clip::Clip;
 use crate::edit::clip_footprint;
 use crate::ids::{ClipId, TrackId};
@@ -17,7 +13,7 @@ use crate::track::Track;
 
 /// A single problem found by [`Timeline::validate`].
 ///
-/// Each variant names the offending [`ClipId`] / [`TrackId`] (or animation key)
+/// Each variant names the offending [`ClipId`] / [`TrackId`]
 /// and the cause. This is informational, not an error: a timeline may render even
 /// with issues present.
 #[non_exhaustive]
@@ -61,12 +57,6 @@ pub enum TimelineIssue {
         /// The offending clip.
         clip: ClipId,
     },
-    /// An animation-map key is malformed, or targets a track index that does not
-    /// exist (so the animation reaches no layer).
-    UnknownAnimationKey {
-        /// The offending key.
-        key: String,
-    },
 }
 
 impl Timeline {
@@ -98,20 +88,8 @@ impl Timeline {
         for track in self.video_tracks.iter().chain(self.audio_tracks.iter()) {
             check_track(track, &mut issues);
         }
-        check_animation_keys(
-            "video",
-            &self.video_animations,
-            self.video_tracks.len(),
-            &["x", "y", "scale_x", "scale_y", "rotation", "opacity"],
-            &mut issues,
-        );
-        check_animation_keys(
-            "audio",
-            &self.audio_animations,
-            self.audio_tracks.len(),
-            &["volume", "pan"],
-            &mut issues,
-        );
+        // Track-level automation is typed and lives on the track itself, so it can
+        // no longer target a non-existent track or use a malformed key.
         issues
     }
 }
@@ -179,34 +157,12 @@ fn check_overlaps(track: &Track, issues: &mut Vec<TimelineIssue>) {
     }
 }
 
-/// Flags animation keys that do not match `{prefix}_{track_index}_{property}`, or
-/// whose track index is out of range for the current track count.
-fn check_animation_keys(
-    prefix: &str,
-    animations: &HashMap<String, AnimationTrack<f64>>,
-    track_count: usize,
-    valid_props: &[&str],
-    issues: &mut Vec<TimelineIssue>,
-) {
-    for key in animations.keys() {
-        let parts: Vec<&str> = key.splitn(3, '_').collect();
-        let idx = parts.get(1).and_then(|p| p.parse::<usize>().ok());
-        let ok = parts.len() == 3
-            && parts[0] == prefix
-            && idx.is_some_and(|i| i < track_count)
-            && valid_props.contains(&parts[2]);
-        if !ok {
-            issues.push(TimelineIssue::UnknownAnimationKey { key: key.clone() });
-        }
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use std::time::Duration;
 
-    use ff_filter::{AnimationTrack, XfadeTransition};
+    use ff_filter::XfadeTransition;
     use ff_format::Color;
 
     use super::*;
@@ -358,32 +314,6 @@ mod tests {
             track: t.video_tracks()[0].id,
             clip: id,
         }));
-    }
-
-    #[test]
-    fn validate_should_detect_unknown_animation_key() {
-        // "bogus" is malformed; "video_9_x" targets a non-existent track index.
-        let t = base(vec![
-            Clip::new("a.mp4").trim(Duration::ZERO, Duration::from_secs(4)),
-        ])
-        .video_animation("bogus", AnimationTrack::new())
-        .video_animation("video_9_x", AnimationTrack::new())
-        .video_animation("video_0_x", AnimationTrack::new()) // valid
-        .build()
-        .unwrap();
-        let issues = t.validate();
-        assert!(issues.contains(&TimelineIssue::UnknownAnimationKey {
-            key: "bogus".into()
-        }));
-        assert!(issues.contains(&TimelineIssue::UnknownAnimationKey {
-            key: "video_9_x".into()
-        }));
-        assert!(
-            !issues.contains(&TimelineIssue::UnknownAnimationKey {
-                key: "video_0_x".into()
-            }),
-            "a valid, in-range key is not flagged"
-        );
     }
 
     #[test]

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use avio::{
     AnimationTrack, BlendMode, Clip, ClipSource, Command, Easing, Keyframe, Marker, Timeline,
-    XfadeTransition, apply,
+    VideoProperty, XfadeTransition, apply,
 };
 use ff_filter::{FilterStep, PitchAlgo};
 use ff_format::{Color, TextSpec};
@@ -48,7 +48,8 @@ fn sample_timeline() -> Timeline {
                 .volume(-6.0),
         ])
         .video_animation(
-            "video_1_scale_x",
+            1,
+            VideoProperty::ScaleX,
             AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear)),
         )
         .build()

--- a/crates/avio/tests/timeline_tests.rs
+++ b/crates/avio/tests/timeline_tests.rs
@@ -9,7 +9,7 @@ mod fixtures;
 
 use std::time::Duration;
 
-use avio::{Clip, EncoderConfig, Timeline, TimelineError, Track};
+use avio::{AudioProperty, Clip, EncoderConfig, Timeline, TimelineError, Track};
 use ff_encode::{AudioCodec, BitrateMode, VideoCodec};
 use ff_filter::FilterStep;
 use ff_filter::animation::{AnimationTrack, Easing};
@@ -563,9 +563,9 @@ fn timeline_with_volume_animation_should_encode_successfully() {
         .frame_rate(FPS)
         .video_track(vec![clip.clone()])
         .audio_track(vec![clip])
-        // "audio_0_volume" is the key used by TimelineBuilder for the first
-        // audio track's volume animation (format: "audio_{track_idx}_{prop}").
-        .audio_animation("audio_0_volume", vol_track)
+        // Volume automation on the first audio track (index 0), now keyed by
+        // the track itself rather than an "audio_{idx}_volume" string.
+        .audio_animation(0, AudioProperty::Volume, vol_track)
         .build()
     {
         Ok(t) => t,


### PR DESCRIPTION
## Objective

- Track-level automation was a `HashMap<String, AnimationTrack<f64>>` keyed `"video_{track_index}_{property}"` / `"audio_{track_index}_{property}"`, so reordering or removing a track silently misaligned it.
- Unknown keys only warned at render, and the model was inconsistent with the id-addressed clip model.

## Solution

- Replace the string maps with a typed `TrackAutomation` held on each `Track` (opacity/x/y/scale_x/scale_y/rotation for video, volume/pan for audio). Because the automation lives on the track, reordering or removing a track carries or drops it structurally — mirroring the per-property clip-level tracks on `Clip`.
- `derive` consumes `&TrackAutomation` instead of parsing `"{prefix}_{idx}_{prop}"` keys; `validate.rs` drops the now-impossible unknown-key check and its `TimelineIssue` variant.
- Builder `video_animation`/`audio_animation` take a track index plus a typed `VideoProperty`/`AudioProperty` (out-of-range index is ignored with a warn); `Track` gains `with_*_animation` builders. Automation persists through serde.
- Tests cover reorder/remove alignment, the serde round-trip, the typed builders, and the out-of-range-index path.

Honouring is complete for the supported properties; no `video_{index}_{prop}` string keys remain.

Closes #1590