### PR TITLE
feat(avio): ShapeMask typed clip effect + derive-to-ff-render mapping + parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -226,6 +226,27 @@ pub enum EffectKind {
         /// When `true`, mask by `1 - luma` (dark pixels stay opaque).
         invert: bool,
     },
+    /// Rectangular shape mask: keeps the clip opaque inside the rectangle and clears
+    /// the alpha outside (the `geq` filter on the CPU path, `ff_render::ShapeMaskNode`
+    /// on the GPU). `invert` swaps inside and outside.
+    ///
+    /// `x` / `y` / `width` / `height` are keyframeable per-pixel [`Param`]s (a moving
+    /// or resizing mask), so a constant rectangle compiles to the `RectMask` filter
+    /// and any animated bound uses `RectMaskAnimated` (the GPU animates per frame; the
+    /// CPU renders its `t = 0` bounds, like [`ChromaKey`](Self::ChromaKey)). A constant
+    /// zero `width` or `height` masks nothing, so it compiles to no filter.
+    ShapeMask {
+        /// Left edge of the rectangle, in pixels.
+        x: Param,
+        /// Top edge of the rectangle, in pixels.
+        y: Param,
+        /// Rectangle width, in pixels (a constant `0` is a no-op).
+        width: Param,
+        /// Rectangle height, in pixels (a constant `0` is a no-op).
+        height: Param,
+        /// When `true`, keep the exterior and clear the interior.
+        invert: bool,
+    },
 }
 
 /// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
@@ -507,8 +528,49 @@ impl EffectKind {
             // LumaMask is structural (no scalar param): it always maps to the `geq`
             // self-luma mask. `invert` carries straight through.
             EffectKind::LumaMask { invert } => Some(FilterStep::LumaMask { invert: *invert }),
+            // ShapeMask maps to the rectangular `geq` mask. All-const bounds compile to
+            // `RectMask` (a constant zero width/height masks nothing, so it is a no-op);
+            // any animated bound uses `RectMaskAnimated` (the GPU animates per frame;
+            // the CPU renders its `t = 0` bounds).
+            EffectKind::ShapeMask {
+                x,
+                y,
+                width,
+                height,
+                invert,
+            } => {
+                if x.is_const() && y.is_const() && width.is_const() && height.is_const() {
+                    let (w, h) = (param_to_u32(width), param_to_u32(height));
+                    if w == 0 || h == 0 {
+                        return None;
+                    }
+                    Some(FilterStep::RectMask {
+                        x: param_to_u32(x),
+                        y: param_to_u32(y),
+                        width: w,
+                        height: h,
+                        invert: *invert,
+                    })
+                } else {
+                    Some(FilterStep::RectMaskAnimated {
+                        x: x.to_animated(),
+                        y: y.to_animated(),
+                        width: width.to_animated(),
+                        height: height.to_animated(),
+                        invert: *invert,
+                    })
+                }
+            }
         }
     }
+}
+
+/// Rounds a constant [`Param`] to a non-negative pixel count for the `RectMask`
+/// filter (`u32`). An animated parameter has no constant value; callers only use this
+/// on the all-const path, so it clamps to `0`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn param_to_u32(p: &Param) -> u32 {
+    p.as_const().unwrap_or(0.0).max(0.0).round() as u32
 }
 
 /// Formats an RGB triple (each channel `0.0..=1.0`) as an `FFmpeg` `0xRRGGBB`
@@ -969,5 +1031,62 @@ mod tests {
                 other => panic!("expected LumaMask {{ invert: {invert} }}, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn shape_mask_const_should_compile_to_rect_mask_with_rounded_bounds() {
+        let kind = EffectKind::ShapeMask {
+            x: Param::Const(10.4),
+            y: Param::Const(20.6),
+            width: Param::Const(30.0),
+            height: Param::Const(40.0),
+            invert: true,
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::RectMask {
+                x,
+                y,
+                width,
+                height,
+                invert,
+            } => {
+                assert_eq!((x, y, width, height), (10, 21, 30, 40));
+                assert!(invert);
+            }
+            other => panic!("expected RectMask, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shape_mask_zero_size_should_compile_to_nothing() {
+        let kind = EffectKind::ShapeMask {
+            x: Param::Const(0.0),
+            y: Param::Const(0.0),
+            width: Param::Const(0.0),
+            height: Param::Const(10.0),
+            invert: false,
+        };
+        assert!(
+            kind.to_filter_step().is_none(),
+            "a zero-width rectangle masks nothing, so it is a no-op"
+        );
+    }
+
+    #[test]
+    fn shape_mask_any_animated_should_compile_to_rect_mask_animated() {
+        let kind = EffectKind::ShapeMask {
+            x: Param::Animated(animated_track()),
+            y: Param::Const(0.0),
+            width: Param::Const(30.0),
+            height: Param::Const(40.0),
+            invert: false,
+        };
+        assert!(
+            matches!(
+                kind.to_filter_step().unwrap(),
+                FilterStep::RectMaskAnimated { .. }
+            ),
+            "any animated bound routes through RectMaskAnimated"
+        );
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -294,6 +294,20 @@ pub enum GpuEffect {
         /// When `true`, mask by `1 - luma` (dark pixels stay opaque).
         invert: bool,
     },
+    /// `ff_render::ShapeMaskNode` (a rectangular alpha mask). The compositor builds
+    /// the rectangle mask from these pixel bounds when applying this.
+    ShapeMask {
+        /// Left edge of the rectangle, in pixels.
+        x: u32,
+        /// Top edge of the rectangle, in pixels.
+        y: u32,
+        /// Rectangle width, in pixels.
+        width: u32,
+        /// Rectangle height, in pixels.
+        height: u32,
+        /// When `true`, keep the exterior and clear the interior.
+        invert: bool,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -664,6 +678,28 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
         FilterStep::LumaMask { invert } => {
             StepClass::Effect(GpuEffect::LumaMask { invert: *invert })
         }
+        // ShapeMask (rectangular mask): the compositor builds the rectangle mask from
+        // these bounds. A zero-size rectangle masks nothing (Skip).
+        FilterStep::RectMask {
+            x,
+            y,
+            width,
+            height,
+            invert,
+        } => shape_mask_step(*x, *y, *width, *height, *invert),
+        FilterStep::RectMaskAnimated {
+            x,
+            y,
+            width,
+            height,
+            invert,
+        } => shape_mask_step(
+            round_u32(x.value_at(t)),
+            round_u32(y.value_at(t)),
+            round_u32(width.value_at(t)),
+            round_u32(height.value_at(t)),
+            *invert,
+        ),
         // Everything else (other colour, masks, animated geometry, xfade, ...) has
         // no GPU node yet. `_` is required: `FilterStep` is `#[non_exhaustive]`
         // from ff-filter (RK-003).
@@ -774,6 +810,28 @@ fn chroma_key_step(key_color: [f32; 3], tolerance: f32, softness: f32) -> StepCl
         tolerance,
         softness,
     })
+}
+
+/// Classifies a rectangular shape-mask step: a zero `width` or `height` masks
+/// nothing, so it is a no-op (`Skip`); otherwise it maps to the GPU node with the
+/// rectangle bounds the compositor bakes into the mask.
+fn shape_mask_step(x: u32, y: u32, width: u32, height: u32, invert: bool) -> StepClass {
+    if width == 0 || height == 0 {
+        return StepClass::Skip;
+    }
+    StepClass::Effect(GpuEffect::ShapeMask {
+        x,
+        y,
+        width,
+        height,
+        invert,
+    })
+}
+
+/// Rounds an animated pixel bound (`f64`) to a non-negative `u32` for the mask.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn round_u32(v: f64) -> u32 {
+    v.max(0.0).round() as u32
 }
 
 /// Parses an `FFmpeg` `0xRRGGBB` / `#RRGGBB` colour string into an RGB triple
@@ -1567,5 +1625,65 @@ mod tests {
                 _ => panic!("expected a LumaMask GPU effect for invert={invert}"),
             }
         }
+    }
+
+    #[test]
+    fn classify_rect_mask_should_map_to_shape_mask_with_bounds() {
+        let step = FilterStep::RectMask {
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+            invert: true,
+        };
+        match classify_step(&step, Duration::ZERO) {
+            StepClass::Effect(GpuEffect::ShapeMask {
+                x,
+                y,
+                width,
+                height,
+                invert,
+            }) => {
+                assert_eq!((x, y, width, height), (10, 20, 30, 40));
+                assert!(invert);
+            }
+            _ => panic!("expected a ShapeMask GPU effect"),
+        }
+    }
+
+    #[test]
+    fn classify_rect_mask_animated_should_evaluate_bounds_at_t() {
+        let step = FilterStep::RectMaskAnimated {
+            x: AnimatedValue::Static(5.0),
+            y: AnimatedValue::Static(6.0),
+            width: AnimatedValue::Static(7.0),
+            height: AnimatedValue::Static(8.0),
+            invert: false,
+        };
+        match classify_step(&step, Duration::from_secs(1)) {
+            StepClass::Effect(GpuEffect::ShapeMask {
+                x,
+                y,
+                width,
+                height,
+                ..
+            }) => assert_eq!((x, y, width, height), (5, 6, 7, 8)),
+            _ => panic!("expected a ShapeMask GPU effect"),
+        }
+    }
+
+    #[test]
+    fn classify_rect_mask_zero_size_should_skip() {
+        let step = FilterStep::RectMask {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 10,
+            invert: false,
+        };
+        assert!(matches!(
+            classify_step(&step, Duration::ZERO),
+            StepClass::Skip
+        ));
     }
 }

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -32,7 +32,7 @@ use ff_format::VideoFrame;
 use ff_render::{
     ChromaKeyNode, ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode,
     FrameLayer, GaussianBlurNode, GlowNode, HslNode, LayerTransform, LumaMaskNode, LutNode,
-    RenderContext, RenderGraph, ScaleNode, SharpenNode, VignetteNode,
+    RenderContext, RenderGraph, ScaleNode, ShapeMaskNode, SharpenNode, VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -237,6 +237,19 @@ impl GpuCompositor {
                     in_w,
                     in_h,
                 )),
+                // ShapeMask builds a rectangular alpha mask from the pixel bounds
+                // (preserves dimensions; the mask is sized to the source frame).
+                GpuEffect::ShapeMask {
+                    x,
+                    y,
+                    width,
+                    height,
+                    invert,
+                } => graph.push(ShapeMaskNode::new(
+                    build_shape_mask(in_w, in_h, *x, *y, *width, *height, *invert),
+                    in_w,
+                    in_h,
+                )),
             };
         }
         let out = graph.process_gpu(&rgba, in_w, in_h).ok()?;
@@ -273,6 +286,36 @@ fn build_luma_mask(rgba: &[u8], invert: bool) -> Vec<u8> {
             0.2126 * f32::from(px[0]) + 0.7152 * f32::from(px[1]) + 0.0722 * f32::from(px[2]);
         let grey = (255.0 - luma).clamp(0.0, 255.0).round() as u8;
         mask.extend_from_slice(&[grey, grey, grey, 255]);
+    }
+    mask
+}
+
+/// Builds the mask [`ff_render::ShapeMaskNode`] consumes: alpha `255` inside the
+/// rectangle `[x, x+width) x [y, y+height)` and `0` outside (swapped when `invert`).
+/// The node keeps a pixel where the mask alpha is `> 1`, so this exactly matches the
+/// CPU `RectMask` `geq` (`between(X, x, x+width-1)`), which is inclusive of the far
+/// edge. RGB is unused by the node, so it is left `0`.
+fn build_shape_mask(
+    w: u32,
+    h: u32,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+    invert: bool,
+) -> Vec<u8> {
+    let (inside, outside) = if invert { (0u8, 255u8) } else { (255u8, 0u8) };
+    let (x_end, y_end) = (x.saturating_add(width), y.saturating_add(height));
+    let mut mask = Vec::with_capacity((w as usize) * (h as usize) * 4);
+    for py in 0..h {
+        for px in 0..w {
+            let alpha = if px >= x && px < x_end && py >= y && py < y_end {
+                inside
+            } else {
+                outside
+            };
+            mask.extend_from_slice(&[0, 0, 0, alpha]);
+        }
     }
     mask
 }

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -99,6 +99,13 @@ const TOL_CHROMAKEY_MEAN: f64 = 25.0;
 // (dark pixels reveal the background). Loose enough to cover the invert path's mask
 // quantisation (the grey mask rounds 255-luma to a u8).
 const TOL_LUMAMASK_MEAN: f64 = 6.0;
+// ShapeMask: GPU ShapeMaskNode (rectangle alpha mask) vs the CPU `geq` RectMask. The
+// mask is position-based (hard edges, colour-independent) and both paths use the same
+// inclusive rectangle bounds, so they agree almost exactly. As with the other masks
+// the compositor discards composited alpha, so the masked foreground is composited
+// over an opaque background; a centre vertical band pins the rectangle's x-bounds
+// (RK-015), not merely that a mask was applied.
+const TOL_SHAPEMASK_MEAN: f64 = 4.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -188,6 +195,27 @@ fn band_mean_rgb(buf: &[u8], w: u32, x0: u32, x1: u32) -> [f64; 3] {
     for (i, px) in buf.chunks_exact(4).enumerate() {
         let x = i % wu;
         if x >= x0 && x < x1 {
+            for c in 0..3 {
+                sum[c] += u64::from(px[c]);
+            }
+            n += 1;
+        }
+    }
+    let d = n.max(1) as f64;
+    [sum[0] as f64 / d, sum[1] as f64 / d, sum[2] as f64 / d]
+}
+
+/// Mean RGB over the rectangular region `[x0, x1) x [y0, y1)`. The shape-mask fixture
+/// uses a centre box, so both its x- and y-bounds must be checked (a band would leave
+/// one axis unexercised — a transposition / y-offset bug would slip through).
+fn box_mean_rgb(buf: &[u8], w: u32, x0: u32, y0: u32, x1: u32, y1: u32) -> [f64; 3] {
+    let wu = w as usize;
+    let (x0, y0, x1, y1) = (x0 as usize, y0 as usize, x1 as usize, y1 as usize);
+    let mut sum = [0u64; 3];
+    let mut n = 0u64;
+    for (i, px) in buf.chunks_exact(4).enumerate() {
+        let (x, y) = (i % wu, i / wu);
+        if x >= x0 && x < x1 && y >= y0 && y < y1 {
             for c in 0..3 {
                 sum[c] += u64::from(px[c]);
             }
@@ -1063,6 +1091,127 @@ fn luma_mask_invert_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_LUMAMASK_MEAN,
         "GPU and CPU inverted luma-mask diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn shape_mask_gpu_should_match_cpu_within_tolerance() {
+    // ShapeMask parity: GPU ShapeMaskNode (map_scene maps `RectMask`) vs the CPU `geq`
+    // rectangle mask. The mask keeps the interior opaque and clears the exterior, so
+    // the masked foreground is composited over an opaque background: the rectangle
+    // interior shows the foreground, the exterior reveals the background. A centre
+    // *box* (bounded in x AND y) pins both axes (RK-015): a full-height band would
+    // leave the y-bounds and any x<->y / width<->height transposition unexercised.
+    // Double-gated (adapter + filters).
+    let (w, h) = (64, 48);
+    let (rx, ry, rw, rh) = (w / 4, h / 4, w / 2, h / 2); // centre box: x[16,48) y[12,36)
+    let bg = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [30, 60, 200])).unwrap(); // blue
+    let fg = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [220, 40, 40])).unwrap(); // red
+    let bg_layer = base_layer(w, h, vec![]);
+    let fg_layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::RectMask {
+            x: rx,
+            y: ry,
+            width: rw,
+            height: rh,
+            invert: false,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite2(&[&bg_layer, &fg_layer], &[&bg, &fg], (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some((gpu_out, _, _)) = gpu.composite(
+        &[(&bg_layer, &bg), (&fg_layer, &fg)],
+        (w, h),
+        Duration::ZERO,
+    ) else {
+        panic!("a supported shape-mask composite must render on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    // Non-vacuity guards (RK-015): the box interior keeps the red foreground; the
+    // corner (outside in both x and y) reveals the blue background. Driving both axes
+    // catches a y-offset or transposition bug that a full-height band would miss.
+    let interior = box_mean_rgb(&gpu_out, w, rx, ry, rx + rw, ry + rh);
+    let corner = box_mean_rgb(&gpu_out, w, 0, 0, rx, ry);
+    println!("shape-mask GPU interior={interior:?} corner={corner:?}");
+    assert!(
+        interior[0] > 128.0 && interior[2] < 128.0,
+        "the box interior must keep the red foreground; got {interior:?}"
+    );
+    assert!(
+        corner[2] > 128.0 && corner[0] < 128.0,
+        "the corner must reveal the blue background; got {corner:?}"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "shape-mask GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_SHAPEMASK_MEAN,
+        "GPU and CPU shape-mask composite diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn shape_mask_invert_gpu_should_match_cpu_within_tolerance() {
+    // Inverted mirror: the box interior is cleared (reveals the background) and the
+    // exterior keeps the foreground. Drives build_shape_mask's invert branch and the
+    // geq inverted inside/outside, in both axes. Double-gated (adapter + filters).
+    let (w, h) = (64, 48);
+    let (rx, ry, rw, rh) = (w / 4, h / 4, w / 2, h / 2);
+    let bg = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [30, 60, 200])).unwrap();
+    let fg = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [220, 40, 40])).unwrap();
+    let bg_layer = base_layer(w, h, vec![]);
+    let fg_layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::RectMask {
+            x: rx,
+            y: ry,
+            width: rw,
+            height: rh,
+            invert: true,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite2(&[&bg_layer, &fg_layer], &[&bg, &fg], (w, h)) else {
+        return; // filters unavailable
+    };
+    let Some((gpu_out, _, _)) = gpu.composite(
+        &[(&bg_layer, &bg), (&fg_layer, &fg)],
+        (w, h),
+        Duration::ZERO,
+    ) else {
+        panic!("a supported inverted shape-mask composite must render on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+    let interior = box_mean_rgb(&gpu_out, w, rx, ry, rx + rw, ry + rh);
+    let corner = box_mean_rgb(&gpu_out, w, 0, 0, rx, ry);
+    println!("shape-mask(invert) GPU interior={interior:?} corner={corner:?}");
+    assert!(
+        interior[2] > 128.0 && interior[0] < 128.0,
+        "the inverted box interior must reveal the blue background; got {interior:?}"
+    );
+    assert!(
+        corner[0] > 128.0 && corner[2] < 128.0,
+        "outside the inverted box must keep the red foreground; got {corner:?}"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "shape-mask(invert) GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_SHAPEMASK_MEAN,
+        "GPU and CPU inverted shape-mask diverged beyond tolerance: mean={mean}"
     );
 }
 

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -331,6 +331,7 @@ pub(super) unsafe fn build_video_composition(
                     | FilterStep::ColorKey { .. }
                     | FilterStep::LumaKey { .. }
                     | FilterStep::RectMask { .. }
+                    | FilterStep::RectMaskAnimated { .. }
                     | FilterStep::LumaMask { .. }
                     | FilterStep::PolygonMatte { .. }
                     | FilterStep::FeatherMask { .. }

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -793,6 +793,27 @@ pub enum FilterStep {
         invert: bool,
     },
 
+    /// [`RectMask`](Self::RectMask) with optionally animated `x` / `y` / `width` /
+    /// `height`.
+    ///
+    /// The GPU animates the rectangle per frame; the CPU (`libavfilter`) path renders
+    /// the `Duration::ZERO` values (the `geq` rectangle bounds are static, so the CPU
+    /// path is kept static and the GPU-default path is the animated one, matching
+    /// [`ChromaKeyAnimated`](Self::ChromaKeyAnimated)). `width` / `height` are clamped
+    /// to at least `1` at render time so a zero-size frame never fails `geq` build.
+    RectMaskAnimated {
+        /// Left edge in pixels, evaluated at `Duration::ZERO` on the CPU.
+        x: AnimatedValue<f64>,
+        /// Top edge in pixels, evaluated at `Duration::ZERO` on the CPU.
+        y: AnimatedValue<f64>,
+        /// Width in pixels (clamped to `>= 1`), evaluated at `Duration::ZERO` on the CPU.
+        width: AnimatedValue<f64>,
+        /// Height in pixels (clamped to `>= 1`), evaluated at `Duration::ZERO` on the CPU.
+        height: AnimatedValue<f64>,
+        /// When `true`, the mask is inverted: outside is opaque, inside is transparent.
+        invert: bool,
+    },
+
     /// Set the alpha channel to the frame's own BT.709 luma using `FFmpeg`'s `geq`
     /// filter (a self-referential continuous luma mask).
     ///
@@ -1317,6 +1338,7 @@ impl FilterStep {
             Self::LumaKey { .. } => "lumakey",
             // RectMask uses geq to set alpha per-pixel based on rectangle bounds.
             Self::RectMask { .. } => "geq",
+            Self::RectMaskAnimated { .. } => "geq",
             Self::LumaMask { .. } => "geq",
             // FeatherMask is a compound step (split → alphaextract → gblur → alphamerge);
             // "alphaextract" is used by validate_filter_steps as the primary check.
@@ -1734,6 +1756,30 @@ impl FilterStep {
                 height,
                 invert,
             } => {
+                let xw = x + width - 1;
+                let yh = y + height - 1;
+                let (inside, outside) = if *invert { (0, 255) } else { (255, 0) };
+                format!(
+                    "r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':\
+                     a='if(between(X,{x},{xw})*between(Y,{y},{yh}),{inside},{outside})'"
+                )
+            }
+            Self::RectMaskAnimated {
+                x,
+                y,
+                width,
+                height,
+                invert,
+            } => {
+                // The CPU path is static (the GPU animates per frame): render the
+                // `Duration::ZERO` rectangle. width/height are clamped to >= 1 so a
+                // degenerate frame never fails `geq` build.
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let px = |v: &AnimatedValue<f64>, min: f64| {
+                    v.value_at(Duration::ZERO).max(min).round() as u32
+                };
+                let (x, y) = (px(x, 0.0), px(y, 0.0));
+                let (width, height) = (px(width, 1.0), px(height, 1.0));
                 let xw = x + width - 1;
                 let yh = y + height - 1;
                 let (inside, outside) = if *invert { (0, 255) } else { (255, 0) };
@@ -2350,6 +2396,42 @@ mod tests {
         };
         assert_eq!(step.filter_name(), "chromakey");
         assert_eq!(step.args(), "color=0x00FF00:similarity=0.3:blend=0.1");
+    }
+
+    #[test]
+    fn rect_mask_animated_should_render_static_zero_bounds_via_geq() {
+        // The CPU path is static: args() renders the Duration::ZERO rectangle through
+        // the same geq expression as the const RectMask variant.
+        let step = FilterStep::RectMaskAnimated {
+            x: AnimatedValue::Static(10.0),
+            y: AnimatedValue::Static(20.0),
+            width: AnimatedValue::Static(30.0),
+            height: AnimatedValue::Static(40.0),
+            invert: false,
+        };
+        assert_eq!(step.filter_name(), "geq");
+        // xw = 10 + 30 - 1 = 39, yh = 20 + 40 - 1 = 59.
+        assert_eq!(
+            step.args(),
+            "r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':\
+             a='if(between(X,10,39)*between(Y,20,59),255,0)'"
+        );
+    }
+
+    #[test]
+    fn rect_mask_animated_invert_should_swap_inside_outside() {
+        let step = FilterStep::RectMaskAnimated {
+            x: AnimatedValue::Static(0.0),
+            y: AnimatedValue::Static(0.0),
+            width: AnimatedValue::Static(8.0),
+            height: AnimatedValue::Static(8.0),
+            invert: true,
+        };
+        assert_eq!(
+            step.args(),
+            "r='r(X,Y)':g='g(X,Y)':b='b(X,Y)':\
+             a='if(between(X,0,7)*between(Y,0,7),0,255)'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- ShapeMask exists only as an `ff-render` node; avio has no typed clip effect for it and no GPU mapping, so it always falls back to CPU.
- Add the typed effect + derive-to-ff-render mapping (preview + export) + GPU/CPU parity, mirroring the ChromaKey mapping pair (#1654).

## Solution

- `effect`: add `EffectKind::ShapeMask { x, y, width, height, invert }` — a rectangular alpha mask that keeps the clip opaque inside the rectangle and clears it outside. The bounds are keyframeable `Param`s: all-const bounds compile to the existing `RectMask` filter, any animated bound uses `RectMaskAnimated`; a constant zero width/height masks nothing (no filter).
- `ff-filter`: add `FilterStep::RectMaskAnimated`, a `geq` step rendered at `t = 0` on the CPU (geq bakes the rectangle into the expression, so it cannot animate via sendcmd) while the GPU animates per frame, matching `ChromaKeyAnimated`. Registered in the compositor's alpha-effect list so overlay keeps the masked transparency on export.
- `gpu`: add `GpuEffect::ShapeMask` and classify `RectMask` / `RectMaskAnimated` (a zero-size rectangle is a no-op). The compositor builds a rectangle alpha mask (255 inside, 0 outside, swapped when inverted) and applies `ff_render::ShapeMaskNode`; the mask's inclusive bounds match `geq`'s `between` exactly (pixel-exact parity).
- `parity`: probe-gated GPU/CPU parity for the normal and inverted paths. A centre box (bounded in x and y) over an opaque background pins both axes, so a y-offset or transposition bug is caught, not merely that a mask was applied.

Closes #1656