### PR TITLE
feat(avio): typed HSL clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -164,6 +164,25 @@ pub enum EffectKind {
         /// Blue channel curve control points. Empty = identity.
         blue: Vec<[f32; 2]>,
     },
+    /// HSL adjustment (the `hue` filter on the CPU path, `ff_render::HslNode` on
+    /// the GPU).
+    ///
+    /// A hue rotation in degrees, a saturation multiplier, and a lightness offset.
+    /// The CPU `hue` filter works in YUV (chroma rotation plus a luma-add
+    /// brightness), so it approximates the GPU node's HSL-space adjustment within a
+    /// documented tolerance. Neutral parameters (`hue_shift = 0.0`,
+    /// `saturation = 1.0`, `lightness = 0.0`, all constant) compile to no filter.
+    /// Because `hue`'s options are string expressions, an animated parameter
+    /// animates on the GPU-default path but renders its `t = 0` value on the CPU
+    /// fallback.
+    Hsl {
+        /// Hue rotation in degrees. Range −180.0..=180.0 (neutral: 0.0).
+        hue_shift: Param,
+        /// Saturation multiplier. Range 0.0..=2.0 (neutral: 1.0).
+        saturation: Param,
+        /// Lightness offset. Range −1.0..=1.0 (neutral: 0.0).
+        lightness: Param,
+    },
 }
 
 /// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
@@ -376,6 +395,36 @@ impl EffectKind {
                     g: pts(green),
                     b: pts(blue),
                 })
+            }
+            // Hsl maps to the `hue` filter (hue_shift -> h degrees, saturation -> s,
+            // lightness -> b brightness). A fully neutral, all-constant adjustment
+            // compiles to nothing; any animated parameter uses `HslAnimated` (which
+            // the GPU animates per frame; the CPU renders its `t = 0` values).
+            EffectKind::Hsl {
+                hue_shift,
+                saturation,
+                lightness,
+            } => {
+                if hue_shift.is_const() && saturation.is_const() && lightness.is_const() {
+                    #[allow(clippy::float_cmp)]
+                    let neutral = hue_shift.as_const() == Some(0.0)
+                        && saturation.as_const() == Some(1.0)
+                        && lightness.as_const() == Some(0.0);
+                    if neutral {
+                        return None;
+                    }
+                    Some(FilterStep::Hsl {
+                        hue: hue_shift.as_const().unwrap_or(0.0) as f32,
+                        saturation: saturation.as_const().unwrap_or(1.0) as f32,
+                        lightness: lightness.as_const().unwrap_or(0.0) as f32,
+                    })
+                } else {
+                    Some(FilterStep::HslAnimated {
+                        hue: hue_shift.to_animated(),
+                        saturation: saturation.to_animated(),
+                        lightness: lightness.to_animated(),
+                    })
+                }
             }
         }
     }
@@ -697,5 +746,55 @@ mod tests {
             }
             other => panic!("expected Curves, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn hsl_neutral_should_compile_to_nothing() {
+        let kind = EffectKind::Hsl {
+            hue_shift: Param::Const(0.0),
+            saturation: Param::Const(1.0),
+            lightness: Param::Const(0.0),
+        };
+        assert!(
+            kind.to_filter_step().is_none(),
+            "a neutral HSL adjustment is a no-op"
+        );
+    }
+
+    #[test]
+    fn hsl_const_should_compile_to_hsl() {
+        let kind = EffectKind::Hsl {
+            hue_shift: Param::Const(20.0),
+            saturation: Param::Const(1.2),
+            lightness: Param::Const(0.05),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Hsl {
+                hue,
+                saturation,
+                lightness,
+            } => {
+                assert!((hue - 20.0).abs() < 1e-5);
+                assert!((saturation - 1.2).abs() < 1e-5);
+                assert!((lightness - 0.05).abs() < 1e-5);
+            }
+            other => panic!("expected Hsl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hsl_any_animated_should_compile_to_hsl_animated() {
+        let kind = EffectKind::Hsl {
+            hue_shift: Param::Animated(animated_track()),
+            saturation: Param::Const(1.0),
+            lightness: Param::Const(0.0),
+        };
+        assert!(
+            matches!(
+                kind.to_filter_step().unwrap(),
+                FilterStep::HslAnimated { .. }
+            ),
+            "any animated parameter routes through HslAnimated"
+        );
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -265,6 +265,15 @@ pub enum GpuEffect {
         /// Blue channel curve control points.
         blue: Vec<[f32; 2]>,
     },
+    /// `ff_render::HslNode` (hue / saturation / lightness adjustment).
+    Hsl {
+        /// Hue rotation in degrees.
+        hue_shift: f32,
+        /// Saturation multiplier (neutral `1.0`).
+        saturation: f32,
+        /// Lightness offset (neutral `0.0`).
+        lightness: f32,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -584,6 +593,20 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
                 })
             }
         }
+        FilterStep::Hsl {
+            hue,
+            saturation,
+            lightness,
+        } => hsl_step(*hue, *saturation, *lightness),
+        FilterStep::HslAnimated {
+            hue,
+            saturation,
+            lightness,
+        } => hsl_step(
+            hue.value_at(t) as f32,
+            saturation.value_at(t) as f32,
+            lightness.value_at(t) as f32,
+        ),
         // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
         // `#[non_exhaustive]` from ff-filter (RK-003).
@@ -663,6 +686,21 @@ fn glow_step(threshold: f32, radius: f32, intensity: f32) -> StepClass {
         threshold,
         radius,
         intensity,
+    })
+}
+
+/// Classifies an HSL step: a fully neutral adjustment is a no-op (`Skip`);
+/// otherwise it maps straight to the GPU node (hue degrees / saturation multiplier
+/// / lightness offset already in the node's convention).
+#[allow(clippy::float_cmp)]
+fn hsl_step(hue_shift: f32, saturation: f32, lightness: f32) -> StepClass {
+    if hue_shift == 0.0 && saturation == 1.0 && lightness == 0.0 {
+        return StepClass::Skip;
+    }
+    StepClass::Effect(GpuEffect::Hsl {
+        hue_shift,
+        saturation,
+        lightness,
     })
 }
 

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -31,8 +31,8 @@ use std::time::Duration;
 use ff_format::VideoFrame;
 use ff_render::{
     ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode, FrameLayer,
-    GaussianBlurNode, GlowNode, LayerTransform, RenderContext, RenderGraph, ScaleNode, SharpenNode,
-    VignetteNode,
+    GaussianBlurNode, GlowNode, HslNode, LayerTransform, RenderContext, RenderGraph, ScaleNode,
+    SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -211,6 +211,12 @@ impl GpuCompositor {
                     green.clone(),
                     blue.clone(),
                 )),
+                // Hsl preserves the frame dimensions too.
+                GpuEffect::Hsl {
+                    hue_shift,
+                    saturation,
+                    lightness,
+                } => graph.push(HslNode::new(*hue_shift, *saturation, *lightness)),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -69,6 +69,12 @@ const TOL_COLOR_WHEELS_MEAN: f64 = 20.0;
 // ~1.4 here (effect vs input ~23). Tested on a colour gradient (RK-022): the per-channel
 // curves shift colour.
 const TOL_CURVES_MEAN: f64 = 8.0;
+// HSL: GPU HslNode (true HSL space) vs the CPU `hue` filter (YUV chroma rotation
+// for hue/saturation, a luma add for brightness). The colour models differ but
+// still agree closely for a modest adjustment: ~6.7 here (effect vs input ~21).
+// Tested on a colour gradient (RK-022) where the hue/saturation shift moves every
+// channel.
+const TOL_HSL_MEAN: f64 = 20.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -622,6 +628,54 @@ fn curves_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_CURVES_MEAN,
         "GPU and CPU curves diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn hsl_gpu_should_match_cpu_within_tolerance() {
+    // HSL parity: GPU HslNode (map_scene maps `Hsl`) vs the CPU `hue` filter. The
+    // node works in HSL space; `hue` works in YUV (chroma rotation + a luma-add
+    // brightness), so they only agree within a wide calibrated tolerance.
+    // Double-gated (adapter + filters). A colour gradient (RK-022) exercises the
+    // hue/saturation shift across channels; the adjustment changes the frame, so a
+    // GPU that skipped it would diverge (non-vacuous, RK-015).
+    let (w, h) = (64, 48);
+    let input = gradient_rgba(w, h);
+    let frame = VideoFrame::from_rgba(w, h, input.clone()).unwrap();
+    // Modest hue rotation + saturation boost + a small lightness lift.
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::Hsl {
+            hue: 20.0,
+            saturation: 1.2,
+            lightness: 0.05,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported Hsl layer must composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    let effect = mean_abs_diff_rgb(&gpu_out, &input);
+    println!(
+        "hsl GPU vs CPU: mean={mean:.3} max={} (GPU vs input: {effect:.3})",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    // Non-vacuous (RK-015): the HSL adjustment must actually change the frame.
+    assert!(
+        effect > 2.0,
+        "the GPU HSL adjustment must visibly change the frame; got {effect}"
+    );
+    assert!(
+        mean <= TOL_HSL_MEAN,
+        "GPU and CPU HSL diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/graph/composition/realtime_composer.rs
+++ b/crates/ff-filter/src/graph/composition/realtime_composer.rs
@@ -474,6 +474,64 @@ mod tests {
     }
 
     #[test]
+    fn base_layer_with_hsl_animated_should_build() {
+        // `HslAnimated` builds the `hue` filter from its `Duration::ZERO` values
+        // through the generic `add_and_link_step` path. This drives that build for
+        // real (the args-only unit test does not). Same probe-gate: skip where
+        // FFmpeg has no filters.
+        let probe = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        if RealtimeComposer::new(&[probe]).is_err() {
+            println!("Skipping: FFmpeg filters unavailable");
+            return;
+        }
+
+        // Non-neutral hue/saturation/lightness so the filter is not the identity.
+        let layer = RealtimeLayer {
+            width: 8,
+            height: 8,
+            pixel_format: PixelFormat::Rgba,
+            effects: vec![FilterStep::HslAnimated {
+                hue: AnimatedValue::Static(20.0),
+                saturation: AnimatedValue::Static(1.2),
+                lightness: AnimatedValue::Static(0.05),
+            }],
+            opacity: AnimatedValue::Static(1.0),
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            scale_x: AnimatedValue::Static(1.0),
+            scale_y: AnimatedValue::Static(1.0),
+            rotation: AnimatedValue::Static(0.0),
+            blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
+        };
+        let mut composer = RealtimeComposer::new(&[layer])
+            .expect("HslAnimated must build the hue filter once filters exist");
+        let frame = VideoFrame::from_rgba(8, 8, vec![120u8; 8 * 8 * 4]).unwrap();
+        if composer.push_layer(0, &frame).is_err() {
+            println!("Skipping: push failed (FFmpeg unavailable?)");
+            return;
+        }
+        match composer.pull() {
+            Ok(Some(out)) => assert_eq!(out.format(), PixelFormat::Rgba),
+            Ok(None) => println!("Skipping: no frame produced"),
+            Err(e) => println!("Skipping: {e}"),
+        }
+    }
+
+    #[test]
     fn base_layer_with_raw_effect_should_build() {
         // #1376: `FilterStep::Raw` (the arbitrary-avfilter escape hatch) must work as a
         // per-layer effect through the realtime (preview) compositor's `add_and_link_step`

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -214,6 +214,32 @@ pub enum FilterStep {
         /// Vertical centre. `0.0` maps to `h/2`.
         y0: f32,
     },
+    /// HSL adjustment via `FFmpeg` `hue` filter (`ff_render::HslNode` on the GPU).
+    ///
+    /// `hue` works in YUV (a chroma rotation for hue/saturation, a luma add for
+    /// brightness), so it approximates the GPU node's HSL-space adjustment within a
+    /// documented tolerance. `lightness` is scaled to the filter's `b` brightness.
+    Hsl {
+        /// Hue rotation in degrees.
+        hue: f32,
+        /// Saturation multiplier (neutral `1.0`).
+        saturation: f32,
+        /// Lightness offset in `[-1, 1]` (scaled to the `hue` filter's brightness).
+        lightness: f32,
+    },
+    /// HSL adjustment with optionally animated parameters.
+    ///
+    /// The GPU animates per frame; the CPU (`libavfilter`) path renders the
+    /// `Duration::ZERO` values (`hue`'s options accept `t`-expressions, but the CPU
+    /// path is kept static so the GPU-default path is the single animated one).
+    HslAnimated {
+        /// Hue rotation in degrees, evaluated at `Duration::ZERO`.
+        hue: AnimatedValue<f64>,
+        /// Saturation multiplier, evaluated at `Duration::ZERO`.
+        saturation: AnimatedValue<f64>,
+        /// Lightness offset in `[-1, 1]`, evaluated at `Duration::ZERO`.
+        lightness: AnimatedValue<f64>,
+    },
     /// Horizontal flip (mirror left-right).
     HFlip,
     /// Vertical flip (mirror top-bottom).
@@ -1112,6 +1138,19 @@ fn glow_compound_args(threshold: f32, radius: f32, intensity: f32) -> String {
     )
 }
 
+/// Lightness offset `[-1, 1]` -> the `hue` filter's brightness `[-10, 10]`. The
+/// filter adds `b * 25.5` to 8-bit luma, so `±1` lightness maps to `±10` b, a
+/// roughly full-range luma shift. This YUV luma-add only approximates the GPU
+/// node's HSL-space lightness, hence the wide parity tolerance.
+const HSL_LIGHTNESS_TO_BRIGHTNESS: f32 = 10.0;
+
+/// Renders the `hue` filter args for an HSL adjustment (hue degrees, saturation
+/// multiplier, lightness scaled to the filter's brightness).
+fn hsl_args(hue: f32, saturation: f32, lightness: f32) -> String {
+    let b = lightness * HSL_LIGHTNESS_TO_BRIGHTNESS;
+    format!("h={hue}:s={saturation}:b={b}")
+}
+
 fn kelvin_to_rgb(temp_k: u32) -> (f64, f64, f64) {
     let t = (f64::from(temp_k) / 100.0).clamp(10.0, 400.0);
     let r = if t <= 66.0 {
@@ -1169,6 +1208,8 @@ impl FilterStep {
             Self::Curves { .. } => "curves",
             Self::WhiteBalance { .. } => "colorchannelmixer",
             Self::Hue { .. } => "hue",
+            Self::Hsl { .. } => "hue",
+            Self::HslAnimated { .. } => "hue",
             Self::Gamma { .. } => "eq",
             Self::ThreeWayCC { .. } => "curves",
             Self::ThreeWayCCAnimated { .. } => "curves",
@@ -1441,6 +1482,25 @@ impl FilterStep {
                 format!("rr={r}:gg={g_adj}:bb={b}")
             }
             Self::Hue { degrees } => format!("h={degrees}"),
+            Self::Hsl {
+                hue,
+                saturation,
+                lightness,
+            } => hsl_args(*hue, *saturation, *lightness),
+            Self::HslAnimated {
+                hue,
+                saturation,
+                lightness,
+            } => {
+                // The CPU path is static (the GPU animates per frame): render the
+                // `Duration::ZERO` values.
+                #[allow(clippy::cast_possible_truncation)]
+                hsl_args(
+                    hue.value_at(Duration::ZERO) as f32,
+                    saturation.value_at(Duration::ZERO) as f32,
+                    lightness.value_at(Duration::ZERO) as f32,
+                )
+            }
             Self::Gamma { r, g, b } => format!("gamma_r={r}:gamma_g={g}:gamma_b={b}"),
             Self::Vignette { angle, x0, y0 } => {
                 let cx = if *x0 == 0.0 {


### PR DESCRIPTION
## Objective

- Make the HSL adjustment a typed, keyframeable clip effect wired into the GPU compositing bridge (preview + export), pairing the built `ff_render::HslNode`.
- Keep the GPU and CPU paths in agreement within a documented tolerance, with a whole-frame CPU fallback for anything the GPU node cannot represent.

## Solution

- Add `EffectKind::Hsl { hue_shift, saturation, lightness }` (each a keyframeable `Param`) and the `FilterStep::Hsl` / `HslAnimated` variants it compiles to; the CPU `hue` filter works in YUV (chroma rotation for hue/saturation, a luma-add brightness), so `lightness` is scaled to the filter's brightness and the two colour models agree only within a calibrated tolerance.
- A neutral, all-constant adjustment compiles to nothing; any animated parameter routes through `HslAnimated`, which the GPU animates per frame while the CPU renders its `t = 0` value, matching the other GPU-animated effects.
- `map_scene` classifies the step to `GpuEffect::Hsl` (a neutral step is skipped); the existing `FilterStep::Hue` stays unmapped so the unsupported-effect fallback path is unchanged.
- Add a probe-gated GPU/CPU parity test over a colour gradient, a probe-gated `HslAnimated` build test, and `to_filter_step` unit tests.

Closes #1646