### PR TITLE
feat(avio): typed Curves clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -59,8 +59,8 @@ impl Param {
 /// A typed effect that a clip can carry. `#[non_exhaustive]`: more kinds are added
 /// over time, so external matchers must include a `_` arm.
 ///
-/// The v1 curated set is [`ColorCorrect`](Self::ColorCorrect), [`Blur`](Self::Blur),
-/// and [`Sharpen`](Self::Sharpen).
+/// The set grows as effect nodes are wired into the GPU bridge; each kind documents
+/// the `ff-filter` step / `ff-render` node it maps to.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
@@ -146,6 +146,23 @@ pub enum EffectKind {
         midtones_gamma: [Param; 3],
         /// Highlights gain, per channel. Range 0.0..=4.0 (neutral: 1.0).
         highlights_gain: [Param; 3],
+    },
+    /// Per-channel tone curves (the `curves` filter on the CPU path,
+    /// `ff_render::CurvesNode` on the GPU).
+    ///
+    /// Each curve is a list of `[input, output]` control points in `[0, 1]`. Unlike
+    /// the other kinds, a curve is a structural parameter, not a scalar, so it carries
+    /// no keyframeable [`Param`]; an empty set of curves is a no-op. The master curve
+    /// applies to every channel, then the per-channel curve.
+    Curves {
+        /// Master curve control points (applied to every channel). Empty = identity.
+        master: Vec<[f32; 2]>,
+        /// Red channel curve control points. Empty = identity.
+        red: Vec<[f32; 2]>,
+        /// Green channel curve control points. Empty = identity.
+        green: Vec<[f32; 2]>,
+        /// Blue channel curve control points. Empty = identity.
+        blue: Vec<[f32; 2]>,
     },
 }
 
@@ -340,6 +357,25 @@ impl EffectKind {
                         ],
                     })
                 }
+            }
+            // Curves map straight to the `curves` filter (control points as tuples);
+            // an all-empty set of curves is the identity, so it compiles to nothing.
+            EffectKind::Curves {
+                master,
+                red,
+                green,
+                blue,
+            } => {
+                if master.is_empty() && red.is_empty() && green.is_empty() && blue.is_empty() {
+                    return None;
+                }
+                let pts = |c: &[[f32; 2]]| c.iter().map(|p| (p[0], p[1])).collect::<Vec<_>>();
+                Some(FilterStep::Curves {
+                    master: pts(master),
+                    r: pts(red),
+                    g: pts(green),
+                    b: pts(blue),
+                })
             }
         }
     }
@@ -629,6 +665,37 @@ mod tests {
                 );
             }
             other => panic!("expected ThreeWayCCAnimated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn curves_empty_should_compile_to_nothing() {
+        let kind = EffectKind::Curves {
+            master: vec![],
+            red: vec![],
+            green: vec![],
+            blue: vec![],
+        };
+        assert!(
+            kind.to_filter_step().is_none(),
+            "an all-empty Curves is the identity (no-op)"
+        );
+    }
+
+    #[test]
+    fn curves_should_compile_to_curves_with_tuple_points() {
+        let kind = EffectKind::Curves {
+            master: vec![[0.0, 0.0], [0.5, 0.7], [1.0, 1.0]],
+            red: vec![],
+            green: vec![],
+            blue: vec![],
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Curves { master, r, .. } => {
+                assert_eq!(master, vec![(0.0, 0.0), (0.5, 0.7), (1.0, 1.0)]);
+                assert!(r.is_empty(), "an empty per-channel curve stays empty");
+            }
+            other => panic!("expected Curves, got {other:?}"),
         }
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -254,6 +254,17 @@ pub enum GpuEffect {
         /// Highlights gain (neutral 1.0) per channel `[R, G, B]`.
         highlights_gain: [f32; 3],
     },
+    /// `ff_render::CurvesNode` (per-channel tone curves).
+    Curves {
+        /// Master curve control points `[input, output]` (applied to every channel).
+        master: Vec<[f32; 2]>,
+        /// Red channel curve control points.
+        red: Vec<[f32; 2]>,
+        /// Green channel curve control points.
+        green: Vec<[f32; 2]>,
+        /// Blue channel curve control points.
+        blue: Vec<[f32; 2]>,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -558,6 +569,20 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             };
             let l = at(lift);
             color_wheels_step([l[0] - 1.0, l[1] - 1.0, l[2] - 1.0], at(gamma), at(gain))
+        }
+        // An all-empty set of curves is the identity, so skip it (no-op).
+        FilterStep::Curves { master, r, g, b } => {
+            if master.is_empty() && r.is_empty() && g.is_empty() && b.is_empty() {
+                StepClass::Skip
+            } else {
+                let pts = |c: &[(f32, f32)]| c.iter().map(|&(x, y)| [x, y]).collect::<Vec<_>>();
+                StepClass::Effect(GpuEffect::Curves {
+                    master: pts(master),
+                    red: pts(r),
+                    green: pts(g),
+                    blue: pts(b),
+                })
+            }
         }
         // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
@@ -1180,6 +1205,39 @@ mod tests {
         assert!(
             plan.layers[0].effects.is_empty(),
             "a neutral three-way corrector is a no-op and is skipped"
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_curves_with_array_points() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Curves {
+            master: vec![(0.0, 0.0), (0.5, 0.7), (1.0, 1.0)],
+            r: vec![],
+            g: vec![],
+            b: vec![],
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        let [GpuEffect::Curves { master, red, .. }] = plan.layers[0].effects.as_slice() else {
+            panic!("curves must map to a single Curves effect");
+        };
+        assert_eq!(master.as_slice(), [[0.0, 0.0], [0.5, 0.7], [1.0, 1.0]]);
+        assert!(red.is_empty(), "an empty per-channel curve stays empty");
+    }
+
+    #[test]
+    fn map_scene_should_skip_empty_curves() {
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Curves {
+            master: vec![],
+            r: vec![],
+            g: vec![],
+            b: vec![],
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert!(
+            plan.layers[0].effects.is_empty(),
+            "an all-empty Curves is a no-op and is skipped"
         );
     }
 

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -30,8 +30,9 @@ use std::time::Duration;
 
 use ff_format::VideoFrame;
 use ff_render::{
-    ColorGradeNode, ColorWheelsNode, Compositor, FilmGrainNode, FrameLayer, GaussianBlurNode,
-    GlowNode, LayerTransform, RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
+    ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode, FrameLayer,
+    GaussianBlurNode, GlowNode, LayerTransform, RenderContext, RenderGraph, ScaleNode, SharpenNode,
+    VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -197,6 +198,18 @@ impl GpuCompositor {
                     *shadows_lift,
                     *midtones_gamma,
                     *highlights_gain,
+                )),
+                // Curves preserves the frame dimensions too.
+                GpuEffect::Curves {
+                    master,
+                    red,
+                    green,
+                    blue,
+                } => graph.push(CurvesNode::new(
+                    master.clone(),
+                    red.clone(),
+                    green.clone(),
+                    blue.clone(),
                 )),
             };
         }

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -64,6 +64,11 @@ const TOL_GLOW_MEAN: f64 = 15.0;
 // loose calibrated tolerance: ~8.8 here (effect vs input ~7.7). Tested on a colour
 // gradient (RK-022): the corrector shifts each channel, so it is colour-relevant.
 const TOL_COLOR_WHEELS_MEAN: f64 = 20.0;
+// Curves: GPU CurvesNode (Steffen monotone-cubic LUT) vs the CPU `curves` filter
+// (its own spline). Both interpolate the same control points, so they agree closely:
+// ~1.4 here (effect vs input ~23). Tested on a colour gradient (RK-022): the per-channel
+// curves shift colour.
+const TOL_CURVES_MEAN: f64 = 8.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -568,6 +573,55 @@ fn color_wheels_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_COLOR_WHEELS_MEAN,
         "GPU and CPU ColorWheels diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn curves_gpu_should_match_cpu_within_tolerance() {
+    // Curves parity: GPU CurvesNode (map_scene maps `Curves`) vs the CPU `curves`
+    // filter. Both interpolate the same control points but with different splines
+    // (Steffen monotone cubic vs FFmpeg's), so a loose calibrated tolerance.
+    // Double-gated (adapter + filters). A colour gradient (RK-022) exercises the
+    // per-channel tone shift; the curve changes the frame, so a GPU that skipped it
+    // would diverge (non-vacuous, RK-015).
+    let (w, h) = (64, 48);
+    let input = gradient_rgba(w, h);
+    let frame = VideoFrame::from_rgba(w, h, input.clone()).unwrap();
+    // Lifted-midtones master curve + a slight red boost.
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::Curves {
+            master: vec![(0.0, 0.0), (0.5, 0.62), (1.0, 1.0)],
+            r: vec![(0.0, 0.05), (1.0, 1.0)],
+            g: vec![],
+            b: vec![],
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported Curves layer must composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    let effect = mean_abs_diff_rgb(&gpu_out, &input);
+    println!(
+        "curves GPU vs CPU: mean={mean:.3} max={} (GPU vs input: {effect:.3})",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    // Non-vacuous (RK-015): the curve must actually change the frame.
+    assert!(
+        effect > 2.0,
+        "the GPU curves must visibly grade the frame; got {effect}"
+    );
+    assert!(
+        mean <= TOL_CURVES_MEAN,
+        "GPU and CPU curves diverged beyond tolerance: mean={mean}"
     );
 }
 


### PR DESCRIPTION
## Objective

- Make the per-channel Curves effect a typed clip effect wired into the GPU compositing bridge (preview + export), pairing the existing `CurvesNode`.
- Keep the GPU and CPU paths in agreement within a documented tolerance, with a whole-frame CPU fallback for anything the GPU node cannot represent.

## Solution

- Add `EffectKind::Curves { master, red, green, blue }`, each curve a list of `[input, output]` control points. It maps straight to the existing `FilterStep::Curves` (control points as tuples); `map_scene` converts them back to arrays for the GPU node, so no ff-filter change is needed.
- A curve is a structural parameter rather than a scalar, so it carries no keyframeable `Param`; an all-empty set of curves is the identity and compiles to nothing / is skipped (RK-020).
- Add a probe-gated parity test over a colour gradient (per-channel tone shift, RK-022) with a documented tolerance; the GPU (Steffen monotone-cubic LUT) and CPU (the curves filter's own spline) interpolate the same control points and so agree closely.

Closes #1645