### PR TITLE
feat(ff-preview): render generated Text/Solid sources in preview

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -134,7 +134,7 @@ mod player;
 #[cfg(feature = "preview")]
 pub use ff_preview::{
     PlayerHandle, PreviewError, Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement,
-    SceneRunner, SceneVideoTrack,
+    SceneRunner, SceneSource, SceneVideoTrack,
 };
 #[cfg(feature = "preview")]
 pub use player::TimelinePlayer;

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -986,12 +986,13 @@ fn video_placement(
     // actual xfade kind; overlays force no transition (matching the compositor).
     let xfade_kind = if is_base { clip.transition } else { None };
     ff_preview::ScenePlacement {
-        // Preview compositing of generated (Text/Solid) sources is deferred; a
-        // non-file clip projects an empty path (the preview runner renders nothing).
-        source: clip
-            .source_path()
-            .map(Path::to_path_buf)
-            .unwrap_or_default(),
+        // File clips decode; generated (Text/Solid) clips are rendered by the runner
+        // via ff-filter's SolidSource/TextSource (the same filters export uses).
+        source: match &clip.source {
+            crate::clip::ClipSource::File(path) => ff_preview::SceneSource::File(path.clone()),
+            crate::clip::ClipSource::Text(spec) => ff_preview::SceneSource::Text(spec.clone()),
+            crate::clip::ClipSource::Solid(color) => ff_preview::SceneSource::Solid(*color),
+        },
         offset: clip.offset,
         in_point: clip.in_point.unwrap_or(Duration::ZERO),
         out_point: clip.out_point,
@@ -1156,7 +1157,9 @@ mod tests {
         assert_eq!(scene.audio_tracks.len(), 1);
 
         let base = &scene.video_tracks[0].placements[0];
-        assert_eq!(base.source.to_str(), Some("a.mp4"));
+        assert!(
+            matches!(&base.source, ff_preview::SceneSource::File(p) if p.to_str() == Some("a.mp4"))
+        );
         assert_eq!(base.offset, Duration::from_millis(500));
         assert_eq!(base.in_point, Duration::from_secs(1));
         assert_eq!(base.out_point, Some(Duration::from_secs(3)));
@@ -1368,6 +1371,39 @@ mod tests {
         assert!(matches!(
             scene.audio_tracks[0].placements[0].pan,
             AnimatedValue::Track(_)
+        ));
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
+    fn to_scene_should_project_text_and_solid_as_scene_source() {
+        use ff_format::{Color, TextSpec};
+
+        // #1615: generated (Text/Solid) clips project as SceneSource variants (not an
+        // empty path) so the runner renders them; File clips stay File; timeline order
+        // is preserved.
+        let timeline = Timeline::builder()
+            .canvas(1920, 1080)
+            .frame_rate(30.0)
+            .video_track(vec![
+                Clip::new("base.mp4"),
+                Clip::text(TextSpec::new("Title")).trim(Duration::ZERO, Duration::from_secs(2)),
+                Clip::solid(Color::rgb(255, 0, 0)).trim(Duration::ZERO, Duration::from_secs(1)),
+            ])
+            .build()
+            .unwrap();
+        let placements = &timeline.to_scene().video_tracks[0].placements;
+        assert!(matches!(
+            &placements[0].source,
+            ff_preview::SceneSource::File(p) if p.to_str() == Some("base.mp4")
+        ));
+        assert!(matches!(
+            &placements[1].source,
+            ff_preview::SceneSource::Text(spec) if spec.text == "Title"
+        ));
+        assert!(matches!(
+            &placements[2].source,
+            ff_preview::SceneSource::Solid(c) if *c == Color::rgb(255, 0, 0)
         ));
     }
 

--- a/crates/avio/tests/timeline_preview_tests.rs
+++ b/crates/avio/tests/timeline_preview_tests.rs
@@ -196,3 +196,74 @@ fn timeline_runner_seek_should_deliver_seek_completed_event() {
         "SeekCompleted must be delivered within 3 seconds of seek"
     );
 }
+
+#[test]
+#[ignore = "requires the color filter; run with -- --include-ignored"]
+fn timeline_runner_should_render_and_advance_generated_solid_sources() {
+    // #1615: a scene made only of generated (Solid) clips — a base and an overlay —
+    // must render through the real runner and, crucially, ADVANCE: the held frames
+    // carry a synthetic per-frame PTS, so V1 honours the clip duration and the overlay
+    // `sync_overlays` loop terminates (a fixed PTS would stall V1 / spin the overlay).
+    use std::sync::{Arc, Mutex};
+
+    use avio::Color;
+
+    struct PtsSink {
+        pts: Arc<Mutex<Vec<Duration>>>,
+        handle: PlayerHandle,
+    }
+    impl FrameSink for PtsSink {
+        fn push_frame(&mut self, _rgba: &[u8], _w: u32, _h: u32, pts: Duration) {
+            let mut log = self
+                .pts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            log.push(pts);
+            if log.len() >= 12 {
+                self.handle.stop();
+            }
+        }
+    }
+
+    let timeline = Timeline::builder()
+        .canvas(64, 48)
+        .frame_rate(30.0)
+        .video_track(vec![
+            Clip::solid(Color::rgb(20, 40, 200)).trim(Duration::ZERO, Duration::from_secs(1)),
+        ])
+        .video_track(vec![
+            Clip::solid(Color::rgb(200, 40, 20)).trim(Duration::ZERO, Duration::from_secs(1)),
+        ])
+        .build()
+        .expect("timeline build failed");
+
+    let (mut runner, handle) = match TimelinePlayer::open(&timeline) {
+        Ok(p) => p,
+        Err(e) => {
+            println!("skipping: open failed: {e}");
+            return;
+        }
+    };
+
+    let pts = Arc::new(Mutex::new(Vec::<Duration>::new()));
+    runner.set_sink(Box::new(PtsSink {
+        pts: Arc::clone(&pts),
+        handle: handle.clone(),
+    }));
+    // If this returns, `sync_overlays` did not spin forever on the held overlay.
+    let _ = runner.run();
+
+    let pts = pts
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if pts.is_empty() {
+        println!("skipping: color filter unavailable (no generated frames rendered)");
+        return;
+    }
+    // The composited PTS must advance (V1 held source is not frozen at t=0).
+    assert!(
+        pts.last() > pts.first(),
+        "generated-source playback PTS must advance: {:?}",
+        &pts[..pts.len().min(6)]
+    );
+}

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -57,5 +57,5 @@ pub use proxy::{ProxyGenerator, ProxyJob, ProxyResolution};
 #[cfg(feature = "timeline")]
 pub use scene::{
     Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, ScenePlayer, SceneRunner,
-    SceneVideoTrack,
+    SceneSource, SceneVideoTrack,
 };

--- a/crates/ff-preview/src/scene/mod.rs
+++ b/crates/ff-preview/src/scene/mod.rs
@@ -42,13 +42,147 @@ use crate::playback::master_clock::MasterClock;
 use crate::playback::player_handle::PlayerHandle;
 
 pub use runner::SceneRunner;
-pub use types::{Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneVideoTrack};
+pub use types::{
+    Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneSource, SceneVideoTrack,
+};
 
 use audio_resampling::spawn_audio_track_thread;
-use ff_filter::{AnimatedValue, XfadeTransition};
+use ff_filter::{AnimatedValue, SolidSource, TextSource, XfadeTransition};
+use ff_format::VideoFrame;
 use state::{
-    AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer, db_to_linear,
+    AudioFadeConfig, AudioOnlyTrack, ClipState, ClipVideoSource, LavfiOverlayState, OverlayLayer,
+    db_to_linear,
 };
+
+/// Resolves the canvas size for generated (solid/text) sources: the explicit scene
+/// canvas, else the first file placement's video size, else `(0, 0)` (no file to
+/// size from, so a generated source renders nothing).
+fn resolve_canvas_dims(scene: &Scene) -> (u32, u32) {
+    if let Some(dims) = scene.canvas {
+        return dims;
+    }
+    for track in &scene.video_tracks {
+        for p in &track.placements {
+            if let Some(path) = p.source.as_file()
+                && let Ok(info) = ff_probe::open(path)
+                && let Some(v) = info.primary_video()
+            {
+                return (v.width(), v.height());
+            }
+        }
+    }
+    (0, 0)
+}
+
+/// Builds the constant held frame for a generated source (pulled once via
+/// `ff-filter`'s `SolidSource` / `TextSource`, the same `color` / `drawtext` filters
+/// export uses), or `None` when unavailable — e.g. the filters are missing on a
+/// minimal `FFmpeg` (RK-002), so the clip renders nothing rather than failing `open`.
+fn generated_held_frame(source: &SceneSource, cw: u32, ch: u32, fps: f64) -> Option<VideoFrame> {
+    if cw == 0 || ch == 0 {
+        log::warn!("generated source has no canvas size to render into, cw={cw} ch={ch}");
+        return None;
+    }
+    let pulled = match source {
+        SceneSource::Solid(color) => {
+            SolidSource::new(*color, cw, ch, fps).map(|mut s| pull_first(&mut s))
+        }
+        SceneSource::Text(spec) => {
+            TextSource::new(spec, cw, ch, fps).map(|mut s| pull_first(&mut s))
+        }
+        SceneSource::File(_) => return None,
+    };
+    match pulled {
+        Ok(Some(frame)) => Some(frame),
+        Ok(None) => {
+            log::warn!("generated source produced no frame; rendering nothing");
+            None
+        }
+        Err(e) => {
+            log::warn!("generated source unavailable, rendering nothing, error={e}");
+            None
+        }
+    }
+}
+
+/// The timeline span of a generated clip, from its `out_point` (a generated source is
+/// infinite, so `out_point` bounds it — mirroring the export-side
+/// `GeneratedSourceNeedsDuration`). Warns and yields zero when unbounded.
+fn generated_span(out_point: Option<Duration>, in_pt: Duration) -> Duration {
+    if let Some(op) = out_point {
+        op.saturating_sub(in_pt)
+    } else {
+        log::warn!(
+            "generated clip has no out_point; preview shows zero duration (bound it with a trim)"
+        );
+        Duration::ZERO
+    }
+}
+
+/// Opens the per-clip video source: a decoding [`DecodeBuffer`] seeked to `in_pt`
+/// for a file, or a constant [`Held`](ClipVideoSource::Held) frame (built at
+/// `cw`x`ch`) for a generated source.
+fn open_clip_video_source(
+    source: &SceneSource,
+    in_pt: Duration,
+    cw: u32,
+    ch: u32,
+    fps: f64,
+) -> Result<ClipVideoSource, PreviewError> {
+    match source.as_file() {
+        Some(path) => {
+            let mut buf = DecodeBuffer::open(path).build()?;
+            if in_pt > Duration::ZERO {
+                buf.seek(in_pt)?;
+            }
+            Ok(ClipVideoSource::File(buf))
+        }
+        None => Ok(ClipVideoSource::held(
+            generated_held_frame(source, cw, ch, fps),
+            in_pt,
+            fps,
+        )),
+    }
+}
+
+/// The file path of a source (empty for a generated one) — the `ClipState.source`
+/// field, used only to spawn an audio thread (a generated clip has no audio).
+fn source_path(source: &SceneSource) -> PathBuf {
+    source
+        .as_file()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default()
+}
+
+/// Pulls the first frame from a freshly built generated source, retrying while the
+/// graph is still priming (`Ok(None)`). Returns `None` on error or if the source
+/// never yields a frame.
+fn pull_first<S: GeneratedPull>(source: &mut S) -> Option<VideoFrame> {
+    for _ in 0..16 {
+        match source.pull() {
+            Ok(Some(frame)) => return Some(frame),
+            Ok(None) => {}
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
+/// Shared `pull` shape of the generated frame sources so [`pull_first`] can retry
+/// either.
+trait GeneratedPull {
+    fn pull(&mut self) -> Result<Option<VideoFrame>, ff_filter::FilterError>;
+}
+impl GeneratedPull for SolidSource {
+    fn pull(&mut self) -> Result<Option<VideoFrame>, ff_filter::FilterError> {
+        SolidSource::pull(self)
+    }
+}
+impl GeneratedPull for TextSource {
+    fn pull(&mut self) -> Result<Option<VideoFrame>, ff_filter::FilterError> {
+        TextSource::pull(self)
+    }
+}
 
 // -- Constants --
 
@@ -84,7 +218,7 @@ impl ScenePlayer {
     #[allow(clippy::too_many_lines)]
     pub fn open(scene: &Scene) -> Result<(SceneRunner, PlayerHandle), PreviewError> {
         struct ProbeResult {
-            source: PathBuf,
+            source: SceneSource,
             in_pt: Duration,
             clip_dur: Duration,
             offset: Duration,
@@ -109,6 +243,8 @@ impl ScenePlayer {
         }
 
         let fps = scene.fps.max(1.0);
+        // Canvas size for generated (solid/text) sources, which have no file to probe.
+        let canvas = resolve_canvas_dims(scene);
         let clip_list = &v_tracks[0].placements;
 
         // Phase 1: probe all clips
@@ -118,27 +254,36 @@ impl ScenePlayer {
 
         for p in clip_list {
             let in_pt = p.in_point;
-            let info = ff_probe::open(&p.source)?;
             let speed = p.speed;
 
-            // `in_point` is pre-resolved (defaulted to zero) in the Scene, so this
-            // equals the old `match (in_point, out_point)` for all four cases.
-            let unscaled_dur = p.out_point.map_or_else(
-                || info.duration().saturating_sub(in_pt),
-                |op| op.saturating_sub(in_pt),
-            );
+            // A file clip is probed; a generated (solid/text) clip is sized from the
+            // canvas, bounded by its `out_point`, and carries no audio.
+            let (video_w, video_h, unscaled_dur, has_audio) = if let Some(path) = p.source.as_file()
+            {
+                let info = ff_probe::open(path)?;
+                let dur = p.out_point.map_or_else(
+                    || info.duration().saturating_sub(in_pt),
+                    |op| op.saturating_sub(in_pt),
+                );
+                let (w, h) = info
+                    .primary_video()
+                    .map_or((0, 0), |v| (v.width(), v.height()));
+                (w, h, dur, info.has_audio())
+            } else {
+                (
+                    canvas.0,
+                    canvas.1,
+                    generated_span(p.out_point, in_pt),
+                    false,
+                )
+            };
             let clip_dur = if (speed - 1.0).abs() < 1e-9 {
                 unscaled_dur
             } else {
                 unscaled_dur.div_f64(speed)
             };
 
-            let has_audio = info.has_audio();
             has_any_audio |= has_audio;
-
-            let (video_w, video_h) = info
-                .primary_video()
-                .map_or((0, 0), |v| (v.width(), v.height()));
 
             probes.push(ProbeResult {
                 source: p.source.clone(),
@@ -185,10 +330,7 @@ impl ScenePlayer {
             let timeline_start = p.offset;
             let timeline_end = timeline_start + p.clip_dur;
 
-            let mut decode_buf = DecodeBuffer::open(&p.source).build()?;
-            if p.in_pt > Duration::ZERO {
-                decode_buf.seek(p.in_pt)?;
-            }
+            let decode_buf = open_clip_video_source(&p.source, p.in_pt, p.video_w, p.video_h, fps)?;
 
             // Apply a static V1 audio gain once at open; an animated gain is driven
             // per-tick by the runner.
@@ -242,18 +384,23 @@ impl ScenePlayer {
             let mut layer_clips: Vec<ClipState> = Vec::new();
             for p in &layer.placements {
                 let in_pt = p.in_point;
-                let info = ff_probe::open(&p.source)?;
-                let clip_dur = p.out_point.map_or_else(
-                    || info.duration().saturating_sub(in_pt),
-                    |op| op.saturating_sub(in_pt),
-                );
+                // File clip: probe. Generated (solid/text) clip: canvas-sized, bounded
+                // by `out_point`, no audio.
+                let (clip_dur, has_audio) = match p.source.as_file() {
+                    Some(path) => {
+                        let info = ff_probe::open(path)?;
+                        let dur = p.out_point.map_or_else(
+                            || info.duration().saturating_sub(in_pt),
+                            |op| op.saturating_sub(in_pt),
+                        );
+                        (dur, info.has_audio())
+                    }
+                    None => (generated_span(p.out_point, in_pt), false),
+                };
                 let timeline_start = p.offset;
                 let timeline_end = timeline_start + clip_dur;
-                let mut decode_buf = DecodeBuffer::open(&p.source).build()?;
-                if in_pt > Duration::ZERO {
-                    decode_buf.seek(in_pt)?;
-                }
-                if info.has_audio() {
+                let decode_buf = open_clip_video_source(&p.source, in_pt, canvas.0, canvas.1, fps)?;
+                if has_audio {
                     let mixer_ref = mixer_arc
                         .get_or_insert_with(|| Arc::new(Mutex::new(AudioMixer::new(48_000))));
                     let handle = mixer_ref
@@ -274,7 +421,7 @@ impl ScenePlayer {
                         handle.set_pan(pan0 as f32);
                     }
                     audio_only_tracks.push(AudioOnlyTrack {
-                        source: p.source.clone(),
+                        source: source_path(&p.source),
                         timeline_start,
                         timeline_end,
                         in_point: in_pt,
@@ -398,7 +545,8 @@ impl ScenePlayer {
             .is_some_and(|c| c.timeline_start == Duration::ZERO);
         let (initial_audio_cancel, initial_audio_thread) = if first_clip_at_origin {
             if let Some(handle) = clip_states.first().and_then(|c| c.audio_track.clone()) {
-                let source = clip_states[0].source.clone();
+                // The first V1 clip has audio, so it is a file source; derive its path.
+                let source = source_path(&clip_states[0].source);
                 let in_pt = clip_states[0].in_point;
                 let clip0_speed = clip_states[0].speed;
                 let clip0_pitch = clip_states[0].pitch;
@@ -484,6 +632,65 @@ impl ScenePlayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_canvas_dims_should_prefer_explicit_canvas_then_fall_back() {
+        let scene = |canvas| Scene {
+            fps: 30.0,
+            canvas,
+            lavfi_overlay: None,
+            video_tracks: vec![],
+            audio_tracks: vec![],
+        };
+        // An explicit canvas wins.
+        assert_eq!(
+            resolve_canvas_dims(&scene(Some((1920, 1080)))),
+            (1920, 1080)
+        );
+        // No explicit canvas and no file placement to size from -> (0, 0), so a
+        // generated source renders nothing rather than guessing.
+        assert_eq!(resolve_canvas_dims(&scene(None)), (0, 0));
+    }
+
+    #[test]
+    #[ignore = "requires the color/drawtext filters; run with -- --include-ignored"]
+    fn preview_should_render_text_and_solid_sources() {
+        use ff_format::{Color, TextSpec};
+
+        // #1615: a generated source's held frame is built via `SolidSource` /
+        // `TextSource` — the same `color` / `drawtext` filters export uses — so preview
+        // matches export. Probe-gated (RK-002): the filters are absent on a minimal
+        // FFmpeg, so `generated_held_frame` returns `None` and the test skips.
+        let red = Color::rgb(200, 30, 40);
+        let Some(frame) = generated_held_frame(&SceneSource::Solid(red), 16, 16, 30.0) else {
+            println!("Skipping: color filter unavailable");
+            return;
+        };
+        assert_eq!((frame.width(), frame.height()), (16, 16));
+        let Some(plane) = frame.plane(0) else {
+            println!("Skipping: no rgba plane");
+            return;
+        };
+        let stride = frame.stride(0).unwrap_or(16 * 4);
+        // Centre pixel (8, 8) in the rgba plane must be ~red (non-vacuous: an empty
+        // path would render nothing).
+        let off = 8 * stride + 8 * 4;
+        let (r, g, b) = (plane[off], plane[off + 1], plane[off + 2]);
+        assert!(
+            r.abs_diff(200) <= 6 && g.abs_diff(30) <= 6 && b.abs_diff(40) <= 6,
+            "solid centre pixel must be ~red, got ({r}, {g}, {b})"
+        );
+
+        // Text: the `color`→`drawtext` path must at least produce a canvas-sized frame
+        // where the drawtext filter is available.
+        if let Some(tf) =
+            generated_held_frame(&SceneSource::Text(TextSpec::new("Hi")), 64, 32, 30.0)
+        {
+            assert_eq!((tf.width(), tf.height()), (64, 32));
+        } else {
+            println!("Skipping text: drawtext filter unavailable");
+        }
+    }
 
     // blend_rgba delegate
 

--- a/crates/ff-preview/src/scene/runner.rs
+++ b/crates/ff-preview/src/scene/runner.rs
@@ -423,16 +423,20 @@ impl SceneRunner {
                 }
             }
 
-            // Error events from active clip
+            // Error events from active clip (a generated held source has no channel).
             {
                 let active = self.active;
-                while let Ok(msg) = self.clips[active].decode_buf.error_events().try_recv() {
-                    let _ = self.event_tx.try_send(PlayerEvent::Error(msg));
+                if let Some(rx) = self.clips[active].decode_buf.error_events() {
+                    while let Ok(msg) = rx.try_recv() {
+                        let _ = self.event_tx.try_send(PlayerEvent::Error(msg));
+                    }
                 }
             }
             let trans_next = self.transition.as_ref().map(|tp| tp.next_idx);
-            if let Some(next_idx) = trans_next {
-                while let Ok(msg) = self.clips[next_idx].decode_buf.error_events().try_recv() {
+            if let Some(next_idx) = trans_next
+                && let Some(rx) = self.clips[next_idx].decode_buf.error_events()
+            {
+                while let Ok(msg) = rx.try_recv() {
                     let _ = self.event_tx.try_send(PlayerEvent::Error(msg));
                 }
             }
@@ -1121,7 +1125,13 @@ impl SceneRunner {
         handle.clear(); // discard stale samples
 
         let c = &self.clips[clip_idx];
-        let source = c.source.clone();
+        // Only a file source reaches here (a generated clip has no `audio_track`,
+        // so the guard above returns early); derive its path for the audio thread.
+        let source = c
+            .source
+            .as_file()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default();
         // V1 clip audio honours its own fades + speed (the A-track path already does).
         // `clip_dur` must be the SOURCE-time span (the resampler multiplies it by
         // `1/speed` to get timeline time, as the A-tracks feed `out-in` source span);

--- a/crates/ff-preview/src/scene/runner_layout.rs
+++ b/crates/ff-preview/src/scene/runner_layout.rs
@@ -46,9 +46,8 @@ impl SceneRunner {
                 return Err(PreviewError::Ffmpeg {
                     code: -1,
                     message: format!(
-                        "V1 clip[{i}] source mismatch: runner={} timeline={}",
-                        self.clips[i].source.display(),
-                        p.source.display(),
+                        "V1 clip[{i}] source mismatch: runner={:?} timeline={:?}",
+                        self.clips[i].source, p.source,
                     ),
                 });
             }

--- a/crates/ff-preview/src/scene/state.rs
+++ b/crates/ff-preview/src/scene/state.rs
@@ -7,17 +7,116 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Receiver;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
 use ff_filter::{AnimatedValue, LavfiSource, RealtimeLayerDescriptor, XfadeTransition};
-use ff_format::VideoFrame;
+use ff_format::{Rational, Timestamp, VideoFrame};
 
 use crate::audio::AudioTrackHandle;
+use crate::error::PreviewError;
 use crate::playback::SwsRgbaConverter;
-use crate::playback::decode_buffer::DecodeBuffer;
+use crate::playback::decode_buffer::{DecodeBuffer, FrameResult};
 
 use super::audio_resampling::spawn_audio_track_thread;
+
+// ClipVideoSource
+
+/// The per-clip video source the runner pulls frames from: a decoded media file,
+/// or a **held** constant frame for a generated (solid/text) source.
+///
+/// A generated source renders the *same* pixels for its whole timeline span (a solid
+/// fill, or static drawtext), so the pixels are pulled once at open (via `ff-filter`'s
+/// `SolidSource` / `TextSource`) and held. But the runner drives clip progression off
+/// each frame's own PTS (out-point / due-frame checks in `runner.rs` and
+/// `sync_overlays`), so a fixed PTS would stall the timeline (V1) or spin forever
+/// (overlays). The held source therefore stamps each returned frame with a synthetic,
+/// monotonically advancing PTS (stepped by `1/fps`), and `seek` resets that cursor —
+/// exactly the PTS behaviour of a real decoding source. The enum mirrors the subset of
+/// the [`DecodeBuffer`] surface the runner uses, so the compositing loop is unchanged.
+pub(super) enum ClipVideoSource {
+    /// A decoding media file.
+    File(DecodeBuffer),
+    /// A generated source: the constant pixels (`None` when the generator was
+    /// unavailable — e.g. the `color`/`drawtext` filters are missing — so it renders
+    /// nothing rather than failing `open`), plus the synthetic-PTS cursor and step.
+    Held {
+        frame: Option<VideoFrame>,
+        next_pts: Duration,
+        step: Duration,
+    },
+}
+
+/// Microsecond time base for the synthetic held-frame PTS (matching the runner's
+/// own frame stamping).
+fn micros_timestamp(pts: Duration) -> Timestamp {
+    Timestamp::from_duration(pts, Rational::new(1, 1_000_000))
+}
+
+impl ClipVideoSource {
+    /// Builds a held generated source that stamps frames at `1/fps` starting from
+    /// `start_pts` (the clip's `in_point`).
+    pub(super) fn held(frame: Option<VideoFrame>, start_pts: Duration, fps: f64) -> Self {
+        Self::Held {
+            frame,
+            next_pts: start_pts,
+            step: Duration::from_secs_f64(1.0 / fps.max(1.0)),
+        }
+    }
+
+    /// Next frame. A `Held` source returns its constant pixels stamped with the next
+    /// synthetic PTS (so the runner's PTS-driven progression advances), or `Eof` when
+    /// it has no frame.
+    pub(super) fn pop_frame(&mut self) -> FrameResult {
+        match self {
+            Self::File(buf) => buf.pop_frame(),
+            Self::Held {
+                frame: Some(frame),
+                next_pts,
+                step,
+            } => {
+                let mut out = frame.clone();
+                out.set_timestamp(micros_timestamp(*next_pts));
+                *next_pts = next_pts.saturating_add(*step);
+                FrameResult::Frame(out)
+            }
+            Self::Held { frame: None, .. } => FrameResult::Eof,
+        }
+    }
+
+    /// Seeks a file source; for a held source, resets the synthetic-PTS cursor so the
+    /// next frame is stamped at `target_pts` (the runner seeks on clip activation).
+    pub(super) fn seek(&mut self, target_pts: Duration) -> Result<(), PreviewError> {
+        match self {
+            Self::File(buf) => buf.seek(target_pts),
+            Self::Held { next_pts, .. } => {
+                *next_pts = target_pts;
+                Ok(())
+            }
+        }
+    }
+
+    /// Coarse seek for a file source; resets the held cursor like [`seek`](Self::seek).
+    pub(super) fn seek_coarse(&mut self, target_pts: Duration) -> Result<(), PreviewError> {
+        match self {
+            Self::File(buf) => buf.seek_coarse(target_pts),
+            Self::Held { next_pts, .. } => {
+                *next_pts = target_pts;
+                Ok(())
+            }
+        }
+    }
+
+    /// The decode error channel for a file source; `None` for a held source (no
+    /// background decode, so no errors).
+    pub(super) fn error_events(&self) -> Option<&Receiver<String>> {
+        match self {
+            Self::File(buf) => Some(buf.error_events()),
+            Self::Held { .. } => None,
+        }
+    }
+}
 
 /// Converts a gain in dB to a linear amplitude multiplier for the mixer.
 #[allow(clippy::cast_possible_truncation)]
@@ -28,9 +127,12 @@ pub(super) fn db_to_linear(db: f64) -> f32 {
 // ClipState
 
 pub(super) struct ClipState {
-    /// Source file path — needed to spawn audio threads on clip transition.
-    pub(super) source: PathBuf,
-    pub(super) decode_buf: DecodeBuffer,
+    /// The clip's video source (file or generated). Used to spawn the audio thread
+    /// on clip transition (only a `File` source has audio) and to detect a source
+    /// change on a positional re-layout.
+    pub(super) source: super::types::SceneSource,
+    /// The clip's video source: a decoding file, or a generated held frame.
+    pub(super) decode_buf: ClipVideoSource,
     /// Global timeline position where this clip starts.
     pub(super) timeline_start: Duration,
     /// Global timeline position where this clip ends.
@@ -304,6 +406,48 @@ mod tests {
         );
         assert!((db_to_linear(6.0) - 1.995).abs() < 1e-3, "+6 dB ≈ 1.995");
         assert!(db_to_linear(-120.0) < 1e-5, "very quiet ≈ 0");
+    }
+
+    #[test]
+    fn held_source_should_return_injected_frame_with_advancing_pts() {
+        // #1615 (RK-013 injection): the held-frame routing is deterministic without
+        // FFmpeg. The pixels are constant, but the PTS must advance by 1/fps each pull
+        // (the runner drives clip progression off the frame PTS — a fixed PTS would
+        // stall V1 / spin overlays forever). `seek` resets the cursor.
+        let frame = VideoFrame::from_rgba(2, 3, vec![10u8; 2 * 3 * 4]).unwrap();
+        let mut src = ClipVideoSource::held(Some(frame), Duration::ZERO, 30.0);
+
+        let step = Duration::from_secs_f64(1.0 / 30.0);
+        for i in 0..3u32 {
+            let FrameResult::Frame(f) = src.pop_frame() else {
+                panic!("a held source must return its constant frame every pull");
+            };
+            assert_eq!((f.width(), f.height()), (2, 3), "pixels are constant");
+            let want = step * i;
+            let got = f.timestamp().as_duration();
+            assert!(
+                got.abs_diff(want) < Duration::from_micros(1),
+                "held PTS must advance by 1/fps: pull {i} want {want:?} got {got:?}"
+            );
+        }
+
+        // Seek resets the cursor: the next frame is stamped at the seek target.
+        assert!(src.seek(Duration::from_secs(5)).is_ok());
+        let FrameResult::Frame(f) = src.pop_frame() else {
+            panic!("expected a frame after seek");
+        };
+        assert!(
+            f.timestamp().as_duration().abs_diff(Duration::from_secs(5)) < Duration::from_micros(1)
+        );
+        assert!(src.seek_coarse(Duration::from_secs(1)).is_ok());
+        assert!(
+            src.error_events().is_none(),
+            "a held source has no decode error channel"
+        );
+
+        // A held source with no frame (generator unavailable) is end-of-stream.
+        let mut empty = ClipVideoSource::held(None, Duration::ZERO, 30.0);
+        assert!(matches!(empty.pop_frame(), FrameResult::Eof));
     }
 
     #[test]

--- a/crates/ff-preview/src/scene/types.rs
+++ b/crates/ff-preview/src/scene/types.rs
@@ -9,10 +9,40 @@
 //! every edit needs no re-probe and behaviour is preserved. An engine derives a
 //! `Scene` from its own editing model; `Scene` is the only input the runner accepts.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use ff_filter::{AnimatedValue, RealtimeLayerDescriptor, XfadeTransition};
+use ff_format::{Color, TextSpec};
+
+// SceneSource
+
+/// The video source backing a [`ScenePlacement`]: a decoded media file, or a
+/// generated (solid-colour / text) source rendered without a file — the preview
+/// counterpart of the engine's `ClipSource`. Generated sources are produced by
+/// `ff-filter`'s `SolidSource` / `TextSource` (the same `color` / `drawtext`
+/// filters the export path uses), so preview matches export.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SceneSource {
+    /// A decoded media file at this path.
+    File(PathBuf),
+    /// A solid-colour fill for the whole canvas.
+    Solid(Color),
+    /// A text/title overlay rendered by `drawtext`.
+    Text(TextSpec),
+}
+
+impl SceneSource {
+    /// The file path when this is a [`File`](Self::File) source, else `None`
+    /// (a generated source has no path). Used by the file-only open path.
+    #[must_use]
+    pub fn as_file(&self) -> Option<&Path> {
+        match self {
+            Self::File(path) => Some(path.as_path()),
+            Self::Solid(_) | Self::Text(_) => None,
+        }
+    }
+}
 
 // Scene
 
@@ -52,8 +82,8 @@ pub struct SceneVideoTrack {
 /// clip duration when `out_point` is `None`) is done by the runner at open time.
 #[derive(Debug, Clone)]
 pub struct ScenePlacement {
-    /// Source media path.
-    pub source: PathBuf,
+    /// Video source: a media file, or a generated (solid/text) source.
+    pub source: SceneSource,
     /// Global timeline position where this placement starts.
     pub offset: Duration,
     /// Source-file PTS at which playback starts (`Clip::in_point`, defaulted to zero).


### PR DESCRIPTION
## Objective

- Preview dropped generated (Text/Solid) clips: `ScenePlacement.source` was a `PathBuf`, so `to_scene` projected a non-file clip with an empty path and the runner (which probes and decodes a file per placement) rendered nothing, unlike export (follow-up from #1591, the last preview-equals-export gap).

## Solution

- Add a `SceneSource { File(PathBuf), Solid(Color), Text(TextSpec) }` enum and change `ScenePlacement.source` to it; avio's `video_placement` projects a clip's `ClipSource` into it, and both crates re-export `SceneSource`.
- Render generated clips in the runner via ff-filter's `SolidSource` / `TextSource` (the same `color` / `drawtext` filters export uses, not the lavfi movie demuxer), so they render on the same builds where export does; when the filters are absent the clip renders nothing rather than failing open.
- A generated clip's pixels are constant over its span, so they are pulled once at open and held (`ClipVideoSource::Held`), which mirrors the `DecodeBuffer` method surface the runner uses so the compositing loop is unchanged.
- Root cause fix for the held path: the runner drives clip progression off each frame's own PTS (V1 `out_point` and overlay due-frame checks), so a fixed held-frame PTS would stall V1 playback and spin the overlay sync loop forever — the held source now stamps a synthetic per-frame PTS (`1/fps`, reset on seek). Covered by a held-PTS unit test and an end-to-end test that drives a Solid base+overlay through the real runner and asserts the delivered PTS advances.

Live canvas-resize of an already-open generated clip leaves its held frame at the old size, tracked in #1619.

Closes #1615