### PR TITLE
feat(avio): map the clip transition set onto the GPU transition nodes

### DIFF
--- a/crates/avio/src/gpu_transition.rs
+++ b/crates/avio/src/gpu_transition.rs
@@ -1,0 +1,206 @@
+//! Maps a clip's [`XfadeTransition`] onto the `ff-render` transition node that renders
+//! it on the GPU (#1657).
+//!
+//! The mapping is a pure function of the transition kind: it says *which* node and with
+//! *what* geometry, not how to drive it. Progress and the incoming clip's pixels come
+//! from whoever runs the transition, which today is the CPU preview path
+//! (`ff_preview::apply_xfade`) and, once it is wired, the GPU one.
+//!
+//! A kind with no GPU equivalent maps to `None`, which is the caller's signal to keep
+//! that transition on the CPU rather than render something that is not what the model
+//! asked for (RK-020).
+
+use ff_filter::XfadeTransition;
+
+/// The `ff-render` transition node an [`XfadeTransition`] renders as.
+///
+/// Carries the node's *static* geometry only. `progress` and clip B are supplied per
+/// frame by the caller, so this stays comparable and cheap to hand around.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum GpuTransition {
+    /// Linear cross-blend (`ff_render::FadeTransitionNode`).
+    Fade,
+    /// Per-pixel threshold reveal (`ff_render::DissolveTransitionNode`).
+    Dissolve,
+    /// Directional wipe (`ff_render::WipeTransitionNode`), `angle` in **radians**.
+    ///
+    /// The angle points at the edge clip B grows *from*, which is the opposite of the
+    /// transition's name: `wiperight` sweeps its edge rightward and so reveals B from
+    /// the left (`angle = PI`). The model names a direction and `ff_render` wants an
+    /// angle, so the conversion — and its inversion — happen here rather than being
+    /// passed through raw (RK-020).
+    Wipe {
+        /// Wipe direction in radians.
+        angle: f32,
+    },
+    /// Two-phase dip through a solid colour (`ff_render::DipToColorNode`), RGB in
+    /// `[0, 1]`.
+    Dip {
+        /// Dip colour.
+        color: [f32; 3],
+    },
+}
+
+/// The GPU node for `kind`, or `None` when it has no equivalent and must stay on the
+/// CPU path.
+///
+/// [`XfadeTransition`] is `#[non_exhaustive]` and defined in `ff-filter`, so this match
+/// needs a `_` arm (RK-003) and the compiler cannot report a newly added kind here. The
+/// substitute guard is the `MAPPED_KINDS` / `CPU_ONLY_KINDS` tables in this module's
+/// tests, which fail if a listed kind stops behaving as recorded.
+#[must_use]
+pub fn map_transition(kind: XfadeTransition) -> Option<GpuTransition> {
+    match kind {
+        XfadeTransition::Fade => Some(GpuTransition::Fade),
+        XfadeTransition::Dissolve => Some(GpuTransition::Dissolve),
+        // The angle names the side clip B grows *from*, which is the opposite of the
+        // FFmpeg kind's name: `wiperight` sweeps its edge rightward, so B is revealed
+        // from the left. `WipeTransitionNode` fills where `proj > center`, i.e. from
+        // the high end of the projected axis, so `wiperight` needs the axis flipped.
+        XfadeTransition::WipeRight => Some(GpuTransition::Wipe {
+            angle: std::f32::consts::PI,
+        }),
+        XfadeTransition::WipeLeft => Some(GpuTransition::Wipe { angle: 0.0 }),
+        XfadeTransition::WipeDown => Some(GpuTransition::Wipe {
+            angle: -std::f32::consts::FRAC_PI_2,
+        }),
+        XfadeTransition::WipeUp => Some(GpuTransition::Wipe {
+            angle: std::f32::consts::FRAC_PI_2,
+        }),
+        XfadeTransition::FadeBlack => Some(GpuTransition::Dip {
+            color: [0.0, 0.0, 0.0],
+        }),
+        XfadeTransition::FadeWhite => Some(GpuTransition::Dip {
+            color: [1.0, 1.0, 1.0],
+        }),
+        // Slides need a translating sampler, and the geometric / mosaic kinds need
+        // nodes that do not exist yet; all stay on the CPU path.
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every kind that maps to a GPU node, with the node it maps to.
+    ///
+    /// Stands in for the exhaustive match the `#[non_exhaustive]` enum denies us: the test
+    /// below walks this list, so a mapping that silently changes is caught even though a
+    /// *newly added* variant cannot be.
+    const MAPPED_KINDS: &[(XfadeTransition, GpuTransition)] = &[
+        (XfadeTransition::Fade, GpuTransition::Fade),
+        (XfadeTransition::Dissolve, GpuTransition::Dissolve),
+        (
+            XfadeTransition::WipeRight,
+            GpuTransition::Wipe {
+                angle: std::f32::consts::PI,
+            },
+        ),
+        (
+            XfadeTransition::WipeLeft,
+            GpuTransition::Wipe { angle: 0.0 },
+        ),
+        (
+            XfadeTransition::WipeDown,
+            GpuTransition::Wipe {
+                angle: -std::f32::consts::FRAC_PI_2,
+            },
+        ),
+        (
+            XfadeTransition::WipeUp,
+            GpuTransition::Wipe {
+                angle: std::f32::consts::FRAC_PI_2,
+            },
+        ),
+        (
+            XfadeTransition::FadeBlack,
+            GpuTransition::Dip {
+                color: [0.0, 0.0, 0.0],
+            },
+        ),
+        (
+            XfadeTransition::FadeWhite,
+            GpuTransition::Dip {
+                color: [1.0, 1.0, 1.0],
+            },
+        ),
+    ];
+
+    /// Every kind deliberately kept on the CPU path.
+    const CPU_ONLY_KINDS: &[XfadeTransition] = &[
+        XfadeTransition::SlideLeft,
+        XfadeTransition::SlideRight,
+        XfadeTransition::SlideUp,
+        XfadeTransition::SlideDown,
+        XfadeTransition::CircleOpen,
+        XfadeTransition::CircleClose,
+        XfadeTransition::FadeGrays,
+        XfadeTransition::Pixelize,
+    ];
+
+    #[test]
+    fn map_transition_should_return_the_recorded_node_for_every_mapped_kind() {
+        for (kind, want) in MAPPED_KINDS {
+            assert_eq!(
+                map_transition(*kind),
+                Some(*want),
+                "{kind:?} should map to {want:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn map_transition_should_return_none_for_every_cpu_only_kind() {
+        // AC2's first half: an unsupported kind must fall back rather than render an
+        // approximation of what the model asked for.
+        for kind in CPU_ONLY_KINDS {
+            assert_eq!(
+                map_transition(*kind),
+                None,
+                "{kind:?} has no GPU node and must fall back to CPU"
+            );
+        }
+    }
+
+    #[test]
+    fn mapped_and_cpu_only_kinds_should_not_overlap() {
+        // The two lists together are the coverage claim, so an entry appearing in both
+        // would make that claim contradictory rather than merely incomplete.
+        for (kind, _) in MAPPED_KINDS {
+            assert!(
+                !CPU_ONLY_KINDS.contains(kind),
+                "{kind:?} is listed as both mapped and CPU-only"
+            );
+        }
+    }
+
+    #[test]
+    fn wipe_angles_should_oppose_their_named_direction() {
+        // The angle is the one unit conversion in this module and it is *opposite* the
+        // kind's name: `WipeTransitionNode` fills from the high end of the projected
+        // axis, while `wiperight` reveals clip B from the left. Writing the intuitive
+        // pairing here produced a mirrored wipe that the transition parity suite caught
+        // at mean=127.5, so pin the counter-intuitive direction explicitly.
+        let angle_of = |kind| match map_transition(kind) {
+            Some(GpuTransition::Wipe { angle }) => angle,
+            other => panic!("{kind:?} must map to a wipe, got {other:?}"),
+        };
+        assert!(
+            angle_of(XfadeTransition::WipeRight).cos() < -0.99,
+            "wiperight reveals B from the left, so its axis points -x"
+        );
+        assert!(
+            angle_of(XfadeTransition::WipeLeft).cos() > 0.99,
+            "wipeleft reveals B from the right, so its axis points +x"
+        );
+        assert!(
+            angle_of(XfadeTransition::WipeDown).sin() < -0.99,
+            "wipedown reveals B from the top, so its axis points -y"
+        );
+        assert!(
+            angle_of(XfadeTransition::WipeUp).sin() > 0.99,
+            "wipeup reveals B from the bottom, so its axis points +y"
+        );
+    }
+}

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -113,6 +113,8 @@ mod gpu_compositor;
 mod gpu_export;
 #[cfg(all(feature = "gpu", feature = "preview"))]
 mod gpu_preview;
+#[cfg(feature = "gpu")]
+mod gpu_transition;
 mod ids;
 mod marker;
 mod timeline;
@@ -134,6 +136,8 @@ pub use gpu::{
 pub use gpu_compositor::GpuCompositor;
 #[cfg(all(feature = "gpu", feature = "preview"))]
 pub use gpu_preview::GpuPreviewCompositor;
+#[cfg(feature = "gpu")]
+pub use gpu_transition::{GpuTransition, map_transition};
 pub use ids::{ClipId, EffectId, GroupId, MarkerId, TrackId, TrackKind};
 pub use marker::Marker;
 pub use timeline::{Timeline, TimelineBuilder};

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -25,11 +25,17 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use avio::{
-    AnimatedValue, BlendMode, Clip, Color, CompositeOp, FilterStep, GpuCompositor, PixelFormat,
-    PlayerHandle, RealtimeLayer, ScaleAlgorithm, Timeline, TimelinePlayer, VideoFrame,
+    AnimatedValue, BlendMode, Clip, Color, CompositeOp, FilterStep, GpuCompositor, GpuTransition,
+    PixelFormat, PlayerHandle, RealtimeLayer, ScaleAlgorithm, Timeline, TimelinePlayer, VideoFrame,
+    map_transition,
 };
 use ff_filter::RealtimeComposer;
+use ff_filter::XfadeTransition;
 use ff_preview::FrameSink;
+use ff_render::{
+    DipToColorNode, DissolveTransitionNode, FadeTransitionNode, RenderContext, RenderGraph,
+    RenderNode, WipeTransitionNode,
+};
 
 // Per-node tolerance table (#1663). Every mapped `GpuEffect` node has a probe-gated
 // GPU/CPU parity test with a calibrated tolerance; `avio::gpu`'s `parity_coverage`
@@ -1796,6 +1802,166 @@ fn reset_effect_cache_should_reset_motion_blur_accumulation() {
         "after a reset the new clip's first frame must be unblended (no trail); got {}",
         out[0]
     );
+}
+
+// Transition mapping parity (#1657)
+
+/// Mean per-channel difference allowed between a GPU transition node and the CPU
+/// reference the preview runs (`ff_preview::apply_xfade`).
+///
+/// Measured **0.000 (max 0)** here for all eight kinds at progress 0 / 0.5 / 1: the
+/// wipes and the dissolve are hard per-pixel picks, and the fade and dip lerps round
+/// the same way on both sides. The margin covers a driver that rounds a lerp the other
+/// way (±1 per channel) and nothing more.
+///
+/// Deliberately not slack. A wholesale divergence — a dissolve hash that reveals a
+/// different *set* of pixels, or a mirrored wipe — lands near 127 and any bound would
+/// catch it; what a loose bound would hide is a *partial* regression, such as the dip's
+/// phase split shifting by a frame. That is the failure this suite exists to reject.
+const TOL_TRANSITION_MEAN: f64 = 2.0;
+
+/// A GPU context for the transition nodes, or `None` without an adapter.
+fn transition_ctx() -> Option<std::sync::Arc<RenderContext>> {
+    RenderContext::init_blocking().ok().map(std::sync::Arc::new)
+}
+
+/// Runs `node` over clip A on the GPU and reads the result back.
+fn run_transition_gpu(
+    ctx: &std::sync::Arc<RenderContext>,
+    node: impl RenderNode + 'static,
+    a: &[u8],
+    w: u32,
+    h: u32,
+) -> Vec<u8> {
+    RenderGraph::new(std::sync::Arc::clone(ctx))
+        .push(node)
+        .process_gpu(a, w, h)
+        .expect("process_gpu must succeed on a graph with a GPU context")
+}
+
+/// Runs the GPU node `kind` maps to, or `None` when it is a CPU-only kind.
+fn gpu_transition_output(
+    ctx: &std::sync::Arc<RenderContext>,
+    kind: XfadeTransition,
+    a: &[u8],
+    b: &[u8],
+    progress: f32,
+    w: u32,
+    h: u32,
+) -> Option<Vec<u8>> {
+    let out = match map_transition(kind)? {
+        GpuTransition::Fade => run_transition_gpu(
+            ctx,
+            FadeTransitionNode::new(progress, b.to_vec(), w, h),
+            a,
+            w,
+            h,
+        ),
+        GpuTransition::Dissolve => run_transition_gpu(
+            ctx,
+            DissolveTransitionNode::new(progress, b.to_vec(), w, h),
+            a,
+            w,
+            h,
+        ),
+        // Zero softness: the CPU reference has a hard edge, so a feathered GPU edge
+        // would diverge along the seam for reasons that have nothing to do with the
+        // mapping under test.
+        GpuTransition::Wipe { angle } => run_transition_gpu(
+            ctx,
+            WipeTransitionNode::new(progress, 0.0, angle, b.to_vec(), w, h),
+            a,
+            w,
+            h,
+        ),
+        GpuTransition::Dip { color } => run_transition_gpu(
+            ctx,
+            DipToColorNode::new(progress, color, b.to_vec(), w, h),
+            a,
+            w,
+            h,
+        ),
+    };
+    Some(out)
+}
+
+/// The CPU reference the preview actually runs for `kind`.
+fn cpu_transition_output(
+    kind: XfadeTransition,
+    a: &[u8],
+    b: &[u8],
+    progress: f32,
+    w: u32,
+    h: u32,
+) -> Vec<u8> {
+    let mut dst = Vec::new();
+    ff_preview::apply_xfade(kind, a, b, progress, w, h, &mut dst);
+    dst
+}
+
+#[test]
+fn every_mapped_transition_should_match_the_cpu_reference() {
+    // AC2: each mapped kind, against the CPU path the GPU node replaces. Progress 0.5
+    // plus both endpoints — 0 and 1 are what pin direction, since several kinds look
+    // alike at the midpoint (RK-015).
+    //
+    // For `dissolve` this is also the check that `dissolve.wgsl`'s hash matches the Rust
+    // one bit for bit: a different hash reveals the same *proportion* of clip B while
+    // choosing a different *set* of pixels, so only a per-pixel comparison sees it.
+    let Some(ctx) = transition_ctx() else {
+        return; // no adapter
+    };
+    let (w, h) = (32u32, 32u32);
+    let a = gradient_rgba(w, h);
+    let b = checkerboard_rgba(w, h, 4);
+
+    for kind in [
+        XfadeTransition::Fade,
+        XfadeTransition::Dissolve,
+        XfadeTransition::WipeLeft,
+        XfadeTransition::WipeRight,
+        XfadeTransition::WipeUp,
+        XfadeTransition::WipeDown,
+        XfadeTransition::FadeBlack,
+        XfadeTransition::FadeWhite,
+    ] {
+        for progress in [0.0f32, 0.5, 1.0] {
+            let gpu = gpu_transition_output(&ctx, kind, &a, &b, progress, w, h)
+                .unwrap_or_else(|| panic!("{kind:?} must map to a GPU node"));
+            let cpu = cpu_transition_output(kind, &a, &b, progress, w, h);
+            assert_eq!(gpu.len(), cpu.len(), "{kind:?} @{progress}: size mismatch");
+            let mean = mean_abs_diff_rgb(&gpu, &cpu);
+            println!(
+                "{kind:?} @{progress}: mean={mean:.3} max={}",
+                max_abs_diff_rgb(&gpu, &cpu)
+            );
+            assert!(
+                mean <= TOL_TRANSITION_MEAN,
+                "{kind:?} @{progress}: GPU and CPU diverged, mean={mean}"
+            );
+        }
+    }
+}
+
+#[test]
+fn cpu_only_transitions_should_not_map_to_a_gpu_node() {
+    // The other half of AC2, and the reason the suite above can be strict: a kind with
+    // no faithful node returns `None` instead of an approximation.
+    for kind in [
+        XfadeTransition::SlideLeft,
+        XfadeTransition::SlideRight,
+        XfadeTransition::SlideUp,
+        XfadeTransition::SlideDown,
+        XfadeTransition::CircleOpen,
+        XfadeTransition::CircleClose,
+        XfadeTransition::FadeGrays,
+        XfadeTransition::Pixelize,
+    ] {
+        assert!(
+            map_transition(kind).is_none(),
+            "{kind:?} must stay on the CPU path"
+        );
+    }
 }
 
 #[test]

--- a/crates/ff-filter/src/graph/ffmpeg_token/mod.rs
+++ b/crates/ff-filter/src/graph/ffmpeg_token/mod.rs
@@ -61,6 +61,8 @@ impl FfmpegToken for XfadeTransition {
             Self::CircleClose => "circleclose",
             Self::FadeGrays => "fadegrays",
             Self::Pixelize => "pixelize",
+            Self::FadeBlack => "fadeblack",
+            Self::FadeWhite => "fadewhite",
         })
     }
 }

--- a/crates/ff-filter/src/graph/types.rs
+++ b/crates/ff-filter/src/graph/types.rs
@@ -195,6 +195,11 @@ pub enum XfadeTransition {
     FadeGrays,
     /// Pixelize transition.
     Pixelize,
+    /// Dip through black: clip A fades to black, then black fades to clip B.
+    /// `progress = 0.5` is the fully black frame.
+    FadeBlack,
+    /// Dip through white, the mirror of [`FadeBlack`](Self::FadeBlack).
+    FadeWhite,
 }
 
 impl XfadeTransition {
@@ -216,6 +221,8 @@ impl XfadeTransition {
             Self::CircleClose => "circleclose",
             Self::FadeGrays => "fadegrays",
             Self::Pixelize => "pixelize",
+            Self::FadeBlack => "fadeblack",
+            Self::FadeWhite => "fadewhite",
         }
     }
 }

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -1477,7 +1477,7 @@ fn xfade_dissolve_at_half_progress_should_threshold_pixels_not_blend_them() {
 fn xfade_fade_at_half_progress_should_blend_pixels_not_threshold_them() {
     // The contrast that makes the assertion above meaningful: `fade` *is* the linear
     // cross-blend, so at 50% every pixel lands on one mid value. Recording both pins
-    // which FFmpeg token the linear `DissolveTransitionNode` (#1668) corresponds to.
+    // which FFmpeg token the linear fade transition node (#1668) corresponds to.
     if !filters_available() {
         println!("skipping: this FFmpeg build has no filters");
         return;

--- a/crates/ff-preview/src/lib.rs
+++ b/crates/ff-preview/src/lib.rs
@@ -57,5 +57,5 @@ pub use proxy::{ProxyGenerator, ProxyJob, ProxyResolution};
 #[cfg(feature = "timeline")]
 pub use scene::{
     PreviewCompositor, Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, ScenePlayer,
-    SceneRunner, SceneSource, SceneVideoTrack,
+    SceneRunner, SceneSource, SceneVideoTrack, apply_xfade,
 };

--- a/crates/ff-preview/src/scene/inner.rs
+++ b/crates/ff-preview/src/scene/inner.rs
@@ -11,12 +11,15 @@ use ff_filter::XfadeTransition;
 /// Blends the outgoing frame `a` and incoming frame `b` (packed RGBA, `w*h*4`) at
 /// transition progress `alpha` (`0` = all A, `1` = all B) using the `xfade` `kind`.
 ///
-/// `wipe*`, `slide*`, and `dissolve` are rendered host-side here. `fade` and the
-/// geometric / mosaic kinds (`fadegrays`, `circleopen`, `circleclose`, `pixelize`)
-/// fall through to the linear cross-dissolve — exact fidelity for those is deferred
-/// to the GPU compositing work (#1365). Falls back to the linear blend when the
-/// buffers are mismatched or their length is not `w*h*4`.
-pub(super) fn apply_xfade(
+/// `wipe*`, `slide*`, `dissolve` and the `fadeblack` / `fadewhite` dips are rendered
+/// host-side here. `fade` and the geometric / mosaic kinds (`fadegrays`, `circleopen`,
+/// `circleclose`, `pixelize`) fall through to the linear cross-blend — exact fidelity
+/// for those is deferred to the GPU compositing work (#1365). Falls back to the linear
+/// blend when the buffers are mismatched or their length is not `w*h*4`.
+///
+/// Public because it is the reference the GPU transition nodes are compared against:
+/// `avio`'s transition parity tests run each `ff_render` node beside this function.
+pub fn apply_xfade(
     kind: XfadeTransition,
     a: &[u8],
     b: &[u8],
@@ -42,6 +45,8 @@ pub(super) fn apply_xfade(
         XfadeTransition::SlideUp => slide(a, b, w, h, dst, 0, (p * hf) as i64),
         XfadeTransition::SlideDown => slide(a, b, w, h, dst, 0, -((p * hf) as i64)),
         XfadeTransition::Dissolve => dissolve(a, b, w, h, dst, p),
+        XfadeTransition::FadeBlack => dip(a, b, [0, 0, 0], dst, p),
+        XfadeTransition::FadeWhite => dip(a, b, [255, 255, 255], dst, p),
         // `Fade` and the deferred geometric/mosaic kinds (plus any future variant of
         // this `#[non_exhaustive]` enum) render as the linear cross-dissolve.
         _ => blend_rgba(a, b, alpha, dst),
@@ -93,7 +98,44 @@ fn dissolve(a: &[u8], b: &[u8], w: u32, h: u32, dst: &mut Vec<u8>, p: f32) {
     }
 }
 
+/// Two-phase dip: clip A fades to `color`, then `color` fades to clip B. `p = 0.5` is
+/// the fully solid frame. Alpha rides along so a dip over transparency stays sane.
+fn dip(a: &[u8], b: &[u8], color: [u8; 3], dst: &mut Vec<u8>, p: f32) {
+    dst.resize(a.len(), 0);
+    let solid = [color[0], color[1], color[2], 255u8];
+    // First half blends A -> colour, second half colour -> B; both legs run at twice
+    // the outer rate so the dip is complete exactly at the midpoint.
+    let second_half = p >= 0.5;
+    let (clip, t) = if second_half {
+        (b, (p - 0.5) * 2.0)
+    } else {
+        (a, p * 2.0)
+    };
+    for (i, out) in dst.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+        let j = i * 4;
+        for c in 0..4 {
+            // Phase 1 runs clip -> colour, phase 2 colour -> clip; the direction is
+            // fixed for the whole frame, so only the endpoints swap here.
+            let (from, to) = if second_half {
+                (f32::from(solid[c]), f32::from(clip[j + c]))
+            } else {
+                (f32::from(clip[j + c]), f32::from(solid[c]))
+            };
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            {
+                out[c] = (from + (to - from) * t + 0.5).clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+}
+
 /// A cheap deterministic per-pixel hash in `[0.0, 1.0)`.
+///
+/// Mirrored bit-for-bit by `ff_render`'s `DissolveTransitionNode` and its
+/// `dissolve.wgsl`, so the CPU and GPU dissolves reveal the same pixels rather than
+/// merely the same *proportion* of them. Changing it here changes only this copy;
+/// `avio`'s transition parity suite is what catches the drift, and that needs a GPU
+/// adapter to run.
 fn hash01(x: u32, y: u32) -> f32 {
     let mut h = x
         .wrapping_mul(374_761_393)

--- a/crates/ff-preview/src/scene/mod.rs
+++ b/crates/ff-preview/src/scene/mod.rs
@@ -43,6 +43,7 @@ use crate::playback::master_clock::MasterClock;
 use crate::playback::player_handle::PlayerHandle;
 
 pub use compositor::PreviewCompositor;
+pub use inner::apply_xfade;
 pub use runner::SceneRunner;
 pub use types::{
     Scene, SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneSource, SceneVideoTrack,

--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -80,10 +80,10 @@ pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, ColorWheelsNode,
-    CrossfadeNode, CurvesNode, DipToColorNode, DissolveTransitionNode, FilmGrainNode,
-    GaussianBlurNode, GlowNode, HslNode, LumaMaskNode, LutNode, MotionBlurNode, OverlayNode,
-    RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode, SharpenNode, TransformNode,
-    VignetteNode, WipeTransitionNode, YuvFormat, YuvUploadNode,
+    CrossfadeNode, CurvesNode, DipToColorNode, DissolveTransitionNode, FadeTransitionNode,
+    FilmGrainNode, GaussianBlurNode, GlowNode, HslNode, LumaMaskNode, LutNode, MotionBlurNode,
+    OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode, SharpenNode,
+    TransformNode, VignetteNode, WipeTransitionNode, YuvFormat, YuvUploadNode,
 };
 pub use sink::GpuFrameSink;
 

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -29,7 +29,9 @@ pub use hsl::HslNode;
 pub use lut::LutNode;
 pub use overlay::OverlayNode;
 pub use scale::{ScaleAlgorithm, ScaleNode};
-pub use transition::{DipToColorNode, DissolveTransitionNode, WipeTransitionNode};
+pub use transition::{
+    DipToColorNode, DissolveTransitionNode, FadeTransitionNode, WipeTransitionNode,
+};
 pub use upload::{YuvFormat, YuvUploadNode};
 pub use vignette::VignetteNode;
 

--- a/crates/ff-render/src/nodes/transition.rs
+++ b/crates/ff-render/src/nodes/transition.rs
@@ -1,5 +1,5 @@
-//! Two-clip transition nodes: a directional wipe, a linear dissolve, and a two-phase
-//! dip to a solid colour. Like [`CrossfadeNode`](super::crossfade::CrossfadeNode), the second clip
+//! Two-clip transition nodes: a directional wipe, a linear fade, a per-pixel dissolve,
+//! and a two-phase dip to a solid colour. Like [`CrossfadeNode`](super::crossfade::CrossfadeNode), the second clip
 //! (B) is carried as RGBA bytes in the node and uploaded to a GPU texture at render
 //! time: a single render graph has one source, so B cannot arrive as a second GPU
 //! input. Clip A is the node's input (`inputs[0]` / the `process_cpu` argument).
@@ -22,15 +22,23 @@ fn smoothstep(e0: f32, e1: f32, x: f32) -> f32 {
 
 /// Directional wipe that reveals clip B behind a moving edge.
 ///
-/// `progress = 0` outputs clip A, `progress = 1` outputs clip B, and the edge sweeps
-/// across the frame between them along `angle` (radians: `0` = left→right,
-/// `π/2` = top→bottom). `softness` feathers the edge (normalised units).
+/// `progress = 0` outputs clip A, `progress = 1` outputs clip B, and an edge sweeps
+/// across the frame between them. `angle` (radians) points along the axis clip B
+/// **grows from**, because the mask fills where the projection
+/// exceeds the sweeping threshold: at `angle = 0` clip B enters from the **right** and
+/// the edge travels right-to-left; at `angle = π/2` it enters from the **bottom**.
+///
+/// That is the opposite of how `FFmpeg` names its `xfade` wipes — `wiperight` sweeps its
+/// edge rightward, so clip B enters from the left and maps to `angle = π` (RK-020).
+///
+/// `softness` feathers the edge (normalised units).
 pub struct WipeTransitionNode {
     /// Transition progress `[0, 1]`: 0 = clip A, 1 = clip B.
     pub progress: f32,
     /// Edge feather half-width in normalised units (0 = hard edge).
     pub softness: f32,
-    /// Wipe direction in radians (0 = left→right, `π/2` = top→bottom).
+    /// Axis clip B grows from, in radians: `0` = from the right, `π/2` = from the
+    /// bottom. See the type docs — this is the opposite of the `FFmpeg` wipe names.
     pub angle: f32,
     /// Clip B as RGBA bytes (`to_width × to_height × 4`).
     pub to_rgba: Vec<u8>,
@@ -67,6 +75,9 @@ impl WipeTransitionNode {
 
     /// The B-weight (`mask`) at a normalised pixel centre. Shared by the CPU and GPU
     /// paths (`wipe.wgsl` uses the identical formula) so they agree.
+    ///
+    /// Clip B occupies the side where `proj` exceeds `center`, and `center` sweeps down
+    /// as `progress` rises — so B fills in from the **high** end of the projected axis.
     fn mask_at(&self, uv_x: f32, uv_y: f32) -> f32 {
         let (ax, ay) = (self.angle.cos(), self.angle.sin());
         let reach = f32::midpoint(ax.abs(), ay.abs());
@@ -106,9 +117,13 @@ impl RenderNodeCpu for WipeTransitionNode {
     }
 }
 
-// DissolveTransitionNode
+// FadeTransitionNode
 
-/// Linear dissolve: clip A mixed into clip B by `progress`.
+/// Linear cross-blend: clip A mixed into clip B by `progress`.
+///
+/// This is `FFmpeg`'s `xfade=transition=fade`, not its `dissolve` — `dissolve` reveals
+/// clip B one pixel at a time and never produces a mixed value (see
+/// [`DissolveTransitionNode`]).
 ///
 /// `progress = 0` outputs clip A, `progress = 1` outputs clip B, and every value
 /// between is the per-channel mix of the two (alpha included, as the sibling
@@ -120,6 +135,82 @@ impl RenderNodeCpu for WipeTransitionNode {
 /// is therefore the same operation as [`CrossfadeNode`](super::crossfade::CrossfadeNode),
 /// exposed with the `progress` / `to_rgba` shape the rest of this module uses so a
 /// transition set can be mapped uniformly.
+///
+/// Like its siblings this node renders to an `Rgba8Unorm` target (the shared
+/// `build_pipeline` hard-codes that format), so it does not run in an `Rgba16Float`
+/// graph.
+pub struct FadeTransitionNode {
+    /// Transition progress `[0, 1]`: 0 = clip A, 1 = clip B.
+    pub progress: f32,
+    /// Clip B as RGBA bytes (`to_width × to_height × 4`).
+    pub to_rgba: Vec<u8>,
+    /// Width of `to_rgba`.
+    pub to_width: u32,
+    /// Height of `to_rgba`.
+    pub to_height: u32,
+    #[cfg(feature = "wgpu")]
+    pipeline: std::sync::OnceLock<TransitionPipeline>,
+}
+
+impl FadeTransitionNode {
+    /// Creates a fade from clip A (the node input) to clip B (`to_rgba`).
+    #[must_use]
+    pub fn new(progress: f32, to_rgba: Vec<u8>, to_width: u32, to_height: u32) -> Self {
+        Self {
+            progress,
+            to_rgba,
+            to_width,
+            to_height,
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+}
+
+impl RenderNodeCpu for FadeTransitionNode {
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        if self.to_rgba.len() != rgba.len() {
+            log::warn!(
+                "FadeTransitionNode::process_cpu skipped: size mismatch a={} b={}",
+                rgba.len(),
+                self.to_rgba.len()
+            );
+            return;
+        }
+        for (a, b) in rgba.iter_mut().zip(self.to_rgba.iter()) {
+            *a = lerp_u8(f32::from(*a), f32::from(*b), self.progress);
+        }
+    }
+}
+
+// DissolveTransitionNode
+
+/// A deterministic per-pixel hash in `[0.0, 1.0)`.
+///
+/// Kept bit-identical to `ff-preview`'s host-side `hash01` and to `dissolve.wgsl`, so
+/// the CPU fallback, the GPU node and the preview's own transition all reveal the same
+/// pixels. A different hash would reveal the same *proportion* of clip B while choosing
+/// a different *set* of pixels, which a ratio check cannot detect.
+fn hash01(x: u32, y: u32) -> f32 {
+    let mut h = x
+        .wrapping_mul(374_761_393)
+        .wrapping_add(y.wrapping_mul(668_265_263));
+    h = (h ^ (h >> 13)).wrapping_mul(1_274_126_177);
+    h ^= h >> 16;
+    // Top 24 bits over 2^24: max = (2^24 - 1) / 2^24 = 1 - 2^-24, exactly representable
+    // in f32 and strictly < 1.0, so `progress > hash01` reveals every pixel at
+    // progress 1 and none at progress 0.
+    #[allow(clippy::cast_precision_loss)] // 24 bits fit f32's mantissa exactly
+    {
+        (h >> 8) as f32 / (1u32 << 24) as f32
+    }
+}
+
+/// Per-pixel dissolve: clip B is revealed one pixel at a time as `progress` rises.
+///
+/// This is `FFmpeg`'s `xfade=transition=dissolve`. Unlike
+/// [`FadeTransitionNode`] every output pixel is *fully* clip A or *fully* clip B — at
+/// 50% the frame holds only the two source values and no mixture of them.
 ///
 /// Like its siblings this node renders to an `Rgba8Unorm` target (the shared
 /// `build_pipeline` hard-codes that format), so it does not run in an `Rgba16Float`
@@ -153,7 +244,7 @@ impl DissolveTransitionNode {
 }
 
 impl RenderNodeCpu for DissolveTransitionNode {
-    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
         if self.to_rgba.len() != rgba.len() {
             log::warn!(
                 "DissolveTransitionNode::process_cpu skipped: size mismatch a={} b={}",
@@ -162,8 +253,13 @@ impl RenderNodeCpu for DissolveTransitionNode {
             );
             return;
         }
-        for (a, b) in rgba.iter_mut().zip(self.to_rgba.iter()) {
-            *a = lerp_u8(f32::from(*a), f32::from(*b), self.progress);
+        for y in 0..h {
+            for x in 0..w {
+                if self.progress > hash01(x, y) {
+                    let i = ((y * w + x) * 4) as usize;
+                    rgba[i..i + 4].copy_from_slice(&self.to_rgba[i..i + 4]);
+                }
+            }
         }
     }
 }
@@ -512,6 +608,46 @@ impl super::RenderNode for WipeTransitionNode {
 }
 
 #[cfg(feature = "wgpu")]
+impl super::RenderNode for FadeTransitionNode {
+    fn input_count(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &self,
+        inputs: &[&wgpu::Texture],
+        outputs: &[&wgpu::Texture],
+        ctx: &crate::context::RenderContext,
+    ) {
+        let Some(tex_a) = inputs.first() else {
+            log::warn!("FadeTransitionNode::process called with no inputs");
+            return;
+        };
+        let Some(output) = outputs.first() else {
+            log::warn!("FadeTransitionNode::process called with no outputs");
+            return;
+        };
+        // `crossfade.wgsl` is this node's shader: same binding layout as the other
+        // transitions, and its one `f32` uniform is `progress` (see the type docs).
+        let pd = self.pipeline.get_or_init(|| {
+            build_pipeline(
+                &ctx.device,
+                include_str!("../shaders/crossfade.wgsl"),
+                "Dissolve",
+                16,
+            )
+        });
+        ctx.queue.write_buffer(
+            &pd.uniform_buf,
+            0,
+            &pack_f32(&[self.progress, 0.0, 0.0, 0.0]),
+        );
+        let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
+        run_pass(ctx, pd, tex_a, &to_tex, output, "Dissolve pass");
+    }
+}
+
+#[cfg(feature = "wgpu")]
 impl super::RenderNode for DissolveTransitionNode {
     fn input_count(&self) -> usize {
         2
@@ -531,12 +667,10 @@ impl super::RenderNode for DissolveTransitionNode {
             log::warn!("DissolveTransitionNode::process called with no outputs");
             return;
         };
-        // `crossfade.wgsl` is this node's shader: same binding layout as the other
-        // transitions, and its one `f32` uniform is `progress` (see the type docs).
         let pd = self.pipeline.get_or_init(|| {
             build_pipeline(
                 &ctx.device,
-                include_str!("../shaders/crossfade.wgsl"),
+                include_str!("../shaders/dissolve.wgsl"),
                 "Dissolve",
                 16,
             )
@@ -651,34 +785,34 @@ mod tests {
     /// Clip A and clip B of the dissolve tests: every channel differs between the two
     /// and no channel repeats within a frame, so a swapped pair, a dropped channel or a
     /// transposed one all show up in the assertions below.
-    const DISSOLVE_A: [u8; 4] = [10, 200, 30, 255];
-    const DISSOLVE_B: [u8; 4] = [210, 40, 130, 55];
+    const FADE_A: [u8; 4] = [10, 200, 30, 255];
+    const FADE_B: [u8; 4] = [210, 40, 130, 55];
 
     #[test]
-    fn dissolve_progress_zero_should_be_clip_a() {
-        let node = DissolveTransitionNode::new(0.0, DISSOLVE_B.to_vec(), 1, 1);
-        let mut rgba = DISSOLVE_A.to_vec();
+    fn fade_transition_progress_zero_should_be_clip_a() {
+        let node = FadeTransitionNode::new(0.0, FADE_B.to_vec(), 1, 1);
+        let mut rgba = FADE_A.to_vec();
         node.process_cpu(&mut rgba, 1, 1);
-        assert_eq!(rgba, DISSOLVE_A, "progress=0 must output clip A");
+        assert_eq!(rgba, FADE_A, "progress=0 must output clip A");
     }
 
     #[test]
-    fn dissolve_progress_one_should_be_clip_b() {
-        let node = DissolveTransitionNode::new(1.0, DISSOLVE_B.to_vec(), 1, 1);
-        let mut rgba = DISSOLVE_A.to_vec();
+    fn fade_transition_progress_one_should_be_clip_b() {
+        let node = FadeTransitionNode::new(1.0, FADE_B.to_vec(), 1, 1);
+        let mut rgba = FADE_A.to_vec();
         node.process_cpu(&mut rgba, 1, 1);
-        assert_eq!(rgba, DISSOLVE_B, "progress=1 must output clip B");
+        assert_eq!(rgba, FADE_B, "progress=1 must output clip B");
     }
 
     #[test]
-    fn dissolve_half_should_average_the_pair() {
+    fn fade_transition_half_should_average_the_pair() {
         // The acceptance criterion. On its own it cannot tell A from B (the mix is
         // symmetric at 0.5); the endpoint tests above are what pin the direction.
-        let node = DissolveTransitionNode::new(0.5, DISSOLVE_B.to_vec(), 1, 1);
-        let mut rgba = DISSOLVE_A.to_vec();
+        let node = FadeTransitionNode::new(0.5, FADE_B.to_vec(), 1, 1);
+        let mut rgba = FADE_A.to_vec();
         node.process_cpu(&mut rgba, 1, 1);
         for (c, got) in rgba.iter().enumerate() {
-            let want = f32::midpoint(f32::from(DISSOLVE_A[c]), f32::from(DISSOLVE_B[c]));
+            let want = f32::midpoint(f32::from(FADE_A[c]), f32::from(FADE_B[c]));
             assert!(
                 (f32::from(*got) - want).abs() <= 1.0,
                 "channel {c}: got {got} want {want}"
@@ -687,9 +821,71 @@ mod tests {
     }
 
     #[test]
+    fn fade_transition_size_mismatch_should_leave_rgba_unchanged() {
+        let node = FadeTransitionNode::new(0.5, vec![200u8; 8], 2, 1); // 2 px of B
+        let original = FADE_A.to_vec(); // 1 px of A
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, original, "size mismatch must be a no-op");
+    }
+
+    #[test]
+    fn dissolve_progress_zero_should_be_clip_a() {
+        // `progress > hash01` and `hash01 >= 0`, so nothing is revealed at 0.
+        let node = DissolveTransitionNode::new(0.0, vec![210u8, 40, 130, 55], 1, 1);
+        let a = vec![10u8, 200, 30, 255];
+        let mut rgba = a.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, a, "progress=0 must output clip A");
+    }
+
+    #[test]
+    fn dissolve_progress_one_should_be_clip_b() {
+        // `hash01` is strictly < 1, so every pixel is revealed at 1.
+        let b = vec![210u8, 40, 130, 55];
+        let node = DissolveTransitionNode::new(1.0, b.clone(), 1, 1);
+        let mut rgba = vec![10u8, 200, 30, 255];
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, b, "progress=1 must output clip B");
+    }
+
+    #[test]
+    fn dissolve_half_should_threshold_pixels_not_blend_them() {
+        // The property that separates this node from `FadeTransitionNode`: at 50% every
+        // pixel is still fully one clip or the other, and roughly half have flipped.
+        let (w, h) = (32u32, 32u32);
+        let n = (w * h) as usize;
+        let a: Vec<u8> = [0u8, 0, 0, 255].repeat(n);
+        let b: Vec<u8> = [255u8, 255, 255, 255].repeat(n);
+        let node = DissolveTransitionNode::new(0.5, b, w, h);
+        let mut rgba = a.clone();
+        node.process_cpu(&mut rgba, w, h);
+
+        let mut distinct: Vec<u8> = rgba.as_chunks::<4>().0.iter().map(|px| px[0]).collect();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(
+            distinct,
+            vec![0, 255],
+            "a dissolve must never produce a mixed value; got {distinct:?}"
+        );
+        let revealed = rgba
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .filter(|px| px[0] == 255)
+            .count();
+        let ratio = revealed as f64 / n as f64;
+        assert!(
+            (0.35..=0.65).contains(&ratio),
+            "progress=0.5 should reveal about half of clip B, got {ratio:.3}"
+        );
+    }
+
+    #[test]
     fn dissolve_size_mismatch_should_leave_rgba_unchanged() {
-        let node = DissolveTransitionNode::new(0.5, vec![200u8; 8], 2, 1); // 2 px of B
-        let original = DISSOLVE_A.to_vec(); // 1 px of A
+        let node = DissolveTransitionNode::new(1.0, vec![200u8; 8], 2, 1);
+        let original = vec![10u8, 200, 30, 255];
         let mut rgba = original.clone();
         node.process_cpu(&mut rgba, 1, 1);
         assert_eq!(rgba, original, "size mismatch must be a no-op");

--- a/crates/ff-render/src/shaders/dissolve.wgsl
+++ b/crates/ff-render/src/shaders/dissolve.wgsl
@@ -1,0 +1,66 @@
+// Per-pixel dissolve: reveal clip B where a deterministic per-pixel hash falls below
+// the transition progress. Unlike a cross-blend every output pixel is fully clip A or
+// fully clip B, so at 50% the frame holds only the two source values and no mixture.
+//
+// The hash must match `ff-preview`'s host-side `hash01` bit for bit: the two render the
+// same transition on the CPU and GPU paths, and a different hash would reveal a
+// different *set* of pixels while still revealing the same *proportion* — a divergence
+// a ratio check cannot see. WGSL `u32` arithmetic wraps, matching Rust's `wrapping_*`.
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+// ── Bindings ──────────────────────────────────────────────────────────────────
+
+@group(0) @binding(0) var tex_a: texture_2d<f32>;
+@group(0) @binding(1) var tex_b: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+@group(0) @binding(3) var<uniform> u: DissolveUniforms;
+
+struct DissolveUniforms {
+    progress: f32,
+    _pad0:    f32,
+    _pad1:    f32,
+    _pad2:    f32,
+}
+
+// ── Fragment ──────────────────────────────────────────────────────────────────
+
+/// The same deterministic per-pixel hash in `[0, 1)` the CPU path uses.
+fn hash01(x: u32, y: u32) -> f32 {
+    var h: u32 = x * 374761393u + y * 668265263u;
+    h = (h ^ (h >> 13u)) * 1274126177u;
+    h = h ^ (h >> 16u);
+    // Top 24 bits over 2^24: max = 1 - 2^-24, so `progress > hash01` reveals every
+    // pixel at progress 1 and none at progress 0.
+    return f32(h >> 8u) / 16777216.0;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Integer pixel coordinates, so the hash is keyed the same way as the CPU loop's
+    // `(x, y)` rather than by a float UV that would round differently.
+    let dims = vec2<f32>(textureDimensions(tex_a));
+    let px = vec2<u32>(floor(in.uv * dims));
+    if u.progress > hash01(px.x, px.y) {
+        return textureSample(tex_b, samp, in.uv);
+    }
+    return textureSample(tex_a, samp, in.uv);
+}

--- a/crates/ff-render/tests/gpu_nodes.rs
+++ b/crates/ff-render/tests/gpu_nodes.rs
@@ -16,8 +16,9 @@ use std::sync::Arc;
 
 use ff_render::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,
-    DissolveTransitionNode, LumaMaskNode, OverlayNode, RenderContext, RenderGraph, RenderNode,
-    ScaleAlgorithm, ScaleNode, ShapeMaskNode, TransformNode, YuvFormat, YuvUploadNode,
+    DissolveTransitionNode, FadeTransitionNode, LumaMaskNode, OverlayNode, RenderContext,
+    RenderGraph, RenderNode, ScaleAlgorithm, ScaleNode, ShapeMaskNode, TransformNode, YuvFormat,
+    YuvUploadNode,
 };
 
 // Helpers
@@ -179,13 +180,13 @@ fn crossfade_gpu_half_factor_should_average_inputs() {
     );
 }
 
-// DissolveTransitionNode
+// FadeTransitionNode
 
-/// Clip A and clip B for the dissolve test. Every channel differs between the two and
+/// Clip A and clip B for the transition tests. Every channel differs between the two and
 /// none repeats within a frame, so a swapped pair, a dropped channel or a transposed one
 /// all show up. Mirrors the constants the CPU tests in `nodes/transition.rs` use.
-const DISSOLVE_A: [u8; 4] = [10, 200, 30, 255];
-const DISSOLVE_B: [u8; 4] = [210, 40, 130, 55];
+const FADE_A: [u8; 4] = [10, 200, 30, 255];
+const FADE_B: [u8; 4] = [210, 40, 130, 55];
 
 /// A 2x2 frame filled with one tagged colour.
 fn tagged(px: [u8; 4]) -> Vec<u8> {
@@ -193,13 +194,13 @@ fn tagged(px: [u8; 4]) -> Vec<u8> {
 }
 
 #[test]
-fn dissolve_gpu_half_progress_should_average_inputs() {
+fn fade_transition_gpu_half_progress_should_average_inputs() {
     let Some(ctx) = gpu_ctx() else { return };
-    let a = tagged(DISSOLVE_A);
-    let b = tagged(DISSOLVE_B);
-    let out = run_gpu(&ctx, DissolveTransitionNode::new(0.5, b, 2, 2), &a, 2, 2);
+    let a = tagged(FADE_A);
+    let b = tagged(FADE_B);
+    let out = run_gpu(&ctx, FadeTransitionNode::new(0.5, b, 2, 2), &a, 2, 2);
     for c in 0..4 {
-        let want = u8::midpoint(DISSOLVE_A[c], DISSOLVE_B[c]);
+        let want = u8::midpoint(FADE_A[c], FADE_B[c]);
         assert!(
             close(out[c], want, 8),
             "channel {c}: progress=0.5 must blend to ~{want}; got {}",
@@ -209,32 +210,89 @@ fn dissolve_gpu_half_progress_should_average_inputs() {
 }
 
 #[test]
-fn dissolve_gpu_progress_endpoints_should_be_each_clip() {
+fn fade_transition_gpu_progress_endpoints_should_be_each_clip() {
     // The 0.5 blend above is symmetric, so it cannot tell clip A from clip B. These
     // endpoints are what pin the direction on the GPU path.
     let Some(ctx) = gpu_ctx() else { return };
-    let a = tagged(DISSOLVE_A);
-    let b = tagged(DISSOLVE_B);
+    let a = tagged(FADE_A);
+    let b = tagged(FADE_B);
     let at_zero = run_gpu(
         &ctx,
-        DissolveTransitionNode::new(0.0, b.clone(), 2, 2),
+        FadeTransitionNode::new(0.0, b.clone(), 2, 2),
         &a,
         2,
         2,
     );
-    let at_one = run_gpu(&ctx, DissolveTransitionNode::new(1.0, b, 2, 2), &a, 2, 2);
+    let at_one = run_gpu(&ctx, FadeTransitionNode::new(1.0, b, 2, 2), &a, 2, 2);
     for c in 0..4 {
         assert!(
-            close(at_zero[c], DISSOLVE_A[c], 2),
+            close(at_zero[c], FADE_A[c], 2),
             "channel {c}: progress=0 must be clip A; got {}",
             at_zero[c]
         );
         assert!(
-            close(at_one[c], DISSOLVE_B[c], 2),
+            close(at_one[c], FADE_B[c], 2),
             "channel {c}: progress=1 must be clip B; got {}",
             at_one[c]
         );
     }
+}
+
+// DissolveTransitionNode
+
+#[test]
+fn dissolve_gpu_half_progress_should_threshold_pixels_not_blend_them() {
+    // The property that separates a dissolve from a fade, asserted on the GPU path in
+    // its own right (this file states independent expectations, not GPU-vs-CPU parity;
+    // the pixel-for-pixel agreement between the two hashes is checked by avio's
+    // transition parity suite). Black into white makes a mixed value unmistakable.
+    let Some(ctx) = gpu_ctx() else { return };
+    let (w, h) = (32u32, 32u32);
+    let a = solid_rgba(0, 0, 0, 255, w, h);
+    let b = solid_rgba(255, 255, 255, 255, w, h);
+    let out = run_gpu(&ctx, DissolveTransitionNode::new(0.5, b, w, h), &a, w, h);
+
+    let reds: Vec<u8> = out.chunks_exact(4).map(|px| px[0]).collect();
+    let mixed = reds.iter().filter(|v| (8..=247).contains(*v)).count();
+    let revealed = reds.iter().filter(|v| **v > 247).count();
+    println!(
+        "dissolve GPU @50%: revealed={revealed}/{} mixed={mixed}",
+        reds.len()
+    );
+    assert_eq!(
+        mixed, 0,
+        "a dissolve must never produce a mixed value; {mixed} pixels were between"
+    );
+    let ratio = revealed as f64 / reds.len() as f64;
+    assert!(
+        (0.35..=0.65).contains(&ratio),
+        "progress=0.5 should reveal about half of clip B, got {ratio:.3}"
+    );
+}
+
+#[test]
+fn dissolve_gpu_progress_endpoints_should_be_each_clip() {
+    // The 50% case above says nothing about direction; these pin it.
+    let Some(ctx) = gpu_ctx() else { return };
+    let (w, h) = (16u32, 16u32);
+    let a = solid_rgba(0, 0, 0, 255, w, h);
+    let b = solid_rgba(255, 255, 255, 255, w, h);
+    let at_zero = run_gpu(
+        &ctx,
+        DissolveTransitionNode::new(0.0, b.clone(), w, h),
+        &a,
+        w,
+        h,
+    );
+    let at_one = run_gpu(&ctx, DissolveTransitionNode::new(1.0, b, w, h), &a, w, h);
+    assert!(
+        at_zero.chunks_exact(4).all(|px| px[0] < 8),
+        "progress=0 must be entirely clip A"
+    );
+    assert!(
+        at_one.chunks_exact(4).all(|px| px[0] > 247),
+        "progress=1 must be entirely clip B"
+    );
 }
 
 // BlendModeNode


### PR DESCRIPTION
## Objective

- The model already carried dissolve and the four wipes; only dip-to-colour was missing, and nothing connected any of them to `ff-render` — `classify_step` has no `XFade` arm and `eligible_track` rejects `clip.transition.is_some()` outright.
- #1720 measured that FFmpeg's `dissolve` is a per-pixel threshold and its `fade` is the linear blend, which means the node #1668 added under the name `DissolveTransitionNode` is in fact a `fade`. Mapping the model onto the node set needs those names to line up first.

## Solution

- Add `FadeBlack` / `FadeWhite` to `XfadeTransition`. Both are real `xfade` tokens, so the enum stays C-like and its `as_str` stays the token — which paid off immediately: the compiler caught that `FfmpegToken` has a second exhaustive match over the same enum.
- Rename `DissolveTransitionNode` to `FadeTransitionNode` (it is the linear cross-blend) and add a real `DissolveTransitionNode` doing the per-pixel threshold. Its hash is kept bit-identical to `ff-preview`'s host-side `hash01` and to the new `dissolve.wgsl`, so the CPU and GPU dissolves reveal the same pixels rather than merely the same *proportion* of them.
- Add `avio::map_transition`. `XfadeTransition` is `#[non_exhaustive]` and lives in another crate, so the match needs a catch-all and the compiler cannot report a newly added kind; a pair of tables in the tests stands in for that guard. Slides and the geometric kinds map to `None`, which is how a caller knows to stay on the CPU.
- Compare each mapped kind against `ff_preview::apply_xfade` (now public for exactly that purpose) at progress 0, 0.5 and 1. All eight kinds match at **mean 0.000, max 0** — for `dissolve` that is what proves the WGSL and Rust hashes agree, since a different hash would reveal the same proportion of clip B while choosing a different set of pixels.

The parity suite earned its keep on the first run: the wipes came out mirrored at mean 127.5. `WipeTransitionNode` fills from the high end of the projected axis, so `angle = 0` reveals clip B from the right while FFmpeg's `wiperight` reveals it from the left. The node's own doc claimed the opposite and is corrected here.

**Not closing #1657.** Its criteria name the mapping "(preview + export)", and the runner does not yet *call* any of this: the preview applies transitions upstream of compositing and `ff-preview` cannot depend on `ff-render`, so the seam needs a new injection trait. That is #1726, filed with the two findings that shape it. Closing is yours to make once that lands.

The two failing macOS checks are unrelated to this branch: the runner's FFmpeg was bumped to a version without `AVCodec::sample_fmts`, which breaks `ff-encode` on `main` as well. Tracked as #1728.

Refs #1657