### PR TITLE
feat(ff-render): directional wipe and dip-to-color transition nodes

### DIFF
--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -80,9 +80,9 @@ pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, ColorWheelsNode,
-    CrossfadeNode, CurvesNode, FilmGrainNode, GaussianBlurNode, GlowNode, HslNode, LumaMaskNode,
-    LutNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode, SharpenNode,
-    TransformNode, VignetteNode, YuvFormat, YuvUploadNode,
+    CrossfadeNode, CurvesNode, DipToColorNode, FilmGrainNode, GaussianBlurNode, GlowNode, HslNode,
+    LumaMaskNode, LutNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode,
+    SharpenNode, TransformNode, VignetteNode, WipeTransitionNode, YuvFormat, YuvUploadNode,
 };
 pub use sink::GpuFrameSink;
 

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -10,6 +10,7 @@ pub mod hsl;
 pub mod lut;
 pub mod overlay;
 pub mod scale;
+pub mod transition;
 pub mod upload;
 pub mod vignette;
 
@@ -28,6 +29,7 @@ pub use hsl::HslNode;
 pub use lut::LutNode;
 pub use overlay::OverlayNode;
 pub use scale::{ScaleAlgorithm, ScaleNode};
+pub use transition::{DipToColorNode, WipeTransitionNode};
 pub use upload::{YuvFormat, YuvUploadNode};
 pub use vignette::VignetteNode;
 

--- a/crates/ff-render/src/nodes/transition.rs
+++ b/crates/ff-render/src/nodes/transition.rs
@@ -1,0 +1,648 @@
+//! Two-clip transition nodes: a directional wipe and a two-phase dip to a solid
+//! colour. Like [`CrossfadeNode`](super::crossfade::CrossfadeNode), the second clip
+//! (B) is carried as RGBA bytes in the node and uploaded to a GPU texture at render
+//! time: a single render graph has one source, so B cannot arrive as a second GPU
+//! input. Clip A is the node's input (`inputs[0]` / the `process_cpu` argument).
+
+use super::RenderNodeCpu;
+
+/// Linear interpolation `a + (b - a) * t`, rounded to the nearest byte.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn lerp_u8(a: f32, b: f32, t: f32) -> u8 {
+    (a + (b - a) * t + 0.5).clamp(0.0, 255.0) as u8
+}
+
+/// `smoothstep(e0, e1, x)`; callers guarantee `e1 > e0`.
+fn smoothstep(e0: f32, e1: f32, x: f32) -> f32 {
+    let t = ((x - e0) / (e1 - e0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+// WipeTransitionNode
+
+/// Directional wipe that reveals clip B behind a moving edge.
+///
+/// `progress = 0` outputs clip A, `progress = 1` outputs clip B, and the edge sweeps
+/// across the frame between them along `angle` (radians: `0` = left→right,
+/// `π/2` = top→bottom). `softness` feathers the edge (normalised units).
+pub struct WipeTransitionNode {
+    /// Transition progress `[0, 1]`: 0 = clip A, 1 = clip B.
+    pub progress: f32,
+    /// Edge feather half-width in normalised units (0 = hard edge).
+    pub softness: f32,
+    /// Wipe direction in radians (0 = left→right, `π/2` = top→bottom).
+    pub angle: f32,
+    /// Clip B as RGBA bytes (`to_width × to_height × 4`).
+    pub to_rgba: Vec<u8>,
+    /// Width of `to_rgba`.
+    pub to_width: u32,
+    /// Height of `to_rgba`.
+    pub to_height: u32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<TransitionPipeline>,
+}
+
+impl WipeTransitionNode {
+    /// Creates a wipe from clip A (the node input) to clip B (`to_rgba`).
+    #[must_use]
+    pub fn new(
+        progress: f32,
+        softness: f32,
+        angle: f32,
+        to_rgba: Vec<u8>,
+        to_width: u32,
+        to_height: u32,
+    ) -> Self {
+        Self {
+            progress,
+            softness,
+            angle,
+            to_rgba,
+            to_width,
+            to_height,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// The B-weight (`mask`) at a normalised pixel centre. Shared by the CPU and GPU
+    /// paths (`wipe.wgsl` uses the identical formula) so they agree.
+    fn mask_at(&self, uv_x: f32, uv_y: f32) -> f32 {
+        let (ax, ay) = (self.angle.cos(), self.angle.sin());
+        let reach = f32::midpoint(ax.abs(), ay.abs());
+        // Floor the half-width so a zero softness is a near-hard, division-safe edge.
+        let hw = self.softness.max(1e-3);
+        // Sweep the threshold from beyond the far corner (all A at progress 0) to
+        // beyond the near corner (all B at progress 1), so the endpoints are exact.
+        let center = (0.5 + reach + hw) + ((0.5 - reach - hw) - (0.5 + reach + hw)) * self.progress;
+        let proj = (uv_x - 0.5) * ax + (uv_y - 0.5) * ay + 0.5;
+        smoothstep(center - hw, center + hw, proj)
+    }
+}
+
+impl RenderNodeCpu for WipeTransitionNode {
+    #[allow(clippy::cast_precision_loss)]
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
+        if self.to_rgba.len() != rgba.len() {
+            log::warn!(
+                "WipeTransitionNode::process_cpu skipped: size mismatch a={} b={}",
+                rgba.len(),
+                self.to_rgba.len()
+            );
+            return;
+        }
+        let (wf, hf) = (w as f32, h as f32);
+        for y in 0..h {
+            for x in 0..w {
+                let idx = ((y * w + x) * 4) as usize;
+                let mask = self.mask_at((x as f32 + 0.5) / wf, (y as f32 + 0.5) / hf);
+                for c in 0..4 {
+                    let a = f32::from(rgba[idx + c]);
+                    let b = f32::from(self.to_rgba[idx + c]);
+                    rgba[idx + c] = lerp_u8(a, b, mask);
+                }
+            }
+        }
+    }
+}
+
+// DipToColorNode
+
+/// Two-phase transition: clip A fades to a solid `color`, then the colour fades to
+/// clip B. `progress = 0.5` is the fully solid dip (a fade-to-black/white/brand dip).
+pub struct DipToColorNode {
+    /// Transition progress `[0, 1]`: 0 = clip A, 0.5 = solid `color`, 1 = clip B.
+    pub progress: f32,
+    /// Dip colour in RGB `[0, 1]` (e.g. `[0, 0, 0]` for fade-to-black).
+    pub color: [f32; 3],
+    /// Clip B as RGBA bytes (`to_width × to_height × 4`).
+    pub to_rgba: Vec<u8>,
+    /// Width of `to_rgba`.
+    pub to_width: u32,
+    /// Height of `to_rgba`.
+    pub to_height: u32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<TransitionPipeline>,
+}
+
+impl DipToColorNode {
+    /// Creates a dip-to-colour transition from clip A to clip B (`to_rgba`).
+    #[must_use]
+    pub fn new(
+        progress: f32,
+        color: [f32; 3],
+        to_rgba: Vec<u8>,
+        to_width: u32,
+        to_height: u32,
+    ) -> Self {
+        Self {
+            progress,
+            color,
+            to_rgba,
+            to_width,
+            to_height,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl RenderNodeCpu for DipToColorNode {
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        let dip = [
+            self.color[0] * 255.0,
+            self.color[1] * 255.0,
+            self.color[2] * 255.0,
+            255.0,
+        ];
+        if self.progress < 0.5 {
+            // Phase 1: clip A -> dip colour. Clip B is not needed yet.
+            let t = self.progress * 2.0;
+            for px in rgba.as_chunks_mut::<4>().0 {
+                for c in 0..4 {
+                    px[c] = lerp_u8(f32::from(px[c]), dip[c], t);
+                }
+            }
+            return;
+        }
+        // Phase 2: dip colour -> clip B.
+        if self.to_rgba.len() != rgba.len() {
+            log::warn!(
+                "DipToColorNode::process_cpu skipped: size mismatch a={} b={}",
+                rgba.len(),
+                self.to_rgba.len()
+            );
+            return;
+        }
+        let t = (self.progress - 0.5) * 2.0;
+        for (px, b) in rgba
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(self.to_rgba.as_chunks::<4>().0)
+        {
+            for c in 0..4 {
+                px[c] = lerp_u8(dip[c], f32::from(b[c]), t);
+            }
+        }
+    }
+}
+
+// GPU path (shared 2-input plumbing)
+
+#[cfg(feature = "wgpu")]
+struct TransitionPipeline {
+    render_pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    uniform_buf: wgpu::Buffer,
+}
+
+#[cfg(feature = "wgpu")]
+fn tex_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Texture {
+            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+            view_dimension: wgpu::TextureViewDimension::D2,
+            multisampled: false,
+        },
+        count: None,
+    }
+}
+
+/// Builds the shared transition pipeline: bind group `tex_a` / `tex_b` / sampler /
+/// uniform, and a uniform buffer of `uniform_size` bytes.
+#[cfg(feature = "wgpu")]
+fn build_pipeline(
+    device: &wgpu::Device,
+    shader_src: &str,
+    label: &str,
+    uniform_size: u64,
+) -> TransitionPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some(label),
+        source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+    });
+    let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some(label),
+        entries: &[
+            tex_entry(0),
+            tex_entry(1),
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+        ],
+    });
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some(label),
+        bind_group_layouts: &[Some(&bgl)],
+        immediate_size: 0,
+    });
+    let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some(label),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            buffers: &[],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    });
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some(label),
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        ..Default::default()
+    });
+    let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size: uniform_size,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    TransitionPipeline {
+        render_pipeline,
+        bind_group_layout: bgl,
+        sampler,
+        uniform_buf,
+    }
+}
+
+/// Uploads clip B to a temporary `Rgba8Unorm` texture.
+#[cfg(feature = "wgpu")]
+fn upload_frame(
+    ctx: &crate::context::RenderContext,
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+) -> wgpu::Texture {
+    let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Transition to_tex"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+    ctx.queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &tex,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        rgba,
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(width * 4),
+            rows_per_image: None,
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    tex
+}
+
+/// Binds `tex_a` / `tex_b` / sampler / uniform and runs the full-screen pass.
+#[cfg(feature = "wgpu")]
+fn run_pass(
+    ctx: &crate::context::RenderContext,
+    pd: &TransitionPipeline,
+    tex_a: &wgpu::Texture,
+    tex_b: &wgpu::Texture,
+    output: &wgpu::Texture,
+    label: &str,
+) {
+    let a_view = tex_a.create_view(&wgpu::TextureViewDescriptor::default());
+    let b_view = tex_b.create_view(&wgpu::TextureViewDescriptor::default());
+    let out_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some(label),
+        layout: &pd.bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&a_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(&b_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::Sampler(&pd.sampler),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: pd.uniform_buf.as_entire_binding(),
+            },
+        ],
+    });
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) });
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some(label),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &out_view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(&pd.render_pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..6, 0..1);
+    }
+    ctx.queue.submit(std::iter::once(encoder.finish()));
+}
+
+#[cfg(feature = "wgpu")]
+fn pack_f32(values: &[f32]) -> Vec<u8> {
+    values.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for WipeTransitionNode {
+    fn input_count(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(tex_a) = inputs.first() else {
+            log::warn!("WipeTransitionNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("WipeTransitionNode::process called with no outputs");
+            return;
+        };
+        let pd = self.pipeline.get_or_init(|| {
+            build_pipeline(
+                &ctx.device,
+                include_str!("../shaders/wipe.wgsl"),
+                "Wipe",
+                16,
+            )
+        });
+        ctx.queue.write_buffer(
+            &pd.uniform_buf,
+            0,
+            &pack_f32(&[self.progress, self.softness, self.angle, 0.0]),
+        );
+        let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
+        run_pass(ctx, pd, tex_a, &to_tex, output, "Wipe pass");
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl super::RenderNode for DipToColorNode {
+    fn input_count(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(tex_a) = inputs.first() else {
+            log::warn!("DipToColorNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("DipToColorNode::process called with no outputs");
+            return;
+        };
+        let pd = self.pipeline.get_or_init(|| {
+            build_pipeline(&ctx.device, include_str!("../shaders/dip.wgsl"), "Dip", 32)
+        });
+        ctx.queue.write_buffer(
+            &pd.uniform_buf,
+            0,
+            &pack_f32(&[
+                self.progress,
+                0.0,
+                0.0,
+                0.0,
+                self.color[0],
+                self.color[1],
+                self.color[2],
+                1.0,
+            ]),
+        );
+        let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
+        run_pass(ctx, pd, tex_a, &to_tex, output, "Dip pass");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wipe_progress_zero_should_be_clip_a() {
+        let b = vec![200u8, 200, 200, 255];
+        let node = WipeTransitionNode::new(0.0, 0.0, 0.0, b, 1, 1);
+        let a = vec![10u8, 20, 30, 255];
+        let mut rgba = a.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, a, "progress=0 must output clip A");
+    }
+
+    #[test]
+    fn wipe_progress_one_should_be_clip_b() {
+        let b = vec![200u8, 210, 220, 255];
+        let node = WipeTransitionNode::new(1.0, 0.0, 0.0, b.clone(), 1, 1);
+        let mut rgba = vec![10u8, 20, 30, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        for (got, want) in rgba.iter().zip(b.iter()) {
+            assert!(
+                (i32::from(*got) - i32::from(*want)).abs() <= 1,
+                "progress=1 must output clip B; got {got} want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn wipe_half_hard_should_split_left_a_right_b() {
+        // A 2×1 frame, angle=0, softness=0: left pixel = A, right pixel = B.
+        let a = vec![10u8, 20, 30, 255, 10, 20, 30, 255];
+        let b = vec![200u8, 210, 220, 255, 200, 210, 220, 255];
+        let node = WipeTransitionNode::new(0.5, 0.0, 0.0, b, 2, 1);
+        let mut rgba = a.clone();
+        node.process_cpu(&mut rgba, 2, 1);
+        assert_eq!(&rgba[0..4], &[10, 20, 30, 255], "left half must be clip A");
+        for (got, want) in rgba[4..8].iter().zip([200u8, 210, 220, 255].iter()) {
+            assert!(
+                (i32::from(*got) - i32::from(*want)).abs() <= 1,
+                "right half must be clip B"
+            );
+        }
+    }
+
+    #[test]
+    fn wipe_size_mismatch_should_leave_rgba_unchanged() {
+        let b = vec![200u8; 8]; // 2 px
+        let node = WipeTransitionNode::new(0.5, 0.0, 0.0, b, 2, 1);
+        let original = vec![10u8, 20, 30, 255]; // 1 px
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, original, "size mismatch must be a no-op");
+    }
+
+    #[test]
+    fn dip_progress_zero_should_be_clip_a() {
+        let b = vec![200u8, 200, 200, 255];
+        let node = DipToColorNode::new(0.0, [0.0, 0.0, 0.0], b, 1, 1);
+        let a = vec![10u8, 20, 30, 255];
+        let mut rgba = a.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, a, "progress=0 must output clip A");
+    }
+
+    #[test]
+    fn dip_half_black_should_be_black() {
+        let b = vec![200u8, 200, 200, 255];
+        let node = DipToColorNode::new(0.5, [0.0, 0.0, 0.0], b, 1, 1);
+        let mut rgba = vec![120u8, 130, 140, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(
+            &rgba[0..3],
+            &[0, 0, 0],
+            "progress=0.5 with black dip must be a black frame"
+        );
+    }
+
+    #[test]
+    fn dip_progress_one_should_be_clip_b() {
+        let b = vec![200u8, 210, 220, 255];
+        let node = DipToColorNode::new(1.0, [0.0, 0.0, 0.0], b.clone(), 1, 1);
+        let mut rgba = vec![10u8, 20, 30, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        for (got, want) in rgba.iter().zip(b.iter()) {
+            assert!(
+                (i32::from(*got) - i32::from(*want)).abs() <= 1,
+                "progress=1 must output clip B"
+            );
+        }
+    }
+
+    #[test]
+    fn dip_phase_two_size_mismatch_should_leave_rgba_unchanged() {
+        let b = vec![200u8; 8]; // 2 px
+        let node = DipToColorNode::new(0.75, [0.0, 0.0, 0.0], b, 2, 1);
+        let original = vec![10u8, 20, 30, 255]; // 1 px
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, original, "phase-2 size mismatch must be a no-op");
+    }
+}
+
+#[cfg(all(test, feature = "wgpu"))]
+mod gpu_tests {
+    use super::*;
+    use crate::context::RenderContext;
+    use crate::graph::RenderGraph;
+    use std::sync::Arc;
+
+    fn ctx() -> Option<Arc<RenderContext>> {
+        match futures::executor::block_on(RenderContext::init()) {
+            Ok(ctx) => Some(Arc::new(ctx)),
+            Err(_) => None,
+        }
+    }
+
+    #[test]
+    fn wipe_gpu_progress_one_should_be_clip_b() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let a = vec![10u8, 20, 30, 255];
+        let b = vec![200u8, 210, 220, 255];
+        let out = RenderGraph::new(Arc::clone(&ctx))
+            .push(WipeTransitionNode::new(1.0, 0.0, 0.0, b.clone(), 1, 1))
+            .process_gpu(&a, 1, 1)
+            .expect("gpu wipe");
+        for i in 0..3 {
+            assert!(
+                (i32::from(out[i]) - i32::from(b[i])).abs() <= 2,
+                "GPU wipe progress=1 must output clip B at {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn dip_gpu_half_black_should_be_black() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let a = vec![120u8, 130, 140, 255];
+        let b = vec![200u8, 200, 200, 255];
+        let out = RenderGraph::new(Arc::clone(&ctx))
+            .push(DipToColorNode::new(0.5, [0.0, 0.0, 0.0], b, 1, 1))
+            .process_gpu(&a, 1, 1)
+            .expect("gpu dip");
+        for i in 0..3 {
+            assert!(
+                out[i] <= 2,
+                "GPU dip progress=0.5 (black) must be ~0 at {i}"
+            );
+        }
+    }
+}

--- a/crates/ff-render/src/shaders/dip.wgsl
+++ b/crates/ff-render/src/shaders/dip.wgsl
@@ -1,0 +1,46 @@
+// Two-phase dip to a solid colour: clip A fades to the dip colour over the first
+// half of progress, then the colour fades to clip B over the second half.
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var tex_a: texture_2d<f32>;
+@group(0) @binding(1) var tex_b: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+@group(0) @binding(3) var<uniform> u: DipUniforms;
+
+struct DipUniforms {
+    progress: f32,
+    _pad0:    f32,
+    _pad1:    f32,
+    _pad2:    f32,
+    color:    vec4<f32>,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let dip = vec4<f32>(u.color.rgb, 1.0);
+    if (u.progress < 0.5) {
+        let color_a = textureSample(tex_a, samp, in.uv);
+        return mix(color_a, dip, u.progress * 2.0);
+    }
+    let color_b = textureSample(tex_b, samp, in.uv);
+    return mix(dip, color_b, (u.progress - 0.5) * 2.0);
+}

--- a/crates/ff-render/src/shaders/wipe.wgsl
+++ b/crates/ff-render/src/shaders/wipe.wgsl
@@ -1,0 +1,50 @@
+// Directional wipe: reveals clip B behind a moving edge. The threshold `center`
+// sweeps from beyond the far corner (all A at progress 0) to beyond the near
+// corner (all B at progress 1), so the endpoints are exact for any angle. `hw`
+// (the smoothstep half-width) is floored to a small epsilon so a zero softness
+// still gives a near-hard, division-safe edge.
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var tex_a: texture_2d<f32>;
+@group(0) @binding(1) var tex_b: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+@group(0) @binding(3) var<uniform> u: WipeUniforms;
+
+struct WipeUniforms {
+    progress: f32,
+    softness: f32,
+    angle:    f32,
+    _pad:     f32,
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let a = vec2<f32>(cos(u.angle), sin(u.angle));
+    let reach = 0.5 * (abs(a.x) + abs(a.y));
+    let hw = max(u.softness, 1e-3);
+    let center = mix(0.5 + reach + hw, 0.5 - reach - hw, u.progress);
+    let proj = dot(in.uv - vec2<f32>(0.5), a) + 0.5;
+    let mask = smoothstep(center - hw, center + hw, proj);
+    let color_a = textureSample(tex_a, samp, in.uv);
+    let color_b = textureSample(tex_b, samp, in.uv);
+    return mix(color_a, color_b, mask);
+}


### PR DESCRIPTION
## Objective

- Add two GPU transition nodes to `ff-render` (Phase 3): a directional wipe and a two-phase dip through a solid colour (fade-to-black / white / brand dip).

## Solution

- Add `WipeTransitionNode` (reveals clip B behind a moving edge along an angle, with a feathered edge) and `DipToColorNode` (clip A fades to a solid colour, then the colour fades to clip B), each on the GPU (fragment shader) and CPU paths.
- Carry clip B as RGBA bytes in the node and upload it to a temporary texture at render time: a render graph has a single source, so the second clip cannot arrive as a second GPU input. Clip A is the node's input.
- The wipe sweeps its edge threshold from beyond the far corner (all A at progress 0) to beyond the near corner (all B at progress 1), so the endpoints are exact for any angle; the smoothstep half-width is floored to a small epsilon so a zero softness is a near-hard, division-safe edge. The CPU and GPU paths share the same mask and dip formulas so they agree.
- Cover it with CPU tests (endpoints, the hard vertical split, the black dip, size-mismatch no-ops) and adapter-gated GPU tests.

Closes #1048