### PR TITLE
feat(avio)!: unify per-clip video effects onto the typed effect model

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -283,22 +283,19 @@ pub struct Clip {
     pub proxy: Option<PathBuf>,
     /// Ordered per-clip video filter steps applied to the clip's video layer.
     ///
-    /// Applied during `Timeline::render()` after the built-in speed and
-    /// colour-correction steps, allowing callers to attach any video
-    /// [`FilterStep`] (e.g. `Lut3d`, `Curves`, `ChromaKey`, `GBlur`) to a
-    /// single clip. An empty vec (the default) is a no-op.
+    /// Ordered, typed, re-editable per-clip video effects (#1458) — the single
+    /// video-effect surface (#1622).
+    ///
+    /// Each [`ClipEffect`] is an id-addressed [`EffectKind`] with individually
+    /// keyframable [`Param`](crate::Param)s, edited via the `*Effect` commands. During
+    /// derivation each enabled effect compiles to a [`FilterStep`] in list order (see
+    /// [`video_effect_chain`](Self::video_effect_chain)). A step the typed model has no
+    /// variant for is attached through the [`EffectKind::Raw`](crate::EffectKind)
+    /// escape hatch (see [`with_video_effect`](Self::with_video_effect)). An empty vec
+    /// (the default) is a no-op.
     ///
     /// Persisted by the `serde` feature (#1452). Compositor-internal steps
     /// (`Blend` / `Composite` / `AlphaMatte`) are not serialized.
-    pub video_effects: Vec<FilterStep>,
-    /// Ordered, typed, re-editable per-clip video effects (#1458).
-    ///
-    /// The authoring layer above [`video_effects`](Self::video_effects): each
-    /// [`ClipEffect`] is an id-addressed [`EffectKind`] with individually
-    /// keyframable [`Param`](crate::Param)s, edited via the `*Effect` commands.
-    /// During derivation each enabled effect compiles to a [`FilterStep`] (see
-    /// [`video_effect_chain`](Self::video_effect_chain)), prepended before the
-    /// opaque `video_effects`. An empty vec (the default) is a no-op.
     pub effects: Vec<ClipEffect>,
     /// Ordered per-clip audio filter steps applied to the clip's audio track.
     ///
@@ -307,7 +304,10 @@ pub struct Clip {
     /// `ParametricEq`, `NoiseReduce`) to a single clip. An empty vec (the
     /// default) is a no-op.
     ///
-    /// Persisted by the `serde` feature (#1452; see [`video_effects`](Self::video_effects)).
+    /// Persisted by the `serde` feature (#1452; see [`effects`](Self::effects)).
+    ///
+    /// Unlike the video side (#1622), audio has no typed effect model yet, so this is
+    /// still an opaque step list.
     pub audio_effects: Vec<FilterStep>,
 }
 
@@ -383,38 +383,40 @@ impl Clip {
             composite_op: CompositeOp::Over,
             speed: 1.0,
             proxy: None,
-            video_effects: Vec::new(),
             effects: Vec::new(),
             audio_effects: Vec::new(),
         }
     }
 
-    /// Attaches a video [`FilterStep`] to this clip and returns the updated clip.
+    /// Appends a raw video [`FilterStep`] to this clip's [`effects`](Self::effects) as
+    /// an [`EffectKind::Raw`](crate::EffectKind) effect, and returns the updated clip.
     ///
-    /// Steps are applied in the order added, after the built-in speed and
-    /// colour-correction steps, during `Timeline::render()`.
+    /// This is the escape hatch for steps the typed model has no variant for; it is a
+    /// normal typed effect, so it renders in its position in `effects` and can be
+    /// enabled/disabled, reordered and removed through the `*Effect` commands. Prefer a
+    /// typed builder (e.g. [`with_color_grade`](Self::with_color_grade)) when one exists.
     ///
     /// # Examples
     ///
     /// ```
-    /// use avio::Clip;
+    /// use avio::{Clip, EffectKind};
     /// use ff_filter::FilterStep;
     ///
     /// let clip = Clip::new("scene.mp4")
     ///     .with_video_effect(FilterStep::Lut3d { path: "look.cube".into() });
-    /// assert_eq!(clip.video_effects.len(), 1);
+    /// assert!(matches!(clip.effects[0].kind, EffectKind::Raw { .. }));
     /// ```
     #[must_use]
     pub fn with_video_effect(mut self, step: FilterStep) -> Self {
-        self.video_effects.push(step);
+        self.effects.push(ClipEffect::new(EffectKind::Raw { step }));
         self
     }
 
     /// Returns the pixel-domain video effect chain that `Timeline::render()`
     /// applies to this clip's layer: each enabled typed [`effect`](Self::effects)
-    /// compiled to its [`FilterStep`] (a neutral `ColorCorrect` compiles to
-    /// nothing), followed by the caller-attached [`video_effects`](Self::video_effects),
-    /// in order.
+    /// compiled to its [`FilterStep`], in list order (a neutral `ColorCorrect`
+    /// compiles to nothing, and an [`EffectKind::Raw`](crate::EffectKind) effect
+    /// contributes its step verbatim).
     ///
     /// Temporal steps such as `Speed` are intentionally excluded — they affect
     /// timing, not a single frame's pixels. This is the exact list
@@ -447,7 +449,6 @@ impl Clip {
                 steps.push(step);
             }
         }
-        steps.extend(self.video_effects.iter().cloned());
         steps
     }
 
@@ -1608,7 +1609,9 @@ mod tests {
     }
 
     #[test]
-    fn video_effect_chain_should_append_video_effects_after_eq() {
+    fn video_effect_chain_should_compile_raw_step_after_typed_effect() {
+        // #1622 AC2: for the natural authoring order (typed effect, then a raw step)
+        // the derived chain is unchanged from the pre-migration surface.
         let clip = Clip::new("v.mp4")
             .with_color_correction(0.1, 1.0, 1.0)
             .with_video_effect(FilterStep::Hue { degrees: 30.0 });
@@ -1616,6 +1619,41 @@ mod tests {
             clip.video_effect_chain().as_slice(),
             [FilterStep::Eq { .. }, FilterStep::Hue { .. }]
         ));
+    }
+
+    #[test]
+    fn video_effect_chain_should_follow_effects_order() {
+        // #1622: a raw step now renders in its position in `effects`. Authoring it
+        // first puts it first — previously raw steps were forced after every typed
+        // effect regardless of authoring order.
+        let clip = Clip::new("v.mp4")
+            .with_video_effect(FilterStep::Hue { degrees: 30.0 })
+            .with_color_correction(0.1, 1.0, 1.0);
+        assert!(matches!(
+            clip.video_effect_chain().as_slice(),
+            [FilterStep::Hue { .. }, FilterStep::Eq { .. }]
+        ));
+    }
+
+    #[test]
+    fn with_video_effect_should_append_a_raw_typed_effect() {
+        // #1622: the escape hatch is a normal typed effect, so it is id-addressed and
+        // can be toggled/reordered/removed through the `*Effect` commands.
+        let clip = Clip::new("v.mp4").with_video_effect(FilterStep::HFlip);
+        let [effect] = clip.effects.as_slice() else {
+            panic!("expected exactly one effect");
+        };
+        assert!(effect.enabled);
+        assert!(matches!(
+            effect.kind,
+            EffectKind::Raw {
+                step: FilterStep::HFlip
+            }
+        ));
+        // A disabled raw effect drops out of the chain like any other typed effect.
+        let mut disabled = clip.clone();
+        disabled.effects[0].enabled = false;
+        assert!(disabled.video_effect_chain().is_empty());
     }
 
     #[test]

--- a/crates/avio/src/edit.rs
+++ b/crates/avio/src/edit.rs
@@ -1774,9 +1774,11 @@ mod tests {
         let mut clip = Clip::new("a.mp4");
         clip.transition = Some(XfadeTransition::Fade);
         clip.transition_duration = Duration::from_millis(300);
-        clip.video_effects.push(FilterStep::Lut3d {
-            path: "look.cube".into(),
-        });
+        clip.effects.push(ClipEffect::new(EffectKind::Raw {
+            step: FilterStep::Lut3d {
+                path: "look.cube".into(),
+            },
+        }));
         let t = Timeline::builder()
             .canvas(1920, 1080)
             .frame_rate(30.0)
@@ -1798,7 +1800,8 @@ mod tests {
         let moved = &out.video_tracks()[1].clips[0];
         assert_eq!(moved.transition, Some(XfadeTransition::Fade));
         assert_eq!(moved.transition_duration, Duration::from_millis(300));
-        assert_eq!(moved.video_effects.len(), 1);
+        assert_eq!(moved.effects.len(), 1);
+        assert!(matches!(moved.effects[0].kind, EffectKind::Raw { .. }));
     }
 
     #[test]

--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -364,6 +364,19 @@ pub enum EffectKind {
         /// `tblend` ignores it).
         sub_frames: u8,
     },
+    /// Escape hatch: a raw [`FilterStep`] the typed model has no variant for yet
+    /// (`Hue`, `HFlip`, `Crop`, `Denoise`, ...).
+    ///
+    /// This is the **only** way to attach an untyped step, so every effect a clip
+    /// carries still lives in one ordered, id-addressed list: a raw step can be
+    /// enabled/disabled, reordered and removed through the `*Effect` commands like any
+    /// other effect. Its interior is opaque, though — the step's own arguments are not
+    /// individually keyframeable [`Param`]s and [`descriptor`](Self::descriptor)
+    /// reports no parameters for it. Prefer a typed kind whenever one exists.
+    Raw {
+        /// The step rendered verbatim, in this effect's position in the chain.
+        step: FilterStep,
+    },
 }
 
 /// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
@@ -688,6 +701,12 @@ impl EffectKind {
                     },
                 ],
             },
+            // A raw step is opaque: its arguments are not typed `Param`s, so there is
+            // nothing for a host to render a parameter editor from.
+            EffectKind::Raw { .. } => EffectDescriptor {
+                name: "raw",
+                params: Vec::new(),
+            },
         }
     }
 
@@ -1011,6 +1030,8 @@ impl EffectKind {
                     sub_frames: *sub_frames,
                 })
             }
+            // The escape hatch renders its step verbatim.
+            EffectKind::Raw { step } => Some(step.clone()),
         }
     }
 }
@@ -1072,6 +1093,32 @@ mod tests {
 
     fn animated_track() -> AnimationTrack<f64> {
         AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear))
+    }
+
+    #[test]
+    fn raw_should_compile_to_its_filter_step() {
+        // #1622: the escape hatch renders its step verbatim.
+        let kind = EffectKind::Raw {
+            step: FilterStep::Hue { degrees: 30.0 },
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Hue { degrees } => assert!((degrees - 30.0).abs() < 1e-6),
+            other => panic!("expected Hue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn descriptor_should_describe_raw_as_opaque() {
+        // A raw step has no typed parameters, so introspection reports none.
+        let kind = EffectKind::Raw {
+            step: FilterStep::HFlip,
+        };
+        let d = kind.descriptor();
+        assert_eq!(d.name, "raw");
+        assert!(
+            d.params.is_empty(),
+            "a raw step exposes no typed parameters"
+        );
     }
 
     #[test]

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -160,15 +160,18 @@ fn clip_effects_should_round_trip_through_serde() {
         serde_json::from_str(&serde_json::to_string(&back).unwrap()).unwrap();
     assert_eq!(v1, v2, "effect chains must round-trip through serde");
 
-    assert_eq!(
-        back.video_effects.len(),
-        2,
-        "video effects survive the load"
-    );
-    assert!(
-        matches!(back.video_effects[0], FilterStep::Hue { degrees } if (degrees - 30.0).abs() < 1e-6)
-    );
-    assert!(matches!(back.video_effects[1], FilterStep::HFlip));
+    // #1622: a raw video step now persists as an `EffectKind::Raw` typed effect.
+    assert_eq!(back.effects.len(), 2, "video effects survive the load");
+    assert!(matches!(
+        &back.effects[0].kind,
+        EffectKind::Raw { step: FilterStep::Hue { degrees } } if (degrees - 30.0).abs() < 1e-6
+    ));
+    assert!(matches!(
+        &back.effects[1].kind,
+        EffectKind::Raw {
+            step: FilterStep::HFlip
+        }
+    ));
     assert_eq!(
         back.audio_effects.len(),
         2,


### PR DESCRIPTION
## Objective

- A clip carried two video-effect surfaces: the typed, id-addressed `Clip.effects`, and the opaque public `Clip.video_effects`, concatenated after every typed effect.
- The opaque surface could not be toggled, reordered, removed by id, keyframed or introspected, so not every authored effect went through the typed model.

## Solution

- Remove `Clip.video_effects` and add `EffectKind::Raw { step }`, the single documented escape hatch for a `FilterStep` the typed model has no variant for.
- `with_video_effect` now appends a `Raw` typed effect, so a raw step keeps its full capability while gaining id-addressing, enable/disable and reordering through the existing `*Effect` commands.
- `video_effect_chain` is now exactly the enabled typed effects in list order, and `Raw` compiles to its step verbatim, so the derived chain is unchanged for the natural authoring order (the existing doctest asserting `[Eq, Hue]` passes unmodified).
- `descriptor()` reports `Raw` as `name: "raw"` with no parameters, keeping the introspection contract honest about its opacity.
- Tests cover the escape hatch, the chain order, disabling a raw effect, and the serde round-trip; the audio side keeps its opaque `audio_effects` list, tracked in #1712.

Breaking changes:
- `Clip.video_effects` is removed. Code using it must move to `EffectKind::Raw` (or `with_video_effect`), and documents serialized by an older version drop that field on load (the general serialization-compatibility policy is tracked in #1709).
- A raw step now renders in its position in `effects` rather than always after every typed effect.

Closes #1622