### PR TITLE
feat(avio): letterbox non-canvas-aspect layers on the GPU path

### DIFF
--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -3,19 +3,25 @@
 //! Owns the `ff-render` context and a cached `Compositor`, and composites a set of
 //! derived layers (any [`GpuLayerSource`]) with their decoded frames into an rgba
 //! buffer. Both the preview executor ([`GpuPreviewCompositor`](crate::GpuPreviewCompositor))
-//! and the export drain use it, so the mapping-to-GPU logic, the v1 identity/aspect
-//! gate, and the effect execution live in one place.
+//! and the export drain use it, so the mapping-to-GPU logic, the v1 identity gate, the
+//! letterbox, and the effect execution live in one place.
 //!
 //! It returns `None` on any unsupported layer ([`map_scene`] fallback, a non-identity
-//! transform, or an aspect mismatch) or any GPU error, so the caller falls back to the
-//! CPU compositor for that frame -- never a panic, never a partial result.
+//! model transform, or layers of mixed aspect) or any GPU error, so the caller falls
+//! back to the CPU compositor for that frame -- never a panic, never a partial result.
 //!
-//! v1 renders only layers that need no geometric placement (an identity transform and
-//! a frame whose aspect matches the canvas): the model's transform is in canvas pixels
-//! / clockwise degrees while `ff_render::LayerTransform` is UV-space / counter-clockwise
-//! radians, and the compositor stretches each layer to the canvas where the CPU path
-//! letterboxes. Matching those exactly is parity work (Br5), so those cases fall back
-//! to CPU rather than render wrong output.
+//! v1 renders only layers that need no geometric placement (an identity transform): the
+//! model's transform is in canvas pixels / clockwise degrees while
+//! `ff_render::LayerTransform` is UV-space / counter-clockwise radians, so a positioned
+//! or rotated layer falls back to CPU rather than render wrong output (RK-020).
+//!
+//! **Letterbox (#1661):** a frame whose aspect differs from the canvas is *fitted* into
+//! it, matching the CPU compositor's `scale=…:force_original_aspect_ratio=decrease` +
+//! `pad` pass instead of the compositor's default stretch (see [`fit_size`]). Since the
+//! CPU fits the *composited* result while this fits each layer before compositing, the
+//! two agree only when every layer lands in the same band, so a scene whose layers do
+//! not all share one aspect still falls back -- as does one whose aspect is extreme
+//! enough that a fitted side rounds away to nothing.
 //!
 //! **Per-frame cost (#1634):** an effected layer's `RenderGraph` is cached per layer
 //! position ([`CachedEffectGraph`]) and reused while its effect list compares equal, so
@@ -96,8 +102,8 @@ impl GpuCompositor {
     /// back to the CPU compositor.
     ///
     /// `None` means: `map_scene` reported an unsupported blend/composite/effect, a
-    /// layer has a non-identity transform or an aspect that does not match the canvas
-    /// (v1 gate), or a GPU error occurred. The caller must never see a wrong-but-
+    /// layer has a non-identity model transform (v1 gate), the layers do not all share
+    /// one aspect, or a GPU error occurred. The caller must never see a wrong-but-
     /// rendered frame.
     pub fn composite<L: GpuLayerSource>(
         &mut self,
@@ -112,7 +118,7 @@ impl GpuCompositor {
         };
         self.ensure_cache_size(layers.len());
 
-        let mut frame_layers = Vec::with_capacity(plan.layers.len());
+        let mut processed = Vec::with_capacity(plan.layers.len());
         for (idx, (lp, (_, frame))) in plan.layers.iter().zip(layers.iter()).enumerate() {
             // v1 renders only layers that need no geometric placement (see the module
             // docs); a non-identity transform falls back to CPU rather than render
@@ -122,16 +128,15 @@ impl GpuCompositor {
             }
             // The preview adapter does not own its frames, so a no-effects layer must
             // clone; `composite_owned` avoids this for the export drain.
-            let processed = if lp.effects.is_empty() {
+            let out = if lp.effects.is_empty() {
                 (*frame).clone()
             } else {
                 self.apply_effects(idx, lp, frame)?
             };
-            let layer = make_frame_layer(processed, lp, canvas)?;
-            frame_layers.push(layer);
+            processed.push((out, lp));
         }
 
-        self.finish(frame_layers, canvas)
+        self.finish(assemble(processed, canvas)?, canvas)
     }
 
     /// Like [`composite`](Self::composite) but takes ownership of the layer frames, so a
@@ -150,22 +155,21 @@ impl GpuCompositor {
         };
         self.ensure_cache_size(layers.len());
 
-        let mut frame_layers = Vec::with_capacity(plan.layers.len());
+        let mut processed = Vec::with_capacity(plan.layers.len());
         for (idx, (lp, (_, frame))) in plan.layers.iter().zip(layers).enumerate() {
             if !is_identity_transform(lp) {
                 return None;
             }
             // Owned: a no-effects layer moves its frame in, no clone.
-            let processed = if lp.effects.is_empty() {
+            let out = if lp.effects.is_empty() {
                 frame
             } else {
                 self.apply_effects(idx, lp, &frame)?
             };
-            let layer = make_frame_layer(processed, lp, canvas)?;
-            frame_layers.push(layer);
+            processed.push((out, lp));
         }
 
-        self.finish(frame_layers, canvas)
+        self.finish(assemble(processed, canvas)?, canvas)
     }
 
     /// Composites the built `frame_layers` on the (canvas-cached) `Compositor` to rgba.
@@ -405,26 +409,104 @@ fn is_cacheable(effects: &[GpuEffect]) -> bool {
         .any(|e| matches!(e, GpuEffect::LumaMask { .. }))
 }
 
-/// Wraps a processed layer frame in a [`FrameLayer`], or `None` when its aspect does not
-/// match the canvas (the compositor would stretch it where the CPU path letterboxes, so
-/// fall back to CPU rather than render distorted output).
-fn make_frame_layer(
-    processed: VideoFrame,
-    lp: &GpuLayerPlan,
+/// Wraps each processed layer frame in a [`FrameLayer`], letterboxing it into the canvas
+/// (#1661), or `None` when the frames do not all share one aspect or the fit degenerates.
+///
+/// The CPU compositor fits the **composited** result into the canvas, while this fits
+/// each layer *before* compositing. The two coincide exactly when every layer ends up in
+/// the same band, which is what the shared-aspect requirement enforces; a mixed-aspect
+/// scene falls back to CPU rather than render a band per layer (RK-020).
+fn assemble(
+    processed: Vec<(VideoFrame, &GpuLayerPlan)>,
     canvas: (u32, u32),
-) -> Option<FrameLayer> {
-    if u64::from(processed.width()) * u64::from(canvas.1)
-        != u64::from(processed.height()) * u64::from(canvas.0)
+) -> Option<Vec<FrameLayer>> {
+    let (first, _) = processed.first()?;
+    let (w0, h0) = (u64::from(first.width()), u64::from(first.height()));
+    if processed
+        .iter()
+        .any(|(f, _)| u64::from(f.width()) * h0 != u64::from(f.height()) * w0)
     {
         return None;
     }
-    Some(FrameLayer {
-        frame: processed,
-        transform: LayerTransform::default(),
-        blend_mode: lp.blend_mode,
-        opacity: lp.opacity,
-        z_order: lp.z_order,
+
+    let transform = letterbox_transform(first.width(), first.height(), canvas)?;
+    Some(
+        processed
+            .into_iter()
+            .map(|(frame, lp)| FrameLayer {
+                frame,
+                transform: transform.clone(),
+                blend_mode: lp.blend_mode,
+                opacity: lp.opacity,
+                z_order: lp.z_order,
+            })
+            .collect(),
+    )
+}
+
+/// The [`LayerTransform`] that fits an `fw` x `fh` frame inside `canvas`, letterboxing or
+/// pillarboxing the remainder, or `None` when the fit leaves no band to draw.
+///
+/// `transform.wgsl` samples `(uv - 0.5) / scale` and returns transparent outside `[0, 1]`,
+/// so a scale of `fit / canvas` draws the frame as a centred band of exactly that fraction
+/// of the canvas; `blend.wgsl` then leaves the canvas' black in the bars, matching the CPU
+/// path's `pad=…:color=black`. A frame that already matches the canvas aspect yields the
+/// identity, which `ff_render`'s compositor skips entirely -- so that (previously the only
+/// supported) case keeps its exact pixels and its per-frame cost.
+///
+/// Note that an **odd** canvas dimension never yields the identity: the fit rounds down to
+/// an even size, so a matching-aspect frame still scales (by one pixel) and centres half a
+/// pixel off the CPU's `pad=(ow-iw)/2`. That is `FFmpeg`'s own `force_divisible_by=2`
+/// behaviour, so the two paths still agree on geometry.
+fn letterbox_transform(fw: u32, fh: u32, canvas: (u32, u32)) -> Option<LayerTransform> {
+    let (fit_w, fit_h) = fit_size(fw, fh, canvas);
+    // An aspect extreme enough for one fitted side to round away to nothing has no band
+    // to draw. Passing that on as a zero scale would not fail loudly: `transform.wgsl`
+    // floors the divisor at 1e-4, so every sample lands outside `[0, 1]` and the layer
+    // disappears into a silently black frame -- exactly the wrong output this module
+    // must never produce (RK-020). The CPU leg cannot build its `scale` at that size
+    // either, so falling back is the honest answer.
+    if fit_w == 0 || fit_h == 0 {
+        return None;
+    }
+    if (fit_w, fit_h) == canvas {
+        return Some(LayerTransform::default());
+    }
+    Some(LayerTransform {
+        scale_x: ratio(fit_w, canvas.0),
+        scale_y: ratio(fit_h, canvas.1),
+        ..LayerTransform::default()
     })
+}
+
+/// `a / b` as an `f32`, for the pixel counts this module deals in.
+#[allow(clippy::cast_precision_loss)] // pixel dimensions are far inside f32's exact range
+fn ratio(a: u32, b: u32) -> f32 {
+    a as f32 / b as f32
+}
+
+/// The size an `fw` x `fh` frame scales to when fitted inside `canvas`, mirroring the CPU
+/// path's `scale=w:h:force_original_aspect_ratio=decrease:force_divisible_by=2`
+/// (`composition_inner.rs`): each side is the aspect-preserving candidate clamped to the
+/// canvas, then rounded **down** to a multiple of two.
+///
+/// Reproducing the rounding rather than using the exact real-valued ratio is what keeps
+/// the band boundary within a pixel of the CPU leg; the parity test measures the residue.
+/// A degenerate zero-sized frame yields the canvas, i.e. the compositor's plain stretch.
+#[allow(clippy::cast_possible_truncation)] // each side is clamped to the canvas, a u32
+fn fit_size(fw: u32, fh: u32, canvas: (u32, u32)) -> (u32, u32) {
+    if fw == 0 || fh == 0 {
+        return canvas;
+    }
+    let (cw, ch) = (u64::from(canvas.0), u64::from(canvas.1));
+    let (fw, fh) = (u64::from(fw), u64::from(fh));
+    // `av_rescale` rounds to nearest, half away from zero.
+    let rescale = |num: u64, den: u64| (num + den / 2) / den;
+    let even = |v: u64| v / 2 * 2;
+    (
+        even(rescale(ch * fw, fh).min(cw)) as u32,
+        even(rescale(cw * fh, fw).min(ch)) as u32,
+    )
 }
 
 /// Loads a `LutNode` from a `.cube` or `.3dl` file, or `None` when the extension is
@@ -498,4 +580,60 @@ fn is_identity_transform(lp: &GpuLayerPlan) -> bool {
         && (lp.scale_x - 1.0).abs() < 1e-6
         && (lp.scale_y - 1.0).abs() < 1e-6
         && lp.rotation.abs() < 1e-6
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fit_size_should_letterbox_a_wide_frame() {
+        // 16:9 into a square canvas: full width, bars top and bottom.
+        assert_eq!(fit_size(64, 36, (64, 64)), (64, 36));
+    }
+
+    #[test]
+    fn fit_size_should_pillarbox_a_tall_frame() {
+        // The mirror case, so the fit is not accidentally width-only.
+        assert_eq!(fit_size(36, 64, (64, 64)), (36, 64));
+    }
+
+    #[test]
+    fn fit_size_should_round_down_to_an_even_size() {
+        // 3:2 into a square: the exact fit is 66.67 rows, which `av_rescale` rounds to
+        // 67 and `force_divisible_by=2` then takes down to 66. Drives that branch on its
+        // own, since every other case here is already even.
+        assert_eq!(fit_size(30, 20, (100, 100)), (100, 66));
+    }
+
+    #[test]
+    fn letterbox_transform_should_scale_only_the_fitted_axis() {
+        let t = letterbox_transform(64, 36, (64, 64)).expect("a 16:9 fit has a band");
+        assert!((t.scale_x - 1.0).abs() < 1e-6, "full width: {}", t.scale_x);
+        assert!((t.scale_y - 0.5625).abs() < 1e-6, "36/64: {}", t.scale_y);
+        assert!(t.x.abs() < 1e-6 && t.y.abs() < 1e-6 && t.rotation.abs() < 1e-6);
+    }
+
+    #[test]
+    fn letterbox_transform_should_be_identity_for_a_canvas_aspect_frame() {
+        // The previously-only-supported shape must stay on the compositor's
+        // transform-free path, at both the canvas size and a larger one.
+        let same = letterbox_transform(64, 48, (64, 48)).expect("a matching aspect fits");
+        assert!(same.is_identity());
+        let larger = letterbox_transform(1920, 1080, (64, 36)).expect("a matching aspect fits");
+        assert!(larger.is_identity());
+    }
+
+    #[test]
+    fn letterbox_transform_should_reject_a_fit_that_rounds_away_to_nothing() {
+        // 64:1 into a square canvas: the fitted height is one row, which the
+        // even-rounding takes to zero. `transform.wgsl` floors the divisor at 1e-4, so a
+        // zero scale would not error -- it would sample the whole layer out of range and
+        // render a silently black frame. Falling back is the only correct answer.
+        assert_eq!(fit_size(4096, 64, (64, 64)), (64, 0));
+        assert!(letterbox_transform(4096, 64, (64, 64)).is_none());
+        // The mirror case, so the guard is not accidentally height-only.
+        assert_eq!(fit_size(64, 4096, (64, 64)), (0, 64));
+        assert!(letterbox_transform(64, 4096, (64, 64)).is_none());
+    }
 }

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -11,9 +11,10 @@
 //!
 //! v1 handles only a **single active video track of contiguous hard cuts** at unity
 //! speed whose every clip is a file source that maps to the GPU with an identity
-//! transform and a canvas-matching aspect. A source whose frame rate differs from the
-//! timeline's is conformed by the drain (#1660), repeating or skipping source frames so
-//! the clip keeps its on-screen duration. Anything else keeps the whole export on the
+//! transform. A source whose frame rate differs from the timeline's is conformed by the
+//! drain (#1660), repeating or skipping source frames so the clip keeps its on-screen
+//! duration, and one whose aspect differs from the canvas is letterboxed by the shared
+//! compositing core (#1661). Anything else keeps the whole export on the
 //! CPU `MultiTrackComposer` path (see [`eligible_track`]); multi-track / overlay GPU
 //! export is a follow-up.
 
@@ -52,11 +53,11 @@ use crate::track::Track;
 ///   clips in order without honouring `clip.offset`, so a leading gap, an inter-clip
 ///   gap, or an overlap would diverge from the CPU compositor (which places each clip
 ///   via `OffsetPts`),
-/// - each source's native aspect matches the canvas (the compositor would stretch a
-///   differently-shaped frame where the CPU path letterboxes) and its native frame
-///   rate is usable (positive and finite). The rate no longer has to *match* the
-///   timeline `frame_rate`: the drain conforms it (#1660), repeating or skipping
-///   source frames so the clip keeps its on-screen duration.
+/// - each source's native frame rate is usable (positive and finite). Neither the rate
+///   nor the aspect has to *match* the timeline any more: the drain conforms the rate
+///   (#1660), repeating or skipping source frames so the clip keeps its on-screen
+///   duration, and the shared compositing core letterboxes a differently-shaped frame
+///   into the canvas (#1661).
 pub(crate) fn eligible_track(
     video_tracks: &[Track],
     lavfi_overlay: Option<&str>,
@@ -116,18 +117,13 @@ pub(crate) fn eligible_track(
         }
     }
 
-    // Probe pass (I/O): each source's native aspect must match the canvas, and its
-    // frame rate must be usable (it no longer has to match the timeline rate).
+    // Probe pass (I/O): each source's frame rate must be usable. Its aspect no longer
+    // has to match the canvas -- the shared compositing core letterboxes it (#1661).
     for clip in &track.clips {
         let src = clip.source_path()?;
         let Ok(decoder) = VideoDecoder::open(src).build() else {
             return None;
         };
-        if u64::from(decoder.width()) * u64::from(canvas.1)
-            != u64::from(decoder.height()) * u64::from(canvas.0)
-        {
-            return None;
-        }
         // The frame rate no longer has to match: the drain conforms the source to the
         // timeline rate from the frames' own timestamps (#1660). The rate is still
         // required to be usable, since a source that reports none is one whose timing
@@ -443,25 +439,42 @@ mod tests {
         assert_eq!(plan, (0..15).collect::<Vec<_>>());
     }
 
-    /// Encodes a tiny square video at `fps`, or `None` when the environment has no
+    /// Encodes a tiny `w` x `h` video at `fps`, or `None` when the environment has no
     /// usable encoder (skip). The probe pass needs a real file, so eligibility cannot
     /// be exercised without one.
-    fn encode_probe_source(path: &std::path::Path, fps: f64) -> Option<()> {
+    fn encode_probe_source(path: &std::path::Path, w: u32, h: u32, fps: f64) -> Option<()> {
         use ff_encode::{VideoCodec, VideoEncoder};
         use ff_format::{PixelFormat as PF, VideoFrame};
 
         let mut enc = VideoEncoder::create(path)
-            .video(64, 64, fps)
+            .video(w, h, fps)
             .video_codec(VideoCodec::Mpeg4)
             .build()
             .ok()?;
         // A few flat frames are enough: only the stream header (size, rate) is probed.
         for i in 0..4 {
-            let frame = VideoFrame::new_black(64, 64, PF::Yuv420p, i);
+            let frame = VideoFrame::new_black(w, h, PF::Yuv420p, i);
             enc.push_video(&frame).ok()?;
         }
         enc.finish().ok()?;
         Some(())
+    }
+
+    /// Encodes `src` and confirms it can be read back, so a probe-gated eligibility test
+    /// can tell "this environment cannot run the check" (skip) from "the gate rejected
+    /// the source" (fail). Minimal-`FFmpeg` CI has the `Mpeg4` encoder but not always the
+    /// decoder the probe pass opens (RK-002), and gating on the encoder alone reads that
+    /// miss as a rejection.
+    fn probe_source_or_skip(src: &std::path::Path, w: u32, h: u32, fps: f64) -> bool {
+        let _ = std::fs::remove_file(src);
+        if encode_probe_source(src, w, h, fps).is_none() {
+            return false;
+        }
+        if VideoDecoder::open(src).build().is_err() {
+            let _ = std::fs::remove_file(src);
+            return false;
+        }
+        true
     }
 
     #[test]
@@ -477,14 +490,7 @@ mod tests {
         // therefore silently exercising the CPU path. Keeping this assertion green is
         // what stops that false green from coming back.
         let src = std::env::temp_dir().join("avio_eligible_24fps_probe.mp4");
-        let _ = std::fs::remove_file(&src);
-        if encode_probe_source(&src, 24.0).is_none() {
-            return; // no encoder here -> skip
-        }
-        // The probe pass opens a decoder, so a build without this decoder cannot reach
-        // the gate at all — skip rather than read the miss as a rejection (RK-002).
-        if VideoDecoder::open(&src).build().is_err() {
-            let _ = std::fs::remove_file(&src);
+        if !probe_source_or_skip(&src, 64, 64, 24.0) {
             return;
         }
         let t = square_timeline(vec![Clip::new(&src)]); // canvas 64x64, timeline 30 fps
@@ -494,6 +500,27 @@ mod tests {
             eligible_now,
             Some(0),
             "a 24 fps source in a 30 fps timeline must be GPU-eligible after #1660"
+        );
+    }
+
+    #[test]
+    fn eligible_track_should_accept_a_source_whose_aspect_differs_from_the_canvas() {
+        // #1661: the probe pass no longer requires the source aspect to match the canvas
+        // — the shared compositing core letterboxes it — so a 16:9 source on a square
+        // canvas stays on the GPU route instead of falling back to CPU. This is the
+        // direct evidence the gate opened: the end-to-end export cannot show it, because
+        // the CPU fallback letterboxes too and would produce the same picture.
+        let src = std::env::temp_dir().join("avio_eligible_169_probe.mp4");
+        if !probe_source_or_skip(&src, 64, 36, 30.0) {
+            return;
+        }
+        let t = square_timeline(vec![Clip::new(&src)]); // canvas 64x64
+        let eligible_now = eligible(&t);
+        let _ = std::fs::remove_file(&src);
+        assert_eq!(
+            eligible_now,
+            Some(0),
+            "a 16:9 source on a square canvas must be GPU-eligible after #1661"
         );
     }
 

--- a/crates/avio/src/gpu_preview.rs
+++ b/crates/avio/src/gpu_preview.rs
@@ -3,9 +3,9 @@
 //! Wraps [`GpuCompositor`](crate::gpu_compositor::GpuCompositor) as an
 //! `ff_preview::PreviewCompositor`, so the preview runner composites on the GPU by
 //! default and falls back to its built-in CPU compositor when the core returns `None`
-//! (an unsupported layer, no adapter, or a GPU error). All the compositing logic and
-//! the v1 identity/aspect gate live in the shared core; this file only adapts the
-//! preview layer type.
+//! (an unsupported layer, no adapter, or a GPU error). All the compositing logic, the
+//! v1 identity gate, and the letterbox live in the shared core; this file only adapts
+//! the preview layer type.
 
 use std::time::Duration;
 

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -145,6 +145,17 @@ const TOL_SHAPEMASK_MEAN: f64 = 4.0;
 // two frames; a single frame is unblended on both paths and would be vacuous (RK-015).
 // The margin covers GPU-driver rounding on other machines.
 const TOL_MOTIONBLUR_MEAN: f64 = 15.0;
+// Letterbox (#1661): the GPU fits the layer via `LayerTransform` (bilinear sampling in
+// `transform.wgsl`) where the CPU uses `scale=…:force_original_aspect_ratio=decrease` +
+// `pad` (sws). The fitted size mirrors FFmpeg's rounding, so the geometry is identical and
+// only the resampling differs. The 16:9-into-square fixture fits 1:1 (no resampling at
+// all): measured mean 0.0 here, bit-exact. The margin covers GPU-driver rounding elsewhere.
+const TOL_LETTERBOX_MEAN: f64 = 12.0;
+// The same parity where the fit *does* rescale (3:2 upscaled into a 100x66 band), so the
+// GPU's bilinear sampler meets sws's bicubic: measured mean 0.14 (max 1) here. A band
+// misplaced by one row would land far outside this, so the fitted-size rounding is what
+// this number actually certifies.
+const TOL_LETTERBOX_RESCALE_MEAN: f64 = 15.0;
 
 /// A deterministic non-uniform pattern: R ramps in x, G in y, B in x+y. A stretch,
 /// letterbox, axis-swap, or channel bug shows up here where a flat fill would not
@@ -444,6 +455,104 @@ fn passthrough_gpu_should_match_cpu_within_tolerance() {
     assert!(
         mean <= TOL_PASSTHROUGH_MEAN,
         "GPU and CPU passthrough diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn letterbox_gpu_should_match_cpu_within_tolerance() {
+    // #1661: a 16:9 layer on a square canvas used to fall back to CPU, because the
+    // compositor stretched it where the CPU path fits and pads. It now letterboxes, so
+    // both routes must agree. Double-gated (adapter + filters).
+    let (fw, fh) = (64, 36);
+    let canvas = (64, 64);
+    let frame = VideoFrame::from_rgba(fw, fh, gradient_rgba(fw, fh)).unwrap();
+    let layer = base_layer(fw, fh, vec![]);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, canvas) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, canvas) else {
+        panic!("a 16:9 layer on a square canvas must now composite on the GPU");
+    };
+    assert_eq!(gpu_out.len(), cpu.len());
+
+    // The bars are (64 - 36) / 2 = 14 rows top and bottom.
+    let bar = (canvas.1 - fh) / 2;
+    let top = box_mean_rgb(&gpu_out, canvas.0, 0, 0, canvas.0, bar);
+    let bottom = box_mean_rgb(&gpu_out, canvas.0, 0, canvas.1 - bar, canvas.0, canvas.1);
+    let band = box_mean_rgb(&gpu_out, canvas.0, 0, bar, canvas.0, canvas.1 - bar);
+    println!("letterbox GPU bars: top={top:?} bottom={bottom:?} band={band:?}");
+    // Non-vacuity, and the acceptance criterion itself: a *stretched* render fills the
+    // canvas, so its bar rows carry picture, while an all-black render would trivially
+    // match a black reference. Asserting both ends pins the geometry, not just the diff.
+    // RGB only: the compositor writes the canvas alpha to every output pixel (RK-024).
+    for (name, mean) in [("top", top), ("bottom", bottom)] {
+        assert!(
+            mean.iter().all(|c| *c < 2.0),
+            "the {name} letterbox bar must be black, got {mean:?} (a stretch fills it)"
+        );
+    }
+    assert!(
+        band.iter().any(|c| *c > 32.0),
+        "the letterboxed picture band must carry the source, got {band:?}"
+    );
+
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "letterbox GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_LETTERBOX_MEAN,
+        "GPU and CPU letterbox diverged beyond tolerance: mean={mean}"
+    );
+}
+
+#[test]
+fn letterbox_gpu_should_match_cpu_when_the_fit_rescales() {
+    // The 16:9-into-square case above fits 1:1 (64x36 into a 64x36 band), so it drives
+    // the placement but neither the resampling nor the size rounding. This one does
+    // both: a 3:2 source into a 100x100 canvas fits to 100x66 — the exact height is
+    // 66.67, which `av_rescale` takes to 67 and `force_divisible_by=2` back down to 66.
+    // Getting that rounding wrong offsets the whole band by a row against the CPU leg.
+    let (fw, fh) = (30, 20);
+    let canvas = (100, 100);
+    let frame = VideoFrame::from_rgba(fw, fh, gradient_rgba(fw, fh)).unwrap();
+    let layer = base_layer(fw, fh, vec![]);
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite(&layer, &frame, canvas) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite(&mut gpu, &layer, &frame, canvas) else {
+        panic!("a 3:2 layer on a square canvas must composite on the GPU");
+    };
+
+    // The fitted band is 66 rows, so the bars are (100 - 66) / 2 = 17 rows each.
+    let bar = (canvas.1 - 66) / 2;
+    let top = box_mean_rgb(&gpu_out, canvas.0, 0, 0, canvas.0, bar);
+    let band = box_mean_rgb(&gpu_out, canvas.0, 0, bar, canvas.0, canvas.1 - bar);
+    println!("rescaled letterbox GPU bars: top={top:?} band={band:?}");
+    assert!(
+        top.iter().all(|c| *c < 2.0),
+        "the bar above a rescaled fit must be black, got {top:?}"
+    );
+    assert!(
+        band.iter().any(|c| *c > 32.0),
+        "the rescaled picture band must carry the source, got {band:?}"
+    );
+
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!(
+        "rescaled letterbox GPU vs CPU: mean={mean:.3} max={}",
+        max_abs_diff_rgb(&gpu_out, &cpu)
+    );
+    assert!(
+        mean <= TOL_LETTERBOX_RESCALE_MEAN,
+        "GPU and CPU rescaled letterbox diverged beyond tolerance: mean={mean}"
     );
 }
 
@@ -1707,11 +1816,33 @@ fn gpu_compositor_should_fall_back_not_panic_for_unsupported_inputs() {
         "a positioned layer must fall back"
     );
 
-    // Aspect mismatch: a 64x48 frame on a square canvas would be stretched.
-    let square = base_layer(w, h, vec![]);
+    // Mixed aspects across layers (#1661): each layer is letterboxed into the canvas
+    // before compositing, while the CPU fits the *composited* result, so the two only
+    // agree when every layer lands in the same band. A 4:3 layer under a 1:1 one would
+    // give a band per layer -> fall back.
+    let tall = VideoFrame::from_rgba(h, h, gradient_rgba(h, h)).unwrap();
+    let wide_layer = base_layer(w, h, vec![]);
+    let square_layer = base_layer(h, h, vec![]);
     assert!(
-        gpu_composite(&mut gpu, &square, &frame, (48, 48)).is_none(),
-        "an aspect-mismatched frame must fall back"
+        gpu.composite(
+            &[(&wide_layer, &frame), (&square_layer, &tall)],
+            (48, 48),
+            Duration::ZERO,
+        )
+        .is_none(),
+        "layers of mixed aspect must fall back"
+    );
+
+    // An aspect so extreme that the fitted height rounds away to nothing (#1661): a
+    // 64x1 frame fits to 64x0 in a square canvas. A zero scale does not fail in
+    // `transform.wgsl` — it floors the divisor at 1e-4 and samples the layer entirely
+    // out of range — so without the guard this would render a silently black frame
+    // rather than fall back (RK-020).
+    let sliver = VideoFrame::from_rgba(w, 1, gradient_rgba(w, 1)).unwrap();
+    let sliver_layer = base_layer(w, 1, vec![]);
+    assert!(
+        gpu_composite(&mut gpu, &sliver_layer, &sliver, (w, w)).is_none(),
+        "an aspect whose fit rounds away to nothing must fall back"
     );
 
     // Unsupported blend mode (no ff-render equivalent).


### PR DESCRIPTION
## Objective

- The GPU compositor stretches every layer to the canvas, while the CPU compositor fits the composited result and pads the remainder with black. To avoid rendering distorted output, both the shared compositing core and the GPU export eligibility check rejected any frame whose aspect differed from the canvas and fell back to CPU.
- That was the last remaining eligibility barrier on the GPU export path, and it also kept ordinary preview scenes (a 16:9 source on a square canvas) off the GPU.

## Solution

- Compute the fit in `avio` and hand it to `ff-render` as a `LayerTransform`, leaving `ff-render` unchanged: `transform.wgsl` samples `(uv - 0.5) / scale` and returns transparent outside `[0, 1]`, so the frame draws as a centred band, and `blend.wgsl` leaves the canvas' black in the bars.
- `fit_size` mirrors the CPU pass' `force_original_aspect_ratio=decrease` plus `force_divisible_by=2` integer rounding, so the band boundary agrees with the CPU leg. A frame that already matches the canvas aspect yields the identity transform, which the compositor skips entirely, so that case keeps its exact pixels and per-frame cost.
- Drop the aspect equality check from the export probe pass; the frame-rate soundness check stays.
- Keep two fallbacks so the GPU never renders wrong output: layers of mixed aspect (the CPU fits the composited result, this fits each layer, so the two agree only when every layer lands in the same band), and an aspect extreme enough that a fitted side rounds away to nothing (a zero scale would not fail loudly, since `transform.wgsl` floors the divisor at 1e-4 and would render the layer entirely transparent).
- Parity vs the CPU compositor measures mean 0.000 (bit-exact) for 16:9 into a square canvas. That fit is 1:1 and drives neither the resampling nor the rounding, so a second case upscales 3:2 into a 100x66 band and measures mean 0.141 (max 1); a band misplaced by one row would land far outside that. Both assert the bars are black and the picture band is not, which is what distinguishes a letterbox from a stretch.
- An eligibility unit test encodes a real 16:9 source and asserts the export gate now accepts it, since an end-to-end export cannot show it: the CPU fallback letterboxes too and would produce the same picture.

Closes #1661