### PR TITLE
fix(ff-render): carry alpha through the compositor's layer stack

### DIFF
--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -61,8 +61,11 @@ use ff_render::{
 // (Passthrough — no effect — is covered by passthrough_gpu_should_match_cpu_within_tolerance / TOL_PASSTHROUGH_MEAN.)
 //
 // Tolerances (mean absolute per-channel RGB difference, 0..255). Calibrated on the
-// dev machine; alpha is excluded (the compositor blends RGB over transparent black,
-// an alpha detail orthogonal to colour parity). Measured on this build: passthrough
+// dev machine; alpha is excluded because the two legs mean different things by it,
+// not because the GPU discards it. The CPU leg composites onto an opaque `color`
+// canvas and ends in `format=rgba`, so its alpha is 255 everywhere; the GPU's is
+// src-over coverage since #1750, pinned by the ff-render compositor tests.
+// Measured on this build: passthrough
 // is pixel-exact (mean 0.0), colour grade is mean 6.6 (max 33). The thresholds keep a
 // margin for GPU-driver rounding while staying tight enough to fail on a real
 // divergence (a stretch/letterbox/axis-swap of the gradient is tens of levels).

--- a/crates/ff-render/src/compositor/compositor_inner.rs
+++ b/crates/ff-render/src/compositor/compositor_inner.rs
@@ -771,6 +771,95 @@ mod tests {
         );
     }
 
+    /// Before #1750 the composited alpha was `base.a`, i.e. the zero-initialised
+    /// canvas alpha, so it read back 0 for every input and nothing about coverage
+    /// could be asserted at all. It is now src-over coverage.
+    #[test]
+    fn compositor_should_accumulate_alpha_from_a_semi_transparent_layer() {
+        let Some(ctx) = gpu_ctx() else {
+            return;
+        };
+        let (w, h) = (4u32, 4u32);
+        let rgba = [200u8, 120, 60, 255].repeat((w * h) as usize);
+
+        let mut compositor = crate::Compositor::new(Arc::clone(&ctx), w, h);
+        let mut layers = vec![crate::FrameLayer {
+            frame: VideoFrame::from_rgba(w, h, rgba).expect("layer frame"),
+            transform: crate::LayerTransform::default(),
+            blend_mode: BlendMode::Normal,
+            opacity: 0.5,
+            z_order: 0,
+        }];
+        let tex = compositor.composite(&mut layers).expect("compositor path");
+        let out = readback(&ctx, &tex, w, h);
+
+        // ea = 1.0 * 0.5 and ab = 0 on the empty canvas, so ao = 0.5, and the RGB
+        // is premultiplied by it: (200, 120, 60) * 0.5. Asserting both together is
+        // what pins the convention the module docs state; alpha alone would leave
+        // "is the RGB premultiplied or straight?" unanswered.
+        for px in out.chunks_exact(4) {
+            assert!(
+                (i32::from(px[3]) - 128).abs() <= 2,
+                "a half-opacity layer over the empty canvas must read back alpha ~128; got {}",
+                px[3]
+            );
+            for (ch, want) in [100, 60, 30].into_iter().enumerate() {
+                assert!(
+                    (i32::from(px[ch]) - want).abs() <= 2,
+                    "RGB must be premultiplied by the coverage alpha;                      channel {ch} expected ~{want}, got {} (straight would be {})",
+                    px[ch],
+                    want * 2
+                );
+            }
+        }
+    }
+
+    /// The property #1670's Porter-Duff operators consume: alpha is coverage, so
+    /// the region a layer does not reach stays at zero.
+    #[test]
+    fn compositor_should_leave_uncovered_regions_transparent() {
+        let Some(ctx) = gpu_ctx() else {
+            return;
+        };
+        let (w, h) = (4u32, 4u32);
+        let rgba = [200u8, 120, 60, 255].repeat((w * h) as usize);
+
+        // `transform.wgsl` samples `(uv - 0.5) / scale + 0.5` and returns
+        // transparent outside [0, 1], so a half-height layer covers v in
+        // [0.25, 0.75]: rows 1 and 2 of four, leaving rows 0 and 3 untouched.
+        let mut compositor = crate::Compositor::new(Arc::clone(&ctx), w, h);
+        let mut layers = vec![crate::FrameLayer {
+            frame: VideoFrame::from_rgba(w, h, rgba).expect("layer frame"),
+            transform: crate::LayerTransform {
+                scale_y: 0.5,
+                ..Default::default()
+            },
+            blend_mode: BlendMode::Normal,
+            opacity: 1.0,
+            z_order: 0,
+        }];
+        let tex = compositor.composite(&mut layers).expect("compositor path");
+        let out = readback(&ctx, &tex, w, h);
+
+        let alpha_at = |row: u32| out[(row * w * 4 + 3) as usize];
+        assert_eq!(
+            alpha_at(0),
+            0,
+            "the band above the layer must stay transparent"
+        );
+        assert_eq!(
+            alpha_at(3),
+            0,
+            "the band below the layer must stay transparent"
+        );
+        assert!(
+            alpha_at(1) >= 253 && alpha_at(2) >= 253,
+            "the covered rows must be opaque; got {} and {}",
+            alpha_at(1),
+            alpha_at(2)
+        );
+    }
+
     #[test]
     fn composite_to_rgba_should_read_back_the_canvas_size_and_pixels() {
         let Some(ctx) = gpu_ctx() else {

--- a/crates/ff-render/src/compositor/mod.rs
+++ b/crates/ff-render/src/compositor/mod.rs
@@ -1,3 +1,31 @@
+//! Multi-layer GPU compositing: [`FrameLayer`] stack in, one texture out.
+//!
+//! # Alpha convention
+//!
+//! The canvas starts transparent (its texture is zero-initialised) and each
+//! layer is composited onto it in `z_order`. Two rules, which
+//! `shaders/blend.wgsl` and [`nodes::BlendModeNode`](crate::BlendModeNode)
+//! implement identically:
+//!
+//! - **Colour** is composited against an **opaque black backdrop**, so the blend
+//!   result is not reweighted by the backdrop alpha the way W3C's
+//!   `Cs' = (1 - ab) * Cs + ab * B(Cb, Cs)` would. That matches the CPU
+//!   compositor's `color=c=#000000` canvas, which ADR-0007 keeps as the
+//!   correctness reference.
+//! - **Alpha** accumulates as src-over **coverage**, `ao = as + ab * (1 - as)`:
+//!   zero where no layer has drawn (letterbox bands, the transparent regions a
+//!   transform leaves behind), rising toward one as opaque layers cover it
+//!   (#1750).
+//! - **RGB is premultiplied** by that alpha. A white layer composited at opacity
+//!   `0.5` over the empty canvas reads back `(128, 128, 128, 128)`, not
+//!   `(255, 255, 255, 128)`. A consumer that wants straight alpha divides by
+//!   `ao`, guarding `ao == 0`.
+//!
+//! Consumers that flatten to an opaque format (the export path converts rgba to
+//! yuv420p) ignore the alpha and read the premultiplied RGB directly, which is
+//! the same thing as compositing over black; consumers that composite further,
+//! or that need to know what a layer covered, read the alpha.
+
 #[cfg(feature = "wgpu")]
 mod compositor_inner;
 

--- a/crates/ff-render/src/nodes/composite/blend_mode.rs
+++ b/crates/ff-render/src/nodes/composite/blend_mode.rs
@@ -21,6 +21,16 @@
 //! the final `clamp` in the shader and the `Rgba8Unorm` write reproduce
 //! `FFmpeg`'s float-to-8-bit conversion. The 8-bit C path wraps instead, which is
 //! deliberately not replicated. See ADR-0010.
+//!
+//! # Alpha
+//!
+//! Colour is composited against an **opaque black backdrop**, matching the CPU
+//! compositor's `color=c=#000000` canvas, so the blend result is not reweighted
+//! by the backdrop alpha the way W3C's `Cs' = (1 - ab) * Cs + ab * B(Cb, Cs)`
+//! would. Alpha itself accumulates as src-over **coverage**,
+//! `ao = as + ab * (1 - as)`: zero where nothing has drawn, rising toward one as
+//! layers cover (#1750). [`BlendModeNode::process_cpu`] and `shaders/blend.wgsl`
+//! carry the same two formulas.
 
 use super::blend_math::blend_rgb;
 #[cfg(feature = "wgpu")]
@@ -219,15 +229,21 @@ impl RenderNodeCpu for BlendModeNode {
             let og = f32::from(ov[1]) / 255.0;
             let ob = f32::from(ov[2]) / 255.0;
             let oa = f32::from(ov[3]) / 255.0;
+            let ba = f32::from(base[3]) / 255.0;
 
             let [rr, rg, rb] = blend_rgb(self.mode, [br, bg, bb], [or, og, ob]);
             let eff_alpha = oa * self.opacity;
             let out_r = (br + (rr - br) * eff_alpha).clamp(0.0, 1.0);
             let out_g = (bg + (rg - bg) * eff_alpha).clamp(0.0, 1.0);
             let out_b = (bb + (rb - bb) * eff_alpha).clamp(0.0, 1.0);
+            // src-over coverage, mirroring `blend.wgsl`'s `out_a` (#1750). An
+            // out-of-range `opacity` extrapolates as the colour channels do; the
+            // `as u8` cast below saturates, matching the shader's texture write.
+            let out_a = eff_alpha + ba * (1.0 - eff_alpha);
             base[0] = (out_r * 255.0 + 0.5) as u8;
             base[1] = (out_g * 255.0 + 0.5) as u8;
             base[2] = (out_b * 255.0 + 0.5) as u8;
+            base[3] = (out_a * 255.0 + 0.5) as u8;
         }
     }
 }

--- a/crates/ff-render/src/shaders/blend.wgsl
+++ b/crates/ff-render/src/shaders/blend.wgsl
@@ -10,6 +10,10 @@
 // ff-filter links the canvas to `top` and the layer to `bottom`, so throughout
 // this file `a` = base (canvas) and `b` = overlay (layer). The helper functions
 // mirror `nodes/composite/blend_math.rs` one for one.
+//
+// Alpha convention: the canvas carries premultiplied RGB composited against an
+// opaque black backdrop, and its alpha is src-over coverage. See the note at the
+// end of `fs_main`.
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
@@ -375,7 +379,17 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // FFmpeg computes `dst = A + (expr - A) * opacity`, and A is the base here.
     // The clamp reproduces the float-to-8-bit conversion for the modes the
     // `DEPTH == 32` branch leaves outside [0, 1].
+    //
+    // Alpha accumulates as src-over coverage (#1750). The RGB above is
+    // deliberately *not* reweighted by the backdrop alpha the way W3C's
+    // `Cs' = (1 - ab) * Cs + ab * B(Cb, Cs)` would: it composites against an
+    // opaque black backdrop, which is what the CPU compositor's
+    // `color=c=#000000` canvas does, and ADR-0007 keeps that the reference.
+    // `FrameLayer.opacity` is not clamped, so an out-of-range value extrapolates
+    // here exactly as it does in the `mix` above; the `Rgba8Unorm` write
+    // saturates either way, which is why neither needs its own clamp.
     let effective_alpha = overlay.a * u.opacity;
     let out_rgb = mix(base.rgb, blend_rgb, effective_alpha);
-    return vec4<f32>(clamp(out_rgb, vec3<f32>(0.0), vec3<f32>(1.0)), base.a);
+    let out_a = effective_alpha + base.a * (1.0 - effective_alpha);
+    return vec4<f32>(clamp(out_rgb, vec3<f32>(0.0), vec3<f32>(1.0)), out_a);
 }

--- a/crates/ff-render/tests/gpu_nodes.rs
+++ b/crates/ff-render/tests/gpu_nodes.rs
@@ -416,7 +416,10 @@ fn blend_gpu_should_match_the_cpu_path_for_every_mode() {
         let gpu = run_gpu(&ctx, node, &base, 3, 1);
 
         for px in 0..3 {
-            for ch in 0..3 {
+            // Channel 3 included since #1750: both paths now write the src-over
+            // coverage alpha. Both inputs are opaque here, so that channel alone
+            // is not discriminating; the semi-transparent test below is.
+            for ch in 0..4 {
                 let i = px * 4 + ch;
                 assert!(
                     close(gpu[i], cpu[i], 2),
@@ -426,6 +429,41 @@ fn blend_gpu_should_match_the_cpu_path_for_every_mode() {
                 );
             }
         }
+    }
+}
+
+/// The same shader-vs-Rust check where the alpha formula actually does something.
+///
+/// A transparent base and a half-transparent overlay give
+/// `ao = ea + ba * (1 - ea) = 0.502`, so channel 3 is ~128 rather than the 255
+/// both opaque inputs produce above. Before #1750 the GPU wrote the base alpha
+/// (0) and the CPU left it untouched (also 0), so the two agreed by accident.
+#[test]
+fn blend_gpu_should_match_the_cpu_path_for_a_semi_transparent_overlay() {
+    let Some(ctx) = gpu_ctx() else { return };
+
+    let base = solid_rgba(40, 90, 200, 0, 2, 2);
+    let overlay = solid_rgba(170, 60, 30, 128, 2, 2);
+
+    for mode in ALL_BLEND_MODES {
+        let node = BlendModeNode::new(mode, 1.0, overlay.clone(), 2, 2);
+        let mut cpu = base.clone();
+        node.process_cpu(&mut cpu, 2, 2);
+        let gpu = run_gpu(&ctx, node, &base, 2, 2);
+
+        for ch in 0..4 {
+            assert!(
+                close(gpu[ch], cpu[ch], 2),
+                "{mode:?} channel {ch}: GPU {} vs CPU {}",
+                gpu[ch],
+                cpu[ch]
+            );
+        }
+        assert!(
+            close(cpu[3], 128, 2),
+            "{mode:?}: the composited alpha must be ~128, not the base's 0; got {}",
+            cpu[3]
+        );
     }
 }
 


### PR DESCRIPTION
## Objective

- `blend.wgsl` returned `base.a` as the output alpha and the canvas is never written with one, so the composited alpha was always 0 whatever the layers carried.
- That blocks #1670: Porter-Duff needs a backdrop alpha, and every operator degenerates without one. With `ab` at 0 `In` erases everything; with the opaque-backdrop assumption the RGB math implies, `In` becomes the source and `Out` becomes nothing.

## Solution

- One line in the shader plus its mirror in `BlendModeNode::process_cpu`, which wrote `base[0..=2]` and left `base[3]` to match the old shader. Alpha now accumulates as src-over coverage: zero where no layer has drawn, which `transform.wgsl` produces for letterbox bands, rising toward one as opaque layers cover it.
- The RGB math is untouched. It already composites against an opaque black backdrop, which is the CPU reference canvas (`color=c=#000000`), so ADR-0007 keeps it as is rather than going W3C-pure, where the bottom layer's blend mode would stop applying.
- RGB is bit-identical, and the evidence is that the existing suites pass with **no edit**: the `gpu_parity_tests` diff is comment-only so no tolerance moved, and `gpu_export_tests` is untouched. Nothing downstream reads the alpha either (one consumer, sws drops it on rgba to yuv420p, no transition shader uses it in colour math).
- Two compositor tests pin behaviour that could not be written before: a half-opacity layer reads back alpha 128 with RGB premultiplied by it, and a half-height layer leaves the bands at zero. The node-level GPU-vs-Rust check extends to channel 3, with a second case that makes that channel discriminating.
- State the alpha convention in the compositor's module docs, which had none.

Acceptance criterion 3 is withdrawn as self-contradictory with criterion 5; criterion 5 is strengthened. Recorded in a comment on the issue.

Fixes #1750