### PR TITLE
feat(ff-render): GaussianBlurNode and SharpenNode

### DIFF
--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -80,8 +80,8 @@ pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,
-    LumaMaskNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode,
-    TransformNode, YuvFormat, YuvUploadNode,
+    GaussianBlurNode, LumaMaskNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode,
+    ShapeMaskNode, SharpenNode, TransformNode, YuvFormat, YuvUploadNode,
 };
 pub use sink::GpuFrameSink;
 

--- a/crates/ff-render/src/nodes/blur.rs
+++ b/crates/ff-render/src/nodes/blur.rs
@@ -1,0 +1,792 @@
+//! Gaussian blur and unsharp-mask sharpen render nodes.
+//!
+//! [`GaussianBlurNode`] is a two-pass separable Gaussian blur (horizontal then
+//! vertical). [`SharpenNode`] is an unsharp mask: it blurs (two separable passes)
+//! then combines `orig + (orig - blur) * strength` in a third pass. Both expose a
+//! CPU fallback ([`RenderNodeCpu`]) that uses the same discrete kernel with
+//! clamp-to-edge, so the GPU and CPU paths agree within tolerance.
+
+use super::RenderNodeCpu;
+
+/// Maximum number of 1D kernel taps (matches the shader's fixed loop bound and the
+/// 16-slot uniform weight array).
+const MAX_TAPS: usize = 15;
+
+/// Computes a normalised 1D Gaussian kernel for `sigma`: `(tap_count, weights)`.
+///
+/// `sigma` is clamped to `[0.5, 20.0]`; the radius is `min(ceil(2σ), 7)` so the tap
+/// count stays odd and `<= 15` (large sigma is truncated, matching the node's
+/// fixed-size kernel). `weights` is zero-padded to 16 slots (the used taps come
+/// first) so the GPU uniform can carry it directly.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap
+)]
+fn gaussian_kernel(sigma: f32) -> (u32, [f32; 16]) {
+    let sigma = sigma.clamp(0.5, 20.0);
+    let radius = ((2.0 * sigma).ceil() as i32).clamp(1, (MAX_TAPS as i32 - 1) / 2);
+    let tap_count = (2 * radius + 1) as usize;
+
+    let mut weights = [0.0f32; 16];
+    let mut sum = 0.0f32;
+    for (i, slot) in weights.iter_mut().enumerate().take(tap_count) {
+        let x = i as f32 - radius as f32;
+        let w = (-(x * x) / (2.0 * sigma * sigma)).exp();
+        *slot = w;
+        sum += w;
+    }
+    for w in weights.iter_mut().take(tap_count) {
+        *w /= sum;
+    }
+    (tap_count as u32, weights)
+}
+
+/// One directional (horizontal or vertical) pass of a separable blur over an f32
+/// RGBA buffer, clamping sample coordinates to the edge. `radius = (tap_count-1)/2`.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+fn blur_pass_cpu(
+    src: &[f32],
+    dst: &mut [f32],
+    w: usize,
+    h: usize,
+    horizontal: bool,
+    radius: i32,
+    weights: &[f32; 16],
+) {
+    for y in 0..h {
+        for x in 0..w {
+            let mut acc = [0.0f32; 4];
+            for i in 0..=(2 * radius) {
+                let off = i - radius;
+                let (sx, sy) = if horizontal {
+                    ((x as i32 + off).clamp(0, w as i32 - 1), y as i32)
+                } else {
+                    (x as i32, (y as i32 + off).clamp(0, h as i32 - 1))
+                };
+                let p = (sy as usize * w + sx as usize) * 4;
+                let weight = weights[i as usize];
+                for (c, a) in acc.iter_mut().enumerate() {
+                    *a += src[p + c] * weight;
+                }
+            }
+            let d = (y * w + x) * 4;
+            dst[d..d + 4].copy_from_slice(&acc);
+        }
+    }
+}
+
+/// Blurs an 8-bit RGBA buffer in place with a separable Gaussian, returning the
+/// blurred result as f32 (0..1) so a caller (sharpen) can reuse it. `None` when the
+/// buffer size does not match `w × h × 4`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+fn separable_blur_f32(rgba: &[u8], w: u32, h: u32, sigma: f32) -> Option<Vec<f32>> {
+    let (wu, hu) = (w as usize, h as usize);
+    if wu == 0 || hu == 0 || rgba.len() != wu * hu * 4 {
+        return None;
+    }
+    let (tap_count, weights) = gaussian_kernel(sigma);
+    let radius = (tap_count / 2) as i32;
+    let src: Vec<f32> = rgba.iter().map(|&b| f32::from(b) / 255.0).collect();
+    let mut temp = vec![0.0f32; src.len()];
+    blur_pass_cpu(&src, &mut temp, wu, hu, true, radius, &weights);
+    let mut out = vec![0.0f32; src.len()];
+    blur_pass_cpu(&temp, &mut out, wu, hu, false, radius, &weights);
+    Some(out)
+}
+
+// GaussianBlurNode
+
+/// Two-pass separable Gaussian blur.
+pub struct GaussianBlurNode {
+    /// Standard deviation in pixels. Effective range `[0.5, 20.0]` (values outside
+    /// are clamped); a larger sigma is truncated to a 15-tap kernel.
+    pub sigma: f32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<BlurPipeline>,
+}
+
+impl GaussianBlurNode {
+    /// Creates a Gaussian blur node with the given standard deviation.
+    #[must_use]
+    pub fn new(sigma: f32) -> Self {
+        Self {
+            sigma,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl RenderNodeCpu for GaussianBlurNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
+        let Some(out) = separable_blur_f32(rgba, w, h, self.sigma) else {
+            return;
+        };
+        for (b, &f) in rgba.iter_mut().zip(out.iter()) {
+            *b = (f.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+        }
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl GaussianBlurNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &BlurPipeline {
+        self.pipeline
+            .get_or_init(|| create_blur_pipeline(ctx, self.sigma))
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for GaussianBlurNode {
+    fn pass_count(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("GaussianBlurNode::process called with no inputs");
+            return;
+        };
+        if outputs.len() < 2 {
+            log::warn!("GaussianBlurNode::process needs 2 output targets");
+            return;
+        }
+        let pd = self.get_or_create_pipeline(ctx);
+        // Pass 0 (horizontal): source -> outputs[0].
+        encode_blur_pass(ctx, pd, &pd.h_uniform_buf, input, outputs[0]);
+        // Pass 1 (vertical): outputs[0] -> outputs[1] (final).
+        encode_blur_pass(ctx, pd, &pd.v_uniform_buf, outputs[0], outputs[1]);
+    }
+}
+
+// SharpenNode
+
+/// Unsharp-mask sharpen: `orig + (orig - blurred) * strength`.
+pub struct SharpenNode {
+    /// Blur radius (as the Gaussian sigma) for the unsharp mask. Range `[0.5, 5.0]`.
+    pub radius: f32,
+    /// Sharpening strength (`0.0` = no-op). Typical range `[0.0, 3.0]`.
+    pub strength: f32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<SharpenPipeline>,
+}
+
+impl SharpenNode {
+    /// Creates an unsharp-mask sharpen node.
+    #[must_use]
+    pub fn new(radius: f32, strength: f32) -> Self {
+        Self {
+            radius,
+            strength,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl RenderNodeCpu for SharpenNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
+        let Some(blur) = separable_blur_f32(rgba, w, h, self.radius) else {
+            return;
+        };
+        // Sharpen the RGB channels; leave alpha unchanged.
+        for (px, blurred) in rgba
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(blur.as_chunks::<4>().0)
+        {
+            for c in 0..3 {
+                let orig = f32::from(px[c]) / 255.0;
+                let detail = orig - blurred[c];
+                let sharpened = (orig + detail * self.strength).clamp(0.0, 1.0);
+                px[c] = (sharpened * 255.0 + 0.5) as u8;
+            }
+        }
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl SharpenNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &SharpenPipeline {
+        self.pipeline.get_or_init(|| SharpenPipeline {
+            blur: create_blur_pipeline(ctx, self.radius),
+            combine: create_combine_pipeline(ctx, self.strength),
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for SharpenNode {
+    fn pass_count(&self) -> usize {
+        3
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("SharpenNode::process called with no inputs");
+            return;
+        };
+        if outputs.len() < 3 {
+            log::warn!("SharpenNode::process needs 3 output targets");
+            return;
+        }
+        let pd = self.get_or_create_pipeline(ctx);
+        // Passes 0-1: separable Gaussian blur of the source into outputs[1].
+        encode_blur_pass(ctx, &pd.blur, &pd.blur.h_uniform_buf, input, outputs[0]);
+        encode_blur_pass(
+            ctx,
+            &pd.blur,
+            &pd.blur.v_uniform_buf,
+            outputs[0],
+            outputs[1],
+        );
+        // Pass 2: combine original (input) with the blur (outputs[1]) into outputs[2].
+        encode_combine_pass(ctx, &pd.combine, input, outputs[1], outputs[2]);
+    }
+}
+
+// GPU pipeline construction
+
+#[cfg(feature = "wgpu")]
+struct BlurPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    h_uniform_buf: wgpu::Buffer,
+    v_uniform_buf: wgpu::Buffer,
+}
+
+#[cfg(feature = "wgpu")]
+struct CombinePipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buf: wgpu::Buffer,
+}
+
+#[cfg(feature = "wgpu")]
+struct SharpenPipeline {
+    blur: BlurPipeline,
+    combine: CombinePipeline,
+}
+
+#[cfg(feature = "wgpu")]
+fn create_blur_pipeline(ctx: &crate::context::RenderContext, sigma: f32) -> BlurPipeline {
+    let device = &ctx.device;
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("GaussianBlur shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/gaussian_blur.wgsl").into()),
+    });
+
+    let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("GaussianBlur BGL"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+        ],
+    });
+
+    let render_pipeline = fullscreen_pipeline(device, &shader, &bgl, "GaussianBlur");
+
+    let (tap_count, weights) = gaussian_kernel(sigma);
+    let h_uniform_buf = create_uniform(device, "GaussianBlur H uniforms", 80);
+    let v_uniform_buf = create_uniform(device, "GaussianBlur V uniforms", 80);
+    ctx.queue.write_buffer(
+        &h_uniform_buf,
+        0,
+        &pack_blur_uniforms([1.0, 0.0], tap_count, &weights),
+    );
+    ctx.queue.write_buffer(
+        &v_uniform_buf,
+        0,
+        &pack_blur_uniforms([0.0, 1.0], tap_count, &weights),
+    );
+
+    BlurPipeline {
+        render_pipeline,
+        bind_group_layout: bgl,
+        h_uniform_buf,
+        v_uniform_buf,
+    }
+}
+
+#[cfg(feature = "wgpu")]
+fn create_combine_pipeline(ctx: &crate::context::RenderContext, strength: f32) -> CombinePipeline {
+    let device = &ctx.device;
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Sharpen combine shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/sharpen.wgsl").into()),
+    });
+
+    let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Sharpen combine BGL"),
+        entries: &[
+            texture_entry(0),
+            texture_entry(1),
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+        ],
+    });
+
+    let render_pipeline = fullscreen_pipeline(device, &shader, &bgl, "Sharpen combine");
+
+    let uniform_buf = create_uniform(device, "Sharpen uniforms", 16);
+    let mut bytes = [0u8; 16];
+    bytes[0..4].copy_from_slice(&strength.to_le_bytes());
+    ctx.queue.write_buffer(&uniform_buf, 0, &bytes);
+
+    CombinePipeline {
+        render_pipeline,
+        bind_group_layout: bgl,
+        uniform_buf,
+    }
+}
+
+#[cfg(feature = "wgpu")]
+fn texture_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Texture {
+            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+            view_dimension: wgpu::TextureViewDimension::D2,
+            multisampled: false,
+        },
+        count: None,
+    }
+}
+
+#[cfg(feature = "wgpu")]
+fn create_uniform(device: &wgpu::Device, label: &str, size: u64) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    })
+}
+
+#[cfg(feature = "wgpu")]
+fn fullscreen_pipeline(
+    device: &wgpu::Device,
+    shader: &wgpu::ShaderModule,
+    bgl: &wgpu::BindGroupLayout,
+    label: &str,
+) -> wgpu::RenderPipeline {
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some(label),
+        bind_group_layouts: &[Some(bgl)],
+        immediate_size: 0,
+    });
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some(label),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: shader,
+            entry_point: Some("vs_main"),
+            buffers: &[],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
+/// Encodes one separable-blur pass reading `input` and writing `output`, using the
+/// direction baked into `uniform_buf`.
+#[cfg(feature = "wgpu")]
+fn encode_blur_pass(
+    ctx: &crate::context::RenderContext,
+    pd: &BlurPipeline,
+    uniform_buf: &wgpu::Buffer,
+    input: &wgpu::Texture,
+    output: &wgpu::Texture,
+) {
+    let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+    let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("GaussianBlur BG"),
+        layout: &pd.bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&input_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: uniform_buf.as_entire_binding(),
+            },
+        ],
+    });
+    run_fullscreen(
+        ctx,
+        &pd.render_pipeline,
+        &bind_group,
+        &output_view,
+        "GaussianBlur pass",
+    );
+}
+
+/// Encodes the sharpen combine pass reading `orig` + `blur` and writing `output`.
+#[cfg(feature = "wgpu")]
+fn encode_combine_pass(
+    ctx: &crate::context::RenderContext,
+    pd: &CombinePipeline,
+    orig: &wgpu::Texture,
+    blur: &wgpu::Texture,
+    output: &wgpu::Texture,
+) {
+    let orig_view = orig.create_view(&wgpu::TextureViewDescriptor::default());
+    let blur_view = blur.create_view(&wgpu::TextureViewDescriptor::default());
+    let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Sharpen combine BG"),
+        layout: &pd.bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&orig_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(&blur_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: pd.uniform_buf.as_entire_binding(),
+            },
+        ],
+    });
+    run_fullscreen(
+        ctx,
+        &pd.render_pipeline,
+        &bind_group,
+        &output_view,
+        "Sharpen combine pass",
+    );
+}
+
+#[cfg(feature = "wgpu")]
+fn run_fullscreen(
+    ctx: &crate::context::RenderContext,
+    pipeline: &wgpu::RenderPipeline,
+    bind_group: &wgpu::BindGroup,
+    output_view: &wgpu::TextureView,
+    label: &str,
+) {
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) });
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some(label),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: output_view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.draw(0..6, 0..1);
+    }
+    ctx.queue.submit(std::iter::once(encoder.finish()));
+}
+
+/// Packs `BlurUniforms` (direction, `tap_count`, 16 weights) into the 80-byte `std140`
+/// layout the shader declares: `vec2` + `u32` + pad + `array<vec4<f32>, 4>`.
+#[cfg(feature = "wgpu")]
+fn pack_blur_uniforms(direction: [f32; 2], tap_count: u32, weights: &[f32; 16]) -> [u8; 80] {
+    let mut b = [0u8; 80];
+    b[0..4].copy_from_slice(&direction[0].to_le_bytes());
+    b[4..8].copy_from_slice(&direction[1].to_le_bytes());
+    b[8..12].copy_from_slice(&tap_count.to_le_bytes());
+    // b[12..16] is padding (0).
+    for (i, w) in weights.iter().enumerate() {
+        let off = 16 + i * 4;
+        b[off..off + 4].copy_from_slice(&w.to_le_bytes());
+    }
+    b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `w × h` RGBA frame with a single white opaque pixel at `(cx, cy)` on an
+    /// opaque black background (the impulse used to observe the blur kernel).
+    fn impulse(w: usize, h: usize, cx: usize, cy: usize) -> Vec<u8> {
+        let mut v = vec![0u8; w * h * 4];
+        for px in v.as_chunks_mut::<4>().0 {
+            px[3] = 255; // opaque
+        }
+        let p = (cy * w + cx) * 4;
+        v[p] = 255;
+        v[p + 1] = 255;
+        v[p + 2] = 255;
+        v[3 + p] = 255;
+        v
+    }
+
+    #[test]
+    fn gaussian_kernel_should_be_normalised_and_symmetric() {
+        let (tap, weights) = gaussian_kernel(2.0);
+        assert!(tap % 2 == 1, "tap count must be odd; got {tap}");
+        assert!(
+            tap as usize <= MAX_TAPS,
+            "tap count must be <= 15; got {tap}"
+        );
+        let sum: f32 = weights.iter().take(tap as usize).sum();
+        assert!((sum - 1.0).abs() < 1e-5, "weights must sum to 1; got {sum}");
+        let r = (tap / 2) as usize;
+        for i in 0..r {
+            assert!(
+                (weights[r - 1 - i] - weights[r + 1 + i]).abs() < 1e-6,
+                "kernel must be symmetric around the centre tap"
+            );
+        }
+    }
+
+    #[test]
+    fn gaussian_blur_cpu_impulse_should_spread_and_preserve_energy() {
+        let (w, h) = (9usize, 9usize);
+        let frame = impulse(w, h, 4, 4);
+        let mut blurred = frame.clone();
+        GaussianBlurNode::new(1.5).process_cpu(&mut blurred, w as u32, h as u32);
+
+        let centre = (4 * w + 4) * 4;
+        assert!(
+            blurred[centre] < 255,
+            "the impulse centre must lose energy to its neighbours; got {}",
+            blurred[centre]
+        );
+        let neighbour = (4 * w + 5) * 4;
+        assert!(
+            blurred[neighbour] > 0,
+            "an adjacent pixel must gain energy from the impulse; got {}",
+            blurred[neighbour]
+        );
+        // Energy (sum of the R channel) is preserved by a normalised kernel with
+        // clamp-to-edge, since the impulse sits well inside the frame.
+        let sum_before: u32 = frame.iter().step_by(4).map(|&b| u32::from(b)).sum();
+        let sum_after: u32 = blurred.iter().step_by(4).map(|&b| u32::from(b)).sum();
+        assert!(
+            (i64::from(sum_after) - i64::from(sum_before)).abs() <= 8,
+            "a normalised blur must roughly preserve total energy; before={sum_before} after={sum_after}"
+        );
+    }
+
+    #[test]
+    fn gaussian_blur_sigma_zero_should_clamp_and_not_panic() {
+        let (w, h) = (4u32, 4u32);
+        let mut frame = impulse(4, 4, 1, 1);
+        // sigma 0.0 is clamped to 0.5 inside the kernel; must run without panicking.
+        GaussianBlurNode::new(0.0).process_cpu(&mut frame, w, h);
+    }
+
+    #[test]
+    fn sharpen_strength_zero_should_be_a_noop() {
+        let (w, h) = (8u32, 8u32);
+        // A horizontal gradient.
+        let mut frame = vec![0u8; (w * h * 4) as usize];
+        for (i, px) in frame.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let x = (i as u32 % w) as u8;
+            *px = [x * 30, x * 30, x * 30, 255];
+        }
+        let original = frame.clone();
+        SharpenNode::new(1.0, 0.0).process_cpu(&mut frame, w, h);
+        for (a, b) in frame.iter().zip(original.iter()) {
+            assert!(
+                (i32::from(*a) - i32::from(*b)).abs() <= 1,
+                "strength 0 must be a no-op (within rounding); got {a} vs {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn sharpen_cpu_should_increase_edge_contrast() {
+        // Left half dark (100), right half light (150): a vertical edge at x=4.
+        let (w, h) = (8usize, 4usize);
+        let mut frame = vec![0u8; w * h * 4];
+        for (i, px) in frame.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let x = i % w;
+            let v = if x < 4 { 100u8 } else { 150u8 };
+            *px = [v, v, v, 255];
+        }
+        let original = frame.clone();
+        SharpenNode::new(1.0, 1.5).process_cpu(&mut frame, w as u32, h as u32);
+
+        // The pixels straddling the edge must move further apart (overshoot):
+        // the dark side just left of the edge gets darker, the light side lighter.
+        let dark = (0 * w + 3) * 4; // x=3, left of the edge
+        let light = (0 * w + 4) * 4; // x=4, right of the edge
+        let before = i32::from(original[light]) - i32::from(original[dark]);
+        let after = i32::from(frame[light]) - i32::from(frame[dark]);
+        assert!(
+            after > before,
+            "sharpen must widen the edge step; before={before} after={after}"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::*;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use std::sync::Arc;
+
+    /// A headless GPU context, or `None` when no adapter is available (CI).
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    fn impulse(w: usize, h: usize, cx: usize, cy: usize) -> Vec<u8> {
+        let mut v = vec![0u8; w * h * 4];
+        for px in v.as_chunks_mut::<4>().0 {
+            px[3] = 255;
+        }
+        let p = (cy * w + cx) * 4;
+        v[p] = 255;
+        v[p + 1] = 255;
+        v[p + 2] = 255;
+        v[3 + p] = 255;
+        v
+    }
+
+    /// RMSE over the RGB channels of two 8-bit RGBA buffers, normalised to `[0, 1]`.
+    fn rmse_rgb(a: &[u8], b: &[u8]) -> f64 {
+        let mut sum = 0.0f64;
+        let mut n = 0u64;
+        for (pa, pb) in a.chunks_exact(4).zip(b.chunks_exact(4)) {
+            for c in 0..3 {
+                let d = (f64::from(pa[c]) - f64::from(pb[c])) / 255.0;
+                sum += d * d;
+                n += 1;
+            }
+        }
+        if n == 0 { 0.0 } else { (sum / n as f64).sqrt() }
+    }
+
+    #[test]
+    fn gaussian_blur_gpu_should_match_cpu_reference_within_rmse() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (w, h) = (9u32, 9u32);
+        let frame = impulse(9, 9, 4, 4);
+
+        let node = GaussianBlurNode::new(3.0);
+        let mut cpu_ref = frame.clone();
+        node.process_cpu(&mut cpu_ref, w, h);
+
+        let gpu = RenderGraph::new(Arc::clone(&ctx))
+            .push(GaussianBlurNode::new(3.0))
+            .process_gpu(&frame, w, h)
+            .expect("gpu blur");
+
+        assert_eq!(gpu.len(), cpu_ref.len());
+        let rmse = rmse_rgb(&gpu, &cpu_ref);
+        assert!(
+            rmse < 0.005,
+            "GPU blur must match the CPU reference within RMSE 0.005; got {rmse}"
+        );
+    }
+
+    #[test]
+    fn sharpen_gpu_should_increase_edge_contrast() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (w, h) = (8u32, 4u32);
+        let mut frame = vec![0u8; (w * h * 4) as usize];
+        for (i, px) in frame.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let x = i as u32 % w;
+            let v = if x < 4 { 100u8 } else { 150u8 };
+            *px = [v, v, v, 255];
+        }
+
+        let gpu = RenderGraph::new(Arc::clone(&ctx))
+            .push(SharpenNode::new(1.0, 1.5))
+            .process_gpu(&frame, w, h)
+            .expect("gpu sharpen");
+
+        let dark = 3 * 4; // x=3, y=0
+        let light = 4 * 4; // x=4, y=0
+        let before = i32::from(frame[light]) - i32::from(frame[dark]);
+        let after = i32::from(gpu[light]) - i32::from(gpu[dark]);
+        assert!(
+            after > before,
+            "GPU sharpen must widen the edge step; before={before} after={after}"
+        );
+    }
+}

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -1,3 +1,4 @@
+pub mod blur;
 pub mod color_grade;
 pub mod composite;
 pub mod crossfade;
@@ -5,6 +6,7 @@ pub mod overlay;
 pub mod scale;
 pub mod upload;
 
+pub use blur::{GaussianBlurNode, SharpenNode};
 pub use color_grade::ColorGradeNode;
 pub use composite::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, LumaMaskNode, ShapeMaskNode,

--- a/crates/ff-render/src/shaders/gaussian_blur.wgsl
+++ b/crates/ff-render/src/shaders/gaussian_blur.wgsl
@@ -1,0 +1,56 @@
+// Separable Gaussian blur: one 1D pass along `direction` (horizontal or vertical).
+// The node runs this shader twice (H then V) for a full 2D Gaussian. Uses
+// `textureLoad` for exact per-texel convolution with clamp-to-edge, so the GPU
+// result matches the CPU reference within tolerance.
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> u: BlurUniforms;
+
+// Matches Rust #[repr(C)] BlurUniforms (field order/size kept in sync).
+struct BlurUniforms {
+    direction: vec2<f32>,          // (1,0) = horizontal, (0,1) = vertical
+    tap_count: u32,                // odd, 1..=15; taps beyond it carry weight 0
+    _pad: u32,
+    weights: array<vec4<f32>, 4>,  // 16 weights (15 used), packed 4-per-vec4 for std140
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let dims = vec2<i32>(textureDimensions(input_tex));
+    // @builtin(position) is the framebuffer coord (pixel_index + 0.5); truncating
+    // to i32 recovers the integer pixel index.
+    let center = vec2<i32>(in.position.xy);
+    let dir = vec2<i32>(u.direction);              // (1,0) or (0,1)
+    let half_span = i32((u.tap_count - 1u) / 2u);
+
+    var acc = vec4<f32>(0.0);
+    // Fixed bound (max 15 taps); unused taps have weight 0 and add nothing.
+    for (var i: u32 = 0u; i < 15u; i = i + 1u) {
+        let w = u.weights[i / 4u][i % 4u];
+        // Clamp-to-edge: samples past the border reuse the border texel.
+        let coord = clamp(center + dir * (i32(i) - half_span), vec2<i32>(0), dims - vec2<i32>(1));
+        acc = acc + textureLoad(input_tex, coord, 0) * w;
+    }
+    return acc;
+}

--- a/crates/ff-render/src/shaders/sharpen.wgsl
+++ b/crates/ff-render/src/shaders/sharpen.wgsl
@@ -1,0 +1,47 @@
+// Unsharp-mask combine pass: result = orig + (orig - blurred) * strength.
+// The node runs a 2-pass separable Gaussian blur (gaussian_blur.wgsl) first, then
+// this pass combines the original with the blurred result. Uses `textureLoad` so
+// the two inputs are read per-texel with no filtering.
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var orig_tex: texture_2d<f32>;
+@group(0) @binding(1) var blur_tex: texture_2d<f32>;
+@group(0) @binding(2) var<uniform> u: SharpenUniforms;
+
+// Matches Rust #[repr(C)] SharpenUniforms.
+struct SharpenUniforms {
+    strength: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(in.position.xy);
+    let orig = textureLoad(orig_tex, coord, 0);
+    let blurred = textureLoad(blur_tex, coord, 0);
+    let detail = orig.rgb - blurred.rgb;
+    let sharpened = clamp(orig.rgb + detail * u.strength, vec3<f32>(0.0), vec3<f32>(1.0));
+    return vec4<f32>(sharpened, orig.a);
+}


### PR DESCRIPTION
## Objective

- Add the first blur/detail nodes of the GPU effect stack: a two-pass separable Gaussian blur and an unsharp-mask sharpen, each with a CPU fallback.

## Solution

- `GaussianBlurNode`: horizontal then vertical pass (`pass_count = 2`) sharing one cached pipeline; the direction and CPU-computed Gaussian kernel (up to 15 taps) live in two cached uniform buffers written once. The shader uses `textureLoad` for exact per-texel convolution with clamp-to-edge, so the GPU output matches the CPU reference within tolerance (RMSE < 0.005).
- `SharpenNode`: reuses the Gaussian blur shader for a two-pass separable blur, then a third combine pass computes `orig + (orig - blur) * strength` (`pass_count = 3`, so the blur is a true 2D separable Gaussian rather than a single pass).
- Both CPU fallbacks use the same discrete kernel and clamp-to-edge as the GPU path; the nodes are re-exported at the crate root.
- Tests: CPU unit tests (kernel normalisation, impulse spread, sigma clamp, sharpen no-op / edge contrast) plus adapter-gated GPU tests (the AC's GPU-vs-CPU RMSE and GPU sharpen edge contrast).

Closes #1044