### PR TITLE
feat(ff-render): add HSL, Curves, and ColorWheels nodes

### DIFF
--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -79,10 +79,10 @@ pub use error::RenderError;
 pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
-    AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,
-    FilmGrainNode, GaussianBlurNode, GlowNode, LumaMaskNode, OverlayNode, RenderNodeCpu,
-    ScaleAlgorithm, ScaleNode, ShapeMaskNode, SharpenNode, TransformNode, VignetteNode, YuvFormat,
-    YuvUploadNode,
+    AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, ColorWheelsNode,
+    CrossfadeNode, CurvesNode, FilmGrainNode, GaussianBlurNode, GlowNode, HslNode, LumaMaskNode,
+    OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode, SharpenNode,
+    TransformNode, VignetteNode, YuvFormat, YuvUploadNode,
 };
 pub use sink::GpuFrameSink;
 

--- a/crates/ff-render/src/nodes/color_wheels.rs
+++ b/crates/ff-render/src/nodes/color_wheels.rs
@@ -1,0 +1,261 @@
+//! Three-way colour corrector (shadows/midtones/highlights lift, gamma, gain).
+
+use super::RenderNodeCpu;
+
+#[cfg(feature = "wgpu")]
+use super::blur::{create_uniform, fullscreen_pipeline, run_fullscreen, texture_entry};
+
+// ColorWheelsNode
+
+/// Three-way colour corrector: shadows / midtones / highlights lift, gamma, gain.
+///
+/// Each adjustment is weighted by a luminance region so it acts on its tonal
+/// range: `shadows_lift` (additive) on dark pixels, `midtones_gamma` on mid
+/// pixels, `highlights_gain` (multiplicative) on bright pixels.
+pub struct ColorWheelsNode {
+    /// Shadows lift: additive offset per RGB channel (typ. `[-1, 1]`).
+    pub shadows_lift: [f32; 3],
+    /// Midtones gamma: exponent per RGB channel (typ. `[0.1, 10.0]`; `1.0` = no-op).
+    pub midtones_gamma: [f32; 3],
+    /// Highlights gain: multiplier per RGB channel (typ. `[0.0, 4.0]`; `1.0` = no-op).
+    pub highlights_gain: [f32; 3],
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<ColorWheelsPipeline>,
+}
+
+impl ColorWheelsNode {
+    /// Creates a three-way colour corrector.
+    #[must_use]
+    pub fn new(
+        shadows_lift: [f32; 3],
+        midtones_gamma: [f32; 3],
+        highlights_gain: [f32; 3],
+    ) -> Self {
+        Self {
+            shadows_lift,
+            midtones_gamma,
+            highlights_gain,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl Default for ColorWheelsNode {
+    /// Identity node (no lift, unit gamma, unit gain).
+    fn default() -> Self {
+        Self::new([0.0; 3], [1.0; 3], [1.0; 3])
+    }
+}
+
+fn smoothstep(e0: f32, e1: f32, x: f32) -> f32 {
+    let t = ((x - e0) / (e1 - e0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+// CPU path
+
+impl RenderNodeCpu for ColorWheelsNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        for px in rgba.as_chunks_mut::<4>().0 {
+            let rgb = [
+                f32::from(px[0]) / 255.0,
+                f32::from(px[1]) / 255.0,
+                f32::from(px[2]) / 255.0,
+            ];
+            let luma = 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+            let shadow_w = 1.0 - smoothstep(0.0, 0.5, luma);
+            let highlight_w = smoothstep(0.5, 1.0, luma);
+            let mid_w = (1.0 - shadow_w - highlight_w).clamp(0.0, 1.0);
+
+            for c in 0..3 {
+                let mut v = rgb[c] + self.shadows_lift[c] * shadow_w;
+                let gval = v.clamp(0.0, 1.0).powf(1.0 / self.midtones_gamma[c]);
+                v += (gval - v) * mid_w;
+                v *= 1.0 + (self.highlights_gain[c] - 1.0) * highlight_w;
+                px[c] = (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            }
+            // alpha unchanged
+        }
+    }
+}
+
+// GPU path
+
+#[cfg(feature = "wgpu")]
+struct ColorWheelsPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buf: wgpu::Buffer,
+}
+
+#[cfg(feature = "wgpu")]
+impl ColorWheelsNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &ColorWheelsPipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("ColorWheels shader"),
+                source: wgpu::ShaderSource::Wgsl(
+                    include_str!("../shaders/color_wheels.wgsl").into(),
+                ),
+            });
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("ColorWheels BGL"),
+                entries: &[texture_entry(0), uniform_entry(1)],
+            });
+            let render_pipeline = fullscreen_pipeline(device, &shader, &bgl, "ColorWheels");
+            // Three vec3 padded to 16 bytes each (std140).
+            let uniform_buf = create_uniform(device, "ColorWheels uniforms", 48);
+            let mut bytes = [0u8; 48];
+            for (i, v) in self.shadows_lift.iter().enumerate() {
+                bytes[i * 4..i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+            }
+            for (i, v) in self.midtones_gamma.iter().enumerate() {
+                bytes[16 + i * 4..16 + i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+            }
+            for (i, v) in self.highlights_gain.iter().enumerate() {
+                bytes[32 + i * 4..32 + i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+            }
+            ctx.queue.write_buffer(&uniform_buf, 0, &bytes);
+            ColorWheelsPipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                uniform_buf,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for ColorWheelsNode {
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("ColorWheelsNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("ColorWheelsNode::process called with no outputs");
+            return;
+        };
+        let pd = self.get_or_create_pipeline(ctx);
+        let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("ColorWheels BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: pd.uniform_buf.as_entire_binding(),
+                },
+            ],
+        });
+        run_fullscreen(
+            ctx,
+            &pd.render_pipeline,
+            &bind_group,
+            &output_view,
+            "ColorWheels pass",
+        );
+    }
+}
+
+#[cfg(feature = "wgpu")]
+fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_wheels_default_should_be_noop() {
+        let node = ColorWheelsNode::default();
+        let original = vec![20u8, 20, 20, 255, 128, 128, 128, 255, 230, 230, 230, 255];
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 3, 1);
+        for (a, b) in rgba.iter().zip(original.iter()) {
+            assert!(
+                (i32::from(*a) - i32::from(*b)).abs() <= 1,
+                "default colour wheels must preserve the pixel; got {a} vs {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn color_wheels_shadow_lift_should_tint_shadows() {
+        // Magenta lift on shadows: R and B rise, G stays, on a dark pixel.
+        let node = ColorWheelsNode::new([0.1, 0.0, 0.1], [1.0; 3], [1.0; 3]);
+        let mut rgba = vec![20u8, 20, 20, 255]; // dark grey (shadow)
+        node.process_cpu(&mut rgba, 1, 1);
+        assert!(rgba[0] > 20, "shadow lift must raise R; got {}", rgba[0]);
+        assert!(rgba[2] > 20, "shadow lift must raise B; got {}", rgba[2]);
+        assert!(
+            i32::from(rgba[1]) - 20 < i32::from(rgba[0]) - 20,
+            "G must rise less than R (magenta tint)"
+        );
+    }
+
+    #[test]
+    fn color_wheels_shadow_lift_should_spare_highlights() {
+        // The same lift must barely touch a bright pixel (highlight region).
+        let node = ColorWheelsNode::new([0.1, 0.0, 0.1], [1.0; 3], [1.0; 3]);
+        let mut rgba = vec![240u8, 240, 240, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        assert!(
+            (i32::from(rgba[0]) - 240).abs() <= 3,
+            "shadow lift must not tint highlights; got {}",
+            rgba[0]
+        );
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::*;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use std::sync::Arc;
+
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    #[test]
+    fn color_wheels_gpu_shadow_lift_should_tint_shadows() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let frame = vec![20u8, 20, 20, 255];
+        let gpu = RenderGraph::new(Arc::clone(&ctx))
+            .push(ColorWheelsNode::new([0.1, 0.0, 0.1], [1.0; 3], [1.0; 3]))
+            .process_gpu(&frame, 1, 1)
+            .expect("gpu color wheels");
+        assert!(gpu[0] > 20, "shadow lift must raise R; got {}", gpu[0]);
+        assert!(gpu[2] > 20, "shadow lift must raise B; got {}", gpu[2]);
+    }
+}

--- a/crates/ff-render/src/nodes/curves.rs
+++ b/crates/ff-render/src/nodes/curves.rs
@@ -1,0 +1,447 @@
+//! Per-channel tone-curve node using a precomputed Monotone Cubic (Steffen) LUT.
+
+use super::RenderNodeCpu;
+
+#[cfg(feature = "wgpu")]
+use super::blur::{fullscreen_pipeline, run_fullscreen, texture_entry};
+
+/// Number of LUT samples per curve (matches the 256-wide LUT texture).
+const LUT_SIZE: usize = 256;
+
+// CurvesNode
+
+/// Per-channel tone curve adjustment via a precomputed 256-sample LUT.
+///
+/// Each curve is defined by control points `[input, output]` in `[0, 1]` and
+/// interpolated with the Steffen (1990) monotone cubic method (no overshoot).
+/// The master curve is applied to each channel first, then the per-channel curve.
+pub struct CurvesNode {
+    /// Control points for the master curve (applied to every channel).
+    pub master: Vec<[f32; 2]>,
+    /// Control points for the red channel curve.
+    pub red: Vec<[f32; 2]>,
+    /// Control points for the green channel curve.
+    pub green: Vec<[f32; 2]>,
+    /// Control points for the blue channel curve.
+    pub blue: Vec<[f32; 2]>,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<CurvesPipeline>,
+}
+
+impl CurvesNode {
+    /// Creates a curves node from the four channels' control points.
+    #[must_use]
+    pub fn new(
+        master: Vec<[f32; 2]>,
+        red: Vec<[f32; 2]>,
+        green: Vec<[f32; 2]>,
+        blue: Vec<[f32; 2]>,
+    ) -> Self {
+        Self {
+            master,
+            red,
+            green,
+            blue,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl Default for CurvesNode {
+    /// Identity node (linear `[(0,0),(1,1)]` on every channel).
+    fn default() -> Self {
+        let identity = || vec![[0.0, 0.0], [1.0, 1.0]];
+        Self::new(identity(), identity(), identity(), identity())
+    }
+}
+
+fn sgn(x: f32) -> f32 {
+    if x > 0.0 {
+        1.0
+    } else if x < 0.0 {
+        -1.0
+    } else {
+        0.0
+    }
+}
+
+/// Builds a `LUT_SIZE`-entry LUT (evenly spaced outputs over `[0, 1]`) from the
+/// control points using Steffen monotone cubic interpolation.
+///
+/// Points are sanitised first (clamped to `[0, 1]`, sorted by input, duplicate
+/// inputs dropped); fewer than two valid points falls back to identity, so any
+/// input, including non-monotone points, produces a LUT without panicking.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::many_single_char_names
+)]
+fn build_lut(control_points: &[[f32; 2]], samples: usize) -> Vec<f32> {
+    // Sanitise: clamp into the unit square, sort by input, drop duplicate inputs.
+    let mut pts: Vec<[f32; 2]> = control_points
+        .iter()
+        .filter(|p| p[0].is_finite() && p[1].is_finite())
+        .map(|p| [p[0].clamp(0.0, 1.0), p[1].clamp(0.0, 1.0)])
+        .collect();
+    pts.sort_by(|a, b| a[0].partial_cmp(&b[0]).unwrap_or(std::cmp::Ordering::Equal));
+    pts.dedup_by(|a, b| (a[0] - b[0]).abs() < 1e-6);
+
+    let identity = |i: usize| i as f32 / (samples - 1) as f32;
+    if pts.len() < 2 {
+        return (0..samples).map(identity).collect();
+    }
+
+    let n = pts.len();
+    let x: Vec<f32> = pts.iter().map(|p| p[0]).collect();
+    let y: Vec<f32> = pts.iter().map(|p| p[1]).collect();
+    let h: Vec<f32> = (0..n - 1).map(|i| x[i + 1] - x[i]).collect();
+    let s: Vec<f32> = (0..n - 1).map(|i| (y[i + 1] - y[i]) / h[i]).collect();
+
+    // Steffen slopes at each control point.
+    let mut yp = vec![0.0f32; n];
+    if n == 2 {
+        yp[0] = s[0];
+        yp[1] = s[0];
+    } else {
+        for i in 1..n - 1 {
+            let p = (s[i - 1] * h[i] + s[i] * h[i - 1]) / (h[i - 1] + h[i]);
+            yp[i] = (sgn(s[i - 1]) + sgn(s[i])) * s[i - 1].abs().min(s[i].abs()).min(0.5 * p.abs());
+        }
+        // Steffen one-sided endpoint derivatives.
+        let p0 = s[0] * (1.0 + h[0] / (h[0] + h[1])) - s[1] * (h[0] / (h[0] + h[1]));
+        yp[0] = if p0 * s[0] <= 0.0 {
+            0.0
+        } else if p0.abs() > 2.0 * s[0].abs() {
+            2.0 * s[0]
+        } else {
+            p0
+        };
+        let (a, b) = (h[n - 2], h[n - 3]);
+        let pn = s[n - 2] * (1.0 + a / (a + b)) - s[n - 3] * (a / (a + b));
+        yp[n - 1] = if pn * s[n - 2] <= 0.0 {
+            0.0
+        } else if pn.abs() > 2.0 * s[n - 2].abs() {
+            2.0 * s[n - 2]
+        } else {
+            pn
+        };
+    }
+
+    (0..samples)
+        .map(|i| {
+            let xi = identity(i);
+            if xi <= x[0] {
+                return y[0];
+            }
+            if xi >= x[n - 1] {
+                return y[n - 1];
+            }
+            // Locate the interval containing xi.
+            let mut k = 0;
+            while k < n - 1 && xi > x[k + 1] {
+                k += 1;
+            }
+            let t = (xi - x[k]) / h[k];
+            let t2 = t * t;
+            let t3 = t2 * t;
+            let h00 = 2.0 * t3 - 3.0 * t2 + 1.0;
+            let h10 = t3 - 2.0 * t2 + t;
+            let h01 = -2.0 * t3 + 3.0 * t2;
+            let h11 = t3 - t2;
+            (h00 * y[k] + h10 * h[k] * yp[k] + h01 * y[k + 1] + h11 * h[k] * yp[k + 1])
+                .clamp(0.0, 1.0)
+        })
+        .collect()
+}
+
+/// Nearest LUT index for a normalised value (matches `lut_idx` in curves.wgsl).
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn lut_idx(v: f32) -> usize {
+    ((v * 255.0 + 0.5) as i32).clamp(0, 255) as usize
+}
+
+// CPU path
+
+impl RenderNodeCpu for CurvesNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        let master = build_lut(&self.master, LUT_SIZE);
+        let red = build_lut(&self.red, LUT_SIZE);
+        let green = build_lut(&self.green, LUT_SIZE);
+        let blue = build_lut(&self.blue, LUT_SIZE);
+
+        for px in rgba.as_chunks_mut::<4>().0 {
+            // Master applied to each channel first, then the per-channel curve.
+            let mr = master[lut_idx(f32::from(px[0]) / 255.0)];
+            let mg = master[lut_idx(f32::from(px[1]) / 255.0)];
+            let mb = master[lut_idx(f32::from(px[2]) / 255.0)];
+            px[0] = (red[lut_idx(mr)] * 255.0 + 0.5) as u8;
+            px[1] = (green[lut_idx(mg)] * 255.0 + 0.5) as u8;
+            px[2] = (blue[lut_idx(mb)] * 255.0 + 0.5) as u8;
+            // alpha unchanged
+        }
+    }
+}
+
+// GPU path
+
+#[cfg(feature = "wgpu")]
+struct CurvesPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    lut_texture: wgpu::Texture,
+}
+
+#[cfg(feature = "wgpu")]
+impl CurvesNode {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &CurvesPipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+            let red = build_lut(&self.red, LUT_SIZE);
+            let green = build_lut(&self.green, LUT_SIZE);
+            let blue = build_lut(&self.blue, LUT_SIZE);
+            let master = build_lut(&self.master, LUT_SIZE);
+            // Pack as RGBA texels: R=red, G=green, B=blue, A=master.
+            let mut texels = vec![0u8; LUT_SIZE * 4];
+            for i in 0..LUT_SIZE {
+                texels[i * 4] = (red[i] * 255.0 + 0.5) as u8;
+                texels[i * 4 + 1] = (green[i] * 255.0 + 0.5) as u8;
+                texels[i * 4 + 2] = (blue[i] * 255.0 + 0.5) as u8;
+                texels[i * 4 + 3] = (master[i] * 255.0 + 0.5) as u8;
+            }
+
+            let lut_texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("Curves LUT"),
+                size: wgpu::Extent3d {
+                    width: LUT_SIZE as u32,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+            ctx.queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &lut_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &texels,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(LUT_SIZE as u32 * 4),
+                    rows_per_image: None,
+                },
+                wgpu::Extent3d {
+                    width: LUT_SIZE as u32,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+            );
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Curves shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/curves.wgsl").into()),
+            });
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Curves BGL"),
+                entries: &[texture_entry(0), texture_entry(1)],
+            });
+            let render_pipeline = fullscreen_pipeline(device, &shader, &bgl, "Curves");
+
+            CurvesPipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                lut_texture,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for CurvesNode {
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("CurvesNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("CurvesNode::process called with no outputs");
+            return;
+        };
+        let pd = self.get_or_create_pipeline(ctx);
+        let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+        let lut_view = pd
+            .lut_texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Curves BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&lut_view),
+                },
+            ],
+        });
+        run_fullscreen(
+            ctx,
+            &pd.render_pipeline,
+            &bind_group,
+            &output_view,
+            "Curves pass",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> Vec<[f32; 2]> {
+        vec![[0.0, 0.0], [1.0, 1.0]]
+    }
+
+    #[test]
+    fn build_lut_identity_should_be_linear() {
+        let lut = build_lut(&identity(), LUT_SIZE);
+        for (i, &v) in lut.iter().enumerate() {
+            let expected = i as f32 / 255.0;
+            assert!(
+                (v - expected).abs() < 1e-3,
+                "identity LUT[{i}] must be {expected}; got {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_lut_should_stay_within_unit_range() {
+        // Non-monotone control points must not overshoot [0, 1] or panic.
+        let lut = build_lut(&[[0.0, 0.0], [0.3, 0.9], [0.6, 0.1], [1.0, 1.0]], LUT_SIZE);
+        assert_eq!(lut.len(), LUT_SIZE);
+        for &v in &lut {
+            assert!((0.0..=1.0).contains(&v), "LUT value out of range: {v}");
+        }
+    }
+
+    #[test]
+    fn curves_identity_should_be_noop() {
+        let node = CurvesNode::default();
+        let original = vec![10u8, 128, 220, 255, 60, 90, 200, 255];
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 2, 1);
+        for (a, b) in rgba.iter().zip(original.iter()) {
+            assert!(
+                (i32::from(*a) - i32::from(*b)).abs() <= 1,
+                "identity curves must preserve the pixel; got {a} vs {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn curves_lifted_midtones_should_brighten_grey() {
+        let node = CurvesNode::new(
+            vec![[0.0, 0.0], [0.5, 0.7], [1.0, 1.0]],
+            identity(),
+            identity(),
+            identity(),
+        );
+        let mut rgba = vec![128u8, 128, 128, 255]; // 50% grey
+        node.process_cpu(&mut rgba, 1, 1);
+        assert!(
+            rgba[0] > 150,
+            "lifted midtones must brighten 50% grey; got {}",
+            rgba[0]
+        );
+    }
+
+    #[test]
+    fn curves_non_monotone_input_should_not_panic() {
+        // Unsorted, non-monotone points must be handled without panicking.
+        let node = CurvesNode::new(
+            vec![[1.0, 0.2], [0.0, 0.8], [0.5, 0.5]],
+            identity(),
+            identity(),
+            identity(),
+        );
+        let mut rgba = vec![100u8, 150, 200, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::*;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use std::sync::Arc;
+
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    fn identity() -> Vec<[f32; 2]> {
+        vec![[0.0, 0.0], [1.0, 1.0]]
+    }
+
+    #[test]
+    fn curves_gpu_lifted_midtones_should_brighten_grey() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let frame = vec![128u8, 128, 128, 255];
+        let gpu = RenderGraph::new(Arc::clone(&ctx))
+            .push(CurvesNode::new(
+                vec![[0.0, 0.0], [0.5, 0.7], [1.0, 1.0]],
+                identity(),
+                identity(),
+                identity(),
+            ))
+            .process_gpu(&frame, 1, 1)
+            .expect("gpu curves");
+        assert!(
+            gpu[0] > 150,
+            "GPU lifted midtones must brighten 50% grey; got {}",
+            gpu[0]
+        );
+    }
+
+    #[test]
+    fn curves_gpu_identity_should_preserve_input() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let frame = vec![10u8, 128, 220, 255];
+        let gpu = RenderGraph::new(Arc::clone(&ctx))
+            .push(CurvesNode::default())
+            .process_gpu(&frame, 1, 1)
+            .expect("gpu curves");
+        for i in 0..3 {
+            assert!(
+                (i32::from(gpu[i]) - i32::from(frame[i])).abs() <= 2,
+                "identity curves must preserve the input on the GPU path"
+            );
+        }
+    }
+}

--- a/crates/ff-render/src/nodes/hsl.rs
+++ b/crates/ff-render/src/nodes/hsl.rs
@@ -1,0 +1,299 @@
+//! Hue / saturation / lightness adjustment node.
+
+use super::RenderNodeCpu;
+
+#[cfg(feature = "wgpu")]
+use super::blur::{create_uniform, fullscreen_pipeline, run_fullscreen, texture_entry};
+
+// HslNode
+
+/// Hue, saturation, and lightness adjustment.
+pub struct HslNode {
+    /// Hue rotation in degrees (−180 to +180; 0 = no change).
+    pub hue_shift: f32,
+    /// Saturation multiplier (0.0 = greyscale, 1.0 = unchanged, 2.0 = double).
+    pub saturation: f32,
+    /// Lightness offset (−1.0 to +1.0; 0 = no change).
+    pub lightness: f32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<HslPipeline>,
+}
+
+impl HslNode {
+    /// Creates an HSL adjustment node.
+    #[must_use]
+    pub fn new(hue_shift: f32, saturation: f32, lightness: f32) -> Self {
+        Self {
+            hue_shift,
+            saturation,
+            lightness,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl Default for HslNode {
+    /// Identity node (no HSL change).
+    fn default() -> Self {
+        Self::new(0.0, 1.0, 0.0)
+    }
+}
+
+// Shared RGB <-> HSL (kept in sync with hsl.wgsl for GPU/CPU agreement).
+
+/// Converts RGB (each in `[0, 1]`) to HSL with hue in `[0, 1)`.
+// Exact `==` on the max channel is intentional: it picks which channel defines
+// the hue sector, exactly as the WGSL shader does.
+#[allow(clippy::float_cmp, clippy::many_single_char_names)]
+fn rgb_to_hsl(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
+    let mx = r.max(g).max(b);
+    let mn = r.min(g).min(b);
+    let l = f32::midpoint(mx, mn);
+    let d = mx - mn;
+    if d < 1e-6 {
+        return (0.0, 0.0, l);
+    }
+    let s = d / (1.0 - (2.0 * l - 1.0).abs());
+    let mut h = if mx == r {
+        let hh = (g - b) / d;
+        hh - 6.0 * (hh / 6.0).floor()
+    } else if mx == g {
+        (b - r) / d + 2.0
+    } else {
+        (r - g) / d + 4.0
+    };
+    h /= 6.0;
+    (h, s, l)
+}
+
+fn hue_to_rgb(p: f32, q: f32, t_in: f32) -> f32 {
+    let t = t_in - t_in.floor();
+    if t < 1.0 / 6.0 {
+        p + (q - p) * 6.0 * t
+    } else if t < 0.5 {
+        q
+    } else if t < 2.0 / 3.0 {
+        p + (q - p) * (2.0 / 3.0 - t) * 6.0
+    } else {
+        p
+    }
+}
+
+/// Converts HSL (hue in `[0, 1)`) back to RGB (each in `[0, 1]`).
+#[allow(clippy::many_single_char_names)]
+fn hsl_to_rgb(h: f32, s: f32, l: f32) -> (f32, f32, f32) {
+    if s < 1e-6 {
+        return (l, l, l);
+    }
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+    (
+        hue_to_rgb(p, q, h + 1.0 / 3.0),
+        hue_to_rgb(p, q, h),
+        hue_to_rgb(p, q, h - 1.0 / 3.0),
+    )
+}
+
+// CPU path
+
+impl RenderNodeCpu for HslNode {
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::many_single_char_names
+    )]
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        for px in rgba.as_chunks_mut::<4>().0 {
+            let (h, s, l) = rgb_to_hsl(
+                f32::from(px[0]) / 255.0,
+                f32::from(px[1]) / 255.0,
+                f32::from(px[2]) / 255.0,
+            );
+            let h = h + self.hue_shift / 360.0;
+            let s = (s * self.saturation).clamp(0.0, 1.0);
+            let l = (l + self.lightness).clamp(0.0, 1.0);
+            let (r, g, b) = hsl_to_rgb(h - h.floor(), s, l);
+            px[0] = (r.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            px[1] = (g.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            px[2] = (b.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            // alpha unchanged
+        }
+    }
+}
+
+// GPU path
+
+#[cfg(feature = "wgpu")]
+struct HslPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buf: wgpu::Buffer,
+}
+
+#[cfg(feature = "wgpu")]
+impl HslNode {
+    fn get_or_create_pipeline(&self, ctx: &crate::context::RenderContext) -> &HslPipeline {
+        self.pipeline.get_or_init(|| {
+            let device = &ctx.device;
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Hsl shader"),
+                source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/hsl.wgsl").into()),
+            });
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Hsl BGL"),
+                entries: &[texture_entry(0), uniform_entry(1)],
+            });
+            let render_pipeline = fullscreen_pipeline(device, &shader, &bgl, "Hsl");
+            let uniform_buf = create_uniform(device, "Hsl uniforms", 16);
+            let mut bytes = [0u8; 16];
+            bytes[0..4].copy_from_slice(&self.hue_shift.to_le_bytes());
+            bytes[4..8].copy_from_slice(&self.saturation.to_le_bytes());
+            bytes[8..12].copy_from_slice(&self.lightness.to_le_bytes());
+            ctx.queue.write_buffer(&uniform_buf, 0, &bytes);
+            HslPipeline {
+                render_pipeline,
+                bind_group_layout: bgl,
+                uniform_buf,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for HslNode {
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(input) = inputs.first() else {
+            log::warn!("HslNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("HslNode::process called with no outputs");
+            return;
+        };
+        let pd = self.get_or_create_pipeline(ctx);
+        let input_view = input.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Hsl BG"),
+            layout: &pd.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: pd.uniform_buf.as_entire_binding(),
+                },
+            ],
+        });
+        run_fullscreen(
+            ctx,
+            &pd.render_pipeline,
+            &bind_group,
+            &output_view,
+            "Hsl pass",
+        );
+    }
+}
+
+#[cfg(feature = "wgpu")]
+fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid(v: [u8; 3]) -> Vec<u8> {
+        vec![v[0], v[1], v[2], 255]
+    }
+
+    #[test]
+    fn hsl_hue_shift_180_should_invert_red_to_cyan() {
+        let node = HslNode::new(180.0, 1.0, 0.0);
+        let mut rgba = solid([255, 0, 0]); // pure red
+        node.process_cpu(&mut rgba, 1, 1);
+        // Red (H=0) rotated 180 deg is cyan (H=0.5): low R, high G and B.
+        assert!(rgba[0] < 40, "R must drop for cyan; got {}", rgba[0]);
+        assert!(rgba[1] > 215, "G must rise for cyan; got {}", rgba[1]);
+        assert!(rgba[2] > 215, "B must rise for cyan; got {}", rgba[2]);
+    }
+
+    #[test]
+    fn hsl_saturation_zero_should_greyscale() {
+        let node = HslNode::new(0.0, 0.0, 0.0);
+        let mut rgba = solid([200, 100, 50]);
+        node.process_cpu(&mut rgba, 1, 1);
+        let d_rg = (i32::from(rgba[0]) - i32::from(rgba[1])).abs();
+        let d_rb = (i32::from(rgba[0]) - i32::from(rgba[2])).abs();
+        assert!(
+            d_rg <= 1 && d_rb <= 1,
+            "saturation 0 must equalise channels"
+        );
+    }
+
+    #[test]
+    fn hsl_default_should_be_identity() {
+        let node = HslNode::default();
+        let original = solid([200, 100, 50]);
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        for (a, b) in rgba.iter().zip(original.iter()) {
+            assert!(
+                (i32::from(*a) - i32::from(*b)).abs() <= 1,
+                "default HSL must preserve the pixel; got {a} vs {b}"
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::*;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use std::sync::Arc;
+
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    #[test]
+    fn hsl_gpu_hue_shift_180_should_invert_red_to_cyan() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let frame = vec![255u8, 0, 0, 255];
+        let gpu = RenderGraph::new(Arc::clone(&ctx))
+            .push(HslNode::new(180.0, 1.0, 0.0))
+            .process_gpu(&frame, 1, 1)
+            .expect("gpu hsl");
+        assert!(gpu[0] < 40, "R must drop for cyan; got {}", gpu[0]);
+        assert!(gpu[1] > 215, "G must rise for cyan; got {}", gpu[1]);
+        assert!(gpu[2] > 215, "B must rise for cyan; got {}", gpu[2]);
+    }
+}

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -1,9 +1,12 @@
 pub mod blur;
 pub mod color_grade;
+pub mod color_wheels;
 pub mod composite;
 pub mod crossfade;
+pub mod curves;
 pub mod film_grain;
 pub mod glow;
+pub mod hsl;
 pub mod overlay;
 pub mod scale;
 pub mod upload;
@@ -11,13 +14,16 @@ pub mod vignette;
 
 pub use blur::{GaussianBlurNode, SharpenNode};
 pub use color_grade::ColorGradeNode;
+pub use color_wheels::ColorWheelsNode;
 pub use composite::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, LumaMaskNode, ShapeMaskNode,
     TransformNode,
 };
 pub use crossfade::CrossfadeNode;
+pub use curves::CurvesNode;
 pub use film_grain::FilmGrainNode;
 pub use glow::GlowNode;
+pub use hsl::HslNode;
 pub use overlay::OverlayNode;
 pub use scale::{ScaleAlgorithm, ScaleNode};
 pub use upload::{YuvFormat, YuvUploadNode};

--- a/crates/ff-render/src/shaders/color_wheels.wgsl
+++ b/crates/ff-render/src/shaders/color_wheels.wgsl
@@ -1,0 +1,60 @@
+// Three-way colour corrector: shadows lift, midtones gamma, highlights gain.
+// Each adjustment is weighted by a luminance region (shadows = low luma,
+// midtones = mid luma, highlights = high luma) so the wheels affect their
+// tonal range. Applied in sequence lift -> gamma -> gain, per channel.
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> u: ColorWheelsUniforms;
+
+// Matches Rust ColorWheelsUniforms (each vec3 padded to 16 bytes for std140).
+struct ColorWheelsUniforms {
+    shadows_lift:    vec3<f32>,
+    _p0:             f32,
+    midtones_gamma:  vec3<f32>,
+    _p1:             f32,
+    highlights_gain: vec3<f32>,
+    _p2:             f32,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let color = textureLoad(input_tex, vec2<i32>(in.position.xy), 0);
+    let luma = dot(color.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
+
+    let shadow_w = 1.0 - smoothstep(0.0, 0.5, luma);
+    let highlight_w = smoothstep(0.5, 1.0, luma);
+    let mid_w = clamp(1.0 - shadow_w - highlight_w, 0.0, 1.0);
+
+    var rgb = color.rgb;
+    // Lift (shadows): additive.
+    rgb = rgb + u.shadows_lift * shadow_w;
+    // Gamma (midtones): blended toward the gamma-corrected value.
+    let gamma_rgb = pow(clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0)), 1.0 / u.midtones_gamma);
+    rgb = mix(rgb, gamma_rgb, mid_w);
+    // Gain (highlights): multiplicative.
+    rgb = rgb * (vec3<f32>(1.0) + (u.highlights_gain - 1.0) * highlight_w);
+
+    rgb = clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0));
+    return vec4<f32>(rgb, color.a);
+}

--- a/crates/ff-render/src/shaders/curves.wgsl
+++ b/crates/ff-render/src/shaders/curves.wgsl
@@ -1,0 +1,49 @@
+// Per-channel tone curve via a precomputed 256-sample LUT texture. The 256x1
+// Rgba8Unorm LUT holds four curves: R=red, G=green, B=blue, A=master. The master
+// curve is applied to each channel first, then the per-channel curve (Photoshop
+// convention). Nearest lookup: idx = round(value * 255).
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var lut: texture_2d<f32>;   // 256x1 RGBA LUT
+
+fn lut_idx(value: f32) -> i32 {
+    return clamp(i32(value * 255.0 + 0.5), 0, 255);
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let color = textureLoad(input_tex, vec2<i32>(in.position.xy), 0);
+
+    // Master (A channel) applied to each channel first.
+    let mr = textureLoad(lut, vec2<i32>(lut_idx(color.r), 0), 0).a;
+    let mg = textureLoad(lut, vec2<i32>(lut_idx(color.g), 0), 0).a;
+    let mb = textureLoad(lut, vec2<i32>(lut_idx(color.b), 0), 0).a;
+
+    // Then the per-channel curve.
+    let r = textureLoad(lut, vec2<i32>(lut_idx(mr), 0), 0).r;
+    let g = textureLoad(lut, vec2<i32>(lut_idx(mg), 0), 0).g;
+    let b = textureLoad(lut, vec2<i32>(lut_idx(mb), 0), 0).b;
+
+    return vec4<f32>(r, g, b, color.a);
+}

--- a/crates/ff-render/src/shaders/hsl.wgsl
+++ b/crates/ff-render/src/shaders/hsl.wgsl
@@ -1,0 +1,95 @@
+// Hue / saturation / lightness adjustment. Converts the stored RGB to HSL,
+// applies a hue rotation, a saturation multiplier, and a lightness offset, then
+// converts back. Operates on the stored (non-linearised) values, matching the
+// other colour nodes.
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> u: HslUniforms;
+
+// Matches Rust HslUniforms (field order/size kept in sync).
+struct HslUniforms {
+    hue_shift:  f32,   // degrees, -180..180
+    saturation: f32,   // multiplier (0 = grey, 1 = unchanged)
+    lightness:  f32,   // additive offset, -1..1
+    _pad:       f32,
+}
+
+fn rgb_to_hsl(c: vec3<f32>) -> vec3<f32> {
+    let mx = max(c.r, max(c.g, c.b));
+    let mn = min(c.r, min(c.g, c.b));
+    let l = (mx + mn) * 0.5;
+    let d = mx - mn;
+    if (d < 1e-6) {
+        return vec3<f32>(0.0, 0.0, l);
+    }
+    let s = d / (1.0 - abs(2.0 * l - 1.0));
+    var h = 0.0;
+    if (mx == c.r) {
+        h = (c.g - c.b) / d;
+        h = h - 6.0 * floor(h / 6.0);   // modulo 6
+    } else if (mx == c.g) {
+        h = (c.b - c.r) / d + 2.0;
+    } else {
+        h = (c.r - c.g) / d + 4.0;
+    }
+    return vec3<f32>(h / 6.0, s, l);   // h in [0,1)
+}
+
+fn hue_to_rgb(p: f32, q: f32, t_in: f32) -> f32 {
+    var t = t_in - floor(t_in);   // wrap to [0,1)
+    if (t < 1.0 / 6.0) { return p + (q - p) * 6.0 * t; }
+    if (t < 0.5)       { return q; }
+    if (t < 2.0 / 3.0) { return p + (q - p) * (2.0 / 3.0 - t) * 6.0; }
+    return p;
+}
+
+fn hsl_to_rgb(hsl: vec3<f32>) -> vec3<f32> {
+    let h = hsl.x;
+    let s = hsl.y;
+    let l = hsl.z;
+    if (s < 1e-6) {
+        return vec3<f32>(l, l, l);
+    }
+    var q = l + s - l * s;
+    if (l < 0.5) {
+        q = l * (1.0 + s);
+    }
+    let p = 2.0 * l - q;
+    return vec3<f32>(
+        hue_to_rgb(p, q, h + 1.0 / 3.0),
+        hue_to_rgb(p, q, h),
+        hue_to_rgb(p, q, h - 1.0 / 3.0),
+    );
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let color = textureLoad(input_tex, vec2<i32>(in.position.xy), 0);
+    var hsl = rgb_to_hsl(color.rgb);
+    hsl.x = hsl.x + u.hue_shift / 360.0;
+    hsl.y = clamp(hsl.y * u.saturation, 0.0, 1.0);
+    hsl.z = clamp(hsl.z + u.lightness, 0.0, 1.0);
+    let rgb = hsl_to_rgb(hsl);
+    return vec4<f32>(rgb, color.a);
+}


### PR DESCRIPTION
## Objective

- Extend the ff-render effect stack with the colour-science trio (Phase 3).
- Provide both a CPU fallback and a GPU path for each, consistent with the existing nodes.

## Solution

- Add `HslNode { hue_shift, saturation, lightness }`: hue rotation, saturation multiplier, and lightness offset via an RGB<->HSL round-trip.
- Add `CurvesNode { master, red, green, blue }`: per-channel tone curves through a 256-sample LUT built with Steffen (1990) monotone cubic interpolation (no overshoot). Control points are sanitised (clamped, sorted, de-duplicated) so non-monotone input produces a LUT without panicking. On the GPU the four channel LUTs are packed into a lazily-built 256x1 `Rgba8Unorm` texture; the master curve applies to each channel first, then the per-channel curve.
- Add `ColorWheelsNode { shadows_lift, midtones_gamma, highlights_gain }`: a three-way corrector, each adjustment weighted by a luminance region so it acts on its tonal range.
- Re-export all three at the ff-render crate root.
- Cover the acceptance criteria with CPU unit tests and adapter-gated GPU tests (hue inversion red->cyan, identity curves no-op, lifted midtones brighten grey, non-monotone points do not panic, shadow lift tints only shadows).

Closes #1047