### PR TITLE
feat(ff-encode): expose +faststart for progressive MP4/MOV output

### DIFF
--- a/crates/ff-encode/src/shared/container.rs
+++ b/crates/ff-encode/src/shared/container.rs
@@ -69,6 +69,27 @@ impl OutputContainer {
         }
     }
 
+    /// Guess the container from a file path's extension.
+    ///
+    /// Mirrors [`default_extension`](Self::default_extension) in reverse and is
+    /// case-insensitive. Returns `None` for an unknown or missing extension. The
+    /// `mp4` extension maps to progressive [`Mp4`](Self::Mp4), never fragmented
+    /// [`FMp4`](Self::FMp4), which must be selected explicitly.
+    #[must_use]
+    pub fn from_path(path: &std::path::Path) -> Option<Self> {
+        let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+        match ext.as_str() {
+            "mp4" | "m4v" => Some(Self::Mp4),
+            "webm" => Some(Self::WebM),
+            "mkv" => Some(Self::Mkv),
+            "avi" => Some(Self::Avi),
+            "mov" => Some(Self::Mov),
+            "flac" => Some(Self::Flac),
+            "ogg" => Some(Self::Ogg),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if this container is fragmented MP4.
     ///
     /// When `true`, the encoder applies
@@ -77,6 +98,18 @@ impl OutputContainer {
     #[must_use]
     pub const fn is_fragmented(self) -> bool {
         matches!(self, Self::FMp4)
+    }
+
+    /// Returns `true` if this container supports the `+faststart` movflag.
+    ///
+    /// `faststart` (moving the `moov` atom to the front for progressive
+    /// download) is specific to the `mp4`/`mov` muxers, so it applies only to
+    /// [`Mp4`](Self::Mp4) and [`Mov`](Self::Mov). Fragmented MP4
+    /// ([`FMp4`](Self::FMp4)) already streams and uses its own movflags, so it
+    /// is excluded.
+    #[must_use]
+    pub const fn supports_faststart(self) -> bool {
+        matches!(self, Self::Mp4 | Self::Mov)
     }
 }
 
@@ -125,5 +158,39 @@ mod tests {
         assert!(OutputContainer::FMp4.is_fragmented());
         assert!(!OutputContainer::Mp4.is_fragmented());
         assert!(!OutputContainer::Mkv.is_fragmented());
+    }
+
+    #[test]
+    fn from_path_should_map_known_extensions_case_insensitively() {
+        use std::path::Path;
+        assert_eq!(
+            OutputContainer::from_path(Path::new("out.mp4")),
+            Some(OutputContainer::Mp4)
+        );
+        // Case-insensitive, and `mp4` is progressive Mp4 (never FMp4).
+        assert_eq!(
+            OutputContainer::from_path(Path::new("OUT.MP4")),
+            Some(OutputContainer::Mp4)
+        );
+        assert_eq!(
+            OutputContainer::from_path(Path::new("clip.mov")),
+            Some(OutputContainer::Mov)
+        );
+        assert_eq!(
+            OutputContainer::from_path(Path::new("clip.mkv")),
+            Some(OutputContainer::Mkv)
+        );
+        assert_eq!(OutputContainer::from_path(Path::new("clip.xyz")), None);
+        assert_eq!(OutputContainer::from_path(Path::new("noext")), None);
+    }
+
+    #[test]
+    fn supports_faststart_should_be_true_for_mp4_and_mov() {
+        assert!(OutputContainer::Mp4.supports_faststart());
+        assert!(OutputContainer::Mov.supports_faststart());
+        // Fragmented MP4 streams already and uses its own movflags.
+        assert!(!OutputContainer::FMp4.supports_faststart());
+        assert!(!OutputContainer::WebM.supports_faststart());
+        assert!(!OutputContainer::Mkv.supports_faststart());
     }
 }

--- a/crates/ff-encode/src/video/builder/meta.rs
+++ b/crates/ff-encode/src/video/builder/meta.rs
@@ -40,6 +40,20 @@ impl VideoEncoderBuilder {
         self
     }
 
+    /// Relocate the `moov` atom to the front of MP4/MOV output (`movflags=+faststart`).
+    ///
+    /// This makes the file playable via progressive download / streaming before it
+    /// is fully fetched, the standard requirement for web-delivered files. It has no
+    /// effect on non-MP4/MOV containers or on fragmented MP4 (which already streams
+    /// via its own movflags). Because `FFmpeg` relocates the atom by rewriting the
+    /// file at finalize, faststart adds a second pass over the output, so it is not
+    /// free for very large files.
+    #[must_use]
+    pub fn faststart(mut self) -> Self {
+        self.faststart = true;
+        self
+    }
+
     /// Embed a metadata tag in the output container.
     ///
     /// Calls `av_dict_set` on `AVFormatContext->metadata` before the header
@@ -134,6 +148,14 @@ mod tests {
             .video(640, 480, 30.0)
             .two_pass();
         assert!(builder.two_pass);
+    }
+
+    #[test]
+    fn faststart_flag_should_be_stored_in_builder() {
+        let builder = VideoEncoderBuilder::new(PathBuf::from("output.mp4"))
+            .video(640, 480, 30.0)
+            .faststart();
+        assert!(builder.faststart);
     }
 
     #[test]

--- a/crates/ff-encode/src/video/builder/mod.rs
+++ b/crates/ff-encode/src/video/builder/mod.rs
@@ -36,6 +36,8 @@ mod video;
 ///     .preset(Preset::Medium)
 ///     .build()?;
 /// ```
+// A builder aggregates many independent output toggles; the bool count is inherent.
+#[allow(clippy::struct_excessive_bools)]
 pub struct VideoEncoderBuilder {
     pub(crate) path: PathBuf,
     pub(crate) container: Option<OutputContainer>,
@@ -52,6 +54,7 @@ pub struct VideoEncoderBuilder {
     pub(crate) audio_bitrate: Option<u64>,
     pub(crate) progress_callback: Option<Box<dyn EncodeProgressCallback>>,
     pub(crate) two_pass: bool,
+    pub(crate) faststart: bool,
     pub(crate) metadata: Vec<(String, String)>,
     pub(crate) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(crate) subtitle_passthrough: Option<(String, usize)>,
@@ -88,6 +91,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
                 &self.progress_callback.as_ref().map(|_| "<callback>"),
             )
             .field("two_pass", &self.two_pass)
+            .field("faststart", &self.faststart)
             .field("metadata", &self.metadata)
             .field("chapters", &self.chapters)
             .field("subtitle_passthrough", &self.subtitle_passthrough)
@@ -122,6 +126,7 @@ impl VideoEncoderBuilder {
             audio_bitrate: None,
             progress_callback: None,
             two_pass: false,
+            faststart: false,
             metadata: Vec::new(),
             chapters: Vec::new(),
             subtitle_passthrough: None,
@@ -603,6 +608,7 @@ impl VideoEncoder {
             color_primaries: builder.color_primaries,
             attachments: builder.attachments,
             container: builder.container,
+            faststart: builder.faststart,
         };
 
         // Create the inner encoder when at least one of video or audio is
@@ -874,6 +880,7 @@ mod tests {
                 color_primaries: None,
                 attachments: Vec::new(),
                 container: None,
+                faststart: false,
             },
             start_time: std::time::Instant::now(),
             progress_callback: None,

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -37,23 +37,39 @@ impl VideoEncoderInner {
         }
     }
 
-    /// Apply `movflags` for fMP4 containers before `avformat_write_header`.
+    /// Apply `movflags` for MP4/MOV containers before `avformat_write_header`.
     ///
-    /// When `container` is [`crate::OutputContainer::FMp4`], sets
-    /// `movflags=+frag_keyframe+empty_moov+default_base_moof` via `av_opt_set`
-    /// on the format context's `priv_data`. This enables CMAF-compatible
-    /// fragmented output required for HLS fMP4 segments and MPEG-DASH.
+    /// Fragmented MP4 ([`crate::OutputContainer::FMp4`]) sets
+    /// `movflags=+frag_keyframe+empty_moov+default_base_moof` (CMAF-compatible
+    /// output for HLS fMP4 segments and MPEG-DASH). Otherwise, when `faststart`
+    /// is requested on an MP4/MOV container, sets `movflags=+faststart` so the
+    /// `moov` atom is relocated to the front for progressive download. The two
+    /// are mutually exclusive: fragmented output already streams, so `faststart`
+    /// is ignored there. Non-MP4/MOV containers have no `movflags` option, so
+    /// nothing is set. `movflags` is set via `av_opt_set` on `priv_data`.
     ///
+    /// `container` is the explicitly requested container (`None` when the caller
+    /// let the extension decide); the effective container for MP4/MOV detection
+    /// is resolved from `path` in that case.
     pub(super) fn apply_movflags(
         format_ctx: &mut ff_sys::OutputFormatContext,
         container: Option<crate::OutputContainer>,
+        path: &std::path::Path,
+        faststart: bool,
     ) {
-        if container.is_some_and(|c| c.is_fragmented())
-            && let Err(e) =
-                format_ctx.set_opt(c"movflags", c"+frag_keyframe+empty_moov+default_base_moof")
+        let effective = container.or_else(|| crate::OutputContainer::from_path(path));
+        let flags: Option<&std::ffi::CStr> = if effective.is_some_and(|c| c.is_fragmented()) {
+            Some(c"+frag_keyframe+empty_moov+default_base_moof")
+        } else if faststart && effective.is_some_and(|c| c.supports_faststart()) {
+            Some(c"+faststart")
+        } else {
+            None
+        };
+        if let Some(f) = flags
+            && let Err(e) = format_ctx.set_opt(c"movflags", f)
         {
             log::warn!(
-                "av_opt_set movflags failed for fMP4 container error={}",
+                "av_opt_set movflags failed error={}",
                 ff_sys::av_error_string(e.code())
             );
         }

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -147,6 +147,8 @@ pub(super) struct VideoEncoderConfig {
     /// Binary attachments: (raw data, MIME type, filename).
     pub(super) attachments: Vec<(Vec<u8>, String, String)>,
     pub(super) container: Option<crate::OutputContainer>,
+    /// Relocate the `moov` atom to the front for progressive MP4/MOV playback.
+    pub(super) faststart: bool,
 }
 
 impl VideoEncoderInner {
@@ -260,7 +262,12 @@ impl VideoEncoderInner {
                     })?;
                 }
 
-                Self::apply_movflags(&mut encoder.format_ctx, config.container);
+                Self::apply_movflags(
+                    &mut encoder.format_ctx,
+                    config.container,
+                    &config.path,
+                    config.faststart,
+                );
                 Self::apply_metadata(&mut encoder.format_ctx, &config.metadata);
                 Self::apply_chapters(&mut encoder.format_ctx, &config.chapters);
                 encoder

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -123,7 +123,12 @@ impl VideoEncoderInner {
             .open_io(&output_path)
             .map_err(|_| EncodeError::CannotCreateFile { path: output_path })?;
 
-        Self::apply_movflags(&mut self.format_ctx, config.container);
+        Self::apply_movflags(
+            &mut self.format_ctx,
+            config.container,
+            &config.path,
+            config.faststart,
+        );
         Self::apply_metadata(&mut self.format_ctx, &config.metadata);
         Self::apply_chapters(&mut self.format_ctx, &config.chapters);
         self.format_ctx

--- a/crates/ff-encode/tests/faststart_tests.rs
+++ b/crates/ff-encode/tests/faststart_tests.rs
@@ -1,0 +1,138 @@
+//! Integration tests for `.faststart()` progressive MP4/MOV output.
+//!
+//! `.faststart()` sets `movflags=+faststart`, which relocates the `moov` atom to
+//! the front of the file so it plays via progressive download before the whole
+//! file is fetched. These tests encode a tiny MP4 and scan its top-level boxes to
+//! confirm `moov` precedes `mdat` (and that, without the flag, it does not).
+//!
+//! All tests skip gracefully when no MP4-capable video encoder is compiled in.
+
+#![allow(clippy::unwrap_used)]
+
+mod fixtures;
+
+use ff_encode::{VideoCodec, VideoEncoder};
+use fixtures::{FileGuard, assert_valid_output_file, create_black_frame, test_output_path};
+use std::path::Path;
+
+/// Byte offset of the first top-level ISO-BMFF box of type `ty` (e.g. `b"moov"`).
+///
+/// Walks the box list from the start of the file: each box is a 32-bit big-endian
+/// `size` followed by a 4-byte `type`. `size == 1` signals a 64-bit extended size
+/// stored in the 8 bytes after the type; `size == 0` means the box runs to EOF.
+/// Returns `None` if the type is not found or the structure is truncated.
+fn top_level_box_offset(data: &[u8], ty: &[u8; 4]) -> Option<usize> {
+    let mut pos = 0usize;
+    while pos + 8 <= data.len() {
+        let size32 = u32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+        let box_type = &data[pos + 4..pos + 8];
+        if box_type == ty {
+            return Some(pos);
+        }
+        let box_size: u64 = if size32 == 1 {
+            if pos + 16 > data.len() {
+                return None;
+            }
+            u64::from_be_bytes([
+                data[pos + 8],
+                data[pos + 9],
+                data[pos + 10],
+                data[pos + 11],
+                data[pos + 12],
+                data[pos + 13],
+                data[pos + 14],
+                data[pos + 15],
+            ])
+        } else if size32 == 0 {
+            // Extends to end of file: no further boxes.
+            return None;
+        } else {
+            u64::from(size32)
+        };
+        if box_size < 8 {
+            return None;
+        }
+        pos = pos.checked_add(usize::try_from(box_size).ok()?)?;
+    }
+    None
+}
+
+/// Encodes `frames` black frames of a tiny MP4 at `path`, optionally with
+/// `.faststart()`. Returns `false` if no MP4-capable encoder is available (the
+/// caller should skip). The default codec is H.264, which writes an `.mp4`.
+fn encode_tiny_mp4(path: &Path, faststart: bool, frames: usize) -> bool {
+    let builder = VideoEncoder::create(path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::default());
+    let builder = if faststart {
+        builder.faststart()
+    } else {
+        builder
+    };
+
+    let mut encoder = match builder.build() {
+        Ok(enc) => enc,
+        Err(e) => {
+            println!("Skipping: MP4 video encoder unavailable: {e}");
+            return false;
+        }
+    };
+
+    for _ in 0..frames {
+        encoder
+            .push_video(&create_black_frame(320, 240))
+            .expect("Failed to push video frame");
+    }
+    encoder.finish().expect("Failed to finish encoding");
+    true
+}
+
+/// With `.faststart()`, the `moov` atom must appear before `mdat` in the file.
+#[test]
+fn faststart_should_place_moov_before_mdat() {
+    let output_path = test_output_path("faststart_on.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    if !encode_tiny_mp4(&output_path, true, 10) {
+        return;
+    }
+    assert_valid_output_file(&output_path);
+
+    let bytes = std::fs::read(&output_path).expect("Failed to read output file");
+    let moov = top_level_box_offset(&bytes, b"moov").expect("no moov box in output");
+    let mdat = top_level_box_offset(&bytes, b"mdat").expect("no mdat box in output");
+    assert!(
+        moov < mdat,
+        "faststart should place moov before mdat (moov={moov}, mdat={mdat})"
+    );
+
+    // Media content is intact: probe reports the frames we wrote.
+    let info = ff_probe::open(&output_path).expect("Failed to probe output");
+    let video = info.primary_video().expect("No video stream in output");
+    assert!(
+        video.frame_count().unwrap_or(0) >= 10,
+        "Expected at least 10 frames, got {:?}",
+        video.frame_count()
+    );
+}
+
+/// Without `.faststart()`, the MP4 muxer writes `moov` after `mdat`. This proves
+/// the flag is what moves the atom (non-vacuous baseline for the test above).
+#[test]
+fn without_faststart_moov_should_follow_mdat() {
+    let output_path = test_output_path("faststart_off.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+
+    if !encode_tiny_mp4(&output_path, false, 10) {
+        return;
+    }
+    assert_valid_output_file(&output_path);
+
+    let bytes = std::fs::read(&output_path).expect("Failed to read output file");
+    let moov = top_level_box_offset(&bytes, b"moov").expect("no moov box in output");
+    let mdat = top_level_box_offset(&bytes, b"mdat").expect("no mdat box in output");
+    assert!(
+        moov > mdat,
+        "without faststart the default MP4 layout places moov after mdat (moov={moov}, mdat={mdat})"
+    );
+}


### PR DESCRIPTION
## Objective

- The encoder set `movflags` only for fragmented output; there was no user-facing option for `+faststart` on a normal progressive MP4/MOV, the standard requirement for web-delivered files.

## Solution

- Add `VideoEncoderBuilder::faststart()`, which sets `movflags=+faststart` on non-fragmented MP4/MOV output so the `moov` atom is relocated to the front for progressive download.
- Resolve the effective container from the path extension when it is not set explicitly (`OutputContainer::from_path`): the container field stays `None` for extension-auto-detected outputs, so gating on `config.container` alone silently no-ops on a plain `.mp4`.
- Fragmented MP4 keeps precedence and its own movflags; non-MP4/MOV containers set nothing.
- Add an integration test that scans the output ISO-BMFF boxes to confirm `moov` precedes `mdat` with faststart and follows `mdat` without it (non-vacuous baseline), plus unit tests for `supports_faststart()` and `from_path()`.

Closes #1603