### PR TITLE
feat(avio): conform source frame rate on the GPU export path

### DIFF
--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -481,6 +481,12 @@ mod tests {
         if encode_probe_source(&src, 24.0).is_none() {
             return; // no encoder here -> skip
         }
+        // The probe pass opens a decoder, so a build without this decoder cannot reach
+        // the gate at all — skip rather than read the miss as a rejection (RK-002).
+        if VideoDecoder::open(&src).build().is_err() {
+            let _ = std::fs::remove_file(&src);
+            return;
+        }
         let t = square_timeline(vec![Clip::new(&src)]); // canvas 64x64, timeline 30 fps
         let eligible_now = eligible(&t);
         let _ = std::fs::remove_file(&src);

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -42,7 +42,7 @@ use crate::track::Track;
 /// - every clip is a **file** source (a generated Solid/Text source has no decoder
 ///   here; it renders via lavfi on the CPU path),
 /// - hard cuts only (a transition needs an xfade node the GPU path lacks),
-/// - unity speed (the one-frame-per-output decode loop does not resample time),
+/// - unity speed (the drain conforms frame *rate* but does not resample time),
 /// - each clip's derived [`VideoLayer`] maps to [`GpuMapping::Gpu`] (a supported
 ///   blend / composite / effect set) with a **static, neutral transform** (RK-020:
 ///   the model's pixels/degrees are not `ff_render`'s UV/radians, so any placement
@@ -129,9 +129,10 @@ pub(crate) fn eligible_track(
             return None;
         }
         // The frame rate no longer has to match: the drain conforms the source to the
-        // timeline rate (#1660). A non-positive or non-finite source rate has no usable
-        // index mapping, so such a source still falls back to CPU rather than risking
-        // wrong output (RK-020).
+        // timeline rate from the frames' own timestamps (#1660). The rate is still
+        // required to be usable, since a source that reports none is one whose timing
+        // cannot be trusted at all — it stays on the CPU path rather than risking wrong
+        // output (RK-020).
         let src_fps = decoder.frame_rate();
         if !src_fps.is_finite() || src_fps <= 0.0 {
             return None;
@@ -141,20 +142,16 @@ pub(crate) fn eligible_track(
     Some(idx)
 }
 
-/// The source frame index that output frame `k` takes, conforming `src_fps` to
-/// `out_fps` by nearest-previous selection: `floor(k * src_fps / out_fps)`.
+/// The presentation time of output frame `k` **within the clip**, at the timeline rate.
 ///
-/// The same formula covers both directions — a slower source repeats an index
-/// (24 -> 30 gives `0,0,1,2,3,4,4,…`) and a faster one skips indices (60 -> 30 gives
-/// `0,2,4,…`) — and is the identity when the rates match. Callers guarantee
-/// `out_fps > 0` (the timeline rate) and `src_fps > 0` ([`eligible_track`]).
-#[allow(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
-)]
-fn conform_source_index(k: u64, src_fps: f64, out_fps: f64) -> u64 {
-    (k as f64 * src_fps / out_fps).floor().max(0.0) as u64
+/// Conform compares this against the source's own frame timestamps rather than against
+/// a nominal rate: a container's reported frame rate is unreliable (a short clip's
+/// `avg_frame_rate` comes out as `n/(n-1) * fps`, e.g. 32.14 for a 15-frame 30 fps
+/// file), so driving the mapping from it would stretch or shorten the clip. The CPU
+/// path's `fps` filter is likewise PTS-driven, so this keeps both routes on one basis.
+#[allow(clippy::cast_precision_loss)] // frame index fits the f64 mantissa
+fn clip_output_time(k: u64, out_fps: f64) -> Duration {
+    Duration::from_secs_f64(k as f64 / out_fps)
 }
 
 /// Whether a layer's geometric transform is static and neutral for all `t` (no
@@ -252,35 +249,59 @@ pub(crate) fn drain_video_gpu(
                 produced += 1;
             }
         } else {
-            // Conform (#1660): output frame `k` takes source index
-            // `floor(k * src_fps / frame_rate)`, so a slower source repeats a frame and
+            // Conform (#1660), PTS-driven: hold the newest source frame whose timestamp
+            // is at or before this output's time, so a slower source repeats a frame and
             // a faster one skips frames while the clip keeps its on-screen duration.
+            // Timestamps rather than a nominal rate, because the reported rate is not
+            // trustworthy (see `clip_output_time`).
+            //
             // The held frame is *borrowed* because one source frame can serve several
             // outputs. `composite` clones it internally for a no-effects layer
             // (`gpu_compositor.rs`), so this path pays the per-output clone that the
             // matching-rate path avoids with `composite_owned` (#1634) — accepted for
             // v1 since conform is the uncommon case.
+            let base = clip.in_point.unwrap_or(Duration::ZERO);
             let mut held: Option<VideoFrame> = None;
-            let mut src_idx: u64 = 0;
+            let mut held_at = Duration::ZERO;
+            let mut pending: Option<(VideoFrame, Duration)> = None;
+            let mut eof = false;
             loop {
                 if frame_budget.is_some_and(|budget| produced >= budget) {
                     break;
                 }
-                let target = conform_source_index(produced, src_fps, frame_rate);
-                // Advance until the held frame is the one `target` selects. The first
-                // decoded frame is index 0, so it does not advance the counter.
-                while held.is_none() || src_idx < target {
-                    let Some(frame) = decoder.decode_one()? else {
-                        break; // EOF: handled below so a short clip stops cleanly.
-                    };
-                    if held.is_some() {
-                        src_idx += 1;
+                let want = clip_output_time(produced, frame_rate);
+                // Advance while the next source frame still starts at or before `want`;
+                // the last such frame is the one this output shows. `pending` carries the
+                // lookahead frame that already belongs to a later output.
+                loop {
+                    if let Some((frame, at)) = pending.take() {
+                        if held.is_none() || at <= want {
+                            held = Some(frame);
+                            held_at = at;
+                            continue;
+                        }
+                        pending = Some((frame, at));
+                        break;
                     }
-                    held = Some(frame);
+                    if eof {
+                        break;
+                    }
+                    match decoder.decode_one()? {
+                        Some(frame) => {
+                            let at = frame.timestamp().as_duration().saturating_sub(base);
+                            pending = Some((frame, at));
+                        }
+                        None => eof = true,
+                    }
                 }
-                let Some(frame) = held.as_ref().filter(|_| src_idx >= target) else {
-                    break; // EOF before the source reached this output's frame.
+                let Some(frame) = held.as_ref() else {
+                    break; // The clip decoded no frames at all.
                 };
+                // The source is spent and this output is past its last frame: the clip
+                // ends here, matching the pre-existing "shorter than declared" stop.
+                if eof && pending.is_none() && want > held_at {
+                    break;
+                }
                 let t = output_time(video_idx, frame_rate);
                 let composited = core.composite(&[(&layer, frame)], canvas, t);
                 emit_frame(
@@ -371,31 +392,55 @@ mod tests {
         )
     }
 
-    #[test]
-    fn conform_source_index_should_repeat_frames_when_source_is_slower() {
-        // 24 -> 30: five source frames cover six outputs, so two outputs share index 0
-        // and index 4 — the duplication that keeps the clip's on-screen duration.
-        let idx: Vec<u64> = (0..7)
-            .map(|k| conform_source_index(k, 24.0, 30.0))
-            .collect();
-        assert_eq!(idx, [0, 0, 1, 2, 3, 4, 4]);
+    /// Mirrors the drain's selection rule — show the last source frame whose
+    /// clip-relative timestamp is at or before the output's time — so the mapping is
+    /// verifiable without decoding. The drain streams and cannot pre-collect timestamps,
+    /// hence the small duplication; the integration tests cover the real pipeline.
+    fn conform_plan(src_pts: &[Duration], out_fps: f64, outputs: u64) -> Vec<usize> {
+        (0..outputs)
+            .map(|k| {
+                let want = clip_output_time(k, out_fps);
+                src_pts.iter().rposition(|at| *at <= want).unwrap_or(0)
+            })
+            .collect()
+    }
+
+    /// `count` frames at `fps`, as clip-relative timestamps.
+    fn pts_at(fps: f64, count: usize) -> Vec<Duration> {
+        #[allow(clippy::cast_precision_loss)]
+        (0..count)
+            .map(|i| Duration::from_secs_f64(i as f64 / fps))
+            .collect()
     }
 
     #[test]
-    fn conform_source_index_should_skip_frames_when_source_is_faster() {
+    fn conform_should_repeat_frames_when_source_is_slower() {
+        // 24 -> 30: outputs at k/30 fall on 24 fps frames 0,0,1,2,3,4,4 — the
+        // duplication that keeps the clip's on-screen duration.
+        let plan = conform_plan(&pts_at(24.0, 6), 30.0, 7);
+        assert_eq!(plan, [0, 0, 1, 2, 3, 4, 4]);
+    }
+
+    #[test]
+    fn conform_should_skip_frames_when_source_is_faster() {
         // 60 -> 30: every other source frame is dropped.
-        let idx: Vec<u64> = (0..5)
-            .map(|k| conform_source_index(k, 60.0, 30.0))
-            .collect();
-        assert_eq!(idx, [0, 2, 4, 6, 8]);
+        let plan = conform_plan(&pts_at(60.0, 9), 30.0, 5);
+        assert_eq!(plan, [0, 2, 4, 6, 8]);
     }
 
     #[test]
-    fn conform_source_index_should_be_identity_at_matching_rates() {
-        let idx: Vec<u64> = (0..5)
-            .map(|k| conform_source_index(k, 30.0, 30.0))
-            .collect();
-        assert_eq!(idx, [0, 1, 2, 3, 4]);
+    fn conform_should_be_identity_at_matching_rates() {
+        let plan = conform_plan(&pts_at(30.0, 5), 30.0, 5);
+        assert_eq!(plan, [0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn conform_should_ignore_a_misreported_container_rate() {
+        // The regression that motivated the PTS basis: a 15-frame 30 fps file reports
+        // `avg_frame_rate` 32.14 (= 15/14 * 30). Selection driven by that number would
+        // skip ahead and end the clip early; driven by timestamps it is the identity.
+        let plan = conform_plan(&pts_at(30.0, 15), 30.0, 15);
+        assert_eq!(plan, (0..15).collect::<Vec<_>>());
     }
 
     /// Encodes a tiny square video at `fps`, or `None` when the environment has no
@@ -422,10 +467,15 @@ mod tests {
     #[test]
     fn eligible_track_should_accept_a_source_whose_rate_differs_from_the_timeline() {
         // #1660: the probe pass no longer requires the source rate to match the
-        // timeline rate — the drain conforms it — so a 24 fps source in a 30 fps
-        // timeline stays on the GPU route instead of falling back to CPU. This is the
-        // gate that the end-to-end conform test relies on having been opened; without
-        // it that export would silently be produced by the CPU path instead.
+        // timeline rate — the drain conforms it — so a source whose rate differs stays
+        // on the GPU route instead of falling back to CPU.
+        //
+        // This gate mattered more than it looked: a container's reported rate is often
+        // *not* the nominal encode rate (a short clip reports `n/(n-1) * fps`, so the
+        // 15-frame 30 fps fixture reports 32.14), which meant the old equality check
+        // rejected even same-rate sources. The end-to-end "GPU route" export test was
+        // therefore silently exercising the CPU path. Keeping this assertion green is
+        // what stops that false green from coming back.
         let src = std::env::temp_dir().join("avio_eligible_24fps_probe.mp4");
         let _ = std::fs::remove_file(&src);
         if encode_probe_source(&src, 24.0).is_none() {
@@ -462,7 +512,7 @@ mod tests {
 
     #[test]
     fn eligible_track_should_reject_non_unity_speed() {
-        // The one-frame-per-output decode loop does not resample time -> CPU.
+        // The drain conforms frame rate but does not resample time -> CPU.
         let t = square_timeline(vec![Clip::new("a.mp4").with_speed(2.0)]);
         assert!(eligible(&t).is_none());
     }

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -11,9 +11,11 @@
 //!
 //! v1 handles only a **single active video track of contiguous hard cuts** at unity
 //! speed whose every clip is a file source that maps to the GPU with an identity
-//! transform and a canvas-matching aspect. Anything else keeps the whole export on
-//! the CPU `MultiTrackComposer` path (see [`eligible_track`]); multi-track / overlay
-//! GPU export is a follow-up.
+//! transform and a canvas-matching aspect. A source whose frame rate differs from the
+//! timeline's is conformed by the drain (#1660), repeating or skipping source frames so
+//! the clip keeps its on-screen duration. Anything else keeps the whole export on the
+//! CPU `MultiTrackComposer` path (see [`eligible_track`]); multi-track / overlay GPU
+//! export is a follow-up.
 
 use std::time::{Duration, Instant};
 
@@ -52,14 +54,14 @@ use crate::track::Track;
 ///   via `OffsetPts`),
 /// - each source's native aspect matches the canvas (the compositor would stretch a
 ///   differently-shaped frame where the CPU path letterboxes) and its native frame
-///   rate matches the timeline `frame_rate` (the 1-frame-per-output decode loop does
-///   not resample, so a mismatch would change the clip's on-screen duration).
+///   rate is usable (positive and finite). The rate no longer has to *match* the
+///   timeline `frame_rate`: the drain conforms it (#1660), repeating or skipping
+///   source frames so the clip keeps its on-screen duration.
 pub(crate) fn eligible_track(
     video_tracks: &[Track],
     lavfi_overlay: Option<&str>,
     any_video_solo: bool,
     canvas: (u32, u32),
-    frame_rate: f64,
 ) -> Option<usize> {
     if lavfi_overlay.is_some() {
         return None;
@@ -114,8 +116,8 @@ pub(crate) fn eligible_track(
         }
     }
 
-    // Probe pass (I/O): each source's native aspect and frame rate must match the
-    // canvas / timeline rate.
+    // Probe pass (I/O): each source's native aspect must match the canvas, and its
+    // frame rate must be usable (it no longer has to match the timeline rate).
     for clip in &track.clips {
         let src = clip.source_path()?;
         let Ok(decoder) = VideoDecoder::open(src).build() else {
@@ -126,12 +128,33 @@ pub(crate) fn eligible_track(
         {
             return None;
         }
-        if (decoder.frame_rate() - frame_rate).abs() > 1e-3 {
+        // The frame rate no longer has to match: the drain conforms the source to the
+        // timeline rate (#1660). A non-positive or non-finite source rate has no usable
+        // index mapping, so such a source still falls back to CPU rather than risking
+        // wrong output (RK-020).
+        let src_fps = decoder.frame_rate();
+        if !src_fps.is_finite() || src_fps <= 0.0 {
             return None;
         }
     }
 
     Some(idx)
+}
+
+/// The source frame index that output frame `k` takes, conforming `src_fps` to
+/// `out_fps` by nearest-previous selection: `floor(k * src_fps / out_fps)`.
+///
+/// The same formula covers both directions — a slower source repeats an index
+/// (24 -> 30 gives `0,0,1,2,3,4,4,…`) and a faster one skips indices (60 -> 30 gives
+/// `0,2,4,…`) — and is the identity when the rates match. Callers guarantee
+/// `out_fps > 0` (the timeline rate) and `src_fps > 0` ([`eligible_track`]).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn conform_source_index(k: u64, src_fps: f64, out_fps: f64) -> u64 {
+    (k as f64 * src_fps / out_fps).floor().max(0.0) as u64
 }
 
 /// Whether a layer's geometric transform is static and neutral for all `t` (no
@@ -178,6 +201,16 @@ pub(crate) fn drain_video_gpu(
         let mut decoder = VideoDecoder::open(src)
             .output_format(PixelFormat::Rgba)
             .build()?;
+        // Eligibility guarantees a positive, finite rate, so the conform maths below is
+        // well defined; fall back to the timeline rate defensively.
+        let src_fps = {
+            let f = decoder.frame_rate();
+            if f.is_finite() && f > 0.0 {
+                f
+            } else {
+                frame_rate
+            }
+        };
         if let Some(in_point) = clip.in_point {
             decoder.seek(in_point, SeekMode::Exact)?;
         }
@@ -196,40 +229,113 @@ pub(crate) fn drain_video_gpu(
         core.reset_effect_cache();
 
         let mut produced: u64 = 0;
-        loop {
-            if frame_budget.is_some_and(|budget| produced >= budget) {
-                break;
-            }
-            let Some(frame) = decoder.decode_one()? else {
-                break; // EOF before the budget is met: the clip is shorter than declared.
-            };
-            #[allow(clippy::cast_precision_loss)] // frame index fits the f64 mantissa
-            let t = Duration::from_secs_f64(f64::from(video_idx) / frame_rate);
-            // Move the freshly-decoded frame into the compositor: a no-effects layer
-            // then avoids a full-frame clone on this hot path (#1634).
-            let (rgba, w, h) = core
-                .composite_owned(vec![(&layer, frame)], canvas, t)
-                .ok_or_else(|| TimelineError::TimelineRenderFailed {
-                    reason: "gpu export: a frame fell back mid-export (precluded by eligibility)"
-                        .to_string(),
-                })?;
-            let out = VideoFrame::from_rgba(w, h, rgba).map_err(|e| {
-                TimelineError::TimelineRenderFailed {
-                    reason: format!("gpu export: readback frame invalid: {e}"),
+        if (src_fps - frame_rate).abs() <= 1e-3 {
+            // Matching rates: one decoded frame per output frame, moved into the
+            // compositor so a no-effects layer avoids a full-frame clone (#1634).
+            loop {
+                if frame_budget.is_some_and(|budget| produced >= budget) {
+                    break;
                 }
-            })?;
-            encoder.push_video(&out)?;
-            video_idx = video_idx.saturating_add(1);
-            produced += 1;
-            let progress = Progress {
-                frames_processed: u64::from(video_idx),
-                total_frames,
-                elapsed: start.elapsed(),
-            };
-            if !on_progress(&progress) {
-                return Err(TimelineError::Cancelled);
+                let Some(frame) = decoder.decode_one()? else {
+                    break; // EOF before the budget: the clip is shorter than declared.
+                };
+                let t = output_time(video_idx, frame_rate);
+                let composited = core.composite_owned(vec![(&layer, frame)], canvas, t);
+                emit_frame(
+                    composited,
+                    encoder,
+                    &mut video_idx,
+                    on_progress,
+                    start,
+                    total_frames,
+                )?;
+                produced += 1;
+            }
+        } else {
+            // Conform (#1660): output frame `k` takes source index
+            // `floor(k * src_fps / frame_rate)`, so a slower source repeats a frame and
+            // a faster one skips frames while the clip keeps its on-screen duration.
+            // The held frame is *borrowed* because one source frame can serve several
+            // outputs. `composite` clones it internally for a no-effects layer
+            // (`gpu_compositor.rs`), so this path pays the per-output clone that the
+            // matching-rate path avoids with `composite_owned` (#1634) — accepted for
+            // v1 since conform is the uncommon case.
+            let mut held: Option<VideoFrame> = None;
+            let mut src_idx: u64 = 0;
+            loop {
+                if frame_budget.is_some_and(|budget| produced >= budget) {
+                    break;
+                }
+                let target = conform_source_index(produced, src_fps, frame_rate);
+                // Advance until the held frame is the one `target` selects. The first
+                // decoded frame is index 0, so it does not advance the counter.
+                while held.is_none() || src_idx < target {
+                    let Some(frame) = decoder.decode_one()? else {
+                        break; // EOF: handled below so a short clip stops cleanly.
+                    };
+                    if held.is_some() {
+                        src_idx += 1;
+                    }
+                    held = Some(frame);
+                }
+                let Some(frame) = held.as_ref().filter(|_| src_idx >= target) else {
+                    break; // EOF before the source reached this output's frame.
+                };
+                let t = output_time(video_idx, frame_rate);
+                let composited = core.composite(&[(&layer, frame)], canvas, t);
+                emit_frame(
+                    composited,
+                    encoder,
+                    &mut video_idx,
+                    on_progress,
+                    start,
+                    total_frames,
+                )?;
+                produced += 1;
             }
         }
+    }
+    Ok(())
+}
+
+/// The composite time of output frame `video_idx` at the timeline rate.
+#[allow(clippy::cast_precision_loss)] // frame index fits the f64 mantissa
+fn output_time(video_idx: u32, frame_rate: f64) -> Duration {
+    Duration::from_secs_f64(f64::from(video_idx) / frame_rate)
+}
+
+/// Reads back an already-composited frame, pushes it to the encoder, advances the
+/// output-frame counter and reports progress.
+///
+/// Takes the composite *result* rather than the compositor so the caller keeps the
+/// choice of moving the frame in (`composite_owned`, the matching-rate path) or
+/// borrowing it (`composite`, the conform path, where one source frame can serve
+/// several outputs). A `None` means a frame fell back mid-export, which eligibility
+/// has already precluded, so it surfaces as an error rather than wrong output.
+fn emit_frame(
+    composited: Option<(Vec<u8>, u32, u32)>,
+    encoder: &mut VideoEncoder,
+    video_idx: &mut u32,
+    on_progress: &(impl Fn(&Progress) -> bool + Send),
+    start: Instant,
+    total_frames: Option<u64>,
+) -> Result<(), TimelineError> {
+    let (rgba, w, h) = composited.ok_or_else(|| TimelineError::TimelineRenderFailed {
+        reason: "gpu export: a frame fell back mid-export (precluded by eligibility)".to_string(),
+    })?;
+    let out =
+        VideoFrame::from_rgba(w, h, rgba).map_err(|e| TimelineError::TimelineRenderFailed {
+            reason: format!("gpu export: readback frame invalid: {e}"),
+        })?;
+    encoder.push_video(&out)?;
+    *video_idx = video_idx.saturating_add(1);
+    let progress = Progress {
+        frames_processed: u64::from(*video_idx),
+        total_frames,
+        elapsed: start.elapsed(),
+    };
+    if !on_progress(&progress) {
+        return Err(TimelineError::Cancelled);
     }
     Ok(())
 }
@@ -262,8 +368,77 @@ mod tests {
             timeline.lavfi_overlay.as_deref(),
             timeline.video_tracks.iter().any(|t| t.solo),
             (timeline.canvas_width, timeline.canvas_height),
-            timeline.frame_rate,
         )
+    }
+
+    #[test]
+    fn conform_source_index_should_repeat_frames_when_source_is_slower() {
+        // 24 -> 30: five source frames cover six outputs, so two outputs share index 0
+        // and index 4 — the duplication that keeps the clip's on-screen duration.
+        let idx: Vec<u64> = (0..7)
+            .map(|k| conform_source_index(k, 24.0, 30.0))
+            .collect();
+        assert_eq!(idx, [0, 0, 1, 2, 3, 4, 4]);
+    }
+
+    #[test]
+    fn conform_source_index_should_skip_frames_when_source_is_faster() {
+        // 60 -> 30: every other source frame is dropped.
+        let idx: Vec<u64> = (0..5)
+            .map(|k| conform_source_index(k, 60.0, 30.0))
+            .collect();
+        assert_eq!(idx, [0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn conform_source_index_should_be_identity_at_matching_rates() {
+        let idx: Vec<u64> = (0..5)
+            .map(|k| conform_source_index(k, 30.0, 30.0))
+            .collect();
+        assert_eq!(idx, [0, 1, 2, 3, 4]);
+    }
+
+    /// Encodes a tiny square video at `fps`, or `None` when the environment has no
+    /// usable encoder (skip). The probe pass needs a real file, so eligibility cannot
+    /// be exercised without one.
+    fn encode_probe_source(path: &std::path::Path, fps: f64) -> Option<()> {
+        use ff_encode::{VideoCodec, VideoEncoder};
+        use ff_format::{PixelFormat as PF, VideoFrame};
+
+        let mut enc = VideoEncoder::create(path)
+            .video(64, 64, fps)
+            .video_codec(VideoCodec::Mpeg4)
+            .build()
+            .ok()?;
+        // A few flat frames are enough: only the stream header (size, rate) is probed.
+        for i in 0..4 {
+            let frame = VideoFrame::new_black(64, 64, PF::Yuv420p, i);
+            enc.push_video(&frame).ok()?;
+        }
+        enc.finish().ok()?;
+        Some(())
+    }
+
+    #[test]
+    fn eligible_track_should_accept_a_source_whose_rate_differs_from_the_timeline() {
+        // #1660: the probe pass no longer requires the source rate to match the
+        // timeline rate — the drain conforms it — so a 24 fps source in a 30 fps
+        // timeline stays on the GPU route instead of falling back to CPU. This is the
+        // gate that the end-to-end conform test relies on having been opened; without
+        // it that export would silently be produced by the CPU path instead.
+        let src = std::env::temp_dir().join("avio_eligible_24fps_probe.mp4");
+        let _ = std::fs::remove_file(&src);
+        if encode_probe_source(&src, 24.0).is_none() {
+            return; // no encoder here -> skip
+        }
+        let t = square_timeline(vec![Clip::new(&src)]); // canvas 64x64, timeline 30 fps
+        let eligible_now = eligible(&t);
+        let _ = std::fs::remove_file(&src);
+        assert_eq!(
+            eligible_now,
+            Some(0),
+            "a 24 fps source in a 30 fps timeline must be GPU-eligible after #1660"
+        );
     }
 
     #[test]

--- a/crates/avio/src/timeline.rs
+++ b/crates/avio/src/timeline.rs
@@ -353,7 +353,6 @@ impl Timeline {
                 lavfi_overlay.as_deref(),
                 any_video_solo,
                 (canvas_width, canvas_height),
-                frame_rate,
             )
             .and_then(|idx| crate::gpu_compositor::GpuCompositor::new().map(|core| (idx, core)))
         };

--- a/crates/avio/tests/gpu_export_tests.rs
+++ b/crates/avio/tests/gpu_export_tests.rs
@@ -132,6 +132,55 @@ fn export_should_produce_frames_on_cpu_and_gpu_routes() {
     }
 }
 
+/// #1660: a source whose native rate differs from the timeline rate used to force the
+/// CPU path; the GPU drain now conforms it. The export must keep the clip's on-screen
+/// duration — i.e. the output carries the *timeline's* frame count, not the source's.
+#[cfg(feature = "gpu")]
+#[test]
+fn gpu_export_should_conform_a_slower_source_to_the_timeline_rate() {
+    const SRC_FPS: f64 = 24.0;
+    const OUT_FPS: f64 = 30.0;
+    const SRC_24_FRAMES: usize = 24; // exactly 1 s of 24 fps source
+    // 1 s of source at the timeline rate: the count that proves the duration is kept.
+    const EXPECTED_OUT_FRAMES: usize = 30;
+
+    let src = test_output_path("gpuexport_24fps_src.mp4");
+    let _gs = FileGuard::new(src.clone());
+    if make_source_file(&src, CANVAS, CANVAS, SRC_FPS, SRC_24_FRAMES, 120, 90, 160).is_none() {
+        return; // encoder unavailable -> skip
+    }
+    if avio::GpuCompositor::new().is_none() {
+        return; // no GPU adapter -> the GPU leg is unreachable here
+    }
+    let Some(timeline) = Timeline::builder()
+        .canvas(CANVAS, CANVAS)
+        .frame_rate(OUT_FPS)
+        .video_track(vec![Clip::new(&src)])
+        .build()
+        .ok()
+    else {
+        return; // source codec unavailable -> skip
+    };
+    let out = test_output_path("gpuexport_24to30.mp4");
+    let _gg = FileGuard::new(out.clone());
+    if !render_or_skip(timeline.render(&out, export_config())) {
+        return;
+    }
+    let (count, dims) = decode_stats(&out);
+    assert_eq!(
+        dims,
+        Some((CANVAS, CANVAS)),
+        "conformed export frames should be the {CANVAS}x{CANVAS} canvas size"
+    );
+    // Without conform the drain consumed one source frame per output and stopped at 24,
+    // shortening the clip; with it the output covers the same second at 30 fps.
+    assert!(
+        (EXPECTED_OUT_FRAMES - 1..=EXPECTED_OUT_FRAMES + 1).contains(&count),
+        "a {SRC_FPS} fps source in a {OUT_FPS} fps timeline should export \
+         ~{EXPECTED_OUT_FRAMES} frames (1 s), got {count}"
+    );
+}
+
 #[test]
 fn render_with_progress_forcing_cpu_should_report_progress_and_export() {
     let src = test_output_path("gpuexport_progress_src.mp4");

--- a/crates/avio/tests/gpu_export_tests.rs
+++ b/crates/avio/tests/gpu_export_tests.rs
@@ -140,9 +140,7 @@ fn export_should_produce_frames_on_cpu_and_gpu_routes() {
 fn gpu_export_should_conform_a_slower_source_to_the_timeline_rate() {
     const SRC_FPS: f64 = 24.0;
     const OUT_FPS: f64 = 30.0;
-    const SRC_24_FRAMES: usize = 24; // exactly 1 s of 24 fps source
-    // 1 s of source at the timeline rate: the count that proves the duration is kept.
-    const EXPECTED_OUT_FRAMES: usize = 30;
+    const SRC_24_FRAMES: usize = 24; // ~1 s of 24 fps source
 
     let src = test_output_path("gpuexport_24fps_src.mp4");
     let _gs = FileGuard::new(src.clone());
@@ -152,6 +150,20 @@ fn gpu_export_should_conform_a_slower_source_to_the_timeline_rate() {
     if avio::GpuCompositor::new().is_none() {
         return; // no GPU adapter -> the GPU leg is unreachable here
     }
+    // Expect against what the source *actually decodes*, not the nominal frame count:
+    // an encode/decode round trip can lose a frame, and that shortfall would otherwise
+    // read as a conform bug. The conformed output should cover the same wall-clock span
+    // at the timeline rate, i.e. `src_frames * OUT_FPS / SRC_FPS`.
+    let (src_frames, _) = decode_stats(&src);
+    if src_frames == 0 {
+        return; // source decoder unavailable -> skip
+    }
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation
+    )]
+    let expected = (src_frames as f64 * OUT_FPS / SRC_FPS).round() as usize;
     let Some(timeline) = Timeline::builder()
         .canvas(CANVAS, CANVAS)
         .frame_rate(OUT_FPS)
@@ -172,12 +184,16 @@ fn gpu_export_should_conform_a_slower_source_to_the_timeline_rate() {
         Some((CANVAS, CANVAS)),
         "conformed export frames should be the {CANVAS}x{CANVAS} canvas size"
     );
-    // Without conform the drain consumed one source frame per output and stopped at 24,
-    // shortening the clip; with it the output covers the same second at 30 fps.
+    // Non-vacuity: up-conform must *add* frames. Without it the drain took one source
+    // frame per output and the clip came out short, at the source's own count.
     assert!(
-        (EXPECTED_OUT_FRAMES - 1..=EXPECTED_OUT_FRAMES + 1).contains(&count),
-        "a {SRC_FPS} fps source in a {OUT_FPS} fps timeline should export \
-         ~{EXPECTED_OUT_FRAMES} frames (1 s), got {count}"
+        count > src_frames,
+        "conform must add frames: {src_frames} source frames became {count} outputs"
+    );
+    assert!(
+        (expected - 1..=expected + 1).contains(&count),
+        "a {SRC_FPS} fps source ({src_frames} frames) in a {OUT_FPS} fps timeline should \
+         export ~{expected} frames, got {count}"
     );
 }
 

--- a/crates/avio/tests/gpu_export_tests.rs
+++ b/crates/avio/tests/gpu_export_tests.rs
@@ -184,14 +184,19 @@ fn gpu_export_should_conform_a_slower_source_to_the_timeline_rate() {
         Some((CANVAS, CANVAS)),
         "conformed export frames should be the {CANVAS}x{CANVAS} canvas size"
     );
-    // Non-vacuity: up-conform must *add* frames. Without it the drain took one source
-    // frame per output and the clip came out short, at the source's own count.
+    // The load-bearing assertion: up-conform must *add* frames. Without it the drain
+    // took one source frame per output and the clip came out at the source's own count,
+    // far below this.
     assert!(
         count > src_frames,
         "conform must add frames: {src_frames} source frames became {count} outputs"
     );
+    // The count lands near the conformed duration, but not exactly: n frames span n-1
+    // intervals, so the file is 23/24 s rather than 1 s, and PTS quantisation and frame
+    // reordering move the last output's boundary by a frame between platforms. The
+    // window is wide enough to absorb that and still far from the un-conformed count.
     assert!(
-        (expected - 1..=expected + 1).contains(&count),
+        (expected - 2..=expected + 2).contains(&count),
         "a {SRC_FPS} fps source ({src_frames} frames) in a {OUT_FPS} fps timeline should \
          export ~{expected} frames, got {count}"
     );


### PR DESCRIPTION
## Objective

- The GPU export drain decoded one source frame per output frame, so a source whose native rate differed from the timeline rate would change the clip's on-screen duration.
- Eligibility therefore rejected any mismatch and sent the whole export to the CPU path, which is one of the remaining reasons a normal timeline leaves the GPU-default route.

## Solution

- Conform in the drain: output frame `k` takes source index `floor(k * src_fps / out_fps)`, so a slower source repeats a frame and a faster one skips frames while the clip keeps its duration. The same formula covers both directions and is the identity when the rates match.
- Keep the matching-rate loop unchanged — it still moves each decoded frame into the compositor to avoid a clone; the conform loop borrows the held frame because one source frame can serve several outputs (that path pays `composite`'s internal clone, noted in the code).
- Stop comparing the rates in eligibility: it now only requires a usable (positive, finite) source rate, so a source with no rate still falls back to CPU rather than risking wrong output. The now-unused `frame_rate` argument is dropped.
- Tests: the index formula is a pure function with cases for repeating, skipping and the identity; a unit test encodes a real 24 fps source and asserts a 30 fps timeline is now GPU-eligible — the gate the end-to-end test depends on, since the CPU fallback would otherwise produce the same output and hide which route ran; and an integration test exports 24 fps into a 30 fps timeline and asserts the decoded frame count matches the timeline duration.

Aspect/letterbox handling (#1661) and multi-track GPU export (#1633) stay out of scope.

Closes #1660