### PR TITLE
fix(avio): assert the preview covers most of the timeline, not its exact end

### DIFF
--- a/crates/avio/tests/preview_export_parity.rs
+++ b/crates/avio/tests/preview_export_parity.rs
@@ -11,8 +11,9 @@
 //! - Both sides produce frames at the timeline's canvas size.
 //! - The export decodes to the expected frame count for the timeline's duration and
 //!   frame rate.
-//! - The preview's delivered presentation timestamps reach the end of the timeline, so
-//!   it plays the same span the export writes.
+//! - The preview's delivered presentation timestamps cover most of the timeline, so it
+//!   plays substantially the same span the export writes. Not the exact end: the runner
+//!   is real-time and drops late frames, the tail included (see the third boundary below).
 //! - Both sides render the source's (chromatic) colour rather than a blank frame, and
 //!   agree with each other within a coarse tolerance.
 //!
@@ -305,11 +306,15 @@ fn preview_and_export_should_agree_structurally() {
     );
     // The timeline is exactly the source's length: `EXPECTED_FRAMES` frames at `FPS`.
     let end = Duration::from_secs_f64(EXPECTED_FRAMES as f64 / FPS);
-    let frame_period = Duration::from_secs_f64(1.0 / FPS);
+    // Not the exact end: the runner is real-time and drops frames it cannot deliver on
+    // time, the tail included (`SceneRunner`'s "dropped late frame" path), so requiring
+    // it is flaky — a coverage run came in at 366ms of 500ms. Half the span still
+    // separates a runner that played the timeline from one stuck at its opening frames.
     assert!(
-        preview.last_pts + frame_period >= end,
-        "preview must play the whole timeline: last pts {:?}, end {end:?}",
-        preview.last_pts
+        preview.last_pts * 2 >= end,
+        "preview must play most of the timeline: last pts {:?} over {} frames, end {end:?}",
+        preview.last_pts,
+        preview.frames
     );
     // Non-vacuity: the source is strongly chromatic, so a blank / black / grey frame on
     // either side fails here rather than sailing through the comparison below (two


### PR DESCRIPTION
## Objective

- The preview leg of `preview_export_parity` is the real-time runner, which drops frames it cannot deliver on time — `SceneRunner`'s "dropped late frame" path fires whenever a frame's timeline PTS falls more than one frame period behind the wall clock, and the tail is no exception. Requiring the delivered PTS to reach the end of the timeline asserted something the runner does not promise.
- It only ever failed under `llvm-cov`, which is slow enough to push the runner behind; the plain `Test` jobs never reproduced it, so it read as a random flake. It turned PR #1722 (a branch touching only `ff-render`) red at 366ms of 500ms.

## Solution

- Root cause: the old form had no margin at all. 15 frames at 30 fps put the last PTS at 466.667ms, and adding one frame period lands exactly on the 500ms end, so a single dropped frame failed it — and both sides went through `from_secs_f64`, leaving the comparison at the mercy of rounding even on a complete run. The comment above it already said the preview "may drop frames, so it is checked by the span it covers", a tolerance the assertion did not actually have.
- Assert half the span instead. A run stuck at its opening frames still fails, which is what this assertion is for, while a lost tail no longer does. Verified by temporarily stopping the sink at 3 frames: the assertion fires with `last pts 66.666667ms over 3 frames, end 500ms`.
- The failure message now carries the delivered frame count, so a future failure separates "dropped the tail" from "ended early" without going to the log.
- Reword the module doc's guarantee list to match what is asserted; the later note that the preview is checked by span rather than frame count was already accurate and is unchanged.

Test-only; no production code changes. The runner's drop behaviour is correct and stays. The deterministic (non-real-time) preview drive that would remove the flakiness class entirely is the one the module doc already tracks beyond v0.18.

Fixes #1723