### PR TITLE
fix(ci): refresh Homebrew before installing the pinned macOS FFmpeg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
         id: ffmpeg
         if: runner.os == 'macOS'
         run: |
+          # `brew update` first: the pin resolves only if the runner's formula index
+          # knows `ffmpeg@8`, and `macos-latest` currently rotates between two images
+          # whose Homebrew snapshots disagree about that. Image 20260728 has it and
+          # 20260831 does not, so without this the same commit passes or fails depending
+          # on which one it lands on.
+          brew update
           brew install ffmpeg@8 pkg-config
           echo "prefix=$(brew --prefix ffmpeg@8)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Install FFmpeg (macOS)
         id: ffmpeg
         run: |
+          # `brew update` first: the pin resolves only if the runner's formula index
+          # knows `ffmpeg@8`, and `macos-latest` currently rotates between two images
+          # whose Homebrew snapshots disagree about that. Image 20260728 has it and
+          # 20260831 does not, so without this the same commit passes or fails depending
+          # on which one it lands on.
+          brew update
           brew install ffmpeg@8 pkg-config
           echo "prefix=$(brew --prefix ffmpeg@8)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Objective

- `main` is red: `brew install ffmpeg@8` fails with "No available formula".
- `macos-latest` rotates between two images whose Homebrew snapshots disagree about that formula (20260728 has it, 20260831 does not), so the same commit passes or fails depending on which one it lands on. #1734 went green on the older image and broke `main` on the newer one.

## Solution

- Run `brew update` before the install in both workflows, so the pin resolves on either image. `ffmpeg@8` is present upstream (8.1.2, not deprecated or disabled).
- Not falling back to `ffmpeg@7`: that would quietly move macOS onto the major Linux already covers, which is the drift #1728 exists to stop.