### PR TITLE
feat(avio): animate clip scale/rotation per frame in the compositor

### DIFF
--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -18,8 +18,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use ff_filter::{
-    AnimatedValue, AnimationTrack, AudioTrack, BlendMode, CompositeOp, FilterStep, LayerSource,
-    PitchAlgo, ProxySource, RealtimeLayerDescriptor, ScaleAlgorithm, VideoLayer,
+    AnimatedValue, AnimationTrack, AudioTrack, BlendMode, CompositeOp, FilterStep, Keyframe,
+    LayerSource, PitchAlgo, ProxySource, RealtimeLayerDescriptor, ScaleAlgorithm, VideoLayer,
 };
 use ff_format::ChannelLayout;
 
@@ -116,6 +116,80 @@ fn video_transform(clip: &Clip, automation: &TrackAutomation) -> VideoTransform 
     }
 }
 
+/// Multiplies every keyframe value by `dim`, converting a scale **factor** track
+/// into a **pixel** track for [`FilterStep::ScaleAnimated`] (which sizes in pixels,
+/// while the static compositor node uses `canvas * factor`). Timestamps and easing
+/// are preserved so the animation shape is unchanged.
+fn scale_track_pixels(track: &AnimationTrack<f64>, dim: u32) -> AnimationTrack<f64> {
+    let mut out = AnimationTrack::new();
+    for kf in track.keyframes() {
+        out = out.push(Keyframe::new(
+            kf.timestamp,
+            kf.value * f64::from(dim),
+            kf.easing.clone(),
+        ));
+    }
+    out
+}
+
+/// Maps a scale-factor [`AnimatedValue`] to pixels (`value * dim`), keeping the
+/// `Static`/`Track` shape.
+fn to_pixels(value: &AnimatedValue<f64>, dim: u32) -> AnimatedValue<f64> {
+    match value {
+        AnimatedValue::Static(v) => AnimatedValue::Static(v * f64::from(dim)),
+        AnimatedValue::Track(t) => AnimatedValue::Track(scale_track_pixels(t, dim)),
+    }
+}
+
+/// The per-frame geometry: when the merged scale or rotation is animated, returns the
+/// self-animating [`FilterStep::ScaleAnimated`]/[`RotateAnimated`] steps to splice
+/// into the effect chain plus the **neutralized** static scalars (`scale=1.0` /
+/// `rotation=0.0`) so the compositor's static transform node is skipped and the
+/// animation is applied once, per frame, identically in preview and export
+/// (ADR-0005). A non-animated axis returns no step and its scalar unchanged.
+fn animated_geometry(
+    transform: &VideoTransform,
+    canvas_width: u32,
+    canvas_height: u32,
+) -> (
+    Vec<FilterStep>,
+    AnimatedValue<f64>,
+    AnimatedValue<f64>,
+    AnimatedValue<f64>,
+) {
+    let mut steps = Vec::new();
+    let mut scale_x = transform.scale_x.clone();
+    let mut scale_y = transform.scale_y.clone();
+    let mut rotation = transform.rotation.clone();
+
+    // Rotation is emitted BEFORE scale: `RotateAnimated` supersamples around a stable
+    // input size, so it must run on the un-scaled frame; an animated `ScaleAnimated`
+    // then varies the output size, which the downstream `overlay` handles. (Scale is
+    // uniform for the clip `scale`, so the two commute.)
+    if matches!(transform.rotation, AnimatedValue::Track(_)) {
+        steps.push(FilterStep::RotateAnimated {
+            // `angle` is degrees (matching the compositor's static rotate node).
+            angle: transform.rotation.clone(),
+            fill_color: "black".to_string(),
+        });
+        rotation = AnimatedValue::Static(0.0);
+    }
+    // Scale animates as a whole (both axes) whenever either axis is a track, so the
+    // single `ScaleAnimated` owns both dimensions and both scalars neutralize.
+    if matches!(transform.scale_x, AnimatedValue::Track(_))
+        || matches!(transform.scale_y, AnimatedValue::Track(_))
+    {
+        steps.push(FilterStep::ScaleAnimated {
+            width: to_pixels(&transform.scale_x, canvas_width),
+            height: to_pixels(&transform.scale_y, canvas_height),
+            algorithm: ScaleAlgorithm::Bicubic,
+        });
+        scale_x = AnimatedValue::Static(1.0);
+        scale_y = AnimatedValue::Static(1.0);
+    }
+    (steps, scale_x, scale_y, rotation)
+}
+
 /// Maps a clip's [`FitMode`] to the canvas-relative framing [`FilterStep`], or
 /// `None` for [`FitMode::None`] (native size, no framing). Shared by the export
 /// [`video_layer`] and preview [`realtime_descriptor`] paths so both frame a clip
@@ -178,6 +252,14 @@ pub(crate) fn video_layer(
     if (clip.speed - 1.0).abs() > 1e-9 {
         layer_effects.push(FilterStep::Speed { factor: clip.speed });
     }
+    // Per-frame scale/rotation: when the model animates them, splice self-animating
+    // steps here — after the temporal placement (`Trim`/`ResetPts`/`OffsetPts`/`Speed`),
+    // so the `t`-expression sees timeline time — and neutralize the static layer
+    // transform below to avoid double-application (ADR-0005).
+    let transform = video_transform(clip, automation);
+    let (geometry, scale_x, scale_y, rotation) =
+        animated_geometry(&transform, canvas_width, canvas_height);
+    layer_effects.extend(geometry);
     // Frame the source to the project canvas (cover/contain/stretch) before the
     // colour/effect chain; `FitMode::None` emits nothing (native size).
     if let Some(step) = fit_step(clip, canvas_width, canvas_height) {
@@ -213,15 +295,16 @@ pub(crate) fn video_layer(
         ClipSource::Text(spec) => LayerSource::Text(spec.clone()),
         ClipSource::Solid(color) => LayerSource::Solid(*color),
     };
-    let transform = video_transform(clip, automation);
     VideoLayer {
         source,
         proxy,
         x: transform.x,
         y: transform.y,
-        scale_x: transform.scale_x,
-        scale_y: transform.scale_y,
-        rotation: transform.rotation,
+        // Neutralized when scale/rotation is animated (the animation lives in
+        // `effects` as `ScaleAnimated`/`RotateAnimated`); unchanged when static.
+        scale_x,
+        scale_y,
+        rotation,
         opacity: transform.opacity,
         blend_mode: transform.blend_mode,
         composite_op: transform.composite_op,
@@ -248,9 +331,15 @@ pub(crate) fn realtime_descriptor(
     canvas_height: u32,
 ) -> RealtimeLayerDescriptor {
     let transform = video_transform(clip, automation);
+    // Per-frame scale/rotation: the same self-animating steps the export path emits.
+    // The preview runner stamps each pushed frame with the timeline PTS, so the
+    // `t`-expression evaluates at the same time as export (ADR-0005). Placed before
+    // the fit/colour chain, matching the export layer order.
+    let (geometry, scale_x, scale_y, rotation) =
+        animated_geometry(&transform, canvas_width, canvas_height);
+    let mut effects = geometry;
     // Frame to the canvas (same step as the export path) before the colour chain,
     // so preview and export share one framing interpretation.
-    let mut effects = Vec::new();
     if let Some(step) = fit_step(clip, canvas_width, canvas_height) {
         effects.push(step);
     }
@@ -260,9 +349,10 @@ pub(crate) fn realtime_descriptor(
         opacity: transform.opacity,
         x: transform.x,
         y: transform.y,
-        scale_x: transform.scale_x,
-        scale_y: transform.scale_y,
-        rotation: transform.rotation,
+        // Neutralized when animated (the animation lives in `effects`); else unchanged.
+        scale_x,
+        scale_y,
+        rotation,
         blend_mode: transform.blend_mode,
         composite_op: transform.composite_op,
     }
@@ -503,6 +593,92 @@ mod tests {
                 .effects
                 .iter()
                 .any(|s| matches!(s, FilterStep::XFade { .. }))
+        );
+    }
+
+    // Per-frame scale/rotation (ADR-0005)
+
+    #[test]
+    fn video_layer_animated_scale_should_emit_scale_animated_and_neutralize() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 1.5, Easing::Linear));
+        let clip = Clip::new("a.mp4").with_scale_track(track);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+
+        // The static layer transform is neutralized so the compositor's static scale
+        // node is skipped (no double-application).
+        assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+        assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+
+        // The animation is carried as a self-animating ScaleAnimated with the factor
+        // track converted to pixels (factor × canvas).
+        let sa = layer
+            .effects
+            .iter()
+            .find(|s| matches!(s, FilterStep::ScaleAnimated { .. }));
+        let Some(FilterStep::ScaleAnimated { width, height, .. }) = sa else {
+            panic!(
+                "animated scale must emit ScaleAnimated, got {:?}",
+                layer.effects
+            );
+        };
+        assert!((width.value_at(Duration::ZERO) - 960.0).abs() < 1e-6); // 0.5 × 1920
+        assert!((height.value_at(Duration::ZERO) - 540.0).abs() < 1e-6); // 0.5 × 1080
+        assert!((width.value_at(Duration::from_secs(2)) - 2880.0).abs() < 1e-6); // 1.5 × 1920
+    }
+
+    #[test]
+    fn video_layer_animated_rotation_should_emit_rotate_animated_and_neutralize() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(1), 90.0, Easing::Linear));
+        let clip = Clip::new("a.mp4").with_rotation_track(track);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+
+        assert!(matches!(layer.rotation, AnimatedValue::Static(v) if v.abs() < 1e-9));
+        let ra = layer
+            .effects
+            .iter()
+            .find(|s| matches!(s, FilterStep::RotateAnimated { .. }));
+        let Some(FilterStep::RotateAnimated { angle, .. }) = ra else {
+            panic!(
+                "animated rotation must emit RotateAnimated, got {:?}",
+                layer.effects
+            );
+        };
+        // Degrees pass through unchanged (the compositor's rotate node converts).
+        assert!((angle.value_at(Duration::from_secs(1)) - 90.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn video_layer_static_scale_should_stay_on_the_layer() {
+        // AC2: a non-animated scale must NOT be routed through ScaleAnimated and must
+        // stay on the layer scalar, so the static render is unchanged.
+        let clip = Clip::new("a.mp4").with_scale(0.5);
+        let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
+        assert!(
+            !layer
+                .effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::ScaleAnimated { .. }))
+        );
+        assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 0.5).abs() < 1e-9));
+    }
+
+    #[test]
+    fn realtime_descriptor_animated_scale_should_emit_scale_animated() {
+        // The preview path emits the same self-animating step as export (parity).
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 1.0, Easing::Linear));
+        let clip = Clip::new("a.mp4").with_scale_track(track);
+        let desc = realtime_descriptor(&clip, &no_anim(), 1280, 720);
+        assert!(matches!(desc.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+        assert!(
+            desc.effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::ScaleAnimated { .. }))
         );
     }
 
@@ -897,9 +1073,21 @@ mod tests {
         };
         let clip = Clip::new("a.mp4");
         let d = realtime_descriptor(&clip, &automation, 1920, 1080);
-        assert!(matches!(d.scale_x, AnimatedValue::Track(_)));
-        assert!(matches!(d.rotation, AnimatedValue::Track(_)));
+        // Timeline scale/rotation animations are carried as self-animating steps and
+        // the scalars neutralize (ADR-0005), same as the export path.
+        assert!(matches!(d.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
         assert!(matches!(d.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+        assert!(matches!(d.rotation, AnimatedValue::Static(v) if v.abs() < 1e-9));
+        assert!(
+            d.effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::ScaleAnimated { .. }))
+        );
+        assert!(
+            d.effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::RotateAnimated { .. }))
+        );
     }
 
     #[test]
@@ -954,12 +1142,24 @@ mod tests {
 
     #[test]
     fn video_layer_scale_track_should_win_on_both_axes() {
+        // A per-clip scale track drives both axes. Post-ADR-0005 the animation is
+        // carried as a self-animating ScaleAnimated (factor × canvas) and the layer
+        // scalar neutralizes; both width and height reflect the 2.0 factor.
         let mut clip = Clip::new("a.mp4");
         clip.scale_track =
             Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 2.0, Easing::Linear)));
         let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
-        assert!(matches!(layer.scale_x, AnimatedValue::Track(_)));
-        assert!(matches!(layer.scale_y, AnimatedValue::Track(_)));
+        assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+        assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+        let Some(FilterStep::ScaleAnimated { width, height, .. }) = layer
+            .effects
+            .iter()
+            .find(|s| matches!(s, FilterStep::ScaleAnimated { .. }))
+        else {
+            panic!("expected ScaleAnimated, got {:?}", layer.effects);
+        };
+        assert!((width.value_at(Duration::ZERO) - 3840.0).abs() < 1e-6); // 2.0 × 1920
+        assert!((height.value_at(Duration::ZERO) - 2160.0).abs() < 1e-6); // 2.0 × 1080
     }
 
     #[test]
@@ -974,9 +1174,19 @@ mod tests {
         };
         let clip = Clip::new("a.mp4"); // scale defaults to 1.0 (neutral)
         let layer = video_layer(&clip, 0, &automation, 1920, 1080, None, None);
-        assert!(matches!(layer.scale_x, AnimatedValue::Track(_)));
-        // scale_y has no track animation -> the default static 1.0.
+        // The scale_x timeline animation is carried into ScaleAnimated's width; the
+        // un-animated scale_y axis maps to a static height (1.0 × canvas).
+        assert!(matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
         assert!(matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9));
+        let Some(FilterStep::ScaleAnimated { width, height, .. }) = layer
+            .effects
+            .iter()
+            .find(|s| matches!(s, FilterStep::ScaleAnimated { .. }))
+        else {
+            panic!("expected ScaleAnimated, got {:?}", layer.effects);
+        };
+        assert!((width.value_at(Duration::ZERO) - 960.0).abs() < 1e-6); // 0.5 × 1920
+        assert!((height.value_at(Duration::ZERO) - 1080.0).abs() < 1e-6); // 1.0 × 1080
     }
 
     #[test]
@@ -1006,11 +1216,19 @@ mod tests {
 
     #[test]
     fn video_layer_rotation_track_should_win() {
+        // A per-clip rotation track is carried as a self-animating RotateAnimated and
+        // the layer scalar neutralizes (ADR-0005).
         let mut clip = Clip::new("a.mp4");
         clip.rotation_track =
             Some(AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 90.0, Easing::Linear)));
         let layer = video_layer(&clip, 0, &no_anim(), 1920, 1080, None, None);
-        assert!(matches!(layer.rotation, AnimatedValue::Track(_)));
+        assert!(matches!(layer.rotation, AnimatedValue::Static(v) if v.abs() < 1e-9));
+        assert!(
+            layer
+                .effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::RotateAnimated { .. }))
+        );
     }
 
     #[test]

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -1198,11 +1198,12 @@ mod tests {
     #[cfg(feature = "preview")]
     #[test]
     fn to_scene_should_route_timeline_animations_into_the_preview_layer() {
-        use ff_filter::{AnimatedValue, Easing, Keyframe};
+        use ff_filter::{AnimatedValue, Easing, FilterStep, Keyframe};
 
         // Track 1 (overlay) gets timeline scale_x + rotation animations, and an opacity
         // animation the neutral clip should fall back to (the 3-way merge). The single
-        // derive must route all three into the preview placement's layer.
+        // derive must route all three into the preview placement's layer: opacity as an
+        // animated scalar, scale/rotation as self-animating effect steps (ADR-0005).
         let timeline = Timeline::builder()
             .canvas(1920, 1080)
             .frame_rate(30.0)
@@ -1228,9 +1229,27 @@ mod tests {
 
         let scene = timeline.to_scene();
         let overlay = &scene.video_tracks[1].placements[0];
-        assert!(matches!(overlay.layer.scale_x, AnimatedValue::Track(_)));
-        assert!(matches!(overlay.layer.rotation, AnimatedValue::Track(_)));
+        // Opacity animates on the scalar (send_command); scale/rotation move to
+        // self-animating effect steps with a neutralized scalar.
         assert!(matches!(overlay.layer.opacity, AnimatedValue::Track(_)));
+        assert!(
+            matches!(overlay.layer.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9)
+        );
+        assert!(matches!(overlay.layer.rotation, AnimatedValue::Static(v) if v.abs() < 1e-9));
+        assert!(
+            overlay
+                .layer
+                .effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::ScaleAnimated { .. }))
+        );
+        assert!(
+            overlay
+                .layer
+                .effects
+                .iter()
+                .any(|s| matches!(s, FilterStep::RotateAnimated { .. }))
+        );
     }
 
     #[cfg(feature = "preview")]

--- a/crates/ff-filter/tests/composition_tests.rs
+++ b/crates/ff-filter/tests/composition_tests.rs
@@ -621,6 +621,141 @@ fn animated_opacity_fade_should_darken_composite_over_time() {
     );
 }
 
+/// Verifies that a per-frame animated scale/rotation is evaluated each frame in the
+/// compositor (not frozen at `t=0`, ADR-0005): a white overlay pinned at the top-left
+/// grows from a corner square to full canvas, so the centre pixel goes from the black
+/// background to white across the clip. A `RotateAnimated` (0 -> 360 deg) rides the
+/// same layer so the rotated path is exercised (360 deg = identity at the last frame,
+/// leaving the centre covered).
+///
+/// Non-vacuous: a static-at-`t=0` collapse would keep the overlay at its initial 0.25
+/// size for every frame, so the centre would stay black and the assertion would fail.
+#[test]
+#[ignore = "requires FFmpeg filter graph; run with -- --include-ignored"]
+fn compositor_should_evaluate_per_frame_scale_and_rotation() {
+    const W: u32 = 64;
+    const H: u32 = 64;
+    const FPS: f64 = 30.0;
+    const FRAMES: usize = 30;
+
+    let bg_path = test_output_path("scale_bg_64x64.mp4");
+    let layer_path = test_output_path("scale_layer_64x64.mp4");
+    let _bg_guard = FileGuard::new(bg_path.clone());
+    let _layer_guard = FileGuard::new(layer_path.clone());
+
+    // Background: black; overlay source: white.
+    if make_source_file(&bg_path, W, H, FPS, FRAMES, 16, 128, 128).is_none() {
+        return;
+    }
+    if make_source_file(&layer_path, W, H, FPS, FRAMES, 235, 128, 128).is_none() {
+        return;
+    }
+
+    // Scale: 0.25×canvas -> 1.0×canvas (pixels); rotation: 0 -> 360 deg.
+    let end_pts = Duration::from_secs_f64((FRAMES as f64 - 1.0) / FPS);
+    let w_track = AnimationTrack::new()
+        .push(Keyframe::new(
+            Duration::ZERO,
+            0.25 * f64::from(W),
+            Easing::Linear,
+        ))
+        .push(Keyframe::new(end_pts, f64::from(W), Easing::Linear));
+    let h_track = AnimationTrack::new()
+        .push(Keyframe::new(
+            Duration::ZERO,
+            0.25 * f64::from(H),
+            Easing::Linear,
+        ))
+        .push(Keyframe::new(end_pts, f64::from(H), Easing::Linear));
+    let rot_track = AnimationTrack::new()
+        .push(Keyframe::new(Duration::ZERO, 0.0_f64, Easing::Linear))
+        .push(Keyframe::new(end_pts, 360.0_f64, Easing::Linear));
+
+    let mut composer = match MultiTrackComposer::new(W, H)
+        .add_layer(VideoLayer {
+            source: LayerSource::File(bg_path.clone()),
+            proxy: None,
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(1.0),
+            blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
+            effects: vec![],
+        })
+        .add_layer(VideoLayer {
+            source: LayerSource::File(layer_path.clone()),
+            proxy: None,
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            // Neutral scalars: the animation lives in `effects` (ADR-0005).
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            opacity: AnimatedValue::Static(1.0),
+            blend_mode: ff_filter::BlendMode::Normal,
+            composite_op: ff_filter::CompositeOp::Over,
+            effects: vec![
+                FilterStep::RotateAnimated {
+                    angle: AnimatedValue::Track(rot_track),
+                    fill_color: "black".to_string(),
+                },
+                FilterStep::ScaleAnimated {
+                    width: AnimatedValue::Track(w_track),
+                    height: AnimatedValue::Track(h_track),
+                    algorithm: ff_filter::ScaleAlgorithm::Bicubic,
+                },
+            ],
+        })
+        .build()
+    {
+        Ok(g) => g,
+        Err(e) => {
+            println!("Skipping: MultiTrackComposer::build failed: {e}");
+            return;
+        }
+    };
+
+    let cx = (W / 2) as usize;
+    let cy = (H / 2) as usize;
+    let mut lumas: Vec<f64> = Vec::with_capacity(FRAMES);
+    for i in 0..FRAMES {
+        composer.tick(Duration::from_secs_f64(i as f64 / FPS));
+        let frame = match composer.pull_video() {
+            Ok(Some(f)) => f,
+            Ok(None) => {
+                println!("Skipping: composer ended early at frame {i}");
+                return;
+            }
+            Err(e) => {
+                println!("Skipping: pull_video failed at frame {i}: {e}");
+                return;
+            }
+        };
+        if frame.width() != W || frame.height() != H {
+            println!("Skipping: unexpected dims at frame {i}");
+            return;
+        }
+        let stride = frame.stride(0).unwrap_or(W as usize);
+        let Some(y_plane) = frame.plane(0) else {
+            println!("Skipping: Y-plane unavailable at frame {i}");
+            return;
+        };
+        lumas.push(y_plane[cy * stride + cx] as f64);
+    }
+
+    let first = lumas[0];
+    let last = lumas[FRAMES - 1];
+    assert!(
+        last > first + 50.0,
+        "the centre pixel must brighten as the overlay scales up: frame 0 luma={first:.1} \
+         (small) vs frame {} luma={last:.1} (full) — a static-at-t=0 collapse would keep them equal",
+        FRAMES - 1
+    );
+}
+
 // Packed-F32 stereo audio frame with constant amplitude
 
 fn constant_amplitude_frame(amplitude: f32, samples: usize, sample_rate: u32) -> AudioFrame {

--- a/docs/adr/0005-per-frame-compositor-scale-rotation.md
+++ b/docs/adr/0005-per-frame-compositor-scale-rotation.md
@@ -1,0 +1,111 @@
+---
+status: accepted
+date: 2026-08-30
+decision-makers: itsakeyfut
+---
+
+# Animate scale/rotation per frame with self-animating compositor steps, neutralizing the static layer transform
+
+## Context and Problem Statement
+
+ADR-0002 recorded that the model carries per-clip animation while a primitive may
+static-evaluate what it cannot yet animate, and named `scale`/`rotation` as
+evaluated at `t=0` only. The compositor collapses `layer.scale_x/scale_y/rotation`
+via `value_at(0)` on both the offline and realtime paths
+(`ff-filter/src/graph/composition/composition_inner.rs`), so an animated scale or
+rotation renders frozen. Closing that (issue #1614) requires deciding how the
+per-frame animation is realized and how preview is kept equal to export.
+
+## Decision Drivers
+
+* `derive` must stay one pure interpretation shared by export and preview (ADR-0004),
+  and preview must equal export within tolerance for the animated case.
+* The compositor already animates `opacity`/`x`/`y` per-frame via `send_command`
+  (`AnimationEntry`, evaluated at the timeline PTS), and already builds and
+  alpha-handles `FilterStep::ScaleAnimated`/`RotateAnimated` in the per-layer effect
+  loop (`layer_has_alpha_effects` already lists `RotateAnimated`).
+* `ScaleAnimated`/`RotateAnimated` self-animate via an `eval=frame` `t`-expression
+  (`AnimationTrack::to_ffmpeg_expr`), so the same expression drives both graphs with
+  no `send_command` driver; the realtime runner already stamps each pushed frame with
+  the timeline PTS.
+
+## Considered Options
+
+* **A. `derive` emits self-animating `ScaleAnimated`/`RotateAnimated` into the per-clip
+  effect chain and neutralizes the static layer scalar** (`scale=1.0`/`rotation=0.0`).
+* B. Extend the compositor's `send_command`/`AnimationEntry` mechanism (as for
+  `opacity`/`x`/`y`) to the `scale`/`rotate` filter nodes.
+* C. Make the compositor's static `scale`/`rotate` nodes self-animate inline.
+
+## Decision Outcome
+
+Chosen option: **A**. When the merged scale or rotation is `AnimatedValue::Track`,
+`derive` (`video_layer` and `realtime_descriptor`) splices a self-animating
+`ScaleAnimated`/`RotateAnimated` into the effect chain (after the temporal placement,
+so the `t`-expression sees timeline time) and sets the layer scalar neutral, so the
+compositor's static transform node is skipped and the animation is applied once. The
+static (non-animated) case is unchanged, exactly as ADR-0002 describes. This reverses
+ADR-0002's "scale/rotation at `t=0` only" for the animated case; the boundary decision
+in ADR-0002 (the model may expose a track the primitive static-evaluates) still holds
+for any executor that has not caught up.
+
+Preview equals export **by construction**: the identical `t`-expression is placed in
+both graphs, and both present timeline `t` at that node (offline after `OffsetPts`;
+realtime via the runner's per-frame timeline-PTS stamp). No compositor or preview
+source change is needed — the change lives entirely in `avio/derive`.
+
+### Confirmation
+
+`crates/avio/src/derive.rs` unit tests
+(`video_layer_animated_scale_should_emit_scale_animated_and_neutralize`,
+`..._rotation_...`, `realtime_descriptor_animated_scale_should_emit_scale_animated`,
+and `video_layer_static_scale_should_stay_on_the_layer` for the no-regression case)
+fail if an animated transform is left on the scalar (frozen) or a static one is
+routed through `ScaleAnimated`. The probe-gated integration test
+`compositor_should_evaluate_per_frame_scale_and_rotation`
+(`ff-filter/tests/composition_tests.rs`) fails if the composited output does not
+change across frames.
+
+### Consequences
+
+* Good: preview == export for free (one expression, two graphs); no new
+  `send_command` wiring; no `ff-filter`/`ff-preview` source change.
+* Good: the static path is byte-identical (AC2) because emission is gated on an
+  animated axis and the scalar neutralizes only then.
+* Bad: an animated `ScaleAnimated` resizes per frame (a per-frame `scale`), costlier
+  than a one-shot scale; acceptable for the animated case only.
+* Bad/limitation: `RotateAnimated` is emitted **before** `ScaleAnimated` because the
+  rotate supersampling assumes a stable input size, while an animated scale varies the
+  output size per frame (the size-varying result feeds the `overlay`, which handles
+  it). For the uniform clip `scale` the two commute, so this matches the static
+  scale-then-rotate result; a non-uniform track-level `scale_x != scale_y` combined
+  with an animated rotation would differ in order (an accepted edge case).
+* What would reverse this: a per-sample/​per-frame executor divergence that makes the
+  shared `t`-expression insufficient, or moving the transform into a GPU node (#1365).
+
+## Pros and Cons of the Options
+
+### A. derive emits self-animating steps + neutralized scalar
+
+* Good: integrates with the compositor's existing effect-loop and alpha handling;
+  preview == export by construction; avio-only change.
+* Bad: needs a factor→pixel track conversion (`ScaleAnimated` sizes in pixels).
+
+### B. send_command on scale/rotate nodes
+
+* Good: same mechanism as `opacity`/`x`/`y`.
+* Bad: the `scale` filter does not cleanly take per-frame width/height commands;
+  needs a driver loop; risks preview/export divergence the `t`-expression avoids.
+
+### C. inline self-animating static nodes
+
+* Good: keeps nodes in place.
+* Bad: reimplements `ScaleAnimated`/`RotateAnimated`; the offline overlay alpha
+  detection (`layer_has_alpha_effects`) would miss a rotate built outside `effects`.
+
+## More Information
+
+* Issue #1614 (follow-up from #1591); supersedes the `scale`/`rotation` `t=0` note in
+  [ADR-0002](./0002-per-clip-animation-in-the-model.md) for the animated case.
+* `AnimationTrack::to_ffmpeg_expr` (`ff-filter/src/animation/track.rs`); the realtime
+  timeline-PTS stamp (`ff-preview/src/scene/runner.rs`).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,8 +18,9 @@ standard. Copy [`adr-template.md`](./adr-template.md) to start one.
 | [0002](./0002-per-clip-animation-in-the-model.md) | Carry all per-clip animation in the model; a primitive may static-evaluate what it cannot yet animate | accepted | derive unit tests in `crates/avio/src/derive.rs` (scale/rotation, pitch tracks flow; export == preview) |
 | [0003](./0003-ff-sys-safe-wrapper-layer.md) | Give ff-sys a curated RAII safe layer (owned `NonNull` newtypes, typed errors, localized `unsafe`) over the raw bindings | accepted | per-owned-type drop-once tests, `#![deny(unsafe_op_in_unsafe_fn)]` + CI clippy, and the no-raw-pointer guard `crates/ff-sys/tests/seal.rs` |
 | [0004](./0004-avio-engine-not-facade.md) | `avio` exposes only the editing engine and its model-facing types; drop the primitive-facade re-exports | accepted | the primitive-facade re-exports removed from `crates/avio/src/lib.rs` (#1482-#1484), the `lib.rs` accessibility tests assert the kept engine surface, and `avio-examples`/docs build on it (a dedicated regression guard #1485 was declined as premature for a pre-1.0 crate) |
+| [0005](./0005-per-frame-compositor-scale-rotation.md) | Animate scale/rotation per frame via self-animating compositor steps emitted by `derive`, neutralizing the static layer transform | accepted | derive unit tests in `crates/avio/src/derive.rs` (animated scale/rotation emit `ScaleAnimated`/`RotateAnimated` + neutralize; static stays on the layer) and the probe-gated `compositor_should_evaluate_per_frame_scale_and_rotation` |
 
-**By status** - accepted: 0001, 0002, 0003, 0004 · proposed: none · superseded: none
+**By status** - accepted: 0001, 0002, 0003, 0004, 0005 · proposed: none · superseded: none
 
 Records are numbered consecutively from `0001`.
 


### PR DESCRIPTION
## Objective

- An animated clip scale or rotation was frozen at its `t=0` value: both the offline and realtime composition paths collapsed the layer transform via `value_at(0)`, so per-frame scale/rotation animation was lost (follow-up from #1591).

## Solution

- When the merged scale or rotation is an animation track, `derive` emits a self-animating `ScaleAnimated`/`RotateAnimated` into the per-clip effect chain and neutralizes the static layer scalar, so the compositor's static transform node is skipped and the animation is applied once, per frame. The static case is unchanged (a step is emitted only for an animated axis, so no double-application).
- Preview equals export by construction: the identical `t`-expression is placed in both graphs, and both present timeline time at that node (offline after `OffsetPts`, realtime via the runner's per-frame timeline-PTS stamp). No compositor source change is needed; the fix lives entirely in `avio/derive`.
- Rotation is emitted before scale: `RotateAnimated` supersamples around a stable input size, so it must precede a size-varying animated `ScaleAnimated` (the size-varying result feeds the `overlay`, which handles it). For the uniform clip scale the two commute.
- Recorded in ADR-0005 (reverses the scale/rotation `t=0`-only note in ADR-0002 for the animated case).
- Covered by deterministic derive unit tests (emit + neutralize + factor->pixel conversion) and a probe-gated integration test asserting the composited output changes per frame.

Closes #1614