### PR TITLE
feat(avio): ChromaKey typed clip effect + derive-to-ff-render mapping + parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -194,6 +194,25 @@ pub enum EffectKind {
         /// Path to the `.cube` / `.3dl` LUT file. Empty = identity.
         path: String,
     },
+    /// Chroma-key (green-screen removal): makes pixels near `key_color`
+    /// transparent (the `chromakey` filter on the CPU path, `ff_render::ChromaKeyNode`
+    /// on the GPU).
+    ///
+    /// `key_color` is a structural RGB triple (each channel `0.0..=1.0`), not a
+    /// keyframeable [`Param`] — the key colour is picked once, like a
+    /// [`Lut`](Self::Lut) path. `similarity` (match radius) and `softness` (edge
+    /// feather) are keyframeable. A constant `similarity = 0.0` removes nothing, so
+    /// it compiles to no filter. Because `chromakey`'s options are static, an
+    /// animated parameter animates on the GPU-default path but renders its `t = 0`
+    /// value on the CPU fallback (like [`Hsl`](Self::Hsl)).
+    ChromaKey {
+        /// Key colour in RGB, each channel `0.0..=1.0`.
+        key_color: [f32; 3],
+        /// Match radius in `0.0..=1.0` (neutral: `0.0` removes nothing).
+        similarity: Param,
+        /// Edge softness in `0.0..=1.0` (`0.0` = hard edge).
+        softness: Param,
+    },
 }
 
 /// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
@@ -445,8 +464,44 @@ impl EffectKind {
                 }
                 Some(FilterStep::Lut3d { path: path.clone() })
             }
+            // ChromaKey maps to the `chromakey` filter (key colour + similarity +
+            // blend). A constant `similarity = 0.0` removes nothing, so it compiles
+            // to nothing; any animated parameter uses `ChromaKeyAnimated` (the GPU
+            // animates per frame; the CPU renders its `t = 0` values).
+            EffectKind::ChromaKey {
+                key_color,
+                similarity,
+                softness,
+            } => {
+                if similarity.is_const() && softness.is_const() {
+                    #[allow(clippy::float_cmp)]
+                    if similarity.as_const() == Some(0.0) {
+                        return None;
+                    }
+                    Some(FilterStep::ChromaKey {
+                        color: rgb_to_ffmpeg_hex(*key_color),
+                        similarity: similarity.as_const().unwrap_or(0.0) as f32,
+                        blend: softness.as_const().unwrap_or(0.0) as f32,
+                    })
+                } else {
+                    Some(FilterStep::ChromaKeyAnimated {
+                        color: rgb_to_ffmpeg_hex(*key_color),
+                        similarity: similarity.to_animated(),
+                        blend: softness.to_animated(),
+                    })
+                }
+            }
         }
     }
+}
+
+/// Formats an RGB triple (each channel `0.0..=1.0`) as an `FFmpeg` `0xRRGGBB`
+/// colour string, the canonical form [`avio::gpu`](crate::gpu) parses back to the
+/// GPU node's key colour.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn rgb_to_ffmpeg_hex(rgb: [f32; 3]) -> String {
+    let ch = |v: f32| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+    format!("0x{:02X}{:02X}{:02X}", ch(rgb[0]), ch(rgb[1]), ch(rgb[2]))
 }
 
 /// One typed effect in a [`Clip`](crate::Clip)'s ordered effect list.
@@ -837,5 +892,55 @@ mod tests {
             FilterStep::Lut3d { path } => assert_eq!(path, "grade.cube"),
             other => panic!("expected Lut3d, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn chroma_key_zero_similarity_should_compile_to_nothing() {
+        let kind = EffectKind::ChromaKey {
+            key_color: [0.0, 1.0, 0.0],
+            similarity: Param::Const(0.0),
+            softness: Param::Const(0.1),
+        };
+        assert!(
+            kind.to_filter_step().is_none(),
+            "similarity 0 removes nothing, so it is a no-op"
+        );
+    }
+
+    #[test]
+    fn chroma_key_const_should_compile_to_chroma_key_with_hex_colour() {
+        let kind = EffectKind::ChromaKey {
+            key_color: [0.0, 1.0, 0.0],
+            similarity: Param::Const(0.3),
+            softness: Param::Const(0.1),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::ChromaKey {
+                color,
+                similarity,
+                blend,
+            } => {
+                assert_eq!(color, "0x00FF00");
+                assert!((similarity - 0.3).abs() < 1e-5);
+                assert!((blend - 0.1).abs() < 1e-5);
+            }
+            other => panic!("expected ChromaKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chroma_key_any_animated_should_compile_to_chroma_key_animated() {
+        let kind = EffectKind::ChromaKey {
+            key_color: [0.0, 1.0, 0.0],
+            similarity: Param::Animated(animated_track()),
+            softness: Param::Const(0.1),
+        };
+        assert!(
+            matches!(
+                kind.to_filter_step().unwrap(),
+                FilterStep::ChromaKeyAnimated { .. }
+            ),
+            "any animated parameter routes through ChromaKeyAnimated"
+        );
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -279,6 +279,15 @@ pub enum GpuEffect {
         /// Path to the LUT file the compositor loads.
         path: String,
     },
+    /// `ff_render::ChromaKeyNode` (green-screen keying by chroma distance).
+    ChromaKey {
+        /// Key colour in RGB, each channel `0.0..=1.0`.
+        key_color: [f32; 3],
+        /// Chroma-distance threshold (the `chromakey` `similarity`).
+        tolerance: f32,
+        /// Edge softness (the `chromakey` `blend`).
+        softness: f32,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -621,9 +630,32 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
                 StepClass::Effect(GpuEffect::Lut { path: path.clone() })
             }
         }
-        // Everything else (other colour, keying, masks, animated geometry,
-        // xfade, ...) has no GPU node yet. `_` is required: `FilterStep` is
-        // `#[non_exhaustive]` from ff-filter (RK-003).
+        // ChromaKey: parse the canonical `0xRRGGBB` colour back to the node's key
+        // colour. A colour string this parser cannot read (a named/other form from
+        // a non-typed source) has no GPU node, so it falls back to CPU (RK-020).
+        FilterStep::ChromaKey {
+            color,
+            similarity,
+            blend,
+        } => match parse_ffmpeg_hex(color) {
+            Some(key_color) => chroma_key_step(key_color, *similarity, *blend),
+            None => StepClass::Unsupported,
+        },
+        FilterStep::ChromaKeyAnimated {
+            color,
+            similarity,
+            blend,
+        } => match parse_ffmpeg_hex(color) {
+            Some(key_color) => chroma_key_step(
+                key_color,
+                similarity.value_at(t) as f32,
+                blend.value_at(t) as f32,
+            ),
+            None => StepClass::Unsupported,
+        },
+        // Everything else (other colour, masks, animated geometry, xfade, ...) has
+        // no GPU node yet. `_` is required: `FilterStep` is `#[non_exhaustive]`
+        // from ff-filter (RK-003).
         _ => StepClass::Unsupported,
     }
 }
@@ -716,6 +748,42 @@ fn hsl_step(hue_shift: f32, saturation: f32, lightness: f32) -> StepClass {
         saturation,
         lightness,
     })
+}
+
+/// Classifies a chroma-key step: a zero `tolerance` removes nothing, so it is a
+/// no-op (`Skip`); otherwise it maps straight to the GPU node (the `chromakey`
+/// `similarity`/`blend` are the node's `tolerance`/`softness`).
+#[allow(clippy::float_cmp)]
+fn chroma_key_step(key_color: [f32; 3], tolerance: f32, softness: f32) -> StepClass {
+    if tolerance == 0.0 {
+        return StepClass::Skip;
+    }
+    StepClass::Effect(GpuEffect::ChromaKey {
+        key_color,
+        tolerance,
+        softness,
+    })
+}
+
+/// Parses an `FFmpeg` `0xRRGGBB` / `#RRGGBB` colour string into an RGB triple
+/// (each channel `0.0..=1.0`), or `None` for any other form. Used to recover the
+/// GPU node's key colour from the [`FilterStep::ChromaKey`] colour string that
+/// [`EffectKind::ChromaKey`](crate::EffectKind::ChromaKey) emits canonically.
+fn parse_ffmpeg_hex(color: &str) -> Option<[f32; 3]> {
+    let hex = color
+        .strip_prefix("0x")
+        .or_else(|| color.strip_prefix('#'))?;
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some([
+        f32::from(r) / 255.0,
+        f32::from(g) / 255.0,
+        f32::from(b) / 255.0,
+    ])
 }
 
 /// Maps `ff_filter::ScaleAlgorithm` to `ff_render::ScaleAlgorithm` (ff-render has no
@@ -1420,6 +1488,62 @@ mod tests {
         assert!(matches!(
             plan.layers[0].effects.as_slice(),
             [GpuEffect::ColorGrade { .. }]
+        ));
+    }
+
+    #[test]
+    fn parse_ffmpeg_hex_should_read_0x_and_hash_forms_and_reject_others() {
+        assert_eq!(parse_ffmpeg_hex("0x00FF00"), Some([0.0, 1.0, 0.0]));
+        assert_eq!(parse_ffmpeg_hex("#0000FF"), Some([0.0, 0.0, 1.0]));
+        // A named / non-hex colour has no GPU node → None (CPU fallback).
+        assert_eq!(parse_ffmpeg_hex("green"), None);
+        assert_eq!(parse_ffmpeg_hex("0x00FF"), None);
+    }
+
+    #[test]
+    fn classify_chroma_key_should_map_to_node_with_parsed_colour() {
+        let step = FilterStep::ChromaKey {
+            color: "0x00FF00".to_string(),
+            similarity: 0.3,
+            blend: 0.1,
+        };
+        match classify_step(&step, Duration::ZERO) {
+            StepClass::Effect(GpuEffect::ChromaKey {
+                key_color,
+                tolerance,
+                softness,
+            }) => {
+                assert_eq!(key_color, [0.0, 1.0, 0.0]);
+                assert!((tolerance - 0.3).abs() < 1e-5);
+                assert!((softness - 0.1).abs() < 1e-5);
+            }
+            _ => panic!("expected a ChromaKey GPU effect"),
+        }
+    }
+
+    #[test]
+    fn classify_chroma_key_zero_tolerance_should_skip() {
+        let step = FilterStep::ChromaKey {
+            color: "0x00FF00".to_string(),
+            similarity: 0.0,
+            blend: 0.1,
+        };
+        assert!(matches!(
+            classify_step(&step, Duration::ZERO),
+            StepClass::Skip
+        ));
+    }
+
+    #[test]
+    fn classify_chroma_key_unparseable_colour_should_fall_back_to_cpu() {
+        let step = FilterStep::ChromaKey {
+            color: "green".to_string(),
+            similarity: 0.3,
+            blend: 0.1,
+        };
+        assert!(matches!(
+            classify_step(&step, Duration::ZERO),
+            StepClass::Unsupported
         ));
     }
 }

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -30,9 +30,9 @@ use std::time::Duration;
 
 use ff_format::VideoFrame;
 use ff_render::{
-    ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode, FrameLayer,
-    GaussianBlurNode, GlowNode, HslNode, LayerTransform, LutNode, RenderContext, RenderGraph,
-    ScaleNode, SharpenNode, VignetteNode,
+    ChromaKeyNode, ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode,
+    FrameLayer, GaussianBlurNode, GlowNode, HslNode, LayerTransform, LutNode, RenderContext,
+    RenderGraph, ScaleNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -221,6 +221,12 @@ impl GpuCompositor {
                 // load (missing, malformed, or an unsupported extension) makes the
                 // whole frame fall back to CPU rather than render wrong output (RK-020).
                 GpuEffect::Lut { path } => graph.push(load_lut(path)?),
+                // ChromaKey preserves the frame dimensions (it only rewrites alpha).
+                GpuEffect::ChromaKey {
+                    key_color,
+                    tolerance,
+                    softness,
+                } => graph.push(ChromaKeyNode::new(*key_color, *tolerance, *softness)),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -80,6 +80,17 @@ const TOL_HSL_MEAN: f64 = 20.0;
 // RK-005-verified axis order matches FFmpeg's, so a transposition would push the
 // mean to tens. Tested on a colour gradient (RK-022) with a per-channel-shifting LUT.
 const TOL_LUT_MEAN: f64 = 4.0;
+// ChromaKey: GPU ChromaKeyNode (RGB chroma distance) vs the CPU `chromakey` filter
+// (YUV chroma distance). ChromaKey rewrites *alpha*, but the GPU compositor's blend
+// shader outputs the canvas alpha, not the composited overlay alpha (blend.wgsl), so a
+// composited-alpha comparison is not possible and a composited-RGB comparison of the
+// keyed layer alone is vacuous (keying leaves RGB untouched). So the keyed layer is
+// composited over an *opaque* background: the compositor's `mix(base, overlay,
+// overlay.a)` turns the keyed alpha into an RGB difference (background shows through the
+// keyed region), making an RGB parity non-vacuous. The two distance metrics differ, so
+// a loose calibrated tolerance; the flat interiors agree and only the region edge
+// differs between the metrics.
+const TOL_CHROMAKEY_MEAN: f64 = 25.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -110,6 +121,36 @@ fn checkerboard_rgba(w: u32, h: u32, block: u32) -> Vec<u8> {
             let c = if on { 255u8 } else { 0u8 };
             v.extend_from_slice(&[c, c, c, 255]);
         }
+    }
+    v
+}
+
+/// Two flat halves: the left is pure key green (0x00FF00), the right a non-key red.
+/// ChromaKey must drive the left half transparent (revealing the background it is
+/// composited over) and leave the right opaque, so a parity over this fixture is
+/// non-vacuous (RK-015): a GPU that failed to key would keep green in the left half and
+/// diverge from the CPU reference.
+fn key_split_rgba(w: u32, h: u32) -> Vec<u8> {
+    let (wu, hu) = (w as usize, h as usize);
+    let mut v = Vec::with_capacity(wu * hu * 4);
+    for _y in 0..hu {
+        for x in 0..wu {
+            if x < wu / 2 {
+                v.extend_from_slice(&[0, 255, 0, 255]); // key: pure green
+            } else {
+                v.extend_from_slice(&[220, 40, 40, 255]); // non-key: red
+            }
+        }
+    }
+    v
+}
+
+/// A flat, fully opaque `[r, g, b]` fill: used as an opaque background layer so a keyed
+/// foreground shows the background through its transparent regions.
+fn solid_rgba(w: u32, h: u32, rgb: [u8; 3]) -> Vec<u8> {
+    let mut v = Vec::with_capacity((w * h * 4) as usize);
+    for _ in 0..(w * h) {
+        v.extend_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
     }
     v
 }
@@ -148,6 +189,26 @@ fn mean_abs_diff_rgb(a: &[u8], b: &[u8]) -> f64 {
     if n == 0 { 0.0 } else { sum as f64 / n as f64 }
 }
 
+/// Mean RGB over the pixels in one half (`key_half`: x < w/2 = the keyed green half,
+/// else the non-key red half). The chroma-key non-vacuity guard uses this to prove the
+/// background shows through the keyed half (RGB near the background) but not the other.
+fn region_mean_rgb(buf: &[u8], w: u32, key_half: bool) -> [f64; 3] {
+    let wu = w as usize;
+    let mut sum = [0u64; 3];
+    let mut n = 0u64;
+    for (i, px) in buf.chunks_exact(4).enumerate() {
+        let x = i % wu;
+        if (x < wu / 2) == key_half {
+            for c in 0..3 {
+                sum[c] += u64::from(px[c]);
+            }
+            n += 1;
+        }
+    }
+    let d = n.max(1) as f64;
+    [sum[0] as f64 / d, sum[1] as f64 / d, sum[2] as f64 / d]
+}
+
 fn max_abs_diff_rgb(a: &[u8], b: &[u8]) -> u8 {
     a.chunks_exact(4)
         .zip(b.chunks_exact(4))
@@ -181,6 +242,21 @@ fn cpu_composite(layer: &RealtimeLayer, frame: &VideoFrame, canvas: (u32, u32)) 
     let mut composer =
         RealtimeComposer::with_canvas(std::slice::from_ref(layer), Some(canvas)).ok()?;
     composer.push_layer(0, frame).ok()?;
+    composer.pull().ok()??.to_rgba()
+}
+
+/// Composites two layers (bottom first) + their frames on the CPU (`RealtimeComposer`)
+/// to rgba, or `None` when `FFmpeg` filters are unavailable (skip).
+fn cpu_composite2(
+    layers: &[&RealtimeLayer],
+    frames: &[&VideoFrame],
+    canvas: (u32, u32),
+) -> Option<Vec<u8>> {
+    let owned: Vec<RealtimeLayer> = layers.iter().map(|l| (*l).clone()).collect();
+    let mut composer = RealtimeComposer::with_canvas(&owned, Some(canvas)).ok()?;
+    for (i, frame) in frames.iter().enumerate() {
+        composer.push_layer(i, frame).ok()?;
+    }
     composer.pull().ok()??.to_rgba()
 }
 
@@ -748,6 +824,71 @@ fn lut_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_LUT_MEAN,
         "GPU and CPU LUT diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn chroma_key_gpu_should_match_cpu_within_tolerance() {
+    // ChromaKey parity: GPU ChromaKeyNode (map_scene maps `ChromaKey`) vs the CPU
+    // `chromakey` filter. ChromaKey rewrites alpha, but the GPU compositor's blend
+    // shader outputs the canvas alpha rather than the composited overlay alpha
+    // (blend.wgsl), so parity cannot compare composited alpha and a composited-RGB
+    // comparison of the keyed layer alone is vacuous. Instead the keyed foreground is
+    // composited over an *opaque* background: the compositor's `mix(base, overlay,
+    // overlay.a)` turns the keyed alpha into an RGB difference (background shows through
+    // the keyed green half), making an RGB parity non-vacuous (RK-015). Double-gated
+    // (adapter + filters).
+    let (w, h) = (64, 48);
+    let bg_rgb = [30u8, 60, 200]; // opaque blue background
+    let bg = VideoFrame::from_rgba(w, h, solid_rgba(w, h, bg_rgb)).unwrap();
+    // Foreground: left half pure key green, right half non-key red.
+    let fg = VideoFrame::from_rgba(w, h, key_split_rgba(w, h)).unwrap();
+    let bg_layer = base_layer(w, h, vec![]);
+    let fg_layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::ChromaKey {
+            color: "0x00FF00".to_string(),
+            similarity: 0.3,
+            blend: 0.1,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite2(&[&bg_layer, &fg_layer], &[&bg, &fg], (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some((gpu_out, _, _)) = gpu.composite(
+        &[(&bg_layer, &bg), (&fg_layer, &fg)],
+        (w, h),
+        Duration::ZERO,
+    ) else {
+        panic!("a supported chroma-key composite must render on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    // Non-vacuity guard (RK-015): the keyed green half must show the blue background
+    // through it, while the non-key red half stays red. A GPU that failed to key would
+    // keep green in the left half and diverge here.
+    let key_half = region_mean_rgb(&gpu_out, w, true);
+    let non_key_half = region_mean_rgb(&gpu_out, w, false);
+    println!("chroma-key GPU key_half={key_half:?} non_key_half={non_key_half:?}");
+    assert!(
+        key_half[2] > 128.0 && key_half[1] < 128.0,
+        "the keyed green half must reveal the blue background; got {key_half:?}"
+    );
+    assert!(
+        non_key_half[0] > 128.0 && non_key_half[2] < 128.0,
+        "the non-key red half must stay red; got {non_key_half:?}"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "chroma-key GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_CHROMAKEY_MEAN,
+        "GPU and CPU chroma-key composite diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -673,6 +673,22 @@ pub enum FilterStep {
         blend: f32,
     },
 
+    /// [`ChromaKey`](Self::ChromaKey) with optionally animated `similarity` /
+    /// `blend`.
+    ///
+    /// The GPU animates per frame; the CPU (`libavfilter`) path renders the
+    /// `Duration::ZERO` values (`chromakey`'s options are static, so the CPU path
+    /// is kept static and the GPU-default path is the single animated one, matching
+    /// [`HslAnimated`](Self::HslAnimated)).
+    ChromaKeyAnimated {
+        /// `FFmpeg` color string, e.g. `"0x00FF00"`.
+        color: String,
+        /// Match radius in `[0.0, 1.0]`, evaluated at `Duration::ZERO` on the CPU.
+        similarity: AnimatedValue<f64>,
+        /// Edge softness in `[0.0, 1.0]`, evaluated at `Duration::ZERO` on the CPU.
+        blend: AnimatedValue<f64>,
+    },
+
     /// Remove pixels matching `color` in RGB space using `FFmpeg`'s `colorkey`
     /// filter, producing an `rgba` output with transparent areas where the key
     /// color was detected.
@@ -1272,6 +1288,7 @@ impl FilterStep {
                 }
             },
             Self::ChromaKey { .. } => "chromakey",
+            Self::ChromaKeyAnimated { .. } => "chromakey",
             Self::ColorKey { .. } => "colorkey",
             Self::SpillSuppress { .. } => "hue",
             // AlphaMatte is a compound step (matte pipeline → alphamerge);
@@ -1659,6 +1676,20 @@ impl FilterStep {
                 similarity,
                 blend,
             } => format!("color={color}:similarity={similarity}:blend={blend}"),
+            Self::ChromaKeyAnimated {
+                color,
+                similarity,
+                blend,
+            } => {
+                // The CPU path is static (the GPU animates per frame): render the
+                // `Duration::ZERO` values.
+                #[allow(clippy::cast_possible_truncation)]
+                let (s, b) = (
+                    similarity.value_at(Duration::ZERO) as f32,
+                    blend.value_at(Duration::ZERO) as f32,
+                );
+                format!("color={color}:similarity={s}:blend={b}")
+            }
             Self::ColorKey {
                 color,
                 similarity,
@@ -2275,6 +2306,19 @@ mod tests {
             color_trc: None,
         };
         assert_eq!(step.args(), "");
+    }
+
+    #[test]
+    fn chroma_key_animated_should_render_static_zero_values_via_chromakey() {
+        // The CPU path is static: args() renders the Duration::ZERO values through
+        // the same `chromakey` filter as the const variant.
+        let step = FilterStep::ChromaKeyAnimated {
+            color: "0x00FF00".to_string(),
+            similarity: AnimatedValue::Static(0.3),
+            blend: AnimatedValue::Static(0.1),
+        };
+        assert_eq!(step.filter_name(), "chromakey");
+        assert_eq!(step.args(), "color=0x00FF00:similarity=0.3:blend=0.1");
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- ChromaKey exists only as an `ff-render` node and a CPU `FilterStep`; avio has no typed clip effect for it and no GPU mapping, so it always falls back to CPU.
- Add the typed effect + derive-to-ff-render mapping (preview + export) + GPU/CPU parity, mirroring the HSL and LUT mapping pairs.

## Solution

- `effect`: add `EffectKind::ChromaKey { key_color: [f32; 3], similarity, softness }` — structural RGB key colour (picked once, like a LUT path), keyframeable `similarity`/`softness`. A constant `similarity = 0` compiles to no filter; any animated parameter routes through the animated variant. `to_filter_step` emits the canonical `0xRRGGBB` colour string.
- `ff-filter`: add `FilterStep::ChromaKeyAnimated` so an animated parameter animates on the GPU-default path while the CPU path renders the `t = 0` values (chromakey's options are static; mirrors `HslAnimated`).
- `gpu`: add `GpuEffect::ChromaKey`, classify the `ChromaKey` / `ChromaKeyAnimated` steps by parsing the colour string back to the node's key colour. A zero tolerance skips (no-op); an unparseable colour string falls back to CPU rather than render wrong output.
- `gpu_compositor`: apply the effect via `ff_render::ChromaKeyNode`.
- `parity`: add a probe-gated GPU/CPU parity test. The compositor's blend shader outputs the canvas alpha (not the composited overlay alpha), so the keyed foreground is composited over an opaque background, turning the keyed alpha into a non-vacuous RGB difference.

Closes #1654