### PR TITLE
feat(avio): typed Glow clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -116,6 +116,21 @@ pub enum EffectKind {
         /// Chroma-plane grain strength. Range 0.0..=100.0 (neutral: 0.0).
         chroma_strength: Param,
     },
+    /// Glow / bloom (the compound `split`/`curves`/`gblur`/`blend` chain on the CPU
+    /// path, `ff_render::GlowNode` on the GPU).
+    ///
+    /// Extracts highlights above `threshold`, blurs them by `radius`, and adds them
+    /// back weighted by `intensity`. An animated parameter animates on the GPU-default
+    /// path; the CPU renders its `t = 0` value (the glow sub-filters have no runtime
+    /// parameter).
+    Glow {
+        /// Luminance threshold that triggers the glow. Range 0.0..=1.0.
+        threshold: Param,
+        /// Gaussian blur radius (sigma) in pixels. Range 0.5..=50.0.
+        radius: Param,
+        /// Additive blend strength. Range 0.0..=2.0 (neutral: 0.0).
+        intensity: Param,
+    },
 }
 
 impl EffectKind {
@@ -211,6 +226,28 @@ impl EffectKind {
                     chroma_strength: chroma_strength.to_animated(),
                 }
             }),
+            // Glow is a compound step. An all-constant glow uses the static `Glow`;
+            // any animated parameter uses `GlowAnimated` (which the GPU animates per
+            // frame; the CPU renders its `t = 0` values).
+            EffectKind::Glow {
+                threshold,
+                radius,
+                intensity,
+            } => Some(
+                if threshold.is_const() && radius.is_const() && intensity.is_const() {
+                    FilterStep::Glow {
+                        threshold: threshold.as_const().unwrap_or(0.0) as f32,
+                        radius: radius.as_const().unwrap_or(0.5) as f32,
+                        intensity: intensity.as_const().unwrap_or(0.0) as f32,
+                    }
+                } else {
+                    FilterStep::GlowAnimated {
+                        threshold: threshold.to_animated(),
+                        radius: radius.to_animated(),
+                        intensity: intensity.to_animated(),
+                    }
+                },
+            ),
         }
     }
 }
@@ -410,6 +447,40 @@ mod tests {
         assert!(matches!(
             kind.to_filter_step(),
             Some(FilterStep::FilmGrainAnimated { .. })
+        ));
+    }
+
+    #[test]
+    fn glow_const_should_compile_to_glow() {
+        let kind = EffectKind::Glow {
+            threshold: Param::Const(0.8),
+            radius: Param::Const(10.0),
+            intensity: Param::Const(0.8),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Glow {
+                threshold,
+                radius,
+                intensity,
+            } => {
+                assert!((threshold - 0.8).abs() < 1e-6);
+                assert!((radius - 10.0).abs() < 1e-6);
+                assert!((intensity - 0.8).abs() < 1e-6);
+            }
+            other => panic!("expected Glow, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn glow_any_animated_param_should_compile_to_glow_animated() {
+        let kind = EffectKind::Glow {
+            threshold: Param::Const(0.8),
+            radius: Param::Animated(animated_track()),
+            intensity: Param::Const(0.8),
+        };
+        assert!(matches!(
+            kind.to_filter_step(),
+            Some(FilterStep::GlowAnimated { .. })
         ));
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -235,6 +235,16 @@ pub enum GpuEffect {
         /// (the CPU path uses the `noise` filter's own `allf=t` temporal seed).
         frame_index: u32,
     },
+    /// `ff_render::GlowNode` (three-pass bloom).
+    Glow {
+        /// Luminance threshold for highlight extraction.
+        threshold: f32,
+        /// Gaussian blur radius (sigma) for the glow spread; the node clamps it to its
+        /// blur range (`[0.5, 20.0]`), so a larger `noise`/CPU radius spreads further.
+        radius: f32,
+        /// Additive blend weight of the glow layer.
+        intensity: f32,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -508,6 +518,20 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             chroma_strength.value_at(t) as f32,
             t,
         ),
+        FilterStep::Glow {
+            threshold,
+            radius,
+            intensity,
+        } => glow_step(*threshold, *radius, *intensity),
+        FilterStep::GlowAnimated {
+            threshold,
+            radius,
+            intensity,
+        } => glow_step(
+            threshold.value_at(t) as f32,
+            radius.value_at(t) as f32,
+            intensity.value_at(t) as f32,
+        ),
         // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
         // `#[non_exhaustive]` from ff-filter (RK-003).
@@ -553,6 +577,19 @@ fn film_grain_step(luma_strength: f32, chroma_strength: f32, t: Duration) -> Ste
         luma_strength: luma_strength * NODE_GRAIN_SCALE,
         chroma_strength: chroma_strength * NODE_GRAIN_SCALE,
         frame_index: t.as_millis() as u32,
+    })
+}
+
+/// Classifies a glow step: a non-positive intensity is a no-op (`Skip`); otherwise
+/// it maps the (matching) threshold / radius / intensity straight to the GPU node.
+fn glow_step(threshold: f32, radius: f32, intensity: f32) -> StepClass {
+    if intensity <= 0.0 {
+        return StepClass::Skip;
+    }
+    StepClass::Effect(GpuEffect::Glow {
+        threshold,
+        radius,
+        intensity,
     })
 }
 
@@ -987,6 +1024,61 @@ mod tests {
         assert!(
             (luma_strength - 20.0 * NODE_GRAIN_SCALE).abs() < 1e-4,
             "animated strength at t=1s should be ~20*scale; got {luma_strength}"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_glow_directly() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Glow {
+            threshold: 0.8,
+            radius: 10.0,
+            intensity: 0.8,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::Glow {
+                threshold: 0.8,
+                radius: 10.0,
+                intensity: 0.8,
+            }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_evaluate_animated_glow_at_t() {
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 0.4, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(2), 1.2, Easing::Linear));
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::GlowAnimated {
+            threshold: AnimatedValue::Static(0.8),
+            radius: AnimatedValue::Static(10.0),
+            intensity: AnimatedValue::Track(track),
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::from_secs(1)));
+        let [GpuEffect::Glow { intensity, .. }] = plan.layers[0].effects.as_slice() else {
+            panic!("animated glow must map to a single Glow effect");
+        };
+        assert!(
+            (intensity - 0.8).abs() < 1e-3,
+            "animated intensity at t=1s should be ~0.8; got {intensity}"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_skip_zero_intensity_glow() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Glow {
+            threshold: 0.8,
+            radius: 10.0,
+            intensity: 0.0,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert!(
+            plan.layers[0].effects.is_empty(),
+            "zero-intensity glow is a no-op and is skipped"
         );
     }
 

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -30,8 +30,8 @@ use std::time::Duration;
 
 use ff_format::VideoFrame;
 use ff_render::{
-    ColorGradeNode, Compositor, FilmGrainNode, FrameLayer, GaussianBlurNode, LayerTransform,
-    RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
+    ColorGradeNode, Compositor, FilmGrainNode, FrameLayer, GaussianBlurNode, GlowNode,
+    LayerTransform, RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -182,6 +182,12 @@ impl GpuCompositor {
                     *chroma_strength,
                     *frame_index,
                 )),
+                // Glow preserves the frame dimensions too.
+                GpuEffect::Glow {
+                    threshold,
+                    radius,
+                    intensity,
+                } => graph.push(GlowNode::new(*threshold, *radius, *intensity)),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -54,6 +54,11 @@ const TOL_VIGNETTE_MEAN: f64 = 45.0;
 // (NODE_GRAIN_SCALE) so the two grain std-devs match: ~10.9 vs ~11.1 here. The margin
 // covers per-run RNG variance across GPU drivers.
 const TOL_FILMGRAIN_STD: f64 = 6.0;
+// Glow: GPU GlowNode (extract -> blur -> add) vs the CPU compound `split`/`curves`/
+// `gblur`/`blend` chain. Different bloom implementations, so a loose calibrated
+// tolerance: ~4.4 here (effect vs input ~7.4). Tested on a coloured highlight
+// (RK-022): glow spreads the highlight colour, so the two paths stay colour-comparable.
+const TOL_GLOW_MEAN: f64 = 15.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -441,6 +446,64 @@ fn film_grain_gpu_should_match_cpu_grain_strength() {
     assert!(
         (std_gpu - std_cpu).abs() <= TOL_FILMGRAIN_STD,
         "GPU and CPU grain strength diverged: gpu={std_gpu} cpu={std_cpu}"
+    );
+}
+
+#[test]
+fn glow_gpu_should_match_cpu_within_tolerance() {
+    // Glow parity: GPU GlowNode (map_scene maps `Glow`) vs the CPU compound glow.
+    // Different bloom implementations, so a loose calibrated tolerance. Double-gated
+    // (adapter + filters).
+    //
+    // A coloured highlight (bright cyan rect on a dark background, RK-022): glow
+    // extracts the highlight, blurs it, and adds it back, spreading its colour. The
+    // corners around the rect gain a glow halo, so a GPU that skipped the glow would
+    // keep the dark background and diverge (non-vacuous, RK-015). radius <= 20 keeps
+    // it within the GPU blur node's sigma range.
+    let (w, h) = (64, 48);
+    let mut input = vec![0u8; (w * h * 4) as usize];
+    for (i, px) in input.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+        let x = i as u32 % w;
+        let y = i as u32 / w;
+        px[3] = 255;
+        if (24..40).contains(&x) && (16..32).contains(&y) {
+            *px = [40, 230, 230, 255]; // bright cyan highlight
+        }
+    }
+    let frame = VideoFrame::from_rgba(w, h, input.clone()).unwrap();
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::Glow {
+            threshold: 0.5,
+            radius: 8.0,
+            intensity: 1.0,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported glow layer must composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    let effect = mean_abs_diff_rgb(&gpu_out, &input);
+    println!(
+        "glow GPU vs CPU: mean={mean:.3} max={} (GPU vs input: {effect:.3})",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    // Non-vacuous (RK-015): the glow must actually change the frame.
+    assert!(
+        effect > 2.0,
+        "the GPU glow must visibly add a halo; got {effect}"
+    );
+    assert!(
+        mean <= TOL_GLOW_MEAN,
+        "GPU and CPU glow diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/effects/video_effects.rs
+++ b/crates/ff-filter/src/effects/video_effects.rs
@@ -567,6 +567,24 @@ mod tests {
     }
 
     #[test]
+    fn glow_animated_static_should_render_the_zero_time_compound() {
+        use crate::animation::AnimatedValue;
+        let step = FilterStep::GlowAnimated {
+            threshold: AnimatedValue::Static(0.8_f64),
+            radius: AnimatedValue::Static(10.0_f64),
+            intensity: AnimatedValue::Static(0.8_f64),
+        };
+        assert_eq!(step.filter_name(), "split");
+        // Same compound args as the static Glow at these values.
+        let args = step.args();
+        assert!(
+            args.contains("0.8/0") && args.contains("sigma=10"),
+            "{args}"
+        );
+        assert!(args.contains("all_opacity=0.8"), "{args}");
+    }
+
+    #[test]
     fn glow_threshold_above_one_should_be_clamped() {
         let step = FilterStep::Glow {
             threshold: 1.1,

--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -124,6 +124,23 @@ pub(crate) unsafe fn add_and_link_step(
             radius,
             intensity,
         } => return add_glow_step(graph, prev_ctx, *threshold, *radius, *intensity, index),
+        // The `noise`/glow sub-filters have no runtime parameter, so an animated glow
+        // is built statically from its `Duration::ZERO` values (the GPU animates it).
+        #[allow(clippy::cast_possible_truncation)]
+        FilterStep::GlowAnimated {
+            threshold,
+            radius,
+            intensity,
+        } => {
+            return add_glow_step(
+                graph,
+                prev_ctx,
+                threshold.value_at(std::time::Duration::ZERO) as f32,
+                radius.value_at(std::time::Duration::ZERO) as f32,
+                intensity.value_at(std::time::Duration::ZERO) as f32,
+                index,
+            );
+        }
         FilterStep::FeatherMask { radius } => {
             return add_feather_mask_step(graph, prev_ctx, *radius, index);
         }
@@ -2574,6 +2591,25 @@ impl FilterGraphInner {
             {
                 prev_ctx = match add_glow_step(graph, prev_ctx, *threshold, *radius, *intensity, i)
                 {
+                    Ok(ctx) => ctx,
+                    Err(e) => bail!(e),
+                };
+                continue;
+            }
+
+            // GlowAnimated — same compound step, built statically from its
+            // `Duration::ZERO` values (the sub-filters have no runtime parameter).
+            #[allow(clippy::cast_possible_truncation)]
+            if let FilterStep::GlowAnimated {
+                threshold,
+                radius,
+                intensity,
+            } = step
+            {
+                let t0 = threshold.value_at(std::time::Duration::ZERO) as f32;
+                let r0 = radius.value_at(std::time::Duration::ZERO) as f32;
+                let i0 = intensity.value_at(std::time::Duration::ZERO) as f32;
+                prev_ctx = match add_glow_step(graph, prev_ctx, t0, r0, i0, i) {
                     Ok(ctx) => ctx,
                     Err(e) => bail!(e),
                 };

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -352,6 +352,63 @@ mod tests {
     }
 
     #[test]
+    fn base_layer_with_glow_animated_compound_effect_should_build() {
+        // `GlowAnimated` dispatches to the same compound builder (`add_glow_step`) as
+        // `Glow`, using its `Duration::ZERO` values. This drives that dispatch through
+        // `add_and_link_step` for real (the args-only unit test does not). Same
+        // probe-gate as the static Glow test: skip where FFmpeg has no filters.
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        let layer = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::GlowAnimated {
+                threshold: AnimatedValue::Static(0.6),
+                radius: AnimatedValue::Static(4.0),
+                intensity: AnimatedValue::Static(0.5),
+            }],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        let mut composer = RealtimeComposer::new(&[layer])
+            .expect("GlowAnimated compound step must dispatch and build once filters exist");
+        let frame = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn base_layer_with_raw_effect_should_build() {
         // #1376: `FilterStep::Raw` (the arbitrary-avfilter escape hatch) must work as a
         // per-layer effect through the realtime (preview) compositor's `add_and_link_step`

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -847,6 +847,21 @@ pub enum FilterStep {
         /// Additive blend strength (clamped to [0.0, 2.0]).
         intensity: f32,
     },
+    /// Glow / bloom (the compound `split`/`curves`/`gblur`/`blend` chain) with
+    /// optionally animated parameters.
+    ///
+    /// Parameters are evaluated at [`Duration::ZERO`] for the graph build. None of
+    /// the sub-filters expose a runtime-settable glow parameter, so the CPU path
+    /// renders the `Duration::ZERO` values statically; the GPU path
+    /// (`ff_render::GlowNode`) animates them per frame.
+    GlowAnimated {
+        /// Luminance threshold. Evaluated to [0.0, 1.0] at `Duration::ZERO`.
+        threshold: AnimatedValue<f64>,
+        /// Gaussian blur radius in pixels. Evaluated to [0.5, 50.0] at `Duration::ZERO`.
+        radius: AnimatedValue<f64>,
+        /// Additive blend strength. Evaluated to [0.0, 2.0] at `Duration::ZERO`.
+        intensity: AnimatedValue<f64>,
+    },
 
     /// Convolution reverb using an impulse response (IR) audio file.
     ///
@@ -1037,6 +1052,22 @@ pub enum FilterStep {
 /// Tanner Helland's algorithm.
 ///
 /// Returns `(r, g, b)` each in `[0.0, 1.0]`.
+/// Renders the compound glow filter chain (`split` -> `curves` -> `gblur` ->
+/// `blend`) as a filtergraph string. Shared by [`FilterStep::Glow`] and
+/// [`FilterStep::GlowAnimated`]. (The real build goes through `add_glow_step`; this
+/// is for the `args()` completeness path.)
+fn glow_compound_args(threshold: f32, radius: f32, intensity: f32) -> String {
+    let t = threshold.clamp(0.0, 1.0);
+    let r = radius.clamp(0.5, 50.0);
+    let iv = intensity.clamp(0.0, 2.0);
+    let hi_lo = format!("0/0 {t}/0 1/1");
+    format!(
+        "split=2[base][hl];[hl]curves=all='{hi_lo}'[glow_src];\
+         [glow_src]gblur=sigma={r}[glow];\
+         [base][glow]blend=all_mode=addition:all_opacity={iv}"
+    )
+}
+
 fn kelvin_to_rgb(temp_k: u32) -> (f64, f64, f64) {
     let t = (f64::from(temp_k) / 100.0).clamp(10.0, 400.0);
     let r = if t <= 66.0 {
@@ -1185,6 +1216,7 @@ impl FilterStep {
             // Glow is a compound step (split → curves → gblur → blend);
             // "split" is used by validate_filter_steps as the primary check.
             Self::Glow { .. } => "split",
+            Self::GlowAnimated { .. } => "split",
             // ReverbIr is a compound step (amovie[+adelay] → afir);
             // "afir" is used by validate_filter_steps as the primary check.
             Self::ReverbIr { .. } => "afir",
@@ -1819,16 +1851,21 @@ impl FilterStep {
                 threshold,
                 radius,
                 intensity,
+            } => glow_compound_args(*threshold, *radius, *intensity),
+            // The compound step is built by `add_glow_step`, not from this string;
+            // the args are provided for completeness (rendered at `Duration::ZERO`).
+            Self::GlowAnimated {
+                threshold,
+                radius,
+                intensity,
             } => {
-                let t = threshold.clamp(0.0, 1.0);
-                let r = radius.clamp(0.5, 50.0);
-                let iv = intensity.clamp(0.0, 2.0);
-                let hi_lo = format!("0/0 {t}/0 1/1");
-                format!(
-                    "split=2[base][hl];[hl]curves=all='{hi_lo}'[glow_src];\
-                     [glow_src]gblur=sigma={r}[glow];\
-                     [base][glow]blend=all_mode=addition:all_opacity={iv}"
-                )
+                #[allow(clippy::cast_possible_truncation)]
+                let out = glow_compound_args(
+                    threshold.value_at(Duration::ZERO) as f32,
+                    radius.value_at(Duration::ZERO) as f32,
+                    intensity.value_at(Duration::ZERO) as f32,
+                );
+                out
             }
             Self::ReverbEcho {
                 in_gain,


### PR DESCRIPTION
## Objective

- Make the Glow effect a typed, keyframeable clip effect wired into the GPU compositing bridge (preview + export), pairing the existing `GlowNode`.
- Keep the GPU and CPU paths in agreement within a documented tolerance, with a whole-frame CPU fallback for anything the GPU node cannot represent.

## Solution

- Add `EffectKind::Glow { threshold, radius, intensity }`, which maps one-to-one to the compound `split`/`curves`/`gblur`/`blend` glow chain (it shares the same three parameters as the GPU node). `map_scene` classifies `Glow` / `GlowAnimated` to a `Glow` GPU effect driving `ff_render::GlowNode`, and skips a zero intensity as a no-op.
- Add `FilterStep::GlowAnimated`. The glow sub-filters have no runtime-settable parameter, so it builds the compound statically from its `t = 0` values (through the same `add_glow_step` dispatch as the static Glow) while the GPU animates the parameters per frame. A probe-gated build test drives that GlowAnimated compound dispatch.
- Add a probe-gated parity test over a coloured highlight (glow spreads the highlight colour, so the paths stay colour-comparable), asserting the GPU glow matches the CPU compound within a documented tolerance and actually adds a halo.

Closes #1652