### PR TITLE
feat(avio): apply clip pan on export and preview

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -141,6 +141,15 @@ pub struct Clip {
     /// **timeline-global** time. Takes precedence over the static
     /// [`pitch`](Self::pitch) when set. Defaults to `None`.
     pub pitch_track: Option<AnimationTrack<f64>>,
+    /// Per-clip stereo **pan** position applied during audio mixing: `-1.0` is full
+    /// left, `+1.0` is full right, `0.0` is center.
+    ///
+    /// This value is independent of any track-level pan automation. When non-zero
+    /// the clip's own pan overrides the track-level value; set to `0.0` to defer to
+    /// the track level. Values outside `[-1.0, 1.0]` are clamped by [`pan`](Self::pan).
+    ///
+    /// Defaults to `0.0` (center).
+    pub pan: f64,
     /// Audio fade-in duration at the start of the clip (`Duration::ZERO` = no fade).
     ///
     /// When non-zero, a linear ramp from silence to the clip's volume level is
@@ -361,6 +370,7 @@ impl Clip {
             volume_track: None,
             pitch: 0.0,
             pitch_track: None,
+            pan: 0.0,
             fade_in: Duration::ZERO,
             fade_out: Duration::ZERO,
             brightness: 0.0,
@@ -635,6 +645,28 @@ impl Clip {
     pub fn with_volume_track(self, track: AnimationTrack<f64>) -> Self {
         Self {
             volume_track: Some(track),
+            ..self
+        }
+    }
+
+    /// Sets the per-clip stereo **pan** and returns the updated clip.
+    ///
+    /// `-1.0` is full left, `+1.0` is full right, `0.0` is center. The value is
+    /// clamped to `[-1.0, 1.0]`. When non-zero this overrides the track-level pan
+    /// automation for this clip during mixing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use avio::Clip;
+    ///
+    /// let clip = Clip::new("narration.wav").pan(0.5);
+    /// assert_eq!(clip.pan, 0.5);
+    /// ```
+    #[must_use]
+    pub fn pan(self, pan: f64) -> Self {
+        Self {
+            pan: pan.clamp(-1.0, 1.0),
             ..self
         }
     }
@@ -1114,6 +1146,19 @@ mod tests {
     fn clip_volume_positive_should_set_volume_db() {
         let clip = Clip::new("audio.wav").volume(3.0);
         assert_eq!(clip.volume_db, 3.0);
+    }
+
+    #[test]
+    fn clip_new_should_default_pan_to_center() {
+        let clip = Clip::new("audio.wav");
+        assert_eq!(clip.pan, 0.0);
+    }
+
+    #[test]
+    fn clip_pan_setter_should_clamp() {
+        assert_eq!(Clip::new("audio.wav").pan(2.0).pan, 1.0);
+        assert_eq!(Clip::new("audio.wav").pan(-3.0).pan, -1.0);
+        assert_eq!(Clip::new("audio.wav").pan(0.5).pan, 0.5);
     }
 
     #[test]

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -281,6 +281,20 @@ pub(crate) fn audio_volume(clip: &Clip, automation: &TrackAutomation) -> Animate
     }
 }
 
+/// The 3-way-merged audio pan (`-1.0` left .. `+1.0` right): a non-zero static
+/// `Clip.pan` wins, then the track-level `pan` automation, else center (`0.0`).
+/// Mirrors [`audio_volume`] and is shared by the export [`audio_track`] and the
+/// preview projection ([`Timeline::to_scene`](crate::Timeline::to_scene)) so they
+/// cannot diverge.
+#[allow(clippy::float_cmp)]
+pub(crate) fn audio_pan(clip: &Clip, automation: &TrackAutomation) -> AnimatedValue<f64> {
+    if clip.pan != 0.0 {
+        AnimatedValue::Static(clip.pan)
+    } else {
+        track_anim(automation.pan.as_ref(), 0.0)
+    }
+}
+
 /// The per-clip pitch (semitones): a set `pitch_track` evaluated at its `t=0`
 /// value, else the static `Clip.pitch`. Per-sample pitch automation is a deferred
 /// primitive capability (see ADR-0002). Shared by the export [`audio_track`] and
@@ -379,7 +393,7 @@ pub(crate) fn audio_track(
     AudioTrack {
         source: source_path,
         volume,
-        pan: track_anim(automation.pan.as_ref(), 0.0),
+        pan: audio_pan(clip, automation),
         effects,
         sample_rate: 48_000,
         channel_layout: ChannelLayout::Stereo,
@@ -785,6 +799,54 @@ mod tests {
         assert!(matches!(
             audio_volume(&clip, &automation),
             AnimatedValue::Static(x) if (x + 6.0).abs() < 1e-9
+        ));
+    }
+
+    // audio_pan (shared 3-way merge)
+
+    #[test]
+    fn audio_pan_should_prefer_static_clip_pan() {
+        // A non-zero static clip pan wins over the track-level pan animation.
+        let automation = TrackAutomation {
+            pan: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                -0.5,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
+        let clip = Clip::new("a.mp3").pan(0.8);
+        assert!(matches!(
+            audio_pan(&clip, &automation),
+            AnimatedValue::Static(x) if (x - 0.8).abs() < 1e-9
+        ));
+    }
+
+    #[test]
+    fn audio_pan_should_fall_back_to_track_animation() {
+        let automation = TrackAutomation {
+            pan: Some(AnimationTrack::new().push(Keyframe::new(
+                Duration::ZERO,
+                0.5,
+                Easing::Linear,
+            ))),
+            ..Default::default()
+        };
+        let clip = Clip::new("a.mp3"); // center pan, no clip pan
+        assert!(matches!(
+            audio_pan(&clip, &automation),
+            AnimatedValue::Track(_)
+        ));
+    }
+
+    #[test]
+    fn audio_track_should_apply_clip_pan() {
+        // A clip pan reaches the mixer struct's `pan` field (previously discarded).
+        let clip = Clip::new("a.mp3").pan(0.8);
+        let track = audio_track(&clip, &no_anim(), None);
+        assert!(matches!(
+            track.pan,
+            AnimatedValue::Static(x) if (x - 0.8).abs() < 1e-9
         ));
     }
 

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -1010,6 +1010,8 @@ fn video_placement(
         volume: crate::derive::audio_volume(clip, &crate::track::TrackAutomation::default()),
         // The same shared derive as export, so preview pitch matches export.
         pitch: crate::derive::audio_pitch(clip),
+        // The pan 3-way merge, same shared derive as export.
+        pan: crate::derive::audio_pan(clip, &crate::track::TrackAutomation::default()),
     }
 }
 
@@ -1036,6 +1038,8 @@ fn audio_placement(
         volume: crate::derive::audio_volume(clip, automation),
         // The same shared derive as export, so preview pitch matches export.
         pitch: crate::derive::audio_pitch(clip),
+        // The pan 3-way merge (incl. the track-level `pan` automation), matching export.
+        pan: crate::derive::audio_pan(clip, automation),
     }
 }
 
@@ -1316,6 +1320,36 @@ mod tests {
         assert!((scene.video_tracks[0].placements[0].pitch - 3.0).abs() < f64::EPSILON);
         // Audio-only clip: a set pitch_track wins over the static pitch, at t=0.
         assert!((scene.audio_tracks[0].placements[0].pitch - 5.0).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_carry_clip_pan() {
+        use ff_filter::{Easing, Keyframe};
+
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("v.mp4").pan(-0.4)])
+            .audio_track(vec![Clip::new("a.mp3")]) // center clip pan
+            .audio_animation(
+                0,
+                AudioProperty::Pan,
+                AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.6, Easing::Linear)),
+            )
+            .build()
+            .unwrap();
+        let scene = timeline.to_scene();
+        // Video-clip audio carries the static per-clip pan.
+        assert!(matches!(
+            scene.video_tracks[0].placements[0].pan,
+            AnimatedValue::Static(x) if (x + 0.4).abs() < 1e-9
+        ));
+        // Audio-only clip: the center clip pan falls back to the track's pan automation.
+        assert!(matches!(
+            scene.audio_tracks[0].placements[0].pan,
+            AnimatedValue::Track(_)
+        ));
     }
 
     #[cfg(feature = "preview")]

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1583,6 +1583,52 @@ pub(super) unsafe fn build_audio_mix(
             }
         }
 
+        // Static stereo pan (balance): center is a unity passthrough, so a `pan`
+        // filter is inserted only when the pan is off-center. `l_gain`/`r_gain`
+        // attenuate the opposite channel linearly; an animated pan is not applied
+        // per sample (warned above) and uses its initial value. The value is
+        // clamped to [-1.0, 1.0] to match the preview mixer's `set_pan` and avoid
+        // a negative (phase-inverting) gain from an out-of-range track animation.
+        {
+            let pan_pos = track.pan.value_at(Duration::ZERO).clamp(-1.0, 1.0);
+            if pan_pos.abs() > 1e-6 {
+                let l_gain = (1.0 - pan_pos).min(1.0);
+                let r_gain = (1.0 + pan_pos).min(1.0);
+                let node_name = format!("audio_{idx}_pan");
+                let pan_filter = ff_sys::avfilter_get_by_name(c"pan".as_ptr());
+                if pan_filter.is_null() {
+                    bail!(graph, "filter not found: pan");
+                }
+                let Ok(pan_name) = CString::new(node_name.as_str()) else {
+                    bail!(graph, "CString::new failed for pan name");
+                };
+                let Ok(pan_args) = CString::new(format!("stereo|c0={l_gain}*c0|c1={r_gain}*c1"))
+                else {
+                    bail!(graph, "CString::new failed for pan args");
+                };
+                let mut pan_ctx: *mut ff_sys::AVFilterContext = std::ptr::null_mut();
+                let ret = ff_sys::avfilter_graph_create_filter(
+                    &raw mut pan_ctx,
+                    pan_filter,
+                    pan_name.as_ptr(),
+                    pan_args.as_ptr(),
+                    std::ptr::null_mut(),
+                    graph,
+                );
+                if ret < 0 {
+                    bail!(
+                        graph,
+                        format!("failed to create pan filter track={idx} code={ret}")
+                    );
+                }
+                let ret = ff_sys::avfilter_link(chain_end, 0, pan_ctx, 0);
+                if ret < 0 {
+                    bail!(graph, format!("link failed: →pan track={idx}"));
+                }
+                chain_end = pan_ctx;
+            }
+        }
+
         // Per-track effects chain
         for (eff_idx, step) in track.effects.iter().enumerate() {
             let combined_idx = idx * 1000 + eff_idx;

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -771,6 +771,136 @@ fn volume_automation_should_increase_audio_amplitude_over_time() {
     );
 }
 
+/// Per-channel RMS of interleaved packed-F32 stereo samples (`[L0, R0, L1, R1, ...]`).
+/// Returns `(left_rms, right_rms)`.
+fn stereo_rms_bytes(raw: &[u8]) -> (f64, f64) {
+    let n = raw.len() / 4;
+    let sample = |i: usize| {
+        let b = [raw[i * 4], raw[i * 4 + 1], raw[i * 4 + 2], raw[i * 4 + 3]];
+        f32::from_le_bytes(b) as f64
+    };
+    let (mut l_sq, mut r_sq, mut lc, mut rc) = (0.0, 0.0, 0usize, 0usize);
+    for i in 0..n {
+        let s = sample(i);
+        if i % 2 == 0 {
+            l_sq += s * s;
+            lc += 1;
+        } else {
+            r_sq += s * s;
+            rc += 1;
+        }
+    }
+    let l = if lc > 0 {
+        (l_sq / lc as f64).sqrt()
+    } else {
+        0.0
+    };
+    let r = if rc > 0 {
+        (r_sq / rc as f64).sqrt()
+    } else {
+        0.0
+    };
+    (l, r)
+}
+
+/// Verifies that a static clip pan on an `AudioTrack` is applied by the export
+/// mixer: a full-left pan (`-1.0`) attenuates the right channel to silence
+/// (linear stereo balance), so left-channel RMS dominates.
+#[test]
+#[ignore = "requires FFmpeg filter graph; run with -- --include-ignored"]
+fn export_mixer_should_apply_clip_pan() {
+    const SAMPLE_RATE: u32 = 48_000;
+    const CHANNELS: u32 = 2;
+    const FRAME_SAMPLES: usize = 1024;
+    const AUDIO_FRAMES: usize = 30;
+
+    let src_path = test_output_path("pan_apply_src.m4a");
+    let _src_guard = FileGuard::new(src_path.clone());
+
+    let mut enc = match AudioEncoder::create(&src_path)
+        .audio(SAMPLE_RATE, CHANNELS)
+        .audio_codec(AudioCodec::Aac)
+        .build()
+    {
+        Ok(e) => e,
+        Err(e) => {
+            println!("Skipping: AudioEncoder::build failed: {e}");
+            return;
+        }
+    };
+    for _ in 0..AUDIO_FRAMES {
+        let frame = constant_amplitude_frame(0.5, FRAME_SAMPLES, SAMPLE_RATE);
+        if let Err(e) = enc.push(&frame) {
+            println!("Skipping: source push failed: {e}");
+            return;
+        }
+    }
+    if let Err(e) = enc.finish() {
+        println!("Skipping: source encoder finish failed: {e}");
+        return;
+    }
+
+    let mut mixer = match MultiTrackAudioMixer::new(SAMPLE_RATE, ChannelLayout::Stereo)
+        .add_track(AudioTrack {
+            source: src_path.clone(),
+            volume: AnimatedValue::Static(0.0),
+            pan: AnimatedValue::Static(-1.0), // full left
+            effects: vec![],
+            sample_rate: SAMPLE_RATE,
+            channel_layout: ChannelLayout::Stereo,
+        })
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: MultiTrackAudioMixer::build failed: {e}");
+            return;
+        }
+    };
+
+    let mut left = 0.0;
+    let mut right = 0.0;
+    let mut chunk_pts = Duration::ZERO;
+    let chunk_duration = Duration::from_secs_f64(FRAME_SAMPLES as f64 / SAMPLE_RATE as f64);
+    let mut chunks = 0usize;
+    loop {
+        mixer.tick(chunk_pts);
+        match mixer.pull_audio() {
+            Ok(Some(frame)) => {
+                let (l, r) = match frame.format() {
+                    // Packed interleaved F32: [L, R, L, R, ...] in plane 0.
+                    SampleFormat::F32 => frame.plane(0).map_or((0.0, 0.0), stereo_rms_bytes),
+                    // Planar (e.g. F32p from `amix`): plane 0 = left, plane 1 = right.
+                    _ => {
+                        let l = frame.plane(0).map_or(0.0, rms_bytes);
+                        let r = frame.plane(1).map_or(0.0, rms_bytes);
+                        (l, r)
+                    }
+                };
+                left += l;
+                right += r;
+                chunks += 1;
+                chunk_pts += chunk_duration;
+            }
+            Ok(None) => break,
+            Err(e) => {
+                println!("Skipping: pull_audio failed: {e}");
+                return;
+            }
+        }
+    }
+
+    if chunks < 5 || left <= 0.0 {
+        println!("Skipping: too few audio chunks ({chunks}) or no left signal ({left:.6})");
+        return;
+    }
+    assert!(
+        left > right * 8.0,
+        "full-left pan must attenuate the right channel: left RMS sum ({left:.6}) \
+         must be > 8× right RMS sum ({right:.6})"
+    );
+}
+
 /// Verifies that frames pulled from `MultiTrackComposer` always have `yuv420p` format,
 /// regardless of FFmpeg's internal format negotiation.
 ///

--- a/crates/ff-preview/src/scene/mod.rs
+++ b/crates/ff-preview/src/scene/mod.rs
@@ -198,6 +198,16 @@ impl ScenePlayer {
             {
                 handle.set_volume(db_to_linear(*db));
             }
+            // Apply pan once at open at its `t=0` value (an animated pan uses its
+            // initial value, matching the export mixer).
+            if let Some(handle) = &audio_track_handles[i] {
+                let pan0 = clip_list[i].pan.value_at(Duration::ZERO);
+                if pan0 != 0.0 {
+                    // `set_pan` clamps to [-1.0, 1.0], so the f32 narrowing is safe.
+                    #[allow(clippy::cast_possible_truncation)]
+                    handle.set_pan(pan0 as f32);
+                }
+            }
             clip_states.push(ClipState {
                 source: p.source.clone(),
                 decode_buf,
@@ -254,6 +264,14 @@ impl ScenePlayer {
                         && *db != 0.0
                     {
                         handle.set_volume(db_to_linear(*db));
+                    }
+                    // Apply pan once at open at its `t=0` value (an animated pan uses
+                    // its initial value, matching the export mixer).
+                    let pan0 = p.pan.value_at(Duration::ZERO);
+                    if pan0 != 0.0 {
+                        // `set_pan` clamps to [-1.0, 1.0], so the f32 narrowing is safe.
+                        #[allow(clippy::cast_possible_truncation)]
+                        handle.set_pan(pan0 as f32);
                     }
                     audio_only_tracks.push(AudioOnlyTrack {
                         source: p.source.clone(),
@@ -328,6 +346,14 @@ impl ScenePlayer {
                     && *db != 0.0
                 {
                     handle.set_volume(db_to_linear(*db));
+                }
+                // Apply pan once at open at its `t=0` value (an animated pan uses its
+                // initial value, matching the export mixer).
+                let pan0 = p.pan.value_at(Duration::ZERO);
+                if pan0 != 0.0 {
+                    // `set_pan` clamps to [-1.0, 1.0], so the f32 narrowing is safe.
+                    #[allow(clippy::cast_possible_truncation)]
+                    handle.set_pan(pan0 as f32);
                 }
                 audio_only_tracks.push(AudioOnlyTrack {
                     source: p.source.clone(),

--- a/crates/ff-preview/src/scene/types.rs
+++ b/crates/ff-preview/src/scene/types.rs
@@ -86,6 +86,11 @@ pub struct ScenePlacement {
     /// is evaluated at its `t=0` value (static, per ADR-0002); the preview applies
     /// it duration-preserving, matching the export shift at the model level.
     pub pitch: f64,
+    /// Resolved stereo pan (`-1.0` left .. `+1.0` right, `0.0` center), static or
+    /// animated. Applied once at open at its `t=0` value; per-sample pan automation
+    /// is a deferred capability, so an animated pan uses its initial value (matching
+    /// the export mixer).
+    pub pan: AnimatedValue<f64>,
 }
 
 // SceneAudioTrack
@@ -124,4 +129,9 @@ pub struct SceneAudioPlacement {
     /// is evaluated at its `t=0` value (static, per ADR-0002); the preview applies
     /// it duration-preserving, matching the export shift at the model level.
     pub pitch: f64,
+    /// Resolved stereo pan (`-1.0` left .. `+1.0` right, `0.0` center), static or
+    /// animated. Applied once at open at its `t=0` value; per-sample pan automation
+    /// is a deferred capability, so an animated pan uses its initial value (matching
+    /// the export mixer).
+    pub pan: AnimatedValue<f64>,
 }


### PR DESCRIPTION
## Objective

- Clip pan was computed in derivation but never applied in the export mixer, and there was no clip-level pan field applied on either path (part of the preview-equals-export parity work).

## Solution

- Add `Clip.pan` (clamped to `[-1, 1]`) with a `pan()` setter and a shared `derive::audio_pan` merge (clip pan over track-level pan automation), feeding both the export `AudioTrack` and the preview scene.
- Apply the pan in the export mixer via a `pan` filter node using a linear stereo balance, inserted only off-center (center stays unity); the value is clamped to match the preview mixer.
- Carry `pan` on `ScenePlacement` / `SceneAudioPlacement` and apply it at open through the existing constant-power `set_pan`.
- Add an integration test that a full-left pan silences the right channel, plus unit tests for the merge, the setter clamp, and the scene projection.

This addresses only the pan gap of #1591; per-frame scale/rotation (#1614) and generated Text/Solid sources in preview (#1615) are split into follow-ups on the same milestone.

Part of #1591