### PR TITLE
fix(ff-filter): declare the buffersrc frame rate so xfade can be configured

### DIFF
--- a/crates/ff-filter/src/filter_inner/build.rs
+++ b/crates/ff-filter/src/filter_inner/build.rs
@@ -2261,16 +2261,70 @@ pub(super) unsafe fn add_alphamerge_step(
 /// creating a video `buffer` (buffersrc) context.
 ///
 /// The format follows libavfilter's `buffer` filter parameter syntax:
-/// `video_size=WxH:pix_fmt=N:time_base=NUM/DEN:pixel_aspect=1/1`.
+/// `video_size=WxH:pix_fmt=N:time_base=NUM/DEN:pixel_aspect=1/1`, with
+/// `:frame_rate=NUM/DEN` appended when `frame_rate` is set.
+///
+/// The rate is omitted when unset, which leaves the buffersrc reporting `0/1` — fine
+/// for every filter except the ones that demand a constant frame rate. `xfade` is one:
+/// without a rate it refuses to configure with "The inputs needs to be a constant frame
+/// rate". `FilterGraphBuilder::build` is what rejects that combination up front.
 pub(crate) fn video_buffersrc_args(
     width: u32,
     height: u32,
     pix_fmt: std::os::raw::c_int,
+    frame_rate: Option<f64>,
 ) -> String {
-    format!(
+    let mut args = format!(
         "video_size={}x{}:pix_fmt={}:time_base={}/{}:pixel_aspect=1/1",
         width, height, pix_fmt, VIDEO_TIME_BASE_NUM, VIDEO_TIME_BASE_DEN,
-    )
+    );
+    if let Some(fps) = frame_rate {
+        use std::fmt::Write as _;
+        let (num, den) = frame_rate_to_rational(fps);
+        let _ = write!(args, ":frame_rate={num}/{den}");
+    }
+    args
+}
+
+/// The smallest declarable input frame rate.
+///
+/// Below this, [`frame_rate_to_rational`]'s `round(fps * SCALE)` numerator is zero and
+/// the emitted token degenerates to `0/1` — the unusable rate an *undeclared* buffersrc
+/// reports, which is what declaring one is meant to avoid. `FilterGraphBuilder::build`
+/// rejects anything smaller, so the conversion below never sees it.
+pub(crate) const MIN_INPUT_FRAME_RATE: f64 = 1.0 / FRAME_RATE_SCALE;
+
+/// Denominator the declared frame rate is scaled by before reduction.
+const FRAME_RATE_SCALE: f64 = 1000.0;
+
+/// Converts a frame rate to the exact `num/den` pair emitted in the buffersrc args.
+///
+/// Scales by 1000 and reduces, so `30.0` becomes `30/1` and `29.97` becomes `2997/100`.
+/// An exact rational rather than a decimal: libavfilter would parse `29.97` through
+/// `av_parse_video_rate`, and this repo verifies `FFmpeg` values against the C source
+/// rather than assuming (`docs/rules/design.md`), which a plain rational makes
+/// unnecessary. It also pins the emitted token in a build-independent unit test.
+///
+/// Note this is the literal rate, not the broadcast one: `23.976` becomes `2997/125`
+/// (= 23.976), not `24000/1001` (= 23.97602…). The declared rate only has to be a valid
+/// constant-frame-rate declaration for the filters that require one, and the ~1e-5
+/// difference does not affect them; frame timing comes from each frame's own PTS.
+///
+/// Callers guarantee `fps` is finite and at least [`MIN_INPUT_FRAME_RATE`]
+/// (`FilterGraphBuilder::build` rejects anything else), which is exactly the bound that
+/// keeps the numerator from rounding to zero. The scaled value fits an `i64` for every
+/// realistic rate.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn frame_rate_to_rational(fps: f64) -> (i64, i64) {
+    let scale = FRAME_RATE_SCALE as i64;
+    let num = (fps * FRAME_RATE_SCALE).round() as i64;
+    let divisor = gcd(num, scale);
+    (num / divisor, scale / divisor)
+}
+
+/// Greatest common divisor of two positive integers (Euclid).
+fn gcd(a: i64, b: i64) -> i64 {
+    if b == 0 { a.max(1) } else { gcd(b, a % b) }
 }
 
 /// Build the `args` string passed to `avfilter_graph_create_filter` when

--- a/crates/ff-filter/src/filter_inner/mod.rs
+++ b/crates/ff-filter/src/filter_inner/mod.rs
@@ -20,8 +20,8 @@ mod push_pull;
 pub(crate) use build::add_and_link_step;
 pub(crate) use build::add_asetrate_resample_chain;
 pub(crate) use build::{
-    NormalBlendParams, add_blend_normal_step, add_blend_photographic_step, add_composite_step,
-    video_buffersrc_args,
+    MIN_INPUT_FRAME_RATE, NormalBlendParams, add_blend_normal_step, add_blend_photographic_step,
+    add_composite_step, video_buffersrc_args,
 };
 pub(crate) use convert::pixel_format_to_av;
 
@@ -152,6 +152,9 @@ pub(crate) struct FilterGraphInner {
     peak_output_idx: usize,
     /// True once the two-pass peak measurement + correction has been executed.
     peak_pass2_done: bool,
+    /// Frame rate declared on the video buffersrc, or `None` to leave it unset.
+    /// Required by filters that demand a constant frame rate (`xfade`).
+    input_frame_rate: Option<f64>,
 }
 
 // SAFETY: `FilterGraphInner` owns all raw pointers exclusively.  No other
@@ -161,7 +164,11 @@ unsafe impl Send for FilterGraphInner {}
 
 impl FilterGraphInner {
     /// Create a new (uninitialised) inner.  No `FFmpeg` calls are made here.
-    pub(crate) fn new(steps: Vec<FilterStep>, hw: Option<HwAccel>) -> Self {
+    pub(crate) fn new(
+        steps: Vec<FilterStep>,
+        hw: Option<HwAccel>,
+        input_frame_rate: Option<f64>,
+    ) -> Self {
         Self {
             graph: None,
             audio_graph: None,
@@ -179,6 +186,7 @@ impl FilterGraphInner {
             peak_output: Vec::new(),
             peak_output_idx: 0,
             peak_pass2_done: false,
+            input_frame_rate,
         }
     }
 
@@ -225,6 +233,8 @@ impl FilterGraphInner {
             peak_output: Vec::new(),
             peak_output_idx: 0,
             peak_pass2_done: false,
+            // Pre-built graphs never format buffersrc args, so the rate is moot here.
+            input_frame_rate: None,
         }
     }
 
@@ -258,6 +268,8 @@ impl FilterGraphInner {
             peak_output: Vec::new(),
             peak_output_idx: 0,
             peak_pass2_done: false,
+            // Pre-built graphs never format buffersrc args, so the rate is moot here.
+            input_frame_rate: None,
         }
     }
 
@@ -287,6 +299,8 @@ impl FilterGraphInner {
             peak_output: Vec::new(),
             peak_output_idx: 0,
             peak_pass2_done: false,
+            // Pre-built graphs never format buffersrc args, so the rate is moot here.
+            input_frame_rate: None,
         }
     }
 }
@@ -307,6 +321,7 @@ mod tests {
                 height: 720,
                 algorithm: crate::graph::ScaleAlgorithm::Fast,
             }],
+            None,
             None,
         );
         assert!(
@@ -338,6 +353,7 @@ mod tests {
                 algorithm: crate::graph::ScaleAlgorithm::Fast,
             }],
             None,
+            None,
         );
         drop(inner); // must not panic or double-free
     }
@@ -358,7 +374,7 @@ mod tests {
     #[test]
     fn video_buffersrc_args_should_contain_size_pix_fmt_and_time_base() {
         // pix_fmt 0 = AV_PIX_FMT_YUV420P
-        let args = video_buffersrc_args(1920, 1080, 0);
+        let args = video_buffersrc_args(1920, 1080, 0, None);
         assert!(
             args.contains("video_size=1920x1080"),
             "missing video_size: {args}"
@@ -372,6 +388,34 @@ mod tests {
             args.contains("pixel_aspect=1/1"),
             "missing pixel_aspect: {args}"
         );
+    }
+
+    #[test]
+    fn video_buffersrc_args_should_omit_frame_rate_when_unset() {
+        // Leaving the rate out is the shape every non-CFR filter has always seen; only
+        // `xfade` and friends need it, so an undeclared graph must not change.
+        let args = video_buffersrc_args(1920, 1080, 0, None);
+        assert!(
+            !args.contains("frame_rate"),
+            "an undeclared rate must emit no frame_rate: {args}"
+        );
+    }
+
+    #[test]
+    fn video_buffersrc_args_should_emit_a_reduced_rational_frame_rate() {
+        // A rational, not a decimal: libavfilter would have to parse `29.97` through
+        // `av_parse_video_rate`, and this pins the emitted token without depending on
+        // that. The reduction keeps the common case readable (`30/1`, not `30000/1000`).
+        for (fps, want) in [
+            (30.0, "frame_rate=30/1"),
+            (60.0, "frame_rate=60/1"),
+            (25.0, "frame_rate=25/1"),
+            (29.97, "frame_rate=2997/100"),
+            (23.976, "frame_rate=2997/125"),
+        ] {
+            let args = video_buffersrc_args(64, 64, 0, Some(fps));
+            assert!(args.contains(want), "fps {fps} should emit {want}: {args}");
+        }
     }
 
     /// The audio buffersrc args string must contain all fields required by the
@@ -418,6 +462,7 @@ mod tests {
                 algorithm: crate::graph::ScaleAlgorithm::Fast,
             }],
             None,
+            None,
         );
         assert_eq!(inner.video_input_count(), 1);
     }
@@ -425,7 +470,7 @@ mod tests {
     /// Overlay requires two buffersrc contexts (main + secondary).
     #[test]
     fn video_input_count_should_return_2_for_overlay() {
-        let inner = FilterGraphInner::new(vec![FilterStep::Overlay { x: 10, y: 10 }], None);
+        let inner = FilterGraphInner::new(vec![FilterStep::Overlay { x: 10, y: 10 }], None, None);
         assert_eq!(inner.video_input_count(), 2);
     }
 
@@ -444,6 +489,7 @@ mod tests {
                     algorithm: crate::graph::ScaleAlgorithm::Fast,
                 },
             ],
+            None,
             None,
         );
         assert_eq!(inner.video_input_count(), 1);
@@ -492,6 +538,7 @@ mod tests {
                 algorithm: crate::graph::ScaleAlgorithm::Fast,
             }],
             None,
+            None,
         );
 
         assert!(
@@ -524,7 +571,7 @@ mod tests {
     fn apply_animations_with_empty_slice_should_be_a_no_op() {
         use std::time::Duration;
 
-        let inner = FilterGraphInner::new(vec![], None);
+        let inner = FilterGraphInner::new(vec![], None, None);
         // No FFmpeg calls expected; must not panic.
         inner.apply_animations(&[], Duration::ZERO);
     }

--- a/crates/ff-filter/src/filter_inner/push_pull.rs
+++ b/crates/ff-filter/src/filter_inner/push_pull.rs
@@ -104,7 +104,12 @@ impl FilterGraphInner {
         }
 
         let pix_fmt = pixel_format_to_av(frame.format());
-        let args = video_buffersrc_args(frame.width(), frame.height(), pix_fmt);
+        let args = video_buffersrc_args(
+            frame.width(),
+            frame.height(),
+            pix_fmt,
+            self.input_frame_rate,
+        );
         let num_inputs = self.video_input_count();
 
         // SAFETY: all raw pointers are checked for null after allocation; the

--- a/crates/ff-filter/src/graph/builder/mod.rs
+++ b/crates/ff-filter/src/graph/builder/mod.rs
@@ -11,7 +11,7 @@ pub(super) use super::types::{
 pub(super) use crate::animation::{AnimatedValue, AnimationEntry};
 pub(super) use crate::blend::BlendMode;
 pub(super) use crate::error::FilterError;
-use crate::filter_inner::FilterGraphInner;
+use crate::filter_inner::{FilterGraphInner, MIN_INPUT_FRAME_RATE};
 
 mod audio;
 mod video;
@@ -39,6 +39,9 @@ pub struct FilterGraphBuilder {
     pub(super) hw: Option<HwAccel>,
     /// Registered animation entries, transferred to [`FilterGraph`] on [`build()`](Self::build).
     pub(super) animations: Vec<AnimationEntry>,
+    /// Frame rate declared on the video buffersrc. `None` leaves it unset, which is what
+    /// every filter but the constant-frame-rate ones wants.
+    pub(super) input_frame_rate: Option<f64>,
 }
 
 impl FilterGraphBuilder {
@@ -83,6 +86,21 @@ impl FilterGraphBuilder {
             filter: filter.into(),
             args: args.into(),
         })
+    }
+
+    /// Declare the frame rate of the frames that will be pushed, in frames per second.
+    ///
+    /// Only the filters that require a constant frame rate need it — [`xfade`](Self::xfade)
+    /// is one, and rejects a graph whose input rate is `0/1`, which is what an undeclared
+    /// buffersrc reports. Leaving it unset is correct for everything else, so this is
+    /// opt-in; [`build`](Self::build) rejects a graph that needs a rate and has none.
+    ///
+    /// The rate declares the *timing contract* of the input link. Frame presentation
+    /// still comes from each frame's own timestamp.
+    #[must_use]
+    pub fn input_frame_rate(mut self, fps: f64) -> Self {
+        self.input_frame_rate = Some(fps);
+        self
     }
 
     /// Enable hardware-accelerated filtering.
@@ -779,6 +797,40 @@ impl FilterGraphBuilder {
             }
         }
 
+        // A declared rate reaches libavfilter as the buffersrc's `frame_rate`, so a
+        // token it cannot use has to be caught here — filter args are only validated at
+        // push time (see `build`'s lazy-graph note), long after the caller set this.
+        //
+        // The lower bound is not cosmetic: the emitted rational is `round(fps * 1000)`
+        // over 1000, so anything under 0.0005 rounds the numerator to zero and emits
+        // `frame_rate=0/1` — exactly the unusable rate an *undeclared* buffersrc
+        // reports, and the one this check exists to keep out.
+        if let Some(fps) = self.input_frame_rate
+            && (!fps.is_finite() || fps < MIN_INPUT_FRAME_RATE)
+        {
+            return Err(FilterError::InvalidConfig {
+                reason: format!(
+                    "input_frame_rate {fps} must be finite and >= {MIN_INPUT_FRAME_RATE} \
+                     (a smaller rate rounds to the unusable 0/1)"
+                ),
+            });
+        }
+        // `xfade` requires a constant frame rate on its inputs and refuses to configure
+        // against the `0/1` an undeclared buffersrc reports. Without this the failure
+        // surfaces only on the first push, as an opaque FFmpeg "Invalid argument".
+        if self.input_frame_rate.is_none()
+            && self
+                .steps
+                .iter()
+                .any(|s| matches!(s, FilterStep::XFade { .. }))
+        {
+            return Err(FilterError::InvalidConfig {
+                reason: "xfade requires a constant frame rate: call input_frame_rate() \
+                         with the rate of the pushed frames"
+                    .to_string(),
+            });
+        }
+
         crate::filter_inner::validate_filter_steps(&self.steps)?;
         let output_resolution = self.steps.iter().rev().find_map(|s| {
             if let FilterStep::Scale { width, height, .. } = s {
@@ -788,7 +840,7 @@ impl FilterGraphBuilder {
             }
         });
         Ok(FilterGraph {
-            inner: FilterGraphInner::new(self.steps, self.hw),
+            inner: FilterGraphInner::new(self.steps, self.hw, self.input_frame_rate),
             output_resolution,
             pending_animations: self.animations,
         })

--- a/crates/ff-filter/src/graph/builder/video/transitions.rs
+++ b/crates/ff-filter/src/graph/builder/video/transitions.rs
@@ -304,13 +304,54 @@ mod tests {
 
     #[test]
     fn builder_xfade_with_valid_params_should_succeed() {
+        // The rate is part of a valid xfade graph: the filter needs a constant frame
+        // rate on its inputs, which an undeclared buffersrc does not report.
         let result = FilterGraph::builder()
+            .input_frame_rate(30.0)
             .xfade(XfadeTransition::Dissolve, 1.0, 4.0)
             .build();
         assert!(
             result.is_ok(),
             "xfade(Dissolve, 1.0, 4.0) must build successfully, got {result:?}"
         );
+    }
+
+    #[test]
+    fn builder_xfade_without_input_frame_rate_should_return_invalid_config() {
+        // Without this the graph builds and the failure surfaces only on the first
+        // push, as an opaque FFmpeg "Invalid argument" from the buffersrc's `0/1`.
+        let result = FilterGraph::builder()
+            .xfade(XfadeTransition::Dissolve, 1.0, 4.0)
+            .build();
+        assert!(
+            matches!(result, Err(FilterError::InvalidConfig { .. })),
+            "expected InvalidConfig for a rate-less xfade, got {result:?}"
+        );
+        if let Err(FilterError::InvalidConfig { reason }) = result {
+            assert!(
+                reason.contains("frame rate"),
+                "reason should mention the frame rate: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_with_unusable_input_frame_rate_should_return_invalid_config() {
+        // A rate reaches libavfilter as a token, so a nonsense one has to be caught
+        // here rather than at push time. `0.0001` is the non-obvious member: it is
+        // finite and positive, but the emitted rational rounds its numerator to zero,
+        // so it would declare `frame_rate=0/1` — the very rate this check exists to
+        // keep out, wearing the disguise of a valid one.
+        for fps in [0.0, -30.0, f64::NAN, f64::INFINITY, 0.0001] {
+            let result = FilterGraph::builder()
+                .input_frame_rate(fps)
+                .xfade(XfadeTransition::Dissolve, 1.0, 4.0)
+                .build();
+            assert!(
+                matches!(result, Err(FilterError::InvalidConfig { .. })),
+                "expected InvalidConfig for input_frame_rate {fps}, got {result:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ff-filter/src/graph/composition/composition_inner.rs
+++ b/crates/ff-filter/src/graph/composition/composition_inner.rs
@@ -1073,7 +1073,12 @@ pub(super) unsafe fn build_realtime_composition(
         Vec::with_capacity(layers.len());
     for (idx, layer) in layers.iter().enumerate() {
         let pix = crate::filter_inner::pixel_format_to_av(layer.pixel_format);
-        let args_str = crate::filter_inner::video_buffersrc_args(layer.width, layer.height, pix);
+        // No declared rate: this path has never declared one and none of its filters
+        // require a constant one (the `fps` filter below is inserted only for a
+        // `Speed` step). Declaring it here would change the input link for every
+        // composition, which is beyond fixing `FilterGraph::xfade`.
+        let args_str =
+            crate::filter_inner::video_buffersrc_args(layer.width, layer.height, pix, None);
         let Ok(args) = CString::new(args_str.as_str()) else {
             bail!(graph, "CString::new failed for buffersrc args");
         };

--- a/crates/ff-filter/src/graph/types.rs
+++ b/crates/ff-filter/src/graph/types.rs
@@ -164,9 +164,12 @@ pub enum PitchAlgo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum XfadeTransition {
-    /// Blend frames (cross-dissolve).
+    /// Reveal clip B one pixel at a time, thresholding a pseudo-random value against
+    /// the progress. **Not** a cross-blend: at 50% every pixel is still fully clip A or
+    /// fully clip B, never a mix of the two. Use [`Fade`](Self::Fade) for a blend.
     Dissolve,
-    /// Fade through black.
+    /// Linear cross-blend: every pixel is `mix(A, B, progress)`, so at 50% the frame is
+    /// the arithmetic mean of the two clips.
     Fade,
     /// Wipe from right to left.
     WipeLeft,

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -15,7 +15,7 @@ use ff_filter::{
 };
 use ff_format::{
     AlphaMode, AudioFrame, ColorPrimaries, ColorRange, ColorSpace, ColorTransfer, PixelFormat,
-    PooledBuffer, SampleFormat, Timestamp, VideoFrame,
+    PooledBuffer, Rational, SampleFormat, Timestamp, VideoFrame,
 };
 
 /// 64×64 Yuv420p frame filled with grey (Y=128, U=128, V=128).
@@ -1324,36 +1324,56 @@ fn push_video_through_fade_out_white_should_return_frame_with_same_dimensions() 
     );
 }
 
+/// Whether this FFmpeg build has filters at all, probed with a universally valid
+/// `format=pix_fmts=yuv420p` (no conversion). CI's Linux FFmpeg is `--disable-everything`
+/// and has none; a full build has them. Mirrors the probe
+/// `format_graph_with_ffmpeg_tokens_should_be_accepted_by_ffmpeg` uses.
+fn filters_available() -> bool {
+    let frame = make_yuv420p_frame(64, 64);
+    let Ok(mut probe) = FilterGraph::builder()
+        .format(vec![PixelFormat::Yuv420p], vec![], vec![])
+        .build()
+    else {
+        return false;
+    };
+    probe.push_video(0, &frame).is_ok()
+}
+
+/// A 64x64 Yuv420p frame of flat luma `y` (neutral chroma) stamped at `secs`.
+fn make_luma_frame_at(y: u8, secs: f64) -> VideoFrame {
+    let mut frame = make_yuv_frame(64, 64, y, 128, 128);
+    #[allow(clippy::cast_possible_truncation)]
+    frame.set_timestamp(Timestamp::new(
+        (secs * 1000.0).round() as i64,
+        Rational::new(1, 1000),
+    ));
+    frame
+}
+
 #[test]
 fn push_two_clips_through_xfade_dissolve_should_return_frame_with_same_dimensions() {
-    let mut graph = match FilterGraph::builder()
+    // #1720: this used to swallow its own failure. The buffersrc declared no frame rate,
+    // so `xfade` — which requires a constant one — refused to configure, and the `match`
+    // below reported it as a skip. It therefore never ran, on any build. The skip now
+    // covers only "this FFmpeg has no filters"; anything past that is a real failure.
+    if !filters_available() {
+        println!("skipping: this FFmpeg build has no filters");
+        return;
+    }
+    let mut graph = FilterGraph::builder()
+        .input_frame_rate(30.0)
         .xfade(XfadeTransition::Dissolve, 1.0, 4.0)
         .build()
-    {
-        Ok(g) => g,
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    };
+        .expect("a rate-declaring xfade graph must build");
     let clip_a = make_yuv420p_frame(64, 64);
     let clip_b = make_yuv420p_frame(64, 64);
     // Push clip A to slot 0 first; this initialises the graph.
-    match graph.push_video(0, &clip_a) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
-    // Push clip B to slot 1.
-    match graph.push_video(1, &clip_b) {
-        Ok(()) => {}
-        Err(e) => {
-            println!("Skipping: {e}");
-            return;
-        }
-    }
+    graph
+        .push_video(0, &clip_a)
+        .expect("xfade must accept clip A once the input rate is declared");
+    graph
+        .push_video(1, &clip_b)
+        .expect("xfade must accept clip B once the input rate is declared");
     let result = graph.pull_video().expect("pull_video must not fail");
     let out = result.expect("expected Some(frame) after xfade push");
     assert_eq!(
@@ -1365,6 +1385,120 @@ fn push_two_clips_through_xfade_dissolve_should_return_frame_with_same_dimension
         out.height(),
         64,
         "output height should match input after xfade"
+    );
+}
+
+/// Drives `xfade` from a black clip A to a white clip B over a 1 s transition starting
+/// at 0, and returns `(seconds, luma histogram)` for each output frame. Black-to-white
+/// makes the two candidate behaviours unmistakable: a linear blend lands every pixel on
+/// one mid value, a per-pixel threshold leaves every pixel at 0 or 255.
+fn record_xfade_luma(kind: XfadeTransition) -> Vec<(f64, std::collections::BTreeMap<u8, usize>)> {
+    let mut graph = FilterGraph::builder()
+        .input_frame_rate(30.0)
+        .xfade(kind, 1.0, 0.0)
+        .build()
+        .expect("a rate-declaring xfade graph must build");
+    let mut recorded = Vec::new();
+    for i in 0..20 {
+        let secs = f64::from(i) / 30.0;
+        graph
+            .push_video(0, &make_luma_frame_at(0, secs))
+            .expect("xfade must accept clip A");
+        graph
+            .push_video(1, &make_luma_frame_at(255, secs))
+            .expect("xfade must accept clip B");
+        while let Some(out) = graph.pull_video().expect("pull_video must not fail") {
+            let plane = out.plane(0).expect("luma plane");
+            let mut hist: std::collections::BTreeMap<u8, usize> = std::collections::BTreeMap::new();
+            for &v in plane {
+                *hist.entry(v).or_default() += 1;
+            }
+            recorded.push((secs, hist));
+        }
+    }
+    recorded
+}
+
+/// The histogram recorded closest to `secs`.
+fn histogram_at(
+    recorded: &[(f64, std::collections::BTreeMap<u8, usize>)],
+    secs: f64,
+) -> &std::collections::BTreeMap<u8, usize> {
+    let (_, hist) = recorded
+        .iter()
+        .min_by(|a, b| {
+            (a.0 - secs)
+                .abs()
+                .partial_cmp(&(b.0 - secs).abs())
+                .expect("finite timestamps")
+        })
+        .expect("at least one recorded frame");
+    hist
+}
+
+#[test]
+fn xfade_dissolve_at_half_progress_should_threshold_pixels_not_blend_them() {
+    // #1720 AC3: record what `xfade=transition=dissolve` actually does, so the GPU
+    // transition mapping (#1657) has a reference instead of an assumption.
+    //
+    // Measured here: at 50% progress the output holds exactly two luma values, 0 and
+    // 255, at roughly half each (2074 white / 2022 black of 4096) -- and *no* mid-grey.
+    // `dissolve` is therefore a per-pixel threshold against a pseudo-random value, not
+    // the linear cross-blend `XfadeTransition::Dissolve`'s own doc describes.
+    if !filters_available() {
+        println!("skipping: this FFmpeg build has no filters");
+        return;
+    }
+    let recorded = record_xfade_luma(XfadeTransition::Dissolve);
+    assert!(
+        !recorded.is_empty(),
+        "the dissolve produced no frames; the filter chain did not run"
+    );
+    let hist = histogram_at(&recorded, 0.5);
+    let total: usize = hist.values().sum();
+    let white = hist.get(&255).copied().unwrap_or(0);
+    println!(
+        "dissolve @50%: distinct_luma={} white={white}/{total}",
+        hist.len()
+    );
+    assert_eq!(
+        hist.keys().copied().collect::<Vec<_>>(),
+        vec![0, 255],
+        "dissolve at 50% must hold only the two source values, got {hist:?}"
+    );
+    let ratio = white as f64 / total as f64;
+    assert!(
+        (0.35..=0.65).contains(&ratio),
+        "dissolve at 50% should reveal about half of clip B, got {ratio:.3}"
+    );
+}
+
+#[test]
+fn xfade_fade_at_half_progress_should_blend_pixels_not_threshold_them() {
+    // The contrast that makes the assertion above meaningful: `fade` *is* the linear
+    // cross-blend, so at 50% every pixel lands on one mid value. Recording both pins
+    // which FFmpeg token the linear `DissolveTransitionNode` (#1668) corresponds to.
+    if !filters_available() {
+        println!("skipping: this FFmpeg build has no filters");
+        return;
+    }
+    let recorded = record_xfade_luma(XfadeTransition::Fade);
+    assert!(
+        !recorded.is_empty(),
+        "the fade produced no frames; the filter chain did not run"
+    );
+    let hist = histogram_at(&recorded, 0.5);
+    println!("fade @50%: distinct_luma={} hist={hist:?}", hist.len());
+    let mid = hist
+        .keys()
+        .copied()
+        .find(|v| (100..=155).contains(v))
+        .unwrap_or_else(|| panic!("fade at 50% must produce a mid-grey, got {hist:?}"));
+    let at_mid = hist[&mid];
+    let total: usize = hist.values().sum();
+    assert!(
+        at_mid * 100 / total >= 90,
+        "fade at 50% must put nearly every pixel on one mid value, got {hist:?}"
     );
 }
 


### PR DESCRIPTION
## Objective

- `video_buffersrc_args` built the `buffer` arguments without a `frame_rate=` field, so the buffersrc reported `0/1`. `xfade` requires a constant frame rate on its inputs and refused to configure against that, making `FilterGraph::xfade` unusable at runtime on every build.
- The test that should have caught it wrapped the push under test in a `match` that printed `Skipping` — a gate meant for the minimal-FFmpeg CI, which also swallowed this configuration failure on a full build. It had never exercised `xfade` anywhere.
- This blocked #1657 / #1659, which need a working CPU `xfade` as their parity reference, and blocked establishing what `xfade=transition=dissolve` actually does.

## Solution

- Add `FilterGraphBuilder::input_frame_rate(fps)`, threaded to the buffersrc through the same path `hardware(HwAccel)` already uses. The rate is opt-in, so an undeclared graph emits exactly the argument string it always has.
- `build()` rejects a graph that has an `XFade` step and no rate, turning an opaque FFmpeg "Invalid argument" on the first push into a clear build error. It also rejects a rate below `MIN_INPUT_FRAME_RATE`: the emitted rational is `round(fps * 1000)` over 1000, so anything smaller rounds its numerator to zero and would declare the very `0/1` this change exists to avoid. That bound lives next to the conversion that creates it.
- Emit a reduced rational (`30/1`, `2997/100`) rather than a decimal, so the value does not rest on how `av_parse_video_rate` handles one — a question this repo answers against the pinned C source, which is not available here. It also pins the token in a build-independent unit test.
- Narrow the skip in the existing `xfade` test to "this FFmpeg has no filters", probed with a baseline `format` graph the way the neighbouring tests already do; everything past that gate is asserted.
- With `xfade` runnable, record what the transitions do. Pushing a black clip into a white one and reading the luma at 50% progress: `fade` gives a single mid value (`{127: 4096}`), while `dissolve` gives only `0` and `255`, roughly half each, with no mid-grey. `dissolve` is a per-pixel threshold, not a cross-blend, so `XfadeTransition`'s doc comments for both variants were wrong and are corrected.

The measurement has a consequence the mapping work needs: `DissolveTransitionNode` (#1668) is a linear blend, so it corresponds to `fade`, not `dissolve`. Noted on #1657 and #1668; settling it belongs to #1657, not here.

Fixes #1720