### PR TITLE
feat(avio)!: unify per-clip audio effects onto the typed effect model

### DIFF
--- a/crates/avio/src/clip.rs
+++ b/crates/avio/src/clip.rs
@@ -14,7 +14,7 @@ use ff_filter::{
 };
 use ff_format::{Color, PixelFormat, TextSpec, VideoFrame};
 
-use crate::effect::{ClipEffect, EffectKind, Param};
+use crate::effect::{ClipEffect, EffectDomain, EffectKind, Param};
 use crate::error::TimelineError;
 use crate::ids::{ClipId, GroupId};
 
@@ -283,32 +283,24 @@ pub struct Clip {
     pub proxy: Option<PathBuf>,
     /// Ordered per-clip video filter steps applied to the clip's video layer.
     ///
-    /// Ordered, typed, re-editable per-clip video effects (#1458) — the single
-    /// video-effect surface (#1622).
+    /// Ordered, typed, re-editable per-clip effects (#1458) — the single effect
+    /// surface for both media domains (#1622 video, #1712 audio).
     ///
     /// Each [`ClipEffect`] is an id-addressed [`EffectKind`] with individually
-    /// keyframable [`Param`](crate::Param)s, edited via the `*Effect` commands. During
-    /// derivation each enabled effect compiles to a [`FilterStep`] in list order (see
-    /// [`video_effect_chain`](Self::video_effect_chain)). A step the typed model has no
-    /// variant for is attached through the [`EffectKind::Raw`](crate::EffectKind)
-    /// escape hatch (see [`with_video_effect`](Self::with_video_effect)). An empty vec
-    /// (the default) is a no-op.
+    /// keyframable [`Param`](crate::Param)s, edited via the `*Effect` commands. Each
+    /// kind declares its [`EffectDomain`](crate::EffectDomain), and during derivation
+    /// the video and audio paths each compile the enabled effects of their own domain,
+    /// in list order (see [`video_effect_chain`](Self::video_effect_chain) and
+    /// [`audio_effect_chain`](Self::audio_effect_chain)). A step the typed model has no
+    /// variant for is attached through the [`EffectKind::Raw`](crate::EffectKind) /
+    /// [`EffectKind::AudioRaw`](crate::EffectKind) escape hatches (see
+    /// [`with_video_effect`](Self::with_video_effect) /
+    /// [`with_audio_effect`](Self::with_audio_effect)). An empty vec (the default) is a
+    /// no-op.
     ///
     /// Persisted by the `serde` feature (#1452). Compositor-internal steps
     /// (`Blend` / `Composite` / `AlphaMatte`) are not serialized.
     pub effects: Vec<ClipEffect>,
-    /// Ordered per-clip audio filter steps applied to the clip's audio track.
-    ///
-    /// Applied during the audio mix after the built-in speed and fade steps,
-    /// allowing callers to attach any audio [`FilterStep`] (e.g. `ACompressor`,
-    /// `ParametricEq`, `NoiseReduce`) to a single clip. An empty vec (the
-    /// default) is a no-op.
-    ///
-    /// Persisted by the `serde` feature (#1452; see [`effects`](Self::effects)).
-    ///
-    /// Unlike the video side (#1622), audio has no typed effect model yet, so this is
-    /// still an opaque step list.
-    pub audio_effects: Vec<FilterStep>,
 }
 
 impl Clip {
@@ -384,7 +376,6 @@ impl Clip {
             speed: 1.0,
             proxy: None,
             effects: Vec::new(),
-            audio_effects: Vec::new(),
         }
     }
 
@@ -441,9 +432,43 @@ impl Clip {
     /// ```
     #[must_use]
     pub fn video_effect_chain(&self) -> Vec<FilterStep> {
+        self.effect_chain(EffectDomain::Video)
+    }
+
+    /// Returns the audio effect chain the audio mix applies to this clip: each enabled
+    /// [`EffectDomain::Audio`](crate::EffectDomain) effect compiled to its
+    /// [`FilterStep`], in list order (a neutral `Volume` compiles to nothing, and an
+    /// [`EffectKind::AudioRaw`](crate::EffectKind) effect contributes its step
+    /// verbatim). The audio counterpart of
+    /// [`video_effect_chain`](Self::video_effect_chain) (#1712).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use avio::Clip;
+    /// use ff_filter::FilterStep;
+    ///
+    /// let clip = Clip::new("scene.mp4").with_audio_effect(FilterStep::Volume(-6.0));
+    /// assert!(matches!(
+    ///     clip.audio_effect_chain().as_slice(),
+    ///     [FilterStep::Volume(_)]
+    /// ));
+    /// // Audio effects never leak into the video chain.
+    /// assert!(clip.video_effect_chain().is_empty());
+    /// ```
+    #[must_use]
+    pub fn audio_effect_chain(&self) -> Vec<FilterStep> {
+        self.effect_chain(EffectDomain::Audio)
+    }
+
+    /// The enabled effects of one domain, compiled to their steps in list order. One
+    /// clip list holds both domains, so each derive path selects its own (#1712); the
+    /// relative order within a domain is preserved.
+    fn effect_chain(&self, domain: EffectDomain) -> Vec<FilterStep> {
         let mut steps = Vec::new();
         for effect in &self.effects {
             if effect.enabled
+                && effect.kind.domain() == domain
                 && let Some(step) = effect.kind.to_filter_step()
             {
                 steps.push(step);
@@ -542,13 +567,29 @@ impl Clip {
         crate::derive::realtime_descriptor(self, &crate::track::TrackAutomation::default(), 0, 0)
     }
 
-    /// Attaches an audio [`FilterStep`] to this clip and returns the updated clip.
+    /// Appends a raw audio [`FilterStep`] to this clip's [`effects`](Self::effects) as
+    /// an [`EffectKind::AudioRaw`](crate::EffectKind) effect, and returns the updated
+    /// clip.
     ///
-    /// Steps are applied in the order added, after the built-in speed and fade
-    /// steps, during the audio mix.
+    /// The audio escape hatch (#1712), mirroring
+    /// [`with_video_effect`](Self::with_video_effect): it is a normal typed effect, so
+    /// it renders in its position in the audio chain and can be enabled/disabled,
+    /// reordered and removed through the `*Effect` commands. Prefer a typed audio kind
+    /// (e.g. [`EffectKind::Volume`](crate::EffectKind)) when one exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use avio::{Clip, EffectKind};
+    /// use ff_filter::FilterStep;
+    ///
+    /// let clip = Clip::new("scene.mp4").with_audio_effect(FilterStep::Volume(-6.0));
+    /// assert!(matches!(clip.effects[0].kind, EffectKind::AudioRaw { .. }));
+    /// ```
     #[must_use]
     pub fn with_audio_effect(mut self, step: FilterStep) -> Self {
-        self.audio_effects.push(step);
+        self.effects
+            .push(ClipEffect::new(EffectKind::AudioRaw { step }));
         self
     }
 
@@ -1654,6 +1695,55 @@ mod tests {
         let mut disabled = clip.clone();
         disabled.effects[0].enabled = false;
         assert!(disabled.video_effect_chain().is_empty());
+    }
+
+    #[test]
+    fn video_effect_chain_should_exclude_audio_effects() {
+        // #1712: one list holds both domains, so each chain must select its own.
+        let clip = Clip::new("v.mp4")
+            .with_color_correction(0.1, 1.0, 1.0)
+            .with_audio_effect(FilterStep::Volume(-6.0));
+        assert!(matches!(
+            clip.video_effect_chain().as_slice(),
+            [FilterStep::Eq { .. }]
+        ));
+        assert!(matches!(
+            clip.audio_effect_chain().as_slice(),
+            [FilterStep::Volume(_)]
+        ));
+    }
+
+    #[test]
+    fn audio_effect_chain_should_compile_audio_effects_in_order() {
+        // Relative order within the audio domain is preserved even when video effects
+        // are interleaved in the shared list.
+        use crate::effect::{ClipEffect, EffectKind, Param};
+        let mut clip = Clip::new("v.mp4").with_audio_effect(FilterStep::Volume(-6.0));
+        clip.effects.push(ClipEffect::new(EffectKind::Blur {
+            radius: Param::Const(2.0),
+        }));
+        clip.effects.push(ClipEffect::new(EffectKind::Volume {
+            gain_db: Param::Const(3.0),
+        }));
+        let chain = clip.audio_effect_chain();
+        assert_eq!(chain.len(), 2, "only the audio effects, in order");
+        assert!(matches!(chain[0], FilterStep::Volume(db) if (db - (-6.0)).abs() < 1e-6));
+        assert!(matches!(chain[1], FilterStep::Volume(db) if (db - 3.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn with_audio_effect_should_append_an_audio_raw_typed_effect() {
+        // #1712: the audio escape hatch is a normal typed effect (id-addressed,
+        // toggleable) like the video one.
+        let clip = Clip::new("v.mp4").with_audio_effect(FilterStep::Volume(-6.0));
+        let [effect] = clip.effects.as_slice() else {
+            panic!("expected exactly one effect");
+        };
+        assert!(effect.enabled);
+        assert!(matches!(effect.kind, EffectKind::AudioRaw { .. }));
+        let mut disabled = clip.clone();
+        disabled.effects[0].enabled = false;
+        assert!(disabled.audio_effect_chain().is_empty());
     }
 
     #[test]

--- a/crates/avio/src/derive.rs
+++ b/crates/avio/src/derive.rs
@@ -477,8 +477,8 @@ pub(crate) fn audio_track(
             }
         }
     }
-    // Caller-attached per-clip audio effects run last.
-    effects.extend(clip.audio_effects.iter().cloned());
+    // The clip's typed audio effects run last, in list order (#1712).
+    effects.extend(clip.audio_effect_chain());
 
     AudioTrack {
         source: source_path,

--- a/crates/avio/src/effect.rs
+++ b/crates/avio/src/effect.rs
@@ -59,6 +59,24 @@ impl Param {
     }
 }
 
+/// Which of a clip's media streams an [`EffectKind`] applies to (#1712).
+///
+/// A clip keeps **one** ordered effect list ([`Clip::effects`](crate::Clip::effects))
+/// for both domains, so effect ids, enable/disable, reordering, undo history and
+/// [`descriptor`](EffectKind::descriptor) are shared machinery. Each derive path
+/// selects its own domain (see [`Clip::video_effect_chain`](crate::Clip::video_effect_chain)
+/// and [`Clip::audio_effect_chain`](crate::Clip::audio_effect_chain)), preserving the
+/// relative order within that domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum EffectDomain {
+    /// Applies to the clip's video frames.
+    Video,
+    /// Applies to the clip's audio samples.
+    Audio,
+}
+
 /// A host-facing description of an effect kind and its editable parameters, returned
 /// by [`EffectKind::descriptor`]. Lets a UI render a parameter panel generically,
 /// without hard-coding each [`EffectKind`] variant.
@@ -377,6 +395,27 @@ pub enum EffectKind {
         /// The step rendered verbatim, in this effect's position in the chain.
         step: FilterStep,
     },
+    /// Audio gain in decibels (the `volume` filter) — an [`EffectDomain::Audio`] effect.
+    ///
+    /// A neutral constant (`0.0` dB) compiles to no filter at all, preserving
+    /// bit-identical audio. `gain_db` is keyframeable per the typed model, but
+    /// `FFmpeg`'s `volume` step carries no runtime-settable parameter here, so an
+    /// animated gain renders its `t = 0` value (the same documented limitation as
+    /// [`Sharpen`](Self::Sharpen) and [`MotionBlur`](Self::MotionBlur)).
+    Volume {
+        /// Gain in decibels. Range −60.0..=30.0 (neutral: 0.0).
+        gain_db: Param,
+    },
+    /// Escape hatch for a raw audio [`FilterStep`] the typed model has no variant for
+    /// (`ACompressor`, `NoiseReduce`, `ParametricEq`, ...) — the audio counterpart of
+    /// [`Raw`](Self::Raw), and an [`EffectDomain::Audio`] effect.
+    ///
+    /// Like `Raw` it is opaque: the step's arguments are not individually keyframeable
+    /// [`Param`]s and [`descriptor`](Self::descriptor) reports no parameters for it.
+    AudioRaw {
+        /// The step rendered verbatim, in this effect's position in the audio chain.
+        step: FilterStep,
+    },
 }
 
 /// Projects a `shadows_lift` parameter (additive, neutral `0.0`) onto the
@@ -400,6 +439,38 @@ fn lift_to_animated(p: &Param) -> AnimatedValue<f64> {
 }
 
 impl EffectKind {
+    /// Which media stream this kind applies to (#1712).
+    ///
+    /// A clip keeps one effect list for both domains; each derive path selects its own
+    /// domain, so the value here decides whether a kind reaches
+    /// [`Clip::video_effect_chain`](crate::Clip::video_effect_chain) or
+    /// [`Clip::audio_effect_chain`](crate::Clip::audio_effect_chain).
+    ///
+    /// The `match` is exhaustive with **no** `_` arm: a new [`EffectKind`] variant
+    /// fails to compile until its domain is declared, so a kind can never silently
+    /// default to the wrong pipeline (RK-003).
+    #[must_use]
+    pub fn domain(&self) -> EffectDomain {
+        match self {
+            EffectKind::ColorCorrect { .. }
+            | EffectKind::Blur { .. }
+            | EffectKind::Sharpen { .. }
+            | EffectKind::Vignette { .. }
+            | EffectKind::FilmGrain { .. }
+            | EffectKind::Glow { .. }
+            | EffectKind::ColorWheels { .. }
+            | EffectKind::Curves { .. }
+            | EffectKind::Hsl { .. }
+            | EffectKind::Lut { .. }
+            | EffectKind::ChromaKey { .. }
+            | EffectKind::LumaMask { .. }
+            | EffectKind::ShapeMask { .. }
+            | EffectKind::MotionBlur { .. }
+            | EffectKind::Raw { .. } => EffectDomain::Video,
+            EffectKind::Volume { .. } | EffectKind::AudioRaw { .. } => EffectDomain::Audio,
+        }
+    }
+
     /// Host-facing introspection: the kind's stable `snake_case` name and a
     /// [`ParamDescriptor`] for every parameter (name, type, range, default, current
     /// value), so a UI can render an editable parameter panel without hard-coding each
@@ -705,6 +776,17 @@ impl EffectKind {
             // nothing for a host to render a parameter editor from.
             EffectKind::Raw { .. } => EffectDescriptor {
                 name: "raw",
+                params: Vec::new(),
+            },
+            EffectKind::Volume { gain_db } => EffectDescriptor {
+                name: "volume",
+                params: vec![ParamDescriptor {
+                    name: "gain_db",
+                    value: scalar(-60.0..=30.0, 0.0, gain_db),
+                }],
+            },
+            EffectKind::AudioRaw { .. } => EffectDescriptor {
+                name: "audio_raw",
                 params: Vec::new(),
             },
         }
@@ -1030,8 +1112,18 @@ impl EffectKind {
                     sub_frames: *sub_frames,
                 })
             }
-            // The escape hatch renders its step verbatim.
-            EffectKind::Raw { step } => Some(step.clone()),
+            // The escape hatches render their step verbatim.
+            EffectKind::Raw { step } | EffectKind::AudioRaw { step } => Some(step.clone()),
+            // A neutral gain is no change, so it compiles to nothing. `volume` has no
+            // runtime-settable parameter here, so an animated gain renders at `t = 0`.
+            EffectKind::Volume { gain_db } => {
+                let db = gain_db.to_animated().value_at(Duration::ZERO);
+                #[allow(clippy::float_cmp)]
+                if db == 0.0 {
+                    return None;
+                }
+                Some(FilterStep::Volume(db))
+            }
         }
     }
 }
@@ -1093,6 +1185,92 @@ mod tests {
 
     fn animated_track() -> AnimationTrack<f64> {
         AnimationTrack::new().push(Keyframe::new(Duration::ZERO, 0.5, Easing::Linear))
+    }
+
+    #[test]
+    fn domain_should_classify_video_and_audio_kinds() {
+        // #1712: one list holds both domains, so the kind must declare which pipeline
+        // it belongs to.
+        let video = EffectKind::Blur {
+            radius: Param::Const(2.0),
+        };
+        assert_eq!(video.domain(), EffectDomain::Video);
+        assert_eq!(
+            EffectKind::Raw {
+                step: FilterStep::HFlip
+            }
+            .domain(),
+            EffectDomain::Video
+        );
+        let audio = EffectKind::Volume {
+            gain_db: Param::Const(-6.0),
+        };
+        assert_eq!(audio.domain(), EffectDomain::Audio);
+        assert_eq!(
+            EffectKind::AudioRaw {
+                step: FilterStep::Volume(-3.0)
+            }
+            .domain(),
+            EffectDomain::Audio
+        );
+    }
+
+    #[test]
+    fn volume_should_compile_to_volume_step() {
+        let kind = EffectKind::Volume {
+            gain_db: Param::Const(-6.0),
+        };
+        match kind.to_filter_step().unwrap() {
+            FilterStep::Volume(db) => assert!((db - (-6.0)).abs() < 1e-6),
+            other => panic!("expected Volume, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn volume_neutral_should_compile_to_nothing() {
+        let kind = EffectKind::Volume {
+            gain_db: Param::Const(0.0),
+        };
+        assert!(
+            kind.to_filter_step().is_none(),
+            "0 dB is no change, so it is a no-op"
+        );
+    }
+
+    #[test]
+    fn audio_raw_should_compile_to_its_filter_step() {
+        let kind = EffectKind::AudioRaw {
+            step: FilterStep::Volume(-3.0),
+        };
+        assert!(matches!(
+            kind.to_filter_step().unwrap(),
+            FilterStep::Volume(_)
+        ));
+    }
+
+    #[test]
+    fn descriptor_should_list_volume_param() {
+        let kind = EffectKind::Volume {
+            gain_db: Param::Const(-6.0),
+        };
+        let d = kind.descriptor();
+        assert_eq!(d.name, "volume");
+        assert_eq!(d.params.len(), 1);
+        assert_eq!(d.params[0].name, "gain_db");
+        assert_eq!(
+            d.params[0].value,
+            ParamValue::Scalar {
+                range: -60.0..=30.0,
+                default: 0.0,
+                current: Some(-6.0),
+            }
+        );
+        // The audio escape hatch is opaque, like the video one.
+        let raw = EffectKind::AudioRaw {
+            step: FilterStep::Volume(-3.0),
+        };
+        assert_eq!(raw.descriptor().name, "audio_raw");
+        assert!(raw.descriptor().params.is_empty());
     }
 
     #[test]

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -122,7 +122,9 @@ mod validate;
 pub use clip::{Clip, ClipSource, FitMode, VideoEffectRenderer};
 pub use edit::{ClipProperty, Command, EditError, apply};
 pub use editor::Editor;
-pub use effect::{ClipEffect, EffectDescriptor, EffectKind, Param, ParamDescriptor, ParamValue};
+pub use effect::{
+    ClipEffect, EffectDescriptor, EffectDomain, EffectKind, Param, ParamDescriptor, ParamValue,
+};
 pub use error::TimelineError;
 #[cfg(feature = "gpu")]
 pub use gpu::{

--- a/crates/avio/src/track.rs
+++ b/crates/avio/src/track.rs
@@ -132,10 +132,13 @@ pub struct Track {
     /// audio path unchanged. Ignored for video tracks (they carry no audio).
     ///
     /// Persisted by the `serde` feature (#1452), like
-    /// [`Clip::audio_effects`](crate::Clip::audio_effects) and
+    /// [`Clip::effects`](crate::Clip::effects) and
     /// [`Timeline::audio_filter`](crate::Timeline). The compositor-internal
     /// `FilterStep` variants (`Blend` / `Composite` / `AlphaMatte`) are not
     /// serialized, but an audio chain never contains them.
+    ///
+    /// This track-level chain stays an opaque step list: unlike the per-clip effects
+    /// (#1712) it is a bus-style insert, not a typed, id-addressed authoring surface.
     pub audio_effects: Vec<FilterStep>,
     /// Typed, id-addressed track-level automation (see [`TrackAutomation`]).
     /// Empty by default; set via the `with_*_animation` builders or

--- a/crates/avio/tests/serde_persistence.rs
+++ b/crates/avio/tests/serde_persistence.rs
@@ -160,8 +160,13 @@ fn clip_effects_should_round_trip_through_serde() {
         serde_json::from_str(&serde_json::to_string(&back).unwrap()).unwrap();
     assert_eq!(v1, v2, "effect chains must round-trip through serde");
 
-    // #1622: a raw video step now persists as an `EffectKind::Raw` typed effect.
-    assert_eq!(back.effects.len(), 2, "video effects survive the load");
+    // #1622 / #1712: raw video and audio steps now persist as typed `Raw` / `AudioRaw`
+    // effects in the single `effects` list, in authoring order.
+    assert_eq!(
+        back.effects.len(),
+        4,
+        "video and audio effects survive the load"
+    );
     assert!(matches!(
         &back.effects[0].kind,
         EffectKind::Raw { step: FilterStep::Hue { degrees } } if (degrees - 30.0).abs() < 1e-6
@@ -172,21 +177,21 @@ fn clip_effects_should_round_trip_through_serde() {
             step: FilterStep::HFlip
         }
     ));
-    assert_eq!(
-        back.audio_effects.len(),
-        2,
-        "audio effects survive the load"
-    );
     assert!(
         matches!(
-            back.audio_effects[1],
-            FilterStep::PitchShift {
-                algo: PitchAlgo::Rubberband,
-                ..
+            &back.effects[3].kind,
+            EffectKind::AudioRaw {
+                step: FilterStep::PitchShift {
+                    algo: PitchAlgo::Rubberband,
+                    ..
+                }
             }
         ),
         "the PitchShift algo backend survives the round-trip"
     );
+    // The domain split holds after a round-trip: each chain sees only its own effects.
+    assert_eq!(back.video_effect_chain().len(), 2);
+    assert_eq!(back.audio_effect_chain().len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Objective

- #1622 unified the video side onto the typed effect model, but audio kept the historical opaque `Clip.audio_effects: Vec<FilterStep>`.
- That surface was not id-addressed, keyframeable, toggleable, reorderable or introspectable, so audio effects sat outside the editing model.

## Solution

- Give `EffectKind` a `domain()` discriminator (`EffectDomain::Video` / `Audio`) so one clip effect list carries both media domains, and each derive path compiles the enabled effects of its own domain in list order. Effect ids, enable/disable, reordering, undo history and `descriptor()` therefore work for audio with **no new commands** — this is the placement decision the issue asked to record, documented on `EffectDomain` / `domain()`.
- Remove `Clip.audio_effects` and add two audio kinds: `Volume { gain_db }` as the representative typed effect (a neutral 0 dB compiles to nothing; an animated gain renders its `t = 0` value because the `volume` step carries no runtime parameter, the same documented limitation as `Sharpen` / `MotionBlur`), and `AudioRaw { step }` as the audio escape hatch mirroring `Raw`.
- Route both chains through one `Clip::effect_chain(domain)` helper, so an audio kind can never leak into the video chain or the reverse, and keep the audio steps at their existing position at the end of the derived audio chain.
- Tests cover the domain split, the chain order with interleaved video effects, the escape hatch (including disabling it), the neutral-gain no-op, and the serde round-trip.

Breaking changes:
- `Clip.audio_effects` is removed. Code using it must move to `EffectKind::AudioRaw` (or `with_audio_effect`), and documents serialized by an older version drop that field on load (the general serialization-compatibility policy is tracked in #1709).
- The track-level `Track.audio_effects` bus chain is unchanged and stays an opaque step list.

Closes #1712