### PR TITLE
feat(ff-encode): add a codec private-option escape hatch

### DIFF
--- a/crates/ff-encode/src/audio/builder.rs
+++ b/crates/ff-encode/src/audio/builder.rs
@@ -35,6 +35,8 @@ pub struct AudioEncoderBuilder {
     pub(crate) audio_codec: AudioCodec,
     pub(crate) audio_bitrate: Option<u64>,
     pub(crate) codec_options: Option<AudioCodecOptions>,
+    /// Codec-private options set by name, applied after `codec_options`.
+    pub(crate) codec_opts: Vec<(String, String)>,
     pub(crate) audio_codec_explicit: bool,
 }
 
@@ -48,6 +50,7 @@ impl AudioEncoderBuilder {
             audio_codec: AudioCodec::default(),
             audio_bitrate: None,
             codec_options: None,
+            codec_opts: Vec::new(),
             audio_codec_explicit: false,
         }
     }
@@ -79,6 +82,30 @@ impl AudioEncoderBuilder {
     #[must_use]
     pub fn container(mut self, container: OutputContainer) -> Self {
         self.container = Some(container);
+        self
+    }
+
+    /// Set a codec-*private* option by name, for the long tail that has no typed
+    /// builder (libopus and AAC tuning knobs, and so on).
+    ///
+    /// Repeatable, and applied in call order via `av_opt_set` on the codec's
+    /// `priv_data` before `avcodec_open2`, **after**
+    /// [`codec_options()`](Self::codec_options) — so a key named here overrides
+    /// the same key set through the typed API.
+    ///
+    /// # Escape-hatch semantics
+    ///
+    /// Prefer [`codec_options()`](Self::codec_options): it is validated at
+    /// compile time and portable across encoders. Nothing here is checked until
+    /// `FFmpeg` sees it, and keys are codec-specific.
+    ///
+    /// Unlike the typed options, which log and continue when an encoder does not
+    /// support them, an option rejected here fails [`build()`](Self::build) with
+    /// [`crate::EncodeError::InvalidConfig`] — the key was named explicitly, so
+    /// dropping it silently would defeat the purpose.
+    #[must_use]
+    pub fn codec_opt(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.codec_opts.push((key.into(), value.into()));
         self
     }
 
@@ -266,6 +293,7 @@ impl AudioEncoder {
             codec: builder.audio_codec,
             bitrate: builder.audio_bitrate,
             codec_options: builder.codec_options,
+            codec_opts: builder.codec_opts,
             _progress_callback: false,
         };
 
@@ -323,6 +351,21 @@ impl Drop for AudioEncoder {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn audio_codec_opt_should_collect_pairs_in_order() {
+        let builder = crate::AudioEncoder::create("out.m4a")
+            .codec_opt("frame_duration", "20")
+            .codec_opt("vbr", "on");
+        assert_eq!(
+            builder.codec_opts,
+            vec![
+                ("frame_duration".to_string(), "20".to_string()),
+                ("vbr".to_string(), "on".to_string()),
+            ],
+            "pairs must be kept in call order"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/ff-encode/src/audio/encoder_inner.rs
+++ b/crates/ff-encode/src/audio/encoder_inner.rs
@@ -68,6 +68,8 @@ pub(super) struct AudioEncoderConfig {
     pub(super) codec: AudioCodec,
     pub(super) bitrate: Option<u64>,
     pub(super) codec_options: Option<AudioCodecOptions>,
+    /// Codec-private options set by name; applied after `codec_options`.
+    pub(super) codec_opts: Vec<(String, String)>,
     pub(super) _progress_callback: bool,
 }
 
@@ -199,6 +201,15 @@ impl AudioEncoderInner {
             // codec initialisation.
             Self::apply_codec_options(&mut codec_ctx, opts, &encoder_name);
         }
+
+        // After the typed options, so a key the caller named by hand wins. This
+        // one propagates rather than warning: the caller asked for the key
+        // specifically, so a rejection is a configuration error.
+        crate::shared::codec_opts::apply_codec_opts(
+            &mut codec_ctx,
+            &config.codec_opts,
+            &encoder_name,
+        )?;
 
         // Open codec
         codec_ctx

--- a/crates/ff-encode/src/shared/codec_opts.rs
+++ b/crates/ff-encode/src/shared/codec_opts.rs
@@ -1,0 +1,142 @@
+//! Applying caller-supplied codec-private options to an encoder context.
+//!
+//! The escape hatch behind [`VideoEncoderBuilder::codec_opt`] and
+//! [`AudioEncoderBuilder::codec_opt`], kept in one place because three separate
+//! sites open a codec context (video single-pass, video two-pass, audio) and an
+//! option dropped at any of them fails silently.
+//!
+//! [`VideoEncoderBuilder::codec_opt`]: crate::VideoEncoderBuilder::codec_opt
+//! [`AudioEncoderBuilder::codec_opt`]: crate::AudioEncoderBuilder::codec_opt
+
+use crate::EncodeError;
+
+/// Apply caller-supplied `(key, value)` options to `ctx` before `avcodec_open2`.
+///
+/// Targets the codec's `priv_data`, so these are codec-*private* options
+/// (`x264-params`, `aq-mode`, libopus tuning) rather than the `AVCodecContext`
+/// fields the typed builders already own.
+///
+/// Pairs are applied in the order given, so a repeated key resolves the way the
+/// caller wrote it.
+///
+/// # Errors
+///
+/// Returns [`EncodeError::InvalidConfig`] naming the key, the value and the
+/// encoder as soon as one option is rejected. Unlike the typed codec options,
+/// which log and continue because `preset`/`tune` legitimately fail on hardware
+/// encoders, a key here was named by hand and dropping it silently would defeat
+/// the escape hatch.
+///
+/// The variant is `InvalidConfig` rather than [`EncodeError::Ffmpeg`] because
+/// the fault is the caller's configuration, and only that variant can carry the
+/// key and value that make the message actionable. `FFmpeg`'s numeric code is
+/// kept in the text so nothing is lost: `AVERROR_OPTION_NOT_FOUND` (the key does
+/// not exist) and `AVERROR(ERANGE)` (the value is out of range) stay
+/// distinguishable.
+pub(crate) fn apply_codec_opts(
+    ctx: &mut ff_sys::CodecContext,
+    opts: &[(String, String)],
+    encoder_name: &str,
+) -> Result<(), EncodeError> {
+    for (key, value) in opts {
+        ctx.set_opt(key, value)
+            .map_err(|e| EncodeError::InvalidConfig {
+                reason: format!(
+                    "codec option rejected key={key} value={value} encoder={encoder_name} error={} (code={})",
+                    ff_sys::av_error_string(e.code()),
+                    e.code()
+                ),
+            })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A generic context (no codec) has null `priv_data`, so `av_opt_set`
+    /// reports any key as unknown. That holds on every FFmpeg build, which is
+    /// what makes these assertions build-independent — the same fact `ff-sys`
+    /// relies on in `codec_context.rs`.
+    fn generic_ctx() -> ff_sys::CodecContext {
+        ff_sys::CodecContext::new(None).expect("alloc should succeed")
+    }
+
+    #[test]
+    fn apply_codec_opts_should_reject_an_unknown_option() {
+        let mut ctx = generic_ctx();
+        let opts = [("no_such_option_xyz".to_string(), "1".to_string())];
+        let err = apply_codec_opts(&mut ctx, &opts, "libx264")
+            .expect_err("an unknown key must not be accepted");
+        assert!(
+            matches!(err, EncodeError::InvalidConfig { .. }),
+            "expected InvalidConfig, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn apply_codec_opts_should_name_the_failing_key_and_encoder() {
+        // A bare "invalid configuration" would leave the caller guessing which
+        // of several options FFmpeg refused.
+        let mut ctx = generic_ctx();
+        let opts = [("no_such_option_xyz".to_string(), "banana".to_string())];
+        let err = apply_codec_opts(&mut ctx, &opts, "libx264").expect_err("must fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("no_such_option_xyz"),
+            "the error must name the key; got {message:?}"
+        );
+        assert!(
+            message.contains("banana"),
+            "the error must name the value; got {message:?}"
+        );
+        assert!(
+            message.contains("libx264"),
+            "the error must name the encoder; got {message:?}"
+        );
+        // The numeric code is what separates "no such key" from "value out of
+        // range"; `docs/rules/error-handling.md` keeps FFmpeg's codes rather
+        // than flattening them into prose.
+        assert!(
+            message.contains("code="),
+            "the error must keep FFmpeg's numeric code; got {message:?}"
+        );
+        // A `\`-continued format string silently bakes the next line's indent
+        // into the literal, which is how this message once acquired a 22-space
+        // gap. Cheap to assert, invisible otherwise.
+        assert!(
+            !message.contains("  "),
+            "the message must not contain a run of spaces; got {message:?}"
+        );
+    }
+
+    #[test]
+    fn apply_codec_opts_empty_should_succeed() {
+        // Non-vacuity guard: a helper that always returned an error would pass
+        // both tests above.
+        let mut ctx = generic_ctx();
+        apply_codec_opts(&mut ctx, &[], "libx264").expect("no options must be a no-op");
+    }
+
+    #[test]
+    fn apply_codec_opts_should_stop_at_the_first_rejected_option() {
+        // Reporting the first failure rather than the last is what makes the
+        // message actionable when several keys are wrong.
+        let mut ctx = generic_ctx();
+        let opts = [
+            ("first_bad_option".to_string(), "1".to_string()),
+            ("second_bad_option".to_string(), "2".to_string()),
+        ];
+        let err = apply_codec_opts(&mut ctx, &opts, "libx264").expect_err("must fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("first_bad_option"),
+            "the first failure must be reported; got {message:?}"
+        );
+        assert!(
+            !message.contains("second_bad_option"),
+            "application must stop at the first failure; got {message:?}"
+        );
+    }
+}

--- a/crates/ff-encode/src/shared/mod.rs
+++ b/crates/ff-encode/src/shared/mod.rs
@@ -2,6 +2,7 @@
 
 mod bitrate;
 mod codec;
+pub(crate) mod codec_opts;
 mod container;
 mod hardware;
 mod preset;

--- a/crates/ff-encode/src/video/builder/meta.rs
+++ b/crates/ff-encode/src/video/builder/meta.rs
@@ -93,6 +93,48 @@ impl VideoEncoderBuilder {
         self
     }
 
+    /// Set a codec-*private* option by name, for the long tail that has no typed
+    /// builder (`x264-params`, `aq-mode`, `psy-rd`, ...).
+    ///
+    /// Applies to the **video** codec only. A video output's audio track opens
+    /// its own codec context, which this does not reach; use
+    /// [`AudioEncoder`](crate::AudioEncoder) for audio-only output that needs
+    /// the same escape hatch.
+    ///
+    /// Repeatable, and applied in call order via `av_opt_set` on the codec's
+    /// `priv_data` before `avcodec_open2`, **after**
+    /// [`codec_options()`](Self::codec_options) — so a key named here overrides
+    /// the same key set through the typed API.
+    ///
+    /// # Escape-hatch semantics
+    ///
+    /// Prefer [`codec_options()`](Self::codec_options): it is validated at
+    /// compile time and portable across encoders. Nothing here is checked until
+    /// `FFmpeg` sees it, and keys are codec-specific.
+    ///
+    /// Unlike the typed options, which log and continue when an encoder does not
+    /// support them, an option rejected here fails
+    /// [`build()`](Self::build) with [`crate::EncodeError::InvalidConfig`] — the
+    /// key was named explicitly, so dropping it silently would defeat the
+    /// purpose. The consequence is worth planning for: a configuration carrying
+    /// libx264 keys will fail once the caller switches to a hardware encoder.
+    ///
+    /// ```no_run
+    /// # use ff_encode::VideoEncoder;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let encoder = VideoEncoder::create("out.mp4")
+    ///     .video(1920, 1080, 30.0)
+    ///     .codec_opt("x264-params", "keyint=48:min-keyint=48")
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn codec_opt(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.codec_opts.push((key.into(), value.into()));
+        self
+    }
+
     /// Set per-codec encoding options.
     ///
     /// Applied via `av_opt_set` before `avcodec_open2` during [`build()`](Self::build).

--- a/crates/ff-encode/src/video/builder/mod.rs
+++ b/crates/ff-encode/src/video/builder/mod.rs
@@ -59,6 +59,8 @@ pub struct VideoEncoderBuilder {
     pub(crate) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(crate) subtitle_passthrough: Option<(String, usize)>,
     pub(crate) codec_options: Option<VideoCodecOptions>,
+    /// Codec-private options set by name, applied after `codec_options`.
+    pub(crate) codec_opts: Vec<(String, String)>,
     pub(crate) video_codec_explicit: bool,
     pub(crate) audio_codec_explicit: bool,
     pub(crate) pixel_format: Option<ff_format::PixelFormat>,
@@ -96,6 +98,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
             .field("chapters", &self.chapters)
             .field("subtitle_passthrough", &self.subtitle_passthrough)
             .field("codec_options", &self.codec_options)
+            .field("codec_opts", &self.codec_opts)
             .field("video_codec_explicit", &self.video_codec_explicit)
             .field("audio_codec_explicit", &self.audio_codec_explicit)
             .field("pixel_format", &self.pixel_format)
@@ -131,6 +134,7 @@ impl VideoEncoderBuilder {
             chapters: Vec::new(),
             subtitle_passthrough: None,
             codec_options: None,
+            codec_opts: Vec::new(),
             video_codec_explicit: false,
             audio_codec_explicit: false,
             pixel_format: None,
@@ -601,6 +605,7 @@ impl VideoEncoder {
             chapters: builder.chapters,
             subtitle_passthrough: builder.subtitle_passthrough,
             codec_options: builder.codec_options,
+            codec_opts: builder.codec_opts,
             pixel_format: builder.pixel_format,
             hdr10_metadata: builder.hdr10_metadata,
             color_space: builder.color_space,
@@ -809,6 +814,42 @@ impl Drop for VideoEncoder {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    #[test]
+    fn codec_opt_should_collect_pairs_in_order() {
+        // Order is preserved because it decides the outcome for a repeated key,
+        // and because comma-joined values like `x264-params` are position
+        // sensitive.
+        let builder = VideoEncoder::create("out.mp4")
+            .codec_opt("x264-params", "keyint=48")
+            .codec_opt("aq-mode", "2")
+            .codec_opt("x264-params", "keyint=24");
+        assert_eq!(
+            builder.codec_opts,
+            vec![
+                ("x264-params".to_string(), "keyint=48".to_string()),
+                ("aq-mode".to_string(), "2".to_string()),
+                ("x264-params".to_string(), "keyint=24".to_string()),
+            ],
+            "pairs must be kept in call order, duplicates included"
+        );
+    }
+
+    #[test]
+    fn codec_opt_should_appear_in_the_builder_debug() {
+        // `VideoEncoderBuilder` writes its `Debug` by hand, so a new field is
+        // silently missing from debug output unless it is added there too.
+        let builder = VideoEncoder::create("out.mp4").codec_opt("aq-mode", "2");
+        let rendered = format!("{builder:?}");
+        assert!(
+            rendered.contains("codec_opts"),
+            "the field must be listed in the manual Debug impl; got {rendered}"
+        );
+        assert!(
+            rendered.contains("aq-mode"),
+            "the value must be rendered, not just the field name; got {rendered}"
+        );
+    }
+
     use super::super::encoder_inner::{VideoEncoderConfig, VideoEncoderInner};
     use super::*;
     use crate::HardwareEncoder;
@@ -873,6 +914,7 @@ mod tests {
                 chapters: Vec::new(),
                 subtitle_passthrough: None,
                 codec_options: None,
+                codec_opts: Vec::new(),
                 pixel_format: None,
                 hdr10_metadata: None,
                 color_space: None,

--- a/crates/ff-encode/src/video/encoder_inner/context.rs
+++ b/crates/ff-encode/src/video/encoder_inner/context.rs
@@ -120,6 +120,7 @@ impl VideoEncoderInner {
         hardware_encoder: crate::HardwareEncoder,
         two_pass: bool,
         codec_options: Option<&crate::video::codec_options::VideoCodecOptions>,
+        codec_opts: &[(String, String)],
         pixel_format: Option<&ff_format::PixelFormat>,
         color_space: Option<ff_format::ColorSpace>,
         color_transfer: Option<ff_format::ColorTransfer>,
@@ -202,6 +203,11 @@ impl VideoEncoderInner {
             // codec initialisation.
             Self::apply_codec_options(&mut codec_ctx, opts, &encoder_name);
         }
+
+        // After the typed options, so a key the caller named by hand wins. This
+        // one propagates rather than warning: the caller asked for the key
+        // specifically, so a rejection is a configuration error.
+        crate::shared::codec_opts::apply_codec_opts(&mut codec_ctx, codec_opts, &encoder_name)?;
 
         // Apply explicit pixel format override (takes priority over codec-option auto-select).
         if let Some(fmt) = pixel_format {

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -139,6 +139,8 @@ pub(super) struct VideoEncoderConfig {
     pub(super) chapters: Vec<ff_format::chapter::ChapterInfo>,
     pub(super) subtitle_passthrough: Option<(String, usize)>,
     pub(super) codec_options: Option<crate::video::codec_options::VideoCodecOptions>,
+    /// Codec-private options set by name; applied after `codec_options`.
+    pub(super) codec_opts: Vec<(String, String)>,
     pub(super) pixel_format: Option<ff_format::PixelFormat>,
     pub(super) hdr10_metadata: Option<ff_format::Hdr10Metadata>,
     pub(super) color_space: Option<ff_format::ColorSpace>,
@@ -213,6 +215,7 @@ impl VideoEncoderInner {
                     config.hardware_encoder,
                     config.two_pass,
                     config.codec_options.as_ref(),
+                    &config.codec_opts,
                     config.pixel_format.as_ref(),
                     config.color_space,
                     config.color_transfer,

--- a/crates/ff-encode/src/video/encoder_inner/two_pass.rs
+++ b/crates/ff-encode/src/video/encoder_inner/two_pass.rs
@@ -271,6 +271,15 @@ impl VideoEncoderInner {
             Self::apply_codec_options(&mut codec_ctx, opts, &encoder_name);
         }
 
+        // Pass 2 builds its own codec context, so the escape hatch is applied
+        // again here; skipping it would drop every option in two-pass mode while
+        // single-pass kept working.
+        crate::shared::codec_opts::apply_codec_opts(
+            &mut codec_ctx,
+            &config.codec_opts,
+            &encoder_name,
+        )?;
+
         // Apply explicit pixel format override for pass 2 (mirrors pass 1).
         if let Some(fmt) = config.pixel_format.as_ref() {
             codec_ctx.set_pix_fmt(pixel_format_to_av(*fmt));

--- a/crates/ff-encode/tests/audio_encoder_tests.rs
+++ b/crates/ff-encode/tests/audio_encoder_tests.rs
@@ -33,6 +33,52 @@ fn push_synthetic_audio(
     }
 }
 
+/// Build the reference audio encoder with no `codec_opt` applied.
+///
+/// The **baseline probe** for the escape-hatch test below: with this feature an
+/// unrecognised option is itself a `build()` error, so gating on `build()`
+/// failing would make "the encoder is missing from this FFmpeg build"
+/// indistinguishable from "a codec option was wrongly accepted", leaving the
+/// test permanently green.
+fn baseline_audio_builds(path: &str) -> bool {
+    AudioEncoder::create(path)
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .build()
+        .is_ok()
+}
+
+#[test]
+fn audio_codec_opt_unknown_key_should_fail_the_build() {
+    // The audio encoder opens its own codec context, so the escape hatch has a
+    // third application site; without it these options vanish for audio-only
+    // output while video keeps working.
+    let output_path = test_output_path("audio_codec_opt_unknown.m4a");
+    let _guard = FileGuard::new(output_path.clone());
+    let path = output_path.to_str().expect("utf-8 path");
+    if !baseline_audio_builds(path) {
+        println!("Skipping: the aac encoder is unavailable in this FFmpeg build");
+        return;
+    }
+
+    let result = AudioEncoder::create(path)
+        .audio(48000, 2)
+        .audio_codec(AudioCodec::Aac)
+        .codec_opt("no_such_option_xyz", "1")
+        .build();
+
+    match result {
+        Ok(_) => panic!("an unknown codec option must not be accepted silently"),
+        Err(EncodeError::InvalidConfig { reason }) => {
+            assert!(
+                reason.contains("no_such_option_xyz"),
+                "the error must name the rejected key; got {reason:?}"
+            );
+        }
+        Err(other) => panic!("expected InvalidConfig, got {other:?}"),
+    }
+}
+
 #[test]
 fn test_audio_encoder_aac_stereo() {
     let output_path = "test_output_audio_stereo.m4a";

--- a/crates/ff-encode/tests/video_encoder_tests.rs
+++ b/crates/ff-encode/tests/video_encoder_tests.rs
@@ -1298,6 +1298,156 @@ fn test_encode_many_frames() {
 }
 
 // ============================================================================
+// Codec-Private Option Escape Hatch (#1604)
+// ============================================================================
+
+/// Build the reference encoder used by the escape-hatch tests, with no
+/// `codec_opt` applied.
+///
+/// This is the **baseline probe**. The tests below must distinguish "this
+/// encoder is not in the FFmpeg build" from "a codec option was wrongly
+/// accepted or rejected", and with this feature an unrecognised option is itself
+/// a `build()` error. Gating on `build()` failing (as the two-pass test below
+/// does) would collapse those two cases and leave the tests permanently green.
+/// So: if the option-free build fails, the encoder is unavailable and the test
+/// skips; if it succeeds, every later assertion runs unconditionally.
+fn baseline_builds(path: &std::path::Path) -> bool {
+    VideoEncoder::create(path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .build()
+        .is_ok()
+}
+
+#[test]
+fn codec_opt_unknown_key_should_fail_the_build() {
+    let output_path = test_output_path("codec_opt_unknown.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+    if !baseline_builds(&output_path) {
+        println!("Skipping: the mpeg4 encoder is unavailable in this FFmpeg build");
+        return;
+    }
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .codec_opt("no_such_option_xyz", "1")
+        .build();
+
+    match result {
+        Ok(_) => panic!("an unknown codec option must not be accepted silently"),
+        Err(EncodeError::InvalidConfig { reason }) => {
+            assert!(
+                reason.contains("no_such_option_xyz"),
+                "the error must name the rejected key; got {reason:?}"
+            );
+        }
+        Err(other) => panic!("expected InvalidConfig, got {other:?}"),
+    }
+}
+
+#[test]
+fn codec_opt_should_be_accepted_by_a_real_encoder() {
+    let output_path = test_output_path("codec_opt_accepted.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+    if !baseline_builds(&output_path) {
+        println!("Skipping: the mpeg4 encoder is unavailable in this FFmpeg build");
+        return;
+    }
+
+    // `mpegvideo`-family encoders expose `mpv_flags` as a private option, so this
+    // exercises a key the typed builders do not cover, on an encoder present in
+    // essentially any FFmpeg build.
+    let mut encoder = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .preset(Preset::Ultrafast)
+        .codec_opt("mpv_flags", "+strict_gop")
+        .build()
+        .expect("a valid codec-private option must not break the build");
+
+    for _ in 0..5 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("push should succeed");
+    }
+    encoder.finish().expect("finish should succeed");
+    assert_valid_output_file(&output_path);
+}
+
+#[test]
+fn codec_opt_unknown_key_should_fail_a_two_pass_configuration() {
+    // Note what this does *not* cover: `build()` only sets up pass 1, so this
+    // rejects the key at the pass-1 site even though the builder asked for two
+    // passes. Pass 2 constructs its own codec context during `finish()`, which
+    // `codec_opt_should_survive_a_full_two_pass_encode` reaches instead.
+    let output_path = test_output_path("codec_opt_two_pass.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+    if !baseline_builds(&output_path) {
+        println!("Skipping: the mpeg4 encoder is unavailable in this FFmpeg build");
+        return;
+    }
+
+    let result = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(500_000))
+        .preset(Preset::Ultrafast)
+        .two_pass()
+        .codec_opt("no_such_option_xyz", "1")
+        .build();
+
+    match result {
+        Ok(_) => panic!("an unknown codec option must not be accepted in two-pass mode"),
+        Err(EncodeError::InvalidConfig { reason }) => {
+            assert!(
+                reason.contains("no_such_option_xyz"),
+                "the error must name the rejected key; got {reason:?}"
+            );
+        }
+        Err(other) => panic!("expected InvalidConfig, got {other:?}"),
+    }
+}
+
+#[test]
+fn codec_opt_should_survive_a_full_two_pass_encode() {
+    // Pass 2 rebuilds its own codec context and re-applies the escape hatch, so
+    // this is the only test that reaches that site: it runs the encode to
+    // completion, and a pass-2 application that errored (wrong context, applied
+    // after open) would surface here as a `finish()` failure.
+    //
+    // It cannot detect the site being *omitted* — an unapplied option simply
+    // does not change the output — so that remains a review checkpoint rather
+    // than something a black-box test can pin.
+    let output_path = test_output_path("codec_opt_two_pass_full.mp4");
+    let _guard = FileGuard::new(output_path.clone());
+    if !baseline_builds(&output_path) {
+        println!("Skipping: the mpeg4 encoder is unavailable in this FFmpeg build");
+        return;
+    }
+
+    let mut encoder = VideoEncoder::create(&output_path)
+        .video(320, 240, 30.0)
+        .video_codec(VideoCodec::Mpeg4)
+        .bitrate_mode(BitrateMode::Cbr(500_000))
+        .preset(Preset::Ultrafast)
+        .two_pass()
+        .codec_opt("mpv_flags", "+strict_gop")
+        .build()
+        .expect("a valid codec-private option must not break a two-pass build");
+
+    for _ in 0..10 {
+        let frame = create_black_frame(320, 240);
+        encoder.push_video(&frame).expect("push should succeed");
+    }
+    encoder
+        .finish()
+        .expect("pass 2 must accept the same codec-private option");
+    assert_valid_output_file(&output_path);
+}
+
+// ============================================================================
 // Two-Pass Tests
 // ============================================================================
 


### PR DESCRIPTION
## Objective

- The typed codec options cover the common parameters and nothing else. `H264Options` carries seven fields, so the long tail was unreachable: `x264-params`, `aq-mode`, `rc-lookahead`, every NVENC tuning knob, and most libopus keys.
- `ExportPreset::bluray_1080p()` is a concrete casualty: it cannot express `bluray-compat`, VBV constraints or `nal-hrd`, so it does not produce a Blu-ray compliant stream (#1745).

## Solution

- Add `codec_opt(key, value)` to the video and audio builders. Repeatable, applied in call order via `av_opt_set` on the codec's `priv_data` before `avcodec_open2`, and after the typed options so a hand-named key wins.
- Apply through one shared helper: three sites open a codec context (video single-pass, video pass 2, audio), and pass 2 rebuilds its own, so applying only at the first would drop every option in two-pass mode.
- A rejected option fails the build with `InvalidConfig` instead of being logged and skipped. The typed path warns because `preset`/`tune` legitimately fail on hardware encoders; a hand-named key carries no such excuse. The doc states that asymmetry and its consequence for hardware fallback. FFmpeg's numeric code is kept, so `AVERROR_OPTION_NOT_FOUND` and `AVERROR(ERANGE)` stay distinguishable.
- No new `unsafe`: `CodecContext::set_opt` is already a safe wrapper.
- Integration tests gate on a baseline probe, not on `build()` failing, since an unrecognised option is now itself a `build()` error.

Follow-ups filed rather than folded in: #1744, #1745.

Closes #1604
