### PR TITLE
feat(ff-preview,avio): GPU preview path with automatic CPU fallback

### DIFF
--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -21,14 +21,15 @@
 use std::time::Duration;
 
 use ff_filter::{
-    AnimatedValue, BlendMode, CompositeOp, FilterStep, RealtimeLayerDescriptor, ScaleAlgorithm,
-    VideoLayer,
+    AnimatedValue, BlendMode, CompositeOp, FilterStep, RealtimeLayer, RealtimeLayerDescriptor,
+    ScaleAlgorithm, VideoLayer,
 };
 use ff_render::{BlendMode as RenderBlendMode, ScaleAlgorithm as RenderScaleAlgorithm};
 
 /// A derived layer the GPU mapping can read. Implemented for the export
-/// [`VideoLayer`] and the preview [`RealtimeLayerDescriptor`] so the mapping is one
-/// shared implementation.
+/// [`VideoLayer`], the preview [`RealtimeLayerDescriptor`], the runner's realized
+/// [`RealtimeLayer`], and `&T` for any of them (so a `&[&RealtimeLayer]` maps like a
+/// `&[RealtimeLayer]`), keeping the mapping one shared implementation.
 pub trait GpuLayerSource {
     /// Per-clip opacity animation.
     fn opacity(&self) -> &AnimatedValue<f64>;
@@ -110,6 +111,67 @@ impl GpuLayerSource for RealtimeLayerDescriptor {
     }
 }
 
+impl GpuLayerSource for RealtimeLayer {
+    fn opacity(&self) -> &AnimatedValue<f64> {
+        &self.opacity
+    }
+    fn x(&self) -> &AnimatedValue<f64> {
+        &self.x
+    }
+    fn y(&self) -> &AnimatedValue<f64> {
+        &self.y
+    }
+    fn scale_x(&self) -> &AnimatedValue<f64> {
+        &self.scale_x
+    }
+    fn scale_y(&self) -> &AnimatedValue<f64> {
+        &self.scale_y
+    }
+    fn rotation(&self) -> &AnimatedValue<f64> {
+        &self.rotation
+    }
+    fn blend_mode(&self) -> BlendMode {
+        self.blend_mode
+    }
+    fn composite_op(&self) -> CompositeOp {
+        self.composite_op
+    }
+    fn effects(&self) -> &[FilterStep] {
+        &self.effects
+    }
+}
+
+// So a `&[&L]` (e.g. the preview runner's borrowed layers) maps like a `&[L]`.
+impl<T: GpuLayerSource + ?Sized> GpuLayerSource for &T {
+    fn opacity(&self) -> &AnimatedValue<f64> {
+        (**self).opacity()
+    }
+    fn x(&self) -> &AnimatedValue<f64> {
+        (**self).x()
+    }
+    fn y(&self) -> &AnimatedValue<f64> {
+        (**self).y()
+    }
+    fn scale_x(&self) -> &AnimatedValue<f64> {
+        (**self).scale_x()
+    }
+    fn scale_y(&self) -> &AnimatedValue<f64> {
+        (**self).scale_y()
+    }
+    fn rotation(&self) -> &AnimatedValue<f64> {
+        (**self).rotation()
+    }
+    fn blend_mode(&self) -> BlendMode {
+        (**self).blend_mode()
+    }
+    fn composite_op(&self) -> CompositeOp {
+        (**self).composite_op()
+    }
+    fn effects(&self) -> &[FilterStep] {
+        (**self).effects()
+    }
+}
+
 /// A per-layer effect the GPU path can apply, mapped from a [`FilterStep`].
 /// `#[non_exhaustive]`: more kinds are added as node coverage grows.
 #[derive(Debug, Clone, PartialEq)]
@@ -148,15 +210,19 @@ pub enum GpuEffect {
 pub struct GpuLayerPlan {
     /// Compositing order (bottom to top); equals the layer's index.
     pub z_order: i32,
-    /// Horizontal offset in pixels.
+    // These carry the model's units unchanged: `x`/`y` are canvas **pixels** and
+    // `rotation` is **clockwise degrees**. `ff_render::LayerTransform` is UV-space and
+    // counter-clockwise radians, so an executor must convert (or fall back) rather
+    // than feed these straight in (see docs/specs/gpu-compositing-bridge.md).
+    /// Horizontal offset, in canvas pixels (model units).
     pub x: f32,
-    /// Vertical offset in pixels.
+    /// Vertical offset, in canvas pixels (model units).
     pub y: f32,
-    /// Horizontal scale factor.
+    /// Horizontal scale factor (`1.0` = no change).
     pub scale_x: f32,
-    /// Vertical scale factor.
+    /// Vertical scale factor (`1.0` = no change).
     pub scale_y: f32,
-    /// Rotation in the compositor's units.
+    /// Rotation in clockwise degrees (model units).
     pub rotation: f32,
     /// Layer opacity in `[0.0, 1.0]`.
     pub opacity: f32,
@@ -610,6 +676,32 @@ mod tests {
             map_scene(&[layer], (16, 16), Duration::ZERO),
             GpuMapping::Fallback(GpuFallback::UnsupportedCompositeOp(CompositeOp::Under))
         );
+    }
+
+    #[test]
+    fn map_scene_should_accept_realtime_layer_and_references() {
+        // The preview runner maps borrowed `RealtimeLayer`s (`&[&RealtimeLayer]`);
+        // the owned and borrowed forms must produce the same plan.
+        let desc = RealtimeLayerDescriptor {
+            effects: vec![FilterStep::Eq {
+                brightness: 0.5,
+                contrast: 1.0,
+                saturation: 1.0,
+            }],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        let layer = RealtimeLayer::with_dimensions(desc, 8, 8, ff_format::PixelFormat::Rgba);
+        let owned = map_scene(std::slice::from_ref(&layer), (8, 8), Duration::ZERO);
+        let by_ref = map_scene(&[&layer], (8, 8), Duration::ZERO);
+        assert_eq!(owned, by_ref, "a &RealtimeLayer maps like a RealtimeLayer");
+        assert!(matches!(owned, GpuMapping::Gpu(_)));
     }
 
     #[test]

--- a/crates/avio/src/gpu_preview.rs
+++ b/crates/avio/src/gpu_preview.rs
@@ -1,0 +1,301 @@
+//! GPU preview compositor: the executor half of the bridge (Br3, #1626).
+//!
+//! Implements `ff_preview::PreviewCompositor` over `ff-render`, so the preview
+//! runner can composite on the GPU by default and fall back to its built-in CPU
+//! compositor automatically. Per frame it maps the runner's layers with
+//! [`map_scene`](crate::gpu::map_scene), executes each layer's `ColorGrade`/`Scale`
+//! effects with an `ff_render::RenderGraph`, composites the stack with
+//! `ff_render::Compositor`, and reads the result back to rgba. Any unsupported layer
+//! (`map_scene` fallback) or GPU error returns `None`, so the runner uses the CPU
+//! path for that frame (never a panic, never a partial result).
+//!
+//! v1 scope: the GPU path renders only layers that need no geometric placement (an
+//! identity transform and a frame whose aspect matches the canvas). Non-identity
+//! transforms and letterbox cases fall back to CPU, because the compositor's
+//! UV-space transform + stretch-to-canvas model does not yet match the CPU
+//! compositor's native-overlay + pad model; closing that with parity tests is Br5.
+//! Known v1 inefficiencies (deferred with the zero-copy work): a decoded frame is
+//! deep-copied per no-effect layer, and the readback allocates a staging buffer per
+//! frame.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ff_filter::RealtimeLayer;
+use ff_format::VideoFrame;
+use ff_preview::PreviewCompositor;
+use ff_render::{
+    ColorGradeNode, Compositor, FrameLayer, LayerTransform, RenderContext, RenderGraph, ScaleNode,
+};
+
+use crate::gpu::{GpuEffect, GpuLayerPlan, GpuMapping, map_scene};
+
+/// Composites preview frames on the GPU, falling back to `None` (the runner's CPU
+/// path) on unsupported content or any GPU error.
+pub struct GpuPreviewCompositor {
+    ctx: Arc<RenderContext>,
+    /// Compositor cached for its target canvas; rebuilt when the canvas changes.
+    compositor: Option<(Compositor, (u32, u32))>,
+}
+
+impl GpuPreviewCompositor {
+    /// Initialises a GPU context (best available adapter). Returns `None` when no
+    /// adapter is available, so the caller keeps the CPU compositor. Logs the
+    /// selected path once (lifecycle, not per frame).
+    #[must_use]
+    pub fn new() -> Option<Self> {
+        match RenderContext::init_blocking() {
+            Ok(ctx) => {
+                log::info!("preview compositor path=gpu");
+                Some(Self {
+                    ctx: Arc::new(ctx),
+                    compositor: None,
+                })
+            }
+            Err(e) => {
+                log::info!("preview compositor path=cpu reason={e}");
+                None
+            }
+        }
+    }
+
+    /// Applies a layer's mappable effects to its rgba frame via a `RenderGraph`, or
+    /// returns the frame unchanged when it has none. `None` on a GPU error.
+    fn apply_effects(&self, plan: &GpuLayerPlan, frame: &VideoFrame) -> Option<VideoFrame> {
+        if plan.effects.is_empty() {
+            return Some(frame.clone());
+        }
+        let (in_w, in_h) = (frame.width(), frame.height());
+        let rgba = frame.to_rgba()?;
+        let mut graph = RenderGraph::new(self.ctx.clone());
+        // A `Scale` node resizes the frame; track the output dimensions so the
+        // read-back buffer is wrapped at the right size.
+        let (mut out_w, mut out_h) = (in_w, in_h);
+        for effect in &plan.effects {
+            graph = match effect {
+                GpuEffect::ColorGrade {
+                    brightness,
+                    contrast,
+                    saturation,
+                    temperature,
+                    tint,
+                } => graph.push(ColorGradeNode::new(
+                    *brightness,
+                    *contrast,
+                    *saturation,
+                    *temperature,
+                    *tint,
+                )),
+                GpuEffect::Scale {
+                    width,
+                    height,
+                    algorithm,
+                } => {
+                    out_w = *width;
+                    out_h = *height;
+                    graph.push(ScaleNode::new(*width, *height, *algorithm))
+                }
+            };
+        }
+        let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;
+        VideoFrame::from_rgba(out_w, out_h, out).ok()
+    }
+}
+
+impl PreviewCompositor for GpuPreviewCompositor {
+    fn composite(
+        &mut self,
+        layers: &[(&RealtimeLayer, &VideoFrame)],
+        canvas: (u32, u32),
+        t: Duration,
+    ) -> Option<(Vec<u8>, u32, u32)> {
+        // Map the layers to a GPU plan; an unsupported layer falls back to CPU.
+        let refs: Vec<&RealtimeLayer> = layers.iter().map(|(l, _)| *l).collect();
+        let plan = match map_scene(&refs, canvas, t) {
+            GpuMapping::Gpu(plan) => plan,
+            GpuMapping::Fallback(_) => return None,
+        };
+
+        // Execute each layer's effects, then wrap it as a compositor FrameLayer.
+        let mut frame_layers = Vec::with_capacity(plan.layers.len());
+        for (lp, (_, frame)) in plan.layers.iter().zip(layers.iter()) {
+            // v1 renders only layers that need no geometric placement. The model's
+            // transform is in canvas pixels / clockwise degrees, while the
+            // compositor's `LayerTransform` is UV-space / counter-clockwise radians,
+            // and the compositor stretches each layer to the canvas (no letterbox),
+            // whereas the CPU compositor overlays at native size and pads. Matching
+            // those exactly is parity work (Br5), so a non-identity transform falls
+            // back to CPU here rather than render wrong output.
+            if !is_identity_transform(lp) {
+                return None;
+            }
+            let processed = self.apply_effects(lp, frame)?;
+            // Same reason: the compositor would stretch a differently-shaped frame to
+            // fill the canvas, which the CPU path letterboxes instead. Only a frame
+            // whose aspect matches the canvas composites without distortion.
+            if u64::from(processed.width()) * u64::from(canvas.1)
+                != u64::from(processed.height()) * u64::from(canvas.0)
+            {
+                return None;
+            }
+            frame_layers.push(FrameLayer {
+                frame: processed,
+                transform: LayerTransform::default(),
+                blend_mode: lp.blend_mode,
+                opacity: lp.opacity,
+                z_order: lp.z_order,
+            });
+        }
+
+        // Composite (rebuilding the cached compositor if the canvas changed) and
+        // read back to rgba. A GPU error becomes `None` (CPU fallback).
+        let rebuild = match &self.compositor {
+            Some((_, cached)) => *cached != canvas,
+            None => true,
+        };
+        if rebuild {
+            self.compositor = Some((
+                Compositor::new(self.ctx.clone(), canvas.0, canvas.1),
+                canvas,
+            ));
+        }
+        let (compositor, _) = self.compositor.as_mut()?;
+        compositor.composite_to_rgba(&mut frame_layers).ok()
+    }
+}
+
+/// Whether a plan layer's transform is the identity (no translate / scale / rotate),
+/// within a small tolerance. Non-identity transforms fall back to CPU in v1.
+fn is_identity_transform(lp: &GpuLayerPlan) -> bool {
+    lp.x.abs() < 1e-6
+        && lp.y.abs() < 1e-6
+        && (lp.scale_x - 1.0).abs() < 1e-6
+        && (lp.scale_y - 1.0).abs() < 1e-6
+        && lp.rotation.abs() < 1e-6
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use ff_filter::{
+        AnimatedValue, BlendMode, CompositeOp, RealtimeLayer, RealtimeLayerDescriptor,
+    };
+    use ff_format::{Color, PixelFormat, VideoFrame};
+
+    use super::*;
+    use crate::{Clip, Timeline, TimelinePlayer};
+
+    fn identity_layer(w: u32, h: u32) -> RealtimeLayer {
+        let desc = RealtimeLayerDescriptor {
+            effects: Vec::new(),
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        RealtimeLayer::with_dimensions(desc, w, h, PixelFormat::Rgba)
+    }
+
+    #[test]
+    fn open_forcing_cpu_should_not_attach_a_gpu_compositor() {
+        // Forcing CPU must never inject the GPU compositor, regardless of adapter.
+        let timeline = Timeline::builder()
+            .canvas(16, 16)
+            .frame_rate(30.0)
+            .video_track(vec![
+                Clip::solid(Color::rgb(10, 20, 30)).trim(Duration::ZERO, Duration::from_secs(1)),
+            ])
+            .build()
+            .unwrap();
+        match TimelinePlayer::open_forcing_cpu(&timeline) {
+            Ok((runner, _handle)) => assert!(
+                !runner.has_gpu_compositor(),
+                "force-cpu must not attach a gpu compositor"
+            ),
+            // Skip when the preview cannot open here (e.g. the color filter is
+            // unavailable on a minimal FFmpeg): the force-cpu path is unreachable.
+            Err(_) => {}
+        }
+    }
+
+    #[test]
+    fn open_should_attach_a_gpu_compositor_when_available() {
+        // Default open attaches the GPU compositor when an adapter is present
+        // (the GPU-by-default path). Probe-gated: skip without an adapter.
+        if GpuPreviewCompositor::new().is_none() {
+            return;
+        }
+        let timeline = Timeline::builder()
+            .canvas(16, 16)
+            .frame_rate(30.0)
+            .video_track(vec![
+                Clip::solid(Color::rgb(10, 20, 30)).trim(Duration::ZERO, Duration::from_secs(1)),
+            ])
+            .build()
+            .unwrap();
+        match TimelinePlayer::open(&timeline) {
+            Ok((runner, _handle)) => assert!(
+                runner.has_gpu_compositor(),
+                "a gpu adapter is present, so open must attach the gpu compositor"
+            ),
+            // Skip when the preview cannot open here (color filter unavailable).
+            Err(_) => {}
+        }
+    }
+
+    #[test]
+    fn gpu_preview_compositor_should_composite_a_single_layer() {
+        // Probe-gated (RK-002): skip when no GPU adapter is available.
+        let Some(mut gpu) = GpuPreviewCompositor::new() else {
+            return;
+        };
+        let layer = identity_layer(4, 4);
+        let frame = VideoFrame::from_rgba(4, 4, vec![50u8; 4 * 4 * 4]).unwrap();
+        let out = gpu.composite(&[(&layer, &frame)], (4, 4), Duration::ZERO);
+        let (rgba, w, h) = out.expect("gpu composite of a supported single layer");
+        assert_eq!((w, h), (4, 4));
+        assert_eq!(rgba.len(), 4 * 4 * 4);
+    }
+
+    #[test]
+    fn gpu_preview_compositor_should_composite_a_colour_graded_layer() {
+        // Exercises apply_effects: a mapped ColorGrade runs through a RenderGraph.
+        // Probe-gated (RK-002).
+        let Some(mut gpu) = GpuPreviewCompositor::new() else {
+            return;
+        };
+        let mut desc = identity_layer(4, 4);
+        desc.effects = vec![ff_filter::FilterStep::Eq {
+            brightness: 0.4,
+            contrast: 1.2,
+            saturation: 1.0,
+        }];
+        let frame = VideoFrame::from_rgba(4, 4, vec![80u8; 4 * 4 * 4]).unwrap();
+        let out = gpu.composite(&[(&desc, &frame)], (4, 4), Duration::ZERO);
+        let (rgba, w, h) = out.expect("gpu composite of a colour-graded layer");
+        assert_eq!((w, h), (4, 4));
+        assert_eq!(rgba.len(), 4 * 4 * 4);
+    }
+
+    #[test]
+    fn gpu_preview_compositor_should_fall_back_on_a_non_identity_transform() {
+        // A positioned layer cannot be rendered correctly in v1 (pixel-vs-UV units),
+        // so the compositor returns None and the runner uses the CPU path.
+        // Probe-gated (RK-002).
+        let Some(mut gpu) = GpuPreviewCompositor::new() else {
+            return;
+        };
+        let mut layer = identity_layer(4, 4);
+        layer.x = AnimatedValue::Static(100.0);
+        let frame = VideoFrame::from_rgba(4, 4, vec![50u8; 4 * 4 * 4]).unwrap();
+        assert!(
+            gpu.composite(&[(&layer, &frame)], (4, 4), Duration::ZERO)
+                .is_none(),
+            "a non-identity transform must fall back to CPU"
+        );
+    }
+}

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -107,6 +107,8 @@ mod effect;
 mod error;
 #[cfg(feature = "gpu")]
 mod gpu;
+#[cfg(all(feature = "gpu", feature = "preview"))]
+mod gpu_preview;
 mod ids;
 mod marker;
 mod timeline;
@@ -122,6 +124,8 @@ pub use error::TimelineError;
 pub use gpu::{
     GpuEffect, GpuFallback, GpuLayerPlan, GpuLayerSource, GpuMapping, GpuScenePlan, map_scene,
 };
+#[cfg(all(feature = "gpu", feature = "preview"))]
+pub use gpu_preview::GpuPreviewCompositor;
 pub use ids::{ClipId, EffectId, GroupId, MarkerId, TrackId, TrackKind};
 pub use marker::Marker;
 pub use timeline::{Timeline, TimelineBuilder};
@@ -141,8 +145,8 @@ pub use ff_pipeline::{EncoderConfig, EncoderConfigBuilder, Progress};
 mod player;
 #[cfg(feature = "preview")]
 pub use ff_preview::{
-    PlayerHandle, PreviewError, Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement,
-    SceneRunner, SceneSource, SceneVideoTrack,
+    PlayerHandle, PreviewCompositor, PreviewError, Scene, SceneAudioPlacement, SceneAudioTrack,
+    ScenePlacement, SceneRunner, SceneSource, SceneVideoTrack,
 };
 #[cfg(feature = "preview")]
 pub use player::TimelinePlayer;

--- a/crates/avio/src/player.rs
+++ b/crates/avio/src/player.rs
@@ -45,11 +45,55 @@ impl TimelinePlayer {
     /// clip's source, opens a decode buffer per V1 clip, and builds the audio
     /// mixer.
     ///
+    /// With the `gpu` feature, the runner composites on the GPU by default when an
+    /// adapter is available, falling back to the CPU compositor automatically when
+    /// it is not (or per frame on unsupported content / a GPU error). Use
+    /// [`open_forcing_cpu`](Self::open_forcing_cpu) to keep the CPU path even when a
+    /// GPU is present.
+    ///
     /// # Errors
     ///
     /// Returns [`PreviewError`] when the scene has no video tracks, a source file
     /// cannot be opened, or a clip cannot be probed.
     pub fn open(timeline: &Timeline) -> Result<(SceneRunner, PlayerHandle), PreviewError> {
-        ScenePlayer::open(&timeline.to_scene())
+        Self::open_inner(timeline, false)
     }
+
+    /// Open `timeline` forcing the CPU compositor even when a GPU adapter is
+    /// available (deterministic playback / testing).
+    ///
+    /// # Errors
+    ///
+    /// Same as [`open`](Self::open).
+    pub fn open_forcing_cpu(
+        timeline: &Timeline,
+    ) -> Result<(SceneRunner, PlayerHandle), PreviewError> {
+        Self::open_inner(timeline, true)
+    }
+
+    fn open_inner(
+        timeline: &Timeline,
+        force_cpu: bool,
+    ) -> Result<(SceneRunner, PlayerHandle), PreviewError> {
+        let (mut runner, handle) = ScenePlayer::open(&timeline.to_scene())?;
+        Self::attach_gpu_compositor(&mut runner, force_cpu);
+        Ok((runner, handle))
+    }
+
+    /// Attaches the GPU compositor when the `gpu` feature is built, an adapter is
+    /// available, and CPU is not forced. A no-op otherwise (the runner uses its
+    /// built-in CPU compositor).
+    #[cfg(feature = "gpu")]
+    fn attach_gpu_compositor(runner: &mut SceneRunner, force_cpu: bool) {
+        if force_cpu {
+            log::info!("preview compositor path=cpu reason=forced");
+            return;
+        }
+        if let Some(gpu) = crate::gpu_preview::GpuPreviewCompositor::new() {
+            runner.set_gpu_compositor(Box::new(gpu));
+        }
+    }
+
+    #[cfg(not(feature = "gpu"))]
+    fn attach_gpu_compositor(_runner: &mut SceneRunner, _force_cpu: bool) {}
 }

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -56,6 +56,6 @@ pub use proxy::{ProxyGenerator, ProxyJob, ProxyResolution};
 
 #[cfg(feature = "timeline")]
 pub use scene::{
-    Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, ScenePlayer, SceneRunner,
-    SceneSource, SceneVideoTrack,
+    PreviewCompositor, Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, ScenePlayer,
+    SceneRunner, SceneSource, SceneVideoTrack,
 };

--- a/crates/ff-preview/src/scene/compositor.rs
+++ b/crates/ff-preview/src/scene/compositor.rs
@@ -1,0 +1,32 @@
+//! Pluggable layer compositor for the preview runner.
+//!
+//! The runner composites each frame with the built-in CPU compositor
+//! ([`RealtimeComposer`](ff_filter::RealtimeComposer)). A caller that has a GPU
+//! compositor (which `ff-preview` cannot reach directly, since `ff-render` depends
+//! on `ff-preview`, not the reverse) can inject one through this seam: the runner
+//! tries the injected compositor first and falls back to the CPU path whenever it
+//! returns `None` (no GPU, an unsupported layer, or a GPU error). This is how the
+//! `avio` engine wires `ff-render` into the preview without a dependency cycle.
+
+use std::time::Duration;
+
+use ff_filter::RealtimeLayer;
+use ff_format::VideoFrame;
+
+/// An external compositor the preview runner can use in place of its built-in CPU
+/// compositor. Implemented by `avio` over `ff-render`; see the module docs.
+pub trait PreviewCompositor: Send {
+    /// Composite `layers` (bottom to top, paired with each layer's decoded `rgba`
+    /// frame) into a single `rgba` frame at timeline time `t`, targeting the
+    /// `canvas` output size.
+    ///
+    /// Returns `Some((rgba, width, height))` on success, or `None` to fall back to
+    /// the runner's CPU compositor (an unsupported layer, no adapter, or a GPU
+    /// error). Returning `None` must never leave the runner in a bad state.
+    fn composite(
+        &mut self,
+        layers: &[(&RealtimeLayer, &VideoFrame)],
+        canvas: (u32, u32),
+        t: Duration,
+    ) -> Option<(Vec<u8>, u32, u32)>;
+}

--- a/crates/ff-preview/src/scene/mod.rs
+++ b/crates/ff-preview/src/scene/mod.rs
@@ -22,6 +22,7 @@
 //! interleaved stereo `f32` output.
 
 mod audio_resampling;
+mod compositor;
 mod inner;
 mod runner;
 mod runner_layout;
@@ -41,6 +42,7 @@ use crate::playback::decode_buffer::DecodeBuffer;
 use crate::playback::master_clock::MasterClock;
 use crate::playback::player_handle::PlayerHandle;
 
+pub use compositor::PreviewCompositor;
 pub use runner::SceneRunner;
 pub use types::{
     Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneSource, SceneVideoTrack,
@@ -584,6 +586,7 @@ impl ScenePlayer {
             cmd_rx,
             event_tx,
             sink: None,
+            gpu_compositor: None,
             current_pts: Arc::clone(&current_pts),
             paused: Arc::clone(&paused),
             stopped: Arc::clone(&stopped),

--- a/crates/ff-preview/src/scene/runner.rs
+++ b/crates/ff-preview/src/scene/runner.rs
@@ -24,6 +24,7 @@ use crate::playback::player::PlayerCommand;
 use crate::playback::sink::FrameSink;
 
 use super::audio_resampling::spawn_audio_track_thread;
+use super::compositor::PreviewCompositor;
 use super::inner;
 use super::state::{
     AudioFadeConfig, AudioOnlyTrack, ClipState, LavfiOverlayState, OverlayLayer, TransitionState,
@@ -51,6 +52,9 @@ pub struct SceneRunner {
     pub(super) cmd_rx: mpsc::Receiver<PlayerCommand>,
     pub(super) event_tx: mpsc::SyncSender<PlayerEvent>,
     pub(super) sink: Option<Box<dyn FrameSink>>,
+    /// Optional injected GPU compositor, tried before the built-in CPU compositor.
+    /// `avio` supplies one over `ff-render`; `None` (the default) uses the CPU path.
+    pub(super) gpu_compositor: Option<Box<dyn PreviewCompositor>>,
     pub(super) current_pts: Arc<AtomicU64>,
     pub(super) paused: Arc<AtomicBool>,
     pub(super) stopped: Arc<AtomicBool>,
@@ -103,6 +107,18 @@ impl SceneRunner {
     /// Register the frame sink. Call before [`run`](Self::run).
     pub fn set_sink(&mut self, sink: Box<dyn FrameSink>) {
         self.sink = Some(sink);
+    }
+
+    /// Register an external GPU compositor tried before the built-in CPU path.
+    /// Call before [`run`](Self::run). `avio` supplies one over `ff-render`.
+    pub fn set_gpu_compositor(&mut self, compositor: Box<dyn PreviewCompositor>) {
+        self.gpu_compositor = Some(compositor);
+    }
+
+    /// Whether an external GPU compositor is registered (else the CPU path is used).
+    #[must_use]
+    pub fn has_gpu_compositor(&self) -> bool {
+        self.gpu_compositor.is_some()
     }
 
     /// Advances every overlay layer to the frame whose presentation time has
@@ -223,6 +239,40 @@ impl SceneRunner {
             });
             key.push((usize::MAX - 1, 0, lw, lh));
         }
+        // Build the decoded frame for every layer, in the same order as `specs`.
+        // Stamp each with the composite's timeline PTS so the graph's per-frame
+        // animation tick (in `push_video`) evaluates each layer's opacity track at
+        // the same time. Frames from `from_rgba` carry PTS 0 otherwise, and any
+        // registered `AnimationEntry` would be frozen at t=0.
+        let ts = Timestamp::from_duration(t, Rational::new(1, 1_000_000));
+        base_frame.set_timestamp(ts);
+        let mut frames = vec![base_frame];
+        for &(li, ow, oh) in overlays {
+            let mut vf =
+                VideoFrame::from_rgba(ow, oh, self.overlay_layers[li].rgba.clone()).ok()?;
+            vf.set_timestamp(ts);
+            frames.push(vf);
+        }
+        if let Some((lw, lh)) = lavfi_dims {
+            let rgba = self
+                .lavfi
+                .as_ref()
+                .map_or_else(Vec::new, |s| s.rgba.clone());
+            let mut vf = VideoFrame::from_rgba(lw, lh, rgba).ok()?;
+            vf.set_timestamp(ts);
+            frames.push(vf);
+        }
+
+        // Try the injected GPU compositor first; `None` falls through to the CPU
+        // compositor below (unsupported layer, no adapter, or a GPU error).
+        let gpu_canvas = self.canvas.unwrap_or((base_w, base_h));
+        if let Some(out) =
+            try_gpu_composite(self.gpu_compositor.as_mut(), &specs, &frames, gpu_canvas, t)
+        {
+            return Some(out);
+        }
+
+        // CPU compositor (cached, keyed by layer identity/size).
         if self.composer.is_none() || self.composer_key != key {
             self.composer = RealtimeComposer::with_canvas(&specs, self.canvas).ok();
             self.composer_key = if self.composer.is_some() {
@@ -232,33 +282,8 @@ impl SceneRunner {
             };
         }
         let composer = self.composer.as_mut()?;
-        // Stamp every pushed frame with the composite's timeline PTS so the graph's
-        // per-frame animation tick (in `push_video`) evaluates each layer's opacity
-        // track at the same time. Frames from `from_rgba` carry PTS 0 otherwise, and
-        // any registered `AnimationEntry` would be frozen at t=0.
-        let ts = Timestamp::from_duration(t, Rational::new(1, 1_000_000));
-        base_frame.set_timestamp(ts);
-        if composer.push_layer(0, &base_frame).is_err() {
-            return None;
-        }
-        for (slot, &(li, ow, oh)) in overlays.iter().enumerate() {
-            let mut vf =
-                VideoFrame::from_rgba(ow, oh, self.overlay_layers[li].rgba.clone()).ok()?;
-            vf.set_timestamp(ts);
-            if composer.push_layer(slot + 1, &vf).is_err() {
-                return None;
-            }
-        }
-        // Push the lavfi overlay last (topmost slot), reading its held rgba from the
-        // disjoint `lavfi` field (as the overlay loop reads `overlay_layers`).
-        if let Some((lw, lh)) = lavfi_dims {
-            let rgba = self
-                .lavfi
-                .as_ref()
-                .map_or_else(Vec::new, |s| s.rgba.clone());
-            let mut vf = VideoFrame::from_rgba(lw, lh, rgba).ok()?;
-            vf.set_timestamp(ts);
-            if composer.push_layer(overlays.len() + 1, &vf).is_err() {
+        for (slot, vf) in frames.iter().enumerate() {
+            if composer.push_layer(slot, vf).is_err() {
                 return None;
             }
         }
@@ -1163,5 +1188,91 @@ impl Drop for SceneRunner {
         if let Some(h) = self.active_audio_thread.take() {
             let _ = h.join();
         }
+    }
+}
+
+/// Pairs each layer spec with its decoded frame and asks the injected GPU
+/// compositor to composite them, or returns `None` (no compositor, or the
+/// compositor declined) so the caller uses the CPU path. Split out of
+/// `composite_frame` so the seam is unit-testable without a full runner.
+fn try_gpu_composite(
+    gpu: Option<&mut Box<dyn PreviewCompositor>>,
+    specs: &[RealtimeLayer],
+    frames: &[VideoFrame],
+    canvas: (u32, u32),
+    t: Duration,
+) -> Option<(Vec<u8>, u32, u32)> {
+    let gpu = gpu?;
+    let pairs: Vec<(&RealtimeLayer, &VideoFrame)> = specs.iter().zip(frames.iter()).collect();
+    gpu.composite(&pairs, canvas, t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `PreviewCompositor` that returns a fixed result, to drive the seam.
+    struct MockCompositor {
+        result: Option<(Vec<u8>, u32, u32)>,
+        calls: std::cell::Cell<u32>,
+    }
+
+    impl PreviewCompositor for MockCompositor {
+        fn composite(
+            &mut self,
+            _layers: &[(&RealtimeLayer, &VideoFrame)],
+            _canvas: (u32, u32),
+            _t: Duration,
+        ) -> Option<(Vec<u8>, u32, u32)> {
+            self.calls.set(self.calls.get() + 1);
+            self.result.clone()
+        }
+    }
+
+    fn one_spec_and_frame() -> (Vec<RealtimeLayer>, Vec<VideoFrame>) {
+        let desc = ff_filter::RealtimeLayerDescriptor {
+            effects: Vec::new(),
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        let spec = RealtimeLayer::with_dimensions(desc, 2, 2, PixelFormat::Rgba);
+        let frame = VideoFrame::from_rgba(2, 2, vec![0u8; 2 * 2 * 4]).expect("frame");
+        (vec![spec], vec![frame])
+    }
+
+    #[test]
+    fn try_gpu_composite_should_return_none_without_a_compositor() {
+        let (specs, frames) = one_spec_and_frame();
+        assert!(try_gpu_composite(None, &specs, &frames, (2, 2), Duration::ZERO).is_none());
+    }
+
+    #[test]
+    fn try_gpu_composite_should_use_the_compositor_result_when_some() {
+        let (specs, frames) = one_spec_and_frame();
+        let mut gpu: Box<dyn PreviewCompositor> = Box::new(MockCompositor {
+            result: Some((vec![1, 2, 3, 4], 1, 1)),
+            calls: std::cell::Cell::new(0),
+        });
+        let out = try_gpu_composite(Some(&mut gpu), &specs, &frames, (2, 2), Duration::ZERO);
+        assert_eq!(out, Some((vec![1, 2, 3, 4], 1, 1)));
+    }
+
+    #[test]
+    fn try_gpu_composite_should_return_none_when_the_compositor_declines() {
+        let (specs, frames) = one_spec_and_frame();
+        let mut gpu: Box<dyn PreviewCompositor> = Box::new(MockCompositor {
+            result: None,
+            calls: std::cell::Cell::new(0),
+        });
+        // A declining compositor yields None so the caller falls back to CPU.
+        assert!(
+            try_gpu_composite(Some(&mut gpu), &specs, &frames, (2, 2), Duration::ZERO).is_none()
+        );
     }
 }

--- a/crates/ff-render/Cargo.toml
+++ b/crates/ff-render/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-wgpu    = ["dep:wgpu"]
+wgpu    = ["dep:wgpu", "dep:futures"]
 # GPU-resident preview: hand the composited texture to the sink without a
 # GPU-to-CPU readback. Implies wgpu and enables ff-preview's matching path.
 display = ["wgpu", "ff-preview/display"]
@@ -31,6 +31,12 @@ image      = { workspace = true }
 [dependencies.wgpu]
 version  = "30.0.0"
 optional = true
+
+# Block-on executor for the synchronous `RenderContext::init_blocking` (wgpu-gated),
+# so callers (e.g. the preview runner thread) stay executor-agnostic.
+[dependencies.futures]
+workspace = true
+optional  = true
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/crates/ff-render/src/compositor/compositor_inner.rs
+++ b/crates/ff-render/src/compositor/compositor_inner.rs
@@ -382,6 +382,84 @@ fn blend_textures(
     submit_render_pass(ctx, pipeline, &bind_group, &out_view, "Compositor blend");
 }
 
+/// Reads an `Rgba8Unorm` texture back into a dense `w * h * 4` byte buffer,
+/// stripping the `COPY_BYTES_PER_ROW_ALIGNMENT` row padding wgpu requires for the
+/// copy. Records the readback on `ctx`.
+pub(crate) fn read_texture_rgba(
+    ctx: &RenderContext,
+    tex: &wgpu::Texture,
+    w: u32,
+    h: u32,
+) -> Result<Vec<u8>, RenderError> {
+    let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let bpr = (w * 4 + align - 1) & !(align - 1);
+    let staging = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("compositor readback"),
+        size: u64::from(bpr) * u64::from(h),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut enc = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("compositor readback"),
+        });
+    enc.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &staging,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bpr),
+                rows_per_image: None,
+            },
+        },
+        wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        },
+    );
+    ctx.queue.submit(std::iter::once(enc.finish()));
+    let slice = staging.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |r| {
+        tx.send(r).ok();
+    });
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .map_err(|e| RenderError::Composite {
+            message: format!("readback poll failed: {e}"),
+        })?;
+    rx.recv()
+        .map_err(|_| RenderError::Composite {
+            message: "readback map channel closed".to_string(),
+        })?
+        .map_err(|e| RenderError::Composite {
+            message: format!("readback map failed: {e}"),
+        })?;
+    let raw = slice
+        .get_mapped_range()
+        .map_err(|e| RenderError::Composite {
+            message: format!("readback mapped range failed: {e}"),
+        })?;
+    let row = (w * 4) as usize;
+    let mut out = Vec::with_capacity(row * h as usize);
+    for y in 0..h as usize {
+        let s = y * bpr as usize;
+        out.extend_from_slice(&raw[s..s + row]);
+    }
+    drop(raw);
+    staging.unmap();
+    ctx.note_readback();
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -625,5 +703,40 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn composite_to_rgba_should_read_back_the_canvas_size_and_pixels() {
+        let Some(ctx) = gpu_ctx() else {
+            return;
+        };
+        let (w, h) = (4u32, 4u32);
+        // One opaque solid-red rgba layer filling the canvas.
+        let red = {
+            let mut px = Vec::with_capacity((w * h * 4) as usize);
+            for _ in 0..(w * h) {
+                px.extend_from_slice(&[200, 10, 10, 255]);
+            }
+            VideoFrame::from_rgba(w, h, px).expect("rgba frame")
+        };
+        let mut compositor = crate::Compositor::new(Arc::clone(&ctx), w, h);
+        let mut layers = vec![crate::FrameLayer {
+            frame: red,
+            transform: crate::LayerTransform::default(),
+            blend_mode: BlendMode::Normal,
+            opacity: 1.0,
+            z_order: 0,
+        }];
+        let (rgba, out_w, out_h) = compositor
+            .composite_to_rgba(&mut layers)
+            .expect("composite_to_rgba");
+        assert_eq!((out_w, out_h), (w, h));
+        assert_eq!(rgba.len(), (w * h * 4) as usize, "dense w*h*4 readback");
+        // The composited RGB is the red layer over the black canvas (the alpha
+        // channel is a compositor detail; exact-pixel parity is Br5, RK-012).
+        assert!(
+            rgba[0] > 150 && rgba[1] < 60 && rgba[2] < 60,
+            "top-left is red"
+        );
     }
 }

--- a/crates/ff-render/src/compositor/mod.rs
+++ b/crates/ff-render/src/compositor/mod.rs
@@ -148,6 +148,28 @@ impl Compositor {
         };
         graph.composite(&self.ctx, layers, self.width, self.height)
     }
+
+    /// Composite `layers` and read the result back to a dense `rgba` buffer
+    /// (`width * height * 4` bytes, `Rgba8Unorm`), returning `(rgba, width, height)`.
+    ///
+    /// A convenience over [`composite`](Self::composite) for callers that need the
+    /// pixels on the CPU (e.g. handing a frame to an encoder or a CPU frame sink).
+    /// Prefer [`composite`](Self::composite) plus the zero-copy display path when a
+    /// GPU-resident texture is enough.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RenderError`](crate::error::RenderError) on composite failure or if
+    /// the GPU-to-CPU readback fails.
+    pub fn composite_to_rgba(
+        &mut self,
+        layers: &mut [FrameLayer],
+    ) -> Result<(Vec<u8>, u32, u32), crate::error::RenderError> {
+        let texture = self.composite(layers)?;
+        let rgba =
+            compositor_inner::read_texture_rgba(&self.ctx, &texture, self.width, self.height)?;
+        Ok((rgba, self.width, self.height))
+    }
 }
 
 #[cfg(test)]

--- a/crates/ff-render/src/context.rs
+++ b/crates/ff-render/src/context.rs
@@ -54,6 +54,19 @@ impl RenderContext {
         Self::init_with_backend(wgpu::Backends::all()).await
     }
 
+    /// Blocking wrapper over [`init`](Self::init) for synchronous callers.
+    ///
+    /// The preview runner and the export path are synchronous, so the block-on
+    /// executor is kept here in the GPU crate; callers stay executor-agnostic.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RenderError::DeviceCreation`] if no suitable adapter is found or
+    /// the device request fails.
+    pub fn init_blocking() -> Result<Self, RenderError> {
+        futures::executor::block_on(Self::init())
+    }
+
     /// Initialise wgpu with an explicit backend set.
     ///
     /// Useful in CI where only `wgpu::Backends::GL` may be available.

--- a/docs/specs/gpu-compositing-bridge.md
+++ b/docs/specs/gpu-compositing-bridge.md
@@ -65,9 +65,17 @@ Per composited frame:
 4. Deliver the result:
    - **export:** read the texture back to a CPU `VideoFrame` and hand it to the **existing encoder unchanged**
      (composite -> readback -> encoder). Zero-copy GPU->encoder is deferred.
-   - **preview:** hand the texture to `ff_preview`'s `FrameSink` via the `GpuFrameSink` pattern -- zero-copy
-     `push_frame_gpu` where `accepts_gpu_frame()` (the `display` feature), else `process_gpu` readback +
-     `push_frame`.
+   - **preview (Br3 v1):** `Compositor::composite_to_rgba` (composite + readback) -> the existing
+     `FrameSink::push_frame`, so any sink works. The GPU compositor is injected into `ff_preview`'s runner via
+     the `PreviewCompositor` seam (the runner cannot depend on `ff-render` directly); the runner tries it per
+     frame and falls back to the CPU compositor on `None`. **Deferred:** the zero-copy `push_frame_gpu` /
+     `GpuFrameSink` / `display`-feature path (hand a `wgpu::Texture` to the sink without readback).
+
+   **Br3 v1 layer coverage:** the GPU preview path renders only layers that need no geometric placement -- an
+   identity transform and a frame whose aspect matches the canvas. A non-identity transform (the model's
+   pixel/degree units do not yet map to the compositor's UV-space/radian `LayerTransform`) or an aspect
+   mismatch (the compositor stretches to the canvas where the CPU path letterboxes) falls back to CPU per
+   frame. Correct GPU transforms and letterboxing, with GPU-vs-CPU parity tests, are Br5.
 
 `ff_render::Compositor::new` and `RenderGraph::new` both take an `Arc<RenderContext>`; the bridge builds one
 `RenderContext` per session (`RenderContext::init().await`, or `RenderContext::new(device, queue)` to share a


### PR DESCRIPTION
## Objective

- Br2 (#1625) mapped the derived scene to an ff-render GPU plan, but nothing executes it for preview. Br3 makes the GPU compositor the default preview path with automatic CPU fallback, so preview composites on the GPU when an adapter is present and never on wrong output otherwise.

## Solution

- `ff-preview` cannot depend on `ff-render` (the reverse holds), so add a model-free `PreviewCompositor` trait injected into `SceneRunner` and tried inside `composite_frame` (via a `try_gpu_composite` helper); `None` falls through to the existing `RealtimeComposer` CPU path.
- `avio` implements it as `GpuPreviewCompositor`: map the runner's layers with `map_scene`, execute each layer's `ColorGrade`/`Scale` effects with an ff-render `RenderGraph`, composite the stack, and read back to rgba; return `None` (CPU fallback) on an unsupported layer or any GPU error. `TimelinePlayer::open` attaches it by default under the `gpu` feature; `open_forcing_cpu` keeps the CPU path.
- `ff-render` gains `RenderContext::init_blocking` (so avio stays executor-agnostic) and `Compositor::composite_to_rgba` (composite + staging-buffer readback), delivered via the existing `FrameSink::push_frame`.
- v1 renders only layers that need no geometric placement (identity transform, frame aspect matching the canvas): the model's pixel/degree transform does not yet map to the compositor's UV-space/radian `LayerTransform`, and the compositor stretches to the canvas where the CPU path letterboxes, so those cases fall back to CPU rather than render wrong output. Correct GPU transforms with parity tests are Br5; zero-copy texture delivery is deferred. The spec is updated to match.
- Deterministic seam tests use a mock `PreviewCompositor`; GPU-execution tests are probe-gated (skip with no adapter).

Closes #1626