### PR TITLE
feat(avio): typed Vignette clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -93,6 +93,16 @@ pub enum EffectKind {
         /// Sharpening amount (luma). Range −1.5..=1.5 (neutral: 0.0).
         amount: Param,
     },
+    /// Vignette (the `vignette` filter on the CPU path, `ff_render::VignetteNode`
+    /// on the GPU).
+    ///
+    /// A single normalised darkening amount in `[0, 1]` (`0.0` = no vignette),
+    /// centred on the frame. The `vignette` filter re-evaluates its angle per frame,
+    /// so an animated `amount` animates on both paths.
+    Vignette {
+        /// Darkening amount. Range 0.0..=1.0 (neutral: 0.0).
+        amount: Param,
+    },
 }
 
 impl EffectKind {
@@ -161,6 +171,14 @@ impl EffectKind {
                     luma_strength: amount.to_animated(),
                     chroma_strength: AnimatedValue::Static(0.0),
                 },
+            }),
+            // The `vignette` filter self-animates via `eval=frame`, so both the
+            // constant and animated amount route through the one `VignetteAnimated`
+            // variant (centred; a `Static` renders a plain static vignette).
+            EffectKind::Vignette { amount } => Some(FilterStep::VignetteAnimated {
+                amount: amount.to_animated(),
+                x0: 0.0,
+                y0: 0.0,
             }),
         }
     }
@@ -303,6 +321,34 @@ mod tests {
         assert!(matches!(
             kind.to_filter_step(),
             Some(FilterStep::UnsharpAnimated { .. })
+        ));
+    }
+
+    #[test]
+    fn vignette_const_should_compile_to_centred_vignette_animated() {
+        let kind = EffectKind::Vignette {
+            amount: Param::Const(0.6),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::VignetteAnimated { amount, x0, y0 } => {
+                assert!((amount.value_at(std::time::Duration::ZERO) - 0.6).abs() < 1e-6);
+                assert!(
+                    (x0 - 0.0).abs() < 1e-6 && (y0 - 0.0).abs() < 1e-6,
+                    "centred"
+                );
+            }
+            other => panic!("expected VignetteAnimated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vignette_animated_should_compile_to_vignette_animated() {
+        let kind = EffectKind::Vignette {
+            amount: Param::Animated(animated_track()),
+        };
+        assert!(matches!(
+            kind.to_filter_step(),
+            Some(FilterStep::VignetteAnimated { .. })
         ));
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -215,12 +215,29 @@ pub enum GpuEffect {
         /// Sharpening amount (the `unsharp` luma amount).
         strength: f32,
     },
+    /// `ff_render::VignetteNode` (radial darkening).
+    Vignette {
+        /// Normalised distance where darkening begins. Fixed to
+        /// `DEFAULT_VIGNETTE_RADIUS` (the `vignette` filter has no radius option).
+        radius: f32,
+        /// Maximum darkening at the corners (the mapped `vignette` amount).
+        strength: f32,
+        /// Falloff width. Fixed to `DEFAULT_VIGNETTE_FEATHER`.
+        feather: f32,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
 /// has no radius option (a fixed 5×5 luma mask), so the GPU path approximates it
 /// with this constant; the parity tolerance absorbs the small kernel difference.
 const DEFAULT_SHARPEN_RADIUS: f32 = 1.0;
+
+/// Radius / feather the GPU [`ff_render::VignetteNode`] uses. The `vignette` filter
+/// is parameterised only by an `angle` (a `cos^4` falloff), so the GPU node
+/// approximates its profile with fixed radius and feather; only the mapped strength
+/// varies. The parity tolerance absorbs the profile difference.
+const DEFAULT_VIGNETTE_RADIUS: f32 = 0.5;
+const DEFAULT_VIGNETTE_FEATHER: f32 = 0.5;
 
 /// One layer of a [`GpuScenePlan`]: the transform / blend / opacity the
 /// `ff_render::Compositor` needs, plus the per-layer effect nodes to run before
@@ -435,6 +452,32 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
                 StepClass::Effect(GpuEffect::Sharpen {
                     radius: DEFAULT_SHARPEN_RADIUS,
                     strength: luma_strength.value_at(t) as f32,
+                })
+            }
+        }
+        // The GPU VignetteNode is centred; an off-centre `vignette` falls back
+        // rather than render a differently-placed vignette (RK-020).
+        FilterStep::Vignette { angle, x0, y0 } => {
+            if *x0 != 0.0 || *y0 != 0.0 {
+                StepClass::Unsupported
+            } else {
+                StepClass::Effect(GpuEffect::Vignette {
+                    radius: DEFAULT_VIGNETTE_RADIUS,
+                    // The `vignette` angle spans [0, PI/2]; normalise to the node's
+                    // [0, 1] strength.
+                    strength: (angle / std::f32::consts::FRAC_PI_2).clamp(0.0, 1.0),
+                    feather: DEFAULT_VIGNETTE_FEATHER,
+                })
+            }
+        }
+        FilterStep::VignetteAnimated { amount, x0, y0 } => {
+            if *x0 != 0.0 || *y0 != 0.0 {
+                StepClass::Unsupported
+            } else {
+                StepClass::Effect(GpuEffect::Vignette {
+                    radius: DEFAULT_VIGNETTE_RADIUS,
+                    strength: (amount.value_at(t) as f32).clamp(0.0, 1.0),
+                    feather: DEFAULT_VIGNETTE_FEATHER,
                 })
             }
         }
@@ -753,6 +796,69 @@ mod tests {
         layer.effects = vec![FilterStep::Unsharp {
             luma_strength: 0.5,
             chroma_strength: 0.5,
+        }];
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_vignette_animated_to_vignette() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::VignetteAnimated {
+            amount: AnimatedValue::Static(0.6),
+            x0: 0.0,
+            y0: 0.0,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        let [
+            GpuEffect::Vignette {
+                radius,
+                strength,
+                feather,
+            },
+        ] = plan.layers[0].effects.as_slice()
+        else {
+            panic!("vignette must map to a single Vignette effect");
+        };
+        assert!(
+            (strength - 0.6).abs() < 1e-6,
+            "amount maps to strength; got {strength}"
+        );
+        assert!(
+            *radius > 0.0 && *feather > 0.0,
+            "radius/feather use the defaults"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_static_vignette_normalising_angle() {
+        // A hand-built static Vignette at the max angle (PI/2) maps to full strength.
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Vignette {
+            angle: std::f32::consts::FRAC_PI_2,
+            x0: 0.0,
+            y0: 0.0,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        let [GpuEffect::Vignette { strength, .. }] = plan.layers[0].effects.as_slice() else {
+            panic!("vignette must map to a single Vignette effect");
+        };
+        assert!(
+            (strength - 1.0).abs() < 1e-6,
+            "angle PI/2 -> strength 1.0; got {strength}"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_fall_back_on_off_centre_vignette() {
+        // The GPU node is centred, so an off-centre vignette falls back (RK-020).
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::VignetteAnimated {
+            amount: AnimatedValue::Static(0.5),
+            x0: 320.0,
+            y0: 0.0,
         }];
         assert_eq!(
             map_scene(&[layer], (16, 16), Duration::ZERO),

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use ff_format::VideoFrame;
 use ff_render::{
     ColorGradeNode, Compositor, FrameLayer, GaussianBlurNode, LayerTransform, RenderContext,
-    RenderGraph, ScaleNode, SharpenNode,
+    RenderGraph, ScaleNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -166,6 +166,12 @@ impl GpuCompositor {
                 GpuEffect::Sharpen { radius, strength } => {
                     graph.push(SharpenNode::new(*radius, *strength))
                 }
+                // Vignette preserves the frame dimensions too.
+                GpuEffect::Vignette {
+                    radius,
+                    strength,
+                    feather,
+                } => graph.push(VignetteNode::new(*radius, *strength, *feather)),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -44,6 +44,11 @@ const TOL_BLUR_MEAN: f64 = 20.0; // GPU GaussianBlurNode vs FFmpeg `gblur`: ~9.0
 // (effect vs input ~7.9). Grey-calibrated: the test image is achromatic (R=G=B), where
 // an all-RGB node and a luma-only filter coincide; colored edges would diverge more.
 const TOL_SHARPEN_MEAN: f64 = 5.0;
+// GPU VignetteNode (smoothstep radius/feather) vs FFmpeg `vignette` (cos^4 angle):
+// different darkening profiles, so a loose calibrated tolerance (~21 here; effect vs
+// input ~56, so a skipped vignette diverges past this). Tested on a colored gradient
+// (RK-022): vignette scales every channel equally, so it is color-consistent.
+const TOL_VIGNETTE_MEAN: f64 = 45.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -318,6 +323,55 @@ fn sharpen_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_SHARPEN_MEAN,
         "GPU and CPU sharpen diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn vignette_gpu_should_match_cpu_within_tolerance() {
+    // Vignette parity: GPU VignetteNode (map_scene maps `VignetteAnimated`) vs the CPU
+    // `vignette` filter. The falloff profiles differ (smoothstep vs cos^4), so a loose
+    // calibrated tolerance. Double-gated (adapter + filters).
+    //
+    // A colored gradient (RK-022): a vignette scales every channel by the same factor,
+    // so GPU (all-RGB node) and CPU (FFmpeg) stay color-consistent here, unlike a
+    // channel-subset effect. The corners darken, so a GPU that skipped the vignette
+    // would keep the bright gradient and diverge (non-vacuous, RK-015).
+    let (w, h) = (64, 48);
+    let input = gradient_rgba(w, h);
+    let frame = VideoFrame::from_rgba(w, h, input.clone()).unwrap();
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::VignetteAnimated {
+            amount: AnimatedValue::Static(0.8),
+            x0: 0.0,
+            y0: 0.0,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported vignette layer must composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    let effect = mean_abs_diff_rgb(&gpu_out, &input);
+    println!(
+        "vignette GPU vs CPU: mean={mean:.3} max={} (GPU vs input: {effect:.3})",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    // Non-vacuous (RK-015): the vignette must actually darken the frame.
+    assert!(
+        effect > 2.0,
+        "the GPU vignette must visibly darken the frame; got {effect}"
+    );
+    assert!(
+        mean <= TOL_VIGNETTE_MEAN,
+        "GPU and CPU vignette diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -654,6 +654,14 @@ impl FilterGraphBuilder {
                     reason: format!("vignette angle {angle} out of range [0.0, π/2]"),
                 });
             }
+            if let FilterStep::VignetteAnimated { amount, .. } = step {
+                let a0 = amount.value_at(Duration::ZERO);
+                if !(0.0..=1.0).contains(&a0) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("vignette amount {a0} out of range [0.0, 1.0]"),
+                    });
+                }
+            }
             if let FilterStep::Pad { width, height, .. } = step
                 && (*width == 0 || *height == 0)
             {

--- a/crates/ff-filter/src/graph/builder/video/color.rs
+++ b/crates/ff-filter/src/graph/builder/video/color.rs
@@ -372,6 +372,24 @@ impl FilterGraphBuilder {
         self.steps.push(FilterStep::Vignette { angle, x0, y0 });
         self
     }
+
+    /// Apply a vignette with an optionally animated normalised amount.
+    ///
+    /// - `amount`: normalised darkening in `[0, 1]`, scaled to the `vignette`
+    ///   filter's `angle` as `amount * PI/2`. A `Track` self-animates via
+    ///   `eval=frame` (no `send_command`); a `Static` renders a plain vignette.
+    /// - `x0` / `y0`: centre; pass `0.0` for the video centre (`w/2` / `h/2`).
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if `amount`
+    /// evaluates outside `[0.0, 1.0]` at `Duration::ZERO`.
+    #[must_use]
+    pub fn vignette_animated(mut self, amount: AnimatedValue<f64>, x0: f32, y0: f32) -> Self {
+        self.steps
+            .push(FilterStep::VignetteAnimated { amount, x0, y0 });
+        self
+    }
 }
 
 #[cfg(test)]
@@ -1021,6 +1039,61 @@ mod tests {
         assert!(
             matches!(result, Err(FilterError::InvalidConfig { .. })),
             "expected InvalidConfig for angle < 0.0, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn vignette_animated_static_should_scale_amount_to_angle() {
+        // amount 1.0 maps to angle PI/2 (~1.5708); centre defaults to w/2, h/2.
+        let step = FilterStep::VignetteAnimated {
+            amount: AnimatedValue::Static(1.0_f64),
+            x0: 0.0,
+            y0: 0.0,
+        };
+        assert_eq!(step.filter_name(), "vignette");
+        let args = step.args();
+        assert!(
+            args.contains("angle=1.57"),
+            "amount 1.0 -> angle PI/2: {args}"
+        );
+        assert!(args.contains("x0=w/2") && args.contains("y0=h/2"), "{args}");
+        assert!(
+            !args.contains("eval=frame"),
+            "a Static must not self-animate: {args}"
+        );
+    }
+
+    #[test]
+    fn vignette_animated_track_should_use_eval_frame_expression() {
+        use crate::animation::Easing;
+        use std::time::Duration;
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.2, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 0.8, Easing::Linear));
+        let step = FilterStep::VignetteAnimated {
+            amount: AnimatedValue::Track(track),
+            x0: 0.0,
+            y0: 0.0,
+        };
+        let args = step.args();
+        assert!(
+            args.contains("eval=frame"),
+            "a Track must self-animate: {args}"
+        );
+        assert!(
+            args.contains("*PI/2"),
+            "the amount expression is scaled to radians: {args}"
+        );
+    }
+
+    #[test]
+    fn builder_vignette_animated_out_of_range_should_return_invalid_config() {
+        let result = FilterGraph::builder()
+            .vignette_animated(AnimatedValue::Static(1.5_f64), 0.0, 0.0)
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for amount > 1.0, got {result:?}"
         );
     }
 

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -182,6 +182,21 @@ pub enum FilterStep {
         /// Vertical centre of the vignette. `0.0` maps to `h/2`.
         y0: f32,
     },
+    /// Vignette with an optionally animated normalised amount.
+    ///
+    /// `amount` is a normalised darkening strength in `[0, 1]`; it maps to the
+    /// `vignette` filter's `angle` (radians) as `amount * PI/2`. `vignette`
+    /// re-evaluates `angle` per frame under `eval=frame`, so a `Track` self-animates
+    /// via a `t`-expression (like [`RotateAnimated`](Self::RotateAnimated)); a
+    /// `Static` renders a plain static vignette.
+    VignetteAnimated {
+        /// Normalised darkening amount, evaluated to `[0, 1]` at `Duration::ZERO`.
+        amount: AnimatedValue<f64>,
+        /// Horizontal centre. `0.0` maps to `w/2`.
+        x0: f32,
+        /// Vertical centre. `0.0` maps to `h/2`.
+        y0: f32,
+    },
     /// Horizontal flip (mirror left-right).
     HFlip,
     /// Vertical flip (mirror top-bottom).
@@ -1146,6 +1161,7 @@ impl FilterStep {
             Self::UnsharpAnimated { .. } => "unsharp",
             Self::ScaleAnimated { .. } => "scale",
             Self::RotateAnimated { .. } => "rotate",
+            Self::VignetteAnimated { .. } => "vignette",
             Self::MotionBlur { .. } => "tblend",
             Self::LensCorrection { .. } => "lenscorrection",
             Self::FilmGrain { .. } => "noise",
@@ -1719,6 +1735,30 @@ impl FilterStep {
                     format!("angle={}:fillcolor={fill_color}", deg.to_radians())
                 }
             },
+            Self::VignetteAnimated { amount, x0, y0 } => {
+                let cx = if *x0 == 0.0 {
+                    "w/2".to_string()
+                } else {
+                    x0.to_string()
+                };
+                let cy = if *y0 == 0.0 {
+                    "h/2".to_string()
+                } else {
+                    y0.to_string()
+                };
+                match amount {
+                    // `vignette` re-evaluates `angle` per frame under `eval=frame`, so a
+                    // Track self-animates. The normalised amount is scaled to the angle
+                    // (radians) in the expression: `amount * PI/2`.
+                    AnimatedValue::Track(track) => {
+                        let a = track.to_ffmpeg_expr("t");
+                        format!("angle=({a})*PI/2:x0={cx}:y0={cy}:eval=frame")
+                    }
+                    AnimatedValue::Static(a) => {
+                        format!("angle={}:x0={cx}:y0={cy}", a * std::f64::consts::FRAC_PI_2)
+                    }
+                }
+            }
             Self::MotionBlur {
                 shutter_angle_degrees,
                 ..


### PR DESCRIPTION
## Objective

- Make the Vignette effect a typed, keyframeable clip effect wired into the GPU compositing bridge (preview + export), pairing the existing `VignetteNode`.
- Keep the GPU and CPU paths in agreement within a documented tolerance, with a whole-frame CPU fallback for anything the GPU node cannot represent.

## Solution

- Add `EffectKind::Vignette { amount }` (a normalised darkening in `[0, 1]`), compiling to the `vignette` filter centred on the frame. `map_scene` classifies `Vignette` / `VignetteAnimated` to a `Vignette` GPU effect driving `ff_render::VignetteNode`; an off-centre vignette falls back to the CPU compositor (the GPU node is centred).
- Add `FilterStep::VignetteAnimated`. The `vignette` filter has no runtime-settable parameter but re-evaluates its angle per frame under `eval=frame`, so it self-animates via a `t`-expression (like `RotateAnimated`): the normalised amount is scaled to the filter's angle as `amount * PI/2` in the expression, animating on both paths.
- Add a probe-gated parity test over a colored gradient (a vignette scales every channel equally, so it stays color-consistent) with a documented, loose tolerance for the differing falloff profiles (smoothstep vs `cos^4`), asserting the vignette actually darkens the frame.

Closes #1648