### PR TITLE
feat(avio,ff-format): broaden GPU node coverage and add an FFmpeg colour parser

### DIFF
--- a/crates/avio/src/gpu.rs
+++ b/crates/avio/src/gpu.rs
@@ -14,9 +14,11 @@
 //!
 //! Fallback is **whole-frame**: if any layer carries an unsupported blend mode,
 //! composite op, or effect step, the entire frame falls back to the existing CPU
-//! compositor. The mapping never silently drops a step. v1 covers colour grade
-//! (`Eq`) and plain scale as per-layer effects; broader node coverage is tracked as
-//! a follow-up.
+//! compositor. The mapping never silently drops a step.
+//!
+//! `classify_step` is the authority on what is covered — the node-coverage table in
+//! `docs/specs/gpu-compositing-bridge.md` describes it, but read the code when the
+//! two disagree.
 
 use std::time::Duration;
 
@@ -432,10 +434,17 @@ pub fn map_scene<L: GpuLayerSource>(layers: &[L], canvas: (u32, u32), t: Duratio
         };
 
         let mut effects = Vec::new();
+        // Rotation contributed by the effect chain (`RotateAnimated`), which is
+        // **added** to the layer scalar rather than replacing it: on the CPU both
+        // apply — the compositor rotates the layer from `layer.rotation` and the
+        // effect chain rotates again — and where `derive` neutralized the scalar
+        // (ADR-0005) the sum degrades to the step's own angle.
+        let mut step_rotation = 0.0_f32;
         for step in layer.effects() {
             match classify_step(step, t) {
                 StepClass::Skip => {}
                 StepClass::Effect(effect) => effects.push(effect),
+                StepClass::Rotation(degrees) => step_rotation += degrees,
                 StepClass::Unsupported => {
                     return GpuMapping::Fallback(GpuFallback::UnsupportedEffect);
                 }
@@ -449,7 +458,7 @@ pub fn map_scene<L: GpuLayerSource>(layers: &[L], canvas: (u32, u32), t: Duratio
             y: eval_at(layer.y(), t),
             scale_x: eval_at(layer.scale_x(), t),
             scale_y: eval_at(layer.scale_y(), t),
-            rotation: eval_at(layer.rotation(), t),
+            rotation: eval_at(layer.rotation(), t) + step_rotation,
             opacity: eval_at(layer.opacity(), t).clamp(0.0, 1.0),
             blend_mode,
             composite_op,
@@ -475,6 +484,9 @@ fn eval_at(value: &AnimatedValue<f64>, t: Duration) -> f32 {
 enum StepClass {
     Skip,
     Effect(GpuEffect),
+    /// A step that belongs on the layer's transform rather than in its effect
+    /// list: clockwise degrees to add to [`GpuLayerPlan::rotation`].
+    Rotation(f32),
     Unsupported,
 }
 
@@ -534,6 +546,31 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             height: *height,
             algorithm: map_scale_algo(*algorithm),
         }),
+        // `ScaleAnimated` is the same resize step as `Scale` with a track for each
+        // dimension (`derive` emits it under ADR-0005 with the layer scalar
+        // neutralized, sized as `canvas * factor`), so it maps to the same node
+        // evaluated at the frame time. `map_scene` runs per frame, which is what
+        // makes that sound — the same reason the animated blur/sharpen/vignette
+        // arms below evaluate at `t`.
+        //
+        // No zero-size guard: plain `Scale` has none either, and `FFmpeg`'s `scale`
+        // reads `0` as "keep the source size". Falling back at zero would invent a
+        // divergence the static path does not have.
+        FilterStep::ScaleAnimated {
+            width,
+            height,
+            algorithm,
+        } => StepClass::Effect(GpuEffect::Scale {
+            width: round_u32(width.value_at(t)),
+            height: round_u32(height.value_at(t)),
+            algorithm: map_scale_algo(*algorithm),
+        }),
+        // `RotateAnimated` is the rotation `derive` lifted off the layer scalar
+        // (ADR-0005), so it goes back onto the transform rather than into the
+        // effect list — there is no GPU rotate *node*, rotation is a layer property.
+        FilterStep::RotateAnimated { angle, fill_color } => {
+            rotate_animated_step(angle.value_at(t), fill_color)
+        }
         FilterStep::GBlur { sigma } => StepClass::Effect(GpuEffect::Blur { sigma: *sigma }),
         FilterStep::GBlurAnimated { sigma } => StepClass::Effect(GpuEffect::Blur {
             // The blur node is rebuilt each composite (map_scene runs per frame), so
@@ -654,6 +691,10 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
                 })
             }
         }
+        // `hue` is `hsl` with a neutral saturation and lightness: both compile to
+        // the same `hue` filter's `h=` (see `FilterStep::args`), so this is a
+        // rename, not an approximation.
+        FilterStep::Hue { degrees } => hsl_step(*degrees, 1.0, 0.0),
         FilterStep::Hsl {
             hue,
             saturation,
@@ -684,7 +725,7 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             color,
             similarity,
             blend,
-        } => match parse_ffmpeg_hex(color) {
+        } => match parse_key_color(color) {
             Some(key_color) => chroma_key_step(key_color, *similarity, *blend),
             None => StepClass::Unsupported,
         },
@@ -692,7 +733,7 @@ fn classify_step(step: &FilterStep, t: Duration) -> StepClass {
             color,
             similarity,
             blend,
-        } => match parse_ffmpeg_hex(color) {
+        } => match parse_key_color(color) {
             Some(key_color) => chroma_key_step(
                 key_color,
                 similarity.value_at(t) as f32,
@@ -924,30 +965,53 @@ fn motion_blur_step(shutter_angle: f32, sub_frames: u8) -> StepClass {
     })
 }
 
+/// Classifies a `RotateAnimated` step: the angle folds onto the layer transform
+/// rather than becoming an effect node, but only when the fill the CPU `rotate`
+/// would use is one the GPU transform can reproduce.
+///
+/// The GPU transform leaves the corners a rotation exposes **transparent**, while
+/// `rotate` fills them with `fillcolor`. Two fills are safe:
+///
+/// * `none` — transparent, exactly what the transform does.
+/// * `black` — what `derive` emits, and what the CPU compositor's own *static*
+///   layer rotation uses (`composition_inner` builds `rotate` with no `fillcolor`,
+///   whose default is black). Folding therefore makes an animated rotation behave
+///   like a static one on both paths: the black-versus-transparent difference is
+///   the pre-existing one the static mapping already carries, not a new one.
+///
+/// Any other fill has nothing to map to, so it falls back rather than render
+/// different corners (RK-020). The comparison is case-insensitive because
+/// `FFmpeg` colour names are.
+// The model's `f64` degrees narrow to the `f32` the plan carries; that is the
+// intended, lossy conversion, as in `eval_at`.
+#[allow(clippy::cast_possible_truncation)]
+fn rotate_animated_step(degrees: f64, fill_color: &str) -> StepClass {
+    if !(fill_color.eq_ignore_ascii_case("black") || fill_color.eq_ignore_ascii_case("none")) {
+        return StepClass::Unsupported;
+    }
+    StepClass::Rotation(degrees as f32)
+}
+
 /// Rounds an animated pixel bound (`f64`) to a non-negative `u32` for the mask.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn round_u32(v: f64) -> u32 {
     v.max(0.0).round() as u32
 }
 
-/// Parses an `FFmpeg` `0xRRGGBB` / `#RRGGBB` colour string into an RGB triple
-/// (each channel `0.0..=1.0`), or `None` for any other form. Used to recover the
-/// GPU node's key colour from the [`FilterStep::ChromaKey`] colour string that
-/// [`EffectKind::ChromaKey`](crate::EffectKind::ChromaKey) emits canonically.
-fn parse_ffmpeg_hex(color: &str) -> Option<[f32; 3]> {
-    let hex = color
-        .strip_prefix("0x")
-        .or_else(|| color.strip_prefix('#'))?;
-    if hex.len() != 6 {
-        return None;
-    }
-    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+/// Parses an `FFmpeg` colour string into an RGB triple (each channel
+/// `0.0..=1.0`), or `None` when it is not a colour this build can name.
+///
+/// Delegates to [`ff_format::Color::parse_ffmpeg`], so a name (`"green"`) works as
+/// well as the canonical hex the typed effects emit — which is what lets a
+/// hand-written or imported `chromakey=green` reach the GPU node instead of
+/// falling back (#1630). Any alpha the string carries is dropped: the GPU node's
+/// key colour is RGB, and the alpha it produces comes from the keying.
+fn parse_key_color(color: &str) -> Option<[f32; 3]> {
+    let c = ff_format::Color::parse_ffmpeg(color)?;
     Some([
-        f32::from(r) / 255.0,
-        f32::from(g) / 255.0,
-        f32::from(b) / 255.0,
+        f32::from(c.r) / 255.0,
+        f32::from(c.g) / 255.0,
+        f32::from(c.b) / 255.0,
     ])
 }
 
@@ -966,7 +1030,7 @@ fn map_scale_algo(algo: ScaleAlgorithm) -> RenderScaleAlgorithm {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use ff_filter::{AnimationTrack, Easing, Keyframe};
+    use ff_filter::{AnimationTrack, Easing, Keyframe, XfadeTransition};
 
     use super::*;
     use crate::Clip;
@@ -1204,6 +1268,191 @@ mod tests {
                 height: 240,
                 algorithm: RenderScaleAlgorithm::Bicubic,
             }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_scale_animated_to_the_scale_node_at_the_frame_time() {
+        // #1630. Width ramps 320 -> 640 and height 240 -> 480 over 0..2s, so t=1s
+        // must read the midpoint. Asserting at a single `t` would pass for a
+        // mapping that ignored the tracks and used their t=0 values (RK-015).
+        let track = |a: f64, b: f64| {
+            AnimatedValue::Track(
+                AnimationTrack::new()
+                    .push(Keyframe::new(Duration::ZERO, a, Easing::Linear))
+                    .push(Keyframe::new(Duration::from_secs(2), b, Easing::Linear)),
+            )
+        };
+        let step = FilterStep::ScaleAnimated {
+            width: track(320.0, 640.0),
+            height: track(240.0, 480.0),
+            algorithm: ScaleAlgorithm::Bicubic,
+        };
+        let at = |t: Duration| {
+            let mut layer = TestLayer::identity();
+            layer.effects = vec![step.clone()];
+            gpu(map_scene(&[layer], (16, 16), t)).layers[0]
+                .effects
+                .clone()
+        };
+        assert_eq!(
+            at(Duration::ZERO).as_slice(),
+            [GpuEffect::Scale {
+                width: 320,
+                height: 240,
+                // The algorithm must survive: it is the field a fold into the
+                // layer transform would have had to drop.
+                algorithm: RenderScaleAlgorithm::Bicubic,
+            }]
+        );
+        assert_eq!(
+            at(Duration::from_secs(1)).as_slice(),
+            [GpuEffect::Scale {
+                width: 480,
+                height: 360,
+                algorithm: RenderScaleAlgorithm::Bicubic,
+            }]
+        );
+    }
+
+    #[test]
+    fn map_scene_should_fold_rotate_animated_into_the_layer_rotation() {
+        // #1630. `derive` lifts an animated rotation off the layer scalar
+        // (ADR-0005); the mapping puts it back, per frame. Two times again, so a
+        // mapping that ignored the track cannot pass.
+        let step = FilterStep::RotateAnimated {
+            angle: AnimatedValue::Track(
+                AnimationTrack::new()
+                    .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+                    .push(Keyframe::new(Duration::from_secs(2), 90.0, Easing::Linear)),
+            ),
+            fill_color: "black".to_string(),
+        };
+        let at = |t: Duration| {
+            let mut layer = TestLayer::identity();
+            layer.effects = vec![step.clone()];
+            let plan = gpu(map_scene(&[layer], (16, 16), t));
+            // It belongs on the transform, not in the effect list.
+            assert!(
+                plan.layers[0].effects.is_empty(),
+                "a rotation must not become an effect node"
+            );
+            plan.layers[0].rotation
+        };
+        assert!((at(Duration::ZERO) - 0.0).abs() < 1e-3);
+        assert!((at(Duration::from_secs(1)) - 45.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn map_scene_should_add_a_rotate_animated_step_to_the_layer_rotation() {
+        // The CPU applies both the layer scalar (the compositor's own `rotate`)
+        // and the effect chain's, so the mapping sums them. A test with only one
+        // source of rotation passes just as well if the mapping *replaces*, which
+        // is why this one supplies both.
+        let mut layer = TestLayer::identity();
+        layer.rotation = AnimatedValue::Static(30.0);
+        layer.effects = vec![FilterStep::RotateAnimated {
+            angle: AnimatedValue::Static(15.0),
+            fill_color: "black".to_string(),
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert!(
+            (plan.layers[0].rotation - 45.0).abs() < 1e-3,
+            "layer 30deg + step 15deg must be 45deg, got {}",
+            plan.layers[0].rotation
+        );
+    }
+
+    #[test]
+    fn map_scene_should_fall_back_for_a_rotate_animated_with_an_unmappable_fill() {
+        // The GPU transform leaves the exposed corners transparent, so only a fill
+        // that matches (`none`) or the one the static path already uses (`black`)
+        // can fold. Anything else has no mapping and must not be rendered as if it
+        // did (RK-020).
+        for fill in ["black", "none", "BLACK", "None"] {
+            let mut layer = TestLayer::identity();
+            layer.effects = vec![FilterStep::RotateAnimated {
+                angle: AnimatedValue::Static(10.0),
+                fill_color: fill.to_string(),
+            }];
+            assert!(
+                matches!(
+                    map_scene(&[layer], (16, 16), Duration::ZERO),
+                    GpuMapping::Gpu(_)
+                ),
+                "{fill} must fold onto the transform"
+            );
+        }
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::RotateAnimated {
+            angle: AnimatedValue::Static(10.0),
+            fill_color: "red".to_string(),
+        }];
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
+        );
+    }
+
+    #[test]
+    fn map_scene_should_map_hue_to_the_hsl_node() {
+        // #1630. `hue` and `hsl` compile to the same FFmpeg `hue` filter's `h=`,
+        // so `Hue` is `Hsl` with a neutral saturation and lightness.
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::Hue { degrees: 42.0 }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        assert_eq!(
+            plan.layers[0].effects.as_slice(),
+            [GpuEffect::Hsl {
+                hue_shift: 42.0,
+                saturation: 1.0,
+                lightness: 0.0,
+            }]
+        );
+
+        // A zero rotation is the identity, so it is skipped rather than mapped.
+        let mut neutral = TestLayer::identity();
+        neutral.effects = vec![FilterStep::Hue { degrees: 0.0 }];
+        let plan = gpu(map_scene(&[neutral], (16, 16), Duration::ZERO));
+        assert!(plan.layers[0].effects.is_empty());
+    }
+
+    #[test]
+    fn map_scene_should_map_a_chroma_key_with_a_named_colour() {
+        // #1630: the colour string used to have to be hex. A name now resolves
+        // through `ff_format::Color::parse_ffmpeg`, and FFmpeg's `green` is
+        // 0x008000 — so this also pins that the value came from that table.
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::ChromaKey {
+            color: "green".to_string(),
+            similarity: 0.3,
+            blend: 0.1,
+        }];
+        let plan = gpu(map_scene(&[layer], (16, 16), Duration::ZERO));
+        let [GpuEffect::ChromaKey { key_color, .. }] = plan.layers[0].effects.as_slice() else {
+            panic!("a named chroma-key colour must map to the GPU node");
+        };
+        assert!((key_color[0] - 0.0).abs() < 1e-6);
+        assert!((key_color[1] - 128.0 / 255.0).abs() < 1e-6);
+        assert!((key_color[2] - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn map_scene_should_still_fall_back_for_a_color_key() {
+        // Deliberately NOT mapped. `ChromaKeyNode` measures *chroma* distance (it
+        // subtracts BT.709 luma from pixel and key first), which is `chromakey`'s
+        // semantic; `colorkey` is a full-RGB distance. Routing it to that node
+        // would be a silent approximation (RK-020), so it stays a fallback and
+        // this pins that the named-colour parser did not quietly enable it.
+        let mut layer = TestLayer::identity();
+        layer.effects = vec![FilterStep::ColorKey {
+            color: "green".to_string(),
+            similarity: 0.3,
+            blend: 0.1,
+        }];
+        assert_eq!(
+            map_scene(&[layer], (16, 16), Duration::ZERO),
+            GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
         );
     }
 
@@ -1609,8 +1858,15 @@ mod tests {
 
     #[test]
     fn map_scene_should_fall_back_on_unsupported_effect() {
+        // `Hue` stood here until #1630 mapped it; `XFade` needs the 2-input
+        // `CrossfadeNode` the plan has no place for, so it is the current example
+        // of a step with no GPU mapping at all.
         let mut layer = TestLayer::identity();
-        layer.effects = vec![FilterStep::Hue { degrees: 30.0 }];
+        layer.effects = vec![FilterStep::XFade {
+            transition: XfadeTransition::Fade,
+            duration: 1.0,
+            offset: 0.0,
+        }];
         assert_eq!(
             map_scene(&[layer], (16, 16), Duration::ZERO),
             GpuMapping::Fallback(GpuFallback::UnsupportedEffect)
@@ -1808,12 +2064,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_ffmpeg_hex_should_read_0x_and_hash_forms_and_reject_others() {
-        assert_eq!(parse_ffmpeg_hex("0x00FF00"), Some([0.0, 1.0, 0.0]));
-        assert_eq!(parse_ffmpeg_hex("#0000FF"), Some([0.0, 0.0, 1.0]));
-        // A named / non-hex colour has no GPU node → None (CPU fallback).
-        assert_eq!(parse_ffmpeg_hex("green"), None);
-        assert_eq!(parse_ffmpeg_hex("0x00FF"), None);
+    fn parse_key_color_should_read_hex_and_named_forms_and_reject_others() {
+        assert_eq!(parse_key_color("0x00FF00"), Some([0.0, 1.0, 0.0]));
+        assert_eq!(parse_key_color("#0000FF"), Some([0.0, 0.0, 1.0]));
+        // #1630: a name used to be `None` (CPU fallback); it now resolves through
+        // `ff_format::Color::parse_ffmpeg`. FFmpeg's `green` is 0x008000, so this
+        // also pins that the value comes from that table and not from a guess.
+        assert_eq!(parse_key_color("green"), Some([0.0, 128.0 / 255.0, 0.0]));
+        assert_eq!(parse_key_color("lime"), Some([0.0, 1.0, 0.0]));
+        // Alpha is dropped: the node's key colour is RGB.
+        assert_eq!(parse_key_color("0x00FF0080"), Some([0.0, 1.0, 0.0]));
+        assert_eq!(parse_key_color("no_such_colour"), None);
+        assert_eq!(parse_key_color("0x00FF"), None);
     }
 
     #[test]
@@ -1852,8 +2114,10 @@ mod tests {
 
     #[test]
     fn classify_chroma_key_unparseable_colour_should_fall_back_to_cpu() {
+        // `"green"` stood here until #1630 taught the parser colour names. The
+        // fallback is still reachable, just for a string no colour table has.
         let step = FilterStep::ChromaKey {
-            color: "green".to_string(),
+            color: "not_a_colour".to_string(),
             similarity: 0.3,
             blend: 0.1,
         };

--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -317,9 +317,17 @@ impl GpuCompositor {
                     height,
                     algorithm,
                 } => {
-                    out_w = *width;
-                    out_h = *height;
-                    graph.push(ScaleNode::new(*width, *height, *algorithm))
+                    let node = ScaleNode::new(*width, *height, *algorithm);
+                    // Ask the node what it will actually produce rather than
+                    // assuming `width` x `height`: `target_size` passes the input
+                    // size through when either dimension is `0`, matching FFmpeg's
+                    // `scale=0:0`. Recording the literal `0` instead would wrap the
+                    // read-back at the wrong size, `VideoFrame::from_rgba` would
+                    // reject the length, and the whole frame would fall back to the
+                    // CPU for no reason. `ScaleAnimated` reaches zero on a zoom that
+                    // starts from nothing, so this is not hypothetical (#1630).
+                    (out_w, out_h) = node.target_size(out_w, out_h);
+                    graph.push(node)
                 }
                 // Blur preserves the frame dimensions, so out_w/out_h are unchanged.
                 GpuEffect::Blur { sigma } => graph.push(GaussianBlurNode::new(*sigma)),

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -2023,10 +2023,21 @@ fn gpu_compositor_should_fall_back_not_panic_for_unsupported_inputs() {
     // `None` arm covers a mode a future FFmpeg adds, and
     // `map_scene_should_map_every_blend_mode` pins that all 40 map today.
 
-    // Unsupported effect (no GPU node).
-    let hue = base_layer(w, h, vec![FilterStep::Hue { degrees: 30.0 }]);
+    // Unsupported effect (no GPU node). `Hue` stood here until #1630 mapped it onto
+    // `HslNode`; `XFade` needs the two-input `CrossfadeNode`, which the per-layer
+    // plan has no second input for, so it is the current example of a step with no
+    // mapping at all.
+    let xfade = base_layer(
+        w,
+        h,
+        vec![FilterStep::XFade {
+            transition: XfadeTransition::Fade,
+            duration: 1.0,
+            offset: 0.0,
+        }],
+    );
     assert!(
-        gpu_composite(&mut gpu, &hue, &frame, (w, h)).is_none(),
+        gpu_composite(&mut gpu, &xfade, &frame, (w, h)).is_none(),
         "an unsupported effect must fall back"
     );
 }

--- a/crates/ff-filter/tests/color_parse_reference_tests.rs
+++ b/crates/ff-filter/tests/color_parse_reference_tests.rs
@@ -1,0 +1,163 @@
+//! `ff_format::Color::parse_ffmpeg`'s name table, checked against the linked
+//! `FFmpeg` (#1630).
+//!
+//! The table mirrors `libavutil/parseutils.c`'s `color_table`, and a hand-written
+//! copy of 140 rows is exactly where a typo survives forever. `ff-format` has no
+//! `FFmpeg` dependency and so cannot check itself; this test lives here, in the
+//! lowest crate that has one, and asks `FFmpeg` for every row (RK-005: verify
+//! tokens against the real thing, not against documentation).
+//!
+//! Each name is rendered with the `color` filter and the pixel read back. Both
+//! branches are `format=rgba` and the overlay is given `:format=auto` — the
+//! spelling the compositor uses everywhere else for the same reason. Without it
+//! `overlay` takes its `yuv420` default, the chain round-trips through YUV, and
+//! `0x123456` reads back as 17,50,85 instead of 18,52,86; every assertion here
+//! would then be approximate for no reason.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use ff_filter::FilterGraph;
+use ff_format::{Color, PixelFormat, PooledBuffer, Timestamp, VideoFrame};
+
+/// The value the gate renders. Any exact RGB triple would do; this one is not in
+/// the name table, so the gate cannot pass by accident on a table entry.
+const GATE_HEX: &str = "0x123456";
+const GATE_RGB: [u8; 3] = [0x12, 0x34, 0x56];
+
+fn base_frame() -> VideoFrame {
+    let (w, h) = (8u32, 8u32);
+    VideoFrame::new(
+        vec![
+            PooledBuffer::standalone(vec![128u8; (w * h) as usize]),
+            PooledBuffer::standalone(vec![128u8; ((w / 2) * (h / 2)) as usize]),
+            PooledBuffer::standalone(vec![128u8; ((w / 2) * (h / 2)) as usize]),
+        ],
+        vec![w as usize, (w / 2) as usize, (w / 2) as usize],
+        w,
+        h,
+        PixelFormat::Yuv420p,
+        Timestamp::default(),
+        true,
+    )
+    .unwrap()
+}
+
+/// Renders `color=c=<spec>` over an 8x8 base and returns the top-left RGBA pixel.
+///
+/// `None` means this `FFmpeg` build could not run the graph at all — which is
+/// what the gate below distinguishes from a wrong value.
+fn render_color(spec: &str) -> Option<[u8; 4]> {
+    let desc = format!(
+        "format=rgba[a];color=c={spec}:s=8x8,format=rgba[b];[a][b]overlay=0:0:format=auto,format=rgba"
+    );
+    let mut graph = FilterGraph::parse_desc(&desc).ok()?;
+    graph.push_video(0, &base_frame()).ok()?;
+    let frame = graph.pull_video().ok()??;
+    let plane = frame.plane(0)?;
+    Some([plane[0], plane[1], plane[2], plane[3]])
+}
+
+/// Can this build render an exact colour at all?
+///
+/// Probes with a **hex** spec, which `parse_ffmpeg` handles without consulting the
+/// name table — so the gate exercises a different thing from what is asserted and
+/// cannot mask a wrong row (RK-002). Requiring the exact value also rules out a
+/// build whose format conversions are lossy, where every assertion below would be
+/// noise.
+fn exact_color_rendering_available() -> bool {
+    match render_color(GATE_HEX) {
+        Some(px) => {
+            let exact = [px[0], px[1], px[2]] == GATE_RGB;
+            if !exact {
+                println!("skipping: {GATE_HEX} rendered as {px:?}, not exact");
+            }
+            exact
+        }
+        None => {
+            println!("skipping: this FFmpeg build cannot run the color/overlay graph");
+            false
+        }
+    }
+}
+
+#[test]
+fn every_color_name_should_match_what_ffmpeg_renders() {
+    if !exact_color_rendering_available() {
+        return;
+    }
+    let mut checked = 0usize;
+    let mut mismatches = Vec::new();
+    for (name, expected) in Color::ffmpeg_color_names() {
+        let Some(px) = render_color(name) else {
+            mismatches.push(format!("{name}: FFmpeg rejected the name"));
+            continue;
+        };
+        if [px[0], px[1], px[2]] != [expected.r, expected.g, expected.b] {
+            mismatches.push(format!(
+                "{name}: table says {:?}, FFmpeg renders {:?}",
+                [expected.r, expected.g, expected.b],
+                [px[0], px[1], px[2]]
+            ));
+        }
+        checked += 1;
+    }
+    assert!(
+        mismatches.is_empty(),
+        "the colour table disagrees with this FFmpeg:\n{}",
+        mismatches.join("\n")
+    );
+    assert_eq!(
+        checked,
+        Color::ffmpeg_color_names().len(),
+        "every row must have been rendered"
+    );
+}
+
+#[test]
+fn the_table_should_agree_with_ffmpeg_on_the_values_memory_gets_wrong() {
+    // A focused guard for the two rows that would be wrong had the table been
+    // written from the CSS list rather than read out of FFmpeg. It fails loudly
+    // and by name, where the sweep above would bury them in a list.
+    if !exact_color_rendering_available() {
+        return;
+    }
+    let green = render_color("green").expect("green must render");
+    assert_eq!(
+        [green[0], green[1], green[2]],
+        [0x00, 0x80, 0x00],
+        "FFmpeg's `green` is the HTML value, not X11's 0x00FF00"
+    );
+    assert_eq!(
+        Color::parse_ffmpeg("green").map(|c| [c.r, c.g, c.b]),
+        Some([0x00, 0x80, 0x00])
+    );
+    assert!(
+        render_color("lightgray").is_none(),
+        "FFmpeg has `lightgrey` but no `lightgray`; if that changed, add the row"
+    );
+    assert!(render_color("lightgrey").is_some());
+}
+
+#[test]
+fn the_parser_should_not_accept_a_form_ffmpeg_rejects() {
+    // The parser's contract is "accept what FFmpeg accepts", and being *more*
+    // permissive is the harmful direction: the GPU would map a colour the CPU
+    // filter path cannot build, and ADR-0007 makes the CPU the correctness
+    // reference. `0X` is the one form the two disagreed on when the boundary was
+    // measured, so it is checked here against FFmpeg rather than against a belief
+    // about FFmpeg.
+    if !exact_color_rendering_available() {
+        return;
+    }
+    for spec in ["0x123456", "#123456", "GREEN", "green@0.5", "0x12345678"] {
+        assert!(
+            render_color(spec).is_some() && Color::parse_ffmpeg(spec).is_some(),
+            "{spec} must be accepted by both"
+        );
+    }
+    assert!(
+        render_color("0X123456").is_none(),
+        "FFmpeg compares the `0x` prefix case-sensitively; if that changed, the          parser may accept `0X` again"
+    );
+    assert_eq!(Color::parse_ffmpeg("0X123456"), None);
+}

--- a/crates/ff-format/src/color.rs
+++ b/crates/ff-format/src/color.rs
@@ -993,11 +993,349 @@ impl Color {
     pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self { r, g, b, a }
     }
+
+    /// Parses an `FFmpeg` colour string, as `-vf drawbox=color=...` and friends
+    /// accept it.
+    ///
+    /// Recognised forms:
+    ///
+    /// * `#RRGGBB` / `#RRGGBBAA` and `0xRRGGBB` / `0xRRGGBBAA`
+    /// * a colour name, matched case-insensitively (`"green"`, `"DarkOrchid"`)
+    /// * either of the above with an `@alpha` suffix, where alpha is a float in
+    ///   `0.0..=1.0` or a two-digit `0xAA`
+    ///
+    /// Returns `None` for anything else, including `FFmpeg`'s `random` — it has no
+    /// fixed value, so there is nothing to return.
+    ///
+    /// Alpha defaults to opaque when the form does not carry one.
+    #[must_use]
+    pub fn parse_ffmpeg(s: &str) -> Option<Self> {
+        let s = s.trim();
+        // `FFmpeg` splits the alpha suffix off first, so `0xRRGGBB@0.5` is as valid
+        // as `red@0.5`; an `@` on an 8-digit hex overrides that hex's alpha byte.
+        let (body, alpha) = match s.split_once('@') {
+            Some((body, alpha)) => (body, Some(alpha)),
+            None => (s, None),
+        };
+
+        let mut color = parse_hex_color(body).or_else(|| lookup_color_name(body))?;
+        if let Some(alpha) = alpha {
+            color.a = parse_alpha(alpha)?;
+        }
+        Some(color)
+    }
+
+    /// Every colour name [`parse_ffmpeg`](Self::parse_ffmpeg) accepts, with its
+    /// value, in ascending name order.
+    ///
+    /// Lets a host offer the same palette `FFmpeg` understands (a colour picker,
+    /// an autocomplete), and it is what
+    /// `crates/ff-filter/tests/color_parse_reference_tests.rs` walks to re-check
+    /// every row against the linked `FFmpeg`.
+    #[must_use]
+    pub fn ffmpeg_color_names() -> impl ExactSizeIterator<Item = (&'static str, Self)> {
+        FFMPEG_COLOR_NAMES
+            .iter()
+            .map(|&(name, [r, g, b])| (name, Self::rgb(r, g, b)))
+    }
 }
+
+/// Parses `#RRGGBB[AA]` / `0xRRGGBB[AA]`, or `None` for any other shape.
+fn parse_hex_color(s: &str) -> Option<Color> {
+    // `0x` lower-case only: `av_parse_color` compares the prefix case-sensitively,
+    // so accepting `0X` here would map a colour on the GPU that the CPU filter path
+    // cannot build — measured, and the only form the two disagreed on.
+    let hex = s.strip_prefix("0x").or_else(|| s.strip_prefix('#'))?;
+    if hex.len() != 6 && hex.len() != 8 {
+        return None;
+    }
+    let byte = |i: usize| u8::from_str_radix(hex.get(i..i + 2)?, 16).ok();
+    Some(Color {
+        r: byte(0)?,
+        g: byte(2)?,
+        b: byte(4)?,
+        a: if hex.len() == 8 { byte(6)? } else { 255 },
+    })
+}
+
+/// Parses the `@alpha` suffix: a two-digit `0xAA`, or a float in `0.0..=1.0`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn parse_alpha(s: &str) -> Option<u8> {
+    if let Some(hex) = s.strip_prefix("0x") {
+        // Exactly two digits, which is what the documentation above promises;
+        // `from_str_radix` alone would also take `@0x8`.
+        if hex.len() != 2 {
+            return None;
+        }
+        return u8::from_str_radix(hex, 16).ok();
+    }
+    let f: f32 = s.parse().ok()?;
+    if !(0.0..=1.0).contains(&f) {
+        return None;
+    }
+    // Rounding, not truncation: 1.0 must reach 255 and 0.5 must not land a byte low.
+    Some((f * 255.0).round() as u8)
+}
+
+/// Looks `name` up in [`FFMPEG_COLOR_NAMES`], case-insensitively.
+fn lookup_color_name(name: &str) -> Option<Color> {
+    let lower = name.to_ascii_lowercase();
+    let idx = FFMPEG_COLOR_NAMES
+        .binary_search_by(|(n, _)| (*n).cmp(lower.as_str()))
+        .ok()?;
+    let [r, g, b] = FFMPEG_COLOR_NAMES[idx].1;
+    Some(Color::rgb(r, g, b))
+}
+
+/// The colour names the linked `FFmpeg` accepts, lower-cased and sorted so the
+/// lookup can binary-search. Mirrors `libavutil/parseutils.c`'s `color_table`.
+///
+/// These values are **not** the CSS list from memory: each was read out of
+/// `FFmpeg` itself by rendering `color=c=<name>` and sampling the pixel, which is
+/// how the surprises got caught — `green` is `0x008000` (the HTML value, not X11's
+/// `0x00FF00`), and `FFmpeg` carries `lightgrey` but no `lightgray` while every
+/// other grey is spelled `gray`. `ff-format` has no `FFmpeg` to ask at runtime, so
+/// `crates/ff-filter/tests/color_parse_reference_tests.rs` re-checks every row
+/// against it (RK-005: verify tokens against the real thing, not against docs).
+const FFMPEG_COLOR_NAMES: &[(&str, [u8; 3])] = &[
+    ("aliceblue", [0xF0, 0xF8, 0xFF]),
+    ("antiquewhite", [0xFA, 0xEB, 0xD7]),
+    ("aqua", [0x00, 0xFF, 0xFF]),
+    ("aquamarine", [0x7F, 0xFF, 0xD4]),
+    ("azure", [0xF0, 0xFF, 0xFF]),
+    ("beige", [0xF5, 0xF5, 0xDC]),
+    ("bisque", [0xFF, 0xE4, 0xC4]),
+    ("black", [0x00, 0x00, 0x00]),
+    ("blanchedalmond", [0xFF, 0xEB, 0xCD]),
+    ("blue", [0x00, 0x00, 0xFF]),
+    ("blueviolet", [0x8A, 0x2B, 0xE2]),
+    ("brown", [0xA5, 0x2A, 0x2A]),
+    ("burlywood", [0xDE, 0xB8, 0x87]),
+    ("cadetblue", [0x5F, 0x9E, 0xA0]),
+    ("chartreuse", [0x7F, 0xFF, 0x00]),
+    ("chocolate", [0xD2, 0x69, 0x1E]),
+    ("coral", [0xFF, 0x7F, 0x50]),
+    ("cornflowerblue", [0x64, 0x95, 0xED]),
+    ("cornsilk", [0xFF, 0xF8, 0xDC]),
+    ("crimson", [0xDC, 0x14, 0x3C]),
+    ("cyan", [0x00, 0xFF, 0xFF]),
+    ("darkblue", [0x00, 0x00, 0x8B]),
+    ("darkcyan", [0x00, 0x8B, 0x8B]),
+    ("darkgoldenrod", [0xB8, 0x86, 0x0B]),
+    ("darkgray", [0xA9, 0xA9, 0xA9]),
+    ("darkgreen", [0x00, 0x64, 0x00]),
+    ("darkkhaki", [0xBD, 0xB7, 0x6B]),
+    ("darkmagenta", [0x8B, 0x00, 0x8B]),
+    ("darkolivegreen", [0x55, 0x6B, 0x2F]),
+    ("darkorange", [0xFF, 0x8C, 0x00]),
+    ("darkorchid", [0x99, 0x32, 0xCC]),
+    ("darkred", [0x8B, 0x00, 0x00]),
+    ("darksalmon", [0xE9, 0x96, 0x7A]),
+    ("darkseagreen", [0x8F, 0xBC, 0x8F]),
+    ("darkslateblue", [0x48, 0x3D, 0x8B]),
+    ("darkslategray", [0x2F, 0x4F, 0x4F]),
+    ("darkturquoise", [0x00, 0xCE, 0xD1]),
+    ("darkviolet", [0x94, 0x00, 0xD3]),
+    ("deeppink", [0xFF, 0x14, 0x93]),
+    ("deepskyblue", [0x00, 0xBF, 0xFF]),
+    ("dimgray", [0x69, 0x69, 0x69]),
+    ("dodgerblue", [0x1E, 0x90, 0xFF]),
+    ("firebrick", [0xB2, 0x22, 0x22]),
+    ("floralwhite", [0xFF, 0xFA, 0xF0]),
+    ("forestgreen", [0x22, 0x8B, 0x22]),
+    ("fuchsia", [0xFF, 0x00, 0xFF]),
+    ("gainsboro", [0xDC, 0xDC, 0xDC]),
+    ("ghostwhite", [0xF8, 0xF8, 0xFF]),
+    ("gold", [0xFF, 0xD7, 0x00]),
+    ("goldenrod", [0xDA, 0xA5, 0x20]),
+    ("gray", [0x80, 0x80, 0x80]),
+    ("green", [0x00, 0x80, 0x00]),
+    ("greenyellow", [0xAD, 0xFF, 0x2F]),
+    ("honeydew", [0xF0, 0xFF, 0xF0]),
+    ("hotpink", [0xFF, 0x69, 0xB4]),
+    ("indianred", [0xCD, 0x5C, 0x5C]),
+    ("indigo", [0x4B, 0x00, 0x82]),
+    ("ivory", [0xFF, 0xFF, 0xF0]),
+    ("khaki", [0xF0, 0xE6, 0x8C]),
+    ("lavender", [0xE6, 0xE6, 0xFA]),
+    ("lavenderblush", [0xFF, 0xF0, 0xF5]),
+    ("lawngreen", [0x7C, 0xFC, 0x00]),
+    ("lemonchiffon", [0xFF, 0xFA, 0xCD]),
+    ("lightblue", [0xAD, 0xD8, 0xE6]),
+    ("lightcoral", [0xF0, 0x80, 0x80]),
+    ("lightcyan", [0xE0, 0xFF, 0xFF]),
+    ("lightgoldenrodyellow", [0xFA, 0xFA, 0xD2]),
+    ("lightgreen", [0x90, 0xEE, 0x90]),
+    ("lightgrey", [0xD3, 0xD3, 0xD3]),
+    ("lightpink", [0xFF, 0xB6, 0xC1]),
+    ("lightsalmon", [0xFF, 0xA0, 0x7A]),
+    ("lightseagreen", [0x20, 0xB2, 0xAA]),
+    ("lightskyblue", [0x87, 0xCE, 0xFA]),
+    ("lightslategray", [0x77, 0x88, 0x99]),
+    ("lightsteelblue", [0xB0, 0xC4, 0xDE]),
+    ("lightyellow", [0xFF, 0xFF, 0xE0]),
+    ("lime", [0x00, 0xFF, 0x00]),
+    ("limegreen", [0x32, 0xCD, 0x32]),
+    ("linen", [0xFA, 0xF0, 0xE6]),
+    ("magenta", [0xFF, 0x00, 0xFF]),
+    ("maroon", [0x80, 0x00, 0x00]),
+    ("mediumaquamarine", [0x66, 0xCD, 0xAA]),
+    ("mediumblue", [0x00, 0x00, 0xCD]),
+    ("mediumorchid", [0xBA, 0x55, 0xD3]),
+    ("mediumpurple", [0x93, 0x70, 0xD8]),
+    ("mediumseagreen", [0x3C, 0xB3, 0x71]),
+    ("mediumslateblue", [0x7B, 0x68, 0xEE]),
+    ("mediumspringgreen", [0x00, 0xFA, 0x9A]),
+    ("mediumturquoise", [0x48, 0xD1, 0xCC]),
+    ("mediumvioletred", [0xC7, 0x15, 0x85]),
+    ("midnightblue", [0x19, 0x19, 0x70]),
+    ("mintcream", [0xF5, 0xFF, 0xFA]),
+    ("mistyrose", [0xFF, 0xE4, 0xE1]),
+    ("moccasin", [0xFF, 0xE4, 0xB5]),
+    ("navajowhite", [0xFF, 0xDE, 0xAD]),
+    ("navy", [0x00, 0x00, 0x80]),
+    ("oldlace", [0xFD, 0xF5, 0xE6]),
+    ("olive", [0x80, 0x80, 0x00]),
+    ("olivedrab", [0x6B, 0x8E, 0x23]),
+    ("orange", [0xFF, 0xA5, 0x00]),
+    ("orangered", [0xFF, 0x45, 0x00]),
+    ("orchid", [0xDA, 0x70, 0xD6]),
+    ("palegoldenrod", [0xEE, 0xE8, 0xAA]),
+    ("palegreen", [0x98, 0xFB, 0x98]),
+    ("paleturquoise", [0xAF, 0xEE, 0xEE]),
+    ("palevioletred", [0xD8, 0x70, 0x93]),
+    ("papayawhip", [0xFF, 0xEF, 0xD5]),
+    ("peachpuff", [0xFF, 0xDA, 0xB9]),
+    ("peru", [0xCD, 0x85, 0x3F]),
+    ("pink", [0xFF, 0xC0, 0xCB]),
+    ("plum", [0xDD, 0xA0, 0xDD]),
+    ("powderblue", [0xB0, 0xE0, 0xE6]),
+    ("purple", [0x80, 0x00, 0x80]),
+    ("red", [0xFF, 0x00, 0x00]),
+    ("rosybrown", [0xBC, 0x8F, 0x8F]),
+    ("royalblue", [0x41, 0x69, 0xE1]),
+    ("saddlebrown", [0x8B, 0x45, 0x13]),
+    ("salmon", [0xFA, 0x80, 0x72]),
+    ("sandybrown", [0xF4, 0xA4, 0x60]),
+    ("seagreen", [0x2E, 0x8B, 0x57]),
+    ("seashell", [0xFF, 0xF5, 0xEE]),
+    ("sienna", [0xA0, 0x52, 0x2D]),
+    ("silver", [0xC0, 0xC0, 0xC0]),
+    ("skyblue", [0x87, 0xCE, 0xEB]),
+    ("slateblue", [0x6A, 0x5A, 0xCD]),
+    ("slategray", [0x70, 0x80, 0x90]),
+    ("snow", [0xFF, 0xFA, 0xFA]),
+    ("springgreen", [0x00, 0xFF, 0x7F]),
+    ("steelblue", [0x46, 0x82, 0xB4]),
+    ("tan", [0xD2, 0xB4, 0x8C]),
+    ("teal", [0x00, 0x80, 0x80]),
+    ("thistle", [0xD8, 0xBF, 0xD8]),
+    ("tomato", [0xFF, 0x63, 0x47]),
+    ("turquoise", [0x40, 0xE0, 0xD0]),
+    ("violet", [0xEE, 0x82, 0xEE]),
+    ("wheat", [0xF5, 0xDE, 0xB3]),
+    ("white", [0xFF, 0xFF, 0xFF]),
+    ("whitesmoke", [0xF5, 0xF5, 0xF5]),
+    ("yellow", [0xFF, 0xFF, 0x00]),
+    ("yellowgreen", [0x9A, 0xCD, 0x32]),
+];
 
 #[cfg(test)]
 mod color_value_tests {
     use super::Color;
+
+    // parse_ffmpeg
+
+    #[test]
+    fn parse_ffmpeg_should_read_hex_with_and_without_alpha() {
+        assert_eq!(
+            Color::parse_ffmpeg("0x123456"),
+            Some(Color::rgb(18, 52, 86))
+        );
+        assert_eq!(Color::parse_ffmpeg("#123456"), Some(Color::rgb(18, 52, 86)));
+        assert_eq!(
+            Color::parse_ffmpeg("0x12345680"),
+            Some(Color::rgba(18, 52, 86, 128))
+        );
+    }
+
+    #[test]
+    fn parse_ffmpeg_should_read_a_name_case_insensitively() {
+        // `green` is the HTML value, not X11's `0x00FF00` — the distinction the
+        // table was read out of FFmpeg to get right.
+        let green = Some(Color::rgb(0, 128, 0));
+        assert_eq!(Color::parse_ffmpeg("green"), green);
+        assert_eq!(Color::parse_ffmpeg("Green"), green);
+        assert_eq!(Color::parse_ffmpeg("GREEN"), green);
+        assert_eq!(Color::parse_ffmpeg("lime"), Some(Color::rgb(0, 255, 0)));
+        assert_eq!(
+            Color::parse_ffmpeg("DarkOrchid"),
+            Some(Color::rgb(0x99, 0x32, 0xCC))
+        );
+    }
+
+    #[test]
+    fn parse_ffmpeg_should_read_an_alpha_suffix_in_both_spellings() {
+        assert_eq!(
+            Color::parse_ffmpeg("black@0x80"),
+            Some(Color::rgba(0, 0, 0, 128))
+        );
+        assert_eq!(
+            Color::parse_ffmpeg("black@1"),
+            Some(Color::rgba(0, 0, 0, 255))
+        );
+        assert_eq!(
+            Color::parse_ffmpeg("black@0"),
+            Some(Color::rgba(0, 0, 0, 0))
+        );
+        // The suffix overrides a hex form's own alpha byte, as FFmpeg's parser does.
+        assert_eq!(
+            Color::parse_ffmpeg("0x11223344@1.0"),
+            Some(Color::rgba(0x11, 0x22, 0x33, 255))
+        );
+    }
+
+    #[test]
+    fn parse_ffmpeg_should_reject_unparseable_forms() {
+        // `random` has no fixed value, so there is nothing to return.
+        assert_eq!(Color::parse_ffmpeg("random"), None);
+        assert_eq!(Color::parse_ffmpeg("no_such_colour"), None);
+        // FFmpeg has `lightgrey` but no `lightgray`; the table says so, and this
+        // pins that it is the table talking and not a fuzzy match.
+        assert!(Color::parse_ffmpeg("lightgrey").is_some());
+        assert_eq!(Color::parse_ffmpeg("lightgray"), None);
+        assert_eq!(Color::parse_ffmpeg("0x1234"), None);
+        // FFmpeg's prefix comparison is case-sensitive, so `0X` is not a colour.
+        // Accepting it would map on the GPU what the CPU filter path rejects.
+        assert_eq!(Color::parse_ffmpeg("0X123456"), None);
+        // The alpha suffix's hex form is two digits, as the doc says.
+        assert_eq!(Color::parse_ffmpeg("black@0x8"), None);
+        assert_eq!(Color::parse_ffmpeg("black@0x080"), None);
+        assert_eq!(Color::parse_ffmpeg("0xGGGGGG"), None);
+        assert_eq!(Color::parse_ffmpeg("black@1.5"), None);
+        assert_eq!(Color::parse_ffmpeg(""), None);
+    }
+
+    #[test]
+    fn ffmpeg_color_names_should_be_sorted_and_lower_case() {
+        // `lookup_color_name` binary-searches, so an unsorted or mixed-case row
+        // would make some names silently unfindable rather than fail loudly.
+        for pair in super::FFMPEG_COLOR_NAMES.windows(2) {
+            assert!(
+                pair[0].0 < pair[1].0,
+                "table must be sorted and unique: {:?} then {:?}",
+                pair[0].0,
+                pair[1].0
+            );
+        }
+        for (name, _) in super::FFMPEG_COLOR_NAMES {
+            assert_eq!(
+                *name,
+                name.to_ascii_lowercase(),
+                "table names must be lower-case: {name:?}"
+            );
+        }
+    }
 
     #[test]
     fn rgb_should_be_opaque() {

--- a/docs/specs/gpu-compositing-bridge.md
+++ b/docs/specs/gpu-compositing-bridge.md
@@ -101,8 +101,9 @@ textures) is a later optimization, out of scope for the bridge.
 
 `ff-render`'s node set covers a subset of `avio`'s derived vocabulary. A derived construct either maps to a
 node or forces CPU fallback for the whole frame (see below). The mapping **never silently drops** an
-unsupported step. The table is the **v1** state (Br2, `avio::gpu::map_scene`); broadening the covered set is
-tracked in **#1630**.
+unsupported step. This table tracks `avio::gpu::map_scene` as it stands; broadening the covered set further is
+tracked in **#1630** and its follow-ups. Grade it by reading `classify_step`, not by reading this table --
+it drifted badly between Br2 and #1630 and listed covered steps as fallbacks.
 
 | Derived construct (source) | v1 mapping | Status |
 |---|---|---|
@@ -114,16 +115,30 @@ tracked in **#1630**.
 | `FilterStep::EqAnimated` | `ColorGrade` (params at `t`) **only when gamma is neutral at `t`** (ff-render ColorGrade has no gamma) | **covered** (gamma-neutral); non-neutral gamma -> **fallback** |
 | plain `FilterStep::Scale { width, height, algorithm }` | `GpuEffect::Scale` -> `ScaleNode` (ff-render uses a linear filter for all algorithms; `Fast` maps to `Bilinear`) | **covered** |
 | temporal steps: `Trim` / `ResetPts` / `OffsetPts` / `Speed` | skipped (decode-scheduling, applied upstream) | **skipped** (not a fallback) |
-| other colour: `Hue`, `Curves`, `Gamma`, `Vignette`, `WhiteBalance`, `ColorBalanceAnimated`, `ThreeWayCC`, `ParametricEq` | -- | **fallback** (#1630) |
-| `FitToAspect` / `FillToAspect` (fit with pad/crop) | -- | **fallback** (#1630; `ScaleNode` is a plain resize) |
-| animated geometry `ScaleAnimated` / `RotateAnimated` | -- | **fallback** (#1630; ADR-0005 neutralizes the scalar, so v1 falls back rather than lose the animation) |
-| xfade (`XFade`, any kind) | -- | **fallback** (#1630; needs the 2-input `CrossfadeNode`) |
-| keying / masks: `ChromaKey`, `ColorKey`, `AlphaMatte`, `LumaKey`, `RectMask`, `FeatherMask`, ... | -- | **fallback** (#1630; `ChromaKey` needs a colour-string parser, masks need 2-input wiring) |
-| everything else (`GBlur`, `Lut3d`, `NoiseReduce`, `Raw`, ...) | -- | **fallback** (#1630) |
+| `FilterStep::ScaleAnimated` | `GpuEffect::Scale` -> `ScaleNode`, both dimensions evaluated at `t` (`map_scene` runs per frame). The `algorithm` carries through | **covered** (#1630) |
+| `FilterStep::RotateAnimated` | folded onto the layer's `rotation` (added to the layer scalar, not replacing it) rather than becoming a node -- rotation is a layer property, there is no GPU rotate node | **covered** when `fillcolor` is `black` or `none` (#1630); any other fill -> **fallback**. The GPU leaves the corners a rotation exposes transparent while `rotate` fills them, which is the same difference the *static* layer rotation already has, so folding makes the animated case behave like the static one rather than adding a divergence |
+| colour: `Hue`, `Hsl` / `HslAnimated` | `GpuEffect::Hsl` -> `HslNode` (`Hue` is `Hsl` with a neutral saturation/lightness; both compile to the same `hue` filter's `h=`) | **covered** (`Hue` in #1630) |
+| colour: `Curves`, `Vignette` / `VignetteAnimated`, `ThreeWayCC` / `ThreeWayCCAnimated`, `Lut3d`, `Glow` / `GlowAnimated`, `FilmGrain` / `FilmGrainAnimated`, `Unsharp` / `UnsharpAnimated` | `CurvesNode` / `VignetteNode` / `ColorWheelsNode` / `LutNode` / `GlowNode` / `FilmGrainNode` / `SharpenNode` | **covered**. An off-centre `vignette`, a non-zero `unsharp` chroma amount, and a `lut3d` file that will not load each fall back rather than render something else (RK-020) |
+| blur: `GBlur` / `GBlurAnimated` | `GpuEffect::Blur` -> `GaussianBlurNode` (animated sigma at `t`) | **covered** |
+| `MotionBlur` | `MotionBlurNode` (stateful; the shutter is constant per clip) | **covered** |
+| keying: `ChromaKey` / `ChromaKeyAnimated` | `ChromaKeyNode`, key colour via `ff_format::Color::parse_ffmpeg` | **covered**, including **colour names** (#1630; hex-only before that). A string no colour table has -> **fallback** |
+| masks: `RectMask` / `RectMaskAnimated`, `LumaMask` | `ShapeMaskNode` / `LumaMaskNode` (the compositor bakes the mask) | **covered** |
+| colour: `Gamma`, `WhiteBalance`, `ColorBalanceAnimated` | -- | **fallback** (#1759). Each is a *different parameterization* from the node it would land on -- `Gamma` is `eq`'s `pow(x, 1/g)`, `ColorWheelsNode`'s gamma is neutral at 1.0 while `ColorBalanceAnimated` is neutral at 0.0, and `WhiteBalance` is Kelvin through `colorchannelmixer` while `ColorGradeNode`'s temperature is in model units. Mapping any of them needs the shader read first, or it is a silent approximation |
+| `FilterStep::EqAnimated` with a non-neutral gamma | -- | **fallback** (#1763; needs gamma on `ColorGradeNode`, an ff-render change) |
+| keying: `ColorKey`, `SpillSuppress` | -- | **fallback** (#1761). `ChromaKeyNode` measures *chroma* distance (BT.709 luma subtracted from pixel and key), which is `chromakey`'s semantic; `colorkey` is a full-RGB distance, so routing it there would approximate silently |
+| masks: `AlphaMatte`, `LumaKey`, `FeatherMask`, `PolygonMatte` | -- | **fallback** (#1761). `AlphaMatte` carries a whole `FilterGraphBuilder`; `LumaKey`/`FeatherMask` need parameters the executor currently bakes itself |
+| `FitToAspect` / `FillToAspect` (fit with pad/crop) | -- | **fallback** (#1762; `ScaleNode` is a plain resize, needs pad/crop) |
+| xfade (`XFade`, any kind) | -- | **fallback** (#1760; needs the 2-input `CrossfadeNode`, which the per-layer plan has no second input for) |
+| everything else (`Crop`, `Rotate`, `HFlip`/`VFlip`, `NoiseReduce`, `DrawText`, `Raw`, `ParseDesc`, audio steps, ...) | -- | **fallback** |
 
 **Known ff-render gaps to design around:** `YuvUploadNode` uses a **BT.601** conversion only (no BT.709
 selection), and `ScaleNode`'s Bicubic/Lanczos fall back to a linear filter on the GPU. These are `ff-render`
 limitations, not bridge bugs; the bridge documents them and the CPU path remains exact.
+
+BT.709 selection was considered for #1630 and **explicitly re-deferred**: it is not a mapping question at
+all. `map_scene` never sees the upload -- the executor does -- and switching the matrix moves the colour of
+*every* GPU frame, so it needs its own change with GPU-vs-CPU parity fixtures rather than a row added to a
+mapping PR. Tracked as **#1764**.
 
 ## GPU-vs-CPU selection (whole-frame fallback)
 


### PR DESCRIPTION
## Objective

- Four constructs forced a whole-frame CPU fallback in `avio::gpu::map_scene` even though `ff-render` has nodes for them: `Hue`, `ScaleAnimated`, `RotateAnimated`, and `chromakey` with a colour name.
- The node-coverage table in `docs/specs/gpu-compositing-bridge.md` had drifted from the code and listed seven already-covered steps as fallbacks.

## Solution

- Map `Hue` onto `HslNode` (same FFmpeg `hue` filter's `h=`), `ScaleAnimated` onto `ScaleNode` at the frame time, and `RotateAnimated` onto the layer's rotation, added to the layer scalar because the CPU applies both. Only a `black` or `none` fill folds; any other fill still falls back, since the GPU leaves the exposed corners transparent.
- Add `ff_format::Color::parse_ffmpeg` so a colour name reaches the chroma-key node. Its 140 rows were read out of the linked FFmpeg by rendering each name, not transcribed: FFmpeg's `green` is 0x008000, and it has `lightgrey` but no `lightgray`. Two probe-gated tests re-check every row and pin that the parser accepts nothing FFmpeg rejects.
- Fix a latent bug this makes reachable: the compositor recorded a `Scale` effect's literal dimensions, but `ScaleNode::target_size` passes the input size through when either is zero (FFmpeg's `scale=0:0`). A zoom animating up from zero would have fallen back for no reason; the size now comes from the node.
- Rewrite the coverage table against `classify_step`, with each remaining fallback naming the issue that owns it.
- `ColorKey` is deliberately left unmapped: `ChromaKeyNode` measures chroma distance, `colorkey` a full-RGB distance.

Three of the issue's eight scope bullets are relocated to #1759, #1760, #1761, #1762, #1763 and #1764, so this does not close it.

Part of #1630