### PR TITLE
feat(ff-render): add DissolveTransitionNode to the transition node set

### DIFF
--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -80,10 +80,10 @@ pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, ColorWheelsNode,
-    CrossfadeNode, CurvesNode, DipToColorNode, FilmGrainNode, GaussianBlurNode, GlowNode, HslNode,
-    LumaMaskNode, LutNode, MotionBlurNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode,
-    ShapeMaskNode, SharpenNode, TransformNode, VignetteNode, WipeTransitionNode, YuvFormat,
-    YuvUploadNode,
+    CrossfadeNode, CurvesNode, DipToColorNode, DissolveTransitionNode, FilmGrainNode,
+    GaussianBlurNode, GlowNode, HslNode, LumaMaskNode, LutNode, MotionBlurNode, OverlayNode,
+    RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode, SharpenNode, TransformNode,
+    VignetteNode, WipeTransitionNode, YuvFormat, YuvUploadNode,
 };
 pub use sink::GpuFrameSink;
 

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -29,7 +29,7 @@ pub use hsl::HslNode;
 pub use lut::LutNode;
 pub use overlay::OverlayNode;
 pub use scale::{ScaleAlgorithm, ScaleNode};
-pub use transition::{DipToColorNode, WipeTransitionNode};
+pub use transition::{DipToColorNode, DissolveTransitionNode, WipeTransitionNode};
 pub use upload::{YuvFormat, YuvUploadNode};
 pub use vignette::VignetteNode;
 

--- a/crates/ff-render/src/nodes/transition.rs
+++ b/crates/ff-render/src/nodes/transition.rs
@@ -1,5 +1,5 @@
-//! Two-clip transition nodes: a directional wipe and a two-phase dip to a solid
-//! colour. Like [`CrossfadeNode`](super::crossfade::CrossfadeNode), the second clip
+//! Two-clip transition nodes: a directional wipe, a linear dissolve, and a two-phase
+//! dip to a solid colour. Like [`CrossfadeNode`](super::crossfade::CrossfadeNode), the second clip
 //! (B) is carried as RGBA bytes in the node and uploaded to a GPU texture at render
 //! time: a single render graph has one source, so B cannot arrive as a second GPU
 //! input. Clip A is the node's input (`inputs[0]` / the `process_cpu` argument).
@@ -102,6 +102,68 @@ impl RenderNodeCpu for WipeTransitionNode {
                     rgba[idx + c] = lerp_u8(a, b, mask);
                 }
             }
+        }
+    }
+}
+
+// DissolveTransitionNode
+
+/// Linear dissolve: clip A mixed into clip B by `progress`.
+///
+/// `progress = 0` outputs clip A, `progress = 1` outputs clip B, and every value
+/// between is the per-channel mix of the two (alpha included, as the sibling
+/// transitions do).
+///
+/// The GPU path reuses `crossfade.wgsl` rather than carrying a second copy of the same
+/// `mix`: that shader's bindings already match the layout this module's shared
+/// `build_pipeline` sets up, and its single-`f32` uniform is this node's `progress`. It
+/// is therefore the same operation as [`CrossfadeNode`](super::crossfade::CrossfadeNode),
+/// exposed with the `progress` / `to_rgba` shape the rest of this module uses so a
+/// transition set can be mapped uniformly.
+///
+/// Like its siblings this node renders to an `Rgba8Unorm` target (the shared
+/// `build_pipeline` hard-codes that format), so it does not run in an `Rgba16Float`
+/// graph.
+pub struct DissolveTransitionNode {
+    /// Transition progress `[0, 1]`: 0 = clip A, 1 = clip B.
+    pub progress: f32,
+    /// Clip B as RGBA bytes (`to_width × to_height × 4`).
+    pub to_rgba: Vec<u8>,
+    /// Width of `to_rgba`.
+    pub to_width: u32,
+    /// Height of `to_rgba`.
+    pub to_height: u32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<TransitionPipeline>,
+}
+
+impl DissolveTransitionNode {
+    /// Creates a dissolve from clip A (the node input) to clip B (`to_rgba`).
+    #[must_use]
+    pub fn new(progress: f32, to_rgba: Vec<u8>, to_width: u32, to_height: u32) -> Self {
+        Self {
+            progress,
+            to_rgba,
+            to_width,
+            to_height,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl RenderNodeCpu for DissolveTransitionNode {
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        if self.to_rgba.len() != rgba.len() {
+            log::warn!(
+                "DissolveTransitionNode::process_cpu skipped: size mismatch a={} b={}",
+                rgba.len(),
+                self.to_rgba.len()
+            );
+            return;
+        }
+        for (a, b) in rgba.iter_mut().zip(self.to_rgba.iter()) {
+            *a = lerp_u8(f32::from(*a), f32::from(*b), self.progress);
         }
     }
 }
@@ -450,6 +512,46 @@ impl super::RenderNode for WipeTransitionNode {
 }
 
 #[cfg(feature = "wgpu")]
+impl super::RenderNode for DissolveTransitionNode {
+    fn input_count(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(tex_a) = inputs.first() else {
+            log::warn!("DissolveTransitionNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("DissolveTransitionNode::process called with no outputs");
+            return;
+        };
+        // `crossfade.wgsl` is this node's shader: same binding layout as the other
+        // transitions, and its one `f32` uniform is `progress` (see the type docs).
+        let pd = self.pipeline.get_or_init(|| {
+            build_pipeline(
+                &ctx.device,
+                include_str!("../shaders/crossfade.wgsl"),
+                "Dissolve",
+                16,
+            )
+        });
+        ctx.queue.write_buffer(
+            &pd.uniform_buf,
+            0,
+            &pack_f32(&[self.progress, 0.0, 0.0, 0.0]),
+        );
+        let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
+        run_pass(ctx, pd, tex_a, &to_tex, output, "Dissolve pass");
+    }
+}
+
+#[cfg(feature = "wgpu")]
 impl super::RenderNode for DipToColorNode {
     fn input_count(&self) -> usize {
         2
@@ -541,6 +643,53 @@ mod tests {
         let b = vec![200u8; 8]; // 2 px
         let node = WipeTransitionNode::new(0.5, 0.0, 0.0, b, 2, 1);
         let original = vec![10u8, 20, 30, 255]; // 1 px
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, original, "size mismatch must be a no-op");
+    }
+
+    /// Clip A and clip B of the dissolve tests: every channel differs between the two
+    /// and no channel repeats within a frame, so a swapped pair, a dropped channel or a
+    /// transposed one all show up in the assertions below.
+    const DISSOLVE_A: [u8; 4] = [10, 200, 30, 255];
+    const DISSOLVE_B: [u8; 4] = [210, 40, 130, 55];
+
+    #[test]
+    fn dissolve_progress_zero_should_be_clip_a() {
+        let node = DissolveTransitionNode::new(0.0, DISSOLVE_B.to_vec(), 1, 1);
+        let mut rgba = DISSOLVE_A.to_vec();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, DISSOLVE_A, "progress=0 must output clip A");
+    }
+
+    #[test]
+    fn dissolve_progress_one_should_be_clip_b() {
+        let node = DissolveTransitionNode::new(1.0, DISSOLVE_B.to_vec(), 1, 1);
+        let mut rgba = DISSOLVE_A.to_vec();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, DISSOLVE_B, "progress=1 must output clip B");
+    }
+
+    #[test]
+    fn dissolve_half_should_average_the_pair() {
+        // The acceptance criterion. On its own it cannot tell A from B (the mix is
+        // symmetric at 0.5); the endpoint tests above are what pin the direction.
+        let node = DissolveTransitionNode::new(0.5, DISSOLVE_B.to_vec(), 1, 1);
+        let mut rgba = DISSOLVE_A.to_vec();
+        node.process_cpu(&mut rgba, 1, 1);
+        for (c, got) in rgba.iter().enumerate() {
+            let want = f32::midpoint(f32::from(DISSOLVE_A[c]), f32::from(DISSOLVE_B[c]));
+            assert!(
+                (f32::from(*got) - want).abs() <= 1.0,
+                "channel {c}: got {got} want {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn dissolve_size_mismatch_should_leave_rgba_unchanged() {
+        let node = DissolveTransitionNode::new(0.5, vec![200u8; 8], 2, 1); // 2 px of B
+        let original = DISSOLVE_A.to_vec(); // 1 px of A
         let mut rgba = original.clone();
         node.process_cpu(&mut rgba, 1, 1);
         assert_eq!(rgba, original, "size mismatch must be a no-op");

--- a/crates/ff-render/tests/gpu_nodes.rs
+++ b/crates/ff-render/tests/gpu_nodes.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use ff_render::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,
-    LumaMaskNode, OverlayNode, RenderContext, RenderGraph, RenderNode, ScaleAlgorithm, ScaleNode,
-    ShapeMaskNode, TransformNode, YuvFormat, YuvUploadNode,
+    DissolveTransitionNode, LumaMaskNode, OverlayNode, RenderContext, RenderGraph, RenderNode,
+    ScaleAlgorithm, ScaleNode, ShapeMaskNode, TransformNode, YuvFormat, YuvUploadNode,
 };
 
 // Helpers
@@ -177,6 +177,64 @@ fn crossfade_gpu_half_factor_should_average_inputs() {
         "factor=0.5 must blend R to ~100; got {}",
         out[0]
     );
+}
+
+// DissolveTransitionNode
+
+/// Clip A and clip B for the dissolve test. Every channel differs between the two and
+/// none repeats within a frame, so a swapped pair, a dropped channel or a transposed one
+/// all show up. Mirrors the constants the CPU tests in `nodes/transition.rs` use.
+const DISSOLVE_A: [u8; 4] = [10, 200, 30, 255];
+const DISSOLVE_B: [u8; 4] = [210, 40, 130, 55];
+
+/// A 2x2 frame filled with one tagged colour.
+fn tagged(px: [u8; 4]) -> Vec<u8> {
+    solid_rgba(px[0], px[1], px[2], px[3], 2, 2)
+}
+
+#[test]
+fn dissolve_gpu_half_progress_should_average_inputs() {
+    let Some(ctx) = gpu_ctx() else { return };
+    let a = tagged(DISSOLVE_A);
+    let b = tagged(DISSOLVE_B);
+    let out = run_gpu(&ctx, DissolveTransitionNode::new(0.5, b, 2, 2), &a, 2, 2);
+    for c in 0..4 {
+        let want = u8::midpoint(DISSOLVE_A[c], DISSOLVE_B[c]);
+        assert!(
+            close(out[c], want, 8),
+            "channel {c}: progress=0.5 must blend to ~{want}; got {}",
+            out[c]
+        );
+    }
+}
+
+#[test]
+fn dissolve_gpu_progress_endpoints_should_be_each_clip() {
+    // The 0.5 blend above is symmetric, so it cannot tell clip A from clip B. These
+    // endpoints are what pin the direction on the GPU path.
+    let Some(ctx) = gpu_ctx() else { return };
+    let a = tagged(DISSOLVE_A);
+    let b = tagged(DISSOLVE_B);
+    let at_zero = run_gpu(
+        &ctx,
+        DissolveTransitionNode::new(0.0, b.clone(), 2, 2),
+        &a,
+        2,
+        2,
+    );
+    let at_one = run_gpu(&ctx, DissolveTransitionNode::new(1.0, b, 2, 2), &a, 2, 2);
+    for c in 0..4 {
+        assert!(
+            close(at_zero[c], DISSOLVE_A[c], 2),
+            "channel {c}: progress=0 must be clip A; got {}",
+            at_zero[c]
+        );
+        assert!(
+            close(at_one[c], DISSOLVE_B[c], 2),
+            "channel {c}: progress=1 must be clip B; got {}",
+            at_one[c]
+        );
+    }
 }
 
 // BlendModeNode


### PR DESCRIPTION
## Objective

- The two-clip transition family in `nodes/transition.rs` has a directional wipe and a two-phase dip to a solid colour, but not the plainest transition of the three.
- `CrossfadeNode` already performs the same linear blend, but with a different API shape (a `factor`, its own module, its own pipeline cache), so a mapping layer would have to special-case it. #1657 maps `Clip.transition` to this node set and #1659 runs it on the GPU export drain, so a uniform shape matters.

## Solution

- Add `DissolveTransitionNode` with the `progress` / `to_rgba` shape the rest of the module uses. The CPU path calls the module's `lerp_u8`, matching the rounding its siblings use; the GPU path goes through the same `build_pipeline` / `pack_f32` / `upload_frame` / `run_pass` helpers `WipeTransitionNode` does.
- No new shader file: `crossfade.wgsl` is already this operation. Its bindings match the layout `build_pipeline` sets up (tex A, tex B, sampler, uniform), its uniform block is the 16 bytes that helper allocates, and its body is the `mix`. Copying it would leave two copies of one line to drift apart.
- Record in the type docs that the node inherits the family's `Rgba8Unorm` colour target and so does not run in an `Rgba16Float` graph, rather than carrying that constraint silently.
- Tests cover both paths. The 50% blend is symmetric and cannot on its own tell clip A from clip B, so the endpoint cases at progress 0 and 1 are what pin the direction; on the GPU side they double as proof the GPU path ran at all, since a no-op would return clip A at progress 1. The tagged pair differs in every channel and repeats none within a frame, so a swapped pair, a dropped channel or a transposed one all show up.

Semantics are the linear blend the issue describes. Whether FFmpeg's `xfade` token `dissolve` is a linear blend or a noise-thresholded one is a mapping question for #1657; #1720 tracks the `xfade` buffersrc gap that currently blocks answering it.

Closes #1668