### PR TITLE
feat(ff-preview,avio): cache transition pipelines and add the preview blend seam

### DIFF
--- a/crates/avio/src/gpu_preview.rs
+++ b/crates/avio/src/gpu_preview.rs
@@ -9,11 +9,46 @@
 
 use std::time::Duration;
 
-use ff_filter::RealtimeLayer;
+use ff_filter::{RealtimeLayer, XfadeTransition};
 use ff_format::VideoFrame;
 use ff_preview::PreviewCompositor;
 
 use crate::gpu_compositor::GpuCompositor;
+use crate::gpu_transition::{GpuTransition, map_transition};
+
+/// The transition node to render `kind` on, or `None` to leave it on the runner's CPU
+/// path.
+///
+/// Note that the runner does not currently reach any transition for an engine-derived
+/// scene (#1737): it arms at the incoming clip's offset and needs the outgoing clip to
+/// overlap that window, which `avio` never produces. This routing is therefore correct
+/// but dormant until that is fixed.
+///
+/// Narrower than [`map_transition`], and the reason is measurement rather than fidelity:
+/// after #1732 every mapped node produces the same pixels as `apply_xfade`, so this only
+/// decides *where* the work happens. The GPU has to pay two uploads and a readback per
+/// frame, which only the dips earn back — their formula is three `mix`es around two
+/// `smoothstep`s per channel, the heaviest per-pixel arithmetic of the set. Measured
+/// against the CPU path, over three repeats:
+///
+/// | kind | 1080p | 4K |
+/// |---|---|---|
+/// | `FadeBlack` / `FadeWhite` | **2.2x faster** (5.5 vs 12.0 ms) | **1.4x faster** (32 vs 48 ms) |
+/// | `Fade` | 1.2x (5.7 vs 7.3 ms) | tie (30 vs 29 ms) |
+/// | `WipeRight` | 4.4x *slower* (5.4 vs 1.2 ms) | 7.3x *slower* (51 vs 7 ms) |
+/// | `Dissolve` | 2.6x *slower* | 2.1x *slower* |
+///
+/// So only the dips route here. A wipe is a per-row `memcpy` on the CPU and can never
+/// win against a transfer; `Fade` is a single lerp, and its margin sits inside the
+/// run-to-run spread at 4K. `Dissolve` looks worst of all here, but its problem is that
+/// the mask is built on the CPU and *then* uploaded -- caching that field makes the CPU
+/// path 7-9x faster and is #1736, which is where dissolve gets fixed.
+fn preview_transition_node(kind: XfadeTransition) -> Option<GpuTransition> {
+    match map_transition(kind)? {
+        node @ GpuTransition::Dip { .. } => Some(node),
+        GpuTransition::Fade | GpuTransition::Dissolve | GpuTransition::Wipe { .. } => None,
+    }
+}
 
 /// Preview adapter over [`GpuCompositor`]: composites the runner's layers on the GPU,
 /// falling back to `None` (the runner's CPU path) on unsupported content or a GPU error.
@@ -45,11 +80,25 @@ impl PreviewCompositor for GpuPreviewCompositor {
     ) -> Option<(Vec<u8>, u32, u32)> {
         self.core.composite(layers, canvas, t)
     }
+
+    fn blend(
+        &mut self,
+        kind: XfadeTransition,
+        a: &[u8],
+        b: &[u8],
+        progress: f32,
+        w: u32,
+        h: u32,
+    ) -> Option<Vec<u8>> {
+        let node = preview_transition_node(kind)?;
+        self.core.transition(node, progress, a, b.to_vec(), w, h)
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use ff_filter::XfadeTransition;
     use ff_filter::{
         AnimatedValue, BlendMode, CompositeOp, RealtimeLayer, RealtimeLayerDescriptor,
     };
@@ -57,6 +106,55 @@ mod tests {
 
     use super::*;
     use crate::{Clip, Timeline, TimelinePlayer};
+
+    #[test]
+    fn preview_should_route_only_the_dips_to_the_gpu() {
+        // The policy is measured, not assumed: the dips are the only kinds whose GPU
+        // render beats the CPU one once the two uploads and the readback are paid for
+        // (1080p 2.2x, 4K 1.4x, over three repeats). See `preview_transition_node`.
+        for kind in [XfadeTransition::FadeBlack, XfadeTransition::FadeWhite] {
+            assert!(
+                matches!(
+                    preview_transition_node(kind),
+                    Some(GpuTransition::Dip { .. })
+                ),
+                "{kind:?} is measurably faster on the GPU and must route there"
+            );
+        }
+    }
+
+    #[test]
+    fn preview_should_keep_the_cheaper_kinds_on_the_cpu() {
+        // These all map to a node (#1657) and render identically (#1732); routing them
+        // to the GPU would only be slower. `Fade` is here because its margin sits inside
+        // the run-to-run spread at 4K, `WipeRight` because a per-row memcpy cannot lose
+        // to a transfer, and `Dissolve` because its CPU-built mask is the real cost --
+        // fixed by #1736, not by moving it.
+        for kind in [
+            XfadeTransition::Fade,
+            XfadeTransition::Dissolve,
+            XfadeTransition::WipeLeft,
+            XfadeTransition::WipeRight,
+            XfadeTransition::WipeUp,
+            XfadeTransition::WipeDown,
+        ] {
+            assert!(
+                map_transition(kind).is_some(),
+                "{kind:?} still maps to a node; only the routing declines it"
+            );
+            assert!(
+                preview_transition_node(kind).is_none(),
+                "{kind:?} is faster on the CPU and must not route to the GPU"
+            );
+        }
+    }
+
+    #[test]
+    fn preview_should_decline_a_kind_with_no_node() {
+        for kind in [XfadeTransition::SlideLeft, XfadeTransition::Pixelize] {
+            assert!(preview_transition_node(kind).is_none());
+        }
+    }
 
     fn identity_layer(w: u32, h: u32) -> RealtimeLayer {
         let desc = RealtimeLayerDescriptor {

--- a/crates/avio/tests/gpu_preview_transition_test.rs
+++ b/crates/avio/tests/gpu_preview_transition_test.rs
@@ -1,0 +1,119 @@
+//! The preview's GPU blend renders the same picture as the CPU one (#1726).
+//!
+//! `GpuPreviewCompositor::blend` is what the runner reaches when a transition routes to
+//! the GPU. AC1 asks for "no visible difference at the seam", so this measures it against
+//! `ff_preview::apply_xfade` — the path the runner falls back to — rather than asserting
+//! it from the fact that #1732 pinned the two together.
+//!
+//! Both sides work in rgba with no encode in between, so the bound is tight: this is
+//! GPU-versus-CPU arithmetic, not a round trip.
+//!
+//! Probe-gated (RK-002): skips without an adapter.
+
+#![cfg(all(feature = "gpu", feature = "preview"))]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use avio::GpuPreviewCompositor;
+use ff_filter::XfadeTransition;
+use ff_preview::PreviewCompositor;
+
+const W: u32 = 64;
+const H: u32 = 64;
+
+/// The kinds the preview routes to the GPU. Kept beside the assertion rather than
+/// derived from the policy, so a change to the policy shows up here as a decision to
+/// make rather than a test that silently covers less.
+const ROUTED: &[XfadeTransition] = &[XfadeTransition::FadeBlack, XfadeTransition::FadeWhite];
+
+/// Everything else maps to a node but is faster on the CPU, so `blend` must decline it
+/// and leave the runner on `apply_xfade`.
+const NOT_ROUTED: &[XfadeTransition] = &[
+    XfadeTransition::Fade,
+    XfadeTransition::Dissolve,
+    XfadeTransition::WipeLeft,
+    XfadeTransition::WipeRight,
+    XfadeTransition::WipeUp,
+    XfadeTransition::WipeDown,
+    XfadeTransition::SlideLeft,
+    XfadeTransition::Pixelize,
+];
+
+/// Mean absolute RGB difference. Both sides are rgba with no encode between them.
+const TOL_MEAN: f64 = 1.0;
+
+/// Structured, colourful frames: on a flat fill a dip looks the same whatever it does to
+/// the colour channels, so a mis-keyed one would pass unnoticed (RK-022).
+fn structured(phase: u8) -> Vec<u8> {
+    let mut rgba = vec![0u8; (W * H * 4) as usize];
+    for y in 0..H {
+        for x in 0..W {
+            let o = ((y * W + x) * 4) as usize;
+            rgba[o] = u8::try_from(x * 255 / W).unwrap_or(255).wrapping_add(phase);
+            rgba[o + 1] = u8::try_from(y * 255 / H)
+                .unwrap_or(255)
+                .wrapping_add(phase.wrapping_mul(2));
+            rgba[o + 2] = 128u8.wrapping_sub(phase);
+            rgba[o + 3] = 255;
+        }
+    }
+    rgba
+}
+
+fn mean_abs_diff_rgb(a: &[u8], b: &[u8]) -> f64 {
+    let n = a.len().min(b.len()) / 4;
+    assert!(n > 0, "compared an empty frame");
+    let mut sum = 0f64;
+    for i in 0..n {
+        for c in 0..3 {
+            sum += f64::from(a[i * 4 + c].abs_diff(b[i * 4 + c]));
+        }
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let denom = (n * 3) as f64;
+    sum / denom
+}
+
+#[test]
+fn gpu_preview_blend_should_match_the_cpu_reference_for_every_routed_kind() {
+    let Some(mut gpu) = GpuPreviewCompositor::new() else {
+        return; // no adapter -> skip
+    };
+    let (a, b) = (structured(0), structured(100));
+
+    for kind in ROUTED {
+        // The endpoints and the midpoint: 0 and 1 are what pin direction, and the dips
+        // differ from a linear blend mainly in between.
+        for progress in [0.0f32, 0.25, 0.5, 0.75, 1.0] {
+            let out = gpu
+                .blend(*kind, &a, &b, progress, W, H)
+                .unwrap_or_else(|| panic!("{kind:?} routes to the GPU and must blend"));
+            assert_eq!(out.len(), a.len(), "{kind:?} @{progress}: size mismatch");
+
+            let mut reference = Vec::new();
+            ff_preview::apply_xfade(*kind, &a, &b, progress, W, H, &mut reference);
+            let mean = mean_abs_diff_rgb(&out, &reference);
+            println!("{kind:?} @{progress}: mean={mean:.3}");
+            assert!(
+                mean <= TOL_MEAN,
+                "{kind:?} @{progress}: the GPU blend diverged from the CPU one by \
+                 {mean:.3} (tolerance {TOL_MEAN}); the preview would show a seam"
+            );
+        }
+    }
+}
+
+#[test]
+fn gpu_preview_blend_should_decline_the_kinds_it_does_not_render() {
+    // The other half of AC1: a kind the preview keeps on the CPU must return `None` so
+    // the runner falls back, rather than render an approximation of it.
+    let Some(mut gpu) = GpuPreviewCompositor::new() else {
+        return;
+    };
+    let (a, b) = (structured(0), structured(100));
+    for kind in NOT_ROUTED {
+        assert!(
+            gpu.blend(*kind, &a, &b, 0.5, W, H).is_none(),
+            "{kind:?} must be left to the runner's CPU path"
+        );
+    }
+}

--- a/crates/ff-preview/src/scene/compositor.rs
+++ b/crates/ff-preview/src/scene/compositor.rs
@@ -10,7 +10,7 @@
 
 use std::time::Duration;
 
-use ff_filter::RealtimeLayer;
+use ff_filter::{RealtimeLayer, XfadeTransition};
 use ff_format::VideoFrame;
 
 /// An external compositor the preview runner can use in place of its built-in CPU
@@ -29,4 +29,31 @@ pub trait PreviewCompositor: Send {
         canvas: (u32, u32),
         t: Duration,
     ) -> Option<(Vec<u8>, u32, u32)>;
+
+    /// Blend the outgoing frame `a` into the incoming frame `b` at `progress`
+    /// (`0` = all `a`, `1` = all `b`) for the `xfade` `kind`, both packed RGBA of
+    /// `w * h * 4` bytes.
+    ///
+    /// Returns `Some(rgba)` on success, or `None` to leave the frame to the runner's
+    /// CPU `apply_xfade` — which is the answer for a kind the implementor does not
+    /// render, a missing adapter, a GPU error, and a kind it renders correctly but
+    /// slower. Declining must never leave the runner in a bad state.
+    ///
+    /// Defaults to `None`, so an implementor that only composites is unaffected.
+    ///
+    /// This sits beside `composite` rather than in a trait of its own because both
+    /// exist for the same reason — reaching `ff-render`, which depends on this crate —
+    /// and one injected object means one GPU context rather than two.
+    fn blend(
+        &mut self,
+        kind: XfadeTransition,
+        a: &[u8],
+        b: &[u8],
+        progress: f32,
+        w: u32,
+        h: u32,
+    ) -> Option<Vec<u8>> {
+        let _ = (kind, a, b, progress, w, h);
+        None
+    }
 }

--- a/crates/ff-preview/src/scene/runner.rs
+++ b/crates/ff-preview/src/scene/runner.rs
@@ -951,16 +951,37 @@ impl SceneRunner {
                             let alpha = (timeline_pts.saturating_sub(trans_start).as_secs_f32()
                                 / trans_dur.as_secs_f32())
                             .clamp(0.0, 1.0);
-                            inner::apply_xfade(
+                            // Offer the blend to the injected GPU path first; `None`
+                            // falls through to the CPU one below, which covers an
+                            // unrendered kind, no adapter, and a GPU error alike.
+                            if let Some(blended) = try_gpu_blend(
+                                self.gpu_compositor.as_mut(),
                                 trans_kind,
                                 &self.rgba_a,
                                 &self.rgba_b,
                                 alpha,
                                 w,
                                 h,
-                                &mut self.blend_buf,
-                            );
-                            std::mem::swap(&mut self.rgba_a, &mut self.blend_buf);
+                            ) {
+                                // Moved in, not copied into the scratch buffer: the
+                                // readback already owns a correctly sized `Vec`, so
+                                // taking it costs nothing while routing it through
+                                // `blend_buf` would add a full-frame memcpy. The CPU
+                                // branch below swaps instead because `apply_xfade`
+                                // writes into a buffer it does not own.
+                                self.rgba_a = blended;
+                            } else {
+                                inner::apply_xfade(
+                                    trans_kind,
+                                    &self.rgba_a,
+                                    &self.rgba_b,
+                                    alpha,
+                                    w,
+                                    h,
+                                    &mut self.blend_buf,
+                                );
+                                std::mem::swap(&mut self.rgba_a, &mut self.blend_buf);
+                            }
                         }
 
                         // Update overlays (held-frame, advanced by PTS) and composite
@@ -1207,6 +1228,35 @@ fn try_gpu_composite(
     gpu.composite(&pairs, canvas, t)
 }
 
+/// Offer a transition blend to the injected compositor, or `None` when there is none
+/// registered or it declines.
+///
+/// Mirrors [`try_gpu_composite`]: the runner keeps one `if let Some` shape for "the GPU
+/// answered" and treats every other case, including no injection at all, as the CPU path.
+fn try_gpu_blend(
+    gpu: Option<&mut Box<dyn PreviewCompositor>>,
+    kind: XfadeTransition,
+    a: &[u8],
+    b: &[u8],
+    progress: f32,
+    w: u32,
+    h: u32,
+) -> Option<Vec<u8>> {
+    let blended = gpu?.blend(kind, a, b, progress, w, h)?;
+    // A short buffer would be written straight into `rgba_a` and read as a frame, so
+    // check the length here rather than trusting the implementor (the trait is public).
+    if blended.len() == (w as usize) * (h as usize) * 4 {
+        Some(blended)
+    } else {
+        log::warn!(
+            "preview: GPU blend returned {} bytes, expected {}; falling back to the CPU path",
+            blended.len(),
+            (w as usize) * (h as usize) * 4
+        );
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1227,6 +1277,90 @@ mod tests {
             self.calls.set(self.calls.get() + 1);
             self.result.clone()
         }
+    }
+
+    /// A `PreviewCompositor` whose `blend` returns a fixed buffer, to drive the
+    /// transition seam. `composite` is never the subject here.
+    struct MockBlender {
+        result: Option<Vec<u8>>,
+        calls: std::cell::Cell<u32>,
+    }
+
+    impl PreviewCompositor for MockBlender {
+        fn composite(
+            &mut self,
+            _layers: &[(&RealtimeLayer, &VideoFrame)],
+            _canvas: (u32, u32),
+            _t: Duration,
+        ) -> Option<(Vec<u8>, u32, u32)> {
+            None
+        }
+
+        fn blend(
+            &mut self,
+            _kind: XfadeTransition,
+            _a: &[u8],
+            _b: &[u8],
+            _progress: f32,
+            _w: u32,
+            _h: u32,
+        ) -> Option<Vec<u8>> {
+            self.calls.set(self.calls.get() + 1);
+            self.result.clone()
+        }
+    }
+
+    #[test]
+    fn try_gpu_blend_should_return_none_without_a_compositor() {
+        let (a, b) = (vec![0u8; 2 * 2 * 4], vec![255u8; 2 * 2 * 4]);
+        assert!(try_gpu_blend(None, XfadeTransition::Fade, &a, &b, 0.5, 2, 2).is_none());
+    }
+
+    #[test]
+    fn try_gpu_blend_should_use_the_compositor_result_when_some() {
+        let (a, b) = (vec![0u8; 2 * 2 * 4], vec![255u8; 2 * 2 * 4]);
+        let want = vec![7u8; 2 * 2 * 4];
+        let mut gpu: Box<dyn PreviewCompositor> = Box::new(MockBlender {
+            result: Some(want.clone()),
+            calls: std::cell::Cell::new(0),
+        });
+        let out = try_gpu_blend(Some(&mut gpu), XfadeTransition::Fade, &a, &b, 0.5, 2, 2);
+        assert_eq!(out, Some(want));
+    }
+
+    #[test]
+    fn try_gpu_blend_should_return_none_when_the_compositor_declines() {
+        let (a, b) = (vec![0u8; 2 * 2 * 4], vec![255u8; 2 * 2 * 4]);
+        let mut gpu: Box<dyn PreviewCompositor> = Box::new(MockBlender {
+            result: None,
+            calls: std::cell::Cell::new(0),
+        });
+        assert!(try_gpu_blend(Some(&mut gpu), XfadeTransition::Fade, &a, &b, 0.5, 2, 2).is_none());
+    }
+
+    #[test]
+    fn try_gpu_blend_should_reject_a_wrongly_sized_buffer() {
+        // The result is written straight into `rgba_a` and read back as a frame, so a
+        // short buffer has to fall back rather than corrupt the next composite. The
+        // trait is public, so this is not a should-not-happen.
+        let (a, b) = (vec![0u8; 2 * 2 * 4], vec![255u8; 2 * 2 * 4]);
+        let mut gpu: Box<dyn PreviewCompositor> = Box::new(MockBlender {
+            result: Some(vec![7u8; 3]),
+            calls: std::cell::Cell::new(0),
+        });
+        assert!(try_gpu_blend(Some(&mut gpu), XfadeTransition::Fade, &a, &b, 0.5, 2, 2).is_none());
+    }
+
+    #[test]
+    fn try_gpu_blend_should_default_to_none_for_a_composite_only_implementor() {
+        // The trait's default: an existing `PreviewCompositor` that predates this seam
+        // keeps working and simply never takes the GPU blend.
+        let (a, b) = (vec![0u8; 2 * 2 * 4], vec![255u8; 2 * 2 * 4]);
+        let mut gpu: Box<dyn PreviewCompositor> = Box::new(MockCompositor {
+            result: None,
+            calls: std::cell::Cell::new(0),
+        });
+        assert!(try_gpu_blend(Some(&mut gpu), XfadeTransition::Fade, &a, &b, 0.5, 2, 2).is_none());
     }
 
     fn one_spec_and_frame() -> (Vec<RealtimeLayer>, Vec<VideoFrame>) {

--- a/crates/ff-preview/tests/gpu_transition_seam_test.rs
+++ b/crates/ff-preview/tests/gpu_transition_seam_test.rs
@@ -1,0 +1,241 @@
+//! The preview runner routes a transition through the injected GPU seam (#1726).
+//!
+//! `ff-render` depends on this crate, so the runner can only reach a GPU transition node
+//! through [`PreviewCompositor`]. This drives the **real** `SceneRunner` over a two-clip
+//! transition with an injected blender and asserts the runner used what it returned.
+//!
+//! The blender answers with a colour no cross-fade of the source could produce, so a run
+//! that quietly stayed on `apply_xfade` cannot satisfy the assertion — that is the point
+//! of the test, and the reason it does not simply compare against a CPU blend.
+//!
+//! No adapter is involved: this pins the *seam*, not the GPU. `avio`'s
+//! `gpu_preview_transition_test` covers the real nodes, probe-gated.
+//!
+//! **The fixture overlaps its two clips, which the engine does not currently do.** The
+//! runner arms a transition at the incoming clip's offset and blends for `xfade_dur`, so
+//! the outgoing clip has to still be producing frames across that window — but `avio`
+//! passes `clip.offset` through unchanged, and a normal crossfade puts clip B exactly
+//! where clip A ends. Measured on a derived scene: `overlap = 0ns`, and the blend is
+//! reached 0 times against 13 for an overlapping one. That is #1737; until it lands this
+//! suite pins the seam rather than its reachability, and the seam is dormant in
+//! production.
+//!
+//! Probe-gated (RK-002): skips when the shared asset cannot be opened.
+
+#![cfg(feature = "timeline")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ff_filter::{
+    AnimatedValue, BlendMode, CompositeOp, RealtimeLayer, RealtimeLayerDescriptor, XfadeTransition,
+};
+use ff_format::VideoFrame;
+use ff_preview::{
+    FrameSink, PlayerHandle, PreviewCompositor, Scene, ScenePlacement, ScenePlayer, SceneSource,
+    SceneVideoTrack,
+};
+
+/// The colour the injected blender returns. Opaque magenta: the source is real video and
+/// the two clips are the same file, so no `apply_xfade` of them lands here.
+const SENTINEL: [u8; 4] = [255, 0, 255, 255];
+
+fn asset() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../assets/test/av_sync_test_60s.mp4")
+}
+
+/// A compositor that declines to composite and answers every blend with [`SENTINEL`].
+struct SentinelBlender {
+    blends: Arc<Mutex<u32>>,
+}
+
+impl PreviewCompositor for SentinelBlender {
+    fn composite(
+        &mut self,
+        _layers: &[(&RealtimeLayer, &VideoFrame)],
+        _canvas: (u32, u32),
+        _t: Duration,
+    ) -> Option<(Vec<u8>, u32, u32)> {
+        // Not the subject: leave compositing to the runner's CPU path so the sentinel
+        // reaches the sink unmodified by a second GPU stage.
+        None
+    }
+
+    fn blend(
+        &mut self,
+        _kind: XfadeTransition,
+        a: &[u8],
+        _b: &[u8],
+        _progress: f32,
+        _w: u32,
+        _h: u32,
+    ) -> Option<Vec<u8>> {
+        *self.blends.lock().unwrap() += 1;
+        Some(SENTINEL.repeat(a.len() / 4))
+    }
+}
+
+/// Records whether any delivered frame was (almost) entirely [`SENTINEL`].
+struct SentinelSink {
+    saw_sentinel: Arc<Mutex<bool>>,
+    frames: Arc<Mutex<u32>>,
+    handle: PlayerHandle,
+    max_frames: u32,
+}
+
+impl FrameSink for SentinelSink {
+    fn push_frame(&mut self, rgba: &[u8], _w: u32, _h: u32, _pts: Duration) {
+        let px = rgba.len() / 4;
+        if px > 0 {
+            // "Most of the frame", not "every pixel": the runner grades and composites
+            // the blended frame afterwards, and the encode-free path still rounds.
+            let hits = rgba
+                .chunks_exact(4)
+                .filter(|c| {
+                    c[0].abs_diff(SENTINEL[0]) <= 4
+                        && c[1].abs_diff(SENTINEL[1]) <= 4
+                        && c[2].abs_diff(SENTINEL[2]) <= 4
+                })
+                .count();
+            if hits * 100 / px >= 90 {
+                *self.saw_sentinel.lock().unwrap() = true;
+            }
+        }
+        let mut n = self.frames.lock().unwrap();
+        *n += 1;
+        if *n >= self.max_frames {
+            self.handle.stop();
+        }
+    }
+}
+
+fn layer_desc() -> RealtimeLayerDescriptor {
+    RealtimeLayerDescriptor {
+        effects: Vec::new(),
+        opacity: AnimatedValue::Static(1.0),
+        x: AnimatedValue::Static(0.0),
+        y: AnimatedValue::Static(0.0),
+        scale_x: AnimatedValue::Static(1.0),
+        scale_y: AnimatedValue::Static(1.0),
+        rotation: AnimatedValue::Static(0.0),
+        blend_mode: BlendMode::Normal,
+        composite_op: CompositeOp::Over,
+    }
+}
+
+fn placement(
+    offset: Duration,
+    in_point: Duration,
+    dur: Duration,
+    xfade: Option<XfadeTransition>,
+) -> ScenePlacement {
+    ScenePlacement {
+        source: SceneSource::File(asset()),
+        offset,
+        in_point,
+        out_point: Some(in_point + dur),
+        speed: 1.0,
+        xfade_dur: if xfade.is_some() {
+            Duration::from_millis(400)
+        } else {
+            Duration::ZERO
+        },
+        xfade_kind: xfade,
+        opacity: 1.0,
+        layer: layer_desc(),
+        fade_in: Duration::ZERO,
+        fade_out: Duration::ZERO,
+        volume: AnimatedValue::Static(0.0),
+        pitch: 0.0,
+        pan: AnimatedValue::Static(0.0),
+    }
+}
+
+/// Two clips of the same asset with a transition into the second.
+fn transitioned_scene() -> Scene {
+    Scene {
+        fps: 30.0,
+        canvas: None,
+        lavfi_overlay: None,
+        video_tracks: vec![SceneVideoTrack {
+            placements: vec![
+                // Overlapping on purpose; see the module docs. An engine-derived scene
+                // has `overlap = 0ns` and never reaches the blend at all (#1737), so a
+                // faithful fixture would test nothing here.
+                placement(
+                    Duration::ZERO,
+                    Duration::ZERO,
+                    Duration::from_millis(1200),
+                    None,
+                ),
+                placement(
+                    Duration::from_millis(600),
+                    Duration::from_secs(2),
+                    Duration::from_millis(1200),
+                    Some(XfadeTransition::FadeBlack),
+                ),
+            ],
+        }],
+        audio_tracks: Vec::new(),
+    }
+}
+
+/// Runs the scene with `blender` injected (or not) and reports whether the sentinel
+/// reached the sink, or `None` when the environment cannot open the asset.
+fn run_scene(inject: bool) -> Option<(bool, u32)> {
+    let scene = transitioned_scene();
+    let (mut runner, handle) = ScenePlayer::open(&scene).ok()?;
+
+    let saw = Arc::new(Mutex::new(false));
+    let blends = Arc::new(Mutex::new(0));
+    if inject {
+        runner.set_gpu_compositor(Box::new(SentinelBlender {
+            blends: Arc::clone(&blends),
+        }));
+    }
+    runner.set_sink(Box::new(SentinelSink {
+        saw_sentinel: Arc::clone(&saw),
+        frames: Arc::new(Mutex::new(0)),
+        handle,
+        max_frames: 40,
+    }));
+    runner.run().ok()?;
+
+    let saw = *saw.lock().unwrap();
+    let blends = *blends.lock().unwrap();
+    Some((saw, blends))
+}
+
+#[test]
+fn preview_runner_should_use_the_injected_blend_for_a_transition() {
+    let Some((saw, blends)) = run_scene(true) else {
+        return; // asset unavailable -> skip
+    };
+    assert!(
+        blends > 0,
+        "the runner never offered the transition to the seam"
+    );
+    assert!(
+        saw,
+        "the runner called the seam {blends} times but delivered none of its output; \
+         the blend result is being discarded rather than shown"
+    );
+}
+
+#[test]
+fn preview_runner_without_an_injected_blend_should_not_show_the_sentinel() {
+    // The other half, and what makes the test above mean something: with no seam
+    // registered the runner blends on the CPU, which cannot produce the sentinel. If
+    // this ever passed *and* the test above passed for the wrong reason, the sentinel
+    // would have stopped being a discriminator.
+    let Some((saw, blends)) = run_scene(false) else {
+        return;
+    };
+    assert_eq!(
+        blends, 0,
+        "no compositor was injected, so none can be called"
+    );
+    assert!(!saw, "a CPU-only run must not produce the sentinel colour");
+}

--- a/crates/ff-render/src/context.rs
+++ b/crates/ff-render/src/context.rs
@@ -1,5 +1,6 @@
-use std::sync::Mutex;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crate::error::RenderError;
 use crate::pool::TexturePool;
@@ -17,6 +18,29 @@ pub struct RenderContext {
     /// Count of GPU-to-CPU readbacks performed (staging-buffer maps). The
     /// zero-copy display path never increments this; tests assert it stays flat.
     pub(crate) readback_count: AtomicU64,
+    /// Compiled transition pipelines, keyed by shader label.
+    ///
+    /// A transition node carries the incoming clip's pixels, so it is rebuilt for every
+    /// frame of a transition -- the graph feeds `input[1..]` the *source* frame, not a
+    /// caller texture, so there is nowhere else for those pixels to live. Compiling the
+    /// shader per instance would therefore mean compiling it per frame. The pipeline
+    /// depends only on the shader and the layout, never on the node's data, so it is
+    /// cached here on the device that owns it instead (#1726).
+    ///
+    /// **The uniform buffer lives inside each cached entry, so nodes of one kind now
+    /// share it.** That is safe as things stand: a `SceneRunner` owns its own compositor
+    /// and therefore its own context, and the export drains on one thread. Two graphs
+    /// driving the same kind on *one* context concurrently would interleave
+    /// `write_buffer` and `submit` and draw each other's uniforms — if that ever becomes
+    /// possible, the buffer has to come back out of the cache.
+    ///
+    /// The logic lives in `nodes::transition::cached_pipeline`; this is only the store.
+    pub(crate) transition_pipelines: Mutex<
+        HashMap<
+            crate::nodes::transition::TransitionPipelineKey,
+            Arc<crate::nodes::transition::TransitionPipeline>,
+        >,
+    >,
 }
 
 impl RenderContext {
@@ -28,6 +52,7 @@ impl RenderContext {
             queue,
             pool: Mutex::new(TexturePool::new()),
             readback_count: AtomicU64::new(0),
+            transition_pipelines: Mutex::new(HashMap::new()),
         }
     }
 
@@ -40,6 +65,20 @@ impl RenderContext {
     #[cfg(test)]
     pub(crate) fn readback_count(&self) -> u64 {
         self.readback_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of distinct transition pipelines compiled on this device so far.
+    ///
+    /// The cache is what keeps a per-frame node from recompiling its shader, and a
+    /// cache is only load-bearing if something checks it: this lets a test assert the
+    /// count stays at one across a multi-frame transition rather than trust the
+    /// `entry().or_insert_with` by construction (#1726).
+    #[cfg(test)]
+    pub(crate) fn transition_pipeline_count(&self) -> usize {
+        match self.transition_pipelines.lock() {
+            Ok(guard) => guard.len(),
+            Err(poisoned) => poisoned.into_inner().len(),
+        }
     }
 
     /// Initialise wgpu using the default (best available) backend.
@@ -117,6 +156,7 @@ impl RenderContext {
             queue,
             pool: Mutex::new(TexturePool::new()),
             readback_count: AtomicU64::new(0),
+            transition_pipelines: Mutex::new(HashMap::new()),
         })
     }
 }

--- a/crates/ff-render/src/nodes/transition.rs
+++ b/crates/ff-render/src/nodes/transition.rs
@@ -55,8 +55,6 @@ pub struct WipeTransitionNode {
     pub to_width: u32,
     /// Height of `to_rgba`.
     pub to_height: u32,
-    #[cfg(feature = "wgpu")]
-    pipeline: std::sync::OnceLock<TransitionPipeline>,
 }
 
 impl WipeTransitionNode {
@@ -77,8 +75,6 @@ impl WipeTransitionNode {
             to_rgba,
             to_width,
             to_height,
-            #[cfg(feature = "wgpu")]
-            pipeline: std::sync::OnceLock::new(),
         }
     }
 
@@ -189,8 +185,6 @@ pub struct FadeTransitionNode {
     pub to_width: u32,
     /// Height of `to_rgba`.
     pub to_height: u32,
-    #[cfg(feature = "wgpu")]
-    pipeline: std::sync::OnceLock<TransitionPipeline>,
 }
 
 impl FadeTransitionNode {
@@ -202,8 +196,6 @@ impl FadeTransitionNode {
             to_rgba,
             to_width,
             to_height,
-            #[cfg(feature = "wgpu")]
-            pipeline: std::sync::OnceLock::new(),
         }
     }
 }
@@ -254,8 +246,6 @@ pub struct DissolveTransitionNode {
     pub to_width: u32,
     /// Height of `to_rgba`.
     pub to_height: u32,
-    #[cfg(feature = "wgpu")]
-    pipeline: std::sync::OnceLock<TransitionPipeline>,
 }
 
 impl DissolveTransitionNode {
@@ -268,8 +258,6 @@ impl DissolveTransitionNode {
             to_rgba,
             to_width,
             to_height,
-            #[cfg(feature = "wgpu")]
-            pipeline: std::sync::OnceLock::new(),
         }
     }
 }
@@ -320,8 +308,6 @@ pub struct DipToColorNode {
     pub to_width: u32,
     /// Height of `to_rgba`.
     pub to_height: u32,
-    #[cfg(feature = "wgpu")]
-    pipeline: std::sync::OnceLock<TransitionPipeline>,
 }
 
 impl DipToColorNode {
@@ -340,8 +326,6 @@ impl DipToColorNode {
             to_rgba,
             to_width,
             to_height,
-            #[cfg(feature = "wgpu")]
-            pipeline: std::sync::OnceLock::new(),
         }
     }
 }
@@ -386,8 +370,18 @@ impl RenderNodeCpu for DipToColorNode {
 
 // GPU path (shared 2-input plumbing)
 
+/// Identifies a compiled transition pipeline: every input `build_pipeline` bakes in
+/// except the shader source, which the label stands for.
 #[cfg(feature = "wgpu")]
-struct TransitionPipeline {
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub(crate) struct TransitionPipelineKey {
+    pub(crate) label: &'static str,
+    pub(crate) uniform_size: u64,
+    pub(crate) mask: bool,
+}
+
+#[cfg(feature = "wgpu")]
+pub(crate) struct TransitionPipeline {
     render_pipeline: wgpu::RenderPipeline,
     bind_group_layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
@@ -406,6 +400,49 @@ fn tex_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
         },
         count: None,
     }
+}
+
+/// The compiled pipeline for `label`, built once per device and reused afterwards.
+///
+/// Transition nodes are constructed per frame (they own the incoming clip's pixels), so
+/// without this the shader would be compiled per frame: measured at roughly 5 ms a time,
+/// which a 30 fps preview cannot spend. The pipeline is a pure function of the shader and
+/// the layout, so one entry serves every node of that kind on this device (#1726).
+#[cfg(feature = "wgpu")]
+fn cached_pipeline(
+    ctx: &crate::context::RenderContext,
+    label: &'static str,
+    shader_src: &str,
+    uniform_size: u64,
+    mask: bool,
+) -> std::sync::Arc<TransitionPipeline> {
+    let mut cache = match ctx.transition_pipelines.lock() {
+        Ok(guard) => guard,
+        // A poisoned lock means another thread panicked mid-build. The cache holds only
+        // derived data, so recovering it is safe and better than propagating the panic
+        // into a render pass.
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    // Keyed by everything `build_pipeline` bakes in, not by the label alone. The four
+    // labels happen to determine the rest today, but nothing enforces that, and a fifth
+    // node reusing a label would otherwise be handed another shader's pipeline (RK-025:
+    // a cache key has to reflect every input the cached thing was built from). The
+    // colour target is absent because `build_pipeline` hard-codes `Rgba8Unorm` for all
+    // of them; if that ever varies it belongs in this key too.
+    let key = TransitionPipelineKey {
+        label,
+        uniform_size,
+        mask,
+    };
+    std::sync::Arc::clone(cache.entry(key).or_insert_with(|| {
+        std::sync::Arc::new(build_pipeline(
+            &ctx.device,
+            shader_src,
+            label,
+            uniform_size,
+            mask,
+        ))
+    }))
 }
 
 /// Builds the shared transition pipeline: bind group `tex_a` / `tex_b` / sampler /
@@ -646,22 +683,14 @@ impl super::RenderNode for WipeTransitionNode {
             log::warn!("WipeTransitionNode::process called with no outputs");
             return;
         };
-        let pd = self.pipeline.get_or_init(|| {
-            build_pipeline(
-                &ctx.device,
-                include_str!("../shaders/wipe.wgsl"),
-                "Wipe",
-                16,
-                false,
-            )
-        });
+        let pd = cached_pipeline(ctx, "Wipe", include_str!("../shaders/wipe.wgsl"), 16, false);
         ctx.queue.write_buffer(
             &pd.uniform_buf,
             0,
             &pack_f32(&[self.progress, self.softness, self.angle, 0.0]),
         );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
-        run_pass(ctx, pd, tex_a, &to_tex, None, output, "Wipe pass");
+        run_pass(ctx, &pd, tex_a, &to_tex, None, output, "Wipe pass");
     }
 }
 
@@ -687,22 +716,20 @@ impl super::RenderNode for FadeTransitionNode {
         };
         // `crossfade.wgsl` is this node's shader: same binding layout as the other
         // transitions, and its one `f32` uniform is `progress` (see the type docs).
-        let pd = self.pipeline.get_or_init(|| {
-            build_pipeline(
-                &ctx.device,
-                include_str!("../shaders/crossfade.wgsl"),
-                "Fade",
-                16,
-                false,
-            )
-        });
+        let pd = cached_pipeline(
+            ctx,
+            "Fade",
+            include_str!("../shaders/crossfade.wgsl"),
+            16,
+            false,
+        );
         ctx.queue.write_buffer(
             &pd.uniform_buf,
             0,
             &pack_f32(&[self.progress, 0.0, 0.0, 0.0]),
         );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
-        run_pass(ctx, pd, tex_a, &to_tex, None, output, "Fade pass");
+        run_pass(ctx, &pd, tex_a, &to_tex, None, output, "Fade pass");
     }
 }
 
@@ -728,20 +755,18 @@ impl super::RenderNode for DissolveTransitionNode {
         };
         // The only transition that binds a third texture, so the only one that asks
         // `build_pipeline` for the mask entry.
-        let pd = self.pipeline.get_or_init(|| {
-            build_pipeline(
-                &ctx.device,
-                include_str!("../shaders/dissolve.wgsl"),
-                "Dissolve",
-                16,
-                true,
-            )
-        });
+        let pd = cached_pipeline(
+            ctx,
+            "Dissolve",
+            include_str!("../shaders/dissolve.wgsl"),
+            16,
+            true,
+        );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
         let mask_tex = upload_frame(ctx, &self.mask, self.to_width, self.to_height);
         run_pass(
             ctx,
-            pd,
+            &pd,
             tex_a,
             &to_tex,
             Some(&mask_tex),
@@ -771,15 +796,7 @@ impl super::RenderNode for DipToColorNode {
             log::warn!("DipToColorNode::process called with no outputs");
             return;
         };
-        let pd = self.pipeline.get_or_init(|| {
-            build_pipeline(
-                &ctx.device,
-                include_str!("../shaders/dip.wgsl"),
-                "Dip",
-                32,
-                false,
-            )
-        });
+        let pd = cached_pipeline(ctx, "Dip", include_str!("../shaders/dip.wgsl"), 32, false);
         ctx.queue.write_buffer(
             &pd.uniform_buf,
             0,
@@ -795,7 +812,7 @@ impl super::RenderNode for DipToColorNode {
             ]),
         );
         let to_tex = upload_frame(ctx, &self.to_rgba, self.to_width, self.to_height);
-        run_pass(ctx, pd, tex_a, &to_tex, None, output, "Dip pass");
+        run_pass(ctx, &pd, tex_a, &to_tex, None, output, "Dip pass");
     }
 }
 
@@ -1079,6 +1096,63 @@ mod gpu_tests {
             Ok(ctx) => Some(Arc::new(ctx)),
             Err(_) => None,
         }
+    }
+
+    #[test]
+    fn transition_pipeline_should_be_compiled_once_across_frames() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        // AC2 of #1726: a transition node carries the incoming clip's pixels, so it is
+        // rebuilt every frame. Without the shared cache each rebuild recompiled the
+        // shader -- about 5 ms, which a 30 fps preview cannot spend. Drive several
+        // frames of one kind and assert the device compiled it once.
+        let (w, h) = (8u32, 8u32);
+        let n = (w * h) as usize;
+        let a: Vec<u8> = [10u8, 20, 30, 255].repeat(n);
+        let b: Vec<u8> = [200u8, 210, 220, 255].repeat(n);
+        let before = ctx.transition_pipeline_count();
+        for i in 0..5 {
+            #[allow(clippy::cast_precision_loss)]
+            let progress = i as f32 / 5.0;
+            let out = RenderGraph::new(Arc::clone(&ctx))
+                .push(FadeTransitionNode::new(progress, b.clone(), w, h))
+                .process_gpu(&a, w, h)
+                .expect("gpu fade");
+            assert_eq!(out.len(), a.len());
+        }
+        assert_eq!(
+            ctx.transition_pipeline_count() - before,
+            1,
+            "five frames of one kind must compile one pipeline, not five"
+        );
+    }
+
+    #[test]
+    fn transition_pipelines_should_be_cached_per_kind() {
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        // The other half: the cache is keyed by shader, so different kinds must not
+        // collide onto one entry and render as each other.
+        let (w, h) = (8u32, 8u32);
+        let n = (w * h) as usize;
+        let a: Vec<u8> = [10u8, 20, 30, 255].repeat(n);
+        let b: Vec<u8> = [200u8, 210, 220, 255].repeat(n);
+        let before = ctx.transition_pipeline_count();
+        let _ = RenderGraph::new(Arc::clone(&ctx))
+            .push(FadeTransitionNode::new(0.5, b.clone(), w, h))
+            .process_gpu(&a, w, h)
+            .expect("gpu fade");
+        let _ = RenderGraph::new(Arc::clone(&ctx))
+            .push(WipeTransitionNode::new(0.5, 0.0, 0.0, b, w, h))
+            .process_gpu(&a, w, h)
+            .expect("gpu wipe");
+        assert_eq!(
+            ctx.transition_pipeline_count() - before,
+            2,
+            "two kinds must hold two entries"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- Transition nodes carry the incoming clip's pixels, so they are rebuilt every frame and recompiled their shader every frame. The export path pays this once per transition frame today.
- The preview had no way to reach a GPU transition node at all: `ff-render` depends on `ff-preview`, so it needs an injected seam.

## Solution

- Moved the compiled pipeline out of the per-node `OnceLock` into a cache on the device, keyed by everything `build_pipeline` bakes in. A test asserts five frames compile one pipeline.
- Added a defaulted `PreviewCompositor::blend`; the runner offers each transition frame to it and falls back to `apply_xfade` on `None`. `avio` implements it over the existing nodes.
- Only the dips route to the GPU, chosen by measurement rather than by what maps: over three repeats they are 2.2x faster at 1080p and 1.4x at 4K, while wipes are 4-7x *slower* (a per-row memcpy cannot lose to a transfer) and `Fade` ties at 4K. `Dissolve` is worst on the GPU, but its cost is a CPU-built mask, and caching that field makes the **CPU** path 7-9x faster instead. That is #1736.

The seam is dormant in production: the runner arms a transition at the incoming clip's offset and needs the outgoing clip to overlap it, while the engine places clips end to end, so no transition currently reaches this seam *or* `apply_xfade`. That is #1737, and the tests and routing docs say so.

Closes #1726
