### PR TITLE
feat(ff-render): add a P010 semi-planar 10-bit upload path to YuvUploadNode

### DIFF
--- a/crates/ff-render/src/graph/mod.rs
+++ b/crates/ff-render/src/graph/mod.rs
@@ -660,4 +660,135 @@ mod gpu_tests {
             "10-bit precision must distinguish Y=512 from Y=515; got a={a} b={b}"
         );
     }
+
+    /// Bits P010 leaves zeroed at the bottom of each 16-bit sample.
+    const P010_SHIFT: u32 = 6;
+
+    #[test]
+    fn p010_upload_should_preserve_10bit_precision_into_rgba16float() {
+        use ff_format::PixelFormat;
+
+        use crate::nodes::YuvUploadNode;
+
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        let (w, h) = (2u32, 2u32);
+
+        // Render one MSB-aligned 10-bit luma value (neutral chroma) at
+        // Rgba16Float and return the read-back R channel as f32.
+        let render = |y10: u16| -> f32 {
+            let mut node = YuvUploadNode::new_p010(w, h);
+            // 2×2 at 4:2:0: 4 luma samples and one chroma pixel, whose Cb and Cr
+            // are the two interleaved samples of the UV plane.
+            node.set_planes_semi_planar(
+                plane10(y10 << P010_SHIFT, 4),
+                plane10(512 << P010_SHIFT, 2),
+            );
+            let graph = RenderGraph::new(Arc::clone(&ctx))
+                .with_pixel_format(PixelFormat::P010le)
+                .push(node);
+            // The 8-bit `rgba` arg is ignored for an Rgba16Float graph.
+            let out = graph.process_gpu(&[], w, h).expect("hdr frame");
+            assert_eq!(
+                out.len(),
+                (w * h * 8) as usize,
+                "Rgba16Float readback must be 8 bytes/pixel"
+            );
+            f16_to_f32(u16::from_le_bytes([out[0], out[1]]))
+        };
+
+        // Same argument as the planar 10-bit test: Y = 512 and Y = 515 collapse
+        // onto the same 8-bit value but stay 3/1023 ≈ 0.0029 apart in 10-bit.
+        let a = render(512);
+        let b = render(515);
+        assert!(
+            (a - 512.0 / 1023.0).abs() < 0.01,
+            "P010 Y=512 must decode to ~0.5005; got {a}"
+        );
+        assert!(
+            (b - 515.0 / 1023.0).abs() < 0.01,
+            "P010 Y=515 must decode to ~0.5034; got {b}"
+        );
+        assert!(
+            (b - a).abs() > 0.0015,
+            "10-bit precision must distinguish Y=512 from Y=515; got a={a} b={b}"
+        );
+    }
+
+    #[test]
+    fn p010_upload_gpu_should_match_planar_10bit_upload() {
+        use ff_format::PixelFormat;
+
+        use crate::nodes::{YuvFormat, YuvUploadNode};
+
+        const Y: [u16; 8] = [200, 500, 800, 300, 900, 100, 600, 400];
+        const CB: [u16; 2] = [300, 700];
+        const CR: [u16; 2] = [800, 200];
+
+        let Some(ctx) = ctx() else {
+            return;
+        };
+        // 4×2 at 4:2:0 gives a 2×1 chroma plane, so the shader must read the two
+        // chroma columns at the right stride; the columns carry opposite Cb/Cr so
+        // a swapped de-interleave changes the result. The CPU tests cannot cover
+        // any of this — the shader is a separate implementation.
+        let (w, h) = (4u32, 2u32);
+
+        let samples = |values: &[u16], shift: u32| -> Vec<u8> {
+            values
+                .iter()
+                .flat_map(|v| (*v << shift).to_le_bytes())
+                .collect()
+        };
+        let decode = |out: &[u8]| -> Vec<f32> {
+            out.chunks_exact(2)
+                .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+                .collect()
+        };
+
+        let mut planar = YuvUploadNode::new_high_bit_depth(YuvFormat::Yuv420p, w, h);
+        planar.set_planes(samples(&Y, 0), samples(&CB, 0), samples(&CR, 0));
+        let expected = decode(
+            &RenderGraph::new(Arc::clone(&ctx))
+                .with_pixel_format(PixelFormat::Yuv420p10le)
+                .push(planar)
+                .process_gpu(&[], w, h)
+                .expect("planar hdr frame"),
+        );
+
+        let mut p010 = YuvUploadNode::new_p010(w, h);
+        p010.set_planes_semi_planar(
+            samples(&Y, P010_SHIFT),
+            samples(&[CB[0], CR[0], CB[1], CR[1]], P010_SHIFT),
+        );
+        let got = decode(
+            &RenderGraph::new(Arc::clone(&ctx))
+                .with_pixel_format(PixelFormat::P010le)
+                .push(p010)
+                .process_gpu(&[], w, h)
+                .expect("p010 hdr frame"),
+        );
+
+        assert_eq!(
+            got.len(),
+            expected.len(),
+            "both graphs must read back the same number of channels"
+        );
+        for (i, (g, e)) in got.iter().zip(&expected).enumerate() {
+            assert!(
+                (g - e).abs() < 0.002,
+                "channel {i} must match the planar path: p010={g} planar={e}"
+            );
+        }
+        // Non-vacuous: a de-interleave that returned a constant would satisfy the
+        // comparison if both paths were equally broken, so require the fixture to
+        // have actually driven the two chroma columns apart.
+        let red_col0 = got[0];
+        let red_col2 = got[2 * 4];
+        assert!(
+            (red_col0 - red_col2).abs() > 0.1,
+            "the chroma columns must differ in the output; got {red_col0} and {red_col2}"
+        );
+    }
 }

--- a/crates/ff-render/src/nodes/upload.rs
+++ b/crates/ff-render/src/nodes/upload.rs
@@ -12,6 +12,23 @@ pub enum YuvFormat {
     Yuv444p,
 }
 
+/// How the sample data for a [`YuvUploadNode`] is laid out in memory.
+///
+/// One enum rather than a pair of `bool`s (`high_bit_depth` + `semi_planar`)
+/// because the fourth combination — 8-bit semi-planar, i.e. NV12 — is not a
+/// layout this node supports, and a pair of flags would let it be constructed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlaneLayout {
+    /// Three planes, one byte per sample.
+    Planar8,
+    /// Three planes of little-endian `u16` samples holding `0..=1023` in the
+    /// low bits (`Yuv420p10le` and friends).
+    Planar10,
+    /// A luma plane plus one plane of interleaved Cb/Cr, little-endian `u16`
+    /// samples with the 10 significant bits in the *high* bits (`P010le`).
+    SemiPlanar10,
+}
+
 // Pipeline cache
 
 #[cfg(feature = "wgpu")]
@@ -19,8 +36,10 @@ struct YuvPipeline {
     render_pipeline: wgpu::RenderPipeline,
     bind_group_layout: wgpu::BindGroupLayout,
     y_tex: wgpu::Texture,
-    cb_tex: wgpu::Texture,
-    cr_tex: wgpu::Texture,
+    /// Cb for a planar layout; the interleaved Cb/Cr plane for a semi-planar one.
+    chroma_tex: wgpu::Texture,
+    /// Cr — planar layouts only; semi-planar carries it in `chroma_tex`.
+    cr_tex: Option<wgpu::Texture>,
     uniform_buf: wgpu::Buffer,
 }
 
@@ -39,12 +58,16 @@ pub struct YuvUploadNode {
     pub width: u32,
     /// Frame height in pixels.
     pub height: u32,
-    /// `true` for 10-bit planar input (planes are little-endian `u16`, values in
-    /// `0..=1023`) rendered to an `Rgba16Float` target; `false` for 8-bit.
-    high_bit_depth: bool,
+    /// Memory layout of the stored planes, fixed by the constructor used. The
+    /// 10-bit layouts render to an `Rgba16Float` target so precision survives.
+    layout: PlaneLayout,
     y_plane: Vec<u8>,
+    /// Cb — planar layouts only.
     cb_plane: Vec<u8>,
+    /// Cr — planar layouts only.
     cr_plane: Vec<u8>,
+    /// Interleaved Cb/Cr — semi-planar layout only; empty otherwise.
+    uv_plane: Vec<u8>,
     #[cfg(feature = "wgpu")]
     pipeline: std::sync::OnceLock<YuvPipeline>,
 }
@@ -53,6 +76,10 @@ pub struct YuvUploadNode {
 const TEN_BIT_NEUTRAL_CHROMA: u16 = 512;
 /// Maximum 10-bit sample value.
 const TEN_BIT_MAX: f32 = 1023.0;
+/// Bits P010 leaves zeroed at the bottom of each 16-bit sample. Its 10
+/// significant bits are MSB-aligned, matching `FFmpeg`'s own `P010LE` pixel
+/// descriptor (`depth = 10, shift = 6`).
+const P010_SHIFT: u32 = 6;
 
 impl YuvUploadNode {
     /// Create a new 8-bit node. Plane buffers are initialised to neutral values (Y = 0, Cb = Cr = 128).
@@ -63,10 +90,11 @@ impl YuvUploadNode {
             format,
             width,
             height,
-            high_bit_depth: false,
+            layout: PlaneLayout::Planar8,
             y_plane: vec![0u8; (width * height) as usize],
             cb_plane: vec![128u8; (cw * ch) as usize],
             cr_plane: vec![128u8; (cw * ch) as usize],
+            uv_plane: Vec::new(),
             #[cfg(feature = "wgpu")]
             pipeline: std::sync::OnceLock::new(),
         }
@@ -82,16 +110,53 @@ impl YuvUploadNode {
             format,
             width,
             height,
-            high_bit_depth: true,
+            layout: PlaneLayout::Planar10,
             y_plane: vec![0u8; (width * height * 2) as usize],
             cb_plane: u16_le_plane(TEN_BIT_NEUTRAL_CHROMA, (cw * ch) as usize),
             cr_plane: u16_le_plane(TEN_BIT_NEUTRAL_CHROMA, (cw * ch) as usize),
+            uv_plane: Vec::new(),
             #[cfg(feature = "wgpu")]
             pipeline: std::sync::OnceLock::new(),
         }
     }
 
-    /// Replace the stored plane buffers.
+    /// Create a new 10-bit semi-planar (`P010le`) node: a full-resolution luma
+    /// plane plus one plane of interleaved Cb/Cr, both little-endian `u16`.
+    ///
+    /// P010 is always 4:2:0, so there is no [`YuvFormat`] to choose. Its samples
+    /// are MSB-aligned — the 10 significant bits sit in the *high* bits of each
+    /// 16-bit sample, with the low 6 zeroed — unlike
+    /// [`new_high_bit_depth`](Self::new_high_bit_depth), whose planes hold
+    /// `0..=1023` in the low bits. Renders to an `Rgba16Float` target.
+    ///
+    /// Neutral init: Y = 0, Cb = Cr = 512 (MSB-aligned).
+    #[must_use]
+    pub fn new_p010(width: u32, height: u32) -> Self {
+        let format = YuvFormat::Yuv420p;
+        let (cw, ch) = chroma_dims(format, width, height);
+        Self {
+            format,
+            width,
+            height,
+            layout: PlaneLayout::SemiPlanar10,
+            y_plane: vec![0u8; (width * height * 2) as usize],
+            cb_plane: Vec::new(),
+            cr_plane: Vec::new(),
+            // Two samples (Cb, Cr) per chroma pixel.
+            uv_plane: u16_le_plane(TEN_BIT_NEUTRAL_CHROMA << P010_SHIFT, (cw * ch * 2) as usize),
+            #[cfg(feature = "wgpu")]
+            pipeline: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Replace the stored plane buffers of a planar node ([`new`](Self::new) or
+    /// [`new_high_bit_depth`](Self::new_high_bit_depth)).
+    ///
+    /// A semi-planar node ([`new_p010`](Self::new_p010)) reads neither `cb` nor
+    /// `cr`, and its interleaved plane keeps the neutral chroma the constructor
+    /// gave it — which is correctly sized, so no length check catches the
+    /// mistake and the frame renders **greyscale** rather than failing. Use
+    /// [`set_planes_semi_planar`](Self::set_planes_semi_planar) there.
     ///
     /// Expected sizes for `width × height` at `format`, per sample:
     /// - 8-bit: 1 byte; 10-bit ([`new_high_bit_depth`](Self::new_high_bit_depth)): 2 bytes (little-endian `u16`)
@@ -101,6 +166,40 @@ impl YuvUploadNode {
         self.y_plane = y;
         self.cb_plane = cb;
         self.cr_plane = cr;
+    }
+
+    /// Replace the stored planes of a semi-planar node
+    /// ([`new_p010`](Self::new_p010)).
+    ///
+    /// Both planes hold little-endian `u16` samples (2 bytes each):
+    /// - `y`: `width × height` samples
+    /// - `uv`: `chroma_w × chroma_h × 2` samples — Cb and Cr interleaved, one
+    ///   pair per chroma pixel, so `uv` holds twice as many samples as a single
+    ///   planar chroma plane would. This is the layout `ff-format` gives
+    ///   `P010le` (`uv_stride = width × 2` bytes over `height / 2` rows).
+    ///
+    /// Planes are expected dense (no row padding). A plane too short for the
+    /// node's dimensions is refused with a warning rather than read past its end.
+    ///
+    /// The mirror of the trap in [`set_planes`](Self::set_planes): a planar node
+    /// never reads `uv`, so calling this on one updates only the luma and leaves
+    /// the chroma at its neutral init, silently.
+    pub fn set_planes_semi_planar(&mut self, y: Vec<u8>, uv: Vec<u8>) {
+        self.y_plane = y;
+        self.uv_plane = uv;
+    }
+
+    /// `true` when the stored semi-planar planes are large enough for the node's
+    /// dimensions.
+    ///
+    /// Checked up front because a short plane would index past its end on the
+    /// CPU path and hand `write_texture` an undersized slice on the GPU one.
+    fn semi_planar_planes_are_complete(&self) -> bool {
+        let (cw, ch) = chroma_dims(self.format, self.width, self.height);
+        let luma_bytes = (self.width as usize) * (self.height as usize) * 2;
+        // Cb and Cr interleaved: two `u16` samples, so 4 bytes, per chroma pixel.
+        let uv_bytes = (cw as usize) * (ch as usize) * 4;
+        self.y_plane.len() >= luma_bytes && self.uv_plane.len() >= uv_bytes
     }
 }
 
@@ -145,10 +244,10 @@ impl RenderNodeCpu for YuvUploadNode {
         if self.y_plane.is_empty() || self.width == 0 || self.height == 0 {
             return;
         }
-        if self.high_bit_depth {
-            self.process_cpu_10bit(rgba, w, h);
-        } else {
-            self.process_cpu_8bit(rgba, w, h);
+        match self.layout {
+            PlaneLayout::Planar8 => self.process_cpu_8bit(rgba, w, h),
+            PlaneLayout::Planar10 => self.process_cpu_10bit(rgba, w, h),
+            PlaneLayout::SemiPlanar10 => self.process_cpu_p010(rgba, w, h),
         }
     }
 }
@@ -204,13 +303,69 @@ impl YuvUploadNode {
             }
         }
     }
+
+    /// CPU YCbCr→RGBA for 10-bit semi-planar (`P010le`) input: a luma plane plus
+    /// one plane of interleaved Cb/Cr, both little-endian `u16` with the 10
+    /// significant bits MSB-aligned. Like the planar 10-bit leg, the CPU
+    /// fallback writes 8-bit RGBA and so loses precision the GPU `Rgba16Float`
+    /// path preserves.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::many_single_char_names
+    )]
+    fn process_cpu_p010(&self, rgba: &mut [u8], w: u32, h: u32) {
+        if !self.semi_planar_planes_are_complete() {
+            log::warn!(
+                "YuvUploadNode P010 planes too small for the frame: width={} height={} y_len={} uv_len={}",
+                self.width,
+                self.height,
+                self.y_plane.len(),
+                self.uv_plane.len()
+            );
+            return;
+        }
+        let (cw, _) = chroma_dims(self.format, self.width, self.height);
+        let (x_div, y_div) = chroma_divs(self.format);
+        let rows = h.min(self.height) as usize;
+        let cols = w.min(self.width) as usize;
+        for row in 0..rows {
+            for col in 0..cols {
+                let y_val = p010_norm(&self.y_plane, row * self.width as usize + col);
+                let cx = col / x_div as usize;
+                let cy = row / y_div as usize;
+                // Cb and Cr are adjacent samples of the same chroma pixel.
+                let ci = (cy * cw as usize + cx) * 2;
+                let cb = p010_norm(&self.uv_plane, ci) - 0.5;
+                let cr = p010_norm(&self.uv_plane, ci + 1) - 0.5;
+                write_ycbcr_rgba(rgba, (row * w as usize + col) * 4, y_val, cb, cr);
+            }
+        }
+    }
+}
+
+/// Read the `i`-th little-endian `u16` sample of a plane.
+fn raw_u16_le(plane: &[u8], i: usize) -> u16 {
+    u16::from_le_bytes([plane[i * 2], plane[i * 2 + 1]])
 }
 
 /// Read the `i`-th little-endian `u16` sample of a plane as `f32`.
 fn sample_u16_le(plane: &[u8], i: usize) -> f32 {
-    let lo = plane[i * 2];
-    let hi = plane[i * 2 + 1];
-    f32::from(u16::from_le_bytes([lo, hi]))
+    f32::from(raw_u16_le(plane, i))
+}
+
+/// Read the `i`-th MSB-aligned P010 sample of a plane, normalised to `[0, 1]`.
+///
+/// Dropping the zeroed low [`P010_SHIFT`] bits before dividing by
+/// [`TEN_BIT_MAX`] is what makes a P010 sample agree with the planar 10-bit
+/// path: both then divide the same `0..=1023` value.
+///
+/// Named for the normalisation, not for the read: [`sample_u16_le`] returns the
+/// raw value and leaves the divide to its caller, so a `_sample` twin here would
+/// invite dividing by [`TEN_BIT_MAX`] a second time. `p010_norm` is also what the
+/// shader calls its own copy of this.
+fn p010_norm(plane: &[u8], i: usize) -> f32 {
+    f32::from(raw_u16_le(plane, i) >> P010_SHIFT) / TEN_BIT_MAX
 }
 
 /// BT.601 full-range YCbCr → RGBA, writing 4 bytes at `idx` (alpha = 255).
@@ -235,76 +390,76 @@ impl YuvUploadNode {
             let device = &ctx.device;
             let (cw, ch) = chroma_dims(self.format, self.width, self.height);
 
-            // 10-bit planes are R16Uint (raw 0..1023) sampled as integers and
-            // divided by max_value in the shader, rendering to Rgba16Float so
-            // precision survives. R16Uint is a core format (unlike R16Unorm,
-            // which needs an optional device feature). 8-bit planes stay R8Unorm
-            // sampled as normalised floats, rendering to Rgba8Unorm.
-            let (plane_format, target_format, sample_type, shader_src) = if self.high_bit_depth {
-                (
-                    wgpu::TextureFormat::R16Uint,
-                    wgpu::TextureFormat::Rgba16Float,
-                    wgpu::TextureSampleType::Uint,
-                    include_str!("../shaders/yuv_upload_10bit.wgsl"),
-                )
-            } else {
-                (
-                    wgpu::TextureFormat::R8Unorm,
-                    wgpu::TextureFormat::Rgba8Unorm,
-                    wgpu::TextureSampleType::Float { filterable: false },
-                    include_str!("../shaders/yuv_upload.wgsl"),
-                )
-            };
+            // 10-bit planes are *Uint (raw samples) divided by max_value in the
+            // shader, rendering to Rgba16Float so precision survives. R16Uint and
+            // Rg16Uint are core formats (unlike R16Unorm, which needs an optional
+            // device feature). 8-bit planes stay R8Unorm sampled as normalised
+            // floats, rendering to Rgba8Unorm. The target format is threaded
+            // through rather than hardcoded, so an Rgba16Float graph gets a
+            // matching attachment.
+            let (luma_format, chroma_format, target_format, sample_type, shader_src) =
+                match self.layout {
+                    PlaneLayout::Planar8 => (
+                        wgpu::TextureFormat::R8Unorm,
+                        wgpu::TextureFormat::R8Unorm,
+                        wgpu::TextureFormat::Rgba8Unorm,
+                        wgpu::TextureSampleType::Float { filterable: false },
+                        include_str!("../shaders/yuv_upload.wgsl"),
+                    ),
+                    PlaneLayout::Planar10 => (
+                        wgpu::TextureFormat::R16Uint,
+                        wgpu::TextureFormat::R16Uint,
+                        wgpu::TextureFormat::Rgba16Float,
+                        wgpu::TextureSampleType::Uint,
+                        include_str!("../shaders/yuv_upload_10bit.wgsl"),
+                    ),
+                    PlaneLayout::SemiPlanar10 => (
+                        wgpu::TextureFormat::R16Uint,
+                        // Cb and Cr are the two channels of one texel.
+                        wgpu::TextureFormat::Rg16Uint,
+                        wgpu::TextureFormat::Rgba16Float,
+                        wgpu::TextureSampleType::Uint,
+                        include_str!("../shaders/p010_upload.wgsl"),
+                    ),
+                };
+            let planar = self.layout != PlaneLayout::SemiPlanar10;
 
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("YuvUpload shader"),
                 source: wgpu::ShaderSource::Wgsl(shader_src.into()),
             });
 
+            let texture_entry = |binding: u32| wgpu::BindGroupLayoutEntry {
+                binding,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            };
+            // Semi-planar input carries Cb and Cr in one texture, so binding 2 is
+            // absent there. The uniform stays at binding 3 in every layout so all
+            // three upload shaders agree on where it is.
+            let mut entries = vec![texture_entry(0), texture_entry(1)];
+            if planar {
+                entries.push(texture_entry(2));
+            }
+            entries.push(wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            });
+
             let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("YuvUpload BGL"),
-                entries: &[
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type,
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type,
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type,
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 3,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Uniform,
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                ],
+                entries: &entries,
             });
 
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -339,53 +494,39 @@ impl YuvUploadNode {
                 cache: None,
             });
 
+            let plane_tex = |label: &str, format: wgpu::TextureFormat, w: u32, h: u32| {
+                device.create_texture(&wgpu::TextureDescriptor {
+                    label: Some(label),
+                    size: wgpu::Extent3d {
+                        width: w,
+                        height: h,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format,
+                    usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
+                    view_formats: &[],
+                })
+            };
+
             // Y luma plane (full resolution).
-            let y_tex = device.create_texture(&wgpu::TextureDescriptor {
-                label: Some("YuvUpload Y"),
-                size: wgpu::Extent3d {
-                    width: self.width,
-                    height: self.height,
-                    depth_or_array_layers: 1,
+            let y_tex = plane_tex("YuvUpload Y", luma_format, self.width, self.height);
+            // Cb, or the interleaved Cb/Cr plane for a semi-planar layout
+            // (sub-sampled either way).
+            let chroma_tex = plane_tex(
+                if planar {
+                    "YuvUpload Cb"
+                } else {
+                    "YuvUpload UV"
                 },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: plane_format,
-                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
-                view_formats: &[],
-            });
-
-            // Cb chroma plane (sub-sampled).
-            let cb_tex = device.create_texture(&wgpu::TextureDescriptor {
-                label: Some("YuvUpload Cb"),
-                size: wgpu::Extent3d {
-                    width: cw,
-                    height: ch,
-                    depth_or_array_layers: 1,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: plane_format,
-                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
-                view_formats: &[],
-            });
-
-            // Cr chroma plane (sub-sampled).
-            let cr_tex = device.create_texture(&wgpu::TextureDescriptor {
-                label: Some("YuvUpload Cr"),
-                size: wgpu::Extent3d {
-                    width: cw,
-                    height: ch,
-                    depth_or_array_layers: 1,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: plane_format,
-                usage: wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
-                view_formats: &[],
-            });
+                chroma_format,
+                cw,
+                ch,
+            );
+            // Cr chroma plane (sub-sampled) — planar layouts only.
+            let cr_tex = planar.then(|| plane_tex("YuvUpload Cr", chroma_format, cw, ch));
 
             // Uniform buffer: [chroma_x_div, chroma_y_div, pad, pad] = 16 bytes.
             let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
@@ -399,7 +540,7 @@ impl YuvUploadNode {
                 render_pipeline,
                 bind_group_layout: bgl,
                 y_tex,
-                cb_tex,
+                chroma_tex,
                 cr_tex,
                 uniform_buf,
             }
@@ -428,79 +569,66 @@ impl super::RenderNode for YuvUploadNode {
             log::warn!("YuvUploadNode::process called with no outputs");
             return;
         };
+        if self.layout == PlaneLayout::SemiPlanar10 && !self.semi_planar_planes_are_complete() {
+            log::warn!(
+                "YuvUploadNode::process P010 planes too small for the frame: width={} height={} y_len={} uv_len={}",
+                self.width,
+                self.height,
+                self.y_plane.len(),
+                self.uv_plane.len()
+            );
+            return;
+        }
 
         let pd = self.get_or_create_pipeline(ctx);
         let (cw, ch) = chroma_dims(self.format, self.width, self.height);
         let (x_div, y_div) = chroma_divs(self.format);
-        // Bytes per sample: 8-bit R8Unorm = 1, 10-bit R16Unorm = 2.
-        let bps = if self.high_bit_depth { 2 } else { 1 };
+        // Bytes per texel: R8Unorm = 1, R16Uint = 2, Rg16Uint = 4 (Cb and Cr in
+        // one texel).
+        let (luma_bpt, chroma_bpt) = match self.layout {
+            PlaneLayout::Planar8 => (1, 1),
+            PlaneLayout::Planar10 => (2, 2),
+            PlaneLayout::SemiPlanar10 => (2, 4),
+        };
+        let chroma_plane = if self.layout == PlaneLayout::SemiPlanar10 {
+            &self.uv_plane
+        } else {
+            &self.cb_plane
+        };
 
-        // Upload Y luma plane.
-        ctx.queue.write_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: &pd.y_tex,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &self.y_plane,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(self.width * bps),
-                rows_per_image: None,
-            },
-            wgpu::Extent3d {
-                width: self.width,
-                height: self.height,
-                depth_or_array_layers: 1,
-            },
-        );
+        let upload = |tex: &wgpu::Texture, data: &[u8], w: u32, h: u32, bpt: u32| {
+            ctx.queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: tex,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                data,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(w * bpt),
+                    rows_per_image: None,
+                },
+                wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+            );
+        };
 
-        // Upload Cb chroma plane.
-        ctx.queue.write_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: &pd.cb_tex,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &self.cb_plane,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(cw * bps),
-                rows_per_image: None,
-            },
-            wgpu::Extent3d {
-                width: cw,
-                height: ch,
-                depth_or_array_layers: 1,
-            },
-        );
-
-        // Upload Cr chroma plane.
-        ctx.queue.write_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: &pd.cr_tex,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &self.cr_plane,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(cw * bps),
-                rows_per_image: None,
-            },
-            wgpu::Extent3d {
-                width: cw,
-                height: ch,
-                depth_or_array_layers: 1,
-            },
-        );
+        upload(&pd.y_tex, &self.y_plane, self.width, self.height, luma_bpt);
+        upload(&pd.chroma_tex, chroma_plane, cw, ch, chroma_bpt);
+        // Semi-planar input has no separate Cr plane; its texture is not created.
+        if let Some(cr_tex) = pd.cr_tex.as_ref() {
+            upload(cr_tex, &self.cr_plane, cw, ch, chroma_bpt);
+        }
 
         // Uniforms: [chroma_x_div: u32, chroma_y_div: u32, max_value: f32, pad].
-        // max_value is the 10-bit shader's normalisation divisor (1023); the
-        // 8-bit shader ignores this slot (its plane samples are pre-normalised).
+        // max_value is the 10-bit shaders' normalisation divisor (1023) — P010
+        // shifts its MSB-aligned samples down first, so the divisor is the same;
+        // the 8-bit shader ignores this slot (its samples are pre-normalised).
         let mut uniforms = [0u8; 16];
         uniforms[0..4].copy_from_slice(&x_div.to_le_bytes());
         uniforms[4..8].copy_from_slice(&y_div.to_le_bytes());
@@ -510,35 +638,42 @@ impl super::RenderNode for YuvUploadNode {
         let y_view = pd
             .y_tex
             .create_view(&wgpu::TextureViewDescriptor::default());
-        let cb_view = pd
-            .cb_tex
+        let chroma_view = pd
+            .chroma_tex
             .create_view(&wgpu::TextureViewDescriptor::default());
         let cr_view = pd
             .cr_tex
-            .create_view(&wgpu::TextureViewDescriptor::default());
+            .as_ref()
+            .map(|tex| tex.create_view(&wgpu::TextureViewDescriptor::default()));
         let out_view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Mirrors the layout built in `get_or_create_pipeline`: binding 2 exists
+        // only for a planar layout, the uniform is always at binding 3.
+        let mut bg_entries = vec![
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&y_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(&chroma_view),
+            },
+        ];
+        if let Some(cr_view) = cr_view.as_ref() {
+            bg_entries.push(wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::TextureView(cr_view),
+            });
+        }
+        bg_entries.push(wgpu::BindGroupEntry {
+            binding: 3,
+            resource: pd.uniform_buf.as_entire_binding(),
+        });
 
         let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("YuvUpload BG"),
             layout: &pd.bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(&y_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::TextureView(&cb_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::TextureView(&cr_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: pd.uniform_buf.as_entire_binding(),
-                },
-            ],
+            entries: &bg_entries,
         });
 
         let mut encoder = ctx
@@ -733,6 +868,120 @@ mod tests {
             );
             assert_eq!(pixel[3], 255, "alpha must be opaque");
         }
+    }
+
+    /// A plane of the given little-endian `u16` samples.
+    fn u16_le_samples(values: &[u16]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    /// The same samples MSB-aligned the way P010 stores them.
+    fn p010_samples(values: &[u16]) -> Vec<u8> {
+        let shifted: Vec<u16> = values.iter().map(|v| v << P010_SHIFT).collect();
+        u16_le_samples(&shifted)
+    }
+
+    #[test]
+    fn yuv_upload_cpu_p010_should_decode_msb_aligned_samples() {
+        // Y = 768 once the 6-bit shift is undone → 768/1023 ≈ 0.751 → grey ≈ 191.
+        // Non-vacuous: reading the sample without shifting divides 49152 by 1023
+        // and clamps to white (255), which is nowhere near 191.
+        let mut node = YuvUploadNode::new_p010(2, 2);
+        node.set_planes_semi_planar(p010_samples(&[768; 4]), p010_samples(&[512; 2]));
+        let mut rgba = vec![0u8; 16];
+        node.process_cpu(&mut rgba, 2, 2);
+        for pixel in rgba.chunks_exact(4) {
+            let r = i32::from(pixel[0]);
+            assert!(
+                (r - 191).abs() <= 3,
+                "P010 Y=768 must decode to ~191; got {r} (255 means the shift was skipped)"
+            );
+            assert_eq!(pixel[3], 255, "alpha must be opaque");
+        }
+    }
+
+    #[test]
+    fn yuv_upload_cpu_p010_should_deinterleave_cb_and_cr() {
+        // 4×2 at 4:2:0 → a 2×1 chroma plane, so the UV plane holds two pairs:
+        // [Cb0, Cr0, Cb1, Cr1]. Giving the two chroma columns opposite Cb/Cr
+        // makes a swapped or mis-strided read visible: the channel that moves
+        // changes. A single chroma column, or w == h, would hide both.
+        let mut node = YuvUploadNode::new_p010(4, 2);
+        node.set_planes_semi_planar(p010_samples(&[512; 8]), p010_samples(&[512, 800, 800, 512]));
+        let mut rgba = vec![0u8; 32];
+        node.process_cpu(&mut rgba, 4, 2);
+
+        let red_and_blue = |x: usize, y: usize| -> (i32, i32) {
+            let i = (y * 4 + x) * 4;
+            (i32::from(rgba[i]), i32::from(rgba[i + 2]))
+        };
+        // Chroma column 0 covers x = 0..2: Cr is high, so red rises and blue
+        // stays neutral.
+        for x in [0, 1] {
+            for y in [0, 1] {
+                let (r, b) = red_and_blue(x, y);
+                assert!(r > 200, "Cr=800 must push R high at ({x},{y}); got {r}");
+                assert!(b < 160, "Cb=512 must leave B neutral at ({x},{y}); got {b}");
+            }
+        }
+        // Chroma column 1 covers x = 2..4, with the roles swapped.
+        for x in [2, 3] {
+            for y in [0, 1] {
+                let (r, b) = red_and_blue(x, y);
+                assert!(r < 160, "Cr=512 must leave R neutral at ({x},{y}); got {r}");
+                assert!(b > 200, "Cb=800 must push B high at ({x},{y}); got {b}");
+            }
+        }
+    }
+
+    #[test]
+    fn yuv_upload_cpu_p010_should_match_planar_10bit_for_the_same_samples() {
+        // The strongest pin on the shift, and unlike the GPU tests it runs
+        // everywhere: P010 fed `v << 6` must land on exactly the pixels the
+        // already-verified planar 10-bit path produces from `v`. Samples vary per
+        // pixel and the two chroma columns differ, so a transposed or constant
+        // read cannot pass.
+        const Y: [u16; 8] = [100, 300, 500, 700, 900, 200, 400, 600];
+        const CB: [u16; 2] = [300, 700];
+        const CR: [u16; 2] = [800, 200];
+
+        let mut planar = YuvUploadNode::new_high_bit_depth(YuvFormat::Yuv420p, 4, 2);
+        planar.set_planes(u16_le_samples(&Y), u16_le_samples(&CB), u16_le_samples(&CR));
+        let mut expected = vec![0u8; 32];
+        planar.process_cpu(&mut expected, 4, 2);
+
+        let mut p010 = YuvUploadNode::new_p010(4, 2);
+        p010.set_planes_semi_planar(
+            p010_samples(&Y),
+            p010_samples(&[CB[0], CR[0], CB[1], CR[1]]),
+        );
+        let mut got = vec![0u8; 32];
+        p010.process_cpu(&mut got, 4, 2);
+
+        assert_eq!(
+            got, expected,
+            "P010 must decode to the same pixels as the planar 10-bit path"
+        );
+        // Non-vacuous: a flat frame on both sides would satisfy the comparison
+        // without exercising anything, so check the fixture actually varies.
+        assert!(
+            expected.chunks_exact(4).any(|p| p[0] != expected[0]),
+            "the fixture must produce varying pixels"
+        );
+    }
+
+    #[test]
+    fn yuv_upload_cpu_p010_should_refuse_planes_too_small_for_the_frame() {
+        // 4×2 needs 4 UV samples; two must be refused rather than read past the
+        // end of the plane.
+        let mut node = YuvUploadNode::new_p010(4, 2);
+        node.set_planes_semi_planar(p010_samples(&[512; 8]), p010_samples(&[512, 800]));
+        let mut rgba = vec![7u8; 32];
+        node.process_cpu(&mut rgba, 4, 2);
+        assert!(
+            rgba.iter().all(|&b| b == 7),
+            "an undersized UV plane must leave the output untouched"
+        );
     }
 
     #[test]

--- a/crates/ff-render/src/shaders/p010_upload.wgsl
+++ b/crates/ff-render/src/shaders/p010_upload.wgsl
@@ -1,0 +1,79 @@
+// 10-bit semi-planar (P010) YUV upload → RGBA. Two things separate this from the
+// planar 10-bit shader, and both are why it is a file of its own rather than a
+// branch:
+//
+//   1. Chroma arrives as one Rg16Uint plane instead of two R16Uint planes — Cb
+//      is the `.r` channel and Cr the `.g` channel of the same texel — so the
+//      bind group has one texture fewer (binding 2 is absent; the uniform stays
+//      at binding 3 to match the other upload shaders).
+//   2. P010 is MSB-aligned: the 10 significant bits sit in the *high* bits of
+//      each 16-bit sample with the low 6 zeroed. Yuv420p10le instead stores
+//      0..=1023 in the low bits and needs no shift.
+//
+// The render target is Rgba16Float, so 10-bit precision survives the upload.
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0,  1.0), vec2<f32>( 1.0,  1.0), vec2<f32>(-1.0, -1.0),
+        vec2<f32>(-1.0, -1.0), vec2<f32>( 1.0,  1.0), vec2<f32>( 1.0, -1.0),
+    );
+    var uvs = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_idx], 0.0, 1.0);
+    out.uv = uvs[vertex_idx];
+    return out;
+}
+
+@group(0) @binding(0) var y_tex:  texture_2d<u32>;
+@group(0) @binding(1) var uv_tex: texture_2d<u32>;
+@group(0) @binding(3) var<uniform> u: YuvUniforms;
+
+struct YuvUniforms {
+    chroma_x_div: u32,
+    chroma_y_div: u32,
+    // Divisor that maps a raw sample to [0, 1] (1023, applied after the shift).
+    max_value: f32,
+    _pad1: u32,
+}
+
+// Drop P010's zeroed low 6 bits, then normalise. Matches FFmpeg's own P010LE
+// pixel descriptor (depth = 10, shift = 6), so the result agrees with the
+// planar 10-bit path sample for sample.
+fn p010_norm(sample: u32, max_value: f32) -> f32 {
+    return f32(sample >> 6u) / max_value;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let luma_size = textureDimensions(y_tex);
+    let px = min(
+        vec2<i32>(in.uv * vec2<f32>(f32(luma_size.x), f32(luma_size.y))),
+        vec2<i32>(i32(luma_size.x) - 1, i32(luma_size.y) - 1),
+    );
+    let y_val = p010_norm(textureLoad(y_tex, px, 0).r, u.max_value);
+
+    let chroma_size = textureDimensions(uv_tex);
+    let cpx = min(
+        vec2<i32>(px.x / i32(u.chroma_x_div), px.y / i32(u.chroma_y_div)),
+        vec2<i32>(i32(chroma_size.x) - 1, i32(chroma_size.y) - 1),
+    );
+    // One texel carries both chroma samples: Cb in .r, Cr in .g.
+    let chroma = textureLoad(uv_tex, cpx, 0);
+    let cb = p010_norm(chroma.r, u.max_value) - 0.5;
+    let cr = p010_norm(chroma.g, u.max_value) - 0.5;
+
+    // BT.601 full-range YCbCr → linear RGB.
+    let r = clamp(y_val + 1.402  * cr,              0.0, 1.0);
+    let g = clamp(y_val - 0.344  * cb - 0.714 * cr, 0.0, 1.0);
+    let b = clamp(y_val + 1.772  * cb,              0.0, 1.0);
+    return vec4<f32>(r, g, b, 1.0);
+}


### PR DESCRIPTION
## Objective

- `P010le` is the one 10-bit format the GPU upload path cannot take. Format selection already promotes it to `Rgba16Float`, but `YuvUploadNode` only understands three separate planes, not a luma plane plus one plane of interleaved Cb/Cr.
- P010 is also MSB-aligned, unlike `Yuv420p10le`, so its samples cannot be fed through the existing planar 10-bit shader.

## Solution

- Add `new_p010` and `set_planes_semi_planar`, backed by an `Rg16Uint` chroma texture and a new `p010_upload.wgsl` that reads Cb and Cr from the two channels of one texel. The bind group drops its third texture for this layout, keeping the uniform at binding 3 so all three upload shaders agree on where it is.
- Shift each sample right by 6 before normalising, in both the shader and the CPU fallback, matching the `P010LE` pixel descriptor (`depth = 10, shift = 6`). Without it every pixel would divide roughly 49000 by 1023 and clamp to white.
- Replace the private `high_bit_depth` flag with a three-state `PlaneLayout` enum, so the fourth combination (8-bit semi-planar, which is NV12 and unsupported) cannot be constructed.
- Wiring a decoded `P010le` frame to the node stays out of scope: `yuv_format_of` returns `None` for every 10-bit format today, so the planar 10-bit path is not routed either.
- The GPU tests skip without an adapter, so the CPU tests carry the coverage that runs everywhere. The strongest asserts that P010 fed `v << 6` decodes byte-identically to the verified planar path fed `v`.

Closes #1607
