### PR TITLE
fix(ci): pin the macOS FFmpeg so an upstream major bump stops breaking every PR

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,8 +56,16 @@ version-specific tokens are gated behind an `ffmpeg8` cfg in `ff-sys`.
 | Platform | Command |
 |---|---|
 | Ubuntu / Debian | `sudo apt install libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libswscale-dev libswresample-dev pkg-config` |
-| macOS | `brew install ffmpeg pkg-config` |
+| macOS | `brew install ffmpeg@8 pkg-config` (see the note below) |
 | Windows | Install via [vcpkg](https://github.com/microsoft/vcpkg): `vcpkg install ffmpeg:x64-windows` |
+
+On macOS, install the **versioned** formula: Homebrew's plain `ffmpeg` is 9.x, which is
+outside the supported range and fails to build (`no field 'sample_fmts' on type 'AVCodec'`).
+`ffmpeg@8` is keg-only, so point the build at its keg — the same thing CI does:
+
+```sh
+export HOMEBREW_PREFIX="$(brew --prefix ffmpeg@8)"
+```
 
 Verify: `ffmpeg -version` (must show `7.x` or `8.x`)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,33 @@ jobs:
         if: runner.os == 'Linux'
         uses: ./.github/actions/setup-ffmpeg
 
+      # Pinned (#1728). Homebrew's `ffmpeg` moved to 9.x, which drops the deprecated
+      # AVCodec arrays ff-encode reads, and broke every PR overnight. The README
+      # supports 7.x and 8.x, so Linux stays on the pinned 7.1 source build and macOS
+      # covers 8.x. Pinned to the *major*: ffmpeg@8 tracks 8.x rather than an exact
+      # version like the Linux leg's 7.1, because FFmpeg does not remove API within a
+      # major and this leg should still catch real 8.x breakage.
+      #
+      # ffmpeg@8 is keg-only, so ff-sys/build.rs has to be pointed at its keg:
+      # configure_macos() calls try_homebrew() *before* the pkg-config fallback, so
+      # PKG_CONFIG_PATH alone would let whatever `ffmpeg` the image has linked win over
+      # the pin. The prefix goes to a step output rather than $GITHUB_ENV so it reaches
+      # only the cargo step -- HOMEBREW_PREFIX otherwise names the Homebrew root, and
+      # the other steps (rust-cache, install-action) must keep seeing the real one.
       - name: Install FFmpeg (macOS)
+        id: ffmpeg
         if: runner.os == 'macOS'
-        run: brew install ffmpeg pkg-config
+        run: |
+          brew install ffmpeg@8 pkg-config
+          echo "prefix=$(brew --prefix ffmpeg@8)" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # Empty on Linux, where the step above is skipped. Harmless: HOMEBREW_PREFIX is
+      # only read by configure_macos(), which never runs there.
       - run: cargo test --all --all-features
+        env:
+          HOMEBREW_PREFIX: ${{ steps.ffmpeg.outputs.prefix }}
 
   # --------------------------------------------------------------------------
   # Windows (MSVC) compile check. FFmpeg is deliberately NOT installed here:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,9 +37,13 @@ jobs:
       - uses: actions/checkout@v7.0.1
 
       # Full FFmpeg (all filters), matching the macOS test leg in ci.yml, so
-      # filter/integration tests actually run under instrumentation.
+      # filter/integration tests actually run under instrumentation. Pinned to the
+      # same formula for the same reason (#1728); see the note in ci.yml.
       - name: Install FFmpeg (macOS)
-        run: brew install ffmpeg pkg-config
+        id: ffmpeg
+        run: |
+          brew install ffmpeg@8 pkg-config
+          echo "prefix=$(brew --prefix ffmpeg@8)" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -54,6 +58,10 @@ jobs:
       # Same coverage surface as the test job (`--all --all-features`).
       - name: Collect coverage
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+        env:
+          # Scoped to this step, not $GITHUB_ENV: only ff-sys/build.rs wants it, and
+          # taiki-e/install-action above must keep seeing the real Homebrew root.
+          HOMEBREW_PREFIX: ${{ steps.ffmpeg.outputs.prefix }}
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
## Objective

- Homebrew's `ffmpeg` moved to 9.0.1, and FFmpeg 9 drops the deprecated `AVCodec` array members `ff-encode` reads. Every branch's macOS legs started failing to compile overnight, on code none of them had touched (`no field 'sample_fmts' on type 'AVCodec'`).
- The README supports 7.x and 8.x, so CI had silently moved to an **unsupported major**. Linux never drifts because `setup-ffmpeg` builds a pinned 7.1 from source with a sha256 check; macOS just ran `brew install ffmpeg`.

## Solution

- Pin the macOS legs to `ffmpeg@8`. No code change is needed: local FFmpeg 8.0 and upstream `n8.1` both still declare `sample_fmts` (deprecated, present), and Homebrew's `ffmpeg@8` is 8.1.2 — checked rather than assumed. This also leaves one CI leg per major the project promises; before this, 8.x was not built anywhere.
- Pin to the *major*, not an exact version like the Linux leg's 7.1: FFmpeg does not remove API within a major, and this leg should still catch real 8.x breakage.
- `ffmpeg@8` is keg-only, so `ff-sys/build.rs` has to be pointed at its keg. `configure_macos` calls `try_homebrew` **before** the pkg-config fallback, so setting only `PKG_CONFIG_PATH` would let whatever `ffmpeg` the runner image has linked win over the pin. The prefix goes to a step output rather than `$GITHUB_ENV` so it reaches only the cargo step — `HOMEBREW_PREFIX` otherwise names the Homebrew root, and `rust-cache` / `install-action` must keep seeing the real one.
- `CONTRIBUTING.md` pointed macOS contributors at the same unpinned formula, which now walks them straight into the error CI just hit, so it gets the same treatment.

This is CI-only and macOS-only, so it cannot be verified locally — **this PR's CI run is the test**. The pass condition is both macOS jobs green *and* the Linux jobs unchanged. What was checkable here: both workflows parse, no step still writes `HOMEBREW_PREFIX` into `$GITHUB_ENV`, and the Linux legs are untouched by the diff.

FFmpeg 9 itself remains unsupported — supporting it needs a survey of everything else 9 removes, the `avcodec_get_supported_config` migration, a CI leg that builds 9, and a README range change. That is #1729.

Fixes #1728