### PR TITLE
feat(avio): LumaMask typed clip effect + derive-to-ff-render mapping + parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -213,6 +213,19 @@ pub enum EffectKind {
         /// Edge softness in `0.0..=1.0` (`0.0` = hard edge).
         softness: Param,
     },
+    /// Luma mask: multiplies the clip's alpha by its own BT.709 luma (the `geq`
+    /// filter on the CPU path, `ff_render::LumaMaskNode` on the GPU). Bright pixels
+    /// stay opaque, dark pixels become transparent; `invert` uses `1 - luma`.
+    ///
+    /// This is a structural effect with no scalar [`Param`] — like [`Lut`](Self::Lut)
+    /// and [`Curves`](Self::Curves), its "keyframeable per parameter" requirement is
+    /// satisfied vacuously (there is nothing to animate; `invert` is a one-time
+    /// toggle). The mask is the clip's own frame, so no external mask source is
+    /// needed.
+    LumaMask {
+        /// When `true`, mask by `1 - luma` (dark pixels stay opaque).
+        invert: bool,
+    },
 }
 
 /// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
@@ -491,6 +504,9 @@ impl EffectKind {
                     })
                 }
             }
+            // LumaMask is structural (no scalar param): it always maps to the `geq`
+            // self-luma mask. `invert` carries straight through.
+            EffectKind::LumaMask { invert } => Some(FilterStep::LumaMask { invert: *invert }),
         }
     }
 }
@@ -942,5 +958,16 @@ mod tests {
             ),
             "any animated parameter routes through ChromaKeyAnimated"
         );
+    }
+
+    #[test]
+    fn luma_mask_should_compile_to_luma_mask_filter_step() {
+        for invert in [false, true] {
+            let kind = EffectKind::LumaMask { invert };
+            match kind.to_filter_step() {
+                Some(FilterStep::LumaMask { invert: got }) => assert_eq!(got, invert),
+                other => panic!("expected LumaMask {{ invert: {invert} }}, got {other:?}"),
+            }
+        }
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -288,6 +288,12 @@ pub enum GpuEffect {
         /// Edge softness (the `chromakey` `blend`).
         softness: f32,
     },
+    /// `ff_render::LumaMaskNode` (alpha *= the frame's own BT.709 luma). The
+    /// compositor builds the mask from the frame itself when applying this.
+    LumaMask {
+        /// When `true`, mask by `1 - luma` (dark pixels stay opaque).
+        invert: bool,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -653,6 +659,11 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             ),
             None => StepClass::Unsupported,
         },
+        // LumaMask (self-luma mask): the compositor builds the mask from the frame,
+        // so only the `invert` toggle carries into the GPU effect.
+        FilterStep::LumaMask { invert } => {
+            StepClass::Effect(GpuEffect::LumaMask { invert: *invert })
+        }
         // Everything else (other colour, masks, animated geometry, xfade, ...) has
         // no GPU node yet. `_` is required: `FilterStep` is `#[non_exhaustive]`
         // from ff-filter (RK-003).
@@ -1545,5 +1556,16 @@ mod tests {
             classify_step(&step, Duration::ZERO),
             StepClass::Unsupported
         ));
+    }
+
+    #[test]
+    fn classify_luma_mask_should_map_to_node_with_invert_flag() {
+        for invert in [false, true] {
+            let step = FilterStep::LumaMask { invert };
+            match classify_step(&step, Duration::ZERO) {
+                StepClass::Effect(GpuEffect::LumaMask { invert: got }) => assert_eq!(got, invert),
+                _ => panic!("expected a LumaMask GPU effect for invert={invert}"),
+            }
+        }
     }
 }

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -31,8 +31,8 @@ use std::time::Duration;
 use ff_format::VideoFrame;
 use ff_render::{
     ChromaKeyNode, ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode,
-    FrameLayer, GaussianBlurNode, GlowNode, HslNode, LayerTransform, LutNode, RenderContext,
-    RenderGraph, ScaleNode, SharpenNode, VignetteNode,
+    FrameLayer, GaussianBlurNode, GlowNode, HslNode, LayerTransform, LumaMaskNode, LutNode,
+    RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -227,6 +227,16 @@ impl GpuCompositor {
                     tolerance,
                     softness,
                 } => graph.push(ChromaKeyNode::new(*key_color, *tolerance, *softness)),
+                // LumaMask multiplies alpha by the frame's own BT.709 luma, so the
+                // mask is built from the source frame here (preserves dimensions).
+                // The mask is baked from the pre-graph frame; when LumaMask follows
+                // another effect the GPU mask is the source luma while the CPU `geq`
+                // sees the chained frame (a v1 limitation; parity uses it alone).
+                GpuEffect::LumaMask { invert } => graph.push(LumaMaskNode::new(
+                    build_luma_mask(&rgba, *invert),
+                    in_w,
+                    in_h,
+                )),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;
@@ -244,6 +254,27 @@ fn load_lut(path: &str) -> Option<LutNode> {
         Some(ext) if ext.eq_ignore_ascii_case("3dl") => LutNode::from_3dl(p).ok(),
         _ => None,
     }
+}
+
+/// Builds the mask [`ff_render::LumaMaskNode`] consumes for the self-luma mask.
+///
+/// Non-inverted, the mask is the frame itself: the node multiplies the base alpha by
+/// `bt709_luma(mask) = bt709_luma(frame)`. Inverted, each pixel becomes a grey of
+/// `255 - bt709_luma`, so the node's `bt709_luma(grey) = 255 - luma` gives
+/// `alpha *= 1 - luma`. Matches the CPU `geq` self-luma expression.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn build_luma_mask(rgba: &[u8], invert: bool) -> Vec<u8> {
+    if !invert {
+        return rgba.to_vec();
+    }
+    let mut mask = Vec::with_capacity(rgba.len());
+    for px in rgba.as_chunks::<4>().0 {
+        let luma =
+            0.2126 * f32::from(px[0]) + 0.7152 * f32::from(px[1]) + 0.0722 * f32::from(px[2]);
+        let grey = (255.0 - luma).clamp(0.0, 255.0).round() as u8;
+        mask.extend_from_slice(&[grey, grey, grey, 255]);
+    }
+    mask
 }
 
 /// Whether a plan layer's transform is the identity (no translate / scale / rotate),

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -91,6 +91,14 @@ const TOL_LUT_MEAN: f64 = 4.0;
 // a loose calibrated tolerance; the flat interiors agree and only the region edge
 // differs between the metrics.
 const TOL_CHROMAKEY_MEAN: f64 = 25.0;
+// LumaMask: GPU LumaMaskNode (alpha *= own BT.709 luma) vs the CPU `geq` self-luma
+// mask. Both use the same BT.709 coefficients on the same gamma-encoded RGB, so they
+// agree almost exactly (tighter than ChromaKey). As with ChromaKey, the compositor
+// discards composited alpha, so the keyed layer is composited over an opaque
+// background to turn the luma-modulated alpha into a non-vacuous RGB difference
+// (dark pixels reveal the background). Loose enough to cover the invert path's mask
+// quantisation (the grey mask rounds 255-luma to a u8).
+const TOL_LUMAMASK_MEAN: f64 = 6.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -143,6 +151,51 @@ fn key_split_rgba(w: u32, h: u32) -> Vec<u8> {
         }
     }
     v
+}
+
+/// Three vertical bands driving the luma mask non-vacuously (RK-015 / RK-022):
+/// white (luma 1.0 -> opaque), pure red (BT.709 luma ~0.21 -> a *partial* alpha), and
+/// black (luma 0.0 -> transparent). The red band is the important one: its mid alpha
+/// exercises the continuous blend (a threshold key would clear it entirely), and its
+/// value depends on the luma *coefficients* (BT.709 red 0.2126 vs BT.601 0.299 differ
+/// by ~20 levels), so GPU and CPU using different coefficients would diverge here.
+fn luma_bands_rgba(w: u32, h: u32) -> Vec<u8> {
+    let (wu, hu) = (w as usize, h as usize);
+    let third = wu / 3;
+    let mut v = Vec::with_capacity(wu * hu * 4);
+    for _y in 0..hu {
+        for x in 0..wu {
+            let px = if x < third {
+                [255, 255, 255, 255] // white: luma 1 -> opaque
+            } else if x < 2 * third {
+                [255, 0, 0, 255] // pure red: mid luma -> partial alpha
+            } else {
+                [0, 0, 0, 255] // black: luma 0 -> transparent
+            };
+            v.extend_from_slice(&px);
+        }
+    }
+    v
+}
+
+/// Mean RGB over the vertical band `[x0, x1)` (all rows). The three-band luma fixture
+/// is checked band-by-band so the partial-alpha middle band can be asserted directly.
+fn band_mean_rgb(buf: &[u8], w: u32, x0: u32, x1: u32) -> [f64; 3] {
+    let wu = w as usize;
+    let (x0, x1) = (x0 as usize, x1 as usize);
+    let mut sum = [0u64; 3];
+    let mut n = 0u64;
+    for (i, px) in buf.chunks_exact(4).enumerate() {
+        let x = i % wu;
+        if x >= x0 && x < x1 {
+            for c in 0..3 {
+                sum[c] += u64::from(px[c]);
+            }
+            n += 1;
+        }
+    }
+    let d = n.max(1) as f64;
+    [sum[0] as f64 / d, sum[1] as f64 / d, sum[2] as f64 / d]
 }
 
 /// A flat, fully opaque `[r, g, b]` fill: used as an opaque background layer so a keyed
@@ -889,6 +942,127 @@ fn chroma_key_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_CHROMAKEY_MEAN,
         "GPU and CPU chroma-key composite diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn luma_mask_gpu_should_match_cpu_within_tolerance() {
+    // LumaMask parity: GPU LumaMaskNode (map_scene maps `LumaMask`) vs the CPU `geq`
+    // self-luma mask. Both multiply alpha by the frame's own BT.709 luma. As with
+    // ChromaKey the compositor discards composited alpha, so the masked foreground is
+    // composited over an opaque background: the bright (opaque) half shows the
+    // foreground, the dark (transparent) half reveals the background, making an RGB
+    // parity non-vacuous (RK-015). Double-gated (adapter + filters).
+    let (w, h) = (64, 48);
+    let third = w / 3;
+    let bg_rgb = [30u8, 60, 200]; // opaque blue background
+    let bg = VideoFrame::from_rgba(w, h, solid_rgba(w, h, bg_rgb)).unwrap();
+    // Foreground: white | pure red (mid luma) | black bands.
+    let fg = VideoFrame::from_rgba(w, h, luma_bands_rgba(w, h)).unwrap();
+    let bg_layer = base_layer(w, h, vec![]);
+    let fg_layer = base_layer(w, h, vec![FilterStep::LumaMask { invert: false }]);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite2(&[&bg_layer, &fg_layer], &[&bg, &fg], (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some((gpu_out, _, _)) = gpu.composite(
+        &[(&bg_layer, &bg), (&fg_layer, &fg)],
+        (w, h),
+        Duration::ZERO,
+    ) else {
+        panic!("a supported luma-mask composite must render on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    // Non-vacuity guards (RK-015 / RK-022): the white band stays opaque, the black band
+    // reveals the background, and the red band is a *partial* blend (not pure red, not
+    // pure background) whose exact value depends on the BT.709 coefficients. A GPU that
+    // skipped the mask, thresholded instead of blending, or used other coefficients
+    // would diverge from the CPU reference.
+    let white = band_mean_rgb(&gpu_out, w, 0, third);
+    let red = band_mean_rgb(&gpu_out, w, third, 2 * third);
+    let black = band_mean_rgb(&gpu_out, w, 2 * third, w);
+    println!("luma-mask GPU white={white:?} red={red:?} black={black:?}");
+    assert!(
+        white[0] > 192.0 && white[2] > 192.0,
+        "the white band must stay opaque white; got {white:?}"
+    );
+    assert!(
+        black[2] > 128.0 && black[0] < 128.0,
+        "the black band must reveal the blue background; got {black:?}"
+    );
+    // Partial blend: red pulled in above the background red (30), but the blue
+    // background still dominant (mid alpha ~54/255) — a threshold key would leave this
+    // pure background instead.
+    assert!(
+        red[0] > 50.0 && red[0] < 200.0 && red[2] > 120.0,
+        "the red band must be a partial fg/bg blend; got {red:?}"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "luma-mask GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_LUMAMASK_MEAN,
+        "GPU and CPU luma-mask composite diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn luma_mask_invert_gpu_should_match_cpu_within_tolerance() {
+    // The invert branch drives distinct new code: the GPU builds a grey `255 - luma`
+    // mask and the CPU `geq` uses `255 - luma`. With invert the bright half becomes
+    // transparent (reveals the background) and the dark half stays opaque, the mirror
+    // of the non-inverted test. Double-gated (adapter + filters).
+    let (w, h) = (64, 48);
+    let third = w / 3;
+    let bg = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [30, 60, 200])).unwrap();
+    let fg = VideoFrame::from_rgba(w, h, luma_bands_rgba(w, h)).unwrap();
+    let bg_layer = base_layer(w, h, vec![]);
+    let fg_layer = base_layer(w, h, vec![FilterStep::LumaMask { invert: true }]);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite2(&[&bg_layer, &fg_layer], &[&bg, &fg], (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some((gpu_out, _, _)) = gpu.composite(
+        &[(&bg_layer, &bg), (&fg_layer, &fg)],
+        (w, h),
+        Duration::ZERO,
+    ) else {
+        panic!("a supported inverted luma-mask composite must render on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    // Inverted mirror: the white band now reveals the background, the red band becomes
+    // mostly opaque (alpha ~201/255), and the black band stays opaque black.
+    let white = band_mean_rgb(&gpu_out, w, 0, third);
+    let red = band_mean_rgb(&gpu_out, w, third, 2 * third);
+    let black = band_mean_rgb(&gpu_out, w, 2 * third, w);
+    println!("luma-mask(invert) GPU white={white:?} red={red:?} black={black:?}");
+    assert!(
+        white[2] > 128.0 && white[0] < 128.0,
+        "the white band must reveal the blue background when inverted; got {white:?}"
+    );
+    assert!(
+        black[0] < 64.0 && black[2] < 64.0,
+        "the black band must stay opaque black when inverted; got {black:?}"
+    );
+    // Inverted red band is mostly opaque red (mid alpha flips to ~201).
+    assert!(
+        red[0] > 128.0 && red[2] < 128.0,
+        "the inverted red band must be mostly opaque red; got {red:?}"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "luma-mask(invert) GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_LUMAMASK_MEAN,
+        "GPU and CPU inverted luma-mask diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -331,6 +331,7 @@ pub(super) unsafe fn build_video_composition(
                     | FilterStep::ColorKey { .. }
                     | FilterStep::LumaKey { .. }
                     | FilterStep::RectMask { .. }
+                    | FilterStep::LumaMask { .. }
                     | FilterStep::PolygonMatte { .. }
                     | FilterStep::FeatherMask { .. }
                     | FilterStep::AlphaMatte { .. }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -793,6 +793,24 @@ pub enum FilterStep {
         invert: bool,
     },
 
+    /// Set the alpha channel to the frame's own BT.709 luma using `FFmpeg`'s `geq`
+    /// filter (a self-referential continuous luma mask).
+    ///
+    /// `alpha = luma`, where `luma = 0.2126·R + 0.7152·G + 0.0722·B` on the frame's
+    /// own gamma-encoded RGB. Bright pixels stay opaque, dark pixels become
+    /// transparent. When `invert` is `true`, `255 - luma` is used, so dark pixels
+    /// stay opaque. This is the CPU pair of `ff_render::LumaMaskNode` (mask = the
+    /// frame itself, which multiplies the existing alpha by `luma`); on an opaque
+    /// source `alpha = luma` and `alpha *= luma` coincide, and the coefficients
+    /// match exactly. (`geq` exposes no alpha-read function here, so the existing
+    /// alpha is replaced rather than multiplied.)
+    ///
+    /// The output carries an alpha channel (`rgba`).
+    LumaMask {
+        /// When `true`, use `255 - luma` (dark pixels stay opaque).
+        invert: bool,
+    },
+
     /// Feather (soften) the alpha channel edges using a Gaussian blur.
     ///
     /// Splits the stream into a color copy and an alpha copy, blurs the alpha
@@ -1299,6 +1317,7 @@ impl FilterStep {
             Self::LumaKey { .. } => "lumakey",
             // RectMask uses geq to set alpha per-pixel based on rectangle bounds.
             Self::RectMask { .. } => "geq",
+            Self::LumaMask { .. } => "geq",
             // FeatherMask is a compound step (split → alphaextract → gblur → alphamerge);
             // "alphaextract" is used by validate_filter_steps as the primary check.
             Self::FeatherMask { .. } => "alphaextract",
@@ -1722,6 +1741,18 @@ impl FilterStep {
                     "r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':\
                      a='if(between(X,{x},{xw})*between(Y,{y},{yh}),{inside},{outside})'"
                 )
+            }
+            Self::LumaMask { invert } => {
+                // BT.709 luma of the frame's own RGB (0..255) becomes the alpha.
+                // Matches `ff_render::LumaMaskNode` on an opaque source. `invert`
+                // uses `255 - luma` so dark pixels stay opaque.
+                let luma = "0.2126*r(X,Y)+0.7152*g(X,Y)+0.0722*b(X,Y)";
+                let alpha = if *invert {
+                    format!("255-({luma})")
+                } else {
+                    luma.to_string()
+                };
+                format!("r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':a='{alpha}'")
             }
             Self::PolygonMatte { vertices, invert } => {
                 // Build a crossing-number point-in-polygon expression.
@@ -2319,6 +2350,31 @@ mod tests {
         };
         assert_eq!(step.filter_name(), "chromakey");
         assert_eq!(step.args(), "color=0x00FF00:similarity=0.3:blend=0.1");
+    }
+
+    #[test]
+    fn luma_mask_should_render_bt709_self_luma_geq() {
+        // Non-invert: alpha becomes the frame's own BT.709 luma via geq. (geq exposes
+        // no alpha-read function here, so alpha is set to the luma rather than
+        // multiplied; on the opaque source this equals LumaMaskNode's alpha *= luma.)
+        let step = FilterStep::LumaMask { invert: false };
+        assert_eq!(step.filter_name(), "geq");
+        assert_eq!(
+            step.args(),
+            "r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':\
+             a='0.2126*r(X,Y)+0.7152*g(X,Y)+0.0722*b(X,Y)'"
+        );
+    }
+
+    #[test]
+    fn luma_mask_invert_should_use_one_minus_luma() {
+        // Invert: `255 - luma`, so dark pixels stay opaque.
+        let step = FilterStep::LumaMask { invert: true };
+        assert_eq!(
+            step.args(),
+            "r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':\
+             a='255-(0.2126*r(X,Y)+0.7152*g(X,Y)+0.0722*b(X,Y))'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- LumaMask exists only as an `ff-render` node; avio has no typed clip effect for it and no GPU mapping, so it always falls back to CPU.
- Add the typed effect + derive-to-ff-render mapping (preview + export) + GPU/CPU parity, mirroring the ChromaKey mapping pair (#1654).

## Solution

- `effect`: add `EffectKind::LumaMask { invert }` — a self-luma mask where the clip's alpha follows its own BT.709 luma (the mask is the clip's own frame; no external source). Structural effect with no scalar `Param` (like `Lut`/`Curves`), so the keyframeable requirement is satisfied vacuously.
- `ff-filter`: add `FilterStep::LumaMask`, a `geq` step setting alpha to the frame's own BT.709 luma (`255 - luma` inverted). `geq` exposes no alpha-read function in this pipeline, so alpha is derived from `r/g/b(X,Y)`; on an opaque source this equals `LumaMaskNode`'s `alpha *= luma` with matching coefficients. Registered in the compositor's alpha-effect list so overlay keeps the masked transparency on export.
- `gpu`: add `GpuEffect::LumaMask` and classify the step; the compositor builds the mask from the source frame (itself, or a grey `255 - luma` frame when inverted) and applies `ff_render::LumaMaskNode`.
- `parity`: probe-gated GPU/CPU parity for the normal and inverted paths. The masked foreground is composited over an opaque background (the compositor discards composited alpha), and a three-band white / pure-red / black fixture drives the BT.709 coefficients and the continuous (non-threshold) blend through the mid-luma red band.

Closes #1655