### PR TITLE
feat(avio): typed LUT clip effect with GPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -183,6 +183,17 @@ pub enum EffectKind {
         /// Lightness offset. Range −1.0..=1.0 (neutral: 0.0).
         lightness: Param,
     },
+    /// 3D colour LUT (the `lut3d` filter on the CPU path, `ff_render::LutNode` on
+    /// the GPU), loaded from an Adobe `.cube` or Resolve `.3dl` file.
+    ///
+    /// Like [`Curves`](Self::Curves), a LUT is a structural parameter (a file
+    /// path), not a scalar, so it carries no keyframeable [`Param`]; an empty path
+    /// is a no-op. On the GPU a file that cannot be loaded (missing, malformed, or
+    /// an unsupported extension) falls back to the CPU path.
+    Lut {
+        /// Path to the `.cube` / `.3dl` LUT file. Empty = identity.
+        path: String,
+    },
 }
 
 /// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
@@ -425,6 +436,14 @@ impl EffectKind {
                         lightness: lightness.to_animated(),
                     })
                 }
+            }
+            // Lut maps straight to the `lut3d` filter (the same file path the GPU
+            // LutNode loads); an empty path is the identity, so it compiles to nothing.
+            EffectKind::Lut { path } => {
+                if path.is_empty() {
+                    return None;
+                }
+                Some(FilterStep::Lut3d { path: path.clone() })
             }
         }
     }
@@ -796,5 +815,27 @@ mod tests {
             ),
             "any animated parameter routes through HslAnimated"
         );
+    }
+
+    #[test]
+    fn lut_empty_path_should_compile_to_nothing() {
+        let kind = EffectKind::Lut {
+            path: String::new(),
+        };
+        assert!(
+            kind.to_filter_step().is_none(),
+            "an empty LUT path is the identity (no-op)"
+        );
+    }
+
+    #[test]
+    fn lut_should_compile_to_lut3d() {
+        let kind = EffectKind::Lut {
+            path: "grade.cube".to_string(),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Lut3d { path } => assert_eq!(path, "grade.cube"),
+            other => panic!("expected Lut3d, got {other:?}"),
+        }
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -274,6 +274,11 @@ pub enum GpuEffect {
         /// Lightness offset (neutral `0.0`).
         lightness: f32,
     },
+    /// `ff_render::LutNode` (3D colour LUT loaded from a `.cube` / `.3dl` file).
+    Lut {
+        /// Path to the LUT file the compositor loads.
+        path: String,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -607,6 +612,15 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             saturation.value_at(t) as f32,
             lightness.value_at(t) as f32,
         ),
+        // An empty path is the identity (no-op); otherwise the compositor loads the
+        // LUT file. A file it cannot load falls back to CPU there (RK-020).
+        FilterStep::Lut3d { path } => {
+            if path.is_empty() {
+                StepClass::Skip
+            } else {
+                StepClass::Effect(GpuEffect::Lut { path: path.clone() })
+            }
+        }
         // Everything else (other colour, keying, masks, animated geometry,
         // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
         // `#[non_exhaustive]` from ff-filter (RK-003).

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -31,8 +31,8 @@ use std::time::Duration;
 use ff_format::VideoFrame;
 use ff_render::{
     ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode, FrameLayer,
-    GaussianBlurNode, GlowNode, HslNode, LayerTransform, RenderContext, RenderGraph, ScaleNode,
-    SharpenNode, VignetteNode,
+    GaussianBlurNode, GlowNode, HslNode, LayerTransform, LutNode, RenderContext, RenderGraph,
+    ScaleNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -217,10 +217,26 @@ impl GpuCompositor {
                     saturation,
                     lightness,
                 } => graph.push(HslNode::new(*hue_shift, *saturation, *lightness)),
+                // Lut preserves the frame dimensions too. A file the LutNode cannot
+                // load (missing, malformed, or an unsupported extension) makes the
+                // whole frame fall back to CPU rather than render wrong output (RK-020).
+                GpuEffect::Lut { path } => graph.push(load_lut(path)?),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;
         VideoFrame::from_rgba(out_w, out_h, out).ok()
+    }
+}
+
+/// Loads a `LutNode` from a `.cube` or `.3dl` file, or `None` when the extension is
+/// unsupported or the file cannot be loaded. A `None` makes the layer fall back to
+/// the CPU path (RK-020) rather than render wrong output.
+fn load_lut(path: &str) -> Option<LutNode> {
+    let p = std::path::Path::new(path);
+    match p.extension().and_then(|e| e.to_str()) {
+        Some(ext) if ext.eq_ignore_ascii_case("cube") => LutNode::from_cube(p).ok(),
+        Some(ext) if ext.eq_ignore_ascii_case("3dl") => LutNode::from_3dl(p).ok(),
+        _ => None,
     }
 }
 

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -75,6 +75,11 @@ const TOL_CURVES_MEAN: f64 = 8.0;
 // Tested on a colour gradient (RK-022) where the hue/saturation shift moves every
 // channel.
 const TOL_HSL_MEAN: f64 = 20.0;
+// LUT: GPU LutNode vs the CPU `lut3d` filter, both trilinear over the same .cube
+// grid, so they agree almost exactly: ~0.27 here (effect vs input ~10, max 1). The
+// RK-005-verified axis order matches FFmpeg's, so a transposition would push the
+// mean to tens. Tested on a colour gradient (RK-022) with a per-channel-shifting LUT.
+const TOL_LUT_MEAN: f64 = 4.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -676,6 +681,73 @@ fn hsl_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_HSL_MEAN,
         "GPU and CPU HSL diverged beyond tolerance: mean={mean}"
+    );
+}
+
+/// Writes a size-`n` `.cube` LUT to a temp file whose grid applies `shift(r,g,b)`
+/// (each output channel in `[0, 1]`), returning the path. Red-fastest order (the
+/// `.cube` convention).
+fn write_cube(n: usize, shift: impl Fn(f32, f32, f32) -> [f32; 3]) -> std::path::PathBuf {
+    let last = (n - 1) as f32;
+    let mut s = format!("LUT_3D_SIZE {n}\n");
+    for b in 0..n {
+        for g in 0..n {
+            for r in 0..n {
+                let o = shift(r as f32 / last, g as f32 / last, b as f32 / last);
+                s.push_str(&format!("{} {} {}\n", o[0], o[1], o[2]));
+            }
+        }
+    }
+    let path = std::env::temp_dir().join(format!("avio_parity_{}.cube", std::process::id()));
+    std::fs::write(&path, s).expect("write temp cube");
+    path
+}
+
+#[test]
+fn lut_gpu_should_match_cpu_within_tolerance() {
+    // LUT parity: GPU LutNode (map_scene maps `Lut3d`) vs the CPU `lut3d` filter,
+    // both loading the same .cube and interpolating trilinearly. Double-gated
+    // (adapter + filters). A colour gradient (RK-022) with a per-channel-shifting
+    // LUT; the LUT changes the frame, so a GPU that skipped it would diverge
+    // (non-vacuous, RK-015).
+    let (w, h) = (64, 48);
+    let input = gradient_rgba(w, h);
+    let frame = VideoFrame::from_rgba(w, h, input.clone()).unwrap();
+    // A gentle per-channel curve: lift red, keep green, pull blue.
+    let path = write_cube(17, |r, g, b| [(r * 1.1).min(1.0), g, (b * 0.85).max(0.0)]);
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::Lut3d {
+            path: path.to_string_lossy().into_owned(),
+        }],
+    );
+    let result = (|| {
+        let mut gpu = GpuCompositor::new()?; // no adapter
+        let cpu = cpu_composite(&layer, &frame, (w, h))?; // filters unavailable
+        let gpu_out = gpu_composite(&mut gpu, &layer, &frame, (w, h))
+            .expect("a supported Lut layer must composite on the GPU");
+        Some((cpu, gpu_out))
+    })();
+    let _ = std::fs::remove_file(&path);
+    let Some((cpu, gpu_out)) = result else {
+        return; // adapter or filters unavailable
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    let effect = mean_abs_diff_rgb(&gpu_out, &input);
+    println!(
+        "lut GPU vs CPU: mean={mean:.3} max={} (GPU vs input: {effect:.3})",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    // Non-vacuous (RK-015): the LUT must actually change the frame.
+    assert!(
+        effect > 2.0,
+        "the GPU LUT must visibly change the frame; got {effect}"
+    );
+    assert!(
+        mean <= TOL_LUT_MEAN,
+        "GPU and CPU LUT diverged beyond tolerance: mean={mean}"
     );
 }
 


### PR DESCRIPTION
## Objective

- Make the 3D LUT effect a typed clip effect wired into the GPU compositing bridge (preview + export), pairing the built `ff_render::LutNode` with the existing `FilterStep::Lut3d` (FFmpeg `lut3d`).
- Keep the GPU and CPU paths in agreement, with a whole-frame CPU fallback for anything the GPU node cannot load.

## Solution

- Add `EffectKind::Lut { path }` and its `map_scene` classification to `GpuEffect::Lut`. Like `Curves`, a LUT is a structural parameter (a file path), not a scalar, so it carries no keyframeable `Param`; an empty path is the identity and compiles to nothing / is skipped.
- The GPU compositor loads the `LutNode` by extension (`.cube` / `.3dl`); a file it cannot load (missing, malformed, or an unsupported extension) makes the whole frame fall back to the CPU path rather than render wrong output (RK-020). No ff-filter or ff-render change is needed.
- Add a probe-gated parity test that writes a small `.cube`, loads it on both paths, and asserts the GPU `LutNode` and the CPU `lut3d` filter agree within a documented tolerance (both interpolate the same grid trilinearly, so they match almost exactly), plus `to_filter_step` unit tests.

Closes #1644