### PR TITLE
feat(avio): MotionBlur typed clip effect + GPU/CPU mapping and parity

### DIFF
--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -13,6 +13,8 @@
 //! model-free — this type lives in `avio` because it exists to make a *clip's*
 //! effects re-editable (a CLIP/EDIT concern per the engine/primitive litmus).
 
+use std::time::Duration;
+
 use ff_filter::{AnimatedValue, AnimationTrack, FilterStep, Keyframe, Rgb};
 
 use crate::ids::EffectId;
@@ -246,6 +248,26 @@ pub enum EffectKind {
         height: Param,
         /// When `true`, keep the exterior and clear the interior.
         invert: bool,
+    },
+    /// Motion blur (the `tblend` filter on the CPU path, `ff_render::MotionBlurNode`
+    /// on the GPU): a per-clip exposure trail that blends each frame with the
+    /// accumulated previous output.
+    ///
+    /// `shutter_angle` is keyframeable per the typed-effect model, but motion blur is
+    /// **stateful** — the trail accumulates across successive frames on one node
+    /// instance — so a stable shutter is required and the value at `t = 0` is used on
+    /// both paths (the CPU `tblend` likewise has no runtime shutter parameter). A
+    /// constant `shutter_angle = 0.0` is no blur, so it compiles to no filter.
+    /// `sub_frames` is a structural trail-length count (clamped `2..=8` by the GPU
+    /// node); the CPU `tblend` ignores it (it blends only the two most recent frames),
+    /// a documented GPU/CPU divergence.
+    MotionBlur {
+        /// Shutter angle in degrees. Range 0.0..=360.0 (`0.0` = no blur, `180.0` =
+        /// standard film blur). Keyframeable, but rendered at its `t = 0` value.
+        shutter_angle: Param,
+        /// Trail-length sub-frame count (the GPU node clamps it to `2..=8`; the CPU
+        /// `tblend` ignores it).
+        sub_frames: u8,
     },
 }
 
@@ -560,6 +582,24 @@ impl EffectKind {
                         invert: *invert,
                     })
                 }
+            }
+            // MotionBlur maps to `tblend`. Motion blur is stateful (the trail
+            // accumulates across frames on one node), so the shutter cannot animate
+            // per frame: both paths use the value at `t = 0`. A non-positive shutter
+            // is no blur, so it compiles to nothing — matching the GPU classifier's
+            // `<= 0.0` Skip so both paths treat an out-of-range value the same way.
+            EffectKind::MotionBlur {
+                shutter_angle,
+                sub_frames,
+            } => {
+                let angle = shutter_angle.to_animated().value_at(Duration::ZERO) as f32;
+                if angle <= 0.0 {
+                    return None;
+                }
+                Some(FilterStep::MotionBlur {
+                    shutter_angle_degrees: angle,
+                    sub_frames: *sub_frames,
+                })
             }
         }
     }
@@ -1088,5 +1128,65 @@ mod tests {
             ),
             "any animated bound routes through RectMaskAnimated"
         );
+    }
+
+    #[test]
+    fn motion_blur_const_should_map_to_motion_blur_step() {
+        let kind = EffectKind::MotionBlur {
+            shutter_angle: Param::Const(180.0),
+            sub_frames: 4,
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::MotionBlur {
+                shutter_angle_degrees,
+                sub_frames,
+            } => {
+                assert!((shutter_angle_degrees - 180.0).abs() < 1e-4);
+                assert_eq!(sub_frames, 4);
+            }
+            other => panic!("expected MotionBlur, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn motion_blur_non_positive_shutter_should_map_to_none() {
+        // A zero (and any out-of-range negative) shutter is no blur, so it compiles to
+        // nothing on both paths (the GPU classifier likewise skips `<= 0.0`).
+        for angle in [0.0, -10.0] {
+            let kind = EffectKind::MotionBlur {
+                shutter_angle: Param::Const(angle),
+                sub_frames: 4,
+            };
+            assert!(
+                kind.to_filter_step().is_none(),
+                "a non-positive shutter angle ({angle}) is no blur, so it is a no-op"
+            );
+        }
+    }
+
+    #[test]
+    fn motion_blur_animated_shutter_should_render_t0_value() {
+        // The trail needs a stable node, so an animated shutter renders its t=0 value
+        // (here 180) rather than a later keyframe (90).
+        let track = AnimationTrack::new()
+            .push(Keyframe::new(Duration::ZERO, 180.0, Easing::Linear))
+            .push(Keyframe::new(Duration::from_secs(1), 90.0, Easing::Linear));
+        let kind = EffectKind::MotionBlur {
+            shutter_angle: Param::Animated(track),
+            sub_frames: 6,
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::MotionBlur {
+                shutter_angle_degrees,
+                sub_frames,
+            } => {
+                assert!(
+                    (shutter_angle_degrees - 180.0).abs() < 1e-4,
+                    "must use the t=0 shutter value (180), got {shutter_angle_degrees}"
+                );
+                assert_eq!(sub_frames, 6);
+            }
+            other => panic!("expected MotionBlur, got {other:?}"),
+        }
     }
 }

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -308,6 +308,17 @@ pub enum GpuEffect {
         /// When `true`, keep the exterior and clear the interior.
         invert: bool,
     },
+    /// `ff_render::MotionBlurNode` (exposure-trail accumulation). This node is
+    /// **stateful**: the trail accumulates across frames on one node instance, so the
+    /// compositor must reuse its cached graph within a clip and reset it at a clip
+    /// boundary (RK-025). The shutter is a constant (motion blur cannot animate the
+    /// shutter per frame; see [`EffectKind::MotionBlur`](crate::EffectKind::MotionBlur)).
+    MotionBlur {
+        /// Shutter angle in degrees (`0.0` = no blur, `180.0` = standard film blur).
+        shutter_angle: f32,
+        /// Trail-length sub-frame count (the node clamps it to `2..=8`).
+        sub_frames: u8,
+    },
 }
 
 /// Blur radius (sigma) the GPU [`ff_render::SharpenNode`] uses. `FFmpeg` `unsharp`
@@ -700,6 +711,14 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             round_u32(height.value_at(t)),
             *invert,
         ),
+        // MotionBlur (exposure trail): the compositor builds the stateful
+        // `MotionBlurNode`. A zero shutter is no blur (Skip). The shutter is already
+        // constant here (`EffectKind::MotionBlur` collapses an animated shutter to its
+        // t=0 value), so accumulation reuses one node across the clip.
+        FilterStep::MotionBlur {
+            shutter_angle_degrees,
+            sub_frames,
+        } => motion_blur_step(*shutter_angle_degrees, *sub_frames),
         // Everything else (other colour, masks, animated geometry, xfade, ...) has
         // no GPU node yet. `_` is required: `FilterStep` is `#[non_exhaustive]`
         // from ff-filter (RK-003).
@@ -825,6 +844,19 @@ fn shape_mask_step(x: u32, y: u32, width: u32, height: u32, invert: bool) -> Ste
         width,
         height,
         invert,
+    })
+}
+
+/// Classifies a motion-blur step: a non-positive shutter is no blur, so it is a no-op
+/// (`Skip`); otherwise it maps straight to the stateful GPU node (shutter degrees /
+/// sub-frame count in the node's convention).
+fn motion_blur_step(shutter_angle: f32, sub_frames: u8) -> StepClass {
+    if shutter_angle <= 0.0 {
+        return StepClass::Skip;
+    }
+    StepClass::Effect(GpuEffect::MotionBlur {
+        shutter_angle,
+        sub_frames,
     })
 }
 
@@ -1680,6 +1712,36 @@ mod tests {
             width: 0,
             height: 10,
             invert: false,
+        };
+        assert!(matches!(
+            classify_step(&step, Duration::ZERO),
+            StepClass::Skip
+        ));
+    }
+
+    #[test]
+    fn classify_motion_blur_should_map_to_gpu_effect() {
+        let step = FilterStep::MotionBlur {
+            shutter_angle_degrees: 180.0,
+            sub_frames: 6,
+        };
+        match classify_step(&step, Duration::ZERO) {
+            StepClass::Effect(GpuEffect::MotionBlur {
+                shutter_angle,
+                sub_frames,
+            }) => {
+                assert!((shutter_angle - 180.0).abs() < 1e-4);
+                assert_eq!(sub_frames, 6);
+            }
+            _ => panic!("expected a MotionBlur GPU effect"),
+        }
+    }
+
+    #[test]
+    fn classify_motion_blur_zero_shutter_should_skip() {
+        let step = FilterStep::MotionBlur {
+            shutter_angle_degrees: 0.0,
+            sub_frames: 4,
         };
         assert!(matches!(
             classify_step(&step, Duration::ZERO),

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -23,6 +23,13 @@
 //! (or layer count) rebuilds. [`GpuEffect::LumaMask`] is excluded (its node embeds the
 //! source pixels), and [`composite_owned`](GpuCompositor::composite_owned) moves owned
 //! frames so the no-effects export path avoids a `VideoFrame::clone`.
+//!
+//! **Stateful effects (#1653):** a [`GpuEffect::MotionBlur`] node accumulates a trail
+//! across a clip's frames, so its cross-frame reuse *is* the accumulation. A caller
+//! that composites a sequence of clips at one layer position must call
+//! [`reset_effect_cache`](GpuCompositor::reset_effect_cache) at each clip boundary so
+//! the trail does not bleed across a cut (RK-025); the export drain does this. The
+//! preview runner's clip-boundary reset is a documented follow-up.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,7 +38,8 @@ use ff_format::VideoFrame;
 use ff_render::{
     ChromaKeyNode, ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FilmGrainNode,
     FrameLayer, GaussianBlurNode, GlowNode, HslNode, LayerTransform, LumaMaskNode, LutNode,
-    RenderContext, RenderGraph, ScaleNode, ShapeMaskNode, SharpenNode, VignetteNode,
+    MotionBlurNode, RenderContext, RenderGraph, ScaleNode, ShapeMaskNode, SharpenNode,
+    VignetteNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
@@ -190,6 +198,21 @@ impl GpuCompositor {
         }
     }
 
+    /// Drops every cached effect graph (keeping the slot count), so the next composite
+    /// rebuilds each layer's graph from scratch.
+    ///
+    /// A stateful effect node (e.g. [`MotionBlurNode`], whose exposure trail
+    /// accumulates across the frames of one clip) is embedded in the cached graph, so a
+    /// caller that composites a sequence of clips at the same layer position must call
+    /// this **at each clip boundary** — otherwise the previous clip's accumulated trail
+    /// bleeds into the next clip's first frame (RK-025). Stateless effects are
+    /// unaffected beyond a one-frame pipeline rebuild.
+    pub fn reset_effect_cache(&mut self) {
+        for slot in &mut self.effect_cache {
+            *slot = None;
+        }
+    }
+
     /// Applies a layer's mappable effects to its rgba frame via a `RenderGraph`, reusing
     /// the layer's cached graph when the effect list is unchanged and cacheable. `None`
     /// on a GPU error. Must not be called for an empty effect list (the caller handles
@@ -333,6 +356,15 @@ impl GpuCompositor {
                     in_w,
                     in_h,
                 )),
+                // MotionBlur is stateful (the trail accumulates across frames on this
+                // node), so it depends on the cached graph being *reused* across a
+                // clip's frames. It stays cacheable; the accumulation is reset at a
+                // clip boundary via `reset_effect_cache` so a trail never bleeds across
+                // a cut (RK-025). Preserves the frame dimensions.
+                GpuEffect::MotionBlur {
+                    shutter_angle,
+                    sub_frames,
+                } => graph.push(MotionBlurNode::new(*shutter_angle, *sub_frames)),
             };
         }
 

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -191,6 +191,10 @@ pub(crate) fn drain_video_gpu(
 
         let layer = derive::video_layer(clip, 0, &track.automation, canvas.0, canvas.1, None, None);
 
+        // Start each clip with a clean effect cache: a stateful effect (MotionBlur's
+        // exposure trail) must not accumulate across the cut into this clip (RK-025).
+        core.reset_effect_cache();
+
         let mut produced: u64 = 0;
         loop {
             if frame_budget.is_some_and(|budget| produced >= budget) {

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -106,6 +106,14 @@ const TOL_LUMAMASK_MEAN: f64 = 6.0;
 // over an opaque background; a centre vertical band pins the rectangle's x-bounds
 // (RK-015), not merely that a mask was applied.
 const TOL_SHAPEMASK_MEAN: f64 = 4.0;
+// MotionBlur: GPU MotionBlurNode (IIR: mix(current, accumulated prev)) vs the CPU
+// `tblend` filter (FIR-2: a weighted blend of the two most recent frames). Different
+// temporal models, but over two frames at shutter 180 / sub_frames 8 both reduce to
+// `0.5*prev + 0.5*current`, so they align at that calibration point (the CPU tblend
+// ignores sub_frames): measured mean 0.0 here (bit-exact). Temporal, so the parity drives
+// two frames; a single frame is unblended on both paths and would be vacuous (RK-015).
+// The margin covers GPU-driver rounding on other machines.
+const TOL_MOTIONBLUR_MEAN: f64 = 15.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -1384,6 +1392,133 @@ fn composite_owned_should_match_borrowed_for_no_effects() {
     assert_eq!(
         borrowed, owned,
         "composite_owned must match the borrowing composite output"
+    );
+}
+
+/// A single `MotionBlur` layer over two frames on the CPU (`RealtimeComposer`, one
+/// persistent `tblend` graph), returning the second (blended) frame's rgba, or `None`
+/// when `FFmpeg` filters are unavailable (skip). The first pull is the unblended seed.
+fn cpu_motion_blur_two_frames(
+    layer: &RealtimeLayer,
+    f1: &VideoFrame,
+    f2: &VideoFrame,
+    canvas: (u32, u32),
+) -> Option<Vec<u8>> {
+    let mut composer =
+        RealtimeComposer::with_canvas(std::slice::from_ref(layer), Some(canvas)).ok()?;
+    composer.push_layer(0, f1).ok()?;
+    let _ = composer.pull().ok()?; // discard the first (unblended) frame
+    composer.push_layer(0, f2).ok()?;
+    composer.pull().ok()??.to_rgba()
+}
+
+/// A single `MotionBlur` layer over two frames on the GPU (`GpuCompositor`, whose cached
+/// graph reuse lets the stateful node accumulate), returning the second frame's rgba.
+/// `None` when no adapter is present or the layer is unsupported.
+fn gpu_motion_blur_two_frames(
+    gpu: &mut GpuCompositor,
+    layer: &RealtimeLayer,
+    f1: &VideoFrame,
+    f2: &VideoFrame,
+    canvas: (u32, u32),
+) -> Option<Vec<u8>> {
+    gpu.composite(&[(layer, f1)], canvas, Duration::ZERO)?; // seed the accumulation
+    let (rgba, _, _) = gpu.composite(&[(layer, f2)], canvas, Duration::from_millis(33))?;
+    Some(rgba)
+}
+
+/// A single `MotionBlur` layer (shutter 180, sub_frames 8): the calibration point where
+/// the GPU IIR node and the CPU FIR-2 `tblend` both reduce to `0.5*prev + 0.5*current`.
+fn motion_blur_layer(w: u32, h: u32) -> RealtimeLayer {
+    base_layer(
+        w,
+        h,
+        vec![FilterStep::MotionBlur {
+            shutter_angle_degrees: 180.0,
+            sub_frames: 8,
+        }],
+    )
+}
+
+#[test]
+fn motion_blur_gpu_should_match_cpu_within_tolerance() {
+    // AC3 (Br5): the GPU MotionBlurNode and the CPU `tblend` agree within a calibrated
+    // tolerance. Temporal, so two frames of different solid colours make the trail
+    // observable (a single frame is unblended on both = vacuous, RK-015). Double-gated.
+    let (w, h) = (16, 16);
+    let f1 = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [200, 0, 0])).unwrap(); // red
+    let f2 = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [0, 0, 200])).unwrap(); // blue
+    let layer = motion_blur_layer(w, h);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let gpu_out = gpu_motion_blur_two_frames(&mut gpu, &layer, &f1, &f2, (w, h))
+        .expect("gpu motion blur second frame");
+    // The CPU leg must actually run, not silently skip = false green (RK-024 / RK-002).
+    let Some(cpu_out) = cpu_motion_blur_two_frames(&layer, &f1, &f2, (w, h)) else {
+        return; // FFmpeg filters unavailable: skip
+    };
+    // Non-vacuity: the blue frame's trail must carry red from the previous frame (its own
+    // input red is 0), so the GPU output's red channel is ~100, not 0.
+    assert!(
+        gpu_out[0] > 40,
+        "the red frame must leave a trail on the blue frame (red > 0); got {}",
+        gpu_out[0]
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu_out);
+    assert!(
+        mean <= TOL_MOTIONBLUR_MEAN,
+        "GPU/CPU motion blur must agree within {TOL_MOTIONBLUR_MEAN}; got {mean}"
+    );
+}
+
+#[test]
+fn motion_blur_should_accumulate_across_frames() {
+    // #1653: the effect-graph cache reuse within a clip is what lets the stateful
+    // MotionBlurNode accumulate. Composite white then black at layer 0: the second output
+    // must carry a fading trail from the white frame. Adapter-gated (pure GPU).
+    let (w, h) = (8, 8);
+    let white = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [255, 255, 255])).unwrap();
+    let black = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [0, 0, 0])).unwrap();
+    let layer = motion_blur_layer(w, h);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let out = gpu_motion_blur_two_frames(&mut gpu, &layer, &white, &black, (w, h))
+        .expect("gpu motion blur second frame");
+    assert!(
+        out[0] > 0,
+        "the white frame must leave a trail on the black frame; got {}",
+        out[0]
+    );
+}
+
+#[test]
+fn reset_effect_cache_should_reset_motion_blur_accumulation() {
+    // RK-025: resetting the effect cache at a clip boundary drops the stateful node, so a
+    // new clip's first frame is unblended (no white trail bleeds across the cut). Without
+    // the reset the third composite would reuse the accumulated trail. Adapter-gated.
+    let (w, h) = (8, 8);
+    let white = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [255, 255, 255])).unwrap();
+    let black = VideoFrame::from_rgba(w, h, solid_rgba(w, h, [0, 0, 0])).unwrap();
+    let layer = motion_blur_layer(w, h);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    // Clip A: accumulate a white trail, then cut.
+    gpu.composite(&[(&layer, &white)], (w, h), Duration::ZERO)
+        .expect("clip A frame 1");
+    gpu.composite(&[(&layer, &black)], (w, h), Duration::from_millis(33))
+        .expect("clip A frame 2");
+    gpu.reset_effect_cache();
+    // Clip B first frame (black): a fresh node has no history, so it is unblended.
+    let (out, _, _) = gpu
+        .composite(&[(&layer, &black)], (w, h), Duration::from_millis(66))
+        .expect("clip B frame 1");
+    assert!(
+        out[0] <= 2,
+        "after a reset the new clip's first frame must be unblended (no trail); got {}",
+        out[0]
     );
 }
 


### PR DESCRIPTION
## Objective

- `ff_render::MotionBlurNode` (#1051) exists but the editing model cannot reach it: MotionBlur has no typed effect, and the compositor never builds the node.
- A timeline clip should carry a keyframeable motion blur that composites on the GPU for both preview and export, with a CPU fallback.

## Solution

- Wire the mapping pair `EffectKind::MotionBlur` -> `FilterStep::MotionBlur` -> `GpuEffect::MotionBlur` -> `ff_render::MotionBlurNode`; a degenerate (non-positive shutter) case is a no-op and unsupported cases fall back to CPU (RK-020).
- `MotionBlurNode` is stateful (the exposure trail accumulates across a clip's frames on one node), so the effect-graph cache reuse within a clip drives the accumulation; reset the cache at each clip boundary in the export drain so a trail does not bleed across a cut (RK-025).
- `shutter_angle` is a keyframeable `Param` rendered at its `t = 0` value on both paths (the trail needs a stable node); `sub_frames` is a structural trail-length count.
- Add a probe-gated GPU/CPU parity test at the shutter 180 / sub_frames 8 calibration point (where the IIR node and the FIR-2 `tblend` align), plus compositor regression tests for cross-frame accumulation and the clip-boundary reset.
- The preview-path boundary reset and animated-shutter GPU animation are deferred to #1705.

Closes #1653