### PR TITLE
feat(avio): typed colour-grade temperature/tint through the GPU mapping

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -763,16 +763,37 @@ impl Clip {
     /// ));
     /// ```
     #[must_use]
-    pub fn with_color_correction(
+    pub fn with_color_correction(self, brightness: f32, contrast: f32, saturation: f32) -> Self {
+        // Neutral temperature/tint: the plain colour-correction path is unchanged.
+        self.with_color_grade(brightness, contrast, saturation, 0.0, 0.0)
+    }
+
+    /// Sets a colour-correction effect with the full grade, including `temperature`
+    /// and `tint`, and returns the updated clip.
+    ///
+    /// Extends [`with_color_correction`](Self::with_color_correction) with:
+    /// - `temperature`: −1.0..=1.0, where `0.0` is no change (−1.0 cool/blue, +1.0 warm).
+    /// - `tint`:        −1.0..=1.0, where `0.0` is no change (−1.0 magenta, +1.0 green).
+    ///
+    /// `temperature`/`tint` are a GPU-only enrichment: they apply on the GPU-default
+    /// path (`ff_render::ColorGradeNode`); the CPU `eq` fallback applies
+    /// brightness/contrast/saturation only. Like the plain path, an all-neutral grade
+    /// produces bit-identical output to the no-eq render path.
+    #[must_use]
+    pub fn with_color_grade(
         mut self,
         brightness: f32,
         contrast: f32,
         saturation: f32,
+        temperature: f32,
+        tint: f32,
     ) -> Self {
         let kind = EffectKind::ColorCorrect {
             brightness: Param::Const(f64::from(brightness)),
             contrast: Param::Const(f64::from(contrast)),
             saturation: Param::Const(f64::from(saturation)),
+            temperature: Param::Const(f64::from(temperature)),
+            tint: Param::Const(f64::from(tint)),
         };
         // A single color-correct effect is the builder's contract; replace an
         // existing one in place (preserving its id/position) rather than stacking.
@@ -1230,6 +1251,8 @@ mod tests {
             brightness,
             contrast,
             saturation,
+            temperature,
+            tint,
         } = &effect.kind
         else {
             panic!("expected a ColorCorrect effect");
@@ -1237,6 +1260,9 @@ mod tests {
         assert_eq!(brightness.as_const(), Some(0.1_f32.into()));
         assert_eq!(contrast.as_const(), Some(1.2_f32.into()));
         assert_eq!(saturation.as_const(), Some(0.9_f32.into()));
+        // with_color_correction leaves temperature/tint neutral.
+        assert_eq!(temperature.as_const(), Some(0.0_f32.into()));
+        assert_eq!(tint.as_const(), Some(0.0_f32.into()));
         assert!(matches!(brightness, Param::Const(_)));
     }
 
@@ -1276,6 +1302,8 @@ mod tests {
             brightness: Param::Animated(track),
             contrast: Param::Const(1.0),
             saturation: Param::Const(1.0),
+            temperature: Param::Const(0.0),
+            tint: Param::Const(0.0),
         }));
         assert!(matches!(
             clip.video_effect_chain().as_slice(),

--- a/crates/avio/src/edit.rs
+++ b/crates/avio/src/edit.rs
@@ -2557,6 +2557,8 @@ mod tests {
             brightness: Param::Const(brightness),
             contrast: Param::Const(1.0),
             saturation: Param::Const(1.0),
+            temperature: Param::Const(0.0),
+            tint: Param::Const(0.0),
         }
     }
 

--- a/crates/avio/src/editor.rs
+++ b/crates/avio/src/editor.rs
@@ -443,6 +443,8 @@ mod tests {
             brightness: Param::Const(0.5),
             contrast: Param::Const(1.0),
             saturation: Param::Const(1.0),
+            temperature: Param::Const(0.0),
+            tint: Param::Const(0.0),
         };
         ed.apply(&Command::AddEffect { clip, kind: kind() })
             .unwrap();

--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -67,10 +67,16 @@ impl Param {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum EffectKind {
-    /// Brightness / contrast / saturation adjustment (the `eq` filter).
+    /// Brightness / contrast / saturation / temperature / tint adjustment (the `eq`
+    /// filter on the CPU path, `ff_render::ColorGradeNode` on the GPU).
     ///
     /// Neutral parameters (`brightness = 0.0`, `contrast = 1.0`, `saturation = 1.0`,
-    /// all constant) compile to no filter at all, preserving bit-identical output.
+    /// `temperature = 0.0`, `tint = 0.0`, all constant) compile to no filter at all,
+    /// preserving bit-identical output.
+    ///
+    /// `temperature`/`tint` are a GPU-only enrichment: the CPU `eq` fallback applies
+    /// brightness/contrast/saturation only and does not reproduce them (`FFmpeg` `eq`
+    /// has no such parameter), while the GPU-default path applies the full grade.
     ColorCorrect {
         /// Brightness offset. Range −1.0..=1.0 (neutral: 0.0).
         brightness: Param,
@@ -78,6 +84,12 @@ pub enum EffectKind {
         contrast: Param,
         /// Saturation multiplier. Range 0.0..=3.0 (neutral: 1.0).
         saturation: Param,
+        /// Colour temperature offset. Range −1.0..=1.0 (neutral: 0.0; −1.0 cool/blue,
+        /// +1.0 warm/orange). GPU-only (not applied by the CPU `eq` fallback).
+        temperature: Param,
+        /// Colour tint offset. Range −1.0..=1.0 (neutral: 0.0; −1.0 magenta, +1.0
+        /// green). GPU-only (not applied by the CPU `eq` fallback).
+        tint: Param,
     },
     /// Gaussian blur (the `gblur` filter).
     Blur {
@@ -311,16 +323,23 @@ impl EffectKind {
                 brightness,
                 contrast,
                 saturation,
+                temperature,
+                tint,
             } => {
-                let all_const =
-                    brightness.is_const() && contrast.is_const() && saturation.is_const();
+                let all_const = brightness.is_const()
+                    && contrast.is_const()
+                    && saturation.is_const()
+                    && temperature.is_const()
+                    && tint.is_const();
                 if all_const {
                     // Safe: `all_const` guarantees every `as_const` is `Some`.
                     let b = brightness.as_const().unwrap_or(0.0);
                     let c = contrast.as_const().unwrap_or(1.0);
                     let s = saturation.as_const().unwrap_or(1.0);
+                    let temp = temperature.as_const().unwrap_or(0.0);
+                    let ti = tint.as_const().unwrap_or(0.0);
                     #[allow(clippy::float_cmp)]
-                    let neutral = b == 0.0 && c == 1.0 && s == 1.0;
+                    let neutral = b == 0.0 && c == 1.0 && s == 1.0 && temp == 0.0 && ti == 0.0;
                     if neutral {
                         return None;
                     }
@@ -328,6 +347,8 @@ impl EffectKind {
                         brightness: b as f32,
                         contrast: c as f32,
                         saturation: s as f32,
+                        temperature: temp as f32,
+                        tint: ti as f32,
                     })
                 } else {
                     Some(FilterStep::EqAnimated {
@@ -335,6 +356,8 @@ impl EffectKind {
                         contrast: contrast.to_animated(),
                         saturation: saturation.to_animated(),
                         gamma: AnimatedValue::Static(1.0),
+                        temperature: temperature.to_animated(),
+                        tint: tint.to_animated(),
                     })
                 }
             }
@@ -670,6 +693,8 @@ mod tests {
             brightness: Param::Const(0.0),
             contrast: Param::Const(1.0),
             saturation: Param::Const(1.0),
+            temperature: Param::Const(0.0),
+            tint: Param::Const(0.0),
         };
         assert!(
             kind.to_filter_step().is_none(),
@@ -683,6 +708,8 @@ mod tests {
             brightness: Param::Const(0.5),
             contrast: Param::Const(1.2),
             saturation: Param::Const(0.8),
+            temperature: Param::Const(0.3),
+            tint: Param::Const(-0.4),
         };
         let step = kind.to_filter_step().unwrap();
         match step {
@@ -690,10 +717,37 @@ mod tests {
                 brightness,
                 contrast,
                 saturation,
+                temperature,
+                tint,
             } => {
                 assert!((brightness - 0.5).abs() < 1e-6);
                 assert!((contrast - 1.2).abs() < 1e-6);
                 assert!((saturation - 0.8).abs() < 1e-6);
+                assert!((temperature - 0.3).abs() < 1e-6);
+                assert!((tint - (-0.4)).abs() < 1e-6);
+            }
+            other => panic!("expected Eq, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn color_correct_temperature_only_should_compile_to_eq() {
+        // Only temperature/tint are non-neutral (brightness/contrast/saturation neutral):
+        // it must still compile to an Eq step (not skipped as a no-op) so the GPU grade
+        // carries them.
+        let kind = EffectKind::ColorCorrect {
+            brightness: Param::Const(0.0),
+            contrast: Param::Const(1.0),
+            saturation: Param::Const(1.0),
+            temperature: Param::Const(0.6),
+            tint: Param::Const(0.0),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Eq {
+                temperature, tint, ..
+            } => {
+                assert!((temperature - 0.6).abs() < 1e-6);
+                assert!(tint.abs() < 1e-6);
             }
             other => panic!("expected Eq, got {other:?}"),
         }
@@ -705,6 +759,24 @@ mod tests {
             brightness: Param::Animated(animated_track()),
             contrast: Param::Const(1.0),
             saturation: Param::Const(1.0),
+            temperature: Param::Const(0.0),
+            tint: Param::Const(0.0),
+        };
+        assert!(matches!(
+            kind.to_filter_step(),
+            Some(FilterStep::EqAnimated { .. })
+        ));
+    }
+
+    #[test]
+    fn color_correct_animated_temperature_should_compile_to_eq_animated() {
+        // An animated temperature alone routes through the animated variant.
+        let kind = EffectKind::ColorCorrect {
+            brightness: Param::Const(0.0),
+            contrast: Param::Const(1.0),
+            saturation: Param::Const(1.0),
+            temperature: Param::Animated(animated_track()),
+            tint: Param::Const(0.0),
         };
         assert!(matches!(
             kind.to_filter_step(),

--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -177,8 +177,9 @@ impl<T: GpuLayerSource + ?Sized> GpuLayerSource for &T {
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum GpuEffect {
-    /// `ff_render::ColorGradeNode` (brightness / contrast / saturation; temperature
-    /// and tint are neutral until a source carries them).
+    /// `ff_render::ColorGradeNode` (brightness / contrast / saturation / temperature /
+    /// tint). Temperature and tint come from the typed `ColorCorrect` effect and are a
+    /// GPU-only enrichment (the CPU `eq` fallback does not apply them).
     ColorGrade {
         /// Brightness offset.
         brightness: f32,
@@ -482,18 +483,22 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             brightness,
             contrast,
             saturation,
+            temperature,
+            tint,
         } => StepClass::Effect(GpuEffect::ColorGrade {
             brightness: *brightness,
             contrast: *contrast,
             saturation: *saturation,
-            temperature: 0.0,
-            tint: 0.0,
+            temperature: *temperature,
+            tint: *tint,
         }),
         FilterStep::EqAnimated {
             brightness,
             contrast,
             saturation,
             gamma,
+            temperature,
+            tint,
         } => {
             // ff-render's ColorGradeNode has no gamma, so only an `eq` whose gamma
             // is neutral at `t` maps; otherwise fall back so gamma is not dropped.
@@ -502,8 +507,8 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
                     brightness: brightness.value_at(t) as f32,
                     contrast: contrast.value_at(t) as f32,
                     saturation: saturation.value_at(t) as f32,
-                    temperature: 0.0,
-                    tint: 0.0,
+                    temperature: temperature.value_at(t) as f32,
+                    tint: tint.value_at(t) as f32,
                 })
             } else {
                 StepClass::Unsupported
@@ -1010,10 +1015,14 @@ mod tests {
     #[test]
     fn map_scene_should_map_eq_to_color_grade() {
         let mut layer = TestLayer::identity();
+        // Non-neutral temperature/tint must flow through to the node (not the old
+        // hardcoded 0.0), so the assertion below is non-vacuous.
         layer.effects = vec![FilterStep::Eq {
             brightness: 0.5,
             contrast: 1.2,
             saturation: 0.8,
+            temperature: 0.4,
+            tint: -0.3,
         }];
         let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
         assert_eq!(
@@ -1022,8 +1031,8 @@ mod tests {
                 brightness: 0.5,
                 contrast: 1.2,
                 saturation: 0.8,
-                temperature: 0.0,
-                tint: 0.0,
+                temperature: 0.4,
+                tint: -0.3,
             }]
         );
     }
@@ -1036,6 +1045,8 @@ mod tests {
             contrast: AnimatedValue::Static(1.1),
             saturation: AnimatedValue::Static(0.9),
             gamma: AnimatedValue::Static(1.0),
+            temperature: AnimatedValue::Static(0.5),
+            tint: AnimatedValue::Static(-0.2),
         }];
         let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
         assert_eq!(
@@ -1044,8 +1055,8 @@ mod tests {
                 brightness: 0.3,
                 contrast: 1.1,
                 saturation: 0.9,
-                temperature: 0.0,
-                tint: 0.0,
+                temperature: 0.5,
+                tint: -0.2,
             }]
         );
     }
@@ -1060,6 +1071,8 @@ mod tests {
             contrast: AnimatedValue::Static(1.0),
             saturation: AnimatedValue::Static(1.0),
             gamma: AnimatedValue::Static(1.5),
+            temperature: AnimatedValue::Static(0.0),
+            tint: AnimatedValue::Static(0.0),
         }];
         assert_eq!(
             map_scene(&[layer], (16, 16), Duration::ZERO),
@@ -1478,6 +1491,8 @@ mod tests {
                 brightness: 0.1,
                 contrast: 1.0,
                 saturation: 1.0,
+                temperature: 0.0,
+                tint: 0.0,
             },
         ];
         let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
@@ -1531,6 +1546,8 @@ mod tests {
                 brightness: 0.5,
                 contrast: 1.0,
                 saturation: 1.0,
+                temperature: 0.0,
+                tint: 0.0,
             }],
             opacity: AnimatedValue::Static(1.0),
             x: AnimatedValue::Static(0.0),

--- a/crates/avio/src/gpu_preview.rs
+++ b/crates/avio/src/gpu_preview.rs
@@ -146,6 +146,8 @@ mod tests {
             brightness: 0.4,
             contrast: 1.2,
             saturation: 1.0,
+            temperature: 0.0,
+            tint: 0.0,
         }];
         let frame = VideoFrame::from_rgba(4, 4, vec![80u8; 4 * 4 * 4]).unwrap();
         let out = gpu.composite(&[(&desc, &frame)], (4, 4), Duration::ZERO);

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -39,6 +39,11 @@ use ff_preview::FrameSink;
 // divergence (a stretch/letterbox/axis-swap of the gradient is tens of levels).
 const TOL_PASSTHROUGH_MEAN: f64 = 2.0; // identity passthrough: pixel-exact here
 const TOL_COLOR_GRADE_MEAN: f64 = 20.0; // GPU ColorGradeNode vs FFmpeg `eq`: ~6.6 here
+// Extended grade (temperature/tint): the GPU node applies the ±0.1 offset that FFmpeg `eq`
+// cannot express, so the CPU reference is the neutral-eq output plus that offset applied in
+// Rust (mirroring the node). With brightness/contrast/saturation neutral the node reduces to
+// just the offset, so the only divergence is quantisation/driver rounding: ~0.4 here.
+const TOL_GRADE_TEMPTINT_MEAN: f64 = 8.0;
 const TOL_BLUR_MEAN: f64 = 20.0; // GPU GaussianBlurNode vs FFmpeg `gblur`: ~9.0 here (different kernels)
 // GPU SharpenNode (RGB, fixed sigma) vs FFmpeg `unsharp` (luma-only, 5x5): ~0.7 here
 // (effect vs input ~7.9). Grey-calibrated: the test image is achromatic (R=G=B), where
@@ -429,6 +434,8 @@ fn color_grade_gpu_should_match_cpu_within_tolerance() {
             brightness: 0.1,
             contrast: 1.2,
             saturation: 1.1,
+            temperature: 0.0,
+            tint: 0.0,
         }],
     );
     let Some(mut gpu) = GpuCompositor::new() else {
@@ -449,6 +456,78 @@ fn color_grade_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_COLOR_GRADE_MEAN,
         "GPU and CPU colour grade diverged beyond tolerance: mean={mean}"
+    );
+}
+
+/// Applies the `ColorGradeNode`'s temperature/tint offset (`r += temp*0.1`, `b -= temp*0.1`,
+/// `g += tint*0.1`, per pixel, clamped) to an rgba buffer, mirroring the node so the CPU
+/// parity reference reflects a leg FFmpeg `eq` cannot express.
+fn apply_temp_tint_offset(rgba: &[u8], temperature: f32, tint: f32) -> Vec<u8> {
+    let mut out = rgba.to_vec();
+    for px in out.chunks_exact_mut(4) {
+        let r = f32::from(px[0]) / 255.0 + temperature * 0.1;
+        let g = f32::from(px[1]) / 255.0 + tint * 0.1;
+        let b = f32::from(px[2]) / 255.0 - temperature * 0.1;
+        px[0] = (r.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+        px[1] = (g.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+        px[2] = (b.clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+        // alpha unchanged
+    }
+    out
+}
+
+#[test]
+fn color_grade_temperature_tint_gpu_should_match_cpu_reference() {
+    // AC3: temperature/tint must reach the GPU ColorGradeNode (not the old hardcoded 0.0).
+    // FFmpeg `eq` cannot express the node's ±0.1 offset model, so the CPU reference is the
+    // neutral-eq CPU output plus that offset applied in Rust (Q3 decision). Isolate temp/tint
+    // with neutral brightness/contrast/saturation, so the node reduces to just the offset and
+    // the post-offset reference is order-faithful. Double-gated (adapter + filters).
+    let (w, h) = (64, 48);
+    let frame = VideoFrame::from_rgba(w, h, gradient_rgba(w, h)).unwrap();
+    let (temperature, tint) = (0.6_f32, -0.4_f32);
+    let layer = base_layer(
+        w,
+        h,
+        vec![FilterStep::Eq {
+            brightness: 0.0,
+            contrast: 1.0,
+            saturation: 1.0,
+            temperature,
+            tint,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    // The CPU leg must actually run, not silently skip = false green (RK-024 / RK-002).
+    let Some(cpu_neutral) = cpu_composite(&layer, &frame, (w, h)) else {
+        return; // FFmpeg filters unavailable: skip
+    };
+    // The CPU `eq` ignores temperature/tint (GPU-only), so its output must stay ~neutral; the
+    // reference adds the node's offset on top of it.
+    let reference = apply_temp_tint_offset(&cpu_neutral, temperature, tint);
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, (w, h)) else {
+        panic!("a supported colour-graded layer must composite on the GPU");
+    };
+    // Non-vacuity: temperature/tint must actually shift the frame (temp>0 raises R / lowers B,
+    // tint<0 lowers G), so a hardcoded-0.0 regression (GPU == neutral) fails both guards.
+    assert!(
+        mean_abs_diff_rgb(&reference, &cpu_neutral) > 5.0,
+        "the temperature/tint offset must visibly shift the reference"
+    );
+    assert!(
+        mean_abs_diff_rgb(&gpu_out, &cpu_neutral) > 5.0,
+        "the GPU grade must apply temperature/tint (not the old hardcoded 0.0)"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &reference);
+    println!(
+        "grade temp/tint GPU vs reference: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &reference)
+    );
+    assert!(
+        mean <= TOL_GRADE_TEMPTINT_MEAN,
+        "GPU temperature/tint grade diverged from the reference: mean={mean}"
     );
 }
 
@@ -1238,6 +1317,8 @@ fn effect_cache_should_reuse_for_identical_const_effects() {
             brightness: 0.15,
             contrast: 1.2,
             saturation: 1.0,
+            temperature: 0.0,
+            tint: 0.0,
         }],
     );
     let Some(mut gpu) = GpuCompositor::new() else {
@@ -1271,6 +1352,8 @@ fn effect_cache_should_rebuild_on_changed_effect() {
             brightness: -0.3,
             contrast: 1.0,
             saturation: 1.0,
+            temperature: 0.0,
+            tint: 0.0,
         }],
     );
     let bright = base_layer(
@@ -1280,6 +1363,8 @@ fn effect_cache_should_rebuild_on_changed_effect() {
             brightness: 0.3,
             contrast: 1.0,
             saturation: 1.0,
+            temperature: 0.0,
+            tint: 0.0,
         }],
     );
     let Some(mut gpu) = GpuCompositor::new() else {
@@ -1308,6 +1393,8 @@ fn effect_cache_should_not_panic_on_layer_count_change() {
                 brightness: 0.1,
                 contrast: 1.0,
                 saturation: 1.0,
+                temperature: 0.0,
+                tint: 0.0,
             }],
         )
     };
@@ -1345,6 +1432,8 @@ fn effect_cache_should_rebuild_on_input_dimension_change() {
                 brightness: 0.15,
                 contrast: 1.1,
                 saturation: 1.0,
+                temperature: 0.0,
+                tint: 0.0,
             }],
         )
     };

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -207,6 +207,8 @@ fn clip_typed_effects_should_round_trip_through_serde() {
                     brightness: Param::Const(0.25),
                     contrast: Param::Const(1.1),
                     saturation: Param::Const(0.9),
+                    temperature: Param::Const(0.3),
+                    tint: Param::Const(-0.2),
                 },
             },
             Command::AddEffect {

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -221,6 +221,8 @@ impl FilterGraphBuilder {
                 contrast,
                 saturation,
                 gamma,
+                temperature,
+                tint,
             } = step
             {
                 let b = brightness.value_at(Duration::ZERO);
@@ -245,6 +247,18 @@ impl FilterGraphBuilder {
                 if !(0.1..=10.0).contains(&g) {
                     return Err(FilterError::InvalidConfig {
                         reason: format!("eq gamma {g} out of range [0.1, 10.0]"),
+                    });
+                }
+                let temp = temperature.value_at(Duration::ZERO);
+                if !(-1.0..=1.0).contains(&temp) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("eq temperature {temp} out of range [-1.0, 1.0]"),
+                    });
+                }
+                let ti = tint.value_at(Duration::ZERO);
+                if !(-1.0..=1.0).contains(&ti) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("eq tint {ti} out of range [-1.0, 1.0]"),
                     });
                 }
             }
@@ -568,6 +582,8 @@ impl FilterGraphBuilder {
                 brightness,
                 contrast,
                 saturation,
+                temperature,
+                tint,
             } = step
             {
                 if !(-1.0..=1.0).contains(brightness) {
@@ -583,6 +599,16 @@ impl FilterGraphBuilder {
                 if !(0.0..=3.0).contains(saturation) {
                     return Err(FilterError::InvalidConfig {
                         reason: format!("eq saturation {saturation} out of range [0.0, 3.0]"),
+                    });
+                }
+                if !(-1.0..=1.0).contains(temperature) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("eq temperature {temperature} out of range [-1.0, 1.0]"),
+                    });
+                }
+                if !(-1.0..=1.0).contains(tint) {
+                    return Err(FilterError::InvalidConfig {
+                        reason: format!("eq tint {tint} out of range [-1.0, 1.0]"),
                     });
                 }
             }

--- a/crates/ff-filter/src/graph/builder/video/color.rs
+++ b/crates/ff-filter/src/graph/builder/video/color.rs
@@ -178,11 +178,16 @@ impl FilterGraphBuilder {
                 });
             }
         }
+        // temperature/tint are a GPU-only enrichment carried on the typed avio effect;
+        // the ff-filter `eq` builder stays brightness/contrast/saturation/gamma and
+        // leaves them neutral.
         self.steps.push(FilterStep::EqAnimated {
             brightness,
             contrast,
             saturation,
             gamma,
+            temperature: AnimatedValue::Static(0.0),
+            tint: AnimatedValue::Static(0.0),
         });
         self
     }
@@ -508,6 +513,8 @@ mod tests {
             brightness: 0.0,
             contrast: 1.0,
             saturation: 1.0,
+            temperature: 0.0,
+            tint: 0.0,
         };
         assert_eq!(step.filter_name(), "eq");
     }
@@ -518,6 +525,9 @@ mod tests {
             brightness: 0.1,
             contrast: 1.5,
             saturation: 0.8,
+            // GPU-only, not emitted into the `eq` args.
+            temperature: 0.5,
+            tint: -0.5,
         };
         assert_eq!(step.args(), "brightness=0.1:contrast=1.5:saturation=0.8");
     }
@@ -1197,6 +1207,8 @@ mod tests {
             contrast: AnimatedValue::Static(1.5_f64),
             saturation: AnimatedValue::Static(0.8_f64),
             gamma: AnimatedValue::Static(2.0_f64),
+            temperature: AnimatedValue::Static(0.0_f64),
+            tint: AnimatedValue::Static(0.0_f64),
         };
         assert_eq!(step.filter_name(), "eq");
         assert_eq!(

--- a/crates/ff-filter/src/graph/filter_step.rs
+++ b/crates/ff-filter/src/graph/filter_step.rs
@@ -117,15 +117,27 @@ pub enum FilterStep {
     /// Apply a 3D LUT from a `.cube` or `.3dl` file.
     Lut3d { path: String },
     /// Brightness/contrast/saturation adjustment via `FFmpeg` `eq` filter.
+    ///
+    /// `temperature`/`tint` are carried for the derive-to-ff-render `ColorGradeNode`
+    /// mapping (GPU-default path) and are **not** applied by the CPU `eq` filter, which
+    /// has no such option; they are a GPU-only enrichment (like `MotionBlur.sub_frames`
+    /// on the CPU `tblend`). Range −1.0..=1.0 each, neutral 0.0.
     Eq {
         brightness: f32,
         contrast: f32,
         saturation: f32,
+        /// Colour temperature offset (−1.0 cool/blue, +1.0 warm/orange). GPU-only.
+        temperature: f32,
+        /// Colour tint offset (−1.0 magenta, +1.0 green). GPU-only.
+        tint: f32,
     },
     /// Brightness / contrast / saturation / gamma via `FFmpeg` `eq` filter (optionally animated).
     ///
     /// Arguments are evaluated at [`Duration::ZERO`] for the initial graph build.
     /// Per-frame updates are applied via `avfilter_graph_send_command` in #363.
+    ///
+    /// `temperature`/`tint` are carried for the GPU `ColorGradeNode` mapping and are
+    /// **not** applied by the CPU `eq` filter (a GPU-only enrichment; see [`Self::Eq`]).
     EqAnimated {
         /// Brightness offset. Range: −1.0 – 1.0 (neutral: 0.0).
         brightness: AnimatedValue<f64>,
@@ -135,6 +147,10 @@ pub enum FilterStep {
         saturation: AnimatedValue<f64>,
         /// Global gamma correction. Range: 0.1 – 10.0 (neutral: 1.0).
         gamma: AnimatedValue<f64>,
+        /// Colour temperature offset (−1.0 – 1.0; neutral 0.0). GPU-only.
+        temperature: AnimatedValue<f64>,
+        /// Colour tint offset (−1.0 – 1.0; neutral 0.0). GPU-only.
+        tint: AnimatedValue<f64>,
     },
     /// Three-way color balance (shadows / midtones / highlights) via `FFmpeg` `colorbalance` filter
     /// (optionally animated).
@@ -1494,16 +1510,22 @@ impl FilterStep {
             Self::Lut3d { path } => {
                 format!("file={}:interp=trilinear", escape_filter_path(path))
             }
+            // `temperature`/`tint` are GPU-only (the CPU `eq` filter has no such option),
+            // so they are intentionally not emitted into the argument string.
             Self::Eq {
                 brightness,
                 contrast,
                 saturation,
+                temperature: _,
+                tint: _,
             } => format!("brightness={brightness}:contrast={contrast}:saturation={saturation}"),
             Self::EqAnimated {
                 brightness,
                 contrast,
                 saturation,
                 gamma,
+                temperature: _,
+                tint: _,
             } => {
                 let b = brightness.value_at(Duration::ZERO);
                 let c = contrast.value_at(Duration::ZERO);
@@ -2168,11 +2190,15 @@ impl FilterStep {
             Self::GBlurAnimated { sigma } => {
                 push_scalar_entry(&mut entries, node_name, "sigma", sigma);
             }
+            // `temperature`/`tint` are GPU-only; the `eq` filter has no such runtime
+            // command, so they are not pushed here.
             Self::EqAnimated {
                 brightness,
                 contrast,
                 saturation,
                 gamma,
+                temperature: _,
+                tint: _,
             } => {
                 push_scalar_entry(&mut entries, node_name, "brightness", brightness);
                 push_scalar_entry(&mut entries, node_name, "contrast", contrast);


### PR DESCRIPTION
## Objective

- `ff_render::ColorGradeNode` already accepts temperature/tint, but the editing model cannot set them: `classify_step` hardcoded both to `0.0`, so a clip's grade could never carry them.
- The typed `ColorCorrect` effect only exposed brightness/contrast/saturation.

## Solution

- Extend `EffectKind::ColorCorrect` with keyframeable `temperature`/`tint` Params (range `-1.0..=1.0`, neutral `0.0`); a fully neutral grade still compiles to no filter.
- Carry temperature/tint on `FilterStep::Eq`/`EqAnimated` so `classify_step` passes them to `GpuEffect::ColorGrade` instead of the hardcoded `0.0`.
- Treat temperature/tint as a GPU-only enrichment: FFmpeg `eq` cannot express the node's offset model, so the CPU fallback applies brightness/contrast/saturation only and the fields are not emitted into the `eq` args or its `send_command` updates (a documented divergence, like `MotionBlur.sub_frames` on `tblend`).
- Add `Clip::with_color_grade` for the full grade; `with_color_correction` stays a neutral-temperature/tint shorthand.
- Add a probe-gated parity test that isolates temperature/tint and compares the GPU node against a Rust reference (neutral CPU `eq` plus the node's offset), with channel-directional non-vacuity guards.

Closes #1658