### PR TITLE
feat(ff-render): add VignetteNode and FilmGrainNode

### DIFF
--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -80,8 +80,8 @@ pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,
-    GaussianBlurNode, LumaMaskNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode,
-    ShapeMaskNode, SharpenNode, TransformNode, YuvFormat, YuvUploadNode,
+    FilmGrainNode, GaussianBlurNode, LumaMaskNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm,
+    ScaleNode, ShapeMaskNode, SharpenNode, TransformNode, VignetteNode, YuvFormat, YuvUploadNode,
 };
 pub use sink::GpuFrameSink;
 

--- a/crates/ff-render/src/nodes/film_grain.rs
+++ b/crates/ff-render/src/nodes/film_grain.rs
@@ -1,0 +1,402 @@
+use super::RenderNodeCpu;
+
+// Pipeline cache
+
+#[cfg(feature = "wgpu")]
+struct FilmGrainPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buf: wgpu::Buffer,
+}
+
+// FilmGrainNode
+
+/// Film grain: per-pixel pseudo-random noise added in YCbCr (BT.709) so luma and
+/// chroma grain can be dialled independently.
+///
+/// The grain pattern is seeded from the pixel position and `frame_index`, so it
+/// is deterministic within a frame yet changes every frame (no temporal
+/// sticking). The GPU and CPU paths share the same Wang hash.
+pub struct FilmGrainNode {
+    /// Luma (brightness) grain amplitude, e.g. 0.05.
+    pub luma_strength: f32,
+    /// Chroma (colour) grain amplitude, e.g. 0.02.
+    pub chroma_strength: f32,
+    /// Frame index; changing it changes the grain pattern.
+    pub frame_index: u32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<FilmGrainPipeline>,
+}
+
+impl FilmGrainNode {
+    /// Creates a film-grain node with the given strengths and frame index.
+    #[must_use]
+    pub fn new(luma_strength: f32, chroma_strength: f32, frame_index: u32) -> Self {
+        Self {
+            luma_strength,
+            chroma_strength,
+            frame_index,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl Default for FilmGrainNode {
+    /// Identity node (no grain).
+    fn default() -> Self {
+        Self::new(0.0, 0.0, 0)
+    }
+}
+
+// Shared PRNG: kept byte-identical to the WGSL path.
+
+/// Wang hash: a fast integer hash used as a per-pixel PRNG. Matches the WGSL
+/// `wang_hash` (wrapping u32 arithmetic).
+fn wang_hash(seed_in: u32) -> u32 {
+    let mut seed = (seed_in ^ 0x3d) ^ (seed_in >> 16);
+    seed = seed.wrapping_mul(9);
+    seed ^= seed >> 4;
+    seed = seed.wrapping_mul(0x27d4_eb2d);
+    seed ^= seed >> 15;
+    seed
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn rand01(seed: u32) -> f32 {
+    wang_hash(seed) as f32 / 4_294_967_295.0
+}
+
+// CPU path
+
+impl RenderNodeCpu for FilmGrainNode {
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::many_single_char_names,
+        clippy::similar_names
+    )]
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, _h: u32) {
+        if w == 0 {
+            return;
+        }
+        for (i, pixel) in rgba.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let x = i as u32 % w;
+            let y = i as u32 / w;
+            let base = x
+                .wrapping_mul(1973)
+                .wrapping_add(y.wrapping_mul(9277))
+                .wrapping_add(self.frame_index.wrapping_mul(26699));
+
+            let g_luma = (rand01(base) - 0.5) * self.luma_strength;
+            let g_cb = (rand01(base.wrapping_add(1)) - 0.5) * self.chroma_strength;
+            let g_cr = (rand01(base.wrapping_add(2)) - 0.5) * self.chroma_strength;
+
+            let r = f32::from(pixel[0]) / 255.0;
+            let g = f32::from(pixel[1]) / 255.0;
+            let b = f32::from(pixel[2]) / 255.0;
+
+            // RGB -> YCbCr (BT.709), Cb/Cr centred on 0.
+            let mut ly = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+            let mut cb = (b - ly) / 1.8556;
+            let mut cr = (r - ly) / 1.5748;
+
+            ly += g_luma;
+            cb += g_cb;
+            cr += g_cr;
+
+            // YCbCr -> RGB.
+            let nr = ly + 1.5748 * cr;
+            let ng = ly - 0.1873 * cb - 0.4681 * cr;
+            let nb = ly + 1.8556 * cb;
+
+            pixel[0] = (nr.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            pixel[1] = (ng.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            pixel[2] = (nb.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            // alpha unchanged
+        }
+    }
+}
+
+// GPU path
+
+#[cfg(feature = "wgpu")]
+impl FilmGrainNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &FilmGrainPipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("FilmGrain shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/film_grain.wgsl").into()),
+            });
+
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("FilmGrain BGL"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("FilmGrain layout"),
+                bind_group_layouts: &[Some(&bgl)],
+                immediate_size: 0,
+            });
+
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("FilmGrain pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            });
+
+            // 2 x f32 + 2 x u32 = 16 bytes: matches FilmGrainUniforms in the shader.
+            let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("FilmGrain uniforms"),
+                size: 16,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            FilmGrainPipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                uniform_buf,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for FilmGrainNode {
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("FilmGrainNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("FilmGrainNode::process called with no outputs");
+            return;
+        };
+
+        let pd = self.get_or_create_pipeline(ctx);
+
+        // 2 × f32 then 2 × u32, matching FilmGrainUniforms.
+        let mut uniform_bytes = Vec::with_capacity(16);
+        uniform_bytes.extend_from_slice(&self.luma_strength.to_le_bytes());
+        uniform_bytes.extend_from_slice(&self.chroma_strength.to_le_bytes());
+        uniform_bytes.extend_from_slice(&self.frame_index.to_le_bytes());
+        uniform_bytes.extend_from_slice(&0u32.to_le_bytes());
+        ctx.queue.write_buffer(&pd.uniform_buf, 0, &uniform_bytes);
+
+        let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("FilmGrain BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: pd.uniform_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("FilmGrain pass"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("FilmGrain pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &output_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            pass.set_pipeline(&pd.render_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..6, 0..1);
+        }
+        ctx.queue.submit(std::iter::once(encoder.finish()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid_frame(w: u32, h: u32, rgb: [u8; 3]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity((w * h * 4) as usize);
+        for _ in 0..w * h {
+            buf.extend_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
+        }
+        buf
+    }
+
+    // Spread of the R channel across a frame; a uniform input has spread 0, so a
+    // positive spread proves the grain is spatially varying (visibly noisy).
+    fn r_spread(rgba: &[u8]) -> u8 {
+        let mut min = 255u8;
+        let mut max = 0u8;
+        for px in rgba.as_chunks::<4>().0 {
+            min = min.min(px[0]);
+            max = max.max(px[0]);
+        }
+        max - min
+    }
+
+    #[test]
+    fn film_grain_node_should_produce_noise() {
+        let node = FilmGrainNode::new(0.05, 0.02, 0);
+        let (w, h) = (16u32, 16u32);
+        let mut rgba = solid_frame(w, h, [128, 128, 128]);
+        node.process_cpu(&mut rgba, w, h);
+        assert!(
+            r_spread(&rgba) > 0,
+            "grain must make a uniform frame spatially varying"
+        );
+    }
+
+    #[test]
+    fn film_grain_node_frames_should_differ() {
+        let (w, h) = (16u32, 16u32);
+        let mut frame0 = solid_frame(w, h, [128, 128, 128]);
+        let mut frame1 = solid_frame(w, h, [128, 128, 128]);
+        FilmGrainNode::new(0.05, 0.02, 0).process_cpu(&mut frame0, w, h);
+        FilmGrainNode::new(0.05, 0.02, 1).process_cpu(&mut frame1, w, h);
+        assert_ne!(
+            frame0, frame1,
+            "frame_index 0 and 1 must produce different grain (no temporal sticking)"
+        );
+    }
+
+    #[test]
+    fn film_grain_node_zero_strength_should_be_noop() {
+        let node = FilmGrainNode::default();
+        let (w, h) = (8u32, 8u32);
+        let original = solid_frame(w, h, [200, 150, 100]);
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, w, h);
+        // Zero strength adds zero grain; allow ±1 for the YCbCr round-trip.
+        for (a, b) in rgba.iter().zip(original.iter()) {
+            assert!(
+                (i32::from(*a) - i32::from(*b)).abs() <= 1,
+                "zero-strength grain must preserve the frame (±1); got {a} vs {b}"
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::*;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use std::sync::Arc;
+
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    fn solid(w: u32, h: u32, v: u8) -> Vec<u8> {
+        let mut buf = Vec::with_capacity((w * h * 4) as usize);
+        for _ in 0..w * h {
+            buf.extend_from_slice(&[v, v, v, 255]);
+        }
+        buf
+    }
+
+    fn r_spread(rgba: &[u8]) -> u8 {
+        let mut min = 255u8;
+        let mut max = 0u8;
+        for px in rgba.as_chunks::<4>().0 {
+            min = min.min(px[0]);
+            max = max.max(px[0]);
+        }
+        max - min
+    }
+
+    #[test]
+    fn film_grain_gpu_should_produce_noise_and_vary_per_frame() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (w, h) = (16u32, 16u32);
+        let frame = solid(w, h, 128);
+
+        let g0 = RenderGraph::new(Arc::clone(&ctx))
+            .push(FilmGrainNode::new(0.05, 0.02, 0))
+            .process_gpu(&frame, w, h)
+            .expect("gpu grain 0");
+        let g1 = RenderGraph::new(Arc::clone(&ctx))
+            .push(FilmGrainNode::new(0.05, 0.02, 1))
+            .process_gpu(&frame, w, h)
+            .expect("gpu grain 1");
+
+        assert!(r_spread(&g0) > 0, "grain must make the frame noisy");
+        assert_ne!(g0, g1, "frame 0 and 1 must differ (no temporal sticking)");
+    }
+}

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -2,9 +2,11 @@ pub mod blur;
 pub mod color_grade;
 pub mod composite;
 pub mod crossfade;
+pub mod film_grain;
 pub mod overlay;
 pub mod scale;
 pub mod upload;
+pub mod vignette;
 
 pub use blur::{GaussianBlurNode, SharpenNode};
 pub use color_grade::ColorGradeNode;
@@ -13,9 +15,11 @@ pub use composite::{
     TransformNode,
 };
 pub use crossfade::CrossfadeNode;
+pub use film_grain::FilmGrainNode;
 pub use overlay::OverlayNode;
 pub use scale::{ScaleAlgorithm, ScaleNode};
 pub use upload::{YuvFormat, YuvUploadNode};
+pub use vignette::VignetteNode;
 
 // RenderNodeCpu
 

--- a/crates/ff-render/src/nodes/vignette.rs
+++ b/crates/ff-render/src/nodes/vignette.rs
@@ -1,0 +1,350 @@
+use super::RenderNodeCpu;
+
+// Pipeline cache
+
+#[cfg(feature = "wgpu")]
+struct VignettePipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buf: wgpu::Buffer,
+}
+
+// VignetteNode
+
+/// Position-based radial vignette: darkens toward the corners with a smooth
+/// falloff. A pixel's output depends only on its own colour and its normalised
+/// distance from the centre, so the centre is left unmodified and `strength = 0`
+/// is a no-op.
+pub struct VignetteNode {
+    /// Normalised distance from the centre where darkening begins (0.0 – 1.0; a
+    /// corner is ~1.0).
+    pub radius: f32,
+    /// Maximum darkening applied at the corners (0.0 = no vignette; 1.0 = to
+    /// black at full falloff).
+    pub strength: f32,
+    /// Width of the falloff band past `radius` (0.0 = hard edge).
+    pub feather: f32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<VignettePipeline>,
+}
+
+impl VignetteNode {
+    /// Creates a vignette with the given radius, strength, and feather.
+    #[must_use]
+    pub fn new(radius: f32, strength: f32, feather: f32) -> Self {
+        Self {
+            radius,
+            strength,
+            feather,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl Default for VignetteNode {
+    /// Identity node (no darkening).
+    fn default() -> Self {
+        Self::new(0.5, 0.0, 0.2)
+    }
+}
+
+// CPU path
+
+/// Smoothstep matching WGSL semantics; `edge1` is guarded against `feather == 0`
+/// by the caller.
+fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+impl RenderNodeCpu for VignetteNode {
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss,
+        clippy::many_single_char_names
+    )]
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
+        if w == 0 || h == 0 {
+            return;
+        }
+        let wf = w as f32;
+        let hf = h as f32;
+        let edge1 = self.radius + self.feather.max(1e-5);
+        for (i, pixel) in rgba.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let x = (i as u32 % w) as f32 + 0.5;
+            let y = (i as u32 / w) as f32 + 0.5;
+            // Centre-relative UV in [-0.5, 0.5]; distance normalised so a corner
+            // is ~1.0.
+            let dx = x / wf - 0.5;
+            let dy = y / hf - 0.5;
+            let d = (dx * dx + dy * dy).sqrt() * 2.0;
+            let v = smoothstep(self.radius, edge1, d);
+            let factor = 1.0 - v * self.strength;
+
+            for c in &mut pixel[0..3] {
+                *c = (f32::from(*c) * factor).clamp(0.0, 255.0) as u8;
+            }
+            // alpha unchanged
+        }
+    }
+}
+
+// GPU path
+
+#[cfg(feature = "wgpu")]
+impl VignetteNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &VignettePipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Vignette shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/vignette.wgsl").into()),
+            });
+
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Vignette BGL"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Vignette layout"),
+                bind_group_layouts: &[Some(&bgl)],
+                immediate_size: 0,
+            });
+
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Vignette pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            });
+
+            // 4 x f32 = 16 bytes: matches VignetteUniforms in the shader.
+            let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("Vignette uniforms"),
+                size: 16,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            VignettePipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                uniform_buf,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for VignetteNode {
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("VignetteNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("VignetteNode::process called with no outputs");
+            return;
+        };
+
+        let pd = self.get_or_create_pipeline(ctx);
+
+        let uniform_bytes: Vec<u8> = [self.radius, self.strength, self.feather, 0.0]
+            .iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+        ctx.queue.write_buffer(&pd.uniform_buf, 0, &uniform_bytes);
+
+        let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Vignette BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: pd.uniform_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Vignette pass"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Vignette pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &output_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            pass.set_pipeline(&pd.render_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.draw(0..6, 0..1);
+        }
+        ctx.queue.submit(std::iter::once(encoder.finish()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A 9×9 frame has pixel (4,4) exactly at uv (0.5, 0.5), so the centre pixel
+    // can be checked for exact invariance.
+    fn solid_frame(w: u32, h: u32, rgb: [u8; 3]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity((w * h * 4) as usize);
+        for _ in 0..w * h {
+            buf.extend_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
+        }
+        buf
+    }
+
+    #[test]
+    fn vignette_node_should_darken_corners() {
+        let node = VignetteNode::new(0.5, 0.8, 0.2);
+        let (w, h) = (9u32, 9u32);
+        let mut rgba = solid_frame(w, h, [200, 200, 200]);
+        node.process_cpu(&mut rgba, w, h);
+        // Top-left corner pixel must be darker than the original.
+        let corner = rgba[0];
+        assert!(
+            corner < 200,
+            "corner must be darkened by the vignette; got {corner}"
+        );
+    }
+
+    #[test]
+    fn vignette_node_should_leave_centre_unmodified() {
+        let node = VignetteNode::new(0.5, 0.8, 0.2);
+        let (w, h) = (9u32, 9u32);
+        let mut rgba = solid_frame(w, h, [200, 200, 200]);
+        node.process_cpu(&mut rgba, w, h);
+        // Centre pixel (4,4) is at uv (0.5,0.5): dist 0, factor 1, unmodified.
+        let centre = ((4 * w + 4) * 4) as usize;
+        assert_eq!(rgba[centre], 200, "centre R must be unmodified");
+        assert_eq!(rgba[centre + 1], 200, "centre G must be unmodified");
+        assert_eq!(rgba[centre + 2], 200, "centre B must be unmodified");
+    }
+
+    #[test]
+    fn vignette_node_strength_zero_should_be_noop() {
+        let node = VignetteNode::new(0.5, 0.0, 0.2);
+        let (w, h) = (8u32, 8u32);
+        let original = solid_frame(w, h, [200, 150, 100]);
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, w, h);
+        assert_eq!(rgba, original, "strength=0 must be a no-op everywhere");
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::*;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use std::sync::Arc;
+
+    /// A headless GPU context, or `None` when no adapter is available (CI).
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    fn solid(w: u32, h: u32, v: u8) -> Vec<u8> {
+        let mut buf = Vec::with_capacity((w * h * 4) as usize);
+        for _ in 0..w * h {
+            buf.extend_from_slice(&[v, v, v, 255]);
+        }
+        buf
+    }
+
+    #[test]
+    fn vignette_gpu_should_darken_corners_and_keep_centre() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (w, h) = (9u32, 9u32);
+        let frame = solid(w, h, 200);
+        let gpu = RenderGraph::new(Arc::clone(&ctx))
+            .push(VignetteNode::new(0.5, 0.8, 0.2))
+            .process_gpu(&frame, w, h)
+            .expect("gpu vignette");
+
+        let centre = ((4 * w + 4) * 4) as usize;
+        assert!(
+            i32::from(gpu[centre]) >= 199,
+            "centre must stay ~unmodified; got {}",
+            gpu[centre]
+        );
+        assert!(gpu[0] < 200, "corner must be darkened; got {}", gpu[0]);
+    }
+}

--- a/crates/ff-render/src/shaders/film_grain.wgsl
+++ b/crates/ff-render/src/shaders/film_grain.wgsl
@@ -1,0 +1,81 @@
+// Film grain: per-pixel pseudo-random noise added in YCbCr (BT.709) so luma and
+// chroma grain can be dialled independently. The Wang hash is seeded from the
+// pixel position and `frame_index`, so the pattern is deterministic per frame but
+// changes every frame (no temporal sticking). The same hash runs on the CPU path.
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> u: FilmGrainUniforms;
+
+// Matches Rust FilmGrainUniforms (field order/size kept in sync).
+struct FilmGrainUniforms {
+    luma_strength:   f32,
+    chroma_strength: f32,
+    frame_index:     u32,
+    _pad:            u32,
+}
+
+// Wang hash: fast integer hash used as a per-pixel PRNG. Kept byte-identical to
+// the Rust CPU path (wrapping u32 arithmetic).
+fn wang_hash(seed_in: u32) -> u32 {
+    var seed = (seed_in ^ 61u) ^ (seed_in >> 16u);
+    seed = seed * 9u;
+    seed = seed ^ (seed >> 4u);
+    seed = seed * 0x27d4eb2du;
+    seed = seed ^ (seed >> 15u);
+    return seed;
+}
+
+fn rand01(seed: u32) -> f32 {
+    return f32(wang_hash(seed)) / 4294967295.0;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let px = vec2<u32>(vec2<i32>(in.position.xy));
+    let base = px.x * 1973u + px.y * 9277u + u.frame_index * 26699u;
+
+    // Grain centred on zero, scaled by the respective strength.
+    let g_luma = (rand01(base) - 0.5) * u.luma_strength;
+    let g_cb = (rand01(base + 1u) - 0.5) * u.chroma_strength;
+    let g_cr = (rand01(base + 2u) - 0.5) * u.chroma_strength;
+
+    let color = textureLoad(input_tex, vec2<i32>(in.position.xy), 0);
+
+    // RGB -> YCbCr (BT.709), Cb/Cr centred on 0.
+    var y = dot(color.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
+    var cb = (color.b - y) / 1.8556;
+    var cr = (color.r - y) / 1.5748;
+
+    y = y + g_luma;
+    cb = cb + g_cb;
+    cr = cr + g_cr;
+
+    // YCbCr -> RGB.
+    let r = y + 1.5748 * cr;
+    let g = y - 0.1873 * cb - 0.4681 * cr;
+    let b = y + 1.8556 * cb;
+
+    let rgb = clamp(vec3<f32>(r, g, b), vec3<f32>(0.0), vec3<f32>(1.0));
+    return vec4<f32>(rgb, color.a);
+}

--- a/crates/ff-render/src/shaders/vignette.wgsl
+++ b/crates/ff-render/src/shaders/vignette.wgsl
@@ -1,0 +1,48 @@
+// Position-based radial vignette: darkens toward the corners with a smooth
+// falloff. Purely per-texel (the output pixel depends only on its own colour and
+// position), so it uses `textureLoad` and needs no sampler.
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> u: VignetteUniforms;
+
+// Matches Rust VignetteUniforms (field order/size kept in sync).
+struct VignetteUniforms {
+    radius:   f32,   // normalised distance where darkening begins (0..1)
+    strength: f32,   // maximum darkening at the corners (0 = off, 1 = to black)
+    feather:  f32,   // width of the falloff band past `radius`
+    _pad:     f32,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Distance from centre, normalised so a corner is ~1.0.
+    let d = length(in.uv - vec2<f32>(0.5)) * 2.0;
+    // Guard against feather == 0 making smoothstep's edges coincide (0/0).
+    let edge1 = u.radius + max(u.feather, 1e-5);
+    let v = smoothstep(u.radius, edge1, d);
+    let factor = 1.0 - v * u.strength;
+
+    let color = textureLoad(input_tex, vec2<i32>(in.position.xy), 0);
+    return vec4<f32>(color.rgb * factor, color.a);
+}


### PR DESCRIPTION
## Objective

- Extend the ff-render effect stack with a vignette and a film-grain node (Phase 3).
- Provide both a CPU fallback and a GPU path for each, consistent with the existing nodes.

## Solution

- Add `VignetteNode { radius, strength, feather }`: position-based radial darkening, `factor = 1 - smoothstep(radius, radius+feather, dist) * strength`. The centre is left unmodified and `strength = 0` is a no-op; both paths guard against `feather == 0`.
- Add `FilmGrainNode { luma_strength, chroma_strength, frame_index }`: per-pixel noise in YCbCr (BT.709) with independent luma/chroma strengths. A Wang hash seeded from the pixel position and `frame_index` keeps the pattern deterministic per frame but varying across frames (no temporal sticking); the GPU and CPU paths share the same hash.
- Re-export both nodes at the ff-render crate root.
- Cover the acceptance criteria with CPU unit tests and adapter-gated GPU tests (corner darkening, exact centre invariance, `strength = 0` no-op, grain variance, per-frame variation).

Closes #1046