### PR TITLE
feat(avio): GPU-default export path with automatic CPU fallback

### DIFF
--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -1,0 +1,177 @@
+//! Shared GPU compositing core for the bridge (#1626 preview / #1627 export).
+//!
+//! Owns the `ff-render` context and a cached `Compositor`, and composites a set of
+//! derived layers (any [`GpuLayerSource`]) with their decoded frames into an rgba
+//! buffer. Both the preview executor ([`GpuPreviewCompositor`](crate::GpuPreviewCompositor))
+//! and the export drain use it, so the mapping-to-GPU logic, the v1 identity/aspect
+//! gate, and the effect execution live in one place.
+//!
+//! It returns `None` on any unsupported layer ([`map_scene`] fallback, a non-identity
+//! transform, or an aspect mismatch) or any GPU error, so the caller falls back to the
+//! CPU compositor for that frame -- never a panic, never a partial result.
+//!
+//! v1 renders only layers that need no geometric placement (an identity transform and
+//! a frame whose aspect matches the canvas): the model's transform is in canvas pixels
+//! / clockwise degrees while `ff_render::LayerTransform` is UV-space / counter-clockwise
+//! radians, and the compositor stretches each layer to the canvas where the CPU path
+//! letterboxes. Matching those exactly is parity work (Br5), so those cases fall back
+//! to CPU rather than render wrong output.
+//!
+//! **Known v1 inefficiencies (deferred, tracked in #1634):** `apply_effects`
+//! builds a fresh `RenderGraph` and fresh effect nodes per frame, so an effected layer
+//! recompiles its pipeline each frame instead of reusing a cached one; and the
+//! no-effects path deep-copies the source frame (`VideoFrame::clone`). Both are on the
+//! export hot path but cost nothing for the common no-effect export beyond one copy;
+//! a persistent per-effect node cache and an owned-frame `composite` entry point are
+//! the fix.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ff_format::VideoFrame;
+use ff_render::{
+    ColorGradeNode, Compositor, FrameLayer, LayerTransform, RenderContext, RenderGraph, ScaleNode,
+};
+
+use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
+
+/// Composites derived layers on the GPU, returning `None` (CPU fallback) on
+/// unsupported content or any GPU error.
+pub struct GpuCompositor {
+    ctx: Arc<RenderContext>,
+    /// Compositor cached for its target canvas; rebuilt when the canvas changes.
+    compositor: Option<(Compositor, (u32, u32))>,
+}
+
+impl GpuCompositor {
+    /// Initialises a GPU context (best available adapter). Returns `None` when no
+    /// adapter is available, so the caller keeps the CPU path.
+    #[must_use]
+    pub fn new() -> Option<Self> {
+        match RenderContext::init_blocking() {
+            Ok(ctx) => Some(Self {
+                ctx: Arc::new(ctx),
+                compositor: None,
+            }),
+            Err(e) => {
+                // Info, not debug: the GPU->CPU fallback reason must stay visible at
+                // the default log level (per docs/rules/logging.md), since callers
+                // only log `path=cpu` without a reason.
+                log::info!("gpu context unavailable reason={e}");
+                None
+            }
+        }
+    }
+
+    /// Composites `layers` (bottom to top, each paired with its decoded frame) at
+    /// time `t` into a single rgba buffer `(rgba, width, height)`, or `None` to fall
+    /// back to the CPU compositor.
+    ///
+    /// `None` means: `map_scene` reported an unsupported blend/composite/effect, a
+    /// layer has a non-identity transform or an aspect that does not match the canvas
+    /// (v1 gate), or a GPU error occurred. The caller must never see a wrong-but-
+    /// rendered frame.
+    pub fn composite<L: GpuLayerSource>(
+        &mut self,
+        layers: &[(&L, &VideoFrame)],
+        canvas: (u32, u32),
+        t: Duration,
+    ) -> Option<(Vec<u8>, u32, u32)> {
+        let refs: Vec<&L> = layers.iter().map(|(l, _)| *l).collect();
+        let plan = match map_scene(&refs, canvas, t) {
+            GpuMapping::Gpu(plan) => plan,
+            GpuMapping::Fallback(_) => return None,
+        };
+
+        let mut frame_layers = Vec::with_capacity(plan.layers.len());
+        for (lp, (_, frame)) in plan.layers.iter().zip(layers.iter()) {
+            // v1 renders only layers that need no geometric placement (see the module
+            // docs); a non-identity transform falls back to CPU rather than render
+            // wrong output.
+            if !is_identity_transform(lp) {
+                return None;
+            }
+            let processed = self.apply_effects(lp, frame)?;
+            // The compositor would stretch a differently-shaped frame to fill the
+            // canvas, which the CPU path letterboxes instead; only a canvas-aspect
+            // frame composites without distortion.
+            if u64::from(processed.width()) * u64::from(canvas.1)
+                != u64::from(processed.height()) * u64::from(canvas.0)
+            {
+                return None;
+            }
+            frame_layers.push(FrameLayer {
+                frame: processed,
+                transform: LayerTransform::default(),
+                blend_mode: lp.blend_mode,
+                opacity: lp.opacity,
+                z_order: lp.z_order,
+            });
+        }
+
+        let rebuild = match &self.compositor {
+            Some((_, cached)) => *cached != canvas,
+            None => true,
+        };
+        if rebuild {
+            self.compositor = Some((
+                Compositor::new(self.ctx.clone(), canvas.0, canvas.1),
+                canvas,
+            ));
+        }
+        let (compositor, _) = self.compositor.as_mut()?;
+        compositor.composite_to_rgba(&mut frame_layers).ok()
+    }
+
+    /// Applies a layer's mappable effects to its rgba frame via a `RenderGraph`, or
+    /// returns the frame unchanged when it has none. `None` on a GPU error.
+    fn apply_effects(&self, plan: &GpuLayerPlan, frame: &VideoFrame) -> Option<VideoFrame> {
+        if plan.effects.is_empty() {
+            return Some(frame.clone());
+        }
+        let (in_w, in_h) = (frame.width(), frame.height());
+        let rgba = frame.to_rgba()?;
+        let mut graph = RenderGraph::new(self.ctx.clone());
+        // A `Scale` node resizes the frame; track the output dimensions so the
+        // read-back buffer is wrapped at the right size.
+        let (mut out_w, mut out_h) = (in_w, in_h);
+        for effect in &plan.effects {
+            graph = match effect {
+                GpuEffect::ColorGrade {
+                    brightness,
+                    contrast,
+                    saturation,
+                    temperature,
+                    tint,
+                } => graph.push(ColorGradeNode::new(
+                    *brightness,
+                    *contrast,
+                    *saturation,
+                    *temperature,
+                    *tint,
+                )),
+                GpuEffect::Scale {
+                    width,
+                    height,
+                    algorithm,
+                } => {
+                    out_w = *width;
+                    out_h = *height;
+                    graph.push(ScaleNode::new(*width, *height, *algorithm))
+                }
+            };
+        }
+        let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;
+        VideoFrame::from_rgba(out_w, out_h, out).ok()
+    }
+}
+
+/// Whether a plan layer's transform is the identity (no translate / scale / rotate),
+/// within a small tolerance. Non-identity transforms fall back to CPU in v1.
+fn is_identity_transform(lp: &GpuLayerPlan) -> bool {
+    lp.x.abs() < 1e-6
+        && lp.y.abs() < 1e-6
+        && (lp.scale_x - 1.0).abs() < 1e-6
+        && (lp.scale_y - 1.0).abs() < 1e-6
+        && lp.rotation.abs() < 1e-6
+}

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -1,0 +1,352 @@
+//! GPU export path: a deterministic decode -> GPU composite -> readback -> encode
+//! loop for an eligible timeline (bridge Br4, #1627).
+//!
+//! The offline compositor ([`MultiTrackComposer`](ff_filter::MultiTrackComposer))
+//! fuses decode and composite in one filter graph and never exposes a per-layer
+//! frame, so the GPU export cannot reuse it. Instead this module decodes each clip's
+//! source directly ([`ff_decode::VideoDecoder`]), composites each output frame on the
+//! GPU via the shared [`GpuCompositor`](crate::gpu_compositor::GpuCompositor), reads
+//! it back to rgba, and pushes it to the unchanged encoder (whose own sws converts
+//! rgba -> yuv420p).
+//!
+//! v1 handles only a **single active video track of contiguous hard cuts** at unity
+//! speed whose every clip is a file source that maps to the GPU with an identity
+//! transform and a canvas-matching aspect. Anything else keeps the whole export on
+//! the CPU `MultiTrackComposer` path (see [`eligible_track`]); multi-track / overlay
+//! GPU export is a follow-up.
+
+use std::time::{Duration, Instant};
+
+use ff_decode::{SeekMode, VideoDecoder};
+use ff_encode::VideoEncoder;
+use ff_filter::{AnimatedValue, VideoLayer};
+use ff_format::{PixelFormat, VideoFrame};
+use ff_pipeline::Progress;
+
+use crate::derive;
+use crate::error::TimelineError;
+use crate::gpu::{GpuMapping, map_scene};
+use crate::gpu_compositor::GpuCompositor;
+use crate::track::Track;
+
+/// Decides whether a timeline can be exported on the GPU export path, returning the
+/// index of the single eligible video track, or `None` to keep the whole export on
+/// the CPU `MultiTrackComposer` path.
+///
+/// v1 is deliberately narrow (structural + contiguity checks are I/O-free; only the
+/// probe pass reads each source):
+/// - no lavfi overlay (a second compositing layer v1 does not handle),
+/// - exactly one **active** video track with at least one clip,
+/// - every clip is a **file** source (a generated Solid/Text source has no decoder
+///   here; it renders via lavfi on the CPU path),
+/// - hard cuts only (a transition needs an xfade node the GPU path lacks),
+/// - unity speed (the one-frame-per-output decode loop does not resample time),
+/// - each clip's derived [`VideoLayer`] maps to [`GpuMapping::Gpu`] (a supported
+///   blend / composite / effect set) with a **static, neutral transform** (RK-020:
+///   the model's pixels/degrees are not `ff_render`'s UV/radians, so any placement
+///   falls back),
+/// - the clips **tile the timeline with no gap or overlap** (each `clip.offset`
+///   equals the sum of the preceding clips' durations): the decode loop concatenates
+///   clips in order without honouring `clip.offset`, so a leading gap, an inter-clip
+///   gap, or an overlap would diverge from the CPU compositor (which places each clip
+///   via `OffsetPts`),
+/// - each source's native aspect matches the canvas (the compositor would stretch a
+///   differently-shaped frame where the CPU path letterboxes) and its native frame
+///   rate matches the timeline `frame_rate` (the 1-frame-per-output decode loop does
+///   not resample, so a mismatch would change the clip's on-screen duration).
+pub(crate) fn eligible_track(
+    video_tracks: &[Track],
+    lavfi_overlay: Option<&str>,
+    any_video_solo: bool,
+    canvas: (u32, u32),
+    frame_rate: f64,
+) -> Option<usize> {
+    if lavfi_overlay.is_some() {
+        return None;
+    }
+
+    // Exactly one active video track.
+    let mut active = video_tracks
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| t.is_active(any_video_solo));
+    let (idx, track) = active.next()?;
+    if active.next().is_some() {
+        return None;
+    }
+    if track.clips.is_empty() {
+        return None;
+    }
+
+    // Structural pass (no I/O): reject before any source probe so an ineligible
+    // clip anywhere on the track keeps the export on the CPU path deterministically.
+    for clip in &track.clips {
+        if clip.source_path().is_none() || clip.transition.is_some() {
+            return None;
+        }
+        if (clip.speed - 1.0).abs() > 1e-9 {
+            return None;
+        }
+        let layer = derive::video_layer(clip, 0, &track.automation, canvas.0, canvas.1, None, None);
+        if !matches!(
+            map_scene(std::slice::from_ref(&layer), canvas, Duration::ZERO),
+            GpuMapping::Gpu(_)
+        ) || !is_static_neutral_transform(&layer)
+        {
+            return None;
+        }
+    }
+
+    // Contiguity pass (no I/O): the decode loop concatenates clips in order without
+    // honouring `clip.offset`, so it only matches the CPU compositor when the clips
+    // tile the timeline with no gap or overlap. Each clip must start exactly where the
+    // previous ended; only the final clip may run to end-of-file (unknown duration).
+    let mut expected = Duration::ZERO;
+    let last = track.clips.len() - 1;
+    for (i, clip) in track.clips.iter().enumerate() {
+        if clip.offset != expected {
+            return None;
+        }
+        match clip.duration() {
+            Some(d) => expected += d,
+            None if i == last => {}
+            None => return None,
+        }
+    }
+
+    // Probe pass (I/O): each source's native aspect and frame rate must match the
+    // canvas / timeline rate.
+    for clip in &track.clips {
+        let src = clip.source_path()?;
+        let Ok(decoder) = VideoDecoder::open(src).build() else {
+            return None;
+        };
+        if u64::from(decoder.width()) * u64::from(canvas.1)
+            != u64::from(decoder.height()) * u64::from(canvas.0)
+        {
+            return None;
+        }
+        if (decoder.frame_rate() - frame_rate).abs() > 1e-3 {
+            return None;
+        }
+    }
+
+    Some(idx)
+}
+
+/// Whether a layer's geometric transform is static and neutral for all `t` (no
+/// translate / scale / rotate). Combined with the aspect check this is the v1
+/// identity gate: an animated or non-neutral transform makes the timeline
+/// ineligible (RK-020) so it never renders wrong output on the GPU.
+fn is_static_neutral_transform(layer: &VideoLayer) -> bool {
+    matches!(layer.x, AnimatedValue::Static(v) if v.abs() < 1e-9)
+        && matches!(layer.y, AnimatedValue::Static(v) if v.abs() < 1e-9)
+        && matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9)
+        && matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9)
+        && matches!(layer.rotation, AnimatedValue::Static(v) if v.abs() < 1e-9)
+}
+
+/// Drains an eligible single video track to the encoder on the GPU: decode each
+/// clip's frames in order, composite each on the GPU, read it back, and push it to
+/// the unchanged encoder. `on_progress` is invoked after each pushed frame;
+/// returning `false` cancels with [`TimelineError::Cancelled`].
+///
+/// The caller has already established eligibility ([`eligible_track`]), so a
+/// mid-export fallback from the compositor is a should-not-happen and surfaces as
+/// [`TimelineError::TimelineRenderFailed`] rather than silent wrong output.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn drain_video_gpu(
+    track: &Track,
+    canvas: (u32, u32),
+    frame_rate: f64,
+    encoder: &mut VideoEncoder,
+    core: &mut GpuCompositor,
+    on_progress: &(impl Fn(&Progress) -> bool + Send),
+    start: Instant,
+    total_frames: Option<u64>,
+) -> Result<(), TimelineError> {
+    let mut video_idx: u32 = 0;
+    for clip in &track.clips {
+        let src = clip
+            .source_path()
+            .ok_or_else(|| TimelineError::TimelineRenderFailed {
+                reason: "gpu export: clip lost its file source".to_string(),
+            })?;
+        // Decode straight to rgba: the shared core's effect pass reads rgba, and the
+        // compositor and readback stay in one format (the encoder's own sws converts
+        // rgba -> yuv420p on push).
+        let mut decoder = VideoDecoder::open(src)
+            .output_format(PixelFormat::Rgba)
+            .build()?;
+        if let Some(in_point) = clip.in_point {
+            decoder.seek(in_point, SeekMode::Exact)?;
+        }
+
+        // Output-frame budget for this clip (its trimmed duration at the timeline
+        // rate); `None` when the clip runs to end-of-file, so it drains until EOF.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let frame_budget: Option<u64> = clip
+            .duration()
+            .map(|d| (d.as_secs_f64() * frame_rate).round().max(0.0) as u64);
+
+        let layer = derive::video_layer(clip, 0, &track.automation, canvas.0, canvas.1, None, None);
+
+        let mut produced: u64 = 0;
+        loop {
+            if frame_budget.is_some_and(|budget| produced >= budget) {
+                break;
+            }
+            let Some(frame) = decoder.decode_one()? else {
+                break; // EOF before the budget is met: the clip is shorter than declared.
+            };
+            #[allow(clippy::cast_precision_loss)] // frame index fits the f64 mantissa
+            let t = Duration::from_secs_f64(f64::from(video_idx) / frame_rate);
+            let (rgba, w, h) = core
+                .composite(&[(&layer, &frame)], canvas, t)
+                .ok_or_else(|| TimelineError::TimelineRenderFailed {
+                    reason: "gpu export: a frame fell back mid-export (precluded by eligibility)"
+                        .to_string(),
+                })?;
+            let out = VideoFrame::from_rgba(w, h, rgba).map_err(|e| {
+                TimelineError::TimelineRenderFailed {
+                    reason: format!("gpu export: readback frame invalid: {e}"),
+                }
+            })?;
+            encoder.push_video(&out)?;
+            video_idx = video_idx.saturating_add(1);
+            produced += 1;
+            let progress = Progress {
+                frames_processed: u64::from(video_idx),
+                total_frames,
+                elapsed: start.elapsed(),
+            };
+            if !on_progress(&progress) {
+                return Err(TimelineError::Cancelled);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::time::Duration;
+
+    use ff_filter::XfadeTransition;
+    use ff_format::Color;
+
+    use super::*;
+    use crate::{Clip, Timeline};
+
+    /// A canvas-sized (square) single hard-cut file-source track is the shape the GPU
+    /// export handles; the structural checks accept it (the probe is exercised e2e).
+    fn square_timeline(clips: Vec<Clip>) -> Timeline {
+        Timeline::builder()
+            .canvas(64, 64)
+            .frame_rate(30.0)
+            .video_track(clips)
+            .build()
+            .unwrap()
+    }
+
+    fn eligible(timeline: &Timeline) -> Option<usize> {
+        eligible_track(
+            &timeline.video_tracks,
+            timeline.lavfi_overlay.as_deref(),
+            timeline.video_tracks.iter().any(|t| t.solo),
+            (timeline.canvas_width, timeline.canvas_height),
+            timeline.frame_rate,
+        )
+    }
+
+    #[test]
+    fn eligible_track_should_reject_a_generated_source() {
+        // A Solid clip has no decoder on the GPU path, so it stays on the CPU path.
+        let t = square_timeline(vec![
+            Clip::solid(Color::rgb(1, 2, 3)).trim(Duration::ZERO, Duration::from_secs(1)),
+        ]);
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_a_transition() {
+        // A cross-fade needs an xfade node the GPU path lacks -> CPU.
+        let t = square_timeline(vec![
+            Clip::new("a.mp4"),
+            Clip::new("b.mp4").with_transition(XfadeTransition::Fade, Duration::from_millis(500)),
+        ]);
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_non_unity_speed() {
+        // The one-frame-per-output decode loop does not resample time -> CPU.
+        let t = square_timeline(vec![Clip::new("a.mp4").with_speed(2.0)]);
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_a_non_identity_transform() {
+        // A scaled layer is not an identity transform (RK-020) -> CPU.
+        let t = square_timeline(vec![Clip::new("a.mp4").with_scale(0.5)]);
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_a_leading_gap() {
+        // A single clip starting after t=0 (offset > 0) leaves a leading gap the CPU
+        // path renders as black; the offset-ignoring decode loop would drop it -> CPU.
+        let t = square_timeline(vec![
+            Clip::new("a.mp4")
+                .trim(Duration::ZERO, Duration::from_secs(1))
+                .offset(Duration::from_secs(1)),
+        ]);
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_an_inter_clip_gap() {
+        // Two hard-cut clips with a gap between them (clip 1 starts at 2s but clip 0
+        // ends at 1s): the decode loop would concatenate them and drop the gap -> CPU.
+        let t = square_timeline(vec![
+            Clip::new("a.mp4").trim(Duration::ZERO, Duration::from_secs(1)),
+            Clip::new("b.mp4")
+                .trim(Duration::ZERO, Duration::from_secs(1))
+                .offset(Duration::from_secs(2)),
+        ]);
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_an_interior_clip_of_unknown_duration() {
+        // A non-final clip without an out_point cannot be tiled deterministically
+        // (its end, hence the next clip's start, is unknown) -> CPU.
+        let t = square_timeline(vec![
+            Clip::new("a.mp4"), // no out_point -> unknown duration
+            Clip::new("b.mp4").offset(Duration::from_secs(1)),
+        ]);
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_a_lavfi_overlay() {
+        // A lavfi overlay is a second compositing layer v1 does not handle -> CPU.
+        let mut t = square_timeline(vec![Clip::new("a.mp4")]);
+        t.lavfi_overlay = Some("color=red".to_string());
+        assert!(eligible(&t).is_none());
+    }
+
+    #[test]
+    fn eligible_track_should_reject_two_active_video_tracks() {
+        // v1 handles a single track; a second active track -> CPU.
+        let t = Timeline::builder()
+            .canvas(64, 64)
+            .frame_rate(30.0)
+            .video_track(vec![Clip::new("a.mp4")])
+            .video_track(vec![Clip::new("b.mp4")])
+            .build()
+            .unwrap();
+        assert!(eligible(&t).is_none());
+    }
+}

--- a/crates/avio/src/gpu_preview.rs
+++ b/crates/avio/src/gpu_preview.rs
@@ -1,104 +1,38 @@
-//! GPU preview compositor: the executor half of the bridge (Br3, #1626).
+//! GPU preview adapter over the shared compositing core (Br3, #1626).
 //!
-//! Implements `ff_preview::PreviewCompositor` over `ff-render`, so the preview
-//! runner can composite on the GPU by default and fall back to its built-in CPU
-//! compositor automatically. Per frame it maps the runner's layers with
-//! [`map_scene`](crate::gpu::map_scene), executes each layer's `ColorGrade`/`Scale`
-//! effects with an `ff_render::RenderGraph`, composites the stack with
-//! `ff_render::Compositor`, and reads the result back to rgba. Any unsupported layer
-//! (`map_scene` fallback) or GPU error returns `None`, so the runner uses the CPU
-//! path for that frame (never a panic, never a partial result).
-//!
-//! v1 scope: the GPU path renders only layers that need no geometric placement (an
-//! identity transform and a frame whose aspect matches the canvas). Non-identity
-//! transforms and letterbox cases fall back to CPU, because the compositor's
-//! UV-space transform + stretch-to-canvas model does not yet match the CPU
-//! compositor's native-overlay + pad model; closing that with parity tests is Br5.
-//! Known v1 inefficiencies (deferred with the zero-copy work): a decoded frame is
-//! deep-copied per no-effect layer, and the readback allocates a staging buffer per
-//! frame.
+//! Wraps [`GpuCompositor`](crate::gpu_compositor::GpuCompositor) as an
+//! `ff_preview::PreviewCompositor`, so the preview runner composites on the GPU by
+//! default and falls back to its built-in CPU compositor when the core returns `None`
+//! (an unsupported layer, no adapter, or a GPU error). All the compositing logic and
+//! the v1 identity/aspect gate live in the shared core; this file only adapts the
+//! preview layer type.
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use ff_filter::RealtimeLayer;
 use ff_format::VideoFrame;
 use ff_preview::PreviewCompositor;
-use ff_render::{
-    ColorGradeNode, Compositor, FrameLayer, LayerTransform, RenderContext, RenderGraph, ScaleNode,
-};
 
-use crate::gpu::{GpuEffect, GpuLayerPlan, GpuMapping, map_scene};
+use crate::gpu_compositor::GpuCompositor;
 
-/// Composites preview frames on the GPU, falling back to `None` (the runner's CPU
-/// path) on unsupported content or any GPU error.
+/// Preview adapter over [`GpuCompositor`]: composites the runner's layers on the GPU,
+/// falling back to `None` (the runner's CPU path) on unsupported content or a GPU error.
 pub struct GpuPreviewCompositor {
-    ctx: Arc<RenderContext>,
-    /// Compositor cached for its target canvas; rebuilt when the canvas changes.
-    compositor: Option<(Compositor, (u32, u32))>,
+    core: GpuCompositor,
 }
 
 impl GpuPreviewCompositor {
-    /// Initialises a GPU context (best available adapter). Returns `None` when no
-    /// adapter is available, so the caller keeps the CPU compositor. Logs the
-    /// selected path once (lifecycle, not per frame).
+    /// Initialises the GPU core, or `None` when no adapter is available (so the
+    /// runner keeps its CPU compositor). Logs the selected path once (lifecycle).
     #[must_use]
     pub fn new() -> Option<Self> {
-        match RenderContext::init_blocking() {
-            Ok(ctx) => {
-                log::info!("preview compositor path=gpu");
-                Some(Self {
-                    ctx: Arc::new(ctx),
-                    compositor: None,
-                })
-            }
-            Err(e) => {
-                log::info!("preview compositor path=cpu reason={e}");
-                None
-            }
+        if let Some(core) = GpuCompositor::new() {
+            log::info!("preview compositor path=gpu");
+            Some(Self { core })
+        } else {
+            log::info!("preview compositor path=cpu");
+            None
         }
-    }
-
-    /// Applies a layer's mappable effects to its rgba frame via a `RenderGraph`, or
-    /// returns the frame unchanged when it has none. `None` on a GPU error.
-    fn apply_effects(&self, plan: &GpuLayerPlan, frame: &VideoFrame) -> Option<VideoFrame> {
-        if plan.effects.is_empty() {
-            return Some(frame.clone());
-        }
-        let (in_w, in_h) = (frame.width(), frame.height());
-        let rgba = frame.to_rgba()?;
-        let mut graph = RenderGraph::new(self.ctx.clone());
-        // A `Scale` node resizes the frame; track the output dimensions so the
-        // read-back buffer is wrapped at the right size.
-        let (mut out_w, mut out_h) = (in_w, in_h);
-        for effect in &plan.effects {
-            graph = match effect {
-                GpuEffect::ColorGrade {
-                    brightness,
-                    contrast,
-                    saturation,
-                    temperature,
-                    tint,
-                } => graph.push(ColorGradeNode::new(
-                    *brightness,
-                    *contrast,
-                    *saturation,
-                    *temperature,
-                    *tint,
-                )),
-                GpuEffect::Scale {
-                    width,
-                    height,
-                    algorithm,
-                } => {
-                    out_w = *width;
-                    out_h = *height;
-                    graph.push(ScaleNode::new(*width, *height, *algorithm))
-                }
-            };
-        }
-        let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;
-        VideoFrame::from_rgba(out_w, out_h, out).ok()
     }
 }
 
@@ -109,69 +43,8 @@ impl PreviewCompositor for GpuPreviewCompositor {
         canvas: (u32, u32),
         t: Duration,
     ) -> Option<(Vec<u8>, u32, u32)> {
-        // Map the layers to a GPU plan; an unsupported layer falls back to CPU.
-        let refs: Vec<&RealtimeLayer> = layers.iter().map(|(l, _)| *l).collect();
-        let plan = match map_scene(&refs, canvas, t) {
-            GpuMapping::Gpu(plan) => plan,
-            GpuMapping::Fallback(_) => return None,
-        };
-
-        // Execute each layer's effects, then wrap it as a compositor FrameLayer.
-        let mut frame_layers = Vec::with_capacity(plan.layers.len());
-        for (lp, (_, frame)) in plan.layers.iter().zip(layers.iter()) {
-            // v1 renders only layers that need no geometric placement. The model's
-            // transform is in canvas pixels / clockwise degrees, while the
-            // compositor's `LayerTransform` is UV-space / counter-clockwise radians,
-            // and the compositor stretches each layer to the canvas (no letterbox),
-            // whereas the CPU compositor overlays at native size and pads. Matching
-            // those exactly is parity work (Br5), so a non-identity transform falls
-            // back to CPU here rather than render wrong output.
-            if !is_identity_transform(lp) {
-                return None;
-            }
-            let processed = self.apply_effects(lp, frame)?;
-            // Same reason: the compositor would stretch a differently-shaped frame to
-            // fill the canvas, which the CPU path letterboxes instead. Only a frame
-            // whose aspect matches the canvas composites without distortion.
-            if u64::from(processed.width()) * u64::from(canvas.1)
-                != u64::from(processed.height()) * u64::from(canvas.0)
-            {
-                return None;
-            }
-            frame_layers.push(FrameLayer {
-                frame: processed,
-                transform: LayerTransform::default(),
-                blend_mode: lp.blend_mode,
-                opacity: lp.opacity,
-                z_order: lp.z_order,
-            });
-        }
-
-        // Composite (rebuilding the cached compositor if the canvas changed) and
-        // read back to rgba. A GPU error becomes `None` (CPU fallback).
-        let rebuild = match &self.compositor {
-            Some((_, cached)) => *cached != canvas,
-            None => true,
-        };
-        if rebuild {
-            self.compositor = Some((
-                Compositor::new(self.ctx.clone(), canvas.0, canvas.1),
-                canvas,
-            ));
-        }
-        let (compositor, _) = self.compositor.as_mut()?;
-        compositor.composite_to_rgba(&mut frame_layers).ok()
+        self.core.composite(layers, canvas, t)
     }
-}
-
-/// Whether a plan layer's transform is the identity (no translate / scale / rotate),
-/// within a small tolerance. Non-identity transforms fall back to CPU in v1.
-fn is_identity_transform(lp: &GpuLayerPlan) -> bool {
-    lp.x.abs() < 1e-6
-        && lp.y.abs() < 1e-6
-        && (lp.scale_x - 1.0).abs() < 1e-6
-        && (lp.scale_y - 1.0).abs() < 1e-6
-        && lp.rotation.abs() < 1e-6
 }
 
 #[cfg(test)]

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -107,6 +107,10 @@ mod effect;
 mod error;
 #[cfg(feature = "gpu")]
 mod gpu;
+#[cfg(feature = "gpu")]
+mod gpu_compositor;
+#[cfg(feature = "gpu")]
+mod gpu_export;
 #[cfg(all(feature = "gpu", feature = "preview"))]
 mod gpu_preview;
 mod ids;
@@ -124,6 +128,8 @@ pub use error::TimelineError;
 pub use gpu::{
     GpuEffect, GpuFallback, GpuLayerPlan, GpuLayerSource, GpuMapping, GpuScenePlan, map_scene,
 };
+#[cfg(feature = "gpu")]
+pub use gpu_compositor::GpuCompositor;
 #[cfg(all(feature = "gpu", feature = "preview"))]
 pub use gpu_preview::GpuPreviewCompositor;
 pub use ids::{ClipId, EffectId, GroupId, MarkerId, TrackId, TrackKind};

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -168,7 +168,25 @@ impl Timeline {
         output: impl AsRef<Path>,
         config: EncoderConfig,
     ) -> Result<(), TimelineError> {
-        self.render_with_progress(output, config, |_| true)
+        self.render_inner(output, config, |_| true, false)
+    }
+
+    /// Like [`render`](Self::render) but forces the CPU `MultiTrackComposer` export
+    /// path, bypassing the GPU export even when an adapter is available.
+    ///
+    /// This is the force-CPU override of the GPU-default export; the output is
+    /// identical in shape to [`render`](Self::render). Without the `gpu` feature it
+    /// is behaviourally identical to [`render`](Self::render).
+    ///
+    /// # Errors
+    ///
+    /// Same as [`render`](Self::render).
+    pub fn render_forcing_cpu(
+        self,
+        output: impl AsRef<Path>,
+        config: EncoderConfig,
+    ) -> Result<(), TimelineError> {
+        self.render_inner(output, config, |_| true, true)
     }
 
     /// Renders the timeline to an output file, invoking `on_progress` after
@@ -213,6 +231,38 @@ impl Timeline {
         output: impl AsRef<Path>,
         config: EncoderConfig,
         on_progress: impl Fn(&Progress) -> bool + Send,
+    ) -> Result<(), TimelineError> {
+        self.render_inner(output, config, on_progress, false)
+    }
+
+    /// Like [`render_with_progress`](Self::render_with_progress) but forces the CPU
+    /// `MultiTrackComposer` export path (the force-CPU override of the GPU-default
+    /// export). Without the `gpu` feature it is identical to
+    /// [`render_with_progress`](Self::render_with_progress).
+    ///
+    /// # Errors
+    ///
+    /// Same as [`render_with_progress`](Self::render_with_progress).
+    pub fn render_with_progress_forcing_cpu(
+        self,
+        output: impl AsRef<Path>,
+        config: EncoderConfig,
+        on_progress: impl Fn(&Progress) -> bool + Send,
+    ) -> Result<(), TimelineError> {
+        self.render_inner(output, config, on_progress, true)
+    }
+
+    /// The shared export driver behind the four public `render*` entry points:
+    /// builds the video composition, audio mix, and encoder, then drains them.
+    /// `force_cpu` bypasses the GPU export path (see
+    /// [`render_forcing_cpu`](Self::render_forcing_cpu)); it is a no-op difference
+    /// without the `gpu` feature.
+    fn render_inner(
+        self,
+        output: impl AsRef<Path>,
+        config: EncoderConfig,
+        on_progress: impl Fn(&Progress) -> bool + Send,
+        force_cpu: bool,
     ) -> Result<(), TimelineError> {
         let output = output.as_ref();
 
@@ -289,9 +339,41 @@ impl Timeline {
             }
         }
 
-        // 2. Build video composition graph.
+        // GPU export decision (Br4, #1627): an eligible single-track hard-cut
+        // timeline with an available adapter composites on the GPU; otherwise the CPU
+        // MultiTrackComposer path below runs unchanged. Decided here so the CPU
+        // composition graph is not built when the GPU export path will run. No
+        // adapter, force-CPU, or an ineligible timeline all fall back to CPU.
+        #[cfg(feature = "gpu")]
+        let gpu_export: Option<(usize, crate::gpu_compositor::GpuCompositor)> = if force_cpu {
+            None
+        } else {
+            crate::gpu_export::eligible_track(
+                &video_tracks,
+                lavfi_overlay.as_deref(),
+                any_video_solo,
+                (canvas_width, canvas_height),
+                frame_rate,
+            )
+            .and_then(|idx| crate::gpu_compositor::GpuCompositor::new().map(|core| (idx, core)))
+        };
+
+        // The CPU composition graph is skipped when the GPU export path will run.
+        let build_cpu_video = {
+            #[cfg(feature = "gpu")]
+            {
+                gpu_export.is_none()
+            }
+            #[cfg(not(feature = "gpu"))]
+            {
+                let _ = force_cpu;
+                true
+            }
+        };
+
+        // 2. Build video composition graph (CPU path).
         let mut video_graph = None;
-        if !video_tracks.is_empty() {
+        if build_cpu_video && !video_tracks.is_empty() {
             // Per-track end-offset (seconds) of the last clip, used to compute
             // the xfade `offset` arg when the next clip has a transition.
             let mut prev_end_by_track: HashMap<usize, f64> = HashMap::new();
@@ -452,33 +534,42 @@ impl Timeline {
 
         let start = Instant::now();
 
-        // 6. Drain video graph → encoder.
-        //    tick() must be called before each pull so that animation entries
-        //    registered on the graph update the filter parameters for that frame.
-        //    on_progress is invoked after each push; returning false cancels.
-        if let Some(mut vgraph) = video_graph {
-            let mut video_idx: u32 = 0;
-            loop {
-                #[allow(clippy::cast_precision_loss)]
-                // frame index fits comfortably in f64 mantissa
-                let pts = Duration::from_secs_f64(f64::from(video_idx) / frame_rate);
-                vgraph.tick(pts);
-                match vgraph.pull_video().map_err(TimelineError::Filter)? {
-                    Some(frame) => {
-                        encoder.push_video(&frame).map_err(TimelineError::Encode)?;
-                        video_idx = video_idx.saturating_add(1);
-                        let progress = Progress {
-                            frames_processed: u64::from(video_idx),
-                            total_frames,
-                            elapsed: start.elapsed(),
-                        };
-                        if !on_progress(&progress) {
-                            return Err(TimelineError::Cancelled);
-                        }
-                    }
-                    None => break,
-                }
-            }
+        // 6. Drain video → encoder: the GPU export path when eligible, else the CPU
+        //    composition graph. Both push to the same unchanged encoder.
+        #[cfg(feature = "gpu")]
+        if let Some((idx, mut core)) = gpu_export {
+            log::info!("export compositor path=gpu");
+            crate::gpu_export::drain_video_gpu(
+                &video_tracks[idx],
+                (canvas_width, canvas_height),
+                frame_rate,
+                &mut encoder,
+                &mut core,
+                &on_progress,
+                start,
+                total_frames,
+            )?;
+        } else if let Some(vgraph) = video_graph {
+            log::info!("export compositor path=cpu");
+            drain_composited_graph(
+                vgraph,
+                &mut encoder,
+                &on_progress,
+                start,
+                total_frames,
+                frame_rate,
+            )?;
+        }
+        #[cfg(not(feature = "gpu"))]
+        if let Some(vgraph) = video_graph {
+            drain_composited_graph(
+                vgraph,
+                &mut encoder,
+                &on_progress,
+                start,
+                total_frames,
+                frame_rate,
+            )?;
         }
 
         // 7. Drain audio graph → (optional master bus) → encoder.
@@ -561,6 +652,42 @@ impl Timeline {
         );
         Ok(())
     }
+}
+
+/// Drains a built CPU composition [`FilterGraph`] to the encoder (the historical
+/// export video loop). `tick()` runs before each pull so per-frame animation entries
+/// update the filter parameters; `on_progress` is invoked after each push and
+/// returning `false` cancels with [`TimelineError::Cancelled`].
+fn drain_composited_graph(
+    mut vgraph: FilterGraph,
+    encoder: &mut VideoEncoder,
+    on_progress: &(impl Fn(&Progress) -> bool + Send),
+    start: Instant,
+    total_frames: Option<u64>,
+    frame_rate: f64,
+) -> Result<(), TimelineError> {
+    let mut video_idx: u32 = 0;
+    loop {
+        #[allow(clippy::cast_precision_loss)] // frame index fits comfortably in f64 mantissa
+        let pts = Duration::from_secs_f64(f64::from(video_idx) / frame_rate);
+        vgraph.tick(pts);
+        match vgraph.pull_video().map_err(TimelineError::Filter)? {
+            Some(frame) => {
+                encoder.push_video(&frame).map_err(TimelineError::Encode)?;
+                video_idx = video_idx.saturating_add(1);
+                let progress = Progress {
+                    frames_processed: u64::from(video_idx),
+                    total_frames,
+                    elapsed: start.elapsed(),
+                };
+                if !on_progress(&progress) {
+                    return Err(TimelineError::Cancelled);
+                }
+            }
+            None => break,
+        }
+    }
+    Ok(())
 }
 
 /// Resolves a clip's effective duration for a fade-out start offset, probing the

--- a/crates/avio/tests/gpu_export_tests.rs
+++ b/crates/avio/tests/gpu_export_tests.rs
@@ -1,0 +1,162 @@
+//! End-to-end export on both routes (Br4, #1627): the GPU export path (composite
+//! -> readback -> existing encoder) and the force-CPU `MultiTrackComposer` path must
+//! each produce a decodable, canvas-sized video from the same single-clip timeline.
+//!
+//! Probe-gated (RK-002): the source encode needs `FFmpeg` codecs and the GPU leg needs
+//! an adapter; both are skipped gracefully when unavailable so the suite is green on
+//! a headless / minimal-`FFmpeg` CI. Only environment-unavailable errors are skipped;
+//! a structural failure (e.g. `TimelineRenderFailed`) fails the test.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod fixtures;
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use avio::{Clip, EncoderConfig, Timeline, TimelineError};
+use ff_decode::VideoDecoder;
+use ff_encode::{BitrateMode, VideoCodec};
+use fixtures::{FileGuard, make_source_file, test_output_path};
+
+const SRC_FRAMES: usize = 15;
+const CANVAS: u32 = 64;
+
+/// Whether a render error means "this environment can't run the pipeline" (skip) as
+/// opposed to a real regression (fail). Mirrors the `timeline_tests` convention: a
+/// filter/encode/decode build failure on minimal-FFmpeg CI is a skip; anything else
+/// (notably `TimelineRenderFailed` / `Cancelled`) is a genuine failure.
+fn is_environment_unavailable(e: &TimelineError) -> bool {
+    matches!(
+        e,
+        TimelineError::Filter(_) | TimelineError::Encode(_) | TimelineError::Decode(_)
+    )
+}
+
+/// `(decoded frame count, dimensions of the first frame)` for an exported file, or
+/// `(0, None)` when it cannot be opened/decoded.
+fn decode_stats(path: &std::path::Path) -> (usize, Option<(u32, u32)>) {
+    let Ok(mut d) = VideoDecoder::open(path).build() else {
+        return (0, None);
+    };
+    let mut n = 0usize;
+    let mut dims = None;
+    while let Ok(Some(f)) = d.decode_one() {
+        if dims.is_none() {
+            dims = Some((f.width(), f.height()));
+        }
+        n += 1;
+    }
+    (n, dims)
+}
+
+/// Asserts an exported file is a valid ~`SRC_FRAMES`-frame, canvas-sized video. A
+/// silently truncated export (e.g. an early loop break) or a wrong-sized frame fails
+/// here rather than passing a bare "non-empty" check.
+fn assert_valid_export(path: &std::path::Path, route: &str) {
+    let (count, dims) = decode_stats(path);
+    assert!(
+        (SRC_FRAMES - 1..=SRC_FRAMES + 1).contains(&count),
+        "{route} export should decode ~{SRC_FRAMES} frames, got {count}"
+    );
+    assert_eq!(
+        dims,
+        Some((CANVAS, CANVAS)),
+        "{route} export frames should be the {CANVAS}x{CANVAS} canvas size"
+    );
+}
+
+fn export_config() -> EncoderConfig {
+    EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Cbr(800_000))
+        .build()
+}
+
+/// A square, single hard-cut, file-source, unity-speed timeline: the shape the GPU
+/// export path handles (aspect matches the canvas, identity transform).
+fn build_timeline(src: &std::path::Path) -> Option<Timeline> {
+    Timeline::builder()
+        .canvas(CANVAS, CANVAS)
+        .frame_rate(30.0)
+        .video_track(vec![Clip::new(src)])
+        .build()
+        .ok()
+}
+
+/// Renders `timeline` to `out`, returning `false` (skip) on an environment-unavailable
+/// error and panicking on a structural one.
+fn render_or_skip(result: Result<(), TimelineError>) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(e) if is_environment_unavailable(&e) => false,
+        Err(e) => panic!("unexpected export error: {e}"),
+    }
+}
+
+#[test]
+fn export_should_produce_frames_on_cpu_and_gpu_routes() {
+    let src = test_output_path("gpuexport_src.mp4");
+    let _gs = FileGuard::new(src.clone());
+    if make_source_file(&src, CANVAS, CANVAS, 30.0, SRC_FRAMES, 120, 90, 160).is_none() {
+        return; // encoder unavailable -> skip
+    }
+
+    // CPU route: force-CPU always uses the MultiTrackComposer path (compiles and runs
+    // without the `gpu` feature).
+    let out_cpu = test_output_path("gpuexport_cpu.mp4");
+    let _gc = FileGuard::new(out_cpu.clone());
+    let Some(cpu_timeline) = build_timeline(&src) else {
+        return; // source codec unavailable -> skip
+    };
+    if !render_or_skip(cpu_timeline.render_forcing_cpu(&out_cpu, export_config())) {
+        return;
+    }
+    assert_valid_export(&out_cpu, "force-CPU");
+
+    // GPU route: the default `render` composites the eligible timeline on the GPU when
+    // an adapter is present. Skip when there is no adapter.
+    #[cfg(feature = "gpu")]
+    {
+        if avio::GpuCompositor::new().is_none() {
+            return; // no GPU adapter -> the GPU leg is unreachable here
+        }
+        let out_gpu = test_output_path("gpuexport_gpu.mp4");
+        let _gg = FileGuard::new(out_gpu.clone());
+        let Some(gpu_timeline) = build_timeline(&src) else {
+            return;
+        };
+        if !render_or_skip(gpu_timeline.render(&out_gpu, export_config())) {
+            return;
+        }
+        assert_valid_export(&out_gpu, "GPU");
+    }
+}
+
+#[test]
+fn render_with_progress_forcing_cpu_should_report_progress_and_export() {
+    let src = test_output_path("gpuexport_progress_src.mp4");
+    let _gs = FileGuard::new(src.clone());
+    if make_source_file(&src, CANVAS, CANVAS, 30.0, SRC_FRAMES, 60, 140, 200).is_none() {
+        return;
+    }
+    let out = test_output_path("gpuexport_progress_cpu.mp4");
+    let _go = FileGuard::new(out.clone());
+    let Some(timeline) = build_timeline(&src) else {
+        return;
+    };
+
+    // on_progress is Fn (not FnMut), so count through an atomic.
+    let frames = AtomicU32::new(0);
+    let result = timeline.render_with_progress_forcing_cpu(&out, export_config(), |_p| {
+        frames.fetch_add(1, Ordering::Relaxed);
+        true
+    });
+    if !render_or_skip(result) {
+        return;
+    }
+    assert!(
+        frames.load(Ordering::Relaxed) >= 1,
+        "the force-CPU progress callback must fire at least once"
+    );
+    assert_valid_export(&out, "force-CPU (progress)");
+}

--- a/docs/specs/gpu-compositing-bridge.md
+++ b/docs/specs/gpu-compositing-bridge.md
@@ -63,19 +63,29 @@ Per composited frame:
    sorts by `z_order`, ingests each layer -- planar YUV via `YuvUploadNode`, packed RGB CPU-side -- applies its
    `TransformNode`, and blends).
 4. Deliver the result:
-   - **export:** read the texture back to a CPU `VideoFrame` and hand it to the **existing encoder unchanged**
-     (composite -> readback -> encoder). Zero-copy GPU->encoder is deferred.
+   - **export (Br4 v1):** the GPU export composites each output frame with the shared `GpuCompositor` (the same
+     executor and identity/aspect gate as preview), reads it back with `Compositor::composite_to_rgba`, and
+     pushes the `rgba` `VideoFrame` to the **existing encoder unchanged** (the encoder's own sws converts
+     `rgba` -> `yuv420p`). `MultiTrackComposer` fuses decode and composite and never exposes a per-layer frame,
+     so the GPU export cannot drive it; `avio::gpu_export` runs its own deterministic per-source decode loop
+     (`ff_decode::VideoDecoder` per clip, decoded straight to `rgba`, one frame per output frame at
+     `t = frame_idx / fps`). Eligibility is a **whole-export** decision (`avio::gpu_export::eligible_track`): v1
+     covers a single active video track of contiguous hard cuts at unity speed whose every clip is a file source
+     mapping to an identity, canvas-aspect GPU layer; anything else -- or no adapter, or `render_forcing_cpu` --
+     keeps the whole export on `MultiTrackComposer`. Multi-track / overlay GPU export and zero-copy
+     GPU->encoder are deferred.
    - **preview (Br3 v1):** `Compositor::composite_to_rgba` (composite + readback) -> the existing
      `FrameSink::push_frame`, so any sink works. The GPU compositor is injected into `ff_preview`'s runner via
      the `PreviewCompositor` seam (the runner cannot depend on `ff-render` directly); the runner tries it per
      frame and falls back to the CPU compositor on `None`. **Deferred:** the zero-copy `push_frame_gpu` /
      `GpuFrameSink` / `display`-feature path (hand a `wgpu::Texture` to the sink without readback).
 
-   **Br3 v1 layer coverage:** the GPU preview path renders only layers that need no geometric placement -- an
-   identity transform and a frame whose aspect matches the canvas. A non-identity transform (the model's
-   pixel/degree units do not yet map to the compositor's UV-space/radian `LayerTransform`) or an aspect
-   mismatch (the compositor stretches to the canvas where the CPU path letterboxes) falls back to CPU per
-   frame. Correct GPU transforms and letterboxing, with GPU-vs-CPU parity tests, are Br5.
+   **v1 layer coverage (Br3 preview / Br4 export, shared core):** the GPU path renders only layers that need no
+   geometric placement -- an identity transform and a frame whose aspect matches the canvas. A non-identity
+   transform (the model's pixel/degree units do not yet map to the compositor's UV-space/radian
+   `LayerTransform`) or an aspect mismatch (the compositor stretches to the canvas where the CPU path
+   letterboxes) falls back to CPU -- per frame in preview, and by making the timeline ineligible (whole-export
+   CPU fallback) in export. Correct GPU transforms and letterboxing, with GPU-vs-CPU parity tests, are Br5.
 
 `ff_render::Compositor::new` and `RenderGraph::new` both take an `Arc<RenderContext>`; the bridge builds one
 `RenderContext` per session (`RenderContext::init().await`, or `RenderContext::new(device, queue)` to share a


### PR DESCRIPTION
## Objective

- Make timeline export composite on the GPU by default (bridge Br4), reading back to rgba and pushing to the existing encoder unchanged, with automatic CPU fallback to `MultiTrackComposer`.
- The CPU compositor fuses decode and composite and exposes no per-layer frame, so the GPU export needs its own deterministic decode/composite/encode loop.

## Solution

- Extract a shared `GpuCompositor` (from the preview compositor) that maps a derived layer set to the GPU, applies the identity/aspect fallback gate (RK-020), runs per-layer effects, and reads back to rgba; the preview adapter becomes a thin wrapper over it.
- Add `gpu_export`: a per-source `VideoDecoder` loop (decoded straight to rgba, one frame per output frame) plus a whole-export eligibility decision. v1 covers a single active video track of contiguous hard cuts at unity speed whose clips are file sources mapping to an identity, canvas-aspect GPU layer.
- Eligibility enforces contiguity against `clip.offset` (the loop concatenates clips without honouring per-clip placement) and native-vs-timeline frame-rate match (the loop does not resample); a gap, overlap, or frame-rate mismatch keeps the whole export on the CPU path instead of producing silently wrong output.
- `render` / `render_with_progress` stay GPU-default; `render_forcing_cpu` / `render_with_progress_forcing_cpu` force CPU. All four share `render_inner`; the CPU video drain is unchanged.
- Tests: eligibility unit tests (generated source, transition, non-unity speed, non-identity transform, lavfi, two tracks, leading/inter-clip gap, unknown-duration interior clip), and a probe-gated end-to-end export verifying decodable, canvas-sized frames on both the CPU and GPU routes.

Follow-ups: multi-track / overlay GPU export (#1633) and GPU compositor per-frame pipeline/copy caching (#1634).

Closes #1627