### PR TITLE
feat(avio): map the Blur effect to the GPU GaussianBlurNode

### DIFF
--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -200,6 +200,12 @@ pub enum GpuEffect {
         /// Resampling algorithm.
         algorithm: RenderScaleAlgorithm,
     },
+    /// `ff_render::GaussianBlurNode` (two-pass separable Gaussian blur).
+    Blur {
+        /// Gaussian standard deviation (blur radius) in pixels; the same value the
+        /// `gblur` filter uses on the CPU path.
+        sigma: f32,
+    },
 }
 
 /// One layer of a [`GpuScenePlan`]: the transform / blend / opacity the
@@ -380,7 +386,13 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             height: *height,
             algorithm: map_scale_algo(*algorithm),
         }),
-        // Everything else (other colour, keying, masks, blur, animated geometry,
+        FilterStep::GBlur { sigma } => StepClass::Effect(GpuEffect::Blur { sigma: *sigma }),
+        FilterStep::GBlurAnimated { sigma } => StepClass::Effect(GpuEffect::Blur {
+            // The blur node is rebuilt each composite (map_scene runs per frame), so
+            // an animated sigma is evaluated at the frame time here.
+            sigma: sigma.value_at(t) as f32,
+        }),
+        // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
         // `#[non_exhaustive]` from ff-filter (RK-003).
         _ => StepClass::Unsupported,
@@ -615,6 +627,37 @@ mod tests {
                 height: 240,
                 algorithm: RenderScaleAlgorithm::Bicubic,
             }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_gblur_to_blur() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::GBlur { sigma: 3.5 }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::Blur { sigma: 3.5 }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_evaluate_animated_gblur_sigma_at_t() {
+        // sigma ramps 2 -> 6 over 0..2s; at t=1s it should read ~4.
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 2.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 6.0, Easing::Linear));
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::GBlurAnimated {
+            sigma: AnimatedValue::Track(track),
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::from_secs(1)));
+        let [GpuEffect::Blur { sigma }] = plan.layers[0].effects.as_slice() else {
+            panic!("animated gblur must map to a single Blur effect");
+        };
+        assert!(
+            (sigma - 4.0).abs() < 1e-3,
+            "animated sigma at t=1s should be ~4; got {sigma}"
         );
     }
 

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -30,7 +30,8 @@ use std::time::Duration;
 
 use ff_format::VideoFrame;
 use ff_render::{
-    ColorGradeNode, Compositor, FrameLayer, LayerTransform, RenderContext, RenderGraph, ScaleNode,
+    ColorGradeNode, Compositor, FrameLayer, GaussianBlurNode, LayerTransform, RenderContext,
+    RenderGraph, ScaleNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -159,6 +160,8 @@ impl GpuCompositor {
                     out_h = *height;
                     graph.push(ScaleNode::new(*width, *height, *algorithm))
                 }
+                // Blur preserves the frame dimensions, so out_w/out_h are unchanged.
+                GpuEffect::Blur { sigma } => graph.push(GaussianBlurNode::new(*sigma)),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -39,6 +39,7 @@ use ff_preview::FrameSink;
 // divergence (a stretch/letterbox/axis-swap of the gradient is tens of levels).
 const TOL_PASSTHROUGH_MEAN: f64 = 2.0; // identity passthrough: pixel-exact here
 const TOL_COLOR_GRADE_MEAN: f64 = 20.0; // GPU ColorGradeNode vs FFmpeg `eq`: ~6.6 here
+const TOL_BLUR_MEAN: f64 = 20.0; // GPU GaussianBlurNode vs FFmpeg `gblur`: ~9.0 here (different kernels)
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -52,6 +53,22 @@ fn gradient_rgba(w: u32, h: u32) -> Vec<u8> {
             let g = (y * 255 / (hu - 1).max(1)) as u8;
             let b = ((x + y) * 255 / (wu + hu - 2).max(1)) as u8;
             v.extend_from_slice(&[r, g, b, 255]);
+        }
+    }
+    v
+}
+
+/// A high-frequency `block`-sized checkerboard (black/white). A blur visibly smooths
+/// it, so a parity test on it is non-vacuous (RK-015): a GPU that failed to blur would
+/// keep the sharp squares and diverge far from the CPU-blurred reference.
+fn checkerboard_rgba(w: u32, h: u32, block: u32) -> Vec<u8> {
+    let (wu, hu) = (w as usize, h as usize);
+    let mut v = Vec::with_capacity(wu * hu * 4);
+    for y in 0..h {
+        for x in 0..w {
+            let on = ((x / block) + (y / block)) % 2 == 0;
+            let c = if on { 255u8 } else { 0u8 };
+            v.extend_from_slice(&[c, c, c, 255]);
         }
     }
     v
@@ -207,6 +224,36 @@ fn color_grade_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_COLOR_GRADE_MEAN,
         "GPU and CPU colour grade diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn blur_gpu_should_match_cpu_within_tolerance() {
+    // Gaussian blur parity: GPU GaussianBlurNode (map_scene maps `GBlur`) vs the CPU
+    // `gblur` filter. Different kernel implementations, so a loose calibrated
+    // tolerance. Double-gated (adapter + filters); a high-frequency checkerboard makes
+    // it non-vacuous (a GPU that did not blur would diverge far).
+    let (w, h) = (64, 48);
+    let frame = VideoFrame::from_rgba(w, h, checkerboard_rgba(w, h, 4)).unwrap();
+    let layer = base_layer(w, h, vec![FilterStep::GBlur { sigma: 3.0 }]);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported blur layer must composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "blur GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_BLUR_MEAN,
+        "GPU and CPU blur diverged beyond tolerance: mean={mean}"
     );
 }
 


### PR DESCRIPTION
## Objective

- Wire the existing typed `EffectKind::Blur` onto the GPU compositing path so a blurred clip renders on the GPU in preview and export, completing the blur vertical slice (node #1044 -> mapping -> parity).

## Solution

- `avio::gpu::map_scene` classifies `FilterStep::GBlur` and `GBlurAnimated` into a new `GpuEffect::Blur { sigma }` (an animated sigma is evaluated at the frame time, since the effect graph is rebuilt per frame); the blur radius is the `gblur` sigma, so the GPU and CPU paths use the same value.
- `GpuCompositor::apply_effects` pushes a `GaussianBlurNode` for `GpuEffect::Blur` (dimensions unchanged). Unsupported effects still fall back to CPU whole-frame (RK-020).
- Tests: `map_scene` unit tests (GBlur -> Blur, animated sigma at t), and a probe-gated GPU/CPU parity test on a high-frequency checkerboard (non-vacuous) asserting the GPU blur matches the CPU `gblur` within a calibrated tolerance (mean ~9, gate 20).

Closes #1650