### PR TITLE
feat(avio): place GPU layers by the CPU compositor's measured geometry

### DIFF
--- a/crates/avio/src/gpu_compositor.rs
+++ b/crates/avio/src/gpu_compositor.rs
@@ -3,25 +3,29 @@
 //! Owns the `ff-render` context and a cached `Compositor`, and composites a set of
 //! derived layers (any [`GpuLayerSource`]) with their decoded frames into an rgba
 //! buffer. Both the preview executor ([`GpuPreviewCompositor`](crate::GpuPreviewCompositor))
-//! and the export drain use it, so the mapping-to-GPU logic, the v1 identity gate, the
+//! and the export drain use it, so the mapping-to-GPU logic, the layer placement, the
 //! letterbox, and the effect execution live in one place.
 //!
-//! It returns `None` on any unsupported layer ([`map_scene`] fallback, a non-identity
-//! model transform, or layers of mixed aspect) or any GPU error, so the caller falls
-//! back to the CPU compositor for that frame -- never a panic, never a partial result.
+//! It returns `None` on any unsupported layer ([`map_scene`] fallback, or a placement
+//! with no GPU equivalent) or any GPU error, so the caller falls back to the CPU
+//! compositor for that frame -- never a panic, never a partial result.
 //!
-//! v1 renders only layers that need no geometric placement (an identity transform): the
-//! model's transform is in canvas pixels / clockwise degrees while
-//! `ff_render::LayerTransform` is UV-space / counter-clockwise radians, so a positioned
-//! or rotated layer falls back to CPU rather than render wrong output (RK-020).
+//! **Placement (#1633):** `layer_transform` reproduces the CPU compositor's geometry,
+//! which works in *base-layer space*: layer 0 defines the size and its own transform is
+//! ignored, every other layer is stretched to that size, scaled by `base * scale`, and
+//! overlaid with its top-left at `(x, y)`. Only the finished composite is fitted into the
+//! canvas. The model's units are canvas pixels / clockwise degrees while
+//! `ff_render::LayerTransform` is UV-space / counter-clockwise radians, so the conversion
+//! lives there and is pinned by measurement against the CPU. A **rotated** non-base layer
+//! still falls back: the CPU's `rotate` fills the corners it exposes with `fillcolor`
+//! while the GPU transform leaves them transparent, so there is nothing to map it to
+//! (RK-020).
 //!
 //! **Letterbox (#1661):** a frame whose aspect differs from the canvas is *fitted* into
 //! it, matching the CPU compositor's `scale=…:force_original_aspect_ratio=decrease` +
-//! `pad` pass instead of the compositor's default stretch (see [`fit_size`]). Since the
-//! CPU fits the *composited* result while this fits each layer before compositing, the
-//! two agree only when every layer lands in the same band, so a scene whose layers do
-//! not all share one aspect still falls back -- as does one whose aspect is extreme
-//! enough that a fitted side rounds away to nothing.
+//! `pad` pass instead of the compositor's default stretch (see [`fit_size`]). A scene
+//! whose base aspect is extreme enough that a fitted side rounds away to nothing still
+//! falls back.
 //!
 //! **Per-frame cost (#1634):** an effected layer's `RenderGraph` is cached per layer
 //! position ([`CachedEffectGraph`]) and reused while its effect list compares equal, so
@@ -103,9 +107,9 @@ impl GpuCompositor {
     /// back to the CPU compositor.
     ///
     /// `None` means: `map_scene` reported an unsupported blend/composite/effect, a
-    /// layer has a non-identity model transform (v1 gate), the layers do not all share
-    /// one aspect, or a GPU error occurred. The caller must never see a wrong-but-
-    /// rendered frame.
+    /// layer's placement has no GPU equivalent (a rotated overlay, or one hanging off
+    /// the base layer's edge), or a GPU error occurred. The caller must never see a
+    /// wrong-but-rendered frame.
     pub fn composite<L: GpuLayerSource>(
         &mut self,
         layers: &[(&L, &VideoFrame)],
@@ -121,12 +125,6 @@ impl GpuCompositor {
 
         let mut processed = Vec::with_capacity(plan.layers.len());
         for (idx, (lp, (_, frame))) in plan.layers.iter().zip(layers.iter()).enumerate() {
-            // v1 renders only layers that need no geometric placement (see the module
-            // docs); a non-identity transform falls back to CPU rather than render
-            // wrong output.
-            if !is_identity_transform(lp) {
-                return None;
-            }
             // The preview adapter does not own its frames, so a no-effects layer must
             // clone; `composite_owned` avoids this for the export drain.
             let out = if lp.effects.is_empty() {
@@ -158,9 +156,6 @@ impl GpuCompositor {
 
         let mut processed = Vec::with_capacity(plan.layers.len());
         for (idx, (lp, (_, frame))) in plan.layers.iter().zip(layers).enumerate() {
-            if !is_identity_transform(lp) {
-                return None;
-            }
             // Owned: a no-effects layer moves its frame in, no clone.
             let out = if lp.effects.is_empty() {
                 frame
@@ -467,33 +462,35 @@ fn is_cacheable(effects: &[GpuEffect]) -> bool {
         .any(|e| matches!(e, GpuEffect::LumaMask { .. }))
 }
 
-/// Wraps each processed layer frame in a [`FrameLayer`], letterboxing it into the canvas
-/// (#1661), or `None` when the frames do not all share one aspect or the fit degenerates.
+/// Wraps each processed layer frame in a [`FrameLayer`] with the transform that places
+/// it, or `None` when a layer's placement has no GPU equivalent.
 ///
-/// The CPU compositor fits the **composited** result into the canvas, while this fits
-/// each layer *before* compositing. The two coincide exactly when every layer ends up in
-/// the same band, which is what the shared-aspect requirement enforces; a mixed-aspect
-/// scene falls back to CPU rather than render a band per layer (RK-020).
+/// The CPU compositor works in **base-layer space**: layer 0 defines the size, every
+/// other layer is stretched to it and overlaid there, and only the finished composite is
+/// fitted into the canvas (`composition_inner.rs:1199-1224` and `:1323`). This reproduces
+/// that by giving layer 0 the fit and every other layer its placement *composed with* the
+/// same fit, so the whole stack lands in one band exactly as the CPU's single composite
+/// fit does. That is why the old shared-aspect requirement is gone: an overlay's own
+/// aspect never survives the stretch, so it cannot disagree with the base's band.
 fn assemble(
     processed: Vec<(VideoFrame, &GpuLayerPlan)>,
     canvas: (u32, u32),
 ) -> Option<Vec<FrameLayer>> {
     let (first, _) = processed.first()?;
-    let (w0, h0) = (u64::from(first.width()), u64::from(first.height()));
-    if processed
+    let base = (first.width(), first.height());
+    let base_fit = letterbox_transform(base.0, base.1, canvas)?;
+    let transforms = processed
         .iter()
-        .any(|(f, _)| u64::from(f.width()) * h0 != u64::from(f.height()) * w0)
-    {
-        return None;
-    }
-
-    let transform = letterbox_transform(first.width(), first.height(), canvas)?;
+        .enumerate()
+        .map(|(idx, (_, lp))| layer_transform(idx, lp, &base_fit, base))
+        .collect::<Option<Vec<_>>>()?;
     Some(
         processed
             .into_iter()
-            .map(|(frame, lp)| FrameLayer {
+            .zip(transforms)
+            .map(|((frame, lp), transform)| FrameLayer {
                 frame,
-                transform: transform.clone(),
+                transform,
                 blend_mode: lp.blend_mode,
                 composite_op: lp.composite_op,
                 opacity: lp.opacity,
@@ -501,6 +498,85 @@ fn assemble(
             })
             .collect(),
     )
+}
+
+/// The [`LayerTransform`] that places layer `index`, or `None` when its placement has no
+/// GPU equivalent.
+///
+/// The rule is the CPU compositor's, **measured** rather than read off the model, because
+/// the two do not say the same thing:
+///
+/// * **Layer 0 is the base.** Its `x` / `y` / `scale` / `rotation` are *ignored* — the CPU
+///   builds no scale, rotate or overlay node for it (`composition_inner.rs:1181-1197`), so
+///   it only ever receives the fit. Measured: a lone layer given `x=10, y=4` or
+///   `scale=0.5` renders byte-identically to the same layer left alone. Applying the
+///   transform here would make the GPU diverge from the correctness reference, so the fix
+///   for a layer that carries one is to stop *falling back*, not to start drawing it.
+///   Whether the model should honour a base transform at all is #1766.
+/// * **Every other layer** is stretched to the base's size (its own aspect does not
+///   survive), scaled by `base * (scale_x, scale_y)`, and overlaid with its **top-left**
+///   at `(x, y)` in base-layer pixels. The finished composite is then fitted into the
+///   canvas, which is `base_fit`.
+///
+/// Composing those: the layer covers `scale` of the base, its centre sits at
+/// `x/bw + scale_x/2` in base UV, and `base_fit` maps base UV `u` to canvas UV
+/// `0.5 + fit * (u - 0.5)`. `transform.wgsl` puts a layer's centre at
+/// `0.5 + scale * translate`, so the fit cancels out of the translate and only multiplies
+/// the scale.
+///
+/// Verified against the CPU on three fixtures, each pinning a different term:
+///
+/// * a 64x64 overlay at `(10, 4)` scaled `0.5` over a 64x64 base in a 64x64 canvas lands
+///   at `(10, 4)..(41, 35)` — the offset and the scale;
+/// * the same overlay scaled `0.5` with no offset over a **64x32** base lands at
+///   `(0, 16)..(31, 31)` — that the multiplier is against the *base*, not the canvas;
+/// * that overlay at `(10, 4)` over the 64x32 base lands at `(10, 20)..(41, 35)` — that
+///   the *offset* is against the base too, which neither of the first two can tell apart
+///   (a mutation check found this one missing).
+///
+/// Rotation on a non-base layer returns `None`: the CPU's `rotate` fills the corners it
+/// exposes with `fillcolor` while the GPU transform leaves them transparent, so there is
+/// nothing to map it to (RK-020).
+fn layer_transform(
+    index: usize,
+    lp: &GpuLayerPlan,
+    base_fit: &LayerTransform,
+    base: (u32, u32),
+) -> Option<LayerTransform> {
+    if index == 0 {
+        return Some(base_fit.clone());
+    }
+    if lp.rotation.abs() > 1e-6 {
+        return None;
+    }
+    let (bw, bh) = (px(base.0), px(base.1));
+    // A zero-sized base has no space to place into, and a non-positive scale has no
+    // extent to draw; either would divide by zero below.
+    if bw <= 0.0 || bh <= 0.0 || lp.scale_x <= 0.0 || lp.scale_y <= 0.0 {
+        return None;
+    }
+    // The CPU's `overlay` writes into the base-sized accumulator, so a layer hanging off
+    // its edge is **clipped** before the composite is fitted into the canvas. The GPU
+    // draws straight into the canvas and has no such bound, so it would let the layer
+    // spill outside the base's band -- picture where the CPU has none. Reject instead of
+    // rendering the spill (RK-020); the cost is a fallback for a partly-offscreen
+    // overlay, which is the same answer as before #1633 for every overlay.
+    let (ox, oy) = (lp.x / bw, lp.y / bh);
+    if ox < -1e-6 || oy < -1e-6 || ox + lp.scale_x > 1.0 + 1e-6 || oy + lp.scale_y > 1.0 + 1e-6 {
+        return None;
+    }
+    Some(LayerTransform {
+        // `base_fit`'s translate moves the whole base, so anything sitting on the base
+        // moves with it. `letterbox_transform` returns a centred fit (translate 0) today,
+        // which is why the term reads as dead -- but leaving it out would make that a
+        // silent precondition of this formula, and the two functions live in one file.
+        // With it, a fit that ever gains an offset carries its layers along.
+        x: (lp.x / bw + lp.scale_x / 2.0 - 0.5 + base_fit.x) / lp.scale_x,
+        y: (lp.y / bh + lp.scale_y / 2.0 - 0.5 + base_fit.y) / lp.scale_y,
+        scale_x: base_fit.scale_x * lp.scale_x,
+        scale_y: base_fit.scale_y * lp.scale_y,
+        rotation: 0.0,
+    })
 }
 
 /// The [`LayerTransform`] that fits an `fw` x `fh` frame inside `canvas`, letterboxing or
@@ -536,6 +612,15 @@ fn letterbox_transform(fw: u32, fh: u32, canvas: (u32, u32)) -> Option<LayerTran
         scale_y: ratio(fit_h, canvas.1),
         ..LayerTransform::default()
     })
+}
+
+/// A pixel count as an `f32`, for the base-space arithmetic in [`layer_transform`].
+///
+/// Distinct from [`ratio`]: `ratio(x, 1)` computes the same number but reads as a
+/// proportion, which this is not.
+#[allow(clippy::cast_precision_loss)] // pixel dimensions are far inside f32's exact range
+fn px(v: u32) -> f32 {
+    v as f32
 }
 
 /// `a / b` as an `f32`, for the pixel counts this module deals in.
@@ -631,19 +716,180 @@ fn build_shape_mask(
     mask
 }
 
-/// Whether a plan layer's transform is the identity (no translate / scale / rotate),
-/// within a small tolerance. Non-identity transforms fall back to CPU in v1.
-fn is_identity_transform(lp: &GpuLayerPlan) -> bool {
-    lp.x.abs() < 1e-6
-        && lp.y.abs() < 1e-6
-        && (lp.scale_x - 1.0).abs() < 1e-6
-        && (lp.scale_y - 1.0).abs() < 1e-6
-        && lp.rotation.abs() < 1e-6
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A plan layer with the given placement and nothing else.
+    fn plan_layer(x: f32, y: f32, scale: (f32, f32), rotation: f32) -> GpuLayerPlan {
+        GpuLayerPlan {
+            z_order: 0,
+            x,
+            y,
+            scale_x: scale.0,
+            scale_y: scale.1,
+            rotation,
+            opacity: 1.0,
+            blend_mode: ff_render::BlendMode::Normal,
+            composite_op: ff_render::CompositeOp::Over,
+            effects: Vec::new(),
+        }
+    }
+
+    /// The canvas pixel box a [`LayerTransform`] draws into: `(x0, y0, x1, y1)`.
+    ///
+    /// Inverts `transform.wgsl`'s mapping — a layer's centre lands at
+    /// `0.5 + scale * translate` and it covers `scale` of the canvas — so a test can be
+    /// written against the pixel box the CPU was *measured* to produce rather than
+    /// against the transform's own numbers, which would just restate the formula.
+    fn canvas_box(t: &LayerTransform, canvas: (u32, u32)) -> (f32, f32, f32, f32) {
+        let (cw, ch) = (ratio(canvas.0, 1), ratio(canvas.1, 1));
+        let cx = 0.5 + t.scale_x * t.x;
+        let cy = 0.5 + t.scale_y * t.y;
+        (
+            (cx - t.scale_x / 2.0) * cw,
+            (cy - t.scale_y / 2.0) * ch,
+            (cx + t.scale_x / 2.0) * cw,
+            (cy + t.scale_y / 2.0) * ch,
+        )
+    }
+
+    fn assert_box(got: (f32, f32, f32, f32), want: (f32, f32, f32, f32), what: &str) {
+        for (g, w) in [
+            (got.0, want.0),
+            (got.1, want.1),
+            (got.2, want.2),
+            (got.3, want.3),
+        ] {
+            assert!((g - w).abs() < 0.01, "{what}: got {got:?}, want {want:?}");
+        }
+    }
+
+    #[test]
+    fn layer_transform_should_ignore_the_base_layers_own_transform() {
+        // Measured: a lone layer given x=10, y=4 or scale=0.5 renders byte-identically
+        // to the same layer left alone, because the CPU builds no scale/rotate/overlay
+        // node for layer 0. So the base must get the fit and nothing else — applying its
+        // transform is what would diverge (#1633).
+        let fit = letterbox_transform(64, 32, (64, 64)).expect("a 2:1 fit has a band");
+        let moved = plan_layer(10.0, 4.0, (0.5, 0.25), 30.0);
+        let got = layer_transform(0, &moved, &fit, (64, 32)).expect("the base always places");
+        assert_box(
+            canvas_box(&got, (64, 64)),
+            canvas_box(&fit, (64, 64)),
+            "a base layer's own transform must not move it",
+        );
+    }
+
+    #[test]
+    fn layer_transform_should_place_an_overlay_at_the_measured_box() {
+        // Measured against `RealtimeComposer`: a 64x64 overlay at (10, 4) scaled 0.5 over
+        // a 64x64 base in a 64x64 canvas lit exactly (10, 4)..(41, 35) inclusive, i.e.
+        // the half-open box (10, 4)..(42, 36).
+        let fit = letterbox_transform(64, 64, (64, 64)).expect("a square fit is the identity");
+        let over = plan_layer(10.0, 4.0, (0.5, 0.5), 0.0);
+        let got = layer_transform(1, &over, &fit, (64, 64)).expect("an overlay places");
+        assert_box(
+            canvas_box(&got, (64, 64)),
+            (10.0, 4.0, 42.0, 36.0),
+            "overlay placement",
+        );
+    }
+
+    #[test]
+    fn layer_transform_should_scale_against_the_base_not_the_canvas() {
+        // The fixture that distinguishes the two readings of the multiplier. Measured:
+        // the same 0.5-scaled overlay over a **64x32** base in a 64x64 canvas lit
+        // (0, 16)..(31, 31) inclusive — half-open (0, 16)..(32, 32). Against the *canvas*
+        // it would have been 32 tall, not 16, and would not sit inside the base's band.
+        let fit = letterbox_transform(64, 32, (64, 64)).expect("a 2:1 fit has a band");
+        let over = plan_layer(0.0, 0.0, (0.5, 0.5), 0.0);
+        let got = layer_transform(1, &over, &fit, (64, 32)).expect("an overlay places");
+        assert_box(
+            canvas_box(&got, (64, 64)),
+            (0.0, 16.0, 32.0, 32.0),
+            "the multiplier is against the base size",
+        );
+    }
+
+    #[test]
+    fn layer_transform_should_reject_a_rotated_overlay() {
+        // The CPU's `rotate` fills the exposed corners with `fillcolor`; the GPU leaves
+        // them transparent. Nothing to map it to, so it falls back (RK-020).
+        let fit = letterbox_transform(64, 64, (64, 64)).expect("a square fit is the identity");
+        let spun = plan_layer(0.0, 0.0, (1.0, 1.0), 30.0);
+        assert!(layer_transform(1, &spun, &fit, (64, 64)).is_none());
+        // ... but the same rotation on the base is ignored, not a fallback: measured, the
+        // CPU renders a rotated lone layer unrotated.
+        assert!(layer_transform(0, &spun, &fit, (64, 64)).is_some());
+    }
+
+    #[test]
+    fn layer_transform_should_carry_a_base_fit_offset_through_to_its_overlays() {
+        // `letterbox_transform` returns a centred fit today, so no other test moves an
+        // overlay by way of the base. Without this, dropping `base_fit.x` from the
+        // formula would pass every test and only break when the fit gains an offset --
+        // exactly the kind of unstated precondition a formula should not carry.
+        let centred = LayerTransform {
+            scale_x: 0.5,
+            scale_y: 0.5,
+            ..LayerTransform::default()
+        };
+        let shifted = LayerTransform {
+            x: 0.25,
+            ..centred.clone()
+        };
+        let over = plan_layer(0.0, 0.0, (1.0, 1.0), 0.0);
+        let a = layer_transform(1, &over, &centred, (64, 64)).expect("places");
+        let b = layer_transform(1, &over, &shifted, (64, 64)).expect("places");
+        let (ax, _, _, _) = canvas_box(&a, (64, 64));
+        let (bx, _, _, _) = canvas_box(&b, (64, 64));
+        // The base moved right by `scale_x * 0.25` of the canvas = 8 px; so must the overlay.
+        assert!(
+            (bx - ax - 8.0).abs() < 0.01,
+            "an overlay must follow the base's fit offset: {ax} -> {bx}"
+        );
+    }
+
+    #[test]
+    fn layer_transform_should_reject_an_overlay_that_spills_outside_the_base() {
+        // `overlay` clips to the base-sized accumulator on the CPU; the GPU would draw
+        // the overhang into the canvas. Found by a mutation check: no parity fixture had
+        // a layer crossing the base edge, so nothing was pinning this.
+        let fit = letterbox_transform(64, 64, (64, 64)).expect("a square fit is the identity");
+        let inside = plan_layer(10.0, 4.0, (0.5, 0.5), 0.0);
+        assert!(layer_transform(1, &inside, &fit, (64, 64)).is_some());
+        // Off the right edge: 10 + 0.9 * 64 > 64.
+        let over_right = plan_layer(10.0, 0.0, (0.9, 0.5), 0.0);
+        assert!(layer_transform(1, &over_right, &fit, (64, 64)).is_none());
+        // Off the bottom, and off the top-left.
+        assert!(
+            layer_transform(1, &plan_layer(0.0, 40.0, (0.5, 0.5), 0.0), &fit, (64, 64)).is_none()
+        );
+        assert!(
+            layer_transform(1, &plan_layer(-1.0, 0.0, (0.5, 0.5), 0.0), &fit, (64, 64)).is_none()
+        );
+        // Exactly flush with the edges is inside, not a spill.
+        assert!(
+            layer_transform(1, &plan_layer(32.0, 32.0, (0.5, 0.5), 0.0), &fit, (64, 64)).is_some()
+        );
+    }
+
+    #[test]
+    fn layer_transform_should_reject_a_degenerate_overlay() {
+        let fit = letterbox_transform(64, 64, (64, 64)).expect("a square fit is the identity");
+        // A non-positive scale has no extent to draw, and would divide by zero.
+        assert!(
+            layer_transform(1, &plan_layer(0.0, 0.0, (0.0, 1.0), 0.0), &fit, (64, 64)).is_none()
+        );
+        assert!(
+            layer_transform(1, &plan_layer(0.0, 0.0, (1.0, -1.0), 0.0), &fit, (64, 64)).is_none()
+        );
+        // A zero-sized base has no space to place into.
+        assert!(
+            layer_transform(1, &plan_layer(0.0, 0.0, (1.0, 1.0), 0.0), &fit, (0, 64)).is_none()
+        );
+    }
 
     #[test]
     fn fit_size_should_letterbox_a_wide_frame() {

--- a/crates/avio/src/gpu_export.rs
+++ b/crates/avio/src/gpu_export.rs
@@ -9,21 +9,26 @@
 //! it back to rgba, and pushes it to the unchanged encoder (whose own sws converts
 //! rgba -> yuv420p).
 //!
-//! v1 handles only a **single active video track** at unity speed whose every clip is a
-//! file source that maps to the GPU with an identity transform. A source whose frame
-//! rate differs from the timeline's is conformed by the drain (#1660), repeating or
-//! skipping source frames so the clip keeps its on-screen duration, and one whose aspect
-//! differs from the canvas is letterboxed by the shared compositing core (#1661). The
-//! clips are otherwise hard cuts, except for a single **cross-fade into the track's last
-//! clip** (#1659). Anything else keeps the whole export on the CPU
-//! `MultiTrackComposer` path (see [`eligible_track`]); multi-track / overlay GPU export
-//! is a follow-up.
+//! The route takes a **single active video track** at unity speed whose every clip is a
+//! file source. Several restrictions the first version had are gone: a source whose frame
+//! rate differs from the timeline's is conformed by the drain (#1660), one whose aspect
+//! differs from the canvas is letterboxed by the shared compositing core (#1661), a
+//! **cross-fade at any boundary** is rendered by the drain rather than rejected (#1659),
+//! and a clip carrying a position or scale is no longer turned away — the drain
+//! composites one layer per output, and a base layer's transform is ignored on both paths
+//! (#1633; see `gpu_compositor::layer_transform`).
+//!
+//! What still keeps the whole export on the CPU `MultiTrackComposer` path (see
+//! [`eligible_track`]): more than one active video track, a lavfi overlay, a generated
+//! (non-file) source, a speed other than 1, clips that do not tile the timeline, and a
+//! transition whose kind or window the GPU cannot render. Multi-track / overlay GPU
+//! export is #1633's remaining half.
 
 use std::time::{Duration, Instant};
 
 use ff_decode::{SeekMode, VideoDecoder};
 use ff_encode::VideoEncoder;
-use ff_filter::{AnimatedValue, VideoLayer, XfadeTransition};
+use ff_filter::{VideoLayer, XfadeTransition};
 use ff_format::{PixelFormat, VideoFrame};
 use ff_pipeline::Progress;
 use ff_render::BlendMode as RenderBlendMode;
@@ -200,9 +205,11 @@ pub(crate) fn eligible_track(
         else {
             return None;
         };
-        if !is_static_neutral_transform(&layer) {
-            return None;
-        }
+        // No transform gate: the drain composites one layer per output, which is the
+        // compositor's **base** layer, and a base layer's x / y / scale / rotation are
+        // ignored on both paths (measured; see `gpu_compositor::layer_transform`). A
+        // positioned or scaled clip therefore renders identically either way, so keeping
+        // it on the CPU bought nothing.
         blendable[i] = plan
             .layers
             .iter()
@@ -402,18 +409,6 @@ fn transition_window(
 #[allow(clippy::cast_precision_loss)] // frame index fits the f64 mantissa
 fn clip_output_time(k: u64, out_fps: f64) -> Duration {
     Duration::from_secs_f64(k as f64 / out_fps)
-}
-
-/// Whether a layer's geometric transform is static and neutral for all `t` (no
-/// translate / scale / rotate). Combined with the aspect check this is the v1
-/// identity gate: an animated or non-neutral transform makes the timeline
-/// ineligible (RK-020) so it never renders wrong output on the GPU.
-fn is_static_neutral_transform(layer: &VideoLayer) -> bool {
-    matches!(layer.x, AnimatedValue::Static(v) if v.abs() < 1e-9)
-        && matches!(layer.y, AnimatedValue::Static(v) if v.abs() < 1e-9)
-        && matches!(layer.scale_x, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9)
-        && matches!(layer.scale_y, AnimatedValue::Static(v) if (v - 1.0).abs() < 1e-9)
-        && matches!(layer.rotation, AnimatedValue::Static(v) if v.abs() < 1e-9)
 }
 
 /// The frame one clip shows for one output, and whether the drain may take it.

--- a/crates/avio/src/gpu_preview.rs
+++ b/crates/avio/src/gpu_preview.rs
@@ -255,20 +255,29 @@ mod tests {
     }
 
     #[test]
-    fn gpu_preview_compositor_should_fall_back_on_a_non_identity_transform() {
-        // A positioned layer cannot be rendered correctly in v1 (pixel-vs-UV units),
-        // so the compositor returns None and the runner uses the CPU path.
+    fn gpu_preview_compositor_should_render_a_positioned_base_layer_unmoved() {
+        // This used to assert a fallback. A lone layer is the compositor's **base**,
+        // and the CPU ignores a base layer transform entirely (measured; see
+        // `gpu_compositor::layer_transform`), so falling back bought nothing -- both
+        // routes render the same pixels either way. #1633.
         // Probe-gated (RK-002).
         let Some(mut gpu) = GpuPreviewCompositor::new() else {
             return;
         };
+        let frame = VideoFrame::from_rgba(4, 4, vec![50u8; 4 * 4 * 4]).unwrap();
+        let plain = identity_layer(4, 4);
+        let reference = gpu
+            .composite(&[(&plain, &frame)], (4, 4), Duration::ZERO)
+            .expect("an identity layer composites");
+
         let mut layer = identity_layer(4, 4);
         layer.x = AnimatedValue::Static(100.0);
-        let frame = VideoFrame::from_rgba(4, 4, vec![50u8; 4 * 4 * 4]).unwrap();
-        assert!(
-            gpu.composite(&[(&layer, &frame)], (4, 4), Duration::ZERO)
-                .is_none(),
-            "a non-identity transform must fall back to CPU"
+        let moved = gpu
+            .composite(&[(&layer, &frame)], (4, 4), Duration::ZERO)
+            .expect("a positioned base layer must no longer fall back");
+        assert_eq!(
+            moved.0, reference.0,
+            "a base layer transform is ignored on the CPU, so it must not move here"
         );
     }
 }

--- a/crates/avio/tests/gpu_parity_tests.rs
+++ b/crates/avio/tests/gpu_parity_tests.rs
@@ -412,6 +412,247 @@ fn gpu_composite(
     Some(rgba)
 }
 
+/// Composites two layers (bottom first) + their frames on the GPU, or `None` on
+/// fallback / no adapter.
+fn gpu_composite2(
+    gpu: &mut GpuCompositor,
+    layers: &[&RealtimeLayer],
+    frames: &[&VideoFrame],
+    canvas: (u32, u32),
+) -> Option<Vec<u8>> {
+    let pairs: Vec<(&RealtimeLayer, &VideoFrame)> =
+        layers.iter().copied().zip(frames.iter().copied()).collect();
+    let (rgba, _w, _h) = gpu.composite(&pairs, canvas, Duration::ZERO)?;
+    Some(rgba)
+}
+
+/// Bounding box of the pixels that carry picture, as `(x0, y0, x1, y1)` inclusive.
+///
+/// The placement tests assert this as well as a mean diff: a mean-only assertion passes
+/// for two *equally wrong* renders, and a layer in the wrong place is exactly that
+/// failure (RK-015).
+fn lit_bbox(buf: &[u8], w: u32, h: u32) -> Option<(u32, u32, u32, u32)> {
+    let (mut x0, mut y0, mut x1, mut y1) = (u32::MAX, u32::MAX, 0u32, 0u32);
+    let mut any = false;
+    for y in 0..h {
+        for x in 0..w {
+            let i = ((y * w + x) * 4) as usize;
+            if buf[i] > 32 || buf[i + 1] > 32 || buf[i + 2] > 32 {
+                any = true;
+                x0 = x0.min(x);
+                y0 = y0.min(y);
+                x1 = x1.max(x);
+                y1 = y1.max(y);
+            }
+        }
+    }
+    any.then_some((x0, y0, x1, y1))
+}
+
+/// A `w` x `h` frame filled with one grey level; `0` reads as "no picture" to
+/// [`lit_bbox`], which is what makes a placement bounding box readable.
+fn flat_frame(w: u32, h: u32, v: u8) -> VideoFrame {
+    VideoFrame::from_rgba(w, h, solid_rgba(w, h, [v; 3])).unwrap()
+}
+
+#[test]
+fn overlay_placement_gpu_should_match_cpu_within_tolerance() {
+    // #1633: a positioned, scaled overlay used to force the whole frame to the CPU. The
+    // CPU places it by stretching to the base size, scaling by `base * scale`, and
+    // overlaying its top-left at (x, y) -- measured as (10, 4)..(41, 35) inclusive for
+    // this fixture, which is what both routes must now produce.
+    let canvas = (64, 64);
+    let base = flat_frame(64, 64, 0);
+    let over = flat_frame(64, 64, 255);
+    let bottom = base_layer(64, 64, vec![]);
+    let mut top = base_layer(64, 64, vec![]);
+    top.x = AnimatedValue::Static(10.0);
+    top.y = AnimatedValue::Static(4.0);
+    top.scale_x = AnimatedValue::Static(0.5);
+    top.scale_y = AnimatedValue::Static(0.5);
+
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return; // no adapter
+    };
+    let Some(cpu) = cpu_composite2(&[&bottom, &top], &[&base, &over], canvas) else {
+        return; // filters unavailable
+    };
+    let Some(gpu_out) = gpu_composite2(&mut gpu, &[&bottom, &top], &[&base, &over], canvas) else {
+        panic!("a positioned overlay must now composite on the GPU");
+    };
+
+    let want = (10u32, 4u32, 41u32, 35u32);
+    assert_eq!(
+        lit_bbox(&gpu_out, canvas.0, canvas.1),
+        Some(want),
+        "the GPU must put the overlay where the CPU was measured to"
+    );
+    assert_eq!(
+        lit_bbox(&cpu, canvas.0, canvas.1),
+        Some(want),
+        "the CPU fixture must still land where it was measured"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!("overlay placement GPU vs CPU: mean={mean:.3}");
+    assert!(
+        mean <= TOL_LETTERBOX_MEAN,
+        "placement diverged: mean={mean}"
+    );
+}
+
+#[test]
+fn overlay_over_a_letterboxed_base_gpu_should_match_cpu_within_tolerance() {
+    // The fixture that pins the multiplier against the **base** size rather than the
+    // canvas: a 0.5-scaled overlay over a 64x32 base in a 64x64 canvas was measured at
+    // (0, 16)..(31, 31) inclusive. Scaled against the canvas it would be twice as tall
+    // and would not sit inside the base's letterbox band at all.
+    let canvas = (64, 64);
+    let base = flat_frame(64, 32, 0);
+    let over = flat_frame(64, 64, 255);
+    let bottom = base_layer(64, 32, vec![]);
+    let mut top = base_layer(64, 64, vec![]);
+    top.scale_x = AnimatedValue::Static(0.5);
+    top.scale_y = AnimatedValue::Static(0.5);
+
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return;
+    };
+    let Some(cpu) = cpu_composite2(&[&bottom, &top], &[&base, &over], canvas) else {
+        return;
+    };
+    let Some(gpu_out) = gpu_composite2(&mut gpu, &[&bottom, &top], &[&base, &over], canvas) else {
+        panic!("an overlay over a letterboxed base must composite on the GPU");
+    };
+
+    let want = (0u32, 16u32, 31u32, 31u32);
+    assert_eq!(lit_bbox(&gpu_out, canvas.0, canvas.1), Some(want));
+    assert_eq!(lit_bbox(&cpu, canvas.0, canvas.1), Some(want));
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!("overlay over letterboxed base GPU vs CPU: mean={mean:.3}");
+    assert!(
+        mean <= TOL_LETTERBOX_MEAN,
+        "placement diverged: mean={mean}"
+    );
+}
+
+#[test]
+fn offset_overlay_over_a_letterboxed_base_gpu_should_match_cpu_within_tolerance() {
+    // The fixture a mutation check said was missing: the offset must be measured against
+    // the **base** size, and only a fixture with a non-canvas base *and* a non-zero
+    // offset can tell that apart from measuring against the canvas. Base 64x32 in a
+    // 64x64 canvas, overlay scaled 0.5 at (10, 4) in base pixels -> the band is rows
+    // 16..47, and the overlay sits at (10, 20)..(41, 35) inside it.
+    let canvas = (64, 64);
+    let base = flat_frame(64, 32, 0);
+    let over = flat_frame(64, 64, 255);
+    let bottom = base_layer(64, 32, vec![]);
+    let mut top = base_layer(64, 64, vec![]);
+    top.x = AnimatedValue::Static(10.0);
+    top.y = AnimatedValue::Static(4.0);
+    top.scale_x = AnimatedValue::Static(0.5);
+    top.scale_y = AnimatedValue::Static(0.5);
+
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return;
+    };
+    let Some(cpu) = cpu_composite2(&[&bottom, &top], &[&base, &over], canvas) else {
+        return;
+    };
+    let Some(gpu_out) = gpu_composite2(&mut gpu, &[&bottom, &top], &[&base, &over], canvas) else {
+        panic!("an offset overlay over a letterboxed base must composite on the GPU");
+    };
+
+    let gpu_box = lit_bbox(&gpu_out, canvas.0, canvas.1);
+    let cpu_box = lit_bbox(&cpu, canvas.0, canvas.1);
+    println!("offset overlay over letterboxed base: gpu={gpu_box:?} cpu={cpu_box:?}");
+    assert_eq!(
+        gpu_box, cpu_box,
+        "the offset must be measured against the base size, not the canvas"
+    );
+    let mean = mean_abs_diff_rgb(&gpu_out, &cpu);
+    println!("offset overlay GPU vs CPU: mean={mean:.3}");
+    assert!(
+        mean <= TOL_LETTERBOX_MEAN,
+        "placement diverged: mean={mean}"
+    );
+}
+
+#[test]
+fn an_overlay_spilling_outside_the_base_should_fall_back() {
+    // `overlay` clips the layer to the base-sized accumulator on the CPU, while the GPU
+    // draws straight into the canvas and would show the overhang. Nothing to map that
+    // to, so it falls back (RK-020). Found by a mutation check: no fixture crossed the
+    // base edge, so nothing pinned it.
+    let canvas = (64, 64);
+    let base = flat_frame(64, 64, 0);
+    let over = flat_frame(64, 64, 255);
+    let bottom = base_layer(64, 64, vec![]);
+    let mut top = base_layer(64, 64, vec![]);
+    top.x = AnimatedValue::Static(40.0); // 40 + 0.5 * 64 = 72 > 64
+    top.scale_x = AnimatedValue::Static(0.5);
+    top.scale_y = AnimatedValue::Static(0.5);
+
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return;
+    };
+    assert!(
+        gpu_composite2(&mut gpu, &[&bottom, &top], &[&base, &over], canvas).is_none(),
+        "an overlay hanging off the base edge must fall back"
+    );
+}
+
+#[test]
+fn a_positioned_single_layer_should_composite_on_the_gpu_unmoved() {
+    // A lone layer is the compositor's *base*, whose transform the CPU ignores entirely
+    // (measured). So the GPU must ignore it too -- and, since both agree, must stop
+    // falling back. Asserting it renders identically to the same layer left alone is
+    // what pins "ignored" rather than "applied a little".
+    let canvas = (64, 64);
+    let frame = VideoFrame::from_rgba(64, 64, gradient_rgba(64, 64)).unwrap();
+    let plain = base_layer(64, 64, vec![]);
+    let mut moved = base_layer(64, 64, vec![]);
+    moved.x = AnimatedValue::Static(10.0);
+    moved.y = AnimatedValue::Static(4.0);
+    moved.scale_x = AnimatedValue::Static(0.5);
+    moved.scale_y = AnimatedValue::Static(0.5);
+    moved.rotation = AnimatedValue::Static(30.0);
+
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return;
+    };
+    let Some(reference) = gpu_composite(&mut gpu, &plain, &frame, canvas) else {
+        panic!("an identity layer must composite");
+    };
+    let Some(got) = gpu_composite(&mut gpu, &moved, &frame, canvas) else {
+        panic!("a positioned base layer must no longer fall back (#1633)");
+    };
+    assert_eq!(
+        got, reference,
+        "a base layer transform is ignored on the CPU, so the GPU must not apply it"
+    );
+}
+
+#[test]
+fn a_rotated_overlay_should_still_fall_back() {
+    // Deliberately unmapped: the CPU `rotate` fills the corners it exposes with
+    // `fillcolor` while the GPU transform leaves them transparent (RK-020). This pins
+    // that lifting the placement gate did not quietly enable rotation too.
+    let canvas = (64, 64);
+    let base = flat_frame(64, 64, 0);
+    let over = flat_frame(64, 64, 255);
+    let bottom = base_layer(64, 64, vec![]);
+    let mut top = base_layer(64, 64, vec![]);
+    top.rotation = AnimatedValue::Static(30.0);
+
+    let Some(mut gpu) = GpuCompositor::new() else {
+        return;
+    };
+    assert!(
+        gpu_composite2(&mut gpu, &[&bottom, &top], &[&base, &over], canvas).is_none(),
+        "a rotated overlay has no GPU equivalent and must fall back"
+    );
+}
+
 #[test]
 fn passthrough_gpu_should_match_input_within_tolerance() {
     // The broadest guard (adapter only, no filters): an identity, canvas-sized layer
@@ -1981,29 +2222,24 @@ fn gpu_compositor_should_fall_back_not_panic_for_unsupported_inputs() {
         return; // no adapter
     };
 
-    // Non-identity transform (RK-020: model pixels are not ff_render UV units).
-    let mut positioned = base_layer(w, h, vec![]);
-    positioned.x = AnimatedValue::Static(10.0);
+    // A positioned layer and a mixed-aspect stack both used to be listed here. #1633
+    // removed those fallbacks rather than fixing them, because neither was rendering
+    // anything wrong: a lone layer is the *base*, whose transform the CPU ignores, and
+    // an overlay is stretched to the base size, so its own aspect never survives to
+    // disagree with the base band. They are covered now by
+    // `a_positioned_single_layer_should_composite_on_the_gpu_unmoved` and
+    // `overlay_over_a_letterboxed_base_gpu_should_match_cpu_within_tolerance`, which
+    // assert the placement against the CPU instead of asserting a refusal.
+    //
+    // A **rotated overlay** is still genuinely unmappable, so it takes their place here.
+    let over = flat_frame(w, h, 255);
+    let bottom = base_layer(w, h, vec![]);
+    let mut spun = base_layer(w, h, vec![]);
+    spun.rotation = AnimatedValue::Static(30.0);
     assert!(
-        gpu_composite(&mut gpu, &positioned, &frame, (w, h)).is_none(),
-        "a positioned layer must fall back"
-    );
-
-    // Mixed aspects across layers (#1661): each layer is letterboxed into the canvas
-    // before compositing, while the CPU fits the *composited* result, so the two only
-    // agree when every layer lands in the same band. A 4:3 layer under a 1:1 one would
-    // give a band per layer -> fall back.
-    let tall = VideoFrame::from_rgba(h, h, gradient_rgba(h, h)).unwrap();
-    let wide_layer = base_layer(w, h, vec![]);
-    let square_layer = base_layer(h, h, vec![]);
-    assert!(
-        gpu.composite(
-            &[(&wide_layer, &frame), (&square_layer, &tall)],
-            (48, 48),
-            Duration::ZERO,
-        )
-        .is_none(),
-        "layers of mixed aspect must fall back"
+        gpu.composite(&[(&bottom, &frame), (&spun, &over)], (w, h), Duration::ZERO)
+            .is_none(),
+        "a rotated overlay must fall back"
     );
 
     // An aspect so extreme that the fitted height rounds away to nothing (#1661): a


### PR DESCRIPTION
## Objective

- The GPU compositor rejected any layer carrying a position or scale, so **preview and export both fell back to the CPU** for a positioned or scaled clip. The gate lived in the shared compositor, not in export eligibility.
- Two of this issue's four headline items had already landed and the module docs had not kept up: letterboxing (#1661) and cross-fades at every boundary (#1659).

## Solution

- Add `layer_transform`, replacing the identity gate with the placement itself. The rule was **measured** against `RealtimeComposer` rather than read off the model, and the measurement contradicted the obvious reading: the compositor works in base-layer space, layer 0's own transform is ignored entirely, every other layer is stretched to the base size, scaled by `base * scale`, and overlaid top-left at `(x, y)`; only the composite is fitted into the canvas.
- The export drain composites one layer per output, which is always the base — so applying its transform would have **diverged** from the CPU. The fix was to stop falling back for something both paths ignore. Output is unchanged; the placement rule is what the multi-layer preview needs, and what the multi-track slice will need.
- Keep two fallbacks with reasons: a rotated non-base layer (the CPU's `rotate` fills the exposed corners, the GPU leaves them transparent) and an overlay hanging off the base edge (`overlay` clips to the base-sized accumulator, the GPU would draw the overhang).
- Drop the mixed-aspect restriction, which existed only because one shared transform served every layer.
- Four mutations of the formula are each caught by a named parity test; the `base_fit` translate term, dead today because the fit is always centred, has its own test so it cannot be dropped silently.

Filed #1766 for the underlying question this measurement exposed: a base layer's position, scale and rotation are silently ignored by both paths, so the model can express something neither renders.

Delivers the non-identity-transform part of the second Solution bullet. The per-frame multi-source scheduler and speed resampling are untouched, so this does not close the issue.

Part of #1633