### PR TITLE
feat(avio,ff-render): map the derived scene to an ff-render GPU plan

### DIFF
--- a/crates/avio/Cargo.toml
+++ b/crates/avio/Cargo.toml
@@ -18,6 +18,10 @@ hwaccel = ["ff-encode/hwaccel"] # hardware-accelerated export
 gpl     = ["ff-encode/gpl"]     # GPL-only codecs (x264 / x265)
 preview = ["dep:ff-preview", "ff-preview/timeline"] # real-time TimelinePlayer / Scene
 serde   = ["dep:serde", "ff-filter/serde", "ff-format/serde"] # (de)serialize the model
+# GPU compositing bridge: map the derived scene to ff-render's GPU compositor
+# (#1365). Off by default so wgpu stays optional for headless / export-only builds;
+# Br3 extends this with "ff-render/display" for the zero-copy preview path.
+gpu     = ["dep:ff-render", "ff-render/wgpu"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -36,8 +40,9 @@ ff-pipeline = { workspace = true }
 ff-analysis = { workspace = true }
 thiserror   = { workspace = true }
 log         = { workspace = true }
-# Opt-in: real-time preview and model (de)serialization.
+# Opt-in: real-time preview, model (de)serialization, and the GPU bridge.
 ff-preview  = { workspace = true, optional = true }
+ff-render   = { workspace = true, optional = true }
 serde       = { version = "1.0.228", features = ["derive"], optional = true }
 
 [[test]]

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -1,0 +1,658 @@
+//! Mapping from the derived scene to an `ff-render` GPU plan (bridge Br2, #1625).
+//!
+//! This is the pure, device-free half of the GPU compositing bridge (ADR-0007,
+//! `docs/specs/gpu-compositing-bridge.md`): it translates avio's derived per-frame
+//! layer set into a [`GpuScenePlan`] describing how to composite the frame on the
+//! GPU, or reports a [`GpuMapping::Fallback`] when the frame contains anything the
+//! `ff-render` node set does not cover. It does **not** touch a GPU: building the
+//! actual `ff_render::Compositor` / `RenderGraph` from a plan and running it against
+//! decoded frames is the preview (Br3) and export (Br4) work.
+//!
+//! The mapping is the single source of truth shared by both paths: it is written
+//! once over [`GpuLayerSource`], implemented for the export `VideoLayer` and the
+//! preview `RealtimeLayerDescriptor`.
+//!
+//! Fallback is **whole-frame**: if any layer carries an unsupported blend mode,
+//! composite op, or effect step, the entire frame falls back to the existing CPU
+//! compositor. The mapping never silently drops a step. v1 covers colour grade
+//! (`Eq`) and plain scale as per-layer effects; broader node coverage is tracked as
+//! a follow-up.
+
+use std::time::Duration;
+
+use ff_filter::{
+    AnimatedValue, BlendMode, CompositeOp, FilterStep, RealtimeLayerDescriptor, ScaleAlgorithm,
+    VideoLayer,
+};
+use ff_render::{BlendMode as RenderBlendMode, ScaleAlgorithm as RenderScaleAlgorithm};
+
+/// A derived layer the GPU mapping can read. Implemented for the export
+/// [`VideoLayer`] and the preview [`RealtimeLayerDescriptor`] so the mapping is one
+/// shared implementation.
+pub trait GpuLayerSource {
+    /// Per-clip opacity animation.
+    fn opacity(&self) -> &AnimatedValue<f64>;
+    /// Horizontal position animation.
+    fn x(&self) -> &AnimatedValue<f64>;
+    /// Vertical position animation.
+    fn y(&self) -> &AnimatedValue<f64>;
+    /// Horizontal scale animation.
+    fn scale_x(&self) -> &AnimatedValue<f64>;
+    /// Vertical scale animation.
+    fn scale_y(&self) -> &AnimatedValue<f64>;
+    /// Rotation animation.
+    fn rotation(&self) -> &AnimatedValue<f64>;
+    /// Layer-to-layer blend mode.
+    fn blend_mode(&self) -> BlendMode;
+    /// Porter-Duff composite operator.
+    fn composite_op(&self) -> CompositeOp;
+    /// Ordered per-clip effect chain.
+    fn effects(&self) -> &[FilterStep];
+}
+
+impl GpuLayerSource for VideoLayer {
+    fn opacity(&self) -> &AnimatedValue<f64> {
+        &self.opacity
+    }
+    fn x(&self) -> &AnimatedValue<f64> {
+        &self.x
+    }
+    fn y(&self) -> &AnimatedValue<f64> {
+        &self.y
+    }
+    fn scale_x(&self) -> &AnimatedValue<f64> {
+        &self.scale_x
+    }
+    fn scale_y(&self) -> &AnimatedValue<f64> {
+        &self.scale_y
+    }
+    fn rotation(&self) -> &AnimatedValue<f64> {
+        &self.rotation
+    }
+    fn blend_mode(&self) -> BlendMode {
+        self.blend_mode
+    }
+    fn composite_op(&self) -> CompositeOp {
+        self.composite_op
+    }
+    fn effects(&self) -> &[FilterStep] {
+        &self.effects
+    }
+}
+
+impl GpuLayerSource for RealtimeLayerDescriptor {
+    fn opacity(&self) -> &AnimatedValue<f64> {
+        &self.opacity
+    }
+    fn x(&self) -> &AnimatedValue<f64> {
+        &self.x
+    }
+    fn y(&self) -> &AnimatedValue<f64> {
+        &self.y
+    }
+    fn scale_x(&self) -> &AnimatedValue<f64> {
+        &self.scale_x
+    }
+    fn scale_y(&self) -> &AnimatedValue<f64> {
+        &self.scale_y
+    }
+    fn rotation(&self) -> &AnimatedValue<f64> {
+        &self.rotation
+    }
+    fn blend_mode(&self) -> BlendMode {
+        self.blend_mode
+    }
+    fn composite_op(&self) -> CompositeOp {
+        self.composite_op
+    }
+    fn effects(&self) -> &[FilterStep] {
+        &self.effects
+    }
+}
+
+/// A per-layer effect the GPU path can apply, mapped from a [`FilterStep`].
+/// `#[non_exhaustive]`: more kinds are added as node coverage grows.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum GpuEffect {
+    /// `ff_render::ColorGradeNode` (brightness / contrast / saturation; temperature
+    /// and tint are neutral until a source carries them).
+    ColorGrade {
+        /// Brightness offset.
+        brightness: f32,
+        /// Contrast multiplier.
+        contrast: f32,
+        /// Saturation multiplier.
+        saturation: f32,
+        /// Colour temperature.
+        temperature: f32,
+        /// Colour tint.
+        tint: f32,
+    },
+    /// `ff_render::ScaleNode` (resize to a fixed target).
+    Scale {
+        /// Target width in pixels.
+        width: u32,
+        /// Target height in pixels.
+        height: u32,
+        /// Resampling algorithm.
+        algorithm: RenderScaleAlgorithm,
+    },
+}
+
+/// One layer of a [`GpuScenePlan`]: the transform / blend / opacity the
+/// `ff_render::Compositor` needs, plus the per-layer effect nodes to run before
+/// compositing. The transform is stored as scalars (evaluated at the frame time);
+/// Br3/Br4 build the `ff_render::LayerTransform` from them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GpuLayerPlan {
+    /// Compositing order (bottom to top); equals the layer's index.
+    pub z_order: i32,
+    /// Horizontal offset in pixels.
+    pub x: f32,
+    /// Vertical offset in pixels.
+    pub y: f32,
+    /// Horizontal scale factor.
+    pub scale_x: f32,
+    /// Vertical scale factor.
+    pub scale_y: f32,
+    /// Rotation in the compositor's units.
+    pub rotation: f32,
+    /// Layer opacity in `[0.0, 1.0]`.
+    pub opacity: f32,
+    /// Blend mode against the layers below.
+    pub blend_mode: RenderBlendMode,
+    /// Per-layer effects applied to the source frame before compositing.
+    pub effects: Vec<GpuEffect>,
+}
+
+/// A whole frame's GPU compositing plan: the output canvas and the z-ordered layers.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GpuScenePlan {
+    /// Output canvas `(width, height)`.
+    pub canvas: (u32, u32),
+    /// Layers in compositing order (bottom to top).
+    pub layers: Vec<GpuLayerPlan>,
+}
+
+/// Why a frame cannot composite on the GPU and falls back to the CPU compositor.
+/// `#[non_exhaustive]`: more reasons appear as coverage changes.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum GpuFallback {
+    /// A blend mode with no `ff-render` equivalent.
+    UnsupportedBlendMode(BlendMode),
+    /// A composite operator other than `Over`.
+    UnsupportedCompositeOp(CompositeOp),
+    /// An effect step with no GPU node.
+    UnsupportedEffect,
+}
+
+/// The result of mapping a frame: a GPU plan, or a whole-frame CPU fallback.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GpuMapping {
+    /// The frame composites on the GPU with this plan.
+    Gpu(GpuScenePlan),
+    /// The frame falls back to the existing CPU compositor (with the reason).
+    Fallback(GpuFallback),
+}
+
+/// Maps a derived layer set (bottom to top) at frame time `t` to a [`GpuMapping`].
+///
+/// Returns [`GpuMapping::Gpu`] only when every layer fully maps to the `ff-render`
+/// node set; the first unsupported blend mode, composite op, or effect step makes
+/// the whole frame a [`GpuMapping::Fallback`] (no step is ever silently dropped).
+#[must_use]
+pub fn map_scene<L: GpuLayerSource>(layers: &[L], canvas: (u32, u32), t: Duration) -> GpuMapping {
+    let mut plan_layers = Vec::with_capacity(layers.len());
+    for (i, layer) in layers.iter().enumerate() {
+        // Check composite first: the blend mode is only applied when the composite
+        // op is `Over` (see `VideoLayer`), so for any other op the composite is the
+        // semantically active reason to fall back. `Over` is the only plain
+        // top-over-bottom composite; the others need node wiring the compositor
+        // does not provide yet.
+        if !matches!(layer.composite_op(), CompositeOp::Over) {
+            return GpuMapping::Fallback(GpuFallback::UnsupportedCompositeOp(layer.composite_op()));
+        }
+        let Some(blend_mode) = map_blend_mode(layer.blend_mode()) else {
+            return GpuMapping::Fallback(GpuFallback::UnsupportedBlendMode(layer.blend_mode()));
+        };
+
+        let mut effects = Vec::new();
+        for step in layer.effects() {
+            match classify_step(step, t) {
+                StepClass::Skip => {}
+                StepClass::Effect(effect) => effects.push(effect),
+                StepClass::Unsupported => {
+                    return GpuMapping::Fallback(GpuFallback::UnsupportedEffect);
+                }
+            }
+        }
+
+        plan_layers.push(GpuLayerPlan {
+            // Layer count fits an i32 in every real timeline; saturate defensively.
+            z_order: i32::try_from(i).unwrap_or(i32::MAX),
+            x: eval_at(layer.x(), t),
+            y: eval_at(layer.y(), t),
+            scale_x: eval_at(layer.scale_x(), t),
+            scale_y: eval_at(layer.scale_y(), t),
+            rotation: eval_at(layer.rotation(), t),
+            opacity: eval_at(layer.opacity(), t).clamp(0.0, 1.0),
+            blend_mode,
+            effects,
+        });
+    }
+    GpuMapping::Gpu(GpuScenePlan {
+        canvas,
+        layers: plan_layers,
+    })
+}
+
+/// Evaluates an animation track at `t` and narrows to the `f32` the GPU nodes use.
+// Transform / colour params are well within `f32` range; the narrowing from the
+// model's `f64` is the intended, lossy conversion.
+#[allow(clippy::cast_possible_truncation)]
+fn eval_at(value: &AnimatedValue<f64>, t: Duration) -> f32 {
+    value.value_at(t) as f32
+}
+
+/// How an effect step maps: skipped (temporal / handled upstream), a GPU effect, or
+/// unsupported (forces whole-frame CPU fallback).
+enum StepClass {
+    Skip,
+    Effect(GpuEffect),
+    Unsupported,
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
+    match step {
+        // Temporal / decode-scheduling steps are applied upstream (the GPU path
+        // composites already-decoded frames), so they are not the compositor's
+        // concern here.
+        FilterStep::Trim { .. }
+        | FilterStep::ResetPts
+        | FilterStep::OffsetPts { .. }
+        | FilterStep::Speed { .. } => StepClass::Skip,
+        FilterStep::Eq {
+            brightness,
+            contrast,
+            saturation,
+        } => StepClass::Effect(GpuEffect::ColorGrade {
+            brightness: *brightness,
+            contrast: *contrast,
+            saturation: *saturation,
+            temperature: 0.0,
+            tint: 0.0,
+        }),
+        FilterStep::EqAnimated {
+            brightness,
+            contrast,
+            saturation,
+            gamma,
+        } => {
+            // ff-render's ColorGradeNode has no gamma, so only an `eq` whose gamma
+            // is neutral at `t` maps; otherwise fall back so gamma is not dropped.
+            if (gamma.value_at(t) - 1.0).abs() < 1e-6 {
+                StepClass::Effect(GpuEffect::ColorGrade {
+                    brightness: brightness.value_at(t) as f32,
+                    contrast: contrast.value_at(t) as f32,
+                    saturation: saturation.value_at(t) as f32,
+                    temperature: 0.0,
+                    tint: 0.0,
+                })
+            } else {
+                StepClass::Unsupported
+            }
+        }
+        FilterStep::Scale {
+            width,
+            height,
+            algorithm,
+        } => StepClass::Effect(GpuEffect::Scale {
+            width: *width,
+            height: *height,
+            algorithm: map_scale_algo(*algorithm),
+        }),
+        // Everything else (other colour, keying, masks, blur, animated geometry,
+        // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
+        // `#[non_exhaustive]` from ff-filter (RK-003).
+        _ => StepClass::Unsupported,
+    }
+}
+
+/// Maps `ff_filter::BlendMode` to the `ff_render::BlendMode` intersection, or `None`
+/// when `ff-render` has no equivalent (forcing fallback).
+fn map_blend_mode(mode: BlendMode) -> Option<RenderBlendMode> {
+    Some(match mode {
+        BlendMode::Normal => RenderBlendMode::Normal,
+        BlendMode::Multiply => RenderBlendMode::Multiply,
+        BlendMode::Screen => RenderBlendMode::Screen,
+        BlendMode::Overlay => RenderBlendMode::Overlay,
+        BlendMode::SoftLight => RenderBlendMode::SoftLight,
+        BlendMode::HardLight => RenderBlendMode::HardLight,
+        BlendMode::ColorDodge => RenderBlendMode::ColorDodge,
+        BlendMode::ColorBurn => RenderBlendMode::ColorBurn,
+        BlendMode::Difference => RenderBlendMode::Difference,
+        BlendMode::Exclusion => RenderBlendMode::Exclusion,
+        BlendMode::Add => RenderBlendMode::Add,
+        BlendMode::Subtract => RenderBlendMode::Subtract,
+        BlendMode::Darken => RenderBlendMode::Darken,
+        BlendMode::Lighten => RenderBlendMode::Lighten,
+        // No ff-render equivalent. `_` is required: `BlendMode` is
+        // `#[non_exhaustive]` from ff-filter (RK-003).
+        _ => return None,
+    })
+}
+
+/// Maps `ff_filter::ScaleAlgorithm` to `ff_render::ScaleAlgorithm` (ff-render has no
+/// `Fast`, so it maps to the closest `Bilinear`).
+fn map_scale_algo(algo: ScaleAlgorithm) -> RenderScaleAlgorithm {
+    match algo {
+        ScaleAlgorithm::Fast | ScaleAlgorithm::Bilinear => RenderScaleAlgorithm::Bilinear,
+        ScaleAlgorithm::Bicubic => RenderScaleAlgorithm::Bicubic,
+        ScaleAlgorithm::Lanczos => RenderScaleAlgorithm::Lanczos,
+        // `ScaleAlgorithm` is `#[non_exhaustive]` from ff-filter (RK-003).
+        _ => RenderScaleAlgorithm::Bilinear,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use ff_filter::{AnimationTrack, Easing, Keyframe};
+
+    use super::*;
+    use crate::Clip;
+    use crate::track::TrackAutomation;
+
+    /// A fully controllable [`GpuLayerSource`] for exercising the mapping in
+    /// isolation (identity transform, Normal blend, Over composite, no effects).
+    struct TestLayer {
+        opacity: AnimatedValue<f64>,
+        x: AnimatedValue<f64>,
+        y: AnimatedValue<f64>,
+        scale_x: AnimatedValue<f64>,
+        scale_y: AnimatedValue<f64>,
+        rotation: AnimatedValue<f64>,
+        blend_mode: BlendMode,
+        composite_op: CompositeOp,
+        effects: Vec<FilterStep>,
+    }
+
+    impl TestLayer {
+        fn identity() -> Self {
+            Self {
+                opacity: AnimatedValue::Static(1.0),
+                x: AnimatedValue::Static(0.0),
+                y: AnimatedValue::Static(0.0),
+                scale_x: AnimatedValue::Static(1.0),
+                scale_y: AnimatedValue::Static(1.0),
+                rotation: AnimatedValue::Static(0.0),
+                blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
+                effects: Vec::new(),
+            }
+        }
+    }
+
+    impl GpuLayerSource for TestLayer {
+        fn opacity(&self) -> &AnimatedValue<f64> {
+            &self.opacity
+        }
+        fn x(&self) -> &AnimatedValue<f64> {
+            &self.x
+        }
+        fn y(&self) -> &AnimatedValue<f64> {
+            &self.y
+        }
+        fn scale_x(&self) -> &AnimatedValue<f64> {
+            &self.scale_x
+        }
+        fn scale_y(&self) -> &AnimatedValue<f64> {
+            &self.scale_y
+        }
+        fn rotation(&self) -> &AnimatedValue<f64> {
+            &self.rotation
+        }
+        fn blend_mode(&self) -> BlendMode {
+            self.blend_mode
+        }
+        fn composite_op(&self) -> CompositeOp {
+            self.composite_op
+        }
+        fn effects(&self) -> &[FilterStep] {
+            &self.effects
+        }
+    }
+
+    fn gpu(mapping: GpuMapping) -> GpuScenePlan {
+        match mapping {
+            GpuMapping::Gpu(plan) => plan,
+            GpuMapping::Fallback(reason) => panic!("expected Gpu, got Fallback({reason:?})"),
+        }
+    }
+
+    #[test]
+    fn map_scene_should_map_identity_layer_to_a_single_gpu_plan_layer() {
+        let plan = gpu(map_scene(
+            &[TestLayer::identity()],
+            (1920, 1080),
+            Duration::ZERO,
+        ));
+        assert_eq!(plan.canvas, (1920, 1080));
+        let [layer] = plan.layers.as_slice() else {
+            panic!("expected one layer");
+        };
+        assert_eq!(layer.z_order, 0);
+        assert_eq!(layer.x, 0.0);
+        assert_eq!(layer.scale_x, 1.0);
+        assert_eq!(layer.rotation, 0.0);
+        assert_eq!(layer.opacity, 1.0);
+        assert_eq!(layer.blend_mode, RenderBlendMode::Normal);
+        assert!(layer.effects.is_empty());
+    }
+
+    #[test]
+    fn map_scene_should_evaluate_animated_transform_at_t() {
+        // x ramps 0 -> 100 over 0..2s; at t=1s it should read ~50.
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 100.0, Easing::Linear));
+        let mut layer = TestLayer::identity();
+        layer.x = AnimatedValue::Track(track);
+        let plan = gpu(map_scene(&[layer], (100, 100), Duration::from_secs(1)));
+        assert!((plan.layers[0].x - 50.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn map_scene_should_map_eq_to_color_grade() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Eq {
+            brightness: 0.5,
+            contrast: 1.2,
+            saturation: 0.8,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::ColorGrade {
+                brightness: 0.5,
+                contrast: 1.2,
+                saturation: 0.8,
+                temperature: 0.0,
+                tint: 0.0,
+            }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_eq_animated_to_color_grade_when_gamma_is_neutral() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::EqAnimated {
+            brightness: AnimatedValue::Static(0.3),
+            contrast: AnimatedValue::Static(1.1),
+            saturation: AnimatedValue::Static(0.9),
+            gamma: AnimatedValue::Static(1.0),
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::ColorGrade {
+                brightness: 0.3,
+                contrast: 1.1,
+                saturation: 0.9,
+                temperature: 0.0,
+                tint: 0.0,
+            }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_fall_back_when_eq_animated_gamma_is_not_neutral() {
+        // ff-render's ColorGrade has no gamma, so a non-neutral gamma must fall back
+        // rather than silently drop the gamma.
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::EqAnimated {
+            brightness: AnimatedValue::Static(0.0),
+            contrast: AnimatedValue::Static(1.0),
+            saturation: AnimatedValue::Static(1.0),
+            gamma: AnimatedValue::Static(1.5),
+        }];
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
+        );
+    }
+
+    #[test]
+    fn map_scene_should_clamp_out_of_range_opacity() {
+        let mut layer = TestLayer::identity();
+        layer.opacity = AnimatedValue::Static(1.5);
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(plan.layers[0].opacity, 1.0);
+    }
+
+    #[test]
+    fn map_scene_should_map_scale_step() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Scale {
+            width: 320,
+            height: 240,
+            algorithm: ScaleAlgorithm::Bicubic,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::Scale {
+                width: 320,
+                height: 240,
+                algorithm: RenderScaleAlgorithm::Bicubic,
+            }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_skip_temporal_steps() {
+        let mut layer = TestLayer::identity();
+        // Temporal steps present on the export layer must be skipped, not fallback.
+        layer.effects = vec![
+            FilterStep::Trim {
+                start: Some(1.0),
+                end: Some(4.0),
+            },
+            FilterStep::ResetPts,
+            FilterStep::OffsetPts { seconds: 2.0 },
+            FilterStep::Speed { factor: 2.0 },
+            FilterStep::Eq {
+                brightness: 0.1,
+                contrast: 1.0,
+                saturation: 1.0,
+            },
+        ];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.len(),
+            1,
+            "temporal steps skipped; only the colour grade remains"
+        );
+        assert!(matches!(
+            plan.layers[0].effects[0],
+            GpuEffect::ColorGrade { .. }
+        ));
+    }
+
+    #[test]
+    fn map_scene_should_fall_back_on_unsupported_effect() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Hue { degrees: 30.0 }];
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
+        );
+    }
+
+    #[test]
+    fn map_scene_should_fall_back_on_unsupported_blend_mode() {
+        let mut layer = TestLayer::identity();
+        layer.blend_mode = BlendMode::Glow;
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedBlendMode(BlendMode::Glow))
+        );
+    }
+
+    #[test]
+    fn map_scene_should_fall_back_on_non_over_composite() {
+        let mut layer = TestLayer::identity();
+        layer.composite_op = CompositeOp::Under;
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedCompositeOp(CompositeOp::Under))
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_the_blend_mode_intersection() {
+        let mut layer = TestLayer::identity();
+        layer.blend_mode = BlendMode::Multiply;
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(plan.layers[0].blend_mode, RenderBlendMode::Multiply);
+    }
+
+    #[test]
+    fn map_scene_should_be_shared_by_video_layer_and_realtime_descriptor() {
+        // The export VideoLayer carries temporal steps; the preview descriptor does
+        // not. After skipping temporal steps both must yield the same plan (single
+        // source of truth). A trimmed, sped-up, colour-corrected clip exercises the
+        // temporal skip.
+        let clip = Clip::new("v.mp4")
+            .trim(Duration::from_secs(1), Duration::from_secs(4))
+            .with_speed(2.0)
+            .with_color_correction(0.5, 1.2, 0.8);
+        let auto = TrackAutomation::default();
+        let video_layer = crate::derive::video_layer(&clip, 0, &auto, 1920, 1080, None, None);
+        let descriptor = crate::derive::realtime_descriptor(&clip, &auto, 1920, 1080);
+
+        let from_export = map_scene(
+            std::slice::from_ref(&video_layer),
+            (1920, 1080),
+            Duration::ZERO,
+        );
+        let from_preview = map_scene(
+            std::slice::from_ref(&descriptor),
+            (1920, 1080),
+            Duration::ZERO,
+        );
+        assert_eq!(
+            from_export, from_preview,
+            "the mapping must agree for the export and preview derived layers"
+        );
+        // And it is a real GPU plan with the single colour grade.
+        let plan = gpu(from_export);
+        assert!(matches!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::ColorGrade { .. }]
+        ));
+    }
+}

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -105,6 +105,8 @@ mod edit;
 mod editor;
 mod effect;
 mod error;
+#[cfg(feature = "gpu")]
+mod gpu;
 mod ids;
 mod marker;
 mod timeline;
@@ -116,6 +118,10 @@ pub use edit::{ClipProperty, Command, EditError, apply};
 pub use editor::Editor;
 pub use effect::{ClipEffect, EffectKind, Param};
 pub use error::TimelineError;
+#[cfg(feature = "gpu")]
+pub use gpu::{
+    GpuEffect, GpuFallback, GpuLayerPlan, GpuLayerSource, GpuMapping, GpuScenePlan, map_scene,
+};
 pub use ids::{ClipId, EffectId, GroupId, MarkerId, TrackId, TrackKind};
 pub use marker::Marker;
 pub use timeline::{Timeline, TimelineBuilder};

--- a/docs/specs/gpu-compositing-bridge.md
+++ b/docs/specs/gpu-compositing-bridge.md
@@ -55,8 +55,8 @@ The bridge maps from `avio`'s existing derived layer types; it introduces no new
 Per composited frame:
 
 1. For each layer, in `z_order` (bottom to top), apply the layer's **mappable spatial effect steps** to its
-   decoded source frame with a per-layer `ff_render::RenderGraph` (`ColorGradeNode`, `ScaleNode`, keying/mask
-   nodes, ...). A layer with no mappable effects passes its decoded frame through unchanged.
+   decoded source frame with a per-layer `ff_render::RenderGraph` (v1: `ColorGradeNode`, `ScaleNode`; more as
+   coverage grows, #1630). A layer with no mappable effects passes its decoded frame through unchanged.
 2. Wrap each processed frame in an `ff_render::FrameLayer { frame: VideoFrame, transform: LayerTransform{ x,
    y, scale_x, scale_y, rotation }, blend_mode: ff_render::BlendMode, opacity: f32, z_order: i32 }`.
 3. `ff_render::Compositor::composite(&mut [FrameLayer]) -> wgpu::Texture` composites the z-ordered stack (it
@@ -83,24 +83,26 @@ textures) is a later optimization, out of scope for the bridge.
 
 `ff-render`'s node set covers a subset of `avio`'s derived vocabulary. A derived construct either maps to a
 node or forces CPU fallback for the whole frame (see below). The mapping **never silently drops** an
-unsupported step.
+unsupported step. The table is the **v1** state (Br2, `avio::gpu::map_scene`); broadening the covered set is
+tracked in **#1630**.
 
-| Derived construct (source) | ff-render node / field | If unsupported |
+| Derived construct (source) | v1 mapping | Status |
 |---|---|---|
-| `x`/`y`/`scale`/`rotation` transform | `FrameLayer.transform: LayerTransform` (and `TransformNode`) | (always supported) |
-| `opacity` | `FrameLayer.opacity` | (always supported) |
-| `blend_mode: ff_filter::BlendMode` (39) | `ff_render::BlendMode` -- the **intersection** of the two enums is what maps: `Normal, Multiply, Screen, Overlay, SoftLight, HardLight, ColorDodge, ColorBurn, Difference, Exclusion, Add, Subtract, Darken, Lighten` | any `ff_filter` mode outside that set -> **fallback**. (`ff_render` also has `Hue`/`Saturation`/`Color`/`Luminosity`, but `ff_filter::BlendMode` has no such variants -- removed in #1219 -- so they are unreachable from the derived scene.) |
-| `composite_op: Over`/`Under` | `OverlayNode` / `AlphaMatteNode` (src-over) | `In`/`Out`/`Atop`/`Xor` -> **fallback** |
-| `FilterStep::Eq` / `EqAnimated` (colour, from `EffectKind::ColorCorrect`) | `ColorGradeNode { brightness, contrast, saturation, temperature, tint }` | animated params evaluate at frame `t` |
-| other colour steps: `Hue`, `Curves`, `Gamma`, `Vignette`, `WhiteBalance`, `ColorBalanceAnimated`, `ThreeWayCC`, `ParametricEq` | (no node) | **fallback** |
-| fit / resize `FilterStep::Scale` / `FitToAspect` / `FillToAspect` | `ScaleNode { width, height, algorithm }` (GPU uses a linear filter for all algorithms) | -- |
-| `FilterStep::ScaleAnimated` / `RotateAnimated` (animated geometry) | evaluate at frame `t` -> `LayerTransform` / `ScaleNode` | -- |
-| xfade linear crossfade (duration only) | `CrossfadeNode { factor, to_rgba, to_w, to_h }` | xfade **kinds** (wipe/slide/dissolve/...) -> **fallback** (CPU renders them today) |
-| `FilterStep::ChromaKey` | `ChromaKeyNode { key_color, tolerance, softness }` | `ColorKey`, `SpillSuppress` -> **fallback** |
-| shape / luma masks (`RectMask`->shape, luma) | `ShapeMaskNode` / `LumaMaskNode` | `FeatherMask`, `PolygonMatte` -> **fallback** |
-| `FilterStep::AlphaMatte` | `AlphaMatteNode` | -- |
-| YUV upload of a planar source | `YuvUploadNode` (`Yuv420p`/`422p`/`444p`, **BT.601** matrix) | -- |
-| everything else (`Blur`/`GBlur`, `Lut3d`, `NoiseReduce`, `Raw`, ...) | (no node) | **fallback** |
+| `x`/`y`/`scale`/`rotation` transform | evaluated at frame `t` -> the layer's `LayerTransform` scalars | **covered** (all layers) |
+| `opacity` | evaluated at `t` -> `FrameLayer.opacity` | **covered** (all layers) |
+| `blend_mode: ff_filter::BlendMode` (39) | `ff_render::BlendMode`, the **intersection** of the two enums: `Normal, Multiply, Screen, Overlay, SoftLight, HardLight, ColorDodge, ColorBurn, Difference, Exclusion, Add, Subtract, Darken, Lighten` | **covered** for those 14; any other -> **fallback**. (`ff_render` also has `Hue`/`Saturation`/`Color`/`Luminosity`, but `ff_filter::BlendMode` has no such variants -- removed in #1219 -- so they are unreachable from the derived scene.) |
+| `composite_op: Over` | plain top-over-bottom composite | **covered** |
+| `FilterStep::Eq` (from a const `EffectKind::ColorCorrect`) | `GpuEffect::ColorGrade` -> `ColorGradeNode { brightness, contrast, saturation, temperature=0, tint=0 }` | **covered** |
+| `FilterStep::EqAnimated` | `ColorGrade` (params at `t`) **only when gamma is neutral at `t`** (ff-render ColorGrade has no gamma) | **covered** (gamma-neutral); non-neutral gamma -> **fallback** |
+| plain `FilterStep::Scale { width, height, algorithm }` | `GpuEffect::Scale` -> `ScaleNode` (ff-render uses a linear filter for all algorithms; `Fast` maps to `Bilinear`) | **covered** |
+| temporal steps: `Trim` / `ResetPts` / `OffsetPts` / `Speed` | skipped (decode-scheduling, applied upstream) | **skipped** (not a fallback) |
+| `composite_op: Under`/`In`/`Out`/`Atop`/`Xor` | -- | **fallback** (#1630) |
+| other colour: `Hue`, `Curves`, `Gamma`, `Vignette`, `WhiteBalance`, `ColorBalanceAnimated`, `ThreeWayCC`, `ParametricEq` | -- | **fallback** (#1630) |
+| `FitToAspect` / `FillToAspect` (fit with pad/crop) | -- | **fallback** (#1630; `ScaleNode` is a plain resize) |
+| animated geometry `ScaleAnimated` / `RotateAnimated` | -- | **fallback** (#1630; ADR-0005 neutralizes the scalar, so v1 falls back rather than lose the animation) |
+| xfade (`XFade`, any kind) | -- | **fallback** (#1630; needs the 2-input `CrossfadeNode`) |
+| keying / masks: `ChromaKey`, `ColorKey`, `AlphaMatte`, `LumaKey`, `RectMask`, `FeatherMask`, ... | -- | **fallback** (#1630; `ChromaKey` needs a colour-string parser, masks need 2-input wiring) |
+| everything else (`GBlur`, `Lut3d`, `NoiseReduce`, `Raw`, ...) | -- | **fallback** (#1630) |
 
 **Known ff-render gaps to design around:** `YuvUploadNode` uses a **BT.601** conversion only (no BT.709
 selection), and `ScaleNode`'s Bicubic/Lanczos fall back to a linear filter on the GPU. These are `ff-render`


### PR DESCRIPTION
## Objective

- ADR-0007 (#1624) recorded how avio should drive ff-render's GPU compositor, but nothing yet maps the derived scene to it. Br2 implements that mapping so Br3 (preview) and Br4 (export) have a single, tested contract to execute.

## Solution

- Add an opt-in avio `gpu` feature (not in `default`, so wgpu stays optional) that pulls in `ff-render`, plus a pure, device-free mapping module.
- `map_scene` turns the derived layer set (`VideoLayer` / `RealtimeLayerDescriptor`, read through one shared `GpuLayerSource` trait so preview and export share a single source of truth) into a `GpuScenePlan`, or a whole-frame `GpuMapping::Fallback` with a reason when a layer carries anything the GPU node set does not cover (never silently dropped). Br3/Br4 execute the plan against decoded frames.
- v1 maps colour grade (`Eq`), plain `Scale`, the transform (evaluated per frame), opacity, the 14-mode blend intersection, and composite `Over`; temporal steps are skipped (handled upstream). Broader node coverage is tracked in #1630.
- Deterministic unit tests (no GPU device, no FFmpeg) cover the transform, blend intersection, colour grade, scale, temporal skip, the `EqAnimated` gamma gate, the opacity clamp, each fallback reason, and that the export and preview derived layers map to the same plan. The spec's node-coverage table is updated to the v1 reality.

Closes #1625