### PR TITLE
feat(avio): typed FilmGrain clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -103,6 +103,19 @@ pub enum EffectKind {
         /// Darkening amount. Range 0.0..=1.0 (neutral: 0.0).
         amount: Param,
     },
+    /// Temporal film grain (the `noise` filter on the CPU path,
+    /// `ff_render::FilmGrainNode` on the GPU).
+    ///
+    /// Luma and chroma grain strengths in the `noise` filter's `[0, 100]` scale
+    /// (`0.0` = none). The grain pattern varies per frame on both paths; because
+    /// `noise` has no runtime-settable parameter, an animated strength animates on
+    /// the GPU-default path but renders its `t = 0` value on the CPU fallback.
+    FilmGrain {
+        /// Luma-plane grain strength. Range 0.0..=100.0 (neutral: 0.0).
+        luma_strength: Param,
+        /// Chroma-plane grain strength. Range 0.0..=100.0 (neutral: 0.0).
+        chroma_strength: Param,
+    },
 }
 
 impl EffectKind {
@@ -179,6 +192,24 @@ impl EffectKind {
                 amount: amount.to_animated(),
                 x0: 0.0,
                 y0: 0.0,
+            }),
+            // FilmGrain maps to `noise`. An all-constant strength uses the static
+            // `FilmGrain`; any animated strength uses `FilmGrainAnimated` (which the
+            // GPU animates per frame; the CPU renders its `t = 0` value, `noise`
+            // having no runtime parameter). The grain pattern is temporal regardless.
+            EffectKind::FilmGrain {
+                luma_strength,
+                chroma_strength,
+            } => Some(if luma_strength.is_const() && chroma_strength.is_const() {
+                FilterStep::FilmGrain {
+                    luma_strength: luma_strength.as_const().unwrap_or(0.0) as f32,
+                    chroma_strength: chroma_strength.as_const().unwrap_or(0.0) as f32,
+                }
+            } else {
+                FilterStep::FilmGrainAnimated {
+                    luma_strength: luma_strength.to_animated(),
+                    chroma_strength: chroma_strength.to_animated(),
+                }
             }),
         }
     }
@@ -349,6 +380,36 @@ mod tests {
         assert!(matches!(
             kind.to_filter_step(),
             Some(FilterStep::VignetteAnimated { .. })
+        ));
+    }
+
+    #[test]
+    fn film_grain_const_should_compile_to_film_grain() {
+        let kind = EffectKind::FilmGrain {
+            luma_strength: Param::Const(20.0),
+            chroma_strength: Param::Const(5.0),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::FilmGrain {
+                luma_strength,
+                chroma_strength,
+            } => {
+                assert!((luma_strength - 20.0).abs() < 1e-6);
+                assert!((chroma_strength - 5.0).abs() < 1e-6);
+            }
+            other => panic!("expected FilmGrain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn film_grain_any_animated_strength_should_compile_to_film_grain_animated() {
+        let kind = EffectKind::FilmGrain {
+            luma_strength: Param::Animated(animated_track()),
+            chroma_strength: Param::Const(5.0),
+        };
+        assert!(matches!(
+            kind.to_filter_step(),
+            Some(FilterStep::FilmGrainAnimated { .. })
         ));
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -225,6 +225,16 @@ pub enum GpuEffect {
         /// Falloff width. Fixed to `DEFAULT_VIGNETTE_FEATHER`.
         feather: f32,
     },
+    /// `ff_render::FilmGrainNode` (temporal grain).
+    FilmGrain {
+        /// Luma grain amplitude (the `noise` strength mapped to the node's scale).
+        luma_strength: f32,
+        /// Chroma grain amplitude (the `noise` strength mapped to the node's scale).
+        chroma_strength: f32,
+        /// Per-frame seed. Derived from the frame time so the grain varies each frame
+        /// (the CPU path uses the `noise` filter's own `allf=t` temporal seed).
+        frame_index: u32,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -238,6 +248,11 @@ const DEFAULT_SHARPEN_RADIUS: f32 = 1.0;
 /// varies. The parity tolerance absorbs the profile difference.
 const DEFAULT_VIGNETTE_RADIUS: f32 = 0.5;
 const DEFAULT_VIGNETTE_FEATHER: f32 = 0.5;
+
+/// Maps the `noise` filter's `[0, 100]` strength to the GPU [`ff_render::FilmGrainNode`]
+/// grain amplitude. Calibrated so a given strength produces a comparable grain
+/// standard deviation on both paths (the parity test compares that, not pixels).
+const NODE_GRAIN_SCALE: f32 = 0.0042;
 
 /// One layer of a [`GpuScenePlan`]: the transform / blend / opacity the
 /// `ff_render::Compositor` needs, plus the per-layer effect nodes to run before
@@ -481,6 +496,18 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
                 })
             }
         }
+        FilterStep::FilmGrain {
+            luma_strength,
+            chroma_strength,
+        } => film_grain_step(*luma_strength, *chroma_strength, t),
+        FilterStep::FilmGrainAnimated {
+            luma_strength,
+            chroma_strength,
+        } => film_grain_step(
+            luma_strength.value_at(t) as f32,
+            chroma_strength.value_at(t) as f32,
+            t,
+        ),
         // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
         // `#[non_exhaustive]` from ff-filter (RK-003).
@@ -509,6 +536,23 @@ fn map_blend_mode(mode: BlendMode) -> Option<RenderBlendMode> {
         // No ff-render equivalent. `_` is required: `BlendMode` is
         // `#[non_exhaustive]` from ff-filter (RK-003).
         _ => return None,
+    })
+}
+
+/// Classifies a film-grain step: a zero strength is a no-op (`Skip`); otherwise it
+/// maps the `noise` `[0, 100]` strength to the node's amplitude and derives a
+/// per-frame seed from the frame time so the grain varies each frame.
+// `as_millis` fits a u32 for any realistic clip time; the grain only needs the seed
+// to differ between frames, so wrapping is harmless.
+#[allow(clippy::cast_possible_truncation)]
+fn film_grain_step(luma_strength: f32, chroma_strength: f32, t: Duration) -> StepClass {
+    if luma_strength <= 0.0 && chroma_strength <= 0.0 {
+        return StepClass::Skip;
+    }
+    StepClass::Effect(GpuEffect::FilmGrain {
+        luma_strength: luma_strength * NODE_GRAIN_SCALE,
+        chroma_strength: chroma_strength * NODE_GRAIN_SCALE,
+        frame_index: t.as_millis() as u32,
     })
 }
 
@@ -863,6 +907,86 @@ mod tests {
         assert_eq!(
             map_scene(&[layer], (16, 16), Duration::ZERO),
             GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_film_grain_with_per_frame_seed() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::FilmGrain {
+            luma_strength: 20.0,
+            chroma_strength: 5.0,
+        }];
+        // Two distinct frame times must yield distinct grain seeds (no sticking).
+        let plan_a = gpu(map_scene(
+            &[TestLayer {
+                effects: layer.effects.clone(),
+                ..TestLayer::identity()
+            }],
+            (16, 16),
+            Duration::from_millis(0),
+        ));
+        let plan_b = gpu(map_scene(&[layer], (16, 16), Duration::from_millis(100)));
+        let [
+            GpuEffect::FilmGrain {
+                luma_strength,
+                frame_index: fa,
+                ..
+            },
+        ] = plan_a.layers[0].effects.as_slice()
+        else {
+            panic!("film grain must map to a single FilmGrain effect");
+        };
+        let [
+            GpuEffect::FilmGrain {
+                frame_index: fb, ..
+            },
+        ] = plan_b.layers[0].effects.as_slice()
+        else {
+            panic!("film grain must map to a single FilmGrain effect");
+        };
+        assert!(
+            *luma_strength > 0.0,
+            "the noise strength maps to a node amplitude"
+        );
+        assert_ne!(
+            fa, fb,
+            "distinct frame times must give distinct grain seeds"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_skip_zero_strength_film_grain() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::FilmGrain {
+            luma_strength: 0.0,
+            chroma_strength: 0.0,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert!(
+            plan.layers[0].effects.is_empty(),
+            "zero-strength grain is a no-op and is skipped"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_evaluate_animated_film_grain_at_t() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 10.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 30.0, Easing::Linear));
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::FilmGrainAnimated {
+            luma_strength: AnimatedValue::Track(track),
+            chroma_strength: AnimatedValue::Static(0.0),
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::from_secs(1)));
+        let [GpuEffect::FilmGrain { luma_strength, .. }] = plan.layers[0].effects.as_slice() else {
+            panic!("animated film grain must map to a single FilmGrain effect");
+        };
+        // amount at t=1s is ~20 (noise scale); scaled to the node amplitude.
+        assert!(
+            (luma_strength - 20.0 * NODE_GRAIN_SCALE).abs() < 1e-4,
+            "animated strength at t=1s should be ~20*scale; got {luma_strength}"
         );
     }
 

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -30,8 +30,8 @@ use std::time::Duration;
 
 use ff_format::VideoFrame;
 use ff_render::{
-    ColorGradeNode, Compositor, FrameLayer, GaussianBlurNode, LayerTransform, RenderContext,
-    RenderGraph, ScaleNode, SharpenNode, VignetteNode,
+    ColorGradeNode, Compositor, FilmGrainNode, FrameLayer, GaussianBlurNode, LayerTransform,
+    RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -172,6 +172,16 @@ impl GpuCompositor {
                     strength,
                     feather,
                 } => graph.push(VignetteNode::new(*radius, *strength, *feather)),
+                // FilmGrain preserves the frame dimensions too.
+                GpuEffect::FilmGrain {
+                    luma_strength,
+                    chroma_strength,
+                    frame_index,
+                } => graph.push(FilmGrainNode::new(
+                    *luma_strength,
+                    *chroma_strength,
+                    *frame_index,
+                )),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -49,6 +49,11 @@ const TOL_SHARPEN_MEAN: f64 = 5.0;
 // input ~56, so a skipped vignette diverges past this). Tested on a colored gradient
 // (RK-022): vignette scales every channel equally, so it is color-consistent.
 const TOL_VIGNETTE_MEAN: f64 = 45.0;
+// Film grain: GPU (Wang hash) and CPU (`noise` RNG) produce different patterns, so
+// parity compares grain *strength* (std of output - input), not pixels. Calibrated
+// (NODE_GRAIN_SCALE) so the two grain std-devs match: ~10.9 vs ~11.1 here. The margin
+// covers per-run RNG variance across GPU drivers.
+const TOL_FILMGRAIN_STD: f64 = 6.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -81,6 +86,26 @@ fn checkerboard_rgba(w: u32, h: u32, block: u32) -> Vec<u8> {
         }
     }
     v
+}
+
+/// Standard deviation of the signed per-channel difference `out - input` over the
+/// RGB channels. For an added-noise effect this is the grain magnitude; the film
+/// grain parity compares this (not pixels, since the GPU and CPU use different RNGs
+/// so their grain patterns never match).
+fn std_delta_rgb(out: &[u8], input: &[u8]) -> f64 {
+    let mut diffs = Vec::with_capacity(out.len() / 4 * 3);
+    for (po, pi) in out.chunks_exact(4).zip(input.chunks_exact(4)) {
+        for c in 0..3 {
+            diffs.push(f64::from(i16::from(po[c]) - i16::from(pi[c])));
+        }
+    }
+    let n = diffs.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = diffs.iter().sum::<f64>() / n;
+    let var = diffs.iter().map(|d| (d - mean).powi(2)).sum::<f64>() / n;
+    var.sqrt()
 }
 
 /// Mean absolute per-channel difference over the RGB channels only (skips alpha).
@@ -372,6 +397,50 @@ fn vignette_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_VIGNETTE_MEAN,
         "GPU and CPU vignette diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn film_grain_gpu_should_match_cpu_grain_strength() {
+    // Film grain parity is statistical, not per-pixel: the GPU node (Wang hash) and
+    // the CPU `noise` filter use different RNGs, so their grain patterns never match.
+    // Instead compare the grain *magnitude* (std of output - input) on a flat mid-grey
+    // frame, which both must move by a comparable amount. Double-gated (adapter +
+    // filters). Non-vacuous (RK-015): a GPU that added no grain gives std 0 and fails.
+    let (w, h) = (64, 48);
+    let mut input = vec![0u8; (w * h * 4) as usize];
+    for px in input.as_chunks_mut::<4>().0 {
+        *px = [128, 128, 128, 255];
+    }
+    let frame = VideoFrame::from_rgba(w, h, input.clone()).unwrap();
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::FilmGrain {
+            luma_strength: 20.0,
+            chroma_strength: 20.0,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported film-grain layer must composite on the GPU");
+    };
+    let std_gpu = std_delta_rgb(&gpu_out, &input);
+    let std_cpu = std_delta_rgb(&cpu, &input);
+    println!("filmgrain grain std: gpu={std_gpu:.3} cpu={std_cpu:.3}");
+    // Non-vacuous: both paths must actually add grain.
+    assert!(
+        std_gpu > 1.0 && std_cpu > 1.0,
+        "both paths must add visible grain; gpu={std_gpu} cpu={std_cpu}"
+    );
+    assert!(
+        (std_gpu - std_cpu).abs() <= TOL_FILMGRAIN_STD,
+        "GPU and CPU grain strength diverged: gpu={std_gpu} cpu={std_cpu}"
     );
 }
 

--- a/crates/ff-filter/src/effects/video_effects.rs
+++ b/crates/ff-filter/src/effects/video_effects.rs
@@ -395,6 +395,18 @@ mod tests {
         assert_eq!(args, "alls=0:c0s=0:c1s=0:allf=t");
     }
 
+    #[test]
+    fn film_grain_animated_static_should_render_the_zero_time_strength() {
+        use crate::animation::AnimatedValue;
+        let step = FilterStep::FilmGrainAnimated {
+            luma_strength: AnimatedValue::Static(20.0_f64),
+            chroma_strength: AnimatedValue::Static(5.0_f64),
+        };
+        assert_eq!(step.filter_name(), "noise");
+        // Renders the same static args as FilmGrain; the pattern stays temporal.
+        assert_eq!(step.args(), "alls=20:c0s=5:c1s=5:allf=t");
+    }
+
     // lens_profile
 
     #[test]

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -797,6 +797,20 @@ pub enum FilterStep {
         /// Grain strength applied to the Cb and Cr planes. Clamped to [0.0, 100.0].
         chroma_strength: f32,
     },
+    /// Temporal film grain (the `noise` filter) with an optionally animated strength.
+    ///
+    /// Strengths are evaluated at [`Duration::ZERO`] for the graph build. Like
+    /// [`UnsharpAnimated`](Self::UnsharpAnimated), `noise` exposes no
+    /// runtime-settable parameter, so the CPU (`libavfilter`) path renders the
+    /// `Duration::ZERO` strength statically; the GPU path animates it per frame. The
+    /// grain *pattern* is temporal on both paths regardless (`allf=t` on the CPU, the
+    /// per-frame seed on the GPU).
+    FilmGrainAnimated {
+        /// Luma-plane grain strength. Evaluated to [0.0, 100.0] at `Duration::ZERO`.
+        luma_strength: AnimatedValue<f64>,
+        /// Chroma-plane grain strength. Evaluated to [0.0, 100.0] at `Duration::ZERO`.
+        chroma_strength: AnimatedValue<f64>,
+    },
 
     /// Uniform scale by a fractional multiplier via `FFmpeg`'s `scale` filter.
     ///
@@ -1165,6 +1179,7 @@ impl FilterStep {
             Self::MotionBlur { .. } => "tblend",
             Self::LensCorrection { .. } => "lenscorrection",
             Self::FilmGrain { .. } => "noise",
+            Self::FilmGrainAnimated { .. } => "noise",
             Self::ScaleMultiplier { .. } => "scale",
             Self::ChromaticAberration { .. } => "rgbashift",
             // Glow is a compound step (split → curves → gblur → blend);
@@ -1777,6 +1792,19 @@ impl FilterStep {
                 let ls = luma_strength.clamp(0.0, 100.0) as u32;
                 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                 let cs = chroma_strength.clamp(0.0, 100.0) as u32;
+                format!("alls={ls}:c0s={cs}:c1s={cs}:allf=t")
+            }
+            Self::FilmGrainAnimated {
+                luma_strength,
+                chroma_strength,
+            } => {
+                // No `eval=frame` / `send_command`: `noise` has no runtime parameter,
+                // so the CPU path renders the `Duration::ZERO` strength statically. The
+                // pattern is still temporal via `allf=t`.
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let ls = luma_strength.value_at(Duration::ZERO).clamp(0.0, 100.0) as u32;
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                let cs = chroma_strength.value_at(Duration::ZERO).clamp(0.0, 100.0) as u32;
                 format!("alls={ls}:c0s={cs}:c1s={cs}:allf=t")
             }
             Self::ScaleMultiplier { factor } => {


### PR DESCRIPTION
## Objective

- Make the FilmGrain effect a typed, keyframeable clip effect wired into the GPU compositing bridge (preview + export), pairing the existing `FilmGrainNode`.
- Keep the GPU and CPU paths in agreement within a documented tolerance, with a whole-frame CPU fallback for anything the GPU node cannot represent.

## Solution

- Add `EffectKind::FilmGrain { luma_strength, chroma_strength }` (in the `noise` filter's `[0, 100]` scale), compiling to the `noise` filter. `map_scene` classifies `FilmGrain` / `FilmGrainAnimated` to a `FilmGrain` GPU effect driving `ff_render::FilmGrainNode`, deriving a per-frame seed from the frame time (so the grain varies each frame) and skipping a zero strength as a no-op.
- Add `FilterStep::FilmGrainAnimated`. Like `unsharp`, `noise` has no runtime-settable parameter, so it renders its `t = 0` strength statically on the CPU while the GPU animates it per frame; the grain pattern is temporal on both paths regardless (`allf=t` on the CPU, the per-frame seed on the GPU).
- Add a probe-gated parity test. The GPU (Wang hash) and CPU (`noise` RNG) use different random sources, so their grain never matches pixel-for-pixel; the test is statistical instead, comparing the grain magnitude (standard deviation of `output - input`) of the two paths, calibrated to agree and asserted non-vacuous.

Closes #1649