### PR TITLE
feat(avio): typed ColorWheels clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -13,7 +13,7 @@
 //! model-free — this type lives in `avio` because it exists to make a *clip's*
 //! effects re-editable (a CLIP/EDIT concern per the engine/primitive litmus).
 
-use ff_filter::{AnimatedValue, AnimationTrack, FilterStep};
+use ff_filter::{AnimatedValue, AnimationTrack, FilterStep, Keyframe, Rgb};
 
 use crate::ids::EffectId;
 
@@ -131,6 +131,42 @@ pub enum EffectKind {
         /// Additive blend strength. Range 0.0..=2.0 (neutral: 0.0).
         intensity: Param,
     },
+    /// Three-way (lift/gamma/gain) colour corrector (the `curves` filter on the CPU
+    /// path, `ff_render::ColorWheelsNode` on the GPU).
+    ///
+    /// Each wheel is a per-channel `[R, G, B]` array. Neutral parameters
+    /// (`shadows_lift = 0.0`, `midtones_gamma = 1.0`, `highlights_gain = 1.0`, all
+    /// constant) compile to no filter at all. Because `curves` takes string options,
+    /// an animated parameter animates on the GPU-default path but renders its `t = 0`
+    /// value on the CPU fallback.
+    ColorWheels {
+        /// Shadows lift, additive per channel. Range −1.0..=1.0 (neutral: 0.0).
+        shadows_lift: [Param; 3],
+        /// Midtones gamma, per channel. Range 0.1..=10.0 (neutral: 1.0; must be > 0).
+        midtones_gamma: [Param; 3],
+        /// Highlights gain, per channel. Range 0.0..=4.0 (neutral: 1.0).
+        highlights_gain: [Param; 3],
+    },
+}
+
+/// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
+/// `ThreeWayCC` `lift` convention (multiplicative-style, neutral `1.0`) by offsetting
+/// the value by `+1.0`. A `Track` is rebuilt keyframe-by-keyframe (an animation track
+/// has no scalar-offset op).
+fn lift_to_animated(p: &Param) -> AnimatedValue<f64> {
+    match p {
+        Param::Const(v) => AnimatedValue::Static(v + 1.0),
+        Param::Animated(track) => AnimatedValue::Track(track.keyframes().iter().fold(
+            AnimationTrack::new(),
+            |t, kf| {
+                t.push(Keyframe {
+                    timestamp: kf.timestamp,
+                    value: kf.value + 1.0,
+                    easing: kf.easing.clone(),
+                })
+            },
+        )),
+    }
 }
 
 impl EffectKind {
@@ -248,6 +284,63 @@ impl EffectKind {
                     }
                 },
             ),
+            // ColorWheels maps to `curves` (via `ThreeWayCC`). The `shadows_lift`
+            // (additive, neutral 0) is offset to the `lift` convention (neutral 1).
+            // A fully neutral, all-constant corrector compiles to nothing.
+            EffectKind::ColorWheels {
+                shadows_lift,
+                midtones_gamma,
+                highlights_gain,
+            } => {
+                let all_const = shadows_lift
+                    .iter()
+                    .chain(midtones_gamma.iter())
+                    .chain(highlights_gain.iter())
+                    .all(Param::is_const);
+                if all_const {
+                    #[allow(clippy::float_cmp)]
+                    let neutral = shadows_lift.iter().all(|p| p.as_const() == Some(0.0))
+                        && midtones_gamma.iter().all(|p| p.as_const() == Some(1.0))
+                        && highlights_gain.iter().all(|p| p.as_const() == Some(1.0));
+                    if neutral {
+                        return None;
+                    }
+                    let lift = Rgb {
+                        r: (shadows_lift[0].as_const().unwrap_or(0.0) + 1.0) as f32,
+                        g: (shadows_lift[1].as_const().unwrap_or(0.0) + 1.0) as f32,
+                        b: (shadows_lift[2].as_const().unwrap_or(0.0) + 1.0) as f32,
+                    };
+                    let gamma = Rgb {
+                        r: midtones_gamma[0].as_const().unwrap_or(1.0) as f32,
+                        g: midtones_gamma[1].as_const().unwrap_or(1.0) as f32,
+                        b: midtones_gamma[2].as_const().unwrap_or(1.0) as f32,
+                    };
+                    let gain = Rgb {
+                        r: highlights_gain[0].as_const().unwrap_or(1.0) as f32,
+                        g: highlights_gain[1].as_const().unwrap_or(1.0) as f32,
+                        b: highlights_gain[2].as_const().unwrap_or(1.0) as f32,
+                    };
+                    Some(FilterStep::ThreeWayCC { lift, gamma, gain })
+                } else {
+                    Some(FilterStep::ThreeWayCCAnimated {
+                        lift: [
+                            lift_to_animated(&shadows_lift[0]),
+                            lift_to_animated(&shadows_lift[1]),
+                            lift_to_animated(&shadows_lift[2]),
+                        ],
+                        gamma: [
+                            midtones_gamma[0].to_animated(),
+                            midtones_gamma[1].to_animated(),
+                            midtones_gamma[2].to_animated(),
+                        ],
+                        gain: [
+                            highlights_gain[0].to_animated(),
+                            highlights_gain[1].to_animated(),
+                            highlights_gain[2].to_animated(),
+                        ],
+                    })
+                }
+            }
         }
     }
 }
@@ -482,5 +575,60 @@ mod tests {
             kind.to_filter_step(),
             Some(FilterStep::GlowAnimated { .. })
         ));
+    }
+
+    fn cw(lift: f64, gamma: f64, gain: f64) -> EffectKind {
+        EffectKind::ColorWheels {
+            shadows_lift: [Param::Const(lift), Param::Const(lift), Param::Const(lift)],
+            midtones_gamma: [
+                Param::Const(gamma),
+                Param::Const(gamma),
+                Param::Const(gamma),
+            ],
+            highlights_gain: [Param::Const(gain), Param::Const(gain), Param::Const(gain)],
+        }
+    }
+
+    #[test]
+    fn color_wheels_neutral_should_compile_to_nothing() {
+        assert!(
+            cw(0.0, 1.0, 1.0).to_filter_step().is_none(),
+            "a neutral ColorWheels is a no-op"
+        );
+    }
+
+    #[test]
+    fn color_wheels_const_should_offset_lift_by_one() {
+        // shadows_lift 0.1 (additive) maps to the ThreeWayCC lift 1.1 (neutral 1.0).
+        match cw(0.1, 1.0, 1.0).to_filter_step().unwrap() {
+            FilterStep::ThreeWayCC { lift, gamma, gain } => {
+                assert!((lift.r - 1.1).abs() < 1e-5, "lift = 1 + shadows_lift");
+                assert!((gamma.r - 1.0).abs() < 1e-6 && (gain.r - 1.0).abs() < 1e-6);
+            }
+            other => panic!("expected ThreeWayCC, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn color_wheels_any_animated_should_compile_to_three_way_cc_animated() {
+        let kind = EffectKind::ColorWheels {
+            shadows_lift: [
+                Param::Animated(animated_track()),
+                Param::Const(0.0),
+                Param::Const(0.0),
+            ],
+            midtones_gamma: [Param::Const(1.0), Param::Const(1.0), Param::Const(1.0)],
+            highlights_gain: [Param::Const(1.0), Param::Const(1.0), Param::Const(1.0)],
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::ThreeWayCCAnimated { lift, .. } => {
+                // The animated lift track (values ~0.5) is offset by +1 (~1.5).
+                assert!(
+                    lift[0].value_at(std::time::Duration::ZERO) > 1.0,
+                    "the animated lift track is offset to the neutral-1.0 convention"
+                );
+            }
+            other => panic!("expected ThreeWayCCAnimated, got {other:?}"),
+        }
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -245,6 +245,15 @@ pub enum GpuEffect {
         /// Additive blend weight of the glow layer.
         intensity: f32,
     },
+    /// `ff_render::ColorWheelsNode` (three-way lift/gamma/gain corrector).
+    ColorWheels {
+        /// Shadows lift (additive, neutral 0.0) per channel `[R, G, B]`.
+        shadows_lift: [f32; 3],
+        /// Midtones gamma (neutral 1.0) per channel `[R, G, B]`.
+        midtones_gamma: [f32; 3],
+        /// Highlights gain (neutral 1.0) per channel `[R, G, B]`.
+        highlights_gain: [f32; 3],
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -532,6 +541,24 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             radius.value_at(t) as f32,
             intensity.value_at(t) as f32,
         ),
+        // The `curves`/`ThreeWayCC` lift is neutral at 1.0; the node's additive
+        // `shadows_lift` is neutral at 0.0, so subtract 1.0.
+        FilterStep::ThreeWayCC { lift, gamma, gain } => color_wheels_step(
+            [lift.r - 1.0, lift.g - 1.0, lift.b - 1.0],
+            [gamma.r, gamma.g, gamma.b],
+            [gain.r, gain.g, gain.b],
+        ),
+        FilterStep::ThreeWayCCAnimated { lift, gamma, gain } => {
+            let at = |a: &[AnimatedValue<f64>; 3]| {
+                [
+                    a[0].value_at(t) as f32,
+                    a[1].value_at(t) as f32,
+                    a[2].value_at(t) as f32,
+                ]
+            };
+            let l = at(lift);
+            color_wheels_step([l[0] - 1.0, l[1] - 1.0, l[2] - 1.0], at(gamma), at(gain))
+        }
         // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
         // `#[non_exhaustive]` from ff-filter (RK-003).
@@ -577,6 +604,27 @@ fn film_grain_step(luma_strength: f32, chroma_strength: f32, t: Duration) -> Ste
         luma_strength: luma_strength * NODE_GRAIN_SCALE,
         chroma_strength: chroma_strength * NODE_GRAIN_SCALE,
         frame_index: t.as_millis() as u32,
+    })
+}
+
+/// Classifies a three-way corrector: a fully neutral corrector is a no-op (`Skip`);
+/// otherwise it maps straight to the GPU node (parameters already in the node's
+/// convention: additive lift neutral 0, gamma/gain neutral 1).
+fn color_wheels_step(
+    shadows_lift: [f32; 3],
+    midtones_gamma: [f32; 3],
+    highlights_gain: [f32; 3],
+) -> StepClass {
+    let neutral = shadows_lift.iter().all(|&v| v.abs() < 1e-6)
+        && midtones_gamma.iter().all(|&v| (v - 1.0).abs() < 1e-6)
+        && highlights_gain.iter().all(|&v| (v - 1.0).abs() < 1e-6);
+    if neutral {
+        return StepClass::Skip;
+    }
+    StepClass::Effect(GpuEffect::ColorWheels {
+        shadows_lift,
+        midtones_gamma,
+        highlights_gain,
     })
 }
 
@@ -1079,6 +1127,59 @@ mod tests {
         assert!(
             plan.layers[0].effects.is_empty(),
             "zero-intensity glow is a no-op and is skipped"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_three_way_cc_to_color_wheels() {
+        // ThreeWayCC lift 1.1 -> node shadows_lift 0.1 (subtract the neutral 1.0).
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::ThreeWayCC {
+            lift: ff_filter::Rgb {
+                r: 1.1,
+                g: 1.1,
+                b: 1.1,
+            },
+            gamma: ff_filter::Rgb {
+                r: 1.2,
+                g: 1.2,
+                b: 1.2,
+            },
+            gain: ff_filter::Rgb::NEUTRAL,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        let [
+            GpuEffect::ColorWheels {
+                shadows_lift,
+                midtones_gamma,
+                ..
+            },
+        ] = plan.layers[0].effects.as_slice()
+        else {
+            panic!("three-way cc must map to a single ColorWheels effect");
+        };
+        assert!(
+            (shadows_lift[0] - 0.1).abs() < 1e-5,
+            "lift 1.1 -> shadows_lift 0.1"
+        );
+        assert!(
+            (midtones_gamma[0] - 1.2).abs() < 1e-6,
+            "gamma maps directly"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_skip_neutral_three_way_cc() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::ThreeWayCC {
+            lift: ff_filter::Rgb::NEUTRAL,
+            gamma: ff_filter::Rgb::NEUTRAL,
+            gain: ff_filter::Rgb::NEUTRAL,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert!(
+            plan.layers[0].effects.is_empty(),
+            "a neutral three-way corrector is a no-op and is skipped"
         );
     }
 

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -30,8 +30,8 @@ use std::time::Duration;
 
 use ff_format::VideoFrame;
 use ff_render::{
-    ColorGradeNode, Compositor, FilmGrainNode, FrameLayer, GaussianBlurNode, GlowNode,
-    LayerTransform, RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
+    ColorGradeNode, ColorWheelsNode, Compositor, FilmGrainNode, FrameLayer, GaussianBlurNode,
+    GlowNode, LayerTransform, RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -188,6 +188,16 @@ impl GpuCompositor {
                     radius,
                     intensity,
                 } => graph.push(GlowNode::new(*threshold, *radius, *intensity)),
+                // ColorWheels preserves the frame dimensions too.
+                GpuEffect::ColorWheels {
+                    shadows_lift,
+                    midtones_gamma,
+                    highlights_gain,
+                } => graph.push(ColorWheelsNode::new(
+                    *shadows_lift,
+                    *midtones_gamma,
+                    *highlights_gain,
+                )),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -59,6 +59,11 @@ const TOL_FILMGRAIN_STD: f64 = 6.0;
 // tolerance: ~4.4 here (effect vs input ~7.4). Tested on a coloured highlight
 // (RK-022): glow spreads the highlight colour, so the two paths stay colour-comparable.
 const TOL_GLOW_MEAN: f64 = 15.0;
+// ColorWheels: GPU ColorWheelsNode (luma-region-weighted lift/gamma/gain) vs the CPU
+// `curves` chain (per-channel 3-point curves). Different lift/gamma/gain models, so a
+// loose calibrated tolerance: ~8.8 here (effect vs input ~7.7). Tested on a colour
+// gradient (RK-022): the corrector shifts each channel, so it is colour-relevant.
+const TOL_COLOR_WHEELS_MEAN: f64 = 20.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -504,6 +509,65 @@ fn glow_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_GLOW_MEAN,
         "GPU and CPU glow diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn color_wheels_gpu_should_match_cpu_within_tolerance() {
+    // ColorWheels parity: GPU ColorWheelsNode vs the CPU `curves`-based ThreeWayCC.
+    // The lift/gamma/gain models differ (luma-region weighting vs per-channel curves),
+    // so a loose calibrated tolerance. Double-gated (adapter + filters). A colour
+    // gradient (RK-022) exercises the per-channel correction; the corrector changes the
+    // frame, so a GPU that skipped it would diverge (non-vacuous, RK-015).
+    let (w, h) = (64, 48);
+    let input = gradient_rgba(w, h);
+    let frame = VideoFrame::from_rgba(w, h, input.clone()).unwrap();
+    // Warm shadows lift + brighter midtones + slightly boosted highlights.
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::ThreeWayCC {
+            lift: ff_filter::Rgb {
+                r: 1.1,
+                g: 1.0,
+                b: 0.95,
+            },
+            gamma: ff_filter::Rgb {
+                r: 1.2,
+                g: 1.1,
+                b: 1.0,
+            },
+            gain: ff_filter::Rgb {
+                r: 1.1,
+                g: 1.05,
+                b: 1.0,
+            },
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported ColorWheels layer must composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    let effect = mean_abs_diff_rgb(&gpu_out, &input);
+    println!(
+        "color-wheels GPU vs CPU: mean={mean:.3} max={} (GPU vs input: {effect:.3})",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    // Non-vacuous (RK-015): the corrector must actually change the frame.
+    assert!(
+        effect > 2.0,
+        "the GPU ColorWheels must visibly grade the frame; got {effect}"
+    );
+    assert!(
+        mean <= TOL_COLOR_WHEELS_MEAN,
+        "GPU and CPU ColorWheels diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -647,6 +647,20 @@ impl FilterGraphBuilder {
                     }
                 }
             }
+            if let FilterStep::ThreeWayCCAnimated {
+                gamma: [gr, gg, gb],
+                ..
+            } = step
+            {
+                for (channel, av) in [("r", gr), ("g", gg), ("b", gb)] {
+                    let val = av.value_at(Duration::ZERO);
+                    if val <= 0.0 {
+                        return Err(FilterError::InvalidConfig {
+                            reason: format!("three_way_cc gamma.{channel} {val} must be > 0.0"),
+                        });
+                    }
+                }
+            }
             if let FilterStep::Vignette { angle, .. } = step
                 && !((0.0)..=std::f32::consts::FRAC_PI_2).contains(angle)
             {

--- a/crates/ff-filter/src/graph/builder/video/color.rs
+++ b/crates/ff-filter/src/graph/builder/video/color.rs
@@ -353,6 +353,30 @@ impl FilterGraphBuilder {
         self
     }
 
+    /// Three-way (lift/gamma/gain) colour corrector with optionally animated
+    /// per-channel `[R, G, B]` parameters (same `Rgb::NEUTRAL` convention as
+    /// [`three_way_cc`](Self::three_way_cc)).
+    ///
+    /// `curves` takes string options, so no `send_command` animation is registered;
+    /// a `Track` renders its `Duration::ZERO` value on the CPU while the GPU bridge
+    /// animates it per frame.
+    ///
+    /// # Validation
+    ///
+    /// [`build`](Self::build) returns [`FilterError::InvalidConfig`] if any `gamma`
+    /// component evaluates to `≤ 0.0` at `Duration::ZERO`.
+    #[must_use]
+    pub fn three_way_cc_animated(
+        mut self,
+        lift: [AnimatedValue<f64>; 3],
+        gamma: [AnimatedValue<f64>; 3],
+        gain: [AnimatedValue<f64>; 3],
+    ) -> Self {
+        self.steps
+            .push(FilterStep::ThreeWayCCAnimated { lift, gamma, gain });
+        self
+    }
+
     /// Apply a vignette effect using `FFmpeg`'s `vignette` filter.
     ///
     /// Darkens the corners of the frame with a smooth radial falloff.
@@ -905,6 +929,57 @@ mod tests {
         assert!(
             args.contains("b='0/0 0.5/0.5 1/1'"),
             "neutral b channel must be identity: {args}"
+        );
+    }
+
+    #[test]
+    fn three_way_cc_animated_static_should_render_the_zero_time_curves() {
+        use crate::animation::AnimatedValue;
+        let neutral = || {
+            [
+                AnimatedValue::Static(1.0_f64),
+                AnimatedValue::Static(1.0_f64),
+                AnimatedValue::Static(1.0_f64),
+            ]
+        };
+        let step = FilterStep::ThreeWayCCAnimated {
+            lift: neutral(),
+            gamma: neutral(),
+            gain: neutral(),
+        };
+        assert_eq!(step.filter_name(), "curves");
+        // Same identity curves as the static ThreeWayCC at neutral values.
+        assert!(
+            step.args().contains("r='0/0 0.5/0.5 1/1'"),
+            "neutral animated r channel must be identity: {}",
+            step.args()
+        );
+    }
+
+    #[test]
+    fn three_way_cc_animated_with_zero_gamma_should_return_invalid_config() {
+        use crate::animation::AnimatedValue;
+        let neutral = || {
+            [
+                AnimatedValue::Static(1.0_f64),
+                AnimatedValue::Static(1.0_f64),
+                AnimatedValue::Static(1.0_f64),
+            ]
+        };
+        let result = FilterGraph::builder()
+            .three_way_cc_animated(
+                neutral(),
+                [
+                    AnimatedValue::Static(0.0_f64),
+                    AnimatedValue::Static(1.0_f64),
+                    AnimatedValue::Static(1.0_f64),
+                ],
+                neutral(),
+            )
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for gamma <= 0.0, got {result:?}"
         );
     }
 

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -409,6 +409,71 @@ mod tests {
     }
 
     #[test]
+    fn base_layer_with_three_way_cc_animated_should_build() {
+        // `ThreeWayCCAnimated` builds the `curves` filter from its `Duration::ZERO`
+        // values through the generic `add_and_link_step` path. This drives that build
+        // for real (the args-only unit test does not). Same probe-gate as the other
+        // compound-effect tests: skip where FFmpeg has no filters.
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        // Non-neutral lift/gamma/gain so the curves are not the identity.
+        let ch = |v: f64| {
+            [
+                AnimatedValue::Static(v),
+                AnimatedValue::Static(v),
+                AnimatedValue::Static(v),
+            ]
+        };
+        let layer = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::ThreeWayCCAnimated {
+                lift: ch(1.1),
+                gamma: ch(1.2),
+                gain: ch(1.05),
+            }],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        let mut composer = RealtimeComposer::new(&[layer])
+            .expect("ThreeWayCCAnimated must build the curves filter once filters exist");
+        let frame = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn base_layer_with_raw_effect_should_build() {
         // #1376: `FilterStep::Raw` (the arbitrary-avfilter escape hatch) must work as a
         // per-layer effect through the realtime (preview) compositor's `add_and_link_step`

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -173,6 +173,23 @@ pub enum FilterStep {
         /// Affects highlights (whites). Neutral: `Rgb::NEUTRAL`.
         gain: Rgb,
     },
+    /// Three-way (lift/gamma/gain) colour corrector with optionally animated
+    /// per-channel parameters.
+    ///
+    /// Parameters are evaluated at [`Duration::ZERO`] for the graph build. `curves`
+    /// takes string curve options rather than scalars, so it is not driven by
+    /// `send_command` here: the CPU (`libavfilter`) path renders the `Duration::ZERO`
+    /// curves statically; the GPU path (`ff_render::ColorWheelsNode`) animates the
+    /// parameters per frame. Each `[R, G, B]` array carries the per-channel tracks,
+    /// with the same `Rgb::NEUTRAL` (1.0) convention as [`ThreeWayCC`](Self::ThreeWayCC).
+    ThreeWayCCAnimated {
+        /// Shadows (lift) per channel `[R, G, B]`. Neutral: 1.0.
+        lift: [AnimatedValue<f64>; 3],
+        /// Midtones (gamma) per channel `[R, G, B]`. Neutral: 1.0; must be > 0.0.
+        gamma: [AnimatedValue<f64>; 3],
+        /// Highlights (gain) per channel `[R, G, B]`. Neutral: 1.0.
+        gain: [AnimatedValue<f64>; 3],
+    },
     /// Vignette effect via `FFmpeg` `vignette` filter.
     Vignette {
         /// Radius angle in radians (valid range: 0.0 – π/2 ≈ 1.5708). Default: π/5 ≈ 0.628.
@@ -1052,6 +1069,33 @@ pub enum FilterStep {
 /// Tanner Helland's algorithm.
 ///
 /// Returns `(r, g, b)` each in `[0.0, 1.0]`.
+/// Renders the three-way (lift/gamma/gain) colour corrector as `curves` `r/g/b`
+/// options. Shared by [`FilterStep::ThreeWayCC`] and
+/// [`FilterStep::ThreeWayCCAnimated`].
+///
+/// The formula maps each channel to a 3-point curve:
+///   input 0.0 -> (lift - 1.0) * gain  (black point)
+///   input 0.5 -> (0.5 * lift)^(1/gamma) * gain  (midtone)
+///   input 1.0 -> gain  (white point)
+/// All neutral (1.0) produces the identity curve `0/0 0.5/0.5 1/1`.
+fn three_way_cc_args(lift: Rgb, gamma: Rgb, gain: Rgb) -> String {
+    let curve = |l: f32, gm: f32, gn: f32| -> String {
+        let l = f64::from(l);
+        let gm = f64::from(gm);
+        let gn = f64::from(gn);
+        let black = ((l - 1.0) * gn).clamp(0.0, 1.0);
+        let mid = ((0.5 * l).powf(1.0 / gm) * gn).clamp(0.0, 1.0);
+        let white = gn.clamp(0.0, 1.0);
+        format!("0/{black} 0.5/{mid} 1/{white}")
+    };
+    format!(
+        "r='{}':g='{}':b='{}'",
+        curve(lift.r, gamma.r, gain.r),
+        curve(lift.g, gamma.g, gain.g),
+        curve(lift.b, gamma.b, gain.b),
+    )
+}
+
 /// Renders the compound glow filter chain (`split` -> `curves` -> `gblur` ->
 /// `blend`) as a filtergraph string. Shared by [`FilterStep::Glow`] and
 /// [`FilterStep::GlowAnimated`]. (The real build goes through `add_glow_step`; this
@@ -1127,6 +1171,7 @@ impl FilterStep {
             Self::Hue { .. } => "hue",
             Self::Gamma { .. } => "eq",
             Self::ThreeWayCC { .. } => "curves",
+            Self::ThreeWayCCAnimated { .. } => "curves",
             Self::Vignette { .. } => "vignette",
             Self::HFlip => "hflip",
             Self::VFlip => "vflip",
@@ -1410,28 +1455,17 @@ impl FilterStep {
                 };
                 format!("angle={angle}:x0={cx}:y0={cy}")
             }
-            Self::ThreeWayCC { lift, gamma, gain } => {
-                // Convert lift/gamma/gain to a 3-point per-channel curves representation.
-                // The formula maps:
-                //   input 0.0 → (lift - 1.0) * gain  (black point)
-                //   input 0.5 → (0.5 * lift)^(1/gamma) * gain  (midtone)
-                //   input 1.0 → gain  (white point)
-                // All neutral (1.0) produces the identity curve 0/0 0.5/0.5 1/1.
-                let curve = |l: f32, gm: f32, gn: f32| -> String {
-                    let l = f64::from(l);
-                    let gm = f64::from(gm);
-                    let gn = f64::from(gn);
-                    let black = ((l - 1.0) * gn).clamp(0.0, 1.0);
-                    let mid = ((0.5 * l).powf(1.0 / gm) * gn).clamp(0.0, 1.0);
-                    let white = gn.clamp(0.0, 1.0);
-                    format!("0/{black} 0.5/{mid} 1/{white}")
+            Self::ThreeWayCC { lift, gamma, gain } => three_way_cc_args(*lift, *gamma, *gain),
+            Self::ThreeWayCCAnimated { lift, gamma, gain } => {
+                // The compound `curves` string is built from the `Duration::ZERO`
+                // values (the CPU path is static; the GPU animates per frame).
+                #[allow(clippy::cast_possible_truncation)]
+                let at0 = |a: &[AnimatedValue<f64>; 3]| Rgb {
+                    r: a[0].value_at(Duration::ZERO) as f32,
+                    g: a[1].value_at(Duration::ZERO) as f32,
+                    b: a[2].value_at(Duration::ZERO) as f32,
                 };
-                format!(
-                    "r='{}':g='{}':b='{}'",
-                    curve(lift.r, gamma.r, gain.r),
-                    curve(lift.g, gamma.g, gain.g),
-                    curve(lift.b, gamma.b, gain.b),
-                )
+                three_way_cc_args(at0(lift), at0(gamma), at0(gain))
             }
             Self::HFlip | Self::VFlip | Self::Reverse | Self::AReverse => String::new(),
             Self::GBlur { sigma } => format!("sigma={sigma}"),


### PR DESCRIPTION
## Objective

- Make the three-way (lift/gamma/gain) ColorWheels effect a typed, keyframeable clip effect wired into the GPU compositing bridge (preview + export), pairing the existing `ColorWheelsNode`.
- Keep the GPU and CPU paths in agreement within a documented tolerance, with a whole-frame CPU fallback for anything the GPU node cannot represent.

## Solution

- Add `EffectKind::ColorWheels { shadows_lift, midtones_gamma, highlights_gain }`, each a per-channel `[R, G, B]` array. It compiles to the `ThreeWayCC` (`curves`) step, offsetting the additive `shadows_lift` (neutral 0) onto the filter's `lift` (neutral 1); `map_scene` inverts that offset when classifying to the GPU node, and a fully neutral corrector compiles to nothing / is skipped.
- Add `FilterStep::ThreeWayCCAnimated`. `curves` takes string options rather than scalars, so it renders its `t = 0` curves statically on the CPU while the GPU animates the parameters per frame; an animated lift track is rebuilt keyframe-by-keyframe to apply the neutral-convention offset. A probe-gated build test drives the animated `curves` build.
- Add a probe-gated parity test over a colour gradient (the corrector shifts each channel) with a documented, loose tolerance for the differing lift/gamma/gain models (luma-region weighting vs per-channel curves), asserting the GPU output matches the CPU compound within tolerance and actually grades the frame.

Closes #1647