### PR TITLE
fix(ff-preview): rebuild a generated held frame on a live canvas resize

### DIFF
--- a/crates/ff-preview/src/scene/runner_layout.rs
+++ b/crates/ff-preview/src/scene/runner_layout.rs
@@ -7,7 +7,29 @@ use std::time::Duration;
 use crate::error::PreviewError;
 
 use super::runner::SceneRunner;
-use super::types::Scene;
+use super::state::ClipVideoSource;
+use super::types::{Scene, SceneSource};
+
+/// Rebuilds a generated clip's held frame when the resolved canvas size changed: a
+/// held frame is rendered *at* the canvas size, so a live resize leaves it stale
+/// (a decoded file is canvas-independent, so `held_frame_dims` is `None` and it is
+/// skipped). Rebuilt via [`ClipVideoSource::held`] so the synthetic advancing PTS
+/// is preserved (RK-019). A `(0, 0)` canvas (no size to render into) is a no-op.
+fn rebuild_held_on_resize(
+    decode_buf: &mut ClipVideoSource,
+    source: &SceneSource,
+    in_pt: Duration,
+    canvas: (u32, u32),
+    fps: f64,
+) {
+    if canvas != (0, 0)
+        && let Some(dims) = decode_buf.held_frame_dims()
+        && dims != canvas
+    {
+        let frame = super::generated_held_frame(source, canvas.0, canvas.1, fps);
+        *decode_buf = ClipVideoSource::held(frame, in_pt, fps);
+    }
+}
 
 impl SceneRunner {
     /// Update clip positions in place from a new [`Scene`] without stopping the
@@ -53,6 +75,10 @@ impl SceneRunner {
             }
         }
 
+        // Canvas size for rebuilding generated held frames on a live resize.
+        let canvas = super::resolve_canvas_dims(scene);
+        let fps = scene.fps.max(1.0);
+
         // Update V1 clip positions
         for (i, p) in v_tracks[0].placements.iter().enumerate() {
             let new_speed = p.speed;
@@ -78,6 +104,13 @@ impl SceneRunner {
             self.clips[i].speed = new_speed;
             self.clips[i].xfade_dur = p.xfade_dur;
             self.clips[i].xfade_kind = p.xfade_kind;
+            rebuild_held_on_resize(
+                &mut self.clips[i].decode_buf,
+                &p.source,
+                p.in_point,
+                canvas,
+                fps,
+            );
         }
 
         // Update overlay layers (V2+)
@@ -97,6 +130,13 @@ impl SceneRunner {
                         layer.clips[j].timeline_end = p.offset + new_dur;
                         layer.clips[j].in_point = p.in_point;
                         layer.clips[j].out_point = p.out_point;
+                        rebuild_held_on_resize(
+                            &mut layer.clips[j].decode_buf,
+                            &p.source,
+                            p.in_point,
+                            canvas,
+                            fps,
+                        );
                     }
                 }
             }
@@ -137,5 +177,85 @@ impl SceneRunner {
         self.seek_timeline(resume_pts)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use ff_filter::{AnimatedValue, BlendMode, CompositeOp, RealtimeLayerDescriptor};
+    use ff_format::Color;
+
+    use super::super::ScenePlayer;
+    use super::super::types::{Scene, ScenePlacement, SceneSource, SceneVideoTrack};
+    use super::*;
+
+    /// A minimal one-clip Solid `Scene` at `w`x`h` (a generated V1 base clip).
+    fn solid_scene(w: u32, h: u32) -> Scene {
+        let layer = RealtimeLayerDescriptor {
+            effects: vec![],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        let placement = ScenePlacement {
+            source: SceneSource::Solid(Color::rgb(20, 40, 200)),
+            offset: Duration::ZERO,
+            in_point: Duration::ZERO,
+            out_point: Some(Duration::from_secs(2)),
+            speed: 1.0,
+            xfade_dur: Duration::ZERO,
+            xfade_kind: None,
+            opacity: 1.0,
+            layer,
+            fade_in: Duration::ZERO,
+            fade_out: Duration::ZERO,
+            volume: AnimatedValue::Static(0.0),
+            pitch: 0.0,
+            pan: AnimatedValue::Static(0.0),
+        };
+        Scene {
+            fps: 30.0,
+            canvas: Some((w, h)),
+            lavfi_overlay: None,
+            video_tracks: vec![SceneVideoTrack {
+                placements: vec![placement],
+            }],
+            audio_tracks: vec![],
+        }
+    }
+
+    #[test]
+    #[ignore = "requires the color filter; run with -- --include-ignored"]
+    fn layout_update_should_rebuild_generated_held_frame_on_canvas_resize() {
+        // #1619: a live canvas resize of an already-open generated clip must rebuild
+        // its held frame at the new size. Probe-gated (RK-002): the color filter is
+        // absent on a minimal FFmpeg, so open yields no held frame and the test skips.
+        let (mut runner, _handle) = match ScenePlayer::open(&solid_scene(16, 16)) {
+            Ok(rh) => rh,
+            Err(e) => {
+                println!("skipping: open failed: {e}");
+                return;
+            }
+        };
+        if runner.clips[0].decode_buf.held_frame_dims() != Some((16, 16)) {
+            println!("skipping: color filter unavailable (no held frame at open)");
+            return;
+        }
+        // Same Solid colour, new canvas -> the source-equality check passes, so the
+        // in-place fast path runs and must rebuild the stale held frame.
+        runner
+            .update_layout_in_place(&solid_scene(32, 32), Duration::ZERO)
+            .expect("in-place update should succeed for the same source");
+        assert_eq!(
+            runner.clips[0].decode_buf.held_frame_dims(),
+            Some((32, 32)),
+            "the generated held frame must be rebuilt at the new canvas size"
+        );
     }
 }

--- a/crates/ff-preview/src/scene/state.rs
+++ b/crates/ff-preview/src/scene/state.rs
@@ -116,6 +116,19 @@ impl ClipVideoSource {
             Self::Held { .. } => None,
         }
     }
+
+    /// The dimensions of a generated source's held frame (its rendered size), or
+    /// `None` for a file source or an unavailable generator. Used to detect a canvas
+    /// resize: a held frame is rendered at the canvas size, so stale dimensions mean
+    /// it must be rebuilt (a decoded file is canvas-independent, hence `None`).
+    pub(super) fn held_frame_dims(&self) -> Option<(u32, u32)> {
+        match self {
+            Self::Held {
+                frame: Some(frame), ..
+            } => Some((frame.width(), frame.height())),
+            Self::File(_) | Self::Held { frame: None, .. } => None,
+        }
+    }
 }
 
 /// Converts a gain in dB to a linear amplitude multiplier for the mixer.
@@ -448,6 +461,22 @@ mod tests {
         // A held source with no frame (generator unavailable) is end-of-stream.
         let mut empty = ClipVideoSource::held(None, Duration::ZERO, 30.0);
         assert!(matches!(empty.pop_frame(), FrameResult::Eof));
+    }
+
+    #[test]
+    fn held_frame_dims_should_report_held_size_and_none_when_empty() {
+        // #1619: the resize rebuild keys off the held frame's rendered size.
+        let frame = VideoFrame::from_rgba(2, 3, vec![0u8; 2 * 3 * 4]).unwrap();
+        assert_eq!(
+            ClipVideoSource::held(Some(frame), Duration::ZERO, 30.0).held_frame_dims(),
+            Some((2, 3))
+        );
+        // No held frame (generator unavailable) — same arm a `File` source takes — so
+        // it reports `None` and the resize rebuild skips it (a file is canvas-independent).
+        assert_eq!(
+            ClipVideoSource::held(None, Duration::ZERO, 30.0).held_frame_dims(),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- After a live canvas resize (`SetCanvas` + `update_scene`), a generated (Solid/Text) clip rendered at the stale size: `update_layout_in_place` skips rebuilding a clip's video source (a decoded file is canvas-independent), but a generated clip's held frame is rendered at the canvas size, and `SceneSource::Solid`/`Text` equality ignores the canvas, so a same-colour clip took the in-place fast path and kept the old-size held frame (follow-up from the #1615 Tier-2 review).

## Solution

- Add `ClipVideoSource::held_frame_dims()` — the rendered size of a held frame, `None` for a file or an unavailable generator.
- In `update_layout_in_place`, rebuild a generated clip's held frame (V1 and overlay) when its dimensions differ from the newly resolved canvas, via `ClipVideoSource::held` so the synthetic advancing PTS is preserved (a fixed PTS would stall V1 / spin the overlay loop). The rebuild fires only on an actual resize and is idempotent; a file clip is skipped.
- In-place rebuild is the only fix: an `Err` from `update_layout_in_place` is ignored (not re-opened), so returning `Err` for a same-source resize would silently drop the resize.
- Covered by a deterministic `held_frame_dims` unit test and a probe-gated integration test that opens a 16x16 Solid clip, resizes to 32x32 in place, and asserts the held frame is rebuilt at the new size.

Closes #1619