### PR TITLE
feat(ff-render): composite the Porter-Duff operators on the GPU

### DIFF
--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -24,7 +24,10 @@ use ff_filter::{
     AnimatedValue, BlendMode, CompositeOp, FilterStep, RealtimeLayer, RealtimeLayerDescriptor,
     ScaleAlgorithm, VideoLayer,
 };
-use ff_render::{BlendMode as RenderBlendMode, ScaleAlgorithm as RenderScaleAlgorithm};
+use ff_render::{
+    BlendMode as RenderBlendMode, CompositeOp as RenderCompositeOp,
+    ScaleAlgorithm as RenderScaleAlgorithm,
+};
 
 /// A derived layer the GPU mapping can read. Implemented for the export
 /// [`VideoLayer`], the preview [`RealtimeLayerDescriptor`], the runner's realized
@@ -365,6 +368,10 @@ pub struct GpuLayerPlan {
     pub opacity: f32,
     /// Blend mode against the layers below.
     pub blend_mode: RenderBlendMode,
+    /// Porter-Duff operator for this layer. The blend mode above is only
+    /// meaningful with `Over`; for any other operator the model does not apply
+    /// it, so `map_scene` sets `Normal` (#1670).
+    pub composite_op: RenderCompositeOp,
     /// Per-layer effects applied to the source frame before compositing.
     pub effects: Vec<GpuEffect>,
 }
@@ -409,16 +416,19 @@ pub enum GpuMapping {
 pub fn map_scene<L: GpuLayerSource>(layers: &[L], canvas: (u32, u32), t: Duration) -> GpuMapping {
     let mut plan_layers = Vec::with_capacity(layers.len());
     for (i, layer) in layers.iter().enumerate() {
-        // Check composite first: the blend mode is only applied when the composite
-        // op is `Over` (see `VideoLayer`), so for any other op the composite is the
-        // semantically active reason to fall back. `Over` is the only plain
-        // top-over-bottom composite; the others need node wiring the compositor
-        // does not provide yet.
-        if !matches!(layer.composite_op(), CompositeOp::Over) {
+        let Some(composite_op) = map_composite_op(layer.composite_op()) else {
             return GpuMapping::Fallback(GpuFallback::UnsupportedCompositeOp(layer.composite_op()));
-        }
-        let Some(blend_mode) = map_blend_mode(layer.blend_mode()) else {
-            return GpuMapping::Fallback(GpuFallback::UnsupportedBlendMode(layer.blend_mode()));
+        };
+        // The blend mode is only applied when the composite op is `Over` (see
+        // `VideoLayer` and `composition_inner.rs`), so any other operator drops
+        // it rather than falling back, matching the CPU path (#1670).
+        let blend_mode = if matches!(composite_op, RenderCompositeOp::Over) {
+            let Some(mode) = map_blend_mode(layer.blend_mode()) else {
+                return GpuMapping::Fallback(GpuFallback::UnsupportedBlendMode(layer.blend_mode()));
+            };
+            mode
+        } else {
+            RenderBlendMode::Normal
         };
 
         let mut effects = Vec::new();
@@ -442,6 +452,7 @@ pub fn map_scene<L: GpuLayerSource>(layers: &[L], canvas: (u32, u32), t: Duratio
             rotation: eval_at(layer.rotation(), t),
             opacity: eval_at(layer.opacity(), t).clamp(0.0, 1.0),
             blend_mode,
+            composite_op,
             effects,
         });
     }
@@ -780,6 +791,25 @@ fn map_blend_mode(mode: BlendMode) -> Option<RenderBlendMode> {
         BlendMode::Xor => RenderBlendMode::Xor,
         // A mode added to `ff-filter` after #1669. `_` is required: `BlendMode`
         // is `#[non_exhaustive]` from ff-filter (RK-003).
+        _ => return None,
+    })
+}
+
+/// Maps `ff_filter::CompositeOp` to `ff_render::CompositeOp`, or `None` when
+/// `ff-render` has no equivalent (forcing fallback).
+///
+/// Every operator `ff-filter` defines today composites on the GPU (#1670); the
+/// `None` arm covers one a future release adds to the `#[non_exhaustive]` enum.
+fn map_composite_op(op: CompositeOp) -> Option<RenderCompositeOp> {
+    Some(match op {
+        CompositeOp::Over => RenderCompositeOp::Over,
+        CompositeOp::Under => RenderCompositeOp::Under,
+        CompositeOp::In => RenderCompositeOp::In,
+        CompositeOp::Out => RenderCompositeOp::Out,
+        CompositeOp::Atop => RenderCompositeOp::Atop,
+        CompositeOp::Xor => RenderCompositeOp::Xor,
+        // An operator added to `ff-filter` after #1670. `_` is required:
+        // `CompositeOp` is `#[non_exhaustive]` from ff-filter (RK-003).
         _ => return None,
     })
 }
@@ -1650,13 +1680,50 @@ mod tests {
         }
     }
 
+    /// #1670's acceptance criterion as an executable check: every composite
+    /// operator the model can express maps to the GPU, so none forces a
+    /// fallback. An operator `ff-filter` adds later has no row here and would
+    /// still fall back, which is what the `_` arm in `map_composite_op` is for.
     #[test]
-    fn map_scene_should_fall_back_on_non_over_composite() {
+    fn map_scene_should_map_every_composite_op() {
+        let ops = [
+            CompositeOp::Over,
+            CompositeOp::Under,
+            CompositeOp::In,
+            CompositeOp::Out,
+            CompositeOp::Atop,
+            CompositeOp::Xor,
+        ];
+        assert_eq!(ops.len(), 6, "ff-filter's CompositeOp set changed");
+        for op in ops {
+            let mut layer = TestLayer::identity();
+            layer.composite_op = op;
+            let mapping = map_scene(&[layer], (16, 16), Duration::ZERO);
+            assert!(
+                !matches!(
+                    mapping,
+                    GpuMapping::Fallback(GpuFallback::UnsupportedCompositeOp(_))
+                ),
+                "{op:?} must map to the GPU; got {mapping:?}"
+            );
+        }
+    }
+
+    /// The model does not combine a blend mode with a non-`Over` composite, so
+    /// the plan carries `Normal` rather than falling back on the blend mode.
+    #[test]
+    fn map_scene_should_drop_the_blend_mode_for_a_non_over_composite() {
         let mut layer = TestLayer::identity();
-        layer.composite_op = CompositeOp::Under;
+        layer.composite_op = CompositeOp::In;
+        layer.blend_mode = BlendMode::Multiply;
+        let GpuMapping::Gpu(plan) = map_scene(&[layer], (16, 16), Duration::ZERO) else {
+            panic!("a non-Over composite must map to the GPU since #1670");
+        };
+        assert_eq!(plan.layers[0].composite_op, RenderCompositeOp::In);
         assert_eq!(
-            map_scene(&[layer], (16, 16), Duration::ZERO),
-            GpuMapping::Fallback(GpuFallback::UnsupportedCompositeOp(CompositeOp::Under))
+            plan.layers[0].blend_mode,
+            RenderBlendMode::Normal,
+            "the blend mode must be dropped, matching the CPU path"
         );
     }
 

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -487,6 +487,7 @@ fn assemble(
                 frame,
                 transform: transform.clone(),
                 blend_mode: lp.blend_mode,
+                composite_op: lp.composite_op,
                 opacity: lp.opacity,
                 z_order: lp.z_order,
             })

--- a/crates/ff-filter/src/composite.rs
+++ b/crates/ff-filter/src/composite.rs
@@ -2,15 +2,34 @@
 
 // CompositeOp
 
-/// Porter-Duff alpha-compositing operator for combining two video layers.
+/// Porter-Duff compositing operator for combining two video layers.
 ///
-/// Unlike [`BlendMode`](crate::BlendMode) (which operates on pixel values), these
-/// operators combine layers by their alpha channels. At least the top layer must
-/// carry an alpha channel (e.g. `rgba` or `yuva420p`).
+/// # What the filter path actually computes
 ///
-/// There is no `blend all_mode` token for Porter-Duff compositing, so this type
-/// has no `FfmpegToken` impl; each operator maps to a specific `FFmpeg` construction
-/// (`overlay` or `blend` with a per-channel expression) in the filter graph.
+/// `Over` and `Under` are built with the `overlay` filter and are genuine alpha
+/// compositing. **`In`, `Out`, `Atop` and `Xor` are not**: they are built with
+/// `blend`'s `all_expr`, which applies one expression to every plane, and the
+/// composite chain normalises both inputs to `yuv420p` first, a format with no
+/// alpha plane. So they evaluate the Porter-Duff formula with each colour
+/// channel standing in for alpha (`In` reduces to a per-channel multiply).
+///
+/// That is a workaround, not a design: `FFmpeg` has no Porter-Duff filter, and
+/// `all_expr` can only reference the same plane of both inputs, so it cannot
+/// express a colour term that depends on the *other* input's alpha. Reaching the
+/// real operators through libavfilter needs `alphaextract` plus a second
+/// `blend`.
+///
+/// The GPU compositor implements the W3C / Porter-Duff definitions properly
+/// (#1670). Preview and export both composite on the GPU, so the split is not
+/// between them: these four render one way with an adapter and another whenever
+/// the whole-frame fallback swaps in this filter path (a headless machine, a
+/// forced-CPU run). Closing that is #1753.
+///
+/// Unlike [`BlendMode`](crate::BlendMode), which is a colour function of two
+/// pixels, these are meant to be alpha algebra. There is no `blend all_mode`
+/// token for Porter-Duff compositing, so this type has no `FfmpegToken` impl;
+/// each operator maps to a specific `FFmpeg` construction (`overlay` or `blend`
+/// with a per-channel expression) in the filter graph.
 // Open catalog: the Porter-Duff operator set is added to incrementally.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -27,7 +46,9 @@ pub enum CompositeOp {
     /// Built via `overlay` with swapped input order.
     Under,
 
-    /// Top layer masked by the bottom layer's alpha (intersection).
+    /// Intended as the top layer masked by the bottom layer's alpha
+    /// (intersection). On the filter path the expression runs per colour plane,
+    /// so it reduces to a per-channel multiply; see the type docs.
     ///
     /// Built via `blend` with `c0_expr='B*A/255'`.
     In,

--- a/crates/ff-filter/tests/push_pull_tests.rs
+++ b/crates/ff-filter/tests/push_pull_tests.rs
@@ -2505,7 +2505,7 @@ fn composite_in_should_produce_black_where_bottom_is_black() {
 }
 
 #[test]
-fn composite_atop_should_use_bottom_alpha_for_output() {
+fn composite_atop_should_combine_both_layers_by_luma() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)
@@ -2547,7 +2547,7 @@ fn composite_atop_should_use_bottom_alpha_for_output() {
 }
 
 #[test]
-fn composite_xor_identical_shapes_should_produce_zero_alpha() {
+fn composite_xor_identical_luma_should_produce_black() {
     let top = FilterGraphBuilder::new().trim(0.0, 5.0);
     let mut graph = match FilterGraph::builder()
         .trim(0.0, 5.0)

--- a/crates/ff-render/src/compositor/compositor_inner.rs
+++ b/crates/ff-render/src/compositor/compositor_inner.rs
@@ -10,7 +10,7 @@ use crate::nodes::composite::{
     upload_rgba_texture,
 };
 use crate::nodes::upload::chroma_dims;
-use crate::nodes::{BlendMode, RenderNode, TransformNode, YuvFormat, YuvUploadNode};
+use crate::nodes::{BlendMode, CompositeOp, RenderNode, TransformNode, YuvFormat, YuvUploadNode};
 
 use super::FrameLayer;
 
@@ -101,6 +101,7 @@ impl CompositorGraph {
                 &layer_tex,
                 &new_canvas,
                 layer.blend_mode,
+                layer.composite_op,
                 layer.opacity,
             );
             canvas = new_canvas;
@@ -328,28 +329,10 @@ fn blend_textures(
     overlay_tex: &wgpu::Texture,
     output_tex: &wgpu::Texture,
     mode: BlendMode,
+    composite: CompositeOp,
     opacity: f32,
 ) {
-    let mode_bytes = (mode as u32).to_le_bytes();
-    let opac_bytes = opacity.to_le_bytes();
-    let uniforms: [u8; 16] = [
-        mode_bytes[0],
-        mode_bytes[1],
-        mode_bytes[2],
-        mode_bytes[3],
-        opac_bytes[0],
-        opac_bytes[1],
-        opac_bytes[2],
-        opac_bytes[3],
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ];
+    let uniforms = crate::nodes::composite::blend_uniform_bytes(mode, composite, opacity);
     ctx.queue.write_buffer(uniform_buf, 0, &uniforms);
 
     let base_view = base_tex.create_view(&wgpu::TextureViewDescriptor::default());
@@ -682,6 +665,7 @@ mod tests {
             frame: yuv420_solid(w, h, yv, uv, vv),
             transform: crate::LayerTransform::default(),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
             opacity: 1.0,
             z_order: 0,
         }];
@@ -732,6 +716,7 @@ mod tests {
                 frame: VideoFrame::from_rgba(w, h, base_rgba.clone()).expect("base frame"),
                 transform: crate::LayerTransform::default(),
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 opacity: 1.0,
                 z_order: 0,
             },
@@ -739,6 +724,7 @@ mod tests {
                 frame: VideoFrame::from_rgba(w, h, ov_rgba.clone()).expect("overlay frame"),
                 transform: crate::LayerTransform::default(),
                 blend_mode: BlendMode::SoftDifference,
+                composite_op: CompositeOp::Over,
                 opacity: 1.0,
                 z_order: 1,
             },
@@ -787,6 +773,7 @@ mod tests {
             frame: VideoFrame::from_rgba(w, h, rgba).expect("layer frame"),
             transform: crate::LayerTransform::default(),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
             opacity: 0.5,
             z_order: 0,
         }];
@@ -835,6 +822,7 @@ mod tests {
                 ..Default::default()
             },
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
             opacity: 1.0,
             z_order: 0,
         }];
@@ -860,6 +848,70 @@ mod tests {
         );
     }
 
+    /// The property #1750 unblocked and the reason #1670 exists: alpha is
+    /// coverage, so `In` masks a layer to what the layers below actually covered.
+    ///
+    /// Layer 0 is half-height, leaving `da = 0` in the bands. Layer 1 fills the
+    /// canvas with `In`, so `co = s * da` and `ao = sa * da` keep it only where
+    /// layer 0 drew. Asserting the bands stay empty is what separates `In` from
+    /// `Over`, which would have covered the whole canvas.
+    #[test]
+    fn compositor_should_mask_a_layer_to_the_coverage_below_with_composite_in() {
+        let Some(ctx) = gpu_ctx() else {
+            return;
+        };
+        let (w, h) = (4u32, 4u32);
+        let below = [200u8, 120, 60, 255].repeat((w * h) as usize);
+        let above = [60u8, 180, 240, 255].repeat((w * h) as usize);
+
+        let mut compositor = crate::Compositor::new(Arc::clone(&ctx), w, h);
+        let mut layers = vec![
+            crate::FrameLayer {
+                frame: VideoFrame::from_rgba(w, h, below).expect("below frame"),
+                transform: crate::LayerTransform {
+                    scale_y: 0.5,
+                    ..Default::default()
+                },
+                blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
+                opacity: 1.0,
+                z_order: 0,
+            },
+            crate::FrameLayer {
+                frame: VideoFrame::from_rgba(w, h, above).expect("above frame"),
+                transform: crate::LayerTransform::default(),
+                blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::In,
+                opacity: 1.0,
+                z_order: 1,
+            },
+        ];
+        let tex = compositor.composite(&mut layers).expect("compositor path");
+        let out = readback(&ctx, &tex, w, h);
+        let px = |row: u32| {
+            let i = (row * w * 4) as usize;
+            [out[i], out[i + 1], out[i + 2], out[i + 3]]
+        };
+
+        for row in [0, 3] {
+            assert_eq!(
+                px(row),
+                [0, 0, 0, 0],
+                "row {row} is outside layer 0's coverage, so `In` must leave it empty"
+            );
+        }
+        for row in [1, 2] {
+            let got = px(row);
+            assert!(
+                (i32::from(got[0]) - 60).abs() <= 2
+                    && (i32::from(got[1]) - 180).abs() <= 2
+                    && (i32::from(got[2]) - 240).abs() <= 2
+                    && got[3] >= 253,
+                "row {row} is covered, so `In` must show layer 1 opaquely; got {got:?}"
+            );
+        }
+    }
+
     #[test]
     fn composite_to_rgba_should_read_back_the_canvas_size_and_pixels() {
         let Some(ctx) = gpu_ctx() else {
@@ -879,6 +931,7 @@ mod tests {
             frame: red,
             transform: crate::LayerTransform::default(),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
             opacity: 1.0,
             z_order: 0,
         }];

--- a/crates/ff-render/src/compositor/mod.rs
+++ b/crates/ff-render/src/compositor/mod.rs
@@ -31,7 +31,7 @@ mod compositor_inner;
 
 use ff_format::VideoFrame;
 
-use crate::nodes::BlendMode;
+use crate::nodes::{BlendMode, CompositeOp};
 
 // LayerTransform
 
@@ -86,7 +86,14 @@ pub struct FrameLayer {
     /// 2D affine transform applied before compositing.
     pub transform: LayerTransform,
     /// Blend mode used when compositing this layer over layers below.
+    ///
+    /// Only meaningful with [`CompositeOp::Over`]: the editing model does not
+    /// combine the two, so `avio::gpu::map_scene` emits `Normal` for a layer
+    /// whose composite operator is anything else.
     pub blend_mode: BlendMode,
+    /// Porter-Duff operator deciding how much of this layer and the canvas
+    /// below survive. Defaults to [`CompositeOp::Over`].
+    pub composite_op: CompositeOp,
     /// Layer opacity (`0.0` = transparent, `1.0` = fully opaque).
     pub opacity: f32,
     /// Z-order — lower values are further back. Layers are sorted ascending
@@ -236,6 +243,7 @@ mod tests {
             frame: make_frame(),
             transform: LayerTransform::default(),
             blend_mode: BlendMode::Normal,
+            composite_op: CompositeOp::Over,
             opacity: 1.0,
             z_order: 0,
         };
@@ -250,6 +258,7 @@ mod tests {
                 frame: make_frame(),
                 transform: LayerTransform::default(),
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 opacity: 1.0,
                 z_order: 3,
             },
@@ -257,6 +266,7 @@ mod tests {
                 frame: make_frame(),
                 transform: LayerTransform::default(),
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 opacity: 1.0,
                 z_order: 1,
             },
@@ -264,6 +274,7 @@ mod tests {
                 frame: make_frame(),
                 transform: LayerTransform::default(),
                 blend_mode: BlendMode::Normal,
+                composite_op: CompositeOp::Over,
                 opacity: 1.0,
                 z_order: 2,
             },

--- a/crates/ff-render/src/lib.rs
+++ b/crates/ff-render/src/lib.rs
@@ -80,10 +80,10 @@ pub use ff_format::{ErrorSeverity, MediaError};
 pub use graph::RenderGraph;
 pub use nodes::{
     AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, ColorWheelsNode,
-    CrossfadeNode, CurvesNode, DipToColorNode, DissolveTransitionNode, FadeTransitionNode,
-    FilmGrainNode, GaussianBlurNode, GlowNode, HslNode, LumaMaskNode, LutNode, MotionBlurNode,
-    OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode, SharpenNode,
-    TransformNode, VignetteNode, WipeTransitionNode, YuvFormat, YuvUploadNode,
+    CompositeOp, CrossfadeNode, CurvesNode, DipToColorNode, DissolveTransitionNode,
+    FadeTransitionNode, FilmGrainNode, GaussianBlurNode, GlowNode, HslNode, LumaMaskNode, LutNode,
+    MotionBlurNode, OverlayNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode,
+    SharpenNode, TransformNode, VignetteNode, WipeTransitionNode, YuvFormat, YuvUploadNode,
 };
 pub use sink::GpuFrameSink;
 

--- a/crates/ff-render/src/nodes/composite.rs
+++ b/crates/ff-render/src/nodes/composite.rs
@@ -8,17 +8,19 @@
 mod blend_math;
 mod blend_mode;
 mod chroma_key;
+mod composite_op;
 mod helpers;
 mod masks;
 mod transform;
 
 pub use blend_mode::{BlendMode, BlendModeNode};
 pub use chroma_key::ChromaKeyNode;
+pub use composite_op::CompositeOp;
 pub use masks::{AlphaMatteNode, LumaMaskNode, ShapeMaskNode};
 pub use transform::TransformNode;
 
 #[cfg(feature = "wgpu")]
 pub(crate) use helpers::{
-    fullscreen_pipeline, linear_sampler, submit_render_pass, two_tex_sampler_uniform_bgl,
-    upload_rgba_texture,
+    blend_uniform_bytes, fullscreen_pipeline, linear_sampler, submit_render_pass,
+    two_tex_sampler_uniform_bgl, upload_rgba_texture,
 };

--- a/crates/ff-render/src/nodes/composite/blend_math.rs
+++ b/crates/ff-render/src/nodes/composite/blend_math.rs
@@ -3,6 +3,7 @@
 use std::f32::consts::PI;
 
 use super::blend_mode::BlendMode;
+use super::composite_op::CompositeOp;
 
 #[allow(clippy::many_single_char_names, clippy::float_cmp)]
 fn rgb_to_hsl(r: f32, g: f32, b: f32) -> [f32; 3] {
@@ -223,6 +224,38 @@ fn vivid_light_ch(a: f32, b: f32) -> f32 {
 /// Apply a per-channel blend function across R, G and B.
 fn map3(f: impl Fn(f32, f32) -> f32, base: [f32; 3], ov: [f32; 3]) -> [f32; 3] {
     [f(base[0], ov[0]), f(base[1], ov[1]), f(base[2], ov[2])]
+}
+
+/// Apply a Porter-Duff operator to a premultiplied source and backdrop.
+///
+/// `s` and `d` are premultiplied colours, `sa` and `da` their alphas; the return
+/// is the premultiplied output colour and its alpha. This is the W3C form
+/// `Co = as * Fa * Cs + ab * Fb * Cb` with `s` and `d` substituted, so it reads
+/// as `co = s * Fa + d * Fb`. `shaders/blend.wgsl` evaluates the same six
+/// expressions; see [`CompositeOp`] for the per-operator formulas.
+pub(super) fn composite_rgba(
+    op: CompositeOp,
+    s: [f32; 3],
+    sa: f32,
+    d: [f32; 3],
+    da: f32,
+) -> ([f32; 3], f32) {
+    let (fa, fb) = match op {
+        CompositeOp::Over => (1.0, 1.0 - sa),
+        CompositeOp::Under => (1.0 - da, 1.0),
+        CompositeOp::In => (da, 0.0),
+        CompositeOp::Out => (1.0 - da, 0.0),
+        CompositeOp::Atop => (da, 1.0 - sa),
+        CompositeOp::Xor => (1.0 - da, 1.0 - sa),
+    };
+    (
+        [
+            s[0] * fa + d[0] * fb,
+            s[1] * fa + d[1] * fb,
+            s[2] * fa + d[2] * fb,
+        ],
+        sa * fa + da * fb,
+    )
 }
 
 // `manual_midpoint`: `Average` stays written as the C's `(A + B) / 2` so it reads
@@ -478,6 +511,84 @@ mod tests {
         // (#1219) and are covered by the GPU/CPU agreement test instead.
         assert_eq!(modes.len(), 40, "a new mode needs rows in CASES");
         assert_eq!(CASES.len(), modes.len() * 3);
+    }
+
+    /// `(op, s, sa, d, da, expected co, expected ao)` for the Porter-Duff
+    /// operators.
+    ///
+    /// The expected values were produced by transcribing the W3C `Fa`/`Fb` table
+    /// a **second time**, in its straight form `Co = as * Fa * Cs + ab * Fb * Cb`,
+    /// while [`composite_rgba`] works in the premultiplied form. Agreement
+    /// between the two routes is evidence neither dropped a factor.
+    ///
+    /// Both alphas sit strictly inside `(0, 1)` and differ, or `In`, `Out` and
+    /// `Atop` degenerate; the colours differ per channel so a dropped channel
+    /// shows (RK-022). All six operators give distinct results on every row.
+    #[allow(clippy::unreadable_literal, clippy::excessive_precision)]
+    #[rustfmt::skip]
+    const COMPOSITE_CASES: &[(CompositeOp, [f32; 3], f32, [f32; 3], f32, [f32; 3], f32)] = &[
+        (CompositeOp::Over, [0.4800000, 0.1800000, 0.0600000], 0.6000, [0.0800000, 0.2800000, 0.3600000], 0.4000, [0.5120000, 0.2920000, 0.2040000], 0.7600000),
+        (CompositeOp::Over, [0.0375000, 0.1375000, 0.2125000], 0.2500, [0.6750000, 0.3375000, 0.1500000], 0.7500, [0.5437500, 0.3906250, 0.3250000], 0.8125000),
+        (CompositeOp::Over, [0.4500000, 0.8100000, 0.3150000], 0.9000, [0.0525000, 0.0150000, 0.0900000], 0.1500, [0.4552500, 0.8115000, 0.3240000], 0.9150000),
+        (CompositeOp::Under, [0.4800000, 0.1800000, 0.0600000], 0.6000, [0.0800000, 0.2800000, 0.3600000], 0.4000, [0.3680000, 0.3880000, 0.3960000], 0.7600000),
+        (CompositeOp::Under, [0.0375000, 0.1375000, 0.2125000], 0.2500, [0.6750000, 0.3375000, 0.1500000], 0.7500, [0.6843750, 0.3718750, 0.2031250], 0.8125000),
+        (CompositeOp::Under, [0.4500000, 0.8100000, 0.3150000], 0.9000, [0.0525000, 0.0150000, 0.0900000], 0.1500, [0.4350000, 0.7035000, 0.3577500], 0.9150000),
+        (CompositeOp::In, [0.4800000, 0.1800000, 0.0600000], 0.6000, [0.0800000, 0.2800000, 0.3600000], 0.4000, [0.1920000, 0.0720000, 0.0240000], 0.2400000),
+        (CompositeOp::In, [0.0375000, 0.1375000, 0.2125000], 0.2500, [0.6750000, 0.3375000, 0.1500000], 0.7500, [0.0281250, 0.1031250, 0.1593750], 0.1875000),
+        (CompositeOp::In, [0.4500000, 0.8100000, 0.3150000], 0.9000, [0.0525000, 0.0150000, 0.0900000], 0.1500, [0.0675000, 0.1215000, 0.0472500], 0.1350000),
+        (CompositeOp::Out, [0.4800000, 0.1800000, 0.0600000], 0.6000, [0.0800000, 0.2800000, 0.3600000], 0.4000, [0.2880000, 0.1080000, 0.0360000], 0.3600000),
+        (CompositeOp::Out, [0.0375000, 0.1375000, 0.2125000], 0.2500, [0.6750000, 0.3375000, 0.1500000], 0.7500, [0.0093750, 0.0343750, 0.0531250], 0.0625000),
+        (CompositeOp::Out, [0.4500000, 0.8100000, 0.3150000], 0.9000, [0.0525000, 0.0150000, 0.0900000], 0.1500, [0.3825000, 0.6885000, 0.2677500], 0.7650000),
+        (CompositeOp::Atop, [0.4800000, 0.1800000, 0.0600000], 0.6000, [0.0800000, 0.2800000, 0.3600000], 0.4000, [0.2240000, 0.1840000, 0.1680000], 0.4000000),
+        (CompositeOp::Atop, [0.0375000, 0.1375000, 0.2125000], 0.2500, [0.6750000, 0.3375000, 0.1500000], 0.7500, [0.5343750, 0.3562500, 0.2718750], 0.7500000),
+        (CompositeOp::Atop, [0.4500000, 0.8100000, 0.3150000], 0.9000, [0.0525000, 0.0150000, 0.0900000], 0.1500, [0.0727500, 0.1230000, 0.0562500], 0.1500000),
+        (CompositeOp::Xor, [0.4800000, 0.1800000, 0.0600000], 0.6000, [0.0800000, 0.2800000, 0.3600000], 0.4000, [0.3200000, 0.2200000, 0.1800000], 0.5200000),
+        (CompositeOp::Xor, [0.0375000, 0.1375000, 0.2125000], 0.2500, [0.6750000, 0.3375000, 0.1500000], 0.7500, [0.5156250, 0.2875000, 0.1656250], 0.6250000),
+        (CompositeOp::Xor, [0.4500000, 0.8100000, 0.3150000], 0.9000, [0.0525000, 0.0150000, 0.0900000], 0.1500, [0.3877500, 0.6900000, 0.2767500], 0.7800000),
+    ];
+
+    #[test]
+    fn composite_rgba_should_match_the_porter_duff_reference() {
+        for &(op, s, sa, d, da, want_co, want_ao) in COMPOSITE_CASES {
+            let (co, ao) = composite_rgba(op, s, sa, d, da);
+            assert!(
+                close3(co, want_co),
+                "{op:?}: expected colour {want_co:?}, got {co:?} (s {s:?} sa {sa}, d {d:?} da {da})"
+            );
+            assert!(
+                (ao - want_ao).abs() < 1e-4,
+                "{op:?}: expected alpha {want_ao}, got {ao}"
+            );
+        }
+    }
+
+    #[test]
+    fn composite_reference_table_should_cover_every_operator() {
+        let mut ops: Vec<u32> = COMPOSITE_CASES.iter().map(|&(op, ..)| op as u32).collect();
+        ops.sort_unstable();
+        ops.dedup();
+        assert_eq!(ops.len(), 6, "a new operator needs rows in COMPOSITE_CASES");
+        assert_eq!(COMPOSITE_CASES.len(), ops.len() * 3);
+    }
+
+    /// `Over` has to stay exactly what the shader wrote before #1670,
+    /// `mix(d, blend, sa)` and `sa + da * (1 - sa)`, because the 44-mode
+    /// agreement test and the parity suite are the regression net for it.
+    #[test]
+    fn composite_rgba_over_should_equal_the_pre_1670_expression() {
+        for &(_, s, sa, d, da, ..) in COMPOSITE_CASES {
+            let (co, ao) = composite_rgba(CompositeOp::Over, s, sa, d, da);
+            for c in 0..3 {
+                // `s` is the premultiplied blend result, so `blend = s / sa`.
+                let blend = s[c] / sa;
+                let mixed = d[c] + (blend - d[c]) * sa;
+                assert!(
+                    (co[c] - mixed).abs() < 1e-5,
+                    "Over channel {c}: {co:?} vs mix() {mixed}"
+                );
+            }
+            assert!((ao - (sa + da * (1.0 - sa))).abs() < 1e-6, "Over alpha");
+        }
     }
 
     /// Each guarded formula has an exact-equality escape in the C that a

--- a/crates/ff-render/src/nodes/composite/blend_mode.rs
+++ b/crates/ff-render/src/nodes/composite/blend_mode.rs
@@ -32,7 +32,8 @@
 //! layers cover (#1750). [`BlendModeNode::process_cpu`] and `shaders/blend.wgsl`
 //! carry the same two formulas.
 
-use super::blend_math::blend_rgb;
+use super::blend_math::{blend_rgb, composite_rgba};
+use super::composite_op::CompositeOp;
 #[cfg(feature = "wgpu")]
 use super::helpers::{
     fullscreen_pipeline, linear_sampler, submit_render_pass, two_tex_sampler_uniform_bgl,
@@ -172,6 +173,9 @@ struct BlendPipeline {
 pub struct BlendModeNode {
     /// Blend algorithm.
     pub mode: BlendMode,
+    /// Porter-Duff operator applied after the blend. Defaults to
+    /// [`CompositeOp::Over`], which is what the node did before #1670.
+    pub composite_op: CompositeOp,
     /// Overlay opacity (0.0 = invisible, 1.0 = fully applied).
     pub opacity: f32,
     /// Overlay frame as RGBA bytes (required for CPU path).
@@ -195,6 +199,7 @@ impl BlendModeNode {
     ) -> Self {
         Self {
             mode,
+            composite_op: CompositeOp::Over,
             opacity,
             overlay_rgba,
             overlay_width,
@@ -231,18 +236,16 @@ impl RenderNodeCpu for BlendModeNode {
             let oa = f32::from(ov[3]) / 255.0;
             let ba = f32::from(base[3]) / 255.0;
 
-            let [rr, rg, rb] = blend_rgb(self.mode, [br, bg, bb], [or, og, ob]);
-            let eff_alpha = oa * self.opacity;
-            let out_r = (br + (rr - br) * eff_alpha).clamp(0.0, 1.0);
-            let out_g = (bg + (rg - bg) * eff_alpha).clamp(0.0, 1.0);
-            let out_b = (bb + (rb - bb) * eff_alpha).clamp(0.0, 1.0);
-            // src-over coverage, mirroring `blend.wgsl`'s `out_a` (#1750). An
-            // out-of-range `opacity` extrapolates as the colour channels do; the
-            // `as u8` cast below saturates, matching the shader's texture write.
-            let out_a = eff_alpha + ba * (1.0 - eff_alpha);
-            base[0] = (out_r * 255.0 + 0.5) as u8;
-            base[1] = (out_g * 255.0 + 0.5) as u8;
-            base[2] = (out_b * 255.0 + 0.5) as u8;
+            let blended = blend_rgb(self.mode, [br, bg, bb], [or, og, ob]);
+            // Premultiply the straight blend result, then composite (#1670).
+            // Mirrors `blend.wgsl`'s tail; an out-of-range `opacity` extrapolates
+            // and the `as u8` casts saturate, matching the shader's texture write.
+            let sa = oa * self.opacity;
+            let s = [blended[0] * sa, blended[1] * sa, blended[2] * sa];
+            let (co, out_a) = composite_rgba(self.composite_op, s, sa, [br, bg, bb], ba);
+            base[0] = (co[0].clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            base[1] = (co[1].clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
+            base[2] = (co[2].clamp(0.0, 1.0) * 255.0 + 0.5) as u8;
             base[3] = (out_a * 255.0 + 0.5) as u8;
         }
     }
@@ -311,26 +314,7 @@ impl crate::nodes::RenderNode for BlendModeNode {
         );
 
         // Write uniforms: [mode_u32, opacity_f32, pad, pad] = 16 bytes.
-        let mode_bytes = (self.mode as u32).to_le_bytes();
-        let opac_bytes = self.opacity.to_le_bytes();
-        let uniforms: [u8; 16] = [
-            mode_bytes[0],
-            mode_bytes[1],
-            mode_bytes[2],
-            mode_bytes[3],
-            opac_bytes[0],
-            opac_bytes[1],
-            opac_bytes[2],
-            opac_bytes[3],
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        ];
+        let uniforms = super::blend_uniform_bytes(self.mode, self.composite_op, self.opacity);
         ctx.queue.write_buffer(&pd.uniform_buf, 0, &uniforms);
 
         let base_view = tex_base.create_view(&wgpu::TextureViewDescriptor::default());

--- a/crates/ff-render/src/nodes/composite/composite_op.rs
+++ b/crates/ff-render/src/nodes/composite/composite_op.rs
@@ -1,0 +1,94 @@
+//! `CompositeOp`: the Porter-Duff alpha-compositing operators.
+//!
+//! # Reference
+//!
+//! These are the operators from W3C Compositing and Blending Level 1, whose
+//! general form is
+//!
+//! ```text
+//! Co = as * Fa * Cs + ab * Fb * Cb
+//! ao = as * Fa      + ab * Fb
+//! ```
+//!
+//! with `Fa` and `Fb` chosen per operator. Every doc comment below gives the
+//! premultiplied form the shader and [`blend_math`](super::blend_math) actually
+//! evaluate, where `s = as * Cs` is the premultiplied source, `d = ab * Cb` the
+//! premultiplied backdrop, and `sa` / `da` their alphas. The two are the same
+//! thing: substituting `s` and `d` into `co = s * Fa + d * Fb` reproduces the
+//! spec's expression. Skia states the same set as one-liners on premultiplied
+//! colour (`kSrcIn: r = s * da`), and Natron's compositor cites these sections
+//! directly.
+//!
+//! # Relationship to `BlendMode`
+//!
+//! [`BlendMode`](super::BlendMode) is a *colour* function of two pixels;
+//! `CompositeOp` is *alpha* algebra deciding how much of each side survives.
+//! W3C applies them in that order, blend then composite, which is how
+//! `shaders/blend.wgsl` is written. avio's editing model does not combine them:
+//! a layer with a non-`Over` composite has its blend mode ignored, so
+//! `avio::gpu::map_scene` emits `Normal` for those layers.
+//!
+//! # Why the CPU path differs
+//!
+//! `ff_filter::CompositeOp` builds In/Out/Atop/Xor from `blend`'s `all_expr`,
+//! which is per-channel arithmetic rather than alpha compositing: `FFmpeg` has
+//! no Porter-Duff filter, and `all_expr` can only reference the same plane of
+//! both inputs, so it cannot express a colour term that depends on the other
+//! input's alpha. The GPU implements the real operators; the divergence is
+//! recorded on #1670.
+
+/// Porter-Duff alpha-compositing operator.
+///
+/// The discriminant is the value written into the shader's `composite` uniform,
+/// so variants are only ever **appended**, never renumbered. Each doc comment
+/// gives the premultiplied output colour `co` and alpha `ao`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u32)]
+pub enum CompositeOp {
+    /// Source over destination. `co = s + d(1-sa)`, `ao = sa + da(1-sa)`.
+    #[default]
+    Over = 0,
+    /// Destination over source. `co = d + s(1-da)`, `ao = da + sa(1-da)`.
+    Under = 1,
+    /// Source shown only where the destination is opaque.
+    /// `co = s·da`, `ao = sa·da`.
+    In = 2,
+    /// Source shown only where the destination is transparent.
+    /// `co = s(1-da)`, `ao = sa(1-da)`.
+    Out = 3,
+    /// Source atop the destination; the destination's shape is kept.
+    /// `co = s·da + d(1-sa)`, `ao = da`.
+    Atop = 4,
+    /// Whichever side the other does not cover.
+    /// `co = s(1-da) + d(1-sa)`, `ao = sa(1-da) + da(1-sa)`.
+    Xor = 5,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CompositeOp;
+
+    /// The discriminant is the shader's `composite` uniform value, so
+    /// renumbering a variant silently changes what `blend.wgsl` composites. A
+    /// new variant needs a row here and a matching `case` in the shader.
+    #[test]
+    fn composite_op_discriminants_should_match_the_shader_codes() {
+        let expected = [
+            (CompositeOp::Over, 0),
+            (CompositeOp::Under, 1),
+            (CompositeOp::In, 2),
+            (CompositeOp::Out, 3),
+            (CompositeOp::Atop, 4),
+            (CompositeOp::Xor, 5),
+        ];
+        for (op, code) in expected {
+            assert_eq!(op as u32, code, "{op:?} moved to a different code");
+        }
+        assert_eq!(expected.len(), 6);
+    }
+
+    #[test]
+    fn composite_op_should_default_to_over() {
+        assert_eq!(CompositeOp::default(), CompositeOp::Over);
+    }
+}

--- a/crates/ff-render/src/nodes/composite/helpers.rs
+++ b/crates/ff-render/src/nodes/composite/helpers.rs
@@ -4,6 +4,32 @@
 //! render-pass submission shared by every GPU node implementation.
 
 #[cfg(feature = "wgpu")]
+use super::blend_mode::BlendMode;
+#[cfg(feature = "wgpu")]
+use super::composite_op::CompositeOp;
+
+/// The 16-byte `BlendUniforms` payload for `shaders/blend.wgsl`.
+///
+/// Assembled in one place because both the standalone `BlendModeNode` and the
+/// multi-layer compositor write it. They used to build the bytes separately, and
+/// a drift between the two would have rendered a different mode on the path
+/// `avio::gpu::map_scene` actually feeds, which no node test would catch.
+///
+/// Layout: `mode: u32`, `opacity: f32`, `composite: u32`, four bytes of padding.
+#[cfg(feature = "wgpu")]
+pub(crate) fn blend_uniform_bytes(
+    mode: BlendMode,
+    composite: CompositeOp,
+    opacity: f32,
+) -> [u8; 16] {
+    let mut out = [0u8; 16];
+    out[0..4].copy_from_slice(&(mode as u32).to_le_bytes());
+    out[4..8].copy_from_slice(&opacity.to_le_bytes());
+    out[8..12].copy_from_slice(&(composite as u32).to_le_bytes());
+    out
+}
+
+#[cfg(feature = "wgpu")]
 pub(crate) fn linear_sampler(device: &wgpu::Device, label: &str) -> wgpu::Sampler {
     device.create_sampler(&wgpu::SamplerDescriptor {
         label: Some(&format!("{label} sampler")),

--- a/crates/ff-render/src/nodes/mod.rs
+++ b/crates/ff-render/src/nodes/mod.rs
@@ -18,8 +18,8 @@ pub use blur::{GaussianBlurNode, MotionBlurNode, SharpenNode};
 pub use color_grade::ColorGradeNode;
 pub use color_wheels::ColorWheelsNode;
 pub use composite::{
-    AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, LumaMaskNode, ShapeMaskNode,
-    TransformNode,
+    AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, CompositeOp, LumaMaskNode,
+    ShapeMaskNode, TransformNode,
 };
 pub use crossfade::CrossfadeNode;
 pub use curves::CurvesNode;

--- a/crates/ff-render/src/shaders/blend.wgsl
+++ b/crates/ff-render/src/shaders/blend.wgsl
@@ -11,9 +11,10 @@
 // this file `a` = base (canvas) and `b` = overlay (layer). The helper functions
 // mirror `nodes/composite/blend_math.rs` one for one.
 //
-// Alpha convention: the canvas carries premultiplied RGB composited against an
-// opaque black backdrop, and its alpha is src-over coverage. See the note at the
-// end of `fs_main`.
+// Alpha convention: the canvas carries premultiplied RGB blended against an
+// opaque black backdrop, and its alpha is coverage. The final step is a
+// Porter-Duff composite selected by `u.composite`; see the note at the end of
+// `fs_main`.
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
@@ -49,8 +50,10 @@ struct BlendUniforms {
     // mode needs a row there and a `case` below.
     mode:    u32,
     opacity: f32,
-    _pad0:   f32,
-    _pad1:   f32,
+    // The `CompositeOp` discriminant, pinned by
+    // `composite_op_discriminants_should_match_the_shader_codes`.
+    composite: u32,
+    _pad1:     f32,
 }
 
 const PI: f32 = 3.14159265358979323846;
@@ -375,21 +378,46 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         default  { blend_rgb = b; }
     }
 
-    // Apply opacity: modulate blend result against base using overlay.a * opacity.
-    // FFmpeg computes `dst = A + (expr - A) * opacity`, and A is the base here.
-    // The clamp reproduces the float-to-8-bit conversion for the modes the
-    // `DEPTH == 32` branch leaves outside [0, 1].
+    // Composite. `blend_rgb` is the straight source colour, so premultiply it
+    // and apply the operator's Fa/Fb: this is W3C's
+    // `Co = as * Fa * Cs + ab * Fb * Cb` with `s = as * Cs` and `d = ab * Cb`
+    // substituted, which reduces to `co = s * Fa + d * Fb`. Mirrors
+    // `blend_math::composite_rgba` one for one (#1670).
     //
-    // Alpha accumulates as src-over coverage (#1750). The RGB above is
-    // deliberately *not* reweighted by the backdrop alpha the way W3C's
-    // `Cs' = (1 - ab) * Cs + ab * B(Cb, Cs)` would: it composites against an
-    // opaque black backdrop, which is what the CPU compositor's
-    // `color=c=#000000` canvas does, and ADR-0007 keeps that the reference.
-    // `FrameLayer.opacity` is not clamped, so an out-of-range value extrapolates
-    // here exactly as it does in the `mix` above; the `Rgba8Unorm` write
-    // saturates either way, which is why neither needs its own clamp.
-    let effective_alpha = overlay.a * u.opacity;
-    let out_rgb = mix(base.rgb, blend_rgb, effective_alpha);
-    let out_a = effective_alpha + base.a * (1.0 - effective_alpha);
+    // `Over` is algebraically the `mix(base.rgb, blend_rgb, sa)` it replaced, so
+    // the 44-mode agreement test stays the regression net for it.
+    //
+    // The blend above is deliberately *not* reweighted by the backdrop alpha the
+    // way W3C's `Cs' = (1 - ab) * Cs + ab * B(Cb, Cs)` would: it blends against
+    // an opaque black backdrop, which is what the CPU compositor's
+    // `color=c=#000000` canvas does, and ADR-0007 keeps that the reference. The
+    // clamp reproduces the float-to-8-bit conversion for the modes the
+    // `DEPTH == 32` branch leaves outside [0, 1]; `FrameLayer.opacity` is not
+    // clamped either, so an out-of-range value extrapolates and the
+    // `Rgba8Unorm` write saturates.
+    let sa = overlay.a * u.opacity;
+    let s = blend_rgb * sa;
+    let d = base.rgb;
+    let da = base.a;
+
+    var fa: f32;
+    var fb: f32;
+    switch u.composite {
+        // Over
+        case 0u { fa = 1.0;      fb = 1.0 - sa; }
+        // Under
+        case 1u { fa = 1.0 - da; fb = 1.0;      }
+        // In
+        case 2u { fa = da;       fb = 0.0;      }
+        // Out
+        case 3u { fa = 1.0 - da; fb = 0.0;      }
+        // Atop
+        case 4u { fa = da;       fb = 1.0 - sa; }
+        // Xor
+        case 5u { fa = 1.0 - da; fb = 1.0 - sa; }
+        default { fa = 1.0;      fb = 1.0 - sa; }
+    }
+    let out_rgb = s * fa + d * fb;
+    let out_a = sa * fa + da * fb;
     return vec4<f32>(clamp(out_rgb, vec3<f32>(0.0), vec3<f32>(1.0)), out_a);
 }

--- a/crates/ff-render/tests/gpu_nodes.rs
+++ b/crates/ff-render/tests/gpu_nodes.rs
@@ -15,10 +15,10 @@
 use std::sync::Arc;
 
 use ff_render::{
-    AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CrossfadeNode,
-    DissolveTransitionNode, FadeTransitionNode, LumaMaskNode, OverlayNode, RenderContext,
-    RenderGraph, RenderNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode, ShapeMaskNode,
-    TransformNode, YuvFormat, YuvUploadNode,
+    AlphaMatteNode, BlendMode, BlendModeNode, ChromaKeyNode, ColorGradeNode, CompositeOp,
+    CrossfadeNode, DissolveTransitionNode, FadeTransitionNode, LumaMaskNode, OverlayNode,
+    RenderContext, RenderGraph, RenderNode, RenderNodeCpu, ScaleAlgorithm, ScaleNode,
+    ShapeMaskNode, TransformNode, YuvFormat, YuvUploadNode,
 };
 
 // Helpers
@@ -466,6 +466,64 @@ fn blend_gpu_should_match_the_cpu_path_for_a_semi_transparent_overlay() {
         );
     }
 }
+
+/// Every Porter-Duff operator, shader against the Rust.
+///
+/// `blend_math.rs`'s table pins the Rust to the W3C `Fa`/`Fb` definitions; this
+/// pins the shader to the Rust, so the two together tie the GPU output to the
+/// spec (#1670).
+///
+/// Both alphas sit strictly inside `(0, 1)` and differ, or `In`, `Out` and
+/// `Atop` degenerate into each other. The final assert is the load-bearing one:
+/// the six operators must produce six distinct pixels, so a shader that ignored
+/// `u.composite` and always composited `Over` would fail rather than agree with
+/// a CPU path making the same mistake.
+#[test]
+fn composite_gpu_should_match_the_cpu_path_for_every_op() {
+    let Some(ctx) = gpu_ctx() else { return };
+
+    let base = solid_rgba(40, 90, 200, 102, 2, 2); // da = 0.4
+    let overlay = solid_rgba(170, 60, 30, 153, 2, 2); // sa = 0.6
+
+    let mut seen = Vec::new();
+    for op in ALL_COMPOSITE_OPS {
+        let mut node = BlendModeNode::new(BlendMode::Normal, 1.0, overlay.clone(), 2, 2);
+        node.composite_op = op;
+        let mut cpu = base.clone();
+        node.process_cpu(&mut cpu, 2, 2);
+        let gpu = run_gpu(&ctx, node, &base, 2, 2);
+
+        for ch in 0..4 {
+            assert!(
+                close(gpu[ch], cpu[ch], 2),
+                "{op:?} channel {ch}: GPU {} vs CPU {}",
+                gpu[ch],
+                cpu[ch]
+            );
+        }
+        seen.push([cpu[0], cpu[1], cpu[2], cpu[3]]);
+    }
+
+    let mut distinct = seen.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        6,
+        "the six operators must give distinct results; got {seen:?}"
+    );
+}
+
+/// Kept in the same order as the `CompositeOp` discriminants; the enum's own
+/// `composite_op_discriminants_should_match_the_shader_codes` pins those.
+const ALL_COMPOSITE_OPS: [CompositeOp; 6] = [
+    CompositeOp::Over,
+    CompositeOp::Under,
+    CompositeOp::In,
+    CompositeOp::Out,
+    CompositeOp::Atop,
+    CompositeOp::Xor,
+];
 
 /// Kept in the same order as the `BlendMode` discriminants; the enum's own
 /// `blend_mode_discriminants_should_match_the_shader_mode_codes` pins those.

--- a/docs/specs/gpu-compositing-bridge.md
+++ b/docs/specs/gpu-compositing-bridge.md
@@ -109,12 +109,11 @@ tracked in **#1630**.
 | `x`/`y`/`scale`/`rotation` transform | evaluated at frame `t` -> the layer's `LayerTransform` scalars | **covered** (all layers) |
 | `opacity` | evaluated at `t` -> `FrameLayer.opacity` | **covered** (all layers) |
 | `blend_mode: ff_filter::BlendMode` (40) | `ff_render::BlendMode`, **all 40** (#1669; 14 before that) | **covered** (every mode; no blend mode forces a fallback). The GPU formulas reproduce `FFmpeg`'s `vf_blend`, so the GPU and the CPU compositor render a mode alike -- see [ADR-0010](../adr/0010-gpu-blend-modes-follow-ffmpeg.md) for the reference, the `A`=base/`B`=overlay pad wiring, and the bitwise-mode exception. (`ff_render` also has `Hue`/`Saturation`/`Color`/`Luminosity`, but `ff_filter::BlendMode` has no such variants -- removed in #1219 -- so they are unreachable from the derived scene.) |
-| `composite_op: Over` | plain top-over-bottom composite | **covered** |
+| `composite_op: ff_filter::CompositeOp` (6) | `ff_render::CompositeOp`, **all 6** (#1670; `Over` only before that) | **covered** (every operator). The GPU evaluates the W3C Porter-Duff `Fa`/`Fb` definitions on premultiplied colour, which needs the coverage alpha #1750 added. The filter path builds `In`/`Out`/`Atop`/`Xor` from `blend`'s `all_expr` on `yuv420p` instead, which is per-channel arithmetic rather than alpha compositing. Preview and export both composite on the GPU, so the split is not between them: **those four render one way with an adapter and another whenever the whole-frame fallback swaps in the filter path** (a headless machine, a forced-CPU run, a frame that falls back for an unrelated reason). ADR-0007 makes the CPU the correctness reference, so this is a gap to close, not a property to rely on -- tracked by #1753. |
 | `FilterStep::Eq` (from a const `EffectKind::ColorCorrect`) | `GpuEffect::ColorGrade` -> `ColorGradeNode { brightness, contrast, saturation, temperature=0, tint=0 }` | **covered** |
 | `FilterStep::EqAnimated` | `ColorGrade` (params at `t`) **only when gamma is neutral at `t`** (ff-render ColorGrade has no gamma) | **covered** (gamma-neutral); non-neutral gamma -> **fallback** |
 | plain `FilterStep::Scale { width, height, algorithm }` | `GpuEffect::Scale` -> `ScaleNode` (ff-render uses a linear filter for all algorithms; `Fast` maps to `Bilinear`) | **covered** |
 | temporal steps: `Trim` / `ResetPts` / `OffsetPts` / `Speed` | skipped (decode-scheduling, applied upstream) | **skipped** (not a fallback) |
-| `composite_op: Under`/`In`/`Out`/`Atop`/`Xor` | -- | **fallback** (#1630) |
 | other colour: `Hue`, `Curves`, `Gamma`, `Vignette`, `WhiteBalance`, `ColorBalanceAnimated`, `ThreeWayCC`, `ParametricEq` | -- | **fallback** (#1630) |
 | `FitToAspect` / `FillToAspect` (fit with pad/crop) | -- | **fallback** (#1630; `ScaleNode` is a plain resize) |
 | animated geometry `ScaleAnimated` / `RotateAnimated` | -- | **fallback** (#1630; ADR-0005 neutralizes the scalar, so v1 falls back rather than lose the animation) |
@@ -133,7 +132,7 @@ Fallback is decided **per composited frame**, at whole-frame granularity:
 - If `RenderContext::init()` fails (no adapter) or a force-CPU override is set, **every** frame composites on
   the existing CPU path.
 - Otherwise, before compositing a frame, a **capability check** walks the frame's layer set. If any layer
-  carries a step with no node in the table above (or a composite operator other than `Over`), that
+  carries a step with no node in the table above, that
   **whole frame** composites on the existing CPU compositor (`MultiTrackComposer` for export,
   `RealtimeComposer` for preview) instead of the GPU path. Otherwise the frame goes GPU.
 - A `GpuFrameSink`-style degrade also applies at runtime: a GPU error on a frame falls through to the CPU path
@@ -168,8 +167,8 @@ avoids mixing GPU and CPU colour spaces within one frame. Per-layer hybrid compo
 
 ## Deferred beyond v0.18.0
 
-- Full node coverage (blur/LUT/glow/curves colour science, xfade kinds on GPU, Porter-Duff In/Out/Atop/Xor,
-  BT.709 YUV upload). The blend modes landed in #1669.
+- Full node coverage (blur/LUT/glow/curves colour science, xfade kinds on GPU, BT.709 YUV upload). The
+  blend modes landed in #1669 and the Porter-Duff operators in #1670.
 - Zero-copy GPU->encoder for export (v1 reads back to CPU and reuses the existing encoder).
 - Exact preview==export pixel convergence (the CPU compositors themselves are not bit-identical across the
   rgba/yuv420p seam, per the C4 Q2 deferral in `engine-and-primitives.md`).


### PR DESCRIPTION
## Objective

- `map_scene` fell back for any `CompositeOp` other than `Over`, so five of six operators dropped the whole frame to the CPU compositor.
- The filter path is not Porter-Duff: it forces `format=yuv420p` before the composite blend, and `blend`'s `all_expr` can only reference the same plane of both inputs, so `In` reduces to a per-channel multiply. FFmpeg has no Porter-Duff filter, so that is a workaround rather than a decision.

## Solution

- Implement the W3C `Fa`/`Fb` definitions on the GPU (matching Skia, Cairo, pixman and Natron). #1750 had already left the shader in premultiplied src-over form, so the six operators are the same two lines generalised, and `Over` reproduces the expression it replaces.
- The operators are only meaningful because of #1750: the backdrop alpha is coverage, so `In` masks a layer to what the layers below actually covered.
- Scope widened from four operators to five: `Under` also fell back and costs one `switch` arm.
- The composite uniform reuses the padding word, so the buffer stays 16 bytes and the bind group layout is unchanged. Those bytes were assembled by hand in two places, which #1669's review flagged; they now come from one helper.
- A non-`Over` composite drops the layer's blend mode rather than falling back, matching the CPU path.
- Three test layers: an 18-row table whose expected values come from transcribing the W3C definitions a second time in their straight form (`composite_rgba` works in the premultiplied form, so agreement is evidence neither dropped a factor); a shader-vs-Rust check over all six that also asserts the six give six distinct pixels; and a compositor test for the masking property. The 44-mode agreement test and `gpu_parity_tests` stay untouched as the regression net for `Over`.
- Correct `ff_filter::CompositeOp`'s type doc, which claimed alpha compositing, and rename three test names that mentioned alpha but described luma.

The criterion's parity clause was withdrawn on the issue before this work: the filter path computes something else, so parity against it would mean implementing the wrong thing. Both preview and export composite on the GPU, so these four now render one way with an adapter and another when the whole-frame fallback swaps in the filter path; closing that is #1753.

Closes #1670