### PR TITLE
test(avio): complete GPU/CPU parity coverage with a per-node tolerance table

### DIFF
--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -913,6 +913,47 @@ mod tests {
     use crate::Clip;
     use crate::track::TrackAutomation;
 
+    /// Names the GPU/CPU parity test (in `crates/avio/tests/gpu_parity_tests.rs`) that
+    /// exercises each mapped [`GpuEffect`] node. The exhaustive `match` is the point:
+    /// adding a `GpuEffect` variant without a parity test fails to compile here, which
+    /// enforces #1663's "a per-effect parity test exists for each supported effect" for
+    /// every future node. **Never add a `_` arm** — that would defeat the guard (this is
+    /// in-crate, so `#[non_exhaustive]` does not force one; RK-003).
+    fn parity_coverage(effect: &GpuEffect) -> &'static str {
+        match effect {
+            GpuEffect::ColorGrade { .. } => "color_grade_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::Scale { .. } => "scale_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::Blur { .. } => "blur_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::Sharpen { .. } => "sharpen_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::Vignette { .. } => "vignette_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::FilmGrain { .. } => "film_grain_gpu_should_match_cpu_grain_strength",
+            GpuEffect::Glow { .. } => "glow_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::ColorWheels { .. } => "color_wheels_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::Curves { .. } => "curves_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::Hsl { .. } => "hsl_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::Lut { .. } => "lut_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::ChromaKey { .. } => "chroma_key_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::LumaMask { .. } => "luma_mask_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::ShapeMask { .. } => "shape_mask_gpu_should_match_cpu_within_tolerance",
+            GpuEffect::MotionBlur { .. } => "motion_blur_gpu_should_match_cpu_within_tolerance",
+        }
+    }
+
+    #[test]
+    fn every_gpu_effect_variant_is_registered_for_parity() {
+        // The compile-time exhaustiveness of `parity_coverage` is the real guard; this
+        // keeps it referenced and spot-checks one mapping.
+        let scale = GpuEffect::Scale {
+            width: 2,
+            height: 2,
+            algorithm: RenderScaleAlgorithm::Bilinear,
+        };
+        assert_eq!(
+            parity_coverage(&scale),
+            "scale_gpu_should_match_cpu_within_tolerance"
+        );
+    }
+
     /// A fully controllable [`GpuLayerSource`] for exercising the mapping in
     /// isolation (identity transform, Normal blend, Over composite, no effects).
     struct TestLayer {

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -26,11 +26,34 @@ use std::time::Duration;
 
 use avio::{
     AnimatedValue, BlendMode, Clip, Color, CompositeOp, FilterStep, GpuCompositor, PixelFormat,
-    PlayerHandle, RealtimeLayer, Timeline, TimelinePlayer, VideoFrame,
+    PlayerHandle, RealtimeLayer, ScaleAlgorithm, Timeline, TimelinePlayer, VideoFrame,
 };
 use ff_filter::RealtimeComposer;
 use ff_preview::FrameSink;
 
+// Per-node tolerance table (#1663). Every mapped `GpuEffect` node has a probe-gated
+// GPU/CPU parity test with a calibrated tolerance; `avio::gpu`'s `parity_coverage`
+// meta-test enforces at compile time that every variant appears here. Columns:
+// GpuEffect node | parity test | CPU reference | tolerance const | measured (this build).
+//
+//   ColorGrade  | color_grade_gpu_should_match_cpu_within_tolerance          | eq          | TOL_COLOR_GRADE_MEAN  | mean ~6.6
+//   ColorGrade  | color_grade_temperature_tint_gpu_should_match_cpu_reference| eq + Rust   | TOL_GRADE_TEMPTINT_MEAN| mean ~0.4
+//   Scale       | scale_gpu_should_match_cpu_within_tolerance                | scale       | TOL_SCALE_MEAN        | mean ~0.14
+//   Blur        | blur_gpu_should_match_cpu_within_tolerance                 | gblur       | TOL_BLUR_MEAN         | mean ~9.0
+//   Sharpen     | sharpen_gpu_should_match_cpu_within_tolerance              | unsharp     | TOL_SHARPEN_MEAN      | mean ~0.7
+//   Vignette    | vignette_gpu_should_match_cpu_within_tolerance             | vignette    | TOL_VIGNETTE_MEAN     | calibrated
+//   FilmGrain   | film_grain_gpu_should_match_cpu_grain_strength            | noise (std) | TOL_FILMGRAIN_STD     | std ~10.9/11.1
+//   Glow        | glow_gpu_should_match_cpu_within_tolerance                 | gblur+blend | TOL_GLOW_MEAN         | calibrated
+//   ColorWheels | color_wheels_gpu_should_match_cpu_within_tolerance         | colorbalance| TOL_COLOR_WHEELS_MEAN | calibrated
+//   Curves      | curves_gpu_should_match_cpu_within_tolerance               | curves      | TOL_CURVES_MEAN       | calibrated
+//   Hsl         | hsl_gpu_should_match_cpu_within_tolerance                  | hue         | TOL_HSL_MEAN          | calibrated
+//   Lut         | lut_gpu_should_match_cpu_within_tolerance                  | lut3d       | TOL_LUT_MEAN          | calibrated
+//   ChromaKey   | chroma_key_gpu_should_match_cpu_within_tolerance           | colorkey(2L)| TOL_CHROMAKEY_MEAN    | calibrated
+//   LumaMask    | luma_mask_gpu_should_match_cpu_within_tolerance (+ _invert) | geq (2L)    | TOL_LUMAMASK_MEAN     | mean ~0.2
+//   ShapeMask   | shape_mask_gpu_should_match_cpu_within_tolerance (+ _invert)| geq (2L)    | TOL_SHAPEMASK_MEAN    | mean 0.0
+//   MotionBlur  | motion_blur_gpu_should_match_cpu_within_tolerance          | tblend      | TOL_MOTIONBLUR_MEAN   | mean 0.0
+// (Passthrough — no effect — is covered by passthrough_gpu_should_match_cpu_within_tolerance / TOL_PASSTHROUGH_MEAN.)
+//
 // Tolerances (mean absolute per-channel RGB difference, 0..255). Calibrated on the
 // dev machine; alpha is excluded (the compositor blends RGB over transparent black,
 // an alpha detail orthogonal to colour parity). Measured on this build: passthrough
@@ -45,6 +68,9 @@ const TOL_COLOR_GRADE_MEAN: f64 = 20.0; // GPU ColorGradeNode vs FFmpeg `eq`: ~6
 // just the offset, so the only divergence is quantisation/driver rounding: ~0.4 here.
 const TOL_GRADE_TEMPTINT_MEAN: f64 = 8.0;
 const TOL_BLUR_MEAN: f64 = 20.0; // GPU GaussianBlurNode vs FFmpeg `gblur`: ~9.0 here (different kernels)
+// GPU ScaleNode (bilinear) vs FFmpeg `scale` (bilinear): different resampler implementations,
+// so a loose calibrated tolerance on a downscaled gradient (~0.14 here).
+const TOL_SCALE_MEAN: f64 = 12.0;
 // GPU SharpenNode (RGB, fixed sigma) vs FFmpeg `unsharp` (luma-only, 5x5): ~0.7 here
 // (effect vs input ~7.9). Grey-calibrated: the test image is achromatic (R=G=B), where
 // an all-RGB node and a luma-only filter coincide; colored edges would diverge more.
@@ -558,6 +584,58 @@ fn blur_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_BLUR_MEAN,
         "GPU and CPU blur diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn scale_gpu_should_match_cpu_within_tolerance() {
+    // Scale parity: GPU ScaleNode (map_scene maps `Scale`) vs the CPU `scale` filter,
+    // both bilinear. Downscale a 64x48 gradient to 32x24 (same 4:3 aspect as the canvas,
+    // so the compositor does not fall back) and compare at the target size. Different
+    // resampler implementations, so a loose calibrated tolerance. Double-gated.
+    let (sw, sh) = (64, 48);
+    let (tw, th) = (32, 24);
+    let frame = VideoFrame::from_rgba(sw, sh, gradient_rgba(sw, sh)).unwrap();
+    let layer = base_layer(
+        sw,
+        sh,
+        vec![FilterStep::Scale {
+            width: tw,
+            height: th,
+            algorithm: ScaleAlgorithm::Bilinear,
+        }],
+    );
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, (tw, th)) else {
+        return; // filters unavailable
+    };
+    let Some((gpu_out, gw, gh)) = gpu.composite(&[(&layer, &frame)], (tw, th), Duration::ZERO)
+    else {
+        panic!("a supported scaled layer must composite on the GPU");
+    };
+    // The Scale node actually ran: the output is the target size, not the source size.
+    assert_eq!(
+        (gw, gh),
+        (tw, th),
+        "the scaled output must be the target size"
+    );
+    assert_eq!(gpu_out.len(), cpu.len());
+    // Non-vacuity (RK-015): the downscaled gradient is not flat, so a bypassed scale (or a
+    // constant frame) would not produce this spread.
+    assert!(
+        max_abs_diff_rgb(&gpu_out, &vec![gpu_out[0]; gpu_out.len()]) > 20,
+        "the scaled gradient must vary across the frame (non-vacuous)"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "scale GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_SCALE_MEAN,
+        "GPU and CPU scale diverged beyond tolerance: mean={mean}"
     );
 }
 


### PR DESCRIPTION
## Objective

- The Br5 parity harness covered 14 of the 15 mapped `GpuEffect` nodes; `Scale` had no parity test.
- The per-effect tolerances were scattered, and nothing enforced that a future node cannot be added without a parity test.

## Solution

- Add a `Scale` parity test (GPU `ScaleNode` vs FFmpeg `scale`, both bilinear, downscaling a gradient), double-gated and non-vacuous (target-size and non-flat guards plus the CPU comparison).
- Add a consolidated per-node tolerance table documenting every node's parity test, CPU reference, tolerance constant and measured mean.
- Add a compile-time meta-test in the avio lib that exhaustively matches every `GpuEffect` variant to its parity test; placed in the lib (not the integration test) so the exhaustive match is not forced to carry a wildcard arm by `#[non_exhaustive]`, so adding a variant without a parity test fails to compile.

Closes #1663