### PR TITLE
chore(avio): persist Track.audio_effects through serde

### DIFF
--- a/crates/avio/src/track.rs
+++ b/crates/avio/src/track.rs
@@ -131,10 +131,11 @@ pub struct Track {
     /// than one clip. An empty chain (the default) is a no-op and leaves the
     /// audio path unchanged. Ignored for video tracks (they carry no audio).
     ///
-    /// Not persisted by the `serde` feature yet: `FilterStep` is not
-    /// serializable, so this field is skipped and deserializes to an empty vec
-    /// (mirroring [`Clip::audio_effects`](crate::Clip::audio_effects)).
-    #[cfg_attr(feature = "serde", serde(skip))]
+    /// Persisted by the `serde` feature (#1452), like
+    /// [`Clip::audio_effects`](crate::Clip::audio_effects) and
+    /// [`Timeline::audio_filter`](crate::Timeline). The compositor-internal
+    /// `FilterStep` variants (`Blend` / `Composite` / `AlphaMatte`) are not
+    /// serialized, but an audio chain never contains them.
     pub audio_effects: Vec<FilterStep>,
     /// Typed, id-addressed track-level automation (see [`TrackAutomation`]).
     /// Empty by default; set via the `with_*_animation` builders or

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use avio::{
     AnimationTrack, BlendMode, Clip, ClipSource, Command, Easing, Keyframe, Marker, Timeline,
-    VideoProperty, XfadeTransition, apply,
+    Track, VideoProperty, XfadeTransition, apply,
 };
 use ff_filter::{FilterStep, PitchAlgo};
 use ff_format::{Color, TextSpec};
@@ -217,6 +217,55 @@ fn timeline_audio_filter_should_round_trip_through_serde() {
         v1, v2,
         "timeline audio_filter must round-trip through serde"
     );
+}
+
+#[test]
+fn timeline_track_audio_effects_should_round_trip_through_serde() {
+    // #1592: `Track.audio_effects` was `#[serde(skip)]`, so a saved project dropped
+    // its track-level (pre-mix) audio chain on reload. It now persists like the
+    // timeline-level `audio_filter` and the per-clip `Clip.audio_effects`.
+    let track = Track::new(vec![Clip::new("music.mp3")]).audio_effects(vec![
+        FilterStep::Volume(-6.0),
+        FilterStep::PitchShift {
+            semitones: 3.0,
+            algo: PitchAlgo::Signal,
+        },
+    ]);
+    let original = Timeline::builder()
+        .canvas(1920, 1080)
+        .frame_rate(30.0)
+        .audio_track_with(track)
+        .build()
+        .unwrap();
+
+    let json = serde_json::to_string(&original).unwrap();
+    assert!(
+        json.contains("audio_effects") && json.contains("PitchShift"),
+        "the track audio_effects chain must be serialized: {json}"
+    );
+    let back: Timeline = serde_json::from_str(&json).unwrap();
+
+    // A dropped chain would make the re-serialized Value differ from the original.
+    let v1: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let v2: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&back).unwrap()).unwrap();
+    assert_eq!(v1, v2, "track audio_effects must round-trip through serde");
+
+    // Non-vacuous: the chain and its variant payloads survive (empty before the fix).
+    let effects = &back.audio_tracks()[0].audio_effects;
+    assert_eq!(
+        effects.len(),
+        2,
+        "both track audio effects survive the round-trip (previously dropped by serde(skip))"
+    );
+    assert!(matches!(effects[0], FilterStep::Volume(v) if (v + 6.0).abs() < 1e-9));
+    assert!(matches!(
+        effects[1],
+        FilterStep::PitchShift {
+            algo: PitchAlgo::Signal,
+            ..
+        }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Objective

- A saved project silently lost its track-level audio effect chain on reload: `Track.audio_effects` carried a stale `#[serde(skip)]` that predates #1452 (which made `FilterStep` serializable), while `Clip.audio_effects` and `Timeline.audio_filter` already persist.

## Solution

- Remove the `#[serde(skip)]` on `Track.audio_effects` so it round-trips, and correct the stale doc comment (the compositor-internal `Blend` / `Composite` / `AlphaMatte` variants stay skipped, but an audio chain never holds them).
- Add `timeline_track_audio_effects_should_round_trip_through_serde`, asserting the chain length and its variant payloads survive a serialize/deserialize cycle.
- Breaking change to the serde on-disk format: documents saved before this change lack the `audio_effects` key and no longer deserialize (no `#[serde(default)]` is added, matching the model's existing fields).
- Bug bucket: the avio model contains exactly one `#[serde(skip)]` (this field); no other load-bearing state is dropped on round-trip.

Closes #1592