### PR TITLE
feat(avio): typed Sharpen clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -59,7 +59,8 @@ impl Param {
 /// A typed effect that a clip can carry. `#[non_exhaustive]`: more kinds are added
 /// over time, so external matchers must include a `_` arm.
 ///
-/// The v1 curated set is [`ColorCorrect`](Self::ColorCorrect) and [`Blur`](Self::Blur).
+/// The v1 curated set is [`ColorCorrect`](Self::ColorCorrect), [`Blur`](Self::Blur),
+/// and [`Sharpen`](Self::Sharpen).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
@@ -80,6 +81,17 @@ pub enum EffectKind {
     Blur {
         /// Blur radius (standard deviation). Must be ≥ 0.0.
         radius: Param,
+    },
+    /// Unsharp-mask sharpen (the `unsharp` filter on the CPU path,
+    /// `ff_render::SharpenNode` on the GPU).
+    ///
+    /// A single luma sharpening amount in `[−1.5, 1.5]` (negative blurs). Because
+    /// `FFmpeg`'s `unsharp` has no runtime-settable parameter, an animated `amount`
+    /// animates on the GPU-default path but renders its `t = 0` value on the CPU
+    /// fallback.
+    Sharpen {
+        /// Sharpening amount (luma). Range −1.5..=1.5 (neutral: 0.0).
+        amount: Param,
     },
 }
 
@@ -134,6 +146,20 @@ impl EffectKind {
                 Param::Const(v) => FilterStep::GBlur { sigma: *v as f32 },
                 Param::Animated(_) => FilterStep::GBlurAnimated {
                     sigma: radius.to_animated(),
+                },
+            }),
+            // Sharpen maps to `unsharp` (chroma left neutral): the GPU
+            // `SharpenNode` is a luma-style unsharp mask. An animated amount
+            // becomes `UnsharpAnimated` (which the GPU animates per frame; the CPU
+            // renders its `t = 0` value, `unsharp` having no runtime parameter).
+            EffectKind::Sharpen { amount } => Some(match amount {
+                Param::Const(v) => FilterStep::Unsharp {
+                    luma_strength: *v as f32,
+                    chroma_strength: 0.0,
+                },
+                Param::Animated(_) => FilterStep::UnsharpAnimated {
+                    luma_strength: amount.to_animated(),
+                    chroma_strength: AnimatedValue::Static(0.0),
                 },
             }),
         }
@@ -249,6 +275,34 @@ mod tests {
         assert!(matches!(
             kind.to_filter_step(),
             Some(FilterStep::GBlurAnimated { .. })
+        ));
+    }
+
+    #[test]
+    fn sharpen_const_should_compile_to_unsharp_with_neutral_chroma() {
+        let kind = EffectKind::Sharpen {
+            amount: Param::Const(1.0),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Unsharp {
+                luma_strength,
+                chroma_strength,
+            } => {
+                assert!((luma_strength - 1.0).abs() < 1e-6);
+                assert!((chroma_strength - 0.0).abs() < 1e-6, "chroma stays neutral");
+            }
+            other => panic!("expected Unsharp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sharpen_animated_should_compile_to_unsharp_animated() {
+        let kind = EffectKind::Sharpen {
+            amount: Param::Animated(animated_track()),
+        };
+        assert!(matches!(
+            kind.to_filter_step(),
+            Some(FilterStep::UnsharpAnimated { .. })
         ));
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -206,7 +206,21 @@ pub enum GpuEffect {
         /// `gblur` filter uses on the CPU path.
         sigma: f32,
     },
+    /// `ff_render::SharpenNode` (unsharp-mask sharpen).
+    Sharpen {
+        /// Unsharp-mask blur radius (sigma). Fixed to [`DEFAULT_SHARPEN_RADIUS`]:
+        /// the `unsharp` filter carries no radius (a fixed 5×5 mask), so the GPU
+        /// node uses a constant that approximates it.
+        radius: f32,
+        /// Sharpening amount (the `unsharp` luma amount).
+        strength: f32,
+    },
 }
+
+/// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
+/// has no radius option (a fixed 5×5 luma mask), so the GPU path approximates it
+/// with this constant; the parity tolerance absorbs the small kernel difference.
+const DEFAULT_SHARPEN_RADIUS: f32 = 1.0;
 
 /// One layer of a [`GpuScenePlan`]: the transform / blend / opacity the
 /// `ff_render::Compositor` needs, plus the per-layer effect nodes to run before
@@ -336,7 +350,9 @@ enum StepClass {
     Unsupported,
 }
 
-#[allow(clippy::cast_possible_truncation)]
+// `chroma != 0.0` compares against the neutral sentinel our mapping always emits,
+// so an exact float comparison is intended here.
+#[allow(clippy::cast_possible_truncation, clippy::float_cmp)]
 fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
     match step {
         // Temporal / decode-scheduling steps are applied upstream (the GPU path
@@ -392,6 +408,36 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             // an animated sigma is evaluated at the frame time here.
             sigma: sigma.value_at(t) as f32,
         }),
+        // The GPU SharpenNode is luma-only; a non-zero chroma amount cannot be
+        // represented, so it falls back rather than silently drop it (RK-020).
+        FilterStep::Unsharp {
+            luma_strength,
+            chroma_strength,
+        } => {
+            if *chroma_strength != 0.0 {
+                StepClass::Unsupported
+            } else {
+                StepClass::Effect(GpuEffect::Sharpen {
+                    radius: DEFAULT_SHARPEN_RADIUS,
+                    strength: *luma_strength,
+                })
+            }
+        }
+        FilterStep::UnsharpAnimated {
+            luma_strength,
+            chroma_strength,
+        } => {
+            if chroma_strength.value_at(t) != 0.0 {
+                StepClass::Unsupported
+            } else {
+                // Rebuilt per frame (map_scene runs per frame), so the animated
+                // amount is evaluated at the frame time here.
+                StepClass::Effect(GpuEffect::Sharpen {
+                    radius: DEFAULT_SHARPEN_RADIUS,
+                    strength: luma_strength.value_at(t) as f32,
+                })
+            }
+        }
         // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
         // `#[non_exhaustive]` from ff-filter (RK-003).
@@ -658,6 +704,59 @@ mod tests {
         assert!(
             (sigma - 4.0).abs() < 1e-3,
             "animated sigma at t=1s should be ~4; got {sigma}"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_unsharp_to_sharpen() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Unsharp {
+            luma_strength: 0.8,
+            chroma_strength: 0.0,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::Sharpen {
+                radius: DEFAULT_SHARPEN_RADIUS,
+                strength: 0.8,
+            }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_evaluate_animated_unsharp_amount_at_t() {
+        // amount ramps 0.2 -> 0.6 over 0..2s; at t=1s it should read ~0.4.
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.2, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 0.6, Easing::Linear));
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::UnsharpAnimated {
+            luma_strength: AnimatedValue::Track(track),
+            chroma_strength: AnimatedValue::Static(0.0),
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::from_secs(1)));
+        let [GpuEffect::Sharpen { strength, .. }] = plan.layers[0].effects.as_slice() else {
+            panic!("animated unsharp must map to a single Sharpen effect");
+        };
+        assert!(
+            (strength - 0.4).abs() < 1e-3,
+            "animated amount at t=1s should be ~0.4; got {strength}"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_fall_back_on_unsharp_with_chroma() {
+        // A non-zero chroma amount cannot be represented by the luma-only GPU node,
+        // so the whole frame must fall back rather than drop the chroma (RK-020).
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Unsharp {
+            luma_strength: 0.5,
+            chroma_strength: 0.5,
+        }];
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
         );
     }
 

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -208,7 +208,7 @@ pub enum GpuEffect {
     },
     /// `ff_render::SharpenNode` (unsharp-mask sharpen).
     Sharpen {
-        /// Unsharp-mask blur radius (sigma). Fixed to [`DEFAULT_SHARPEN_RADIUS`]:
+        /// Unsharp-mask blur radius (sigma). Fixed to `DEFAULT_SHARPEN_RADIUS`:
         /// the `unsharp` filter carries no radius (a fixed 5×5 mask), so the GPU
         /// node uses a constant that approximates it.
         radius: f32,

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use ff_format::VideoFrame;
 use ff_render::{
     ColorGradeNode, Compositor, FrameLayer, GaussianBlurNode, LayerTransform, RenderContext,
-    RenderGraph, ScaleNode,
+    RenderGraph, ScaleNode, SharpenNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -162,6 +162,10 @@ impl GpuCompositor {
                 }
                 // Blur preserves the frame dimensions, so out_w/out_h are unchanged.
                 GpuEffect::Blur { sigma } => graph.push(GaussianBlurNode::new(*sigma)),
+                // Sharpen preserves the frame dimensions too.
+                GpuEffect::Sharpen { radius, strength } => {
+                    graph.push(SharpenNode::new(*radius, *strength))
+                }
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -40,6 +40,10 @@ use ff_preview::FrameSink;
 const TOL_PASSTHROUGH_MEAN: f64 = 2.0; // identity passthrough: pixel-exact here
 const TOL_COLOR_GRADE_MEAN: f64 = 20.0; // GPU ColorGradeNode vs FFmpeg `eq`: ~6.6 here
 const TOL_BLUR_MEAN: f64 = 20.0; // GPU GaussianBlurNode vs FFmpeg `gblur`: ~9.0 here (different kernels)
+// GPU SharpenNode (RGB, fixed sigma) vs FFmpeg `unsharp` (luma-only, 5x5): ~0.7 here
+// (effect vs input ~7.9). Grey-calibrated: the test image is achromatic (R=G=B), where
+// an all-RGB node and a luma-only filter coincide; colored edges would diverge more.
+const TOL_SHARPEN_MEAN: f64 = 5.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -254,6 +258,66 @@ fn blur_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_BLUR_MEAN,
         "GPU and CPU blur diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn sharpen_gpu_should_match_cpu_within_tolerance() {
+    // Sharpen parity: GPU SharpenNode (map_scene maps `Unsharp`, luma-only, fixed
+    // sigma) vs the CPU `unsharp` filter (YUV, 5x5). The algorithms differ, so a
+    // loose calibrated tolerance. Double-gated (adapter + filters).
+    //
+    // A *mid-tone* checkerboard (90/160, not 0/255): a pure black/white board is
+    // saturated, so an unsharp overshoot clamps and the effect is a no-op (a vacuous
+    // test). Mid-tone edges have headroom, so sharpening visibly overshoots them and
+    // a GPU that did not sharpen would diverge (non-vacuous, RK-015).
+    let (w, h) = (64, 48);
+    let mut mid = vec![0u8; (w * h * 4) as usize];
+    for (i, px) in mid.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+        let x = i as u32 % w;
+        let y = i as u32 / w;
+        let v = if (x / 8 + y / 8) % 2 == 0 {
+            90u8
+        } else {
+            160u8
+        };
+        *px = [v, v, v, 255];
+    }
+    let input = mid.clone();
+    let frame = VideoFrame::from_rgba(w, h, mid).unwrap();
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::Unsharp {
+            luma_strength: 0.8,
+            chroma_strength: 0.0,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported sharpen layer must composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    let effect = mean_abs_diff_rgb(&gpu_out, &input);
+    println!(
+        "sharpen GPU vs CPU: mean={mean:.3} max={} (GPU vs input: {effect:.3})",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    // Non-vacuous (RK-015): the sharpen must actually change the frame, so a GPU that
+    // silently skipped it would fail here even though the flat regions match the CPU.
+    assert!(
+        effect > 1.0,
+        "the GPU sharpen must visibly alter the mid-tone edges; got {effect}"
+    );
+    assert!(
+        mean <= TOL_SHARPEN_MEAN,
+        "GPU and CPU sharpen diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -198,6 +198,24 @@ impl FilterGraphBuilder {
                     });
                 }
             }
+            if let FilterStep::UnsharpAnimated {
+                luma_strength,
+                chroma_strength,
+            } = step
+            {
+                let l0 = luma_strength.value_at(Duration::ZERO);
+                let c0 = chroma_strength.value_at(Duration::ZERO);
+                if !(-1.5..=1.5).contains(&l0) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("unsharp luma_strength {l0} out of range [-1.5, 1.5]"),
+                    });
+                }
+                if !(-1.5..=1.5).contains(&c0) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("unsharp chroma_strength {c0} out of range [-1.5, 1.5]"),
+                    });
+                }
+            }
             if let FilterStep::EqAnimated {
                 brightness,
                 contrast,

--- a/crates/ff-filter/src/graph/builder/video/effects.rs
+++ b/crates/ff-filter/src/graph/builder/video/effects.rs
@@ -74,6 +74,30 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Sharpen or blur via unsharp mask with an optionally animated amount.
+    ///
+    /// Unlike [`gblur_animated`](Self::gblur_animated), no animation entry is
+    /// registered: `FFmpeg`'s `unsharp` has no runtime-settable parameter, so on the
+    /// `libavfilter` path the `Duration::ZERO` value renders statically (the GPU
+    /// bridge animates it per frame instead).
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if either
+    /// value evaluates outside `[−1.5, 1.5]` at `Duration::ZERO`.
+    #[must_use]
+    pub fn unsharp_animated(
+        mut self,
+        luma_strength: AnimatedValue<f64>,
+        chroma_strength: AnimatedValue<f64>,
+    ) -> Self {
+        self.steps.push(FilterStep::UnsharpAnimated {
+            luma_strength,
+            chroma_strength,
+        });
+        self
+    }
+
     /// Apply High Quality 3D (`hqdn3d`) noise reduction.
     ///
     /// Typical values: `luma_spatial=4.0`, `chroma_spatial=3.0`,
@@ -513,6 +537,38 @@ mod tests {
                 "reason should mention sigma: {reason}"
             );
         }
+    }
+
+    #[test]
+    fn unsharp_animated_static_value_should_produce_correct_args() {
+        let step = FilterStep::UnsharpAnimated {
+            luma_strength: AnimatedValue::Static(1.0_f64),
+            chroma_strength: AnimatedValue::Static(0.5_f64),
+        };
+        assert_eq!(step.filter_name(), "unsharp");
+        let args = step.args();
+        assert!(
+            args.contains("luma_amount=1") && args.contains("chroma_amount=0.5"),
+            "args must carry the ZERO-time amounts: {args}"
+        );
+        assert!(
+            args.contains("luma_msize_x=5"),
+            "args must set the mask size: {args}"
+        );
+    }
+
+    #[test]
+    fn unsharp_animated_with_luma_out_of_range_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .unsharp_animated(
+                AnimatedValue::Static(2.0_f64),
+                AnimatedValue::Static(0.0_f64),
+            )
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for luma > 1.5, got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -301,6 +301,20 @@ pub enum FilterStep {
         /// Chroma (colour) sharpening/blurring amount. Range: −1.5 – 1.5.
         chroma_strength: f32,
     },
+    /// Unsharp mask with an optionally animated luma/chroma amount.
+    ///
+    /// Arguments are evaluated at [`Duration::ZERO`] for the graph build. Unlike
+    /// [`GBlurAnimated`](Self::GBlurAnimated), `FFmpeg`'s `unsharp` exposes **no
+    /// runtime-settable parameter** (verified against the pinned 7.1/8.0 source),
+    /// so it cannot be driven by `send_command` and it has no per-frame expression.
+    /// On the CPU (`libavfilter`) path it therefore renders the `Duration::ZERO`
+    /// value statically; the GPU path animates it by re-evaluating per frame.
+    UnsharpAnimated {
+        /// Luma amount. Evaluated to −1.5 – 1.5 at `Duration::ZERO`.
+        luma_strength: AnimatedValue<f64>,
+        /// Chroma amount. Evaluated to −1.5 – 1.5 at `Duration::ZERO`.
+        chroma_strength: AnimatedValue<f64>,
+    },
     /// High Quality 3D noise reduction (`hqdn3d`).
     ///
     /// Typical values: `luma_spatial=4.0`, `chroma_spatial=3.0`,
@@ -1129,6 +1143,7 @@ impl FilterStep {
             Self::PolygonMatte { .. } => "geq",
             Self::CropAnimated { .. } => "crop",
             Self::GBlurAnimated { .. } => "gblur",
+            Self::UnsharpAnimated { .. } => "unsharp",
             Self::ScaleAnimated { .. } => "scale",
             Self::RotateAnimated { .. } => "rotate",
             Self::MotionBlur { .. } => "tblend",
@@ -1653,6 +1668,19 @@ impl FilterStep {
             Self::GBlurAnimated { sigma } => {
                 let s0 = sigma.value_at(Duration::ZERO);
                 format!("sigma={s0}")
+            }
+            Self::UnsharpAnimated {
+                luma_strength,
+                chroma_strength,
+            } => {
+                // No `eval=frame` / `send_command`: `unsharp` has no runtime param,
+                // so the CPU path renders the `Duration::ZERO` value statically.
+                let l0 = luma_strength.value_at(Duration::ZERO);
+                let c0 = chroma_strength.value_at(Duration::ZERO);
+                format!(
+                    "luma_msize_x=5:luma_msize_y=5:luma_amount={l0}:\
+                     chroma_msize_x=5:chroma_msize_y=5:chroma_amount={c0}"
+                )
             }
             Self::ScaleAnimated {
                 width,


### PR DESCRIPTION
## Objective

- Make the Sharpen effect a typed, keyframeable clip effect wired into the GPU compositing bridge (preview + export), pairing the existing `SharpenNode`.
- Keep the GPU and CPU paths in agreement, with a documented tolerance and a whole-frame CPU fallback for anything the GPU node cannot represent.

## Solution

- Add `EffectKind::Sharpen { amount }`, compiling to the `unsharp` filter with neutral chroma. `map_scene` classifies `Unsharp` / `UnsharpAnimated` to a `Sharpen` GPU effect driving `ff_render::SharpenNode`; a non-zero chroma amount falls back to the CPU compositor rather than dropping it.
- Add `FilterStep::UnsharpAnimated`. FFmpeg's `unsharp` exposes no runtime-settable parameter (verified against the pinned 7.1/8.0 source), so it cannot be animated by `send_command` like `gblur`: the GPU path animates the amount per frame, and the CPU path renders the `t = 0` value statically.
- Add a probe-gated parity test over a mid-tone checkerboard (a saturated board clamps the overshoot to a no-op), asserting the GPU matches the CPU within a calibrated, grey-calibrated tolerance and that the sharpen actually altered the frame.

Closes #1651