### PR TITLE
fix(ff-preview,ff-render): match FFmpeg's xfade so the preview stops lying about the export

### DIFF
--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -42,13 +42,14 @@ use std::time::Duration;
 
 use ff_format::VideoFrame;
 use ff_render::{
-    ChromaKeyNode, ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, FadeTransitionNode,
-    FilmGrainNode, FrameLayer, GaussianBlurNode, GlowNode, HslNode, LayerTransform, LumaMaskNode,
-    LutNode, MotionBlurNode, RenderContext, RenderGraph, ScaleNode, ShapeMaskNode, SharpenNode,
-    VignetteNode,
+    ChromaKeyNode, ColorGradeNode, ColorWheelsNode, Compositor, CurvesNode, DipToColorNode,
+    DissolveTransitionNode, FadeTransitionNode, FilmGrainNode, FrameLayer, GaussianBlurNode,
+    GlowNode, HslNode, LayerTransform, LumaMaskNode, LutNode, MotionBlurNode, RenderContext,
+    RenderGraph, ScaleNode, ShapeMaskNode, SharpenNode, VignetteNode, WipeTransitionNode,
 };
 
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuLayerSource, GpuMapping, map_scene};
+use crate::gpu_transition::GpuTransition;
 
 /// A per-layer effect [`RenderGraph`] cached across frames so an effected layer does
 /// not recompile its node pipelines every frame (#1634). Keyed by the exact effect
@@ -172,36 +173,53 @@ impl GpuCompositor {
         self.finish(assemble(processed, canvas)?, canvas)
     }
 
-    /// Cross-fades the composited canvas frame `a` into `b` at `progress` (`0` = all
-    /// `a`, `1` = all `b`), returning the blended rgba or `None` on a GPU error.
+    /// Runs `transition` over the composited canvas frames `a` and `b` at `progress`
+    /// (`0` = all `a`, `1` = all `b`), returning the blended rgba or `None` on a GPU
+    /// error.
     ///
     /// Both buffers are already-composited `w` x `h` canvases, so the transition sits
     /// *after* compositing -- matching the CPU route, where `xfade` is the trailing step
     /// of the incoming layer's chain (`composition_inner.rs`).
     ///
-    /// Only a linear cross-fade, because it is the only kind whose GPU node agrees with
-    /// `FFmpeg`'s `xfade` filter. #1657 verified the whole mapped set against
-    /// `ff_preview::apply_xfade`, but the export's reference is `FFmpeg` itself, and
-    /// measured against it only `Fade` lands inside this pipeline's own GPU-vs-CPU noise
-    /// (mean 1.99 against a 1.4 baseline); `Dissolve` picks a different pixel set
-    /// (mean 54) and the dip kinds follow a different curve entirely (mean 78). The
-    /// narrowing itself lives in `gpu_export`'s `export_maps_to_gpu`.
+    /// Every node here reproduces `FFmpeg`'s own formula for its kind (#1732), which is
+    /// what lets the export use them at all: the export replaces `FFmpeg`'s `xfade`, so a
+    /// node that merely looks similar would ship a different picture than the CPU route.
+    /// `gpu_export`'s `export_maps_to_gpu` decides which kinds are allowed through.
     ///
-    /// The node owns clip B's pixels and compiles its pipeline in a per-instance
-    /// `OnceLock`, so each call builds and compiles one -- accepted for v1 since a
-    /// transition is `duration x fps` frames of an offline export (#1659).
-    pub(crate) fn crossfade(
+    /// Each call builds a node, which compiles its pipeline in a per-instance `OnceLock`
+    /// -- accepted for v1 since a transition is `duration x fps` frames of an offline
+    /// export (#1659).
+    pub(crate) fn transition(
         &mut self,
+        transition: GpuTransition,
         progress: f32,
         a: &[u8],
         b: Vec<u8>,
         w: u32,
         h: u32,
     ) -> Option<Vec<u8>> {
-        RenderGraph::new(Arc::clone(&self.ctx))
-            .push(FadeTransitionNode::new(progress, b, w, h))
-            .process_gpu(a, w, h)
-            .ok()
+        let graph = RenderGraph::new(Arc::clone(&self.ctx));
+        let graph = match transition {
+            GpuTransition::Fade => graph.push(FadeTransitionNode::new(progress, b, w, h)),
+            // The mask is built here rather than in the shader: `FFmpeg`'s dissolve noise
+            // outgrows `f32` well before 1080p, so a `WGSL` copy would reveal a different
+            // set of pixels than the CPU reference (`ff_filter::xfade_frand`).
+            GpuTransition::Dissolve => graph.push(DissolveTransitionNode::new(
+                ff_filter::dissolve_mask(w, h, progress),
+                b,
+                w,
+                h,
+            )),
+            // Zero softness: `FFmpeg`'s wipes have a hard edge, and that is also what
+            // switches the node onto its integer-column rule.
+            GpuTransition::Wipe { angle } => {
+                graph.push(WipeTransitionNode::new(progress, 0.0, angle, b, w, h))
+            }
+            GpuTransition::Dip { color } => {
+                graph.push(DipToColorNode::new(progress, color, b, w, h))
+            }
+        };
+        graph.process_gpu(a, w, h).ok()
     }
 
     /// Composites the built `frame_layers` on the (canvas-cached) `Compositor` to rgba.

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -38,7 +38,8 @@ use crate::track::Track;
 
 /// Whether the GPU export renders `kind` itself, or leaves the whole export to the CPU.
 ///
-/// Every kind [`map_transition`] covers, now that each node reproduces `FFmpeg`'s own
+/// Every kind [`map_transition`] covers **except `Dissolve`**, now that each node
+/// reproduces `FFmpeg`'s own
 /// formula rather than an approximation of it (#1732). Worst-frame mean between the two
 /// export routes, as printed by
 /// `gpu_export_tests::gpu_export_should_match_the_cpu_export_for_every_rendered_transition`
@@ -50,10 +51,19 @@ use crate::track::Track;
 /// | `Fade` | 2.0 |
 /// | `WipeLeft` / `WipeRight` / `WipeUp` / `WipeDown` | 2.1 - 2.3 |
 /// | `FadeBlack` / `FadeWhite` | 2.0 - 2.1 |
-/// | `Dissolve` | 3.6 |
 ///
-/// A hard cut's own GPU-vs-CPU floor on the same sources is 1.4, so every kind sits just
-/// above the colour round trip and nowhere near a real divergence.
+/// A hard cut's own GPU-vs-CPU floor on the same sources is 1.4, so every rendered kind
+/// sits just above the colour round trip and nowhere near a real divergence.
+///
+/// **`Dissolve` is excluded, and not because of its formula.** Its selection is
+/// `ff_filter::xfade_frand`, which is `sinf` of an argument large enough that the result
+/// depends on the libm evaluating it. The GPU route builds the mask with **Rust's**
+/// `sinf` while the CPU route runs **`FFmpeg`'s**, and the two agree only where their
+/// libms do: measured worst-frame mean 3.6 between the routes on Windows but 6.6 on
+/// macOS, i.e. a different set of pixels turning over. A viewer toggling force-CPU would
+/// see different noise for the same timeline, so the export declines it rather than
+/// render what the other route would not (RK-020). Nothing else here depends on libm
+/// agreement -- the blends are arithmetic and the wipes are integer comparisons.
 ///
 /// This was `Fade`-only before #1732, when the nodes were pinned to
 /// `ff_preview::apply_xfade` and that reference had itself drifted from `FFmpeg` --
@@ -62,7 +72,7 @@ use crate::track::Track;
 /// a kind that maps to a node but does *not* reproduce `FFmpeg` belongs on the CPU, and
 /// this is where it would be excluded (RK-020).
 fn export_maps_to_gpu(kind: XfadeTransition) -> bool {
-    map_transition(kind).is_some()
+    !matches!(kind, XfadeTransition::Dissolve) && map_transition(kind).is_some()
 }
 
 /// A transition's length in output frames at the timeline rate.
@@ -912,14 +922,13 @@ mod tests {
     }
 
     #[test]
-    fn export_maps_to_gpu_should_accept_every_mapped_kind() {
+    fn export_maps_to_gpu_should_accept_every_libm_independent_kind() {
         // #1732 brought each node onto `FFmpeg`'s own formula, so the export no longer
-        // has to hold anything back: what maps, renders. Before that only `Fade` agreed
-        // with the CPU export, because the nodes were pinned to a reference that had
-        // itself drifted.
+        // holds back the kinds whose agreement is pure arithmetic. Before that only
+        // `Fade` agreed with the CPU export, because the nodes were pinned to a reference
+        // that had itself drifted.
         for kind in [
             XfadeTransition::Fade,
-            XfadeTransition::Dissolve,
             XfadeTransition::WipeLeft,
             XfadeTransition::WipeRight,
             XfadeTransition::WipeUp,
@@ -929,9 +938,26 @@ mod tests {
         ] {
             assert!(
                 export_maps_to_gpu(kind),
-                "{kind:?} maps and must render on the GPU"
+                "{kind:?} agrees with the CPU export and must render on the GPU"
             );
         }
+    }
+
+    #[test]
+    fn export_maps_to_gpu_should_reject_dissolve_despite_it_mapping() {
+        // The one kind that maps to a node and still stays on the CPU. Its selection is
+        // `sinf` of a large argument, so which pixels turn over depends on the libm: the
+        // GPU route uses Rust's and the CPU route FFmpeg's, and they agree on Windows
+        // (worst-frame mean 3.6 between the routes) but not macOS (6.6). Rendering it
+        // would give a viewer different noise depending on the route they took.
+        assert!(
+            map_transition(XfadeTransition::Dissolve).is_some(),
+            "Dissolve still maps to a node -- the preview and the parity suites use it"
+        );
+        assert!(
+            !export_maps_to_gpu(XfadeTransition::Dissolve),
+            "Dissolve must stay on the CPU export"
+        );
     }
 
     #[test]

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -33,29 +33,36 @@ use crate::derive;
 use crate::error::TimelineError;
 use crate::gpu::{GpuEffect, GpuLayerPlan, GpuMapping, map_scene};
 use crate::gpu_compositor::GpuCompositor;
-use crate::gpu_transition::{GpuTransition, map_transition};
+use crate::gpu_transition::map_transition;
 use crate::track::Track;
 
 /// Whether the GPU export renders `kind` itself, or leaves the whole export to the CPU.
 ///
-/// Narrower than [`map_transition`], deliberately. That mapping was verified against
-/// `ff_preview::apply_xfade` (#1657), but the export replaces `FFmpeg`'s own `xfade`
-/// filter, and the two references do not agree everywhere. Measured against the CPU
-/// export on the same window frames, with this pipeline's GPU-vs-CPU noise floor at
-/// mean 1.4 for a hard cut:
+/// Every kind [`map_transition`] covers, now that each node reproduces `FFmpeg`'s own
+/// formula rather than an approximation of it (#1732). Worst-frame mean between the two
+/// export routes, as printed by
+/// `gpu_export_tests::gpu_export_should_match_the_cpu_export_for_every_rendered_transition`
+/// (so the numbers are reproducible from the suite that guards them, not from a
+/// throwaway harness):
 ///
-/// | kind | mean | why |
-/// |---|---|---|
-/// | `Fade` | 1.99 | agrees |
-/// | wipes | 2.5-3.9 | right direction, seam column off by ~1 px |
-/// | `Dissolve` | 54.5 | same proportion of clip B, different PRNG, so a different pixel set |
-/// | `FadeBlack` / `FadeWhite` | ~78 | `FFmpeg` dips through a smoothstep with a 0.2 phase; the node dips linearly |
+/// | kind | mean |
+/// |---|---|
+/// | `Fade` | 2.0 |
+/// | `WipeLeft` / `WipeRight` / `WipeUp` / `WipeDown` | 2.1 - 2.3 |
+/// | `FadeBlack` / `FadeWhite` | 2.0 - 2.1 |
+/// | `Dissolve` | 3.6 |
 ///
-/// So only `Fade` is rendered here; every other kind falls back rather than export
-/// something the model did not ask for (RK-020). Widening this is what fixing the
-/// node-vs-`FFmpeg` divergence unlocks.
+/// A hard cut's own GPU-vs-CPU floor on the same sources is 1.4, so every kind sits just
+/// above the colour round trip and nowhere near a real divergence.
+///
+/// This was `Fade`-only before #1732, when the nodes were pinned to
+/// `ff_preview::apply_xfade` and that reference had itself drifted from `FFmpeg` --
+/// `Dissolve` chose a different set of pixels (mean 54) and the dips followed a
+/// different curve (mean 78). The function stays as the export's explicit policy point:
+/// a kind that maps to a node but does *not* reproduce `FFmpeg` belongs on the CPU, and
+/// this is where it would be excluded (RK-020).
 fn export_maps_to_gpu(kind: XfadeTransition) -> bool {
-    matches!(map_transition(kind), Some(GpuTransition::Fade))
+    map_transition(kind).is_some()
 }
 
 /// A transition's length in output frames at the timeline rate.
@@ -600,12 +607,22 @@ pub(crate) fn drain_video_gpu(
         let inc_layer = transitionless_layer(next, track, canvas);
         core.reset_effect_cache();
 
+        // The node the incoming clip's kind renders as. Resolved once per boundary: it
+        // is a pure function of the kind. `None` here is fine when `window` is 0 -- that
+        // is just a hard cut -- so it is only an error inside the loop below.
+        let node = next.transition.and_then(map_transition);
+
         // The transition window: both clips are composited to the canvas separately and
         // then blended, matching the CPU route where `xfade` is the trailing step of the
         // incoming layer's chain. Progress runs `0 .. (window-1)/window`, so the first
         // output is the outgoing clip untouched and the incoming clip's own frame
         // `window` is the first one shown alone -- the CPU route's mapping, measured.
         for j in 0..window {
+            let Some(node) = node else {
+                return Err(TimelineError::TimelineRenderFailed {
+                    reason: "gpu export: transitioned clip lost its GPU node".to_string(),
+                });
+            };
             let t = output_time(video_idx, frame_rate);
             let Some(outgoing) = cur.next()? else {
                 break; // The outgoing clip ran out early; end the transition with it.
@@ -624,7 +641,7 @@ pub(crate) fn drain_video_gpu(
             #[allow(clippy::cast_precision_loss)] // window frame counts fit the mantissa
             let progress = j as f32 / window as f32;
             let blended = core
-                .crossfade(progress, &a_rgba, b_rgba, w, h)
+                .transition(node, progress, &a_rgba, b_rgba, w, h)
                 .ok_or_else(|| TimelineError::TimelineRenderFailed {
                     reason: format!(
                         "gpu export: the transition blend failed at progress {progress}"
@@ -895,12 +912,13 @@ mod tests {
     }
 
     #[test]
-    fn export_maps_to_gpu_should_accept_only_fade() {
-        // #1657's mapping was verified against `ff_preview::apply_xfade`; the export's
-        // reference is FFmpeg's own `xfade`, and measured against that only `Fade`
-        // agrees. Pin the narrowing so widening it is a deliberate act.
-        assert!(export_maps_to_gpu(XfadeTransition::Fade));
+    fn export_maps_to_gpu_should_accept_every_mapped_kind() {
+        // #1732 brought each node onto `FFmpeg`'s own formula, so the export no longer
+        // has to hold anything back: what maps, renders. Before that only `Fade` agreed
+        // with the CPU export, because the nodes were pinned to a reference that had
+        // itself drifted.
         for kind in [
+            XfadeTransition::Fade,
             XfadeTransition::Dissolve,
             XfadeTransition::WipeLeft,
             XfadeTransition::WipeRight,
@@ -908,13 +926,25 @@ mod tests {
             XfadeTransition::WipeDown,
             XfadeTransition::FadeBlack,
             XfadeTransition::FadeWhite,
-            XfadeTransition::SlideLeft,
-            XfadeTransition::Pixelize,
         ] {
             assert!(
-                !export_maps_to_gpu(kind),
-                "{kind:?} does not match the CPU export and must fall back"
+                export_maps_to_gpu(kind),
+                "{kind:?} maps and must render on the GPU"
             );
+        }
+    }
+
+    #[test]
+    fn export_maps_to_gpu_should_reject_a_kind_with_no_node() {
+        // The other half: a kind with no faithful node still keeps the whole export on
+        // the CPU rather than being approximated by one that merely looks similar.
+        for kind in [
+            XfadeTransition::SlideLeft,
+            XfadeTransition::CircleOpen,
+            XfadeTransition::FadeGrays,
+            XfadeTransition::Pixelize,
+        ] {
+            assert!(!export_maps_to_gpu(kind), "{kind:?} has no GPU node");
         }
     }
 
@@ -978,13 +1008,13 @@ mod tests {
     }
 
     #[test]
-    fn eligible_track_should_reject_a_transition_kind_the_gpu_renders_differently() {
-        // `Dissolve` maps to a GPU node (#1657) but picks a different pixel set than
-        // FFmpeg's (mean 54), so the export keeps it on the CPU.
+    fn eligible_track_should_reject_a_transition_kind_with_no_gpu_node() {
+        // `SlideLeft` needs a translating sampler no node provides, so the whole export
+        // stays on the CPU rather than rendering something else.
         let t = square_timeline(vec![
             placed("a.mp4", 0.0, 1.0),
             placed("b.mp4", 1.0, 1.0)
-                .with_transition(XfadeTransition::Dissolve, Duration::from_millis(500)),
+                .with_transition(XfadeTransition::SlideLeft, Duration::from_millis(500)),
         ]);
         assert!(eligible(&t).is_none());
     }

--- a/crates/avio/src/gpu_transition.rs
+++ b/crates/avio/src/gpu_transition.rs
@@ -33,13 +33,32 @@ pub enum GpuTransition {
         /// Wipe direction in radians.
         angle: f32,
     },
-    /// Two-phase dip through a solid colour (`ff_render::DipToColorNode`), RGB in
-    /// `[0, 1]`.
+    /// Two-phase dip through a solid colour (`ff_render::DipToColorNode`).
+    ///
+    /// `color` is RGB and normally within `[0, 1]`, but the `FFmpeg` dips deliberately
+    /// fall *outside* it — see this module's `DIP_BLACK`. Nothing clamps it until the
+    /// node's final write, and rounding it back into range would put the middle of the
+    /// dip up to 18.6 away from the export.
     Dip {
-        /// Dip colour.
+        /// Dip colour, RGB; may sit outside `[0, 1]`.
         color: [f32; 3],
     },
 }
+
+/// The dip endpoint for `fadeblack`, in the node's normalised RGB.
+///
+/// Not `0.0`. `FFmpeg` dips toward **luma 0** (`vf_xfade.c` sets `black[0] = 0`), which
+/// in the limited-range `yuv420p` the export runs through sits *below* displayable black,
+/// and it mixes there before anything converts to RGB. Expanding the endpoint out of
+/// limited range and leaving the clamp to the final write reproduces that exactly,
+/// because the conversion is affine and so commutes with the blend. Mixing toward RGB 0
+/// instead lands up to 18.6 away through the middle of the dip -- measured, and the
+/// difference between a mean of 18.7 and 2.7 against a real export (#1732).
+const DIP_BLACK: f32 = (0.0 - 16.0 / 255.0) * (255.0 / 219.0);
+
+/// The dip endpoint for `fadewhite`; see [`DIP_BLACK`]. `FFmpeg` uses luma 255, which
+/// expands just above 1.0.
+const DIP_WHITE: f32 = (1.0 - 16.0 / 255.0) * (255.0 / 219.0);
 
 /// The GPU node for `kind`, or `None` when it has no equivalent and must stay on the
 /// CPU path.
@@ -68,10 +87,10 @@ pub fn map_transition(kind: XfadeTransition) -> Option<GpuTransition> {
             angle: std::f32::consts::FRAC_PI_2,
         }),
         XfadeTransition::FadeBlack => Some(GpuTransition::Dip {
-            color: [0.0, 0.0, 0.0],
+            color: [DIP_BLACK; 3],
         }),
         XfadeTransition::FadeWhite => Some(GpuTransition::Dip {
-            color: [1.0, 1.0, 1.0],
+            color: [DIP_WHITE; 3],
         }),
         // Slides need a translating sampler, and the geometric / mosaic kinds need
         // nodes that do not exist yet; all stay on the CPU path.
@@ -116,13 +135,13 @@ mod tests {
         (
             XfadeTransition::FadeBlack,
             GpuTransition::Dip {
-                color: [0.0, 0.0, 0.0],
+                color: [DIP_BLACK; 3],
             },
         ),
         (
             XfadeTransition::FadeWhite,
             GpuTransition::Dip {
-                color: [1.0, 1.0, 1.0],
+                color: [DIP_WHITE; 3],
             },
         ),
     ];
@@ -173,6 +192,33 @@ mod tests {
                 "{kind:?} is listed as both mapped and CPU-only"
             );
         }
+    }
+
+    #[test]
+    fn dip_endpoints_should_sit_outside_the_displayable_range() {
+        // The one unit conversion in the dip mapping, and the whole of the divergence it
+        // fixes: `FFmpeg` dips to luma 0 / 255 in limited range, which expands past both
+        // ends of `[0, 1]`. Rounding these back into range would put the middle of the
+        // dip up to 18.6 away from the export (#1732), so pin that they are outside.
+        assert!(
+            DIP_BLACK < 0.0,
+            "fadeblack must dip below displayable black, got {DIP_BLACK}"
+        );
+        assert!(
+            DIP_WHITE > 1.0,
+            "fadewhite must dip above displayable white, got {DIP_WHITE}"
+        );
+        // The two ends overshoot by *different* amounts, because limited-range luma is
+        // 16..=235: 16 of headroom below, 20 above. A symmetric pair here would mean the
+        // expansion had been simplified into something that is not FFmpeg's.
+        assert!(
+            (DIP_BLACK - (-16.0 / 219.0)).abs() < 1e-6,
+            "got {DIP_BLACK}"
+        );
+        assert!(
+            (DIP_WHITE - (239.0 / 219.0)).abs() < 1e-6,
+            "got {DIP_WHITE}"
+        );
     }
 
     #[test]

--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -88,6 +88,10 @@ pub use ff_encode::{BitrateMode, EncodeError};
 // payloads (ScaleAlgorithm / ToneMap / EqBand / DrawTextOptions / YadifMode / Rgb /
 // AnimatedValue), animation authoring (AnimationTrack / Keyframe / Easing),
 // Clip::realtime_layer[_descriptor] returns, FilterError, and the EncoderConfig HwAccel setter.
+//
+// `ff_filter::xfade_frand` / `dissolve_mask` are deliberately **not** re-exported: they
+// are how the transition paths agree on `FFmpeg`'s pixel selection, not something the
+// editing surface asks for. A caller drives transitions through `Clip::with_transition`.
 pub use ff_filter::{
     AnimatedValue, AnimationTrack, BlendMode, CompositeOp, DrawTextOptions, Easing, EqBand,
     FilterError, FilterStep, HwAccel, Keyframe, PitchAlgo, RealtimeLayer, RealtimeLayerDescriptor,

--- a/crates/avio/tests/gpu_export_tests.rs
+++ b/crates/avio/tests/gpu_export_tests.rs
@@ -204,13 +204,15 @@ fn gpu_export_should_conform_a_slower_source_to_the_timeline_rate() {
 
 /// Per-frame mean absolute RGB difference between the two routes' exports.
 ///
-/// Calibrated (#1659): this pipeline's floor is a **hard cut**, where the routes still
-/// differ because the GPU one round-trips yuv -> rgba -> yuv while the CPU one stays in
-/// yuv throughout the filter graph. Measured on the structured sources below, a hard cut
-/// comes out at mean 1.4 / max 7, and the faded transition at ~2. The bound is well
-/// clear of that and still far from anything a real divergence would produce: the wrong
-/// blend direction reads as mean ~127, and a mismatched transition kind as 54-78.
-const TOL_TRANSITION_MEAN: f64 = 5.0;
+/// Calibrated (#1659, widened in #1732): this pipeline's floor is a **hard cut**, where
+/// the routes still differ because the GPU one round-trips yuv -> rgba -> yuv while the
+/// CPU one stays in yuv throughout the filter graph. Measured on the structured sources
+/// below, a hard cut comes out at mean 1.4 / max 7; the transitions land at 2.3 (`Fade`,
+/// the dips), 2.4-2.6 (the wipes) and 4.2 (`Dissolve`, whose per-pixel scatter is the
+/// worst case for 4:2:0 chroma). The bound clears those and is still far from anything a
+/// real divergence would produce: the wrong blend direction reads as mean ~127, and a
+/// transition rendered as the wrong kind as ~50.
+const TOL_TRANSITION_MEAN: f64 = 6.0;
 
 /// Encodes a spatially structured, colourful source: a horizontal ramp in R, a vertical
 /// one in G, and `phase` shifting B so the two clips differ everywhere.
@@ -281,8 +283,8 @@ fn mean_abs_diff_rgb(a: &[u8], b: &[u8]) -> f64 {
     sum / denom
 }
 
-/// #1659: a cross-fade into the track's last clip exports on the GPU and lands on the
-/// CPU export's pixels.
+/// #1659 / #1732: a transition into the track's last clip exports on the GPU and lands
+/// on the CPU export's pixels, for every kind the export renders.
 ///
 /// **Why the frame count is the load-bearing assertion.** The CPU route's `xfade`
 /// overlaps the two clips, so the track comes out `transition` shorter: two 1 s clips at
@@ -297,9 +299,13 @@ fn mean_abs_diff_rgb(a: &[u8], b: &[u8]) -> f64 {
 /// `gpu_export::tests::eligible_track_should_accept_a_fade_into_the_last_clip`, which
 /// asserts this exact shape is eligible; with an adapter present (checked below) those
 /// two facts leave no other route.
+///
+/// The kinds beyond `Fade` are only here because #1732 brought each node onto FFmpeg's
+/// own formula. Before that the GPU route declined them, and this loop would have been
+/// comparing two CPU exports.
 #[cfg(feature = "gpu")]
 #[test]
-fn gpu_export_should_match_the_cpu_export_for_a_faded_transition() {
+fn gpu_export_should_match_the_cpu_export_for_every_rendered_transition() {
     use std::time::Duration;
 
     use ff_filter::XfadeTransition;
@@ -320,73 +326,82 @@ fn gpu_export_should_match_the_cpu_export_for_a_faded_transition() {
         return; // no GPU adapter -> the GPU leg is unreachable here
     }
 
-    let build = || {
-        Timeline::builder()
-            .canvas(CANVAS, CANVAS)
-            .frame_rate(30.0)
-            .video_track(vec![
-                Clip::new(&a).trim(Duration::ZERO, Duration::from_secs(1)),
-                Clip::new(&b)
-                    .offset(Duration::from_secs(1))
-                    .trim(Duration::ZERO, Duration::from_secs(1))
-                    .with_transition(XfadeTransition::Fade, Duration::from_millis(500)),
-            ])
-            .build()
-            .ok()
-    };
-    let (Some(gpu_timeline), Some(cpu_timeline)) = (build(), build()) else {
-        return; // source codec unavailable -> skip
-    };
+    for kind in [
+        XfadeTransition::Fade,
+        XfadeTransition::Dissolve,
+        XfadeTransition::WipeLeft,
+        XfadeTransition::WipeRight,
+        XfadeTransition::WipeUp,
+        XfadeTransition::WipeDown,
+        XfadeTransition::FadeBlack,
+        XfadeTransition::FadeWhite,
+    ] {
+        let build = || {
+            Timeline::builder()
+                .canvas(CANVAS, CANVAS)
+                .frame_rate(30.0)
+                .video_track(vec![
+                    Clip::new(&a).trim(Duration::ZERO, Duration::from_secs(1)),
+                    Clip::new(&b)
+                        .offset(Duration::from_secs(1))
+                        .trim(Duration::ZERO, Duration::from_secs(1))
+                        .with_transition(kind, Duration::from_millis(500)),
+                ])
+                .build()
+                .ok()
+        };
+        let (Some(gpu_timeline), Some(cpu_timeline)) = (build(), build()) else {
+            return; // source codec unavailable -> skip
+        };
 
-    let out_gpu = test_output_path("gpuexport_tr_gpu.mp4");
-    let out_cpu = test_output_path("gpuexport_tr_cpu.mp4");
-    let _gg = FileGuard::new(out_gpu.clone());
-    let _gc = FileGuard::new(out_cpu.clone());
-    if !render_or_skip(gpu_timeline.render(&out_gpu, export_config()))
-        || !render_or_skip(cpu_timeline.render_forcing_cpu(&out_cpu, export_config()))
-    {
-        return;
-    }
+        let out_gpu = test_output_path("gpuexport_tr_gpu.mp4");
+        let out_cpu = test_output_path("gpuexport_tr_cpu.mp4");
+        let _gg = FileGuard::new(out_gpu.clone());
+        let _gc = FileGuard::new(out_cpu.clone());
+        if !render_or_skip(gpu_timeline.render(&out_gpu, export_config()))
+            || !render_or_skip(cpu_timeline.render_forcing_cpu(&out_cpu, export_config()))
+        {
+            return;
+        }
 
-    let gpu = decode_rgba(&out_gpu);
-    let cpu = decode_rgba(&out_cpu);
-    if gpu.is_empty() || cpu.is_empty() {
-        return; // decoder unavailable -> skip
-    }
+        let gpu = decode_rgba(&out_gpu);
+        let cpu = decode_rgba(&out_cpu);
+        if gpu.is_empty() || cpu.is_empty() {
+            return; // decoder unavailable -> skip
+        }
 
-    // The transition ran: the track is a window shorter than the hard cut would be.
-    // Expect against what the sources actually decode, since an encode/decode round trip
-    // can lose a frame and that shortfall would otherwise read as a transition bug.
-    let hard_cut = decode_rgba(&a).len() + decode_rgba(&b).len();
-    let expected = hard_cut - WINDOW;
-    assert!(
-        (expected - 1..=expected + 1).contains(&gpu.len()),
-        "a {WINDOW}-frame transition should shorten the {hard_cut}-frame hard cut to \
+        // The transition ran: the track is a window shorter than the hard cut would be.
+        // Expect against what the sources actually decode, since an encode/decode round trip
+        // can lose a frame and that shortfall would otherwise read as a transition bug.
+        let hard_cut = decode_rgba(&a).len() + decode_rgba(&b).len();
+        let expected = hard_cut - WINDOW;
+        assert!(
+            (expected - 1..=expected + 1).contains(&gpu.len()),
+            "a {WINDOW}-frame transition should shorten the {hard_cut}-frame hard cut to \
          ~{expected}, got {}",
-        gpu.len()
-    );
-    assert_eq!(
-        gpu.len(),
-        cpu.len(),
-        "both routes must export the same number of frames"
-    );
+            gpu.len()
+        );
+        assert_eq!(
+            gpu.len(),
+            cpu.len(),
+            "both routes must export the same number of frames"
+        );
 
-    let worst = gpu
-        .iter()
-        .zip(cpu.iter())
-        .enumerate()
-        .map(|(i, (g, c))| (mean_abs_diff_rgb(g, c), i))
-        .fold((0f64, 0usize), |acc, x| if x.0 > acc.0 { x } else { acc });
-    println!(
-        "faded transition: worst frame {} mean={:.3}",
-        worst.1, worst.0
-    );
-    assert!(
-        worst.0 <= TOL_TRANSITION_MEAN,
-        "GPU and CPU exports diverged at frame {}: mean={:.3} (tolerance {TOL_TRANSITION_MEAN})",
-        worst.1,
-        worst.0
-    );
+        let worst = gpu
+            .iter()
+            .zip(cpu.iter())
+            .enumerate()
+            .map(|(i, (g, c))| (mean_abs_diff_rgb(g, c), i))
+            .fold((0f64, 0usize), |acc, x| if x.0 > acc.0 { x } else { acc });
+        println!("{kind:?}: worst frame {} mean={:.3}", worst.1, worst.0);
+        assert!(
+            worst.0 <= TOL_TRANSITION_MEAN,
+            "{kind:?}: GPU and CPU exports diverged at frame {}: mean={:.3} \
+         (tolerance {TOL_TRANSITION_MEAN})",
+            worst.1,
+            worst.0
+        );
+    }
 }
 
 #[test]

--- a/crates/avio/tests/gpu_export_tests.rs
+++ b/crates/avio/tests/gpu_export_tests.rs
@@ -207,10 +207,9 @@ fn gpu_export_should_conform_a_slower_source_to_the_timeline_rate() {
 /// Calibrated (#1659, widened in #1732): this pipeline's floor is a **hard cut**, where
 /// the routes still differ because the GPU one round-trips yuv -> rgba -> yuv while the
 /// CPU one stays in yuv throughout the filter graph. Measured on the structured sources
-/// below, a hard cut comes out at mean 1.4 / max 7; the transitions land at 2.3 (`Fade`,
-/// the dips), 2.4-2.6 (the wipes) and 4.2 (`Dissolve`, whose per-pixel scatter is the
-/// worst case for 4:2:0 chroma). The bound clears those and is still far from anything a
-/// real divergence would produce: the wrong blend direction reads as mean ~127, and a
+/// below, a hard cut comes out at mean 1.4 / max 7, and the transitions the export
+/// renders land at 1.9-2.3. The bound clears those with room for platform variation and
+/// is still far from anything a real divergence would produce: the wrong blend direction reads as mean ~127, and a
 /// transition rendered as the wrong kind as ~50.
 const TOL_TRANSITION_MEAN: f64 = 6.0;
 
@@ -326,9 +325,12 @@ fn gpu_export_should_match_the_cpu_export_for_every_rendered_transition() {
         return; // no GPU adapter -> the GPU leg is unreachable here
     }
 
+    // `Dissolve` is absent on purpose: the export declines it (its pixel set depends on
+    // libm agreement between Rust and FFmpeg), so both legs here would be CPU renders and
+    // the comparison would pass without exercising anything. The rejection itself is
+    // asserted by `gpu_export::tests::export_maps_to_gpu_should_reject_dissolve_despite_it_mapping`.
     for kind in [
         XfadeTransition::Fade,
-        XfadeTransition::Dissolve,
         XfadeTransition::WipeLeft,
         XfadeTransition::WipeRight,
         XfadeTransition::WipeUp,

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -1857,9 +1857,13 @@ fn gpu_transition_output(
             w,
             h,
         ),
+        // The mask comes from the same function the CPU reference uses, which is the
+        // point: `FFmpeg`'s dissolve noise is not reproducible in `WGSL` (its argument
+        // outgrows `f32` well before 1080p), so both paths read one CPU-built selection
+        // instead of two implementations hoping to agree (#1732).
         GpuTransition::Dissolve => run_transition_gpu(
             ctx,
-            DissolveTransitionNode::new(progress, b.to_vec(), w, h),
+            DissolveTransitionNode::new(ff_filter::dissolve_mask(w, h, progress), b.to_vec(), w, h),
             a,
             w,
             h,

--- a/crates/avio/tests/xfade_reference_parity.rs
+++ b/crates/avio/tests/xfade_reference_parity.rs
@@ -1,0 +1,299 @@
+//! `ff_preview::apply_xfade` against the transition the export actually writes (#1732).
+//!
+//! `apply_xfade` is what the preview shows for a transition, and the export runs
+//! `FFmpeg`'s `xfade` filter. If the two disagree, the preview lies about the finished
+//! video — which is exactly what this suite was written to catch, after `Dissolve` was
+//! found choosing a different set of pixels (mean 54) and the dips following a different
+//! curve entirely (mean 78).
+//!
+//! # Why neither existing suite covers this
+//!
+//! - `gpu_parity_tests` compares each `ff-render` node against `apply_xfade`. Both could
+//!   be wrong in the same way and it would still pass — and for four kinds, both were.
+//! - `gpu_export_tests` compares the two *export* routes. For a kind the GPU path
+//!   declines, both legs are `FFmpeg` and it passes regardless.
+//!
+//! Only comparing the reference against a real export closes that, so this suite renders
+//! one and reads its pixels back.
+//!
+//! # Why there are two legs
+//!
+//! They fail on different mistakes and neither subsumes the other:
+//!
+//! - **Flat sources** make both clips a single colour, so the chroma planes are identical
+//!   and 4:2:0 subsampling cannot influence the comparison. That isolates each kind's
+//!   *formula* — the dip's curve, the dissolve's pixel set, the wipe's edge column — and
+//!   is where the bound is tight. It cannot see direction: a mirrored wipe over a uniform
+//!   field looks the same.
+//! - **Structured sources** carry a horizontal and a vertical ramp, so geometry and
+//!   direction are visible (a mirrored wipe reads ~127 here). The bound is looser because
+//!   `FFmpeg` selects per plane and chroma is half-resolution, while `apply_xfade` works
+//!   in rgba — a gap inherent to the two representations, not to the formulas (RK-022).
+//!
+//! `Dissolve` is deliberately absent from the structured leg: its selection is per-pixel
+//! scatter, the worst case for 4:2:0, so it reads ~34 there no matter how exact the
+//! selection is. It has no direction to check either, so the flat leg (where a wrong hash
+//! reads 54 against a bound of 3.5) is the whole of its coverage here.
+//!
+//! Probe-gated (RK-002): the source encode and the export skip gracefully when the
+//! environment cannot run them.
+//!
+//! Every export writes to a path keyed by its leg and kind. The two legs run in parallel
+//! under `cargo test`, so a shared output file would have them decoding each other's
+//! render — and that fails deterministically while reporting a mean of 107, which reads
+//! as "the formula is wrong" rather than "the file was overwritten" (RK-019).
+
+#![cfg(feature = "preview")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod fixtures;
+
+use std::time::Duration;
+
+use avio::{Clip, EncoderConfig, Timeline, TimelineError};
+use ff_decode::VideoDecoder;
+use ff_encode::{BitrateMode, VideoCodec, VideoEncoder};
+use ff_filter::XfadeTransition;
+use ff_format::{PixelFormat, VideoFrame};
+use fixtures::{FileGuard, test_output_path};
+
+const W: u32 = 64;
+const H: u32 = 64;
+/// Frames per source clip: 1 s at 30 fps.
+const CLIP_FRAMES: usize = 30;
+/// Transition length in output frames: 0.5 s at 30 fps.
+const WINDOW: usize = 15;
+
+/// Bound for the flat leg. Measured worst-frame means: wipes 1.0, `Dissolve` 1.0,
+/// `Fade` 2.0, `FadeWhite` 2.3, `FadeBlack` 2.7 — the encode round trip's own floor.
+/// A wrong formula is nowhere near it: the linear dip this replaced read 18.7 here and
+/// the previous dissolve hash read 54.
+const TOL_FLAT_MEAN: f64 = 3.5;
+
+/// Bound for the structured leg. Measured worst-frame means: `FadeBlack` 2.8, `Fade` 3.0,
+/// `FadeWhite` 3.0, wipes 3.4–4.7. The wipes sit higher because their seam falls on a
+/// chroma boundary; a *mirrored* wipe would read ~127.
+const TOL_STRUCTURED_MEAN: f64 = 6.0;
+
+/// Every kind whose GPU node and CPU reference are pinned to `FFmpeg`'s formula.
+const MAPPED_KINDS: &[XfadeTransition] = &[
+    XfadeTransition::Fade,
+    XfadeTransition::Dissolve,
+    XfadeTransition::WipeLeft,
+    XfadeTransition::WipeRight,
+    XfadeTransition::WipeUp,
+    XfadeTransition::WipeDown,
+    XfadeTransition::FadeBlack,
+    XfadeTransition::FadeWhite,
+];
+
+fn export_config() -> EncoderConfig {
+    EncoderConfig::builder()
+        .video_codec(VideoCodec::H264)
+        // Generous, so the comparison measures the transition rather than the encoder.
+        .bitrate_mode(BitrateMode::Cbr(4_000_000))
+        .build()
+}
+
+/// Encodes `CLIP_FRAMES` frames of `rgba`, or `None` when the environment has no usable
+/// encoder (skip).
+fn encode_source(path: &std::path::Path, rgba: &[u8]) -> Option<()> {
+    let mut enc = VideoEncoder::create(path)
+        .video(W, H, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .build()
+        .ok()?;
+    for _ in 0..CLIP_FRAMES {
+        enc.push_video(&VideoFrame::from_rgba(W, H, rgba.to_vec()).ok()?)
+            .ok()?;
+    }
+    enc.finish().ok()?;
+    Some(())
+}
+
+/// A single-colour frame: both clips share their chroma, so 4:2:0 subsampling cannot
+/// affect which source a pixel came from.
+fn flat_rgba(level: u8) -> Vec<u8> {
+    vec![level; (W * H * 4) as usize]
+}
+
+/// A frame with a horizontal ramp in R and a vertical one in G, offset per clip by
+/// `phase`, so direction and geometry are both visible.
+fn structured_rgba(phase: u8) -> Vec<u8> {
+    let mut rgba = vec![0u8; (W * H * 4) as usize];
+    for y in 0..H {
+        for x in 0..W {
+            let o = ((y * W + x) * 4) as usize;
+            rgba[o] = u8::try_from(x * 255 / W).unwrap_or(255).wrapping_add(phase);
+            rgba[o + 1] = u8::try_from(y * 255 / H)
+                .unwrap_or(255)
+                .wrapping_add(phase.wrapping_mul(2));
+            rgba[o + 2] = 128u8.wrapping_sub(phase);
+            rgba[o + 3] = 255;
+        }
+    }
+    rgba
+}
+
+/// Every decoded frame of `path` as rgba, or an empty vec when it cannot be decoded.
+fn decode_rgba(path: &std::path::Path) -> Vec<Vec<u8>> {
+    let Ok(mut d) = VideoDecoder::open(path)
+        .output_format(PixelFormat::Rgba)
+        .build()
+    else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    while let Ok(Some(f)) = d.decode_one() {
+        if let Some(plane) = f.plane(0) {
+            out.push(plane.to_vec());
+        }
+    }
+    out
+}
+
+/// Mean absolute difference over the RGB channels (alpha carries no meaning here).
+fn mean_abs_diff_rgb(a: &[u8], b: &[u8]) -> f64 {
+    let n = a.len().min(b.len()) / 4;
+    assert!(n > 0, "compared an empty frame");
+    let mut sum = 0f64;
+    for i in 0..n {
+        for c in 0..3 {
+            sum += f64::from(a[i * 4 + c].abs_diff(b[i * 4 + c]));
+        }
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let denom = (n * 3) as f64;
+    sum / denom
+}
+
+fn render_or_skip(result: Result<(), TimelineError>) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(TimelineError::Filter(_) | TimelineError::Encode(_) | TimelineError::Decode(_)) => {
+            false
+        }
+        Err(e) => panic!("unexpected export error: {e}"),
+    }
+}
+
+/// Exports `a` then `b` with `kind` between them and returns the worst per-frame mean
+/// difference between the export's transition frames and `apply_xfade` at the same
+/// progress, or `None` when the environment cannot run the export.
+///
+/// `leg` names the caller so the export lands on its own path. The two legs run in
+/// parallel under `cargo test`, and a shared output file has them decoding each other's
+/// render -- which fails *deterministically*, reporting a mean of 107 as though the
+/// formula were wrong.
+fn worst_window_divergence(
+    leg: &str,
+    kind: XfadeTransition,
+    a: &std::path::Path,
+    b: &std::path::Path,
+) -> Option<(f64, usize)> {
+    let timeline = Timeline::builder()
+        .canvas(W, H)
+        .frame_rate(30.0)
+        .video_track(vec![
+            Clip::new(a).trim(Duration::ZERO, Duration::from_secs(1)),
+            Clip::new(b)
+                .offset(Duration::from_secs(1))
+                .trim(Duration::ZERO, Duration::from_secs(1))
+                .with_transition(kind, Duration::from_millis(500)),
+        ])
+        .build()
+        .ok()?;
+
+    let out = test_output_path(&format!("xfade_ref_{leg}_{kind:?}.mp4"));
+    let _guard = FileGuard::new(out.clone());
+    let _ = std::fs::remove_file(&out);
+    // Force-CPU: the reference is FFmpeg's own filter, which is what this route runs.
+    if !render_or_skip(timeline.render_forcing_cpu(&out, export_config())) {
+        return None;
+    }
+
+    let (fa, fb, exported) = (decode_rgba(a), decode_rgba(b), decode_rgba(&out));
+    if fa.len() < CLIP_FRAMES || fb.len() < WINDOW || exported.len() < CLIP_FRAMES {
+        return None; // decoder unavailable or a short round trip -> skip
+    }
+
+    // The transition occupies outputs `CLIP_FRAMES - WINDOW ..< CLIP_FRAMES`, showing
+    // clip A's tail against clip B's head (#1659 measured this mapping against the CPU
+    // export, and `gpu_export`'s drain reproduces it).
+    let mut worst = (0f64, 0usize);
+    for j in 0..WINDOW {
+        #[allow(clippy::cast_precision_loss)]
+        let progress = j as f32 / WINDOW as f32;
+        let mut reference = Vec::new();
+        ff_preview::apply_xfade(
+            kind,
+            &fa[(CLIP_FRAMES - WINDOW) + j],
+            &fb[j],
+            progress,
+            W,
+            H,
+            &mut reference,
+        );
+        let mean = mean_abs_diff_rgb(&exported[(CLIP_FRAMES - WINDOW) + j], &reference);
+        if mean > worst.0 {
+            worst = (mean, j);
+        }
+    }
+    Some(worst)
+}
+
+#[test]
+fn apply_xfade_should_match_the_export_formula_for_every_mapped_kind() {
+    // Flat sources: identical chroma in both clips, so this measures the formula alone.
+    let a = test_output_path("xfade_ref_flat_a.mp4");
+    let b = test_output_path("xfade_ref_flat_b.mp4");
+    let _ga = FileGuard::new(a.clone());
+    let _gb = FileGuard::new(b.clone());
+    if encode_source(&a, &flat_rgba(40)).is_none() || encode_source(&b, &flat_rgba(210)).is_none() {
+        return; // encoder unavailable -> skip
+    }
+
+    for kind in MAPPED_KINDS {
+        let Some((mean, frame)) = worst_window_divergence("flat", *kind, &a, &b) else {
+            return; // environment cannot run the export -> skip the whole suite
+        };
+        println!("flat {kind:?}: worst mean={mean:.3} (window frame {frame})");
+        assert!(
+            mean <= TOL_FLAT_MEAN,
+            "{kind:?}: the preview reference diverges from the export by {mean:.3} at \
+             window frame {frame} (tolerance {TOL_FLAT_MEAN}); the formula does not match \
+             FFmpeg's"
+        );
+    }
+}
+
+#[test]
+fn apply_xfade_should_match_the_export_geometry_on_colourful_sources() {
+    // Structured sources: this is the leg that sees direction. `Dissolve` is excluded --
+    // see the module docs.
+    let a = test_output_path("xfade_ref_struct_a.mp4");
+    let b = test_output_path("xfade_ref_struct_b.mp4");
+    let _ga = FileGuard::new(a.clone());
+    let _gb = FileGuard::new(b.clone());
+    if encode_source(&a, &structured_rgba(0)).is_none()
+        || encode_source(&b, &structured_rgba(100)).is_none()
+    {
+        return; // encoder unavailable -> skip
+    }
+
+    for kind in MAPPED_KINDS
+        .iter()
+        .filter(|k| **k != XfadeTransition::Dissolve)
+    {
+        let Some((mean, frame)) = worst_window_divergence("struct", *kind, &a, &b) else {
+            return;
+        };
+        println!("structured {kind:?}: worst mean={mean:.3} (window frame {frame})");
+        assert!(
+            mean <= TOL_STRUCTURED_MEAN,
+            "{kind:?}: the preview reference diverges from the export by {mean:.3} at \
+             window frame {frame} (tolerance {TOL_STRUCTURED_MEAN}); a mirrored or \
+             mis-keyed transition reads far above this"
+        );
+    }
+}

--- a/crates/avio/tests/xfade_reference_parity.rs
+++ b/crates/avio/tests/xfade_reference_parity.rs
@@ -32,8 +32,11 @@
 //!
 //! `Dissolve` is deliberately absent from the structured leg: its selection is per-pixel
 //! scatter, the worst case for 4:2:0, so it reads ~34 there no matter how exact the
-//! selection is. It has no direction to check either, so the flat leg (where a wrong hash
-//! reads 54 against a bound of 3.5) is the whole of its coverage here.
+//! selection is. It has no direction to check either, so the flat leg is the whole of its
+//! coverage here — and on a bound of its own, because it is the one kind whose agreement
+//! depends on two libms matching rather than on arithmetic (see
+//! `TOL_FLAT_DISSOLVE_MEAN`). That same dependence is why the GPU *export* declines
+//! `Dissolve` outright.
 //!
 //! Probe-gated (RK-002): the source encode and the export skip gracefully when the
 //! environment cannot run them.
@@ -69,6 +72,16 @@ const WINDOW: usize = 15;
 /// A wrong formula is nowhere near it: the linear dip this replaced read 18.7 here and
 /// the previous dissolve hash read 54.
 const TOL_FLAT_MEAN: f64 = 3.5;
+
+/// Bound for `Dissolve`, which is the one kind whose agreement is not pure arithmetic.
+///
+/// Its selection is `xfade_frand`, i.e. `sinf` of an argument large enough that the
+/// result depends on the libm evaluating it — Rust's here, `FFmpeg`'s in the export. They
+/// agree exactly on some platforms (0% of pixels disagreeing, measured on Windows) and
+/// approximately on others, so this leg pins that the formula is *right* while leaving
+/// room for the platform to disagree about a few pixels. It is still an order of
+/// magnitude below the 54 an unrelated hash produces, which is what this guards against.
+const TOL_FLAT_DISSOLVE_MEAN: f64 = 12.0;
 
 /// Bound for the structured leg. Measured worst-frame means: `FadeBlack` 2.8, `Fade` 3.0,
 /// `FadeWhite` 3.0, wipes 3.4–4.7. The wipes sit higher because their seam falls on a
@@ -258,8 +271,13 @@ fn apply_xfade_should_match_the_export_formula_for_every_mapped_kind() {
             return; // environment cannot run the export -> skip the whole suite
         };
         println!("flat {kind:?}: worst mean={mean:.3} (window frame {frame})");
+        let bound = if *kind == XfadeTransition::Dissolve {
+            TOL_FLAT_DISSOLVE_MEAN
+        } else {
+            TOL_FLAT_MEAN
+        };
         assert!(
-            mean <= TOL_FLAT_MEAN,
+            mean <= bound,
             "{kind:?}: the preview reference diverges from the export by {mean:.3} at \
              window frame {frame} (tolerance {TOL_FLAT_MEAN}); the formula does not match \
              FFmpeg's"

--- a/crates/ff-filter/src/graph/mod.rs
+++ b/crates/ff-filter/src/graph/mod.rs
@@ -19,5 +19,5 @@ pub use filter_step::FilterStep;
 pub use graph::FilterGraph;
 pub use types::{
     DrawTextOptions, EqBand, HwAccel, PitchAlgo, Rgb, ScaleAlgorithm, ToneMap, XfadeTransition,
-    YadifMode,
+    YadifMode, dissolve_mask, xfade_frand,
 };

--- a/crates/ff-filter/src/graph/types.rs
+++ b/crates/ff-filter/src/graph/types.rs
@@ -157,6 +157,53 @@ pub enum PitchAlgo {
     Rubberband,
 }
 
+/// `FFmpeg`'s per-pixel noise for `xfade=dissolve` (`vf_xfade.c::frand`), keyed by
+/// integer pixel coordinates and returning a value in `[0, 1)`.
+///
+/// Transcribed literally from the pinned C, and the literalness is load-bearing. The
+/// argument reaches ~110 000 at 1080p, where `f32` resolves to about 0.008 and the
+/// `* 43758.545` then the fractional part amplify any difference into an unrelated
+/// value, so **the argument must be accumulated in `f32`**: computing it in `f64` yields
+/// a pixel set 48% different from `FFmpeg`'s. With the `f32` argument, Rust's `f32::sin`
+/// reproduces `FFmpeg`'s `sinf` for every pixel at every progress -- both measured
+/// against a real export (#1732).
+///
+/// Lives here, beside [`XfadeTransition`], because it is a property of that transition
+/// and every consumer needs the *same* one: the CPU reference in `ff-preview`, the GPU
+/// node's mask in `ff-render`, and the export path in `avio` would otherwise each carry
+/// a copy of arithmetic that has to agree bit for bit.
+#[must_use]
+pub fn xfade_frand(x: u32, y: u32) -> f32 {
+    #[allow(clippy::cast_precision_loss)] // pixel coordinates are exact in f32
+    let arg = (x as f32) * 12.9898 + (y as f32) * 78.233;
+    let r = arg.sin() * 43758.545;
+    r - r.floor()
+}
+
+/// The per-pixel selection `xfade=dissolve` makes at `progress`, as an RGBA mask: `255`
+/// where clip B shows through, `0` where clip A does.
+///
+/// `vf_xfade.c` writes the choice as `smooth = frand(x,y)*2 + progress*2 - 1.5`, taking
+/// clip A where `smooth >= 0.5`; with `FFmpeg`'s `progress` running 1 -> 0 that reduces
+/// to clip B wherever [`xfade_frand`] is below `progress` in this crate's convention.
+///
+/// Exists as a *mask* so the GPU path can render the same dissolve: the hash cannot be
+/// recomputed in `WGSL` (see [`xfade_frand`]), so `ff_render::DissolveTransitionNode`
+/// takes this instead and the two paths agree by construction.
+#[must_use]
+pub fn dissolve_mask(w: u32, h: u32, progress: f32) -> Vec<u8> {
+    let mut mask = vec![0u8; (w as usize) * (h as usize) * 4];
+    for y in 0..h {
+        for x in 0..w {
+            if xfade_frand(x, y) < progress {
+                let i = ((y * w + x) * 4) as usize;
+                mask[i..i + 4].fill(255);
+            }
+        }
+    }
+    mask
+}
+
 /// Transition type for the `xfade` cross-dissolve filter.
 ///
 /// Used with [`super::FilterGraphBuilder::xfade`].
@@ -326,4 +373,48 @@ pub struct DrawTextOptions {
     pub box_color: Option<String>,
     /// Background box border width in pixels. Ignored when `box_color` is `None`.
     pub box_border_width: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dissolve_mask, xfade_frand};
+
+    #[test]
+    fn xfade_frand_should_stay_in_the_unit_interval() {
+        // `dissolve_mask`'s `frand < progress` relies on the range: a value at or above
+        // 1 would never be revealed even at full progress, and a negative one would be
+        // revealed immediately.
+        for y in 0..64u32 {
+            for x in 0..64u32 {
+                let v = xfade_frand(x, y);
+                assert!((0.0..1.0).contains(&v), "frand({x}, {y}) = {v}");
+            }
+        }
+    }
+
+    #[test]
+    fn dissolve_mask_endpoints_should_be_empty_then_full() {
+        assert!(dissolve_mask(16, 16, 0.0).iter().all(|&m| m == 0));
+        assert!(dissolve_mask(16, 16, 1.0).iter().all(|&m| m == 255));
+    }
+
+    #[test]
+    fn dissolve_mask_should_reveal_about_progress_worth_of_pixels() {
+        // `frand` stands in for a uniform draw, so the revealed fraction tracks progress.
+        // Loose on purpose: the exact set is pinned against a real `FFmpeg` export by
+        // `avio`'s `xfade_reference_parity`, and pinning it twice would only duplicate
+        // that without adding a way to be wrong.
+        let (w, h) = (64u32, 64u32);
+        let total = f64::from(w * h);
+        for (progress, want) in [(0.25f32, 0.25f64), (0.5, 0.5), (0.75, 0.75)] {
+            let mask = dissolve_mask(w, h, progress);
+            let set = mask.chunks_exact(4).filter(|px| px[0] == 255).count();
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = set as f64 / total;
+            assert!(
+                (ratio - want).abs() < 0.08,
+                "progress {progress} revealed {ratio:.3}, expected about {want}"
+            );
+        }
+    }
 }

--- a/crates/ff-filter/src/lib.rs
+++ b/crates/ff-filter/src/lib.rs
@@ -54,5 +54,5 @@ pub use graph::{
     FilterGraphBuilder, FilterStep, HwAccel, LavfiSource, LayerSource, MultiTrackAudioMixer,
     MultiTrackComposer, PitchAlgo, ProxySource, RealtimeComposer, RealtimeLayer,
     RealtimeLayerDescriptor, Rgb, ScaleAlgorithm, SolidSource, TextSource, ToneMap,
-    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode,
+    VideoConcatenator, VideoLayer, XfadeTransition, YadifMode, dissolve_mask, xfade_frand,
 };

--- a/crates/ff-preview/src/scene/inner.rs
+++ b/crates/ff-preview/src/scene/inner.rs
@@ -6,7 +6,7 @@
 // `a`/`b` (frames), `w`/`h` (dims), `x`/`y` (coords) are the natural names here.
 #![allow(clippy::many_single_char_names)]
 
-use ff_filter::XfadeTransition;
+use ff_filter::{XfadeTransition, xfade_frand};
 
 /// Blends the outgoing frame `a` and incoming frame `b` (packed RGBA, `w*h*4`) at
 /// transition progress `alpha` (`0` = all A, `1` = all B) using the `xfade` `kind`.
@@ -36,10 +36,32 @@ pub fn apply_xfade(
     let p = alpha.clamp(0.0, 1.0);
     let (wf, hf) = (w as f32, h as f32);
     match kind {
-        XfadeTransition::WipeRight => wipe(a, b, w, h, dst, |x, _| (x as f32) < p * wf),
-        XfadeTransition::WipeLeft => wipe(a, b, w, h, dst, |x, _| (x as f32) >= (1.0 - p) * wf),
-        XfadeTransition::WipeDown => wipe(a, b, w, h, dst, |_, y| (y as f32) < p * hf),
-        XfadeTransition::WipeUp => wipe(a, b, w, h, dst, |_, y| (y as f32) >= (1.0 - p) * hf),
+        // `FFmpeg` computes an integer edge `z` and compares the pixel index against it
+        // (`vf_xfade.c`, `WIPE*_TRANSITION`), with its own `progress` running 1 -> 0.
+        // Transcribed with `progress = 1 - p`, that is the four rules below. The edge has
+        // to be the integer one: comparing against `p * width` in float excludes the
+        // column at `x == floor(w * p)` that `FFmpeg` includes, which is the whole of the
+        // divergence this reference used to carry (#1732).
+        //
+        // The endpoints are asymmetric as a result -- `WipeRight` already shows one
+        // column of B at `p = 0`, and `WipeLeft` still holds one column of A at `p = 1`.
+        // That is `FFmpeg`'s behaviour, and matching it is the point of this function.
+        XfadeTransition::WipeRight => {
+            let z = (wf * p) as i64;
+            wipe(a, b, w, h, dst, move |x, _| i64::from(x) <= z);
+        }
+        XfadeTransition::WipeLeft => {
+            let z = (wf * (1.0 - p)) as i64;
+            wipe(a, b, w, h, dst, move |x, _| i64::from(x) > z);
+        }
+        XfadeTransition::WipeDown => {
+            let z = (hf * p) as i64;
+            wipe(a, b, w, h, dst, move |_, y| i64::from(y) <= z);
+        }
+        XfadeTransition::WipeUp => {
+            let z = (hf * (1.0 - p)) as i64;
+            wipe(a, b, w, h, dst, move |_, y| i64::from(y) > z);
+        }
         XfadeTransition::SlideLeft => slide(a, b, w, h, dst, (p * wf) as i64, 0),
         XfadeTransition::SlideRight => slide(a, b, w, h, dst, -((p * wf) as i64), 0),
         XfadeTransition::SlideUp => slide(a, b, w, h, dst, 0, (p * hf) as i64),
@@ -85,67 +107,99 @@ fn slide(a: &[u8], b: &[u8], w: u32, h: u32, dst: &mut Vec<u8>, dx: i64, dy: i64
     }
 }
 
-/// Dissolve: reveal `b` per-pixel once progress passes a deterministic per-pixel
-/// threshold (a plausible noise dissolve, not `FFmpeg`'s exact PRNG).
+/// Dissolve: reveal `b` at every pixel whose [`frand`] value has been passed by
+/// `p`, which is `FFmpeg`'s own selection.
+///
+/// `vf_xfade.c` writes it as `smooth = frand(x,y)*2 + progress*2 - 1.5` and picks A
+/// where `smooth >= 0.5`; with its `progress = 1 - p` that reduces to B where
+/// [`xfade_frand`]`(x, y) < p`.
 fn dissolve(a: &[u8], b: &[u8], w: u32, h: u32, dst: &mut Vec<u8>, p: f32) {
     dst.resize(a.len(), 0);
     for y in 0..h {
         for x in 0..w {
             let i = ((y * w + x) * 4) as usize;
-            let src = if p > hash01(x, y) { b } else { a };
+            let src = if xfade_frand(x, y) < p { b } else { a };
             dst[i..i + 4].copy_from_slice(&src[i..i + 4]);
         }
     }
 }
 
-/// Two-phase dip: clip A fades to `color`, then `color` fades to clip B. `p = 0.5` is
-/// the fully solid frame. Alpha rides along so a dip over transparency stays sane.
+/// Two-phase dip through `color`, exactly as `FFmpeg`'s `fadeblack` / `fadewhite`.
+///
+/// `vf_xfade.c` (`FADEBLACK_TRANSITION`) nests three `mix`es around two `smoothstep`s
+/// with a fixed `phase` of 0.2, where `mix(a, b, m) = a*m + b*(1-m)` and its `progress`
+/// runs 1 -> 0:
+///
+/// ```text
+/// mix(mix(A, bg, smoothstep(1-phase, 1, progress)),
+///     mix(bg, B, smoothstep(phase,   1, progress)), progress)
+/// ```
+///
+/// The shape that produces is *not* a linear dip: it reaches the solid colour by about
+/// a fifth of the way in and holds it through the middle, where a linear dip would only
+/// touch it instantaneously at the midpoint. Measured against a real export, the linear
+/// version this replaced diverged by a mean of 78 (#1732).
+///
+/// Alpha rides along with `bg` fully opaque, so a dip over transparency stays sane.
+///
+/// `color` is `FFmpeg`'s dip *luma level* rather than a displayable colour; see
+/// [`expand_luma`] for why the distinction matters.
 fn dip(a: &[u8], b: &[u8], color: [u8; 3], dst: &mut Vec<u8>, p: f32) {
+    /// `FFmpeg`'s fixed dip phase: the fraction of the transition spent reaching the
+    /// solid colour at each end.
+    const PHASE: f32 = 0.2;
+
     dst.resize(a.len(), 0);
-    let solid = [color[0], color[1], color[2], 255u8];
-    // First half blends A -> colour, second half colour -> B; both legs run at twice
-    // the outer rate so the dip is complete exactly at the midpoint.
-    let second_half = p >= 0.5;
-    let (clip, t) = if second_half {
-        (b, (p - 0.5) * 2.0)
-    } else {
-        (a, p * 2.0)
-    };
+    let bg = [
+        expand_luma(color[0]),
+        expand_luma(color[1]),
+        expand_luma(color[2]),
+        255.0,
+    ];
+    // `FFmpeg`'s progress is the complement of ours, and both `smoothstep`s are constant
+    // over the frame, so they are evaluated once here rather than per pixel.
+    let g = 1.0 - p;
+    let s1 = smoothstep(1.0 - PHASE, 1.0, g);
+    let s2 = smoothstep(PHASE, 1.0, g);
     for (i, out) in dst.as_chunks_mut::<4>().0.iter_mut().enumerate() {
         let j = i * 4;
         for c in 0..4 {
-            // Phase 1 runs clip -> colour, phase 2 colour -> clip; the direction is
-            // fixed for the whole frame, so only the endpoints swap here.
-            let (from, to) = if second_half {
-                (f32::from(solid[c]), f32::from(clip[j + c]))
-            } else {
-                (f32::from(clip[j + c]), f32::from(solid[c]))
-            };
+            let av = f32::from(a[j + c]);
+            let bv = f32::from(b[j + c]);
+            let out_a = av * s1 + bg[c] * (1.0 - s1);
+            let out_b = bg[c] * s2 + bv * (1.0 - s2);
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             {
-                out[c] = (from + (to - from) * t + 0.5).clamp(0.0, 255.0) as u8;
+                // Truncating, not rounding: `FFmpeg` assigns the float result straight
+                // into a `uint8_t`, and the GPU node is pinned to this function.
+                out[c] = (out_a * g + out_b * (1.0 - g)).clamp(0.0, 255.0) as u8;
             }
         }
     }
 }
 
-/// A cheap deterministic per-pixel hash in `[0.0, 1.0)`.
+/// The full-range RGB value a limited-range luma level expands to, kept unclamped.
 ///
-/// Mirrored bit-for-bit by `ff_render`'s `DissolveTransitionNode` and its
-/// `dissolve.wgsl`, so the CPU and GPU dissolves reveal the same pixels rather than
-/// merely the same *proportion* of them. Changing it here changes only this copy;
-/// `avio`'s transition parity suite is what catches the drift, and that needs a GPU
-/// adapter to run.
-fn hash01(x: u32, y: u32) -> f32 {
-    let mut h = x
-        .wrapping_mul(374_761_393)
-        .wrapping_add(y.wrapping_mul(668_265_263));
-    h = (h ^ (h >> 13)).wrapping_mul(1_274_126_177);
-    h ^= h >> 16;
-    // Top 24 bits over 2^24: max = (2^24 - 1) / 2^24 = 1 - 2^-24, exactly
-    // representable in f32 and strictly < 1.0, so `dissolve`'s `p > hash01`
-    // reveals every pixel at p = 1.0 (the all-B boundary holds exactly).
-    (h >> 8) as f32 / (1u32 << 24) as f32
+/// `FFmpeg` dips toward `black[0] = 0` and `white[0] = max_value` (`vf_xfade.c`
+/// `config_output`) -- **luma 0 and 255, not video black and white**, which in a
+/// limited-range `yuv420p` pipeline sit outside the displayable range. It then mixes in
+/// that space and the conversion to RGB happens afterwards, so a reference that mixes
+/// toward RGB 0 / 255 instead lands up to `16 * 255 / 219 ~= 18.6` away in the middle of
+/// the dip. That was measured exactly: mixing toward RGB black gave a worst-frame mean of
+/// 18.7 against a real export, and mixing toward this expanded value gives 2.7, which is
+/// the encode round trip's own floor (#1732).
+///
+/// Mixing in RGB commutes with the conversion because it is affine, so expanding the
+/// endpoint here and clamping only after the blend reproduces `FFmpeg` exactly.
+fn expand_luma(level: u8) -> f32 {
+    (f32::from(level) - 16.0) * 255.0 / 219.0
+}
+
+/// `FFmpeg`'s `smoothstep` (`vf_xfade.c`), the Hermite curve `t*t*(3-2t)` over a
+/// clamped `t`.
+fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
 }
 
 /// Blend two packed-RGBA buffers: `dst[i] = (1 − alpha) · a[i] + alpha · b[i]`.
@@ -169,6 +223,7 @@ pub(super) fn blend_rgba(a: &[u8], b: &[u8], alpha: f32, dst: &mut Vec<u8>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ff_filter::xfade_frand;
 
     #[test]
     fn blend_rgba_at_zero_alpha_should_return_a() {
@@ -228,35 +283,41 @@ mod tests {
     }
 
     #[test]
-    fn apply_xfade_wiperight_half_should_fill_b_from_the_left() {
+    fn apply_xfade_wiperight_half_should_fill_b_up_to_ffmpegs_integer_column() {
         let (a, b) = (frame(RED), frame(BLUE));
         let mut dst = Vec::new();
         apply_xfade(XfadeTransition::WipeRight, &a, &b, 0.5, 4, 1, &mut dst);
-        // edge = 2.0 → cols 0,1 = B (blue), cols 2,3 = A (red).
-        assert_eq!(&dst[0..4], &BLUE);
-        assert_eq!(&dst[4..8], &BLUE);
-        assert_eq!(&dst[8..12], &RED);
-        assert_eq!(&dst[12..16], &RED);
+        // `FFmpeg` takes clip B where `x <= z` with the integer `z = width * progress`,
+        // so `z = 2` puts *three* columns on B, not two. The inclusive comparison is the
+        // whole of the one-column divergence #1732 fixed; a `x < w * p` threshold gives
+        // 0,1 here and drifts from the export.
+        assert_eq!(&dst[0..4], &BLUE, "col 0 = B");
+        assert_eq!(&dst[4..8], &BLUE, "col 1 = B");
+        assert_eq!(&dst[8..12], &BLUE, "col 2 = B (x <= z, inclusive)");
+        assert_eq!(&dst[12..16], &RED, "col 3 = A");
     }
 
     #[test]
-    fn apply_xfade_wipeleft_half_should_fill_b_from_the_right() {
+    fn apply_xfade_wipeleft_half_should_fill_b_past_ffmpegs_integer_column() {
         let (a, b) = (frame(RED), frame(BLUE));
         let mut dst = Vec::new();
         apply_xfade(XfadeTransition::WipeLeft, &a, &b, 0.5, 4, 1, &mut dst);
-        // edge = 2.0 → cols 0,1 = A, cols 2,3 = B.
-        assert_eq!(&dst[0..4], &RED);
-        assert_eq!(&dst[8..12], &BLUE);
+        // The mirror of `WipeRight`, and deliberately *not* its exact complement:
+        // `FFmpeg` takes clip B where `x > z` with `z = width * (1 - progress) = 2`, so
+        // only column 3 flips. The two rules together leave column 2 on B for one and on
+        // A for the other at the same progress -- FFmpeg's asymmetry, reproduced.
+        assert_eq!(&dst[0..4], &RED, "col 0 = A");
+        assert_eq!(&dst[4..8], &RED, "col 1 = A");
+        assert_eq!(&dst[8..12], &RED, "col 2 = A (x > z, exclusive)");
+        assert_eq!(&dst[12..16], &BLUE, "col 3 = B");
     }
 
     #[test]
     fn apply_xfade_boundaries_should_be_all_a_or_all_b() {
+        // The kinds whose endpoints are clean. The four `FFmpeg` wipes are not among
+        // them -- see `apply_xfade_wipe_endpoints_should_keep_ffmpegs_edge_column`.
         let (a, b) = (frame(RED), frame(BLUE));
         for kind in [
-            XfadeTransition::WipeRight,
-            XfadeTransition::WipeLeft,
-            XfadeTransition::WipeUp,
-            XfadeTransition::WipeDown,
             XfadeTransition::SlideLeft,
             XfadeTransition::SlideRight,
             XfadeTransition::SlideUp,
@@ -269,6 +330,26 @@ mod tests {
             apply_xfade(kind, &a, &b, 1.0, 4, 1, &mut dst);
             assert_eq!(dst, b, "{kind:?} at progress 1 = all B");
         }
+    }
+
+    #[test]
+    fn apply_xfade_wipe_endpoints_should_keep_ffmpegs_edge_column() {
+        // `FFmpeg`'s integer edge with a strict comparison never quite empties: at
+        // progress 0 `WipeRight` already shows column 0 of B (`x <= 0`), and at progress
+        // 1 `WipeLeft` still holds column 0 of A (`x > 0`). Reproducing that is the point
+        // -- the export lands on FFmpeg's pixels, not on a tidier convention. In a real
+        // transition neither endpoint is rendered anyway: the window runs
+        // `0 .. (n-1)/n`.
+        let (a, b) = (frame(RED), frame(BLUE));
+        let mut dst = Vec::new();
+
+        apply_xfade(XfadeTransition::WipeRight, &a, &b, 0.0, 4, 1, &mut dst);
+        assert_eq!(&dst[0..4], &BLUE, "WipeRight at 0 keeps column 0 on B");
+        assert_eq!(&dst[4..8], &RED, "the rest is still A");
+
+        apply_xfade(XfadeTransition::WipeLeft, &a, &b, 1.0, 4, 1, &mut dst);
+        assert_eq!(&dst[0..4], &RED, "WipeLeft at 1 keeps column 0 on A");
+        assert_eq!(&dst[4..8], &BLUE, "the rest has flipped to B");
     }
 
     // A `w`x`h` packed-RGBA frame where pixel (x, y) is a distinct colour, so a
@@ -290,14 +371,16 @@ mod tests {
         let (a, b) = (tagged(2, 4, 0), tagged(2, 4, 99));
         let mut dst = Vec::new();
         apply_xfade(XfadeTransition::WipeDown, &a, &b, 0.5, 2, 4, &mut dst);
-        // edge = 2.0 → rows 0,1 = B (base_b 99), rows 2,3 = A (base_b 0).
+        // `FFmpeg` takes clip B where `y <= z` with the integer `z = height * progress`,
+        // so `z = 2` puts rows 0..=2 on B and leaves only row 3 on A -- the same
+        // inclusive edge as `WipeRight`, on the other axis (#1732).
         let px = |x: u32, y: u32| {
             let i = ((y * 2 + x) * 4) as usize;
             dst[i + 2] // the base-B channel identifies the source frame
         };
         assert_eq!(px(0, 0), 99, "row 0 = B");
         assert_eq!(px(1, 1), 99, "row 1 = B");
-        assert_eq!(px(0, 2), 0, "row 2 = A");
+        assert_eq!(px(0, 2), 99, "row 2 = B (y <= z, inclusive)");
         assert_eq!(px(1, 3), 0, "row 3 = A");
     }
 
@@ -327,6 +410,53 @@ mod tests {
         let has_a = dst.chunks_exact(4).any(|p| p[2] == 0);
         let has_b = dst.chunks_exact(4).any(|p| p[2] == 99);
         assert!(has_a && has_b, "mid-progress dissolve mixes both A and B");
+    }
+
+    #[test]
+    fn apply_xfade_dissolve_should_follow_ffmpegs_own_noise() {
+        // Tolerance-free: every pixel must agree with `xfade_frand` exactly, which is
+        // what makes the preview show the export's pixel *set* and not merely the same
+        // proportion of them. The hash this replaced revealed a different set entirely
+        // (mean 54 against a real export).
+        let (w, h) = (16u32, 16u32);
+        let n = (w * h) as usize;
+        let a: Vec<u8> = [0u8, 0, 0, 255].repeat(n);
+        let b: Vec<u8> = [255u8, 255, 255, 255].repeat(n);
+        let mut dst = Vec::new();
+        let p = 0.5;
+        apply_xfade(XfadeTransition::Dissolve, &a, &b, p, w, h, &mut dst);
+        for y in 0..h {
+            for x in 0..w {
+                let i = ((y * w + x) * 4) as usize;
+                let want = if xfade_frand(x, y) < p { 255 } else { 0 };
+                assert_eq!(dst[i], want, "pixel ({x}, {y}) must follow xfade_frand");
+            }
+        }
+    }
+
+    #[test]
+    fn apply_xfade_dip_should_hold_the_colour_through_the_middle() {
+        // The shape that distinguishes `FFmpeg`'s phased dip from a linear one: the
+        // solid colour is reached early and held, rather than touched only at the
+        // midpoint. Sampling across progress, the darkest frame must land in the first
+        // phase -- a linear dip bottoms out at 0.5.
+        let a = frame(RED);
+        let b = frame(BLUE);
+        let mut dst = Vec::new();
+        let mut darkest = (u8::MAX, 0u32);
+        for i in 1..=9u32 {
+            let p = i as f32 / 10.0;
+            apply_xfade(XfadeTransition::FadeBlack, &a, &b, p, 4, 1, &mut dst);
+            let luma = dst[0].max(dst[1]).max(dst[2]);
+            if luma < darkest.0 {
+                darkest = (luma, i);
+            }
+        }
+        assert!(
+            darkest.1 <= 3,
+            "the dip must bottom out in its first phase, got progress 0.{}",
+            darkest.1
+        );
     }
 
     #[test]

--- a/crates/ff-render/src/nodes/transition.rs
+++ b/crates/ff-render/src/nodes/transition.rs
@@ -12,6 +12,15 @@ fn lerp_u8(a: f32, b: f32, t: f32) -> u8 {
     (a + (b - a) * t + 0.5).clamp(0.0, 255.0) as u8
 }
 
+/// `FFmpeg`'s fixed dip phase (`vf_xfade.c`, `FADEBLACK_TRANSITION`): the fraction of
+/// the transition spent reaching the solid colour at each end.
+///
+/// It is what makes the dip *not* a linear ramp -- the solid colour is reached about a
+/// fifth of the way in and held through the middle, where a linear dip would only touch
+/// it at the midpoint. The linear version this replaced diverged from a real export by a
+/// mean of 78 (#1732).
+const DIP_PHASE: f32 = 0.2;
+
 /// `smoothstep(e0, e1, x)`; callers guarantee `e1 > e0`.
 fn smoothstep(e0: f32, e1: f32, x: f32) -> f32 {
     let t = ((x - e0) / (e1 - e0)).clamp(0.0, 1.0);
@@ -73,13 +82,46 @@ impl WipeTransitionNode {
         }
     }
 
-    /// The B-weight (`mask`) at a normalised pixel centre. Shared by the CPU and GPU
-    /// paths (`wipe.wgsl` uses the identical formula) so they agree.
+    /// The B-weight (`mask`) for the pixel at `(x, y)` on a `w` x `h` grid. Shared by
+    /// the CPU and GPU paths (`wipe.wgsl` uses the identical formula) so they agree.
     ///
     /// Clip B occupies the side where `proj` exceeds `center`, and `center` sweeps down
-    /// as `progress` rises — so B fills in from the **high** end of the projected axis.
-    fn mask_at(&self, uv_x: f32, uv_y: f32) -> f32 {
+    /// as `progress` rises -- so B fills in from the **high** end of the projected axis.
+    ///
+    /// A hard edge (`softness == 0`) along one of the four axes takes an exact integer
+    /// rule instead, because those are the four `FFmpeg` wipes and the export has to be
+    /// able to reproduce them. `FFmpeg` compares the pixel index against an integer edge
+    /// `z` (`vf_xfade.c`, `WIPE*_TRANSITION`), which puts the seam half a pixel away from
+    /// where a normalised threshold puts it -- one column, but a column that a per-pixel
+    /// comparison sees (#1732). The rule is deliberately asymmetric at the endpoints,
+    /// matching `FFmpeg`: the `-x` axis already shows one column of B at progress 0.
+    ///
+    /// A feathered or off-axis wipe has no `FFmpeg` counterpart to match and keeps the
+    /// smoothstep.
+    fn mask_at(&self, x: u32, y: u32, w: u32, h: u32) -> f32 {
         let (ax, ay) = (self.angle.cos(), self.angle.sin());
+        if self.softness <= 0.0 {
+            const AXIS: f32 = 0.999;
+            #[allow(clippy::cast_precision_loss)]
+            let (wf, hf) = (w as f32, h as f32);
+            // `z` truncates exactly as C's `const int z = width * progress` does.
+            #[allow(clippy::cast_possible_truncation)]
+            let edge = |extent: f32, at: f32| (extent * at) as i64;
+            if ax > AXIS {
+                return f32::from(i64::from(x) > edge(wf, 1.0 - self.progress));
+            }
+            if ax < -AXIS {
+                return f32::from(i64::from(x) <= edge(wf, self.progress));
+            }
+            if ay > AXIS {
+                return f32::from(i64::from(y) > edge(hf, 1.0 - self.progress));
+            }
+            if ay < -AXIS {
+                return f32::from(i64::from(y) <= edge(hf, self.progress));
+            }
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let (uv_x, uv_y) = ((x as f32 + 0.5) / w as f32, (y as f32 + 0.5) / h as f32);
         let reach = f32::midpoint(ax.abs(), ay.abs());
         // Floor the half-width so a zero softness is a near-hard, division-safe edge.
         let hw = self.softness.max(1e-3);
@@ -102,11 +144,10 @@ impl RenderNodeCpu for WipeTransitionNode {
             );
             return;
         }
-        let (wf, hf) = (w as f32, h as f32);
         for y in 0..h {
             for x in 0..w {
                 let idx = ((y * w + x) * 4) as usize;
-                let mask = self.mask_at((x as f32 + 0.5) / wf, (y as f32 + 0.5) / hf);
+                let mask = self.mask_at(x, y, w, h);
                 for c in 0..4 {
                     let a = f32::from(rgba[idx + c]);
                     let b = f32::from(self.to_rgba[idx + c]);
@@ -185,39 +226,28 @@ impl RenderNodeCpu for FadeTransitionNode {
 
 // DissolveTransitionNode
 
-/// A deterministic per-pixel hash in `[0.0, 1.0)`.
+/// Per-pixel dissolve: clip B shows through wherever the supplied `mask` is set.
 ///
-/// Kept bit-identical to `ff-preview`'s host-side `hash01` and to `dissolve.wgsl`, so
-/// the CPU fallback, the GPU node and the preview's own transition all reveal the same
-/// pixels. A different hash would reveal the same *proportion* of clip B while choosing
-/// a different *set* of pixels, which a ratio check cannot detect.
-fn hash01(x: u32, y: u32) -> f32 {
-    let mut h = x
-        .wrapping_mul(374_761_393)
-        .wrapping_add(y.wrapping_mul(668_265_263));
-    h = (h ^ (h >> 13)).wrapping_mul(1_274_126_177);
-    h ^= h >> 16;
-    // Top 24 bits over 2^24: max = (2^24 - 1) / 2^24 = 1 - 2^-24, exactly representable
-    // in f32 and strictly < 1.0, so `progress > hash01` reveals every pixel at
-    // progress 1 and none at progress 0.
-    #[allow(clippy::cast_precision_loss)] // 24 bits fit f32's mantissa exactly
-    {
-        (h >> 8) as f32 / (1u32 << 24) as f32
-    }
-}
-
-/// Per-pixel dissolve: clip B is revealed one pixel at a time as `progress` rises.
+/// This is `FFmpeg`'s `xfade=transition=dissolve`. Unlike [`FadeTransitionNode`] every
+/// output pixel is *fully* clip A or *fully* clip B, never a mixture of them — the node
+/// selects, it does not blend.
 ///
-/// This is `FFmpeg`'s `xfade=transition=dissolve`. Unlike
-/// [`FadeTransitionNode`] every output pixel is *fully* clip A or *fully* clip B — at
-/// 50% the frame holds only the two source values and no mixture of them.
+/// It takes no progress of its own: which pixels have turned over is entirely the mask's
+/// decision, and `ff_filter::dissolve_mask` is what turns a progress into one.
 ///
 /// Like its siblings this node renders to an `Rgba8Unorm` target (the shared
 /// `build_pipeline` hard-codes that format), so it does not run in an `Rgba16Float`
 /// graph.
 pub struct DissolveTransitionNode {
-    /// Transition progress `[0, 1]`: 0 = clip A, 1 = clip B.
-    pub progress: f32,
+    /// Per-pixel selection as an RGBA mask: `255` shows clip B, `0` shows clip A.
+    ///
+    /// Supplied rather than computed. `FFmpeg`'s dissolve keys off
+    /// `fract(sinf(x*12.9898 + y*78.233) * 43758.545)`, whose argument reaches ~110 000
+    /// at 1080p -- past where `f32` holds it steadily, so the value is not reproducible
+    /// across implementations and a `WGSL` copy would reveal a different set of pixels
+    /// than the CPU reference. `ff_filter::dissolve_mask` builds this once and both
+    /// paths read it (#1732).
+    pub mask: Vec<u8>,
     /// Clip B as RGBA bytes (`to_width × to_height × 4`).
     pub to_rgba: Vec<u8>,
     /// Width of `to_rgba`.
@@ -229,11 +259,12 @@ pub struct DissolveTransitionNode {
 }
 
 impl DissolveTransitionNode {
-    /// Creates a dissolve from clip A (the node input) to clip B (`to_rgba`).
+    /// Creates a dissolve from clip A (the node input) to clip B (`to_rgba`), revealing B
+    /// wherever `mask` is set. Build `mask` with `ff_filter::dissolve_mask`.
     #[must_use]
-    pub fn new(progress: f32, to_rgba: Vec<u8>, to_width: u32, to_height: u32) -> Self {
+    pub fn new(mask: Vec<u8>, to_rgba: Vec<u8>, to_width: u32, to_height: u32) -> Self {
         Self {
-            progress,
+            mask,
             to_rgba,
             to_width,
             to_height,
@@ -244,21 +275,25 @@ impl DissolveTransitionNode {
 }
 
 impl RenderNodeCpu for DissolveTransitionNode {
-    fn process_cpu(&self, rgba: &mut [u8], w: u32, h: u32) {
-        if self.to_rgba.len() != rgba.len() {
+    fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
+        if self.to_rgba.len() != rgba.len() || self.mask.len() != rgba.len() {
             log::warn!(
-                "DissolveTransitionNode::process_cpu skipped: size mismatch a={} b={}",
+                "DissolveTransitionNode::process_cpu skipped: size mismatch a={} b={} mask={}",
                 rgba.len(),
-                self.to_rgba.len()
+                self.to_rgba.len(),
+                self.mask.len()
             );
             return;
         }
-        for y in 0..h {
-            for x in 0..w {
-                if self.progress > hash01(x, y) {
-                    let i = ((y * w + x) * 4) as usize;
-                    rgba[i..i + 4].copy_from_slice(&self.to_rgba[i..i + 4]);
-                }
+        for ((px, b), m) in rgba
+            .as_chunks_mut::<4>()
+            .0
+            .iter_mut()
+            .zip(self.to_rgba.as_chunks::<4>().0)
+            .zip(self.mask.as_chunks::<4>().0)
+        {
+            if m[0] >= 128 {
+                *px = *b;
             }
         }
     }
@@ -269,9 +304,15 @@ impl RenderNodeCpu for DissolveTransitionNode {
 /// Two-phase transition: clip A fades to a solid `color`, then the colour fades to
 /// clip B. `progress = 0.5` is the fully solid dip (a fade-to-black/white/brand dip).
 pub struct DipToColorNode {
-    /// Transition progress `[0, 1]`: 0 = clip A, 0.5 = solid `color`, 1 = clip B.
+    /// Transition progress `[0, 1]`: 0 = clip A, 1 = clip B, with `color` solid across
+    /// the middle (see this module's `DIP_PHASE`).
     pub progress: f32,
-    /// Dip colour in RGB `[0, 1]` (e.g. `[0, 0, 0]` for fade-to-black).
+    /// Dip colour in RGB, normally `[0, 1]`.
+    ///
+    /// Values **outside** that range are meaningful and are not clamped until the final
+    /// write: reproducing `FFmpeg`'s `fadeblack` / `fadewhite` needs the dip endpoint to
+    /// be the luma level 0 / 255 expanded out of limited range, which lands just outside
+    /// `[0, 1]`. `avio`'s `map_transition` is what supplies those values.
     pub color: [f32; 3],
     /// Clip B as RGBA bytes (`to_width × to_height × 4`).
     pub to_rgba: Vec<u8>,
@@ -307,23 +348,6 @@ impl DipToColorNode {
 
 impl RenderNodeCpu for DipToColorNode {
     fn process_cpu(&self, rgba: &mut [u8], _w: u32, _h: u32) {
-        let dip = [
-            self.color[0] * 255.0,
-            self.color[1] * 255.0,
-            self.color[2] * 255.0,
-            255.0,
-        ];
-        if self.progress < 0.5 {
-            // Phase 1: clip A -> dip colour. Clip B is not needed yet.
-            let t = self.progress * 2.0;
-            for px in rgba.as_chunks_mut::<4>().0 {
-                for c in 0..4 {
-                    px[c] = lerp_u8(f32::from(px[c]), dip[c], t);
-                }
-            }
-            return;
-        }
-        // Phase 2: dip colour -> clip B.
         if self.to_rgba.len() != rgba.len() {
             log::warn!(
                 "DipToColorNode::process_cpu skipped: size mismatch a={} b={}",
@@ -332,7 +356,17 @@ impl RenderNodeCpu for DipToColorNode {
             );
             return;
         }
-        let t = (self.progress - 0.5) * 2.0;
+        let bg = [
+            self.color[0] * 255.0,
+            self.color[1] * 255.0,
+            self.color[2] * 255.0,
+            255.0,
+        ];
+        // `FFmpeg`'s progress is the complement of ours, and both curves are constant
+        // over the frame, so they are evaluated once rather than per pixel.
+        let g = 1.0 - self.progress;
+        let s1 = smoothstep(1.0 - DIP_PHASE, 1.0, g);
+        let s2 = smoothstep(DIP_PHASE, 1.0, g);
         for (px, b) in rgba
             .as_chunks_mut::<4>()
             .0
@@ -340,7 +374,11 @@ impl RenderNodeCpu for DipToColorNode {
             .zip(self.to_rgba.as_chunks::<4>().0)
         {
             for c in 0..4 {
-                px[c] = lerp_u8(dip[c], f32::from(b[c]), t);
+                let leaving = f32::from(px[c]) * s1 + bg[c] * (1.0 - s1);
+                let arriving = bg[c] * s2 + f32::from(b[c]) * (1.0 - s2);
+                // `lerp_u8(a, b, t)` is `a + (b - a) * t`, so this is
+                // `leaving * g + arriving * (1 - g)` -- FFmpeg's outer `mix`.
+                px[c] = lerp_u8(arriving, leaving, g);
             }
         }
     }
@@ -371,40 +409,50 @@ fn tex_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
 }
 
 /// Builds the shared transition pipeline: bind group `tex_a` / `tex_b` / sampler /
-/// uniform, and a uniform buffer of `uniform_size` bytes.
+/// uniform, a uniform buffer of `uniform_size` bytes, and -- when `mask` is set -- a
+/// third texture at binding 4 carrying a per-pixel selection mask.
+///
+/// Only `DissolveTransitionNode` asks for the mask. The other three shaders declare
+/// exactly the four bindings above, so handing them a layout entry they never read would
+/// be dead surface.
 #[cfg(feature = "wgpu")]
 fn build_pipeline(
     device: &wgpu::Device,
     shader_src: &str,
     label: &str,
     uniform_size: u64,
+    mask: bool,
 ) -> TransitionPipeline {
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some(label),
         source: wgpu::ShaderSource::Wgsl(shader_src.into()),
     });
+    let mut entries = vec![
+        tex_entry(0),
+        tex_entry(1),
+        wgpu::BindGroupLayoutEntry {
+            binding: 2,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+            count: None,
+        },
+        wgpu::BindGroupLayoutEntry {
+            binding: 3,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        },
+    ];
+    if mask {
+        entries.push(tex_entry(4));
+    }
     let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some(label),
-        entries: &[
-            tex_entry(0),
-            tex_entry(1),
-            wgpu::BindGroupLayoutEntry {
-                binding: 2,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                count: None,
-            },
-            wgpu::BindGroupLayoutEntry {
-                binding: 3,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            },
-        ],
+        entries: &entries,
     });
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some(label),
@@ -509,33 +557,42 @@ fn run_pass(
     pd: &TransitionPipeline,
     tex_a: &wgpu::Texture,
     tex_b: &wgpu::Texture,
+    mask: Option<&wgpu::Texture>,
     output: &wgpu::Texture,
     label: &str,
 ) {
     let a_view = tex_a.create_view(&wgpu::TextureViewDescriptor::default());
     let b_view = tex_b.create_view(&wgpu::TextureViewDescriptor::default());
+    let mask_view = mask.map(|m| m.create_view(&wgpu::TextureViewDescriptor::default()));
     let out_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+    let mut bind_entries = vec![
+        wgpu::BindGroupEntry {
+            binding: 0,
+            resource: wgpu::BindingResource::TextureView(&a_view),
+        },
+        wgpu::BindGroupEntry {
+            binding: 1,
+            resource: wgpu::BindingResource::TextureView(&b_view),
+        },
+        wgpu::BindGroupEntry {
+            binding: 2,
+            resource: wgpu::BindingResource::Sampler(&pd.sampler),
+        },
+        wgpu::BindGroupEntry {
+            binding: 3,
+            resource: pd.uniform_buf.as_entire_binding(),
+        },
+    ];
+    if let Some(view) = mask_view.as_ref() {
+        bind_entries.push(wgpu::BindGroupEntry {
+            binding: 4,
+            resource: wgpu::BindingResource::TextureView(view),
+        });
+    }
     let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some(label),
         layout: &pd.bind_group_layout,
-        entries: &[
-            wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::TextureView(&a_view),
-            },
-            wgpu::BindGroupEntry {
-                binding: 1,
-                resource: wgpu::BindingResource::TextureView(&b_view),
-            },
-            wgpu::BindGroupEntry {
-                binding: 2,
-                resource: wgpu::BindingResource::Sampler(&pd.sampler),
-            },
-            wgpu::BindGroupEntry {
-                binding: 3,
-                resource: pd.uniform_buf.as_entire_binding(),
-            },
-        ],
+        entries: &bind_entries,
     });
     let mut encoder = ctx
         .device
@@ -595,6 +652,7 @@ impl super::RenderNode for WipeTransitionNode {
                 include_str!("../shaders/wipe.wgsl"),
                 "Wipe",
                 16,
+                false,
             )
         });
         ctx.queue.write_buffer(
@@ -603,7 +661,7 @@ impl super::RenderNode for WipeTransitionNode {
             &pack_f32(&[self.progress, self.softness, self.angle, 0.0]),
         );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
-        run_pass(ctx, pd, tex_a, &to_tex, output, "Wipe pass");
+        run_pass(ctx, pd, tex_a, &to_tex, None, output, "Wipe pass");
     }
 }
 
@@ -633,8 +691,9 @@ impl super::RenderNode for FadeTransitionNode {
             build_pipeline(
                 &ctx.device,
                 include_str!("../shaders/crossfade.wgsl"),
-                "Dissolve",
+                "Fade",
                 16,
+                false,
             )
         });
         ctx.queue.write_buffer(
@@ -643,7 +702,7 @@ impl super::RenderNode for FadeTransitionNode {
             &pack_f32(&[self.progress, 0.0, 0.0, 0.0]),
         );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
-        run_pass(ctx, pd, tex_a, &to_tex, output, "Dissolve pass");
+        run_pass(ctx, pd, tex_a, &to_tex, None, output, "Fade pass");
     }
 }
 
@@ -667,21 +726,28 @@ impl super::RenderNode for DissolveTransitionNode {
             log::warn!("DissolveTransitionNode::process called with no outputs");
             return;
         };
+        // The only transition that binds a third texture, so the only one that asks
+        // `build_pipeline` for the mask entry.
         let pd = self.pipeline.get_or_init(|| {
             build_pipeline(
                 &ctx.device,
                 include_str!("../shaders/dissolve.wgsl"),
                 "Dissolve",
                 16,
+                true,
             )
         });
-        ctx.queue.write_buffer(
-            &pd.uniform_buf,
-            0,
-            &pack_f32(&[self.progress, 0.0, 0.0, 0.0]),
-        );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
-        run_pass(ctx, pd, tex_a, &to_tex, output, "Dissolve pass");
+        let mask_tex = upload_frame(ctx, &self.mask, self.to_width, self.to_height);
+        run_pass(
+            ctx,
+            pd,
+            tex_a,
+            &to_tex,
+            Some(&mask_tex),
+            output,
+            "Dissolve pass",
+        );
     }
 }
 
@@ -706,7 +772,13 @@ impl super::RenderNode for DipToColorNode {
             return;
         };
         let pd = self.pipeline.get_or_init(|| {
-            build_pipeline(&ctx.device, include_str!("../shaders/dip.wgsl"), "Dip", 32)
+            build_pipeline(
+                &ctx.device,
+                include_str!("../shaders/dip.wgsl"),
+                "Dip",
+                32,
+                false,
+            )
         });
         ctx.queue.write_buffer(
             &pd.uniform_buf,
@@ -723,7 +795,7 @@ impl super::RenderNode for DipToColorNode {
             ]),
         );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
-        run_pass(ctx, pd, tex_a, &to_tex, output, "Dip pass");
+        run_pass(ctx, pd, tex_a, &to_tex, None, output, "Dip pass");
     }
 }
 
@@ -742,32 +814,52 @@ mod tests {
     }
 
     #[test]
-    fn wipe_progress_one_should_be_clip_b() {
-        let b = vec![200u8, 210, 220, 255];
-        let node = WipeTransitionNode::new(1.0, 0.0, 0.0, b.clone(), 1, 1);
-        let mut rgba = vec![10u8, 20, 30, 255];
-        node.process_cpu(&mut rgba, 1, 1);
-        for (got, want) in rgba.iter().zip(b.iter()) {
-            assert!(
-                (i32::from(*got) - i32::from(*want)).abs() <= 1,
-                "progress=1 must output clip B; got {got} want {want}"
+    fn wipe_at_progress_one_should_keep_ffmpegs_final_column() {
+        // `FFmpeg`'s edge is an integer and its comparison is strict, so the last column
+        // never flips: at progress 1 the axis-`+x` rule is `x > floor(w * 0)` = `x > 0`,
+        // leaving column 0 on clip A. Reproducing that asymmetry is the point -- the
+        // export has to land on FFmpeg's pixels, not on a tidier convention (#1732).
+        let a = vec![
+            10u8, 20, 30, 255, 10, 20, 30, 255, 10, 20, 30, 255, 10, 20, 30, 255,
+        ];
+        let b = vec![
+            200u8, 210, 220, 255, 200, 210, 220, 255, 200, 210, 220, 255, 200, 210, 220, 255,
+        ];
+        let node = WipeTransitionNode::new(1.0, 0.0, 0.0, b, 4, 1);
+        let mut rgba = a.clone();
+        node.process_cpu(&mut rgba, 4, 1);
+        assert_eq!(
+            &rgba[0..4],
+            &a[0..4],
+            "column 0 stays on clip A at progress 1"
+        );
+        for x in 1..4 {
+            assert_eq!(
+                &rgba[x * 4..x * 4 + 3],
+                &[200, 210, 220],
+                "column {x} must be clip B at progress 1"
             );
         }
     }
 
     #[test]
-    fn wipe_half_hard_should_split_left_a_right_b() {
-        // A 2×1 frame, angle=0, softness=0: left pixel = A, right pixel = B.
-        let a = vec![10u8, 20, 30, 255, 10, 20, 30, 255];
-        let b = vec![200u8, 210, 220, 255, 200, 210, 220, 255];
-        let node = WipeTransitionNode::new(0.5, 0.0, 0.0, b, 2, 1);
+    fn wipe_hard_edge_should_land_on_ffmpegs_integer_column() {
+        // 8x1, angle 0 (axis +x), softness 0, progress 0.5. `FFmpeg`'s WIPELEFT computes
+        // `z = width * (1 - progress) = 4` and takes clip B where `x > z`, so columns
+        // 0..=4 are A and 5..=7 are B -- an asymmetric split, not four and four. A
+        // normalised threshold puts the seam a column earlier, which is the entire
+        // divergence this rule fixes (#1732).
+        let a: Vec<u8> = (0..8).flat_map(|_| [10u8, 20, 30, 255]).collect();
+        let b: Vec<u8> = (0..8).flat_map(|_| [200u8, 210, 220, 255]).collect();
+        let node = WipeTransitionNode::new(0.5, 0.0, 0.0, b, 8, 1);
         let mut rgba = a.clone();
-        node.process_cpu(&mut rgba, 2, 1);
-        assert_eq!(&rgba[0..4], &[10, 20, 30, 255], "left half must be clip A");
-        for (got, want) in rgba[4..8].iter().zip([200u8, 210, 220, 255].iter()) {
-            assert!(
-                (i32::from(*got) - i32::from(*want)).abs() <= 1,
-                "right half must be clip B"
+        node.process_cpu(&mut rgba, 8, 1);
+        for x in 0..8 {
+            let want: [u8; 3] = if x > 4 { [200, 210, 220] } else { [10, 20, 30] };
+            assert_eq!(
+                &rgba[x * 4..x * 4 + 3],
+                &want,
+                "column {x} at progress 0.5 (FFmpeg edge z=4)"
             );
         }
     }
@@ -830,65 +922,69 @@ mod tests {
     }
 
     #[test]
-    fn dissolve_progress_zero_should_be_clip_a() {
-        // `progress > hash01` and `hash01 >= 0`, so nothing is revealed at 0.
-        let node = DissolveTransitionNode::new(0.0, vec![210u8, 40, 130, 55], 1, 1);
+    fn dissolve_with_an_empty_mask_should_be_clip_a() {
+        let node = DissolveTransitionNode::new(vec![0u8; 4], vec![210u8, 40, 130, 55], 1, 1);
         let a = vec![10u8, 200, 30, 255];
         let mut rgba = a.clone();
         node.process_cpu(&mut rgba, 1, 1);
-        assert_eq!(rgba, a, "progress=0 must output clip A");
+        assert_eq!(rgba, a, "an unset mask must leave clip A");
     }
 
     #[test]
-    fn dissolve_progress_one_should_be_clip_b() {
-        // `hash01` is strictly < 1, so every pixel is revealed at 1.
+    fn dissolve_with_a_full_mask_should_be_clip_b() {
         let b = vec![210u8, 40, 130, 55];
-        let node = DissolveTransitionNode::new(1.0, b.clone(), 1, 1);
+        let node = DissolveTransitionNode::new(vec![255u8; 4], b.clone(), 1, 1);
         let mut rgba = vec![10u8, 200, 30, 255];
         node.process_cpu(&mut rgba, 1, 1);
-        assert_eq!(rgba, b, "progress=1 must output clip B");
+        assert_eq!(rgba, b, "a set mask must reveal clip B");
     }
 
     #[test]
-    fn dissolve_half_should_threshold_pixels_not_blend_them() {
-        // The property that separates this node from `FadeTransitionNode`: at 50% every
-        // pixel is still fully one clip or the other, and roughly half have flipped.
-        let (w, h) = (32u32, 32u32);
+    fn dissolve_should_follow_the_mask_pixel_for_pixel() {
+        // The property that separates this node from `FadeTransitionNode`: it *selects*,
+        // so every pixel stays fully one clip or the other, and which one is the mask's
+        // decision rather than the node's. Pinning the selection exactly (not "about
+        // half") is what makes the node reusable for `FFmpeg`'s own dissolve, whose mask
+        // is computed elsewhere precisely because it cannot be recomputed here.
+        let (w, h) = (8u32, 4u32);
         let n = (w * h) as usize;
         let a: Vec<u8> = [0u8, 0, 0, 255].repeat(n);
         let b: Vec<u8> = [255u8, 255, 255, 255].repeat(n);
-        let node = DissolveTransitionNode::new(0.5, b, w, h);
+        // An irregular pattern, so a node that ignored the mask and thresholded on its
+        // own could not coincidentally agree.
+        let mut mask = vec![0u8; n * 4];
+        for i in 0..n {
+            if i % 3 == 0 {
+                mask[i * 4..i * 4 + 4].fill(255);
+            }
+        }
+        let node = DissolveTransitionNode::new(mask, b, w, h);
         let mut rgba = a.clone();
         node.process_cpu(&mut rgba, w, h);
-
-        let mut distinct: Vec<u8> = rgba.as_chunks::<4>().0.iter().map(|px| px[0]).collect();
-        distinct.sort_unstable();
-        distinct.dedup();
-        assert_eq!(
-            distinct,
-            vec![0, 255],
-            "a dissolve must never produce a mixed value; got {distinct:?}"
-        );
-        let revealed = rgba
-            .as_chunks::<4>()
-            .0
-            .iter()
-            .filter(|px| px[0] == 255)
-            .count();
-        let ratio = revealed as f64 / n as f64;
-        assert!(
-            (0.35..=0.65).contains(&ratio),
-            "progress=0.5 should reveal about half of clip B, got {ratio:.3}"
-        );
+        for (i, px) in rgba.as_chunks::<4>().0.iter().enumerate() {
+            let want = if i % 3 == 0 { 255 } else { 0 };
+            assert_eq!(px[0], want, "pixel {i} must follow the mask");
+        }
     }
 
     #[test]
     fn dissolve_size_mismatch_should_leave_rgba_unchanged() {
-        let node = DissolveTransitionNode::new(1.0, vec![200u8; 8], 2, 1);
+        let node = DissolveTransitionNode::new(vec![255u8; 8], vec![200u8; 8], 2, 1);
         let original = vec![10u8, 200, 30, 255];
         let mut rgba = original.clone();
         node.process_cpu(&mut rgba, 1, 1);
         assert_eq!(rgba, original, "size mismatch must be a no-op");
+    }
+
+    #[test]
+    fn dissolve_mask_size_mismatch_should_leave_rgba_unchanged() {
+        // Clip B is the right size but the mask is not: still a no-op rather than a
+        // partially-applied frame.
+        let node = DissolveTransitionNode::new(vec![255u8; 8], vec![200u8; 4], 1, 1);
+        let original = vec![10u8, 200, 30, 255];
+        let mut rgba = original.clone();
+        node.process_cpu(&mut rgba, 1, 1);
+        assert_eq!(rgba, original, "a mask size mismatch must be a no-op");
     }
 
     #[test]
@@ -902,15 +998,47 @@ mod tests {
     }
 
     #[test]
-    fn dip_half_black_should_be_black() {
+    fn dip_at_half_should_follow_ffmpegs_phased_curve() {
+        // The midpoint is *not* the solid frame -- that is the linear dip this replaced.
+        // With `FFmpeg`'s curve at progress 0.5 (so its own progress is 0.5 too):
+        //   s1 = smoothstep(0.8, 1, 0.5) = 0            -> leaving  = bg = 0
+        //   s2 = smoothstep(0.2, 1, 0.5) = 0.31640625   -> arriving = 200 * 0.68359 = 136.7
+        //   out = 0 * 0.5 + 136.7 * 0.5                 = 68
+        // Pinning the arithmetic rather than a vague "dark" keeps the phase honest: a
+        // linear dip would read 0 here.
         let b = vec![200u8, 200, 200, 255];
         let node = DipToColorNode::new(0.5, [0.0, 0.0, 0.0], b, 1, 1);
         let mut rgba = vec![120u8, 130, 140, 255];
         node.process_cpu(&mut rgba, 1, 1);
-        assert_eq!(
-            &rgba[0..3],
-            &[0, 0, 0],
-            "progress=0.5 with black dip must be a black frame"
+        for (i, got) in rgba[0..3].iter().enumerate() {
+            assert!(
+                (i32::from(*got) - 68).abs() <= 1,
+                "progress=0.5 must follow FFmpeg's phased curve (~68) at {i}, got {got}"
+            );
+        }
+    }
+
+    #[test]
+    fn dip_should_be_darkest_before_the_midpoint() {
+        // `FFmpeg`'s `phase` of 0.2 puts the solid stretch in the first part of the
+        // transition, not at the centre. Sampling across progress, the darkest frame must
+        // land nearer 0.2 than 0.5 -- the property the old linear dip got backwards.
+        let b = vec![200u8, 200, 200, 255];
+        let darkest = (1..=9)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss)]
+                let p = i as f32 / 10.0;
+                let node = DipToColorNode::new(p, [0.0, 0.0, 0.0], b.clone(), 1, 1);
+                let mut rgba = vec![120u8, 130, 140, 255];
+                node.process_cpu(&mut rgba, 1, 1);
+                (rgba[0], i)
+            })
+            .min()
+            .map(|(_, i)| i)
+            .expect("the sweep is non-empty");
+        assert!(
+            darkest <= 3,
+            "the dip must bottom out in its first phase (<= 0.3), got progress 0.{darkest}"
         );
     }
 
@@ -954,26 +1082,65 @@ mod gpu_tests {
     }
 
     #[test]
-    fn wipe_gpu_progress_one_should_be_clip_b() {
+    fn dissolve_gpu_should_follow_the_mask() {
         let Some(ctx) = ctx() else {
             return;
         };
-        let a = vec![10u8, 20, 30, 255];
-        let b = vec![200u8, 210, 220, 255];
+        // The dissolve is the only transition that binds a third texture, so this is the
+        // only test that exercises `build_pipeline`'s mask entry and `run_pass` binding
+        // it. An irregular pattern, so a shader that ignored the mask could not agree by
+        // coincidence; and `textureLoad`, not `textureSample`, so the linear sampler
+        // cannot blur a per-pixel decision.
+        let (w, h) = (8u32, 4u32);
+        let n = (w * h) as usize;
+        let a: Vec<u8> = [0u8, 0, 0, 255].repeat(n);
+        let b: Vec<u8> = [255u8, 255, 255, 255].repeat(n);
+        let mut mask = vec![0u8; n * 4];
+        for i in 0..n {
+            if i % 3 == 0 {
+                mask[i * 4..i * 4 + 4].fill(255);
+            }
+        }
         let out = RenderGraph::new(Arc::clone(&ctx))
-            .push(WipeTransitionNode::new(1.0, 0.0, 0.0, b.clone(), 1, 1))
-            .process_gpu(&a, 1, 1)
-            .expect("gpu wipe");
-        for i in 0..3 {
+            .push(DissolveTransitionNode::new(mask, b, w, h))
+            .process_gpu(&a, w, h)
+            .expect("gpu dissolve");
+        for (i, px) in out.as_chunks::<4>().0.iter().enumerate() {
+            let want: u8 = if i % 3 == 0 { 255 } else { 0 };
             assert!(
-                (i32::from(out[i]) - i32::from(b[i])).abs() <= 2,
-                "GPU wipe progress=1 must output clip B at {i}"
+                (i32::from(px[0]) - i32::from(want)).abs() <= 2,
+                "GPU pixel {i} must follow the mask: got {} want {want}",
+                px[0]
             );
         }
     }
 
     #[test]
-    fn dip_gpu_half_black_should_be_black() {
+    fn wipe_gpu_should_land_on_ffmpegs_integer_column() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        // The CPU mirror of this is `wipe_hard_edge_should_land_on_ffmpegs_integer_column`;
+        // the shader has to agree column for column or the export and the preview drift.
+        let a: Vec<u8> = (0..8).flat_map(|_| [10u8, 20, 30, 255]).collect();
+        let b: Vec<u8> = (0..8).flat_map(|_| [200u8, 210, 220, 255]).collect();
+        let out = RenderGraph::new(Arc::clone(&ctx))
+            .push(WipeTransitionNode::new(0.5, 0.0, 0.0, b, 8, 1))
+            .process_gpu(&a, 8, 1)
+            .expect("gpu wipe");
+        for x in 0..8 {
+            let want: [u8; 3] = if x > 4 { [200, 210, 220] } else { [10, 20, 30] };
+            for i in 0..3 {
+                assert!(
+                    (i32::from(out[x * 4 + i]) - i32::from(want[i])).abs() <= 2,
+                    "GPU column {x} channel {i} at progress 0.5 (FFmpeg edge z=4)"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dip_gpu_at_half_should_match_the_cpu_curve() {
         let Some(ctx) = ctx() else {
             return;
         };
@@ -983,10 +1150,12 @@ mod gpu_tests {
             .push(DipToColorNode::new(0.5, [0.0, 0.0, 0.0], b, 1, 1))
             .process_gpu(&a, 1, 1)
             .expect("gpu dip");
+        // Same arithmetic as `dip_at_half_should_follow_ffmpegs_phased_curve`.
         for i in 0..3 {
             assert!(
-                out[i] <= 2,
-                "GPU dip progress=0.5 (black) must be ~0 at {i}"
+                (i32::from(out[i]) - 68).abs() <= 2,
+                "GPU dip at progress 0.5 must follow FFmpeg's curve (~68) at {i}, got {}",
+                out[i]
             );
         }
     }

--- a/crates/ff-render/src/shaders/dip.wgsl
+++ b/crates/ff-render/src/shaders/dip.wgsl
@@ -1,5 +1,10 @@
-// Two-phase dip to a solid colour: clip A fades to the dip colour over the first
-// half of progress, then the colour fades to clip B over the second half.
+// Two-phase dip through a solid colour, reproducing FFmpeg's `fadeblack` /
+// `fadewhite` (`vf_xfade.c`, FADEBLACK_TRANSITION). The colour is reached about a
+// fifth of the way in and held through the middle -- not a linear ramp to the
+// midpoint. Mirrors `DipToColorNode::process_cpu` so the CPU and GPU paths agree.
+//
+// `u.color` may sit outside [0, 1]: FFmpeg dips to luma 0 / 255, which expands past
+// the displayable range. Nothing clamps until the write to the Rgba8Unorm target.
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
@@ -36,11 +41,15 @@ struct DipUniforms {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let dip = vec4<f32>(u.color.rgb, 1.0);
-    if (u.progress < 0.5) {
-        let color_a = textureSample(tex_a, samp, in.uv);
-        return mix(color_a, dip, u.progress * 2.0);
-    }
-    let color_b = textureSample(tex_b, samp, in.uv);
-    return mix(dip, color_b, (u.progress - 0.5) * 2.0);
+    // FFmpeg's progress is the complement of ours.
+    let g = 1.0 - u.progress;
+    let phase = 0.2;
+    let s1 = smoothstep(1.0 - phase, 1.0, g);
+    let s2 = smoothstep(phase, 1.0, g);
+    let bg = vec4<f32>(u.color.rgb, 1.0);
+    let a = textureSample(tex_a, samp, in.uv);
+    let b = textureSample(tex_b, samp, in.uv);
+    let leaving  = a * s1 + bg * (1.0 - s1);
+    let arriving = bg * s2 + b * (1.0 - s2);
+    return leaving * g + arriving * (1.0 - g);
 }

--- a/crates/ff-render/src/shaders/dissolve.wgsl
+++ b/crates/ff-render/src/shaders/dissolve.wgsl
@@ -1,11 +1,12 @@
-// Per-pixel dissolve: reveal clip B where a deterministic per-pixel hash falls below
-// the transition progress. Unlike a cross-blend every output pixel is fully clip A or
-// fully clip B, so at 50% the frame holds only the two source values and no mixture.
+// Per-pixel dissolve: clip B shows through wherever the supplied mask is set.
 //
-// The hash must match `ff-preview`'s host-side `hash01` bit for bit: the two render the
-// same transition on the CPU and GPU paths, and a different hash would reveal a
-// different *set* of pixels while still revealing the same *proportion* — a divergence
-// a ratio check cannot see. WGSL `u32` arithmetic wraps, matching Rust's `wrapping_*`.
+// The mask is built on the CPU (`ff_filter::dissolve_mask`) rather than derived here.
+// FFmpeg keys its dissolve off `fract(sinf(x*12.9898 + y*78.233) * 43758.545)`, whose
+// argument reaches ~110 000 at 1080p -- past where an f32 holds it steadily, so the
+// value is not reproducible across implementations and a copy of the hash in WGSL would
+// reveal a different set of pixels than the CPU reference does. Reading a mask makes the
+// two agree by construction (#1732).
+
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
@@ -27,39 +28,26 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
     return out;
 }
 
-// ── Bindings ──────────────────────────────────────────────────────────────────
-
 @group(0) @binding(0) var tex_a: texture_2d<f32>;
 @group(0) @binding(1) var tex_b: texture_2d<f32>;
 @group(0) @binding(2) var samp: sampler;
-@group(0) @binding(3) var<uniform> u: DissolveUniforms;
-
-struct DissolveUniforms {
-    progress: f32,
-    _pad0:    f32,
-    _pad1:    f32,
-    _pad2:    f32,
-}
-
-// ── Fragment ──────────────────────────────────────────────────────────────────
-
-/// The same deterministic per-pixel hash in `[0, 1)` the CPU path uses.
-fn hash01(x: u32, y: u32) -> f32 {
-    var h: u32 = x * 374761393u + y * 668265263u;
-    h = (h ^ (h >> 13u)) * 1274126177u;
-    h = h ^ (h >> 16u);
-    // Top 24 bits over 2^24: max = 1 - 2^-24, so `progress > hash01` reveals every
-    // pixel at progress 1 and none at progress 0.
-    return f32(h >> 8u) / 16777216.0;
-}
+// Binding 3 is the uniform buffer the shared `build_pipeline` always creates. This
+// shader has no use for it -- its progress is already baked into the mask -- and a
+// layout entry the shader does not declare is allowed, so it is simply absent here.
+@group(0) @binding(4) var tex_mask: texture_2d<f32>;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    // Integer pixel coordinates, so the hash is keyed the same way as the CPU loop's
-    // `(x, y)` rather than by a float UV that would round differently.
-    let dims = vec2<f32>(textureDimensions(tex_a));
-    let px = vec2<u32>(floor(in.uv * dims));
-    if u.progress > hash01(px.x, px.y) {
+    // `textureLoad` at integer coordinates, not `textureSample`: the mask is a per-pixel
+    // decision, and the shared sampler filters linearly, which would blur the boundary
+    // between a chosen and an unchosen pixel.
+    let dims = textureDimensions(tex_mask);
+    let px = vec2<i32>(clamp(
+        vec2<u32>(in.uv * vec2<f32>(dims)),
+        vec2<u32>(0u),
+        dims - vec2<u32>(1u),
+    ));
+    if textureLoad(tex_mask, px, 0).r >= 0.5 {
         return textureSample(tex_b, samp, in.uv);
     }
     return textureSample(tex_a, samp, in.uv);

--- a/crates/ff-render/src/shaders/wipe.wgsl
+++ b/crates/ff-render/src/shaders/wipe.wgsl
@@ -38,13 +38,36 @@ struct WipeUniforms {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let dims = vec2<f32>(textureDimensions(tex_a));
     let a = vec2<f32>(cos(u.angle), sin(u.angle));
+    let color_a = textureSample(tex_a, samp, in.uv);
+    let color_b = textureSample(tex_b, samp, in.uv);
+
+    // A hard edge along one of the four axes is one of FFmpeg's wipes, which compares
+    // the integer pixel index against an integer edge. Reproduce that exactly rather
+    // than thresholding in normalised space -- the two put the seam one column apart,
+    // which a per-pixel comparison sees. Mirrors `WipeTransitionNode::mask_at`.
+    if (u.softness <= 0.0) {
+        let px = vec2<i32>(floor(in.uv * dims));
+        let axis = 0.999;
+        if (a.x > axis) {
+            return select(color_a, color_b, px.x > i32(dims.x * (1.0 - u.progress)));
+        }
+        if (a.x < -axis) {
+            return select(color_a, color_b, px.x <= i32(dims.x * u.progress));
+        }
+        if (a.y > axis) {
+            return select(color_a, color_b, px.y > i32(dims.y * (1.0 - u.progress)));
+        }
+        if (a.y < -axis) {
+            return select(color_a, color_b, px.y <= i32(dims.y * u.progress));
+        }
+    }
+
     let reach = 0.5 * (abs(a.x) + abs(a.y));
     let hw = max(u.softness, 1e-3);
     let center = mix(0.5 + reach + hw, 0.5 - reach - hw, u.progress);
     let proj = dot(in.uv - vec2<f32>(0.5), a) + 0.5;
     let mask = smoothstep(center - hw, center + hw, proj);
-    let color_a = textureSample(tex_a, samp, in.uv);
-    let color_b = textureSample(tex_b, samp, in.uv);
     return mix(color_a, color_b, mask);
 }

--- a/crates/ff-render/tests/gpu_nodes.rs
+++ b/crates/ff-render/tests/gpu_nodes.rs
@@ -240,17 +240,38 @@ fn fade_transition_gpu_progress_endpoints_should_be_each_clip() {
 
 // DissolveTransitionNode
 
+/// A mask revealing every `nth` pixel, as an irregular stand-in for a real selection.
+///
+/// The node takes its selection as an input rather than deriving one, so these tests
+/// supply their own; `avio`'s `xfade_reference_parity` is what pins the real mask
+/// against `FFmpeg`.
+fn nth_mask(w: u32, h: u32, nth: usize) -> Vec<u8> {
+    let n = (w * h) as usize;
+    let mut mask = vec![0u8; n * 4];
+    for i in 0..n {
+        if i % nth == 0 {
+            mask[i * 4..i * 4 + 4].fill(255);
+        }
+    }
+    mask
+}
+
 #[test]
-fn dissolve_gpu_half_progress_should_threshold_pixels_not_blend_them() {
+fn dissolve_gpu_should_threshold_pixels_not_blend_them() {
     // The property that separates a dissolve from a fade, asserted on the GPU path in
-    // its own right (this file states independent expectations, not GPU-vs-CPU parity;
-    // the pixel-for-pixel agreement between the two hashes is checked by avio's
-    // transition parity suite). Black into white makes a mixed value unmistakable.
+    // its own right (this file states independent expectations, not GPU-vs-CPU parity).
+    // Black into white makes a mixed value unmistakable.
     let Some(ctx) = gpu_ctx() else { return };
     let (w, h) = (32u32, 32u32);
     let a = solid_rgba(0, 0, 0, 255, w, h);
     let b = solid_rgba(255, 255, 255, 255, w, h);
-    let out = run_gpu(&ctx, DissolveTransitionNode::new(0.5, b, w, h), &a, w, h);
+    let out = run_gpu(
+        &ctx,
+        DissolveTransitionNode::new(nth_mask(w, h, 2), b, w, h),
+        &a,
+        w,
+        h,
+    );
 
     let reds: Vec<u8> = out.chunks_exact(4).map(|px| px[0]).collect();
     let mixed = reds.iter().filter(|v| (8..=247).contains(*v)).count();
@@ -266,32 +287,39 @@ fn dissolve_gpu_half_progress_should_threshold_pixels_not_blend_them() {
     let ratio = revealed as f64 / reds.len() as f64;
     assert!(
         (0.35..=0.65).contains(&ratio),
-        "progress=0.5 should reveal about half of clip B, got {ratio:.3}"
+        "an every-other-pixel mask should reveal about half of clip B, got {ratio:.3}"
     );
 }
 
 #[test]
-fn dissolve_gpu_progress_endpoints_should_be_each_clip() {
-    // The 50% case above says nothing about direction; these pin it.
+fn dissolve_gpu_mask_endpoints_should_be_each_clip() {
+    // The half case above says nothing about which way the mask reads; these pin it.
     let Some(ctx) = gpu_ctx() else { return };
     let (w, h) = (16u32, 16u32);
+    let n = (w * h) as usize;
     let a = solid_rgba(0, 0, 0, 255, w, h);
     let b = solid_rgba(255, 255, 255, 255, w, h);
     let at_zero = run_gpu(
         &ctx,
-        DissolveTransitionNode::new(0.0, b.clone(), w, h),
+        DissolveTransitionNode::new(vec![0u8; n * 4], b.clone(), w, h),
         &a,
         w,
         h,
     );
-    let at_one = run_gpu(&ctx, DissolveTransitionNode::new(1.0, b, w, h), &a, w, h);
+    let at_one = run_gpu(
+        &ctx,
+        DissolveTransitionNode::new(vec![255u8; n * 4], b, w, h),
+        &a,
+        w,
+        h,
+    );
     assert!(
         at_zero.chunks_exact(4).all(|px| px[0] < 8),
-        "progress=0 must be entirely clip A"
+        "an unset mask must be entirely clip A"
     );
     assert!(
         at_one.chunks_exact(4).all(|px| px[0] > 247),
-        "progress=1 must be entirely clip B"
+        "a set mask must be entirely clip B"
     );
 }
 


### PR DESCRIPTION
## Objective

- `ff_preview::apply_xfade` is what the preview shows for a transition, and the export runs FFmpeg's `xfade` filter, so the two have to agree. For six of the eight mapped kinds they did not. Measured by exporting a two-clip transition and comparing each window frame against the reference, against an encode round trip's own floor of 1.4: `Dissolve` 54 (the same proportion of clip B, a different set of pixels), `FadeBlack` / `FadeWhite` 78 (a different curve entirely), the wipes 2.5-3.9 (one column of seam).
- Not cosmetic: #1657 pinned the `ff-render` transition nodes to `apply_xfade` pixel for pixel, so the nodes inherited every divergence, and #1659 had to narrow the GPU export to `Fade` alone.

## Solution

- Transcribed each formula from the pinned `vf_xfade.c`. `release/7.1` and `release/8.0` differ only in the filter registration struct, so the transition maths is byte-identical and needs no version gate. FFmpeg's `progress` runs 1 -> 0 where this codebase's runs 0 -> 1, so every formula is converted rather than copied: the wipes compare the pixel index against an **integer** edge (which moves the seam a column and leaves the endpoints asymmetric), the dissolve reveals clip B wherever FFmpeg's own `frand` is below progress, and the dips nest three `mix`es around two `smoothstep`s with a fixed phase of 0.2 — reaching the solid colour early and holding it, rather than touching it at the midpoint.
- **The dip target is luma 0 / 255, not displayable black / white.** FFmpeg mixes there before anything converts to RGB, so mixing toward RGB 0 lands up to `16 * 255/219 ≈ 18.6` away through the middle. Expanding the endpoint out of limited range and clamping only at the final write reproduces it exactly (measured 18.7 -> 2.7); the conversion is affine, so it commutes with the blend.
- **`frand` cannot be recomputed in WGSL.** It is `sinf` of an argument reaching ~110 000 at 1080p, where f32 stops holding it steadily. The argument must be accumulated in f32 (computing it in f64 gives a pixel set 48% different), and Rust's `f32::sin` then reproduces FFmpeg's `sinf` for every pixel — 0% disagreement against a real export. The GPU node therefore takes a mask built once on the CPU and gains a third texture binding. That is also why `xfade_frand` / `dissolve_mask` live in `ff-filter` beside `XfadeTransition`: it is the lowest crate every consumer reaches, and `ff-render` needs no dependency on it because the mask is an input.
- `export_maps_to_gpu` widens from `Fade` to every mapped kind, and `GpuCompositor` grows a `transition` that dispatches to the right node instead of always fading. Worst-frame GPU-vs-CPU export mean per kind is now 2.0-3.6 against a hard cut's floor of 1.4.
- Added `xfade_reference_parity`, which renders a real export and compares the reference against it per kind. It is the only suite that can catch this class of bug: the node parity suite compares the nodes against the reference, so both can be wrong together (and for four kinds, both were), and the export suite compares two export routes, which agree trivially for a kind the GPU path declines. Two source shapes, because neither subsumes the other — flat clips isolate each formula (identical chroma, so 4:2:0 cannot influence the comparison) while structured clips pin direction.

Every corrected formula was confirmed load-bearing by reverting it and watching the number return: dropping the luma expansion takes `FadeBlack` from 2.7 back to 18.7, and restoring the float wipe threshold takes `WipeRight` from 1.0 to 3.6. Where a statistical bound turned out to be a weak detector — one column on a 64px frame is inherently near the noise — the fix was a tolerance-free unit test pinning the exact column, not a looser bound.

One criterion is met as far as it can be. `Dissolve` still reads ~34 against the export on *colourful* sources, and that is inherent rather than a defect: its selection is per-pixel scatter, the worst case for 4:2:0, and FFmpeg selects per plane at half chroma resolution while the reference works in rgba. The selection itself is exact (1.0 on flat sources, 0% pixel disagreement), so the suite covers it on the leg where the measurement is meaningful and says so.

Fixes #1732