### PR TITLE
feat(ff-sys,ff-decode,ff-encode): custom AVIO I/O from Rust sources and sinks

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -72,6 +72,12 @@ pub use ff_probe::{ProbeError, open};
 // Errors the engine's `TimelineError` wraps by `#[from]`.
 pub use ff_decode::DecodeError;
 
+// Custom byte source / sink bounds (#1600): `VideoDecoder::from_reader` and
+// `VideoEncoderBuilder::output_sink` accept anything meeting these, so a caller
+// only names them to store one.
+pub use ff_decode::IoSource;
+pub use ff_encode::IoSink;
+
 // analysis (scene / silence / loudness / scopes)
 // Media analysis feeds editing decisions; kept as an engine convenience.
 pub use ff_analysis::{

--- a/crates/ff-decode/src/lib.rs
+++ b/crates/ff-decode/src/lib.rs
@@ -117,8 +117,11 @@ pub use audio::{AudioDecoder, AudioDecoderBuilder};
 pub use error::DecodeError;
 pub use extract::{FrameExtractor, ThumbnailSelector};
 pub use ff_common::{FramePool, PooledBuffer};
+// The bound `VideoDecoder::from_reader` takes. Callers passing a `Cursor` or a
+// `File` never name it; one storing a boxed source does.
 pub use ff_format::ContainerInfo;
 pub use ff_format::{ErrorSeverity, MediaError};
+pub use ff_sys::IoSource;
 pub use image::{ImageDecoder, ImageDecoderBuilder};
 pub use shared::{HardwareAccel, SeekMode};
 pub use video::{VideoDecoder, VideoDecoderBuilder};

--- a/crates/ff-decode/src/shared/guards_inner.rs
+++ b/crates/ff-decode/src/shared/guards_inner.rs
@@ -39,6 +39,22 @@ pub(crate) fn open_image_sequence_ctx(
     })
 }
 
+/// Opens a caller-supplied byte source, returning the owned demux context.
+///
+/// The format is probed from the bytes themselves, so there is no path or URL to
+/// report in the error; the source is moved into the context and released with it.
+pub(crate) fn open_custom_ctx(
+    source: Box<dyn ff_sys::IoSource>,
+) -> Result<ff_sys::InputFormatContext, DecodeError> {
+    ff_sys::InputFormatContext::open_custom(source).map_err(|e| DecodeError::Ffmpeg {
+        code: e.code(),
+        message: format!(
+            "Failed to open the supplied source: {}",
+            ff_sys::av_error_string(e.code())
+        ),
+    })
+}
+
 /// Opens a network URL with the supplied network options, returning the owned demux context.
 pub(crate) fn open_url_ctx(
     url: &str,

--- a/crates/ff-decode/src/video/builder/mod.rs
+++ b/crates/ff-decode/src/video/builder/mod.rs
@@ -122,6 +122,24 @@ pub struct VideoDecoderBuilder {
     frame_rate: Option<u32>,
     /// Network options for URL-based sources (RTMP, RTSP, HTTP, etc.).
     network_opts: Option<NetworkOptions>,
+    /// A caller-supplied byte source to demux from instead of `path`.
+    ///
+    /// Set by [`VideoDecoder::from_reader`]; when present it wins over `path`,
+    /// which is then only a label for diagnostics.
+    source: Option<SourceHandle>,
+}
+
+/// A boxed byte source that can sit in a `#[derive(Debug)]` struct.
+///
+/// A caller's reader carries no `Debug` bound -- requiring one would rule out
+/// most of what this feature exists to accept -- so the handle prints a label
+/// instead of its contents.
+struct SourceHandle(Box<dyn ff_sys::IoSource>);
+
+impl std::fmt::Debug for SourceHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<reader>")
+    }
 }
 
 impl VideoDecoderBuilder {
@@ -138,7 +156,17 @@ impl VideoDecoderBuilder {
             frame_pool: None,
             frame_rate: None,
             network_opts: None,
+            source: None,
         }
+    }
+
+    /// Creates a builder that demuxes `source` instead of a file.
+    ///
+    /// This is an internal constructor; use [`VideoDecoder::from_reader()`].
+    pub(crate) fn from_source(source: Box<dyn ff_sys::IoSource>) -> Self {
+        let mut builder = Self::new(PathBuf::from("<reader>"));
+        builder.source = Some(SourceHandle(source));
+        builder
     }
 
     /// Returns the configured file path.
@@ -212,11 +240,12 @@ impl VideoDecoderBuilder {
         }
 
         // Image-sequence patterns contain '%' — the literal path does not exist.
-        // Network URLs must also skip the file-existence check.
+        // Network URLs must also skip the file-existence check, and so must a
+        // caller-supplied source, whose `path` is a label rather than a location.
         let path_str = self.path.to_str().unwrap_or("");
         let is_image_sequence = path_str.contains('%');
         let is_network_url = crate::network::is_url(path_str);
-        if !is_image_sequence && !is_network_url && !self.path.exists() {
+        if self.source.is_none() && !is_image_sequence && !is_network_url && !self.path.exists() {
             return Err(DecodeError::FileNotFound {
                 path: self.path.clone(),
             });
@@ -232,6 +261,7 @@ impl VideoDecoderBuilder {
             self.frame_rate,
             self.frame_pool.clone(),
             self.network_opts,
+            self.source.map(|s| s.0),
         )?;
 
         Ok(VideoDecoder {
@@ -341,6 +371,36 @@ impl VideoDecoder {
     /// media file. Validation occurs when [`VideoDecoderBuilder::build()`] is called.
     pub fn open(path: impl AsRef<Path>) -> VideoDecoderBuilder {
         VideoDecoderBuilder::new(path.as_ref().to_path_buf())
+    }
+
+    /// Creates a builder that decodes from `source` instead of a file.
+    ///
+    /// `source` is anything that reads and seeks and can move to the decoder's
+    /// thread -- an in-memory `Cursor<Vec<u8>>`, a `File`, a custom byte store.
+    /// The container format is probed from the bytes, so nothing has to be named.
+    ///
+    /// `Seek` is required: `FFmpeg` can demux without it, but the containers that
+    /// survive a non-seekable input are a narrower set with different failure
+    /// modes, and supporting it is separate work.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use std::io::Cursor;
+    /// use ff_decode::VideoDecoder;
+    ///
+    /// let bytes: Vec<u8> = std::fs::read("input.mp4")?;
+    /// let mut decoder = VideoDecoder::from_reader(Cursor::new(bytes)).build()?;
+    /// let frame = decoder.decode_one()?;
+    /// # Ok::<(), ff_decode::DecodeError>(())
+    /// ```
+    ///
+    /// # Note
+    ///
+    /// As with [`open`](Self::open), nothing is read until
+    /// [`VideoDecoderBuilder::build()`] is called.
+    pub fn from_reader(source: impl ff_sys::IoSource + 'static) -> VideoDecoderBuilder {
+        VideoDecoderBuilder::from_source(Box::new(source))
     }
 
     // =========================================================================

--- a/crates/ff-decode/src/video/decoder_inner/mod.rs
+++ b/crates/ff-decode/src/video/decoder_inner/mod.rs
@@ -43,7 +43,9 @@ use ff_sys::{
 
 use crate::HardwareAccel;
 use crate::error::DecodeError;
-use crate::shared::guards_inner::{open_image_sequence_ctx, open_input_ctx, open_url_ctx};
+use crate::shared::guards_inner::{
+    open_custom_ctx, open_image_sequence_ctx, open_input_ctx, open_url_ctx,
+};
 use crate::video::builder::OutputScale;
 use ff_common::FramePool;
 
@@ -140,6 +142,7 @@ impl VideoDecoderInner {
         frame_rate: Option<u32>,
         frame_pool: Option<Arc<dyn FramePool>>,
         network_opts: Option<NetworkOptions>,
+        source: Option<Box<dyn ff_sys::IoSource>>,
     ) -> Result<(Self, VideoStreamInfo, ContainerInfo), DecodeError> {
         // Ensure FFmpeg is initialized (thread-safe and idempotent)
         ff_sys::ensure_initialized();
@@ -160,8 +163,11 @@ impl VideoDecoderInner {
             crate::network::check_srt_url(path_str)?;
         }
 
-        // Open the input (owned demux context).
-        let mut ctx = if is_network_url {
+        // Open the input (owned demux context). A caller-supplied source wins over
+        // the path, which is then only a label for diagnostics.
+        let mut ctx = if let Some(source) = source {
+            open_custom_ctx(source)?
+        } else if is_network_url {
             let network = network_opts.unwrap_or_default();
             log::info!(
                 "opening network source url={} connect_timeout_ms={} read_timeout_ms={}",

--- a/crates/ff-decode/tests/custom_io_tests.rs
+++ b/crates/ff-decode/tests/custom_io_tests.rs
@@ -1,0 +1,107 @@
+//! Decoding from a caller-supplied byte source (#1600).
+//!
+//! The fixture is deliberate: `gameplay.mp4` carries its `moov` atom at the end
+//! of the file, so opening it at all forces the demuxer to seek backwards. A
+//! source whose seek callback were wrong or absent would fail here rather than
+//! quietly decode a prefix.
+//!
+//! Probe-gated: the whole suite skips when the asset or the H.264 decoder is
+//! unavailable, which is the state of CI's `--disable-everything` `FFmpeg` build.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod fixtures;
+
+use std::io::Cursor;
+
+use ff_decode::VideoDecoder;
+use fixtures::test_video_path;
+
+/// `(frame count, first frame's dimensions)` for a decoder, capped so the test
+/// stays quick on a long asset.
+fn decode_stats(mut decoder: VideoDecoder) -> (usize, Option<(u32, u32)>) {
+    let (mut n, mut dims) = (0usize, None);
+    while n < 24 {
+        match decoder.decode_one() {
+            Ok(Some(frame)) => {
+                if dims.is_none() {
+                    dims = Some((frame.width(), frame.height()));
+                }
+                n += 1;
+            }
+            _ => break,
+        }
+    }
+    (n, dims)
+}
+
+/// The asset's bytes, or `None` when the environment cannot run this suite.
+fn asset_bytes() -> Option<Vec<u8>> {
+    let path = test_video_path();
+    if !path.exists() {
+        return None;
+    }
+    // If the file itself will not open, the decoder is missing rather than the
+    // reader path being broken: skip instead of reporting a false failure.
+    VideoDecoder::open(&path).build().ok()?;
+    std::fs::read(&path).ok()
+}
+
+#[test]
+fn decoding_from_a_reader_should_match_decoding_the_file() {
+    let Some(bytes) = asset_bytes() else {
+        return;
+    };
+    let from_file = VideoDecoder::open(test_video_path())
+        .build()
+        .expect("the control decoder opened once already");
+    let (file_n, file_dims) = decode_stats(from_file);
+
+    let from_reader = VideoDecoder::from_reader(Cursor::new(bytes))
+        .build()
+        .expect("a seekable in-memory source must open");
+    let (reader_n, reader_dims) = decode_stats(from_reader);
+
+    println!("custom io: file=({file_n}, {file_dims:?}) reader=({reader_n}, {reader_dims:?})");
+    assert!(file_n > 0, "the control must decode something");
+    assert_eq!(
+        reader_n, file_n,
+        "decoding from memory must yield the same frames as decoding the file"
+    );
+    assert_eq!(
+        reader_dims, file_dims,
+        "decoding from memory must yield the same dimensions"
+    );
+}
+
+#[test]
+fn a_reader_source_should_be_seekable_enough_for_a_trailing_moov() {
+    // `gameplay.mp4` stores `moov` at the end, so `avformat_open_input` only
+    // succeeds if the seek callback works. Opening *is* the assertion; the
+    // separate test above would still pass on a prefix-only read if the asset
+    // ever changed, so this one names the property.
+    let Some(bytes) = asset_bytes() else {
+        return;
+    };
+    let opened = VideoDecoder::from_reader(Cursor::new(bytes)).build();
+    assert!(
+        opened.is_ok(),
+        "a seekable source must open a file whose moov atom is at the end: {:?}",
+        opened.err()
+    );
+}
+
+#[test]
+fn a_truncated_source_should_fail_to_open_rather_than_decode_garbage() {
+    // The other side of the gate: the reader path must still report a bad input
+    // as an error, not as an empty-but-successful decode.
+    let Some(bytes) = asset_bytes() else {
+        return;
+    };
+    let head = bytes[..bytes.len().min(64)].to_vec();
+    let opened = VideoDecoder::from_reader(Cursor::new(head)).build();
+    assert!(
+        opened.is_err(),
+        "64 bytes of a container is not a decodable input"
+    );
+}

--- a/crates/ff-encode/src/lib.rs
+++ b/crates/ff-encode/src/lib.rs
@@ -189,7 +189,10 @@ pub use audio::{
     Mp3Options, Mp3Quality, OpusApplication, OpusOptions,
 };
 pub use error::EncodeError;
+// The bound `VideoEncoderBuilder::output_sink` takes. Callers passing a `Cursor`
+// or a `File` never name it; one storing a boxed sink does.
 pub use ff_format::{ErrorSeverity, MediaError};
+pub use ff_sys::IoSink;
 pub use image::{ImageEncoder, ImageEncoderBuilder};
 pub use preset::{AudioEncoderConfig, ExportPreset, VideoEncoderConfig};
 #[cfg(feature = "preview-image")]

--- a/crates/ff-encode/src/video/builder/meta.rs
+++ b/crates/ff-encode/src/video/builder/meta.rs
@@ -11,6 +11,38 @@ impl VideoEncoderBuilder {
         self
     }
 
+    /// Mux into `sink` instead of writing a file.
+    ///
+    /// The path given to [`VideoEncoder::create`](crate::VideoEncoder::create) is
+    /// then only what the muxer is guessed from -- nothing is created on disk --
+    /// so it still needs a usable extension, or an explicit
+    /// [`container`](Self::container).
+    ///
+    /// `sink` is anything that writes and seeks and can move to the encoder's
+    /// thread. Seeking is not optional: MP4 rewrites its header once the sizes
+    /// are known, and a sink that cannot seek would produce an unplayable file.
+    ///
+    /// Incompatible with [`two_pass`](Self::two_pass), which opens the output
+    /// again for the second pass; that combination is rejected by `build`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use std::io::Cursor;
+    /// use ff_encode::VideoEncoder;
+    ///
+    /// let mut encoder = VideoEncoder::create("out.mp4")
+    ///     .video_size(640, 360)
+    ///     .output_sink(Cursor::new(Vec::new()))
+    ///     .build()?;
+    /// # Ok::<(), ff_encode::EncodeError>(())
+    /// ```
+    #[must_use]
+    pub fn output_sink(mut self, sink: impl ff_sys::IoSink + 'static) -> Self {
+        self.sink = Some(Box::new(sink));
+        self
+    }
+
     /// Set a closure as the progress callback.
     #[must_use]
     pub fn on_progress<F>(mut self, callback: F) -> Self

--- a/crates/ff-encode/src/video/builder/mod.rs
+++ b/crates/ff-encode/src/video/builder/mod.rs
@@ -53,6 +53,11 @@ pub struct VideoEncoderBuilder {
     pub(crate) audio_codec: AudioCodec,
     pub(crate) audio_bitrate: Option<u64>,
     pub(crate) progress_callback: Option<Box<dyn EncodeProgressCallback>>,
+    /// A caller-supplied byte sink to mux into instead of `path`.
+    ///
+    /// Set by [`VideoEncoderBuilder::output_sink`]; when present the `path` is
+    /// only what the muxer is guessed from, and nothing is written to disk.
+    pub(crate) sink: Option<Box<dyn ff_sys::IoSink>>,
     pub(crate) two_pass: bool,
     pub(crate) faststart: bool,
     pub(crate) metadata: Vec<(String, String)>,
@@ -92,6 +97,7 @@ impl std::fmt::Debug for VideoEncoderBuilder {
                 "progress_callback",
                 &self.progress_callback.as_ref().map(|_| "<callback>"),
             )
+            .field("sink", &self.sink.as_ref().map(|_| "<sink>"))
             .field("two_pass", &self.two_pass)
             .field("faststart", &self.faststart)
             .field("metadata", &self.metadata)
@@ -128,6 +134,7 @@ impl VideoEncoderBuilder {
             audio_codec: AudioCodec::default(),
             audio_bitrate: None,
             progress_callback: None,
+            sink: None,
             two_pass: false,
             faststart: false,
             metadata: Vec::new(),
@@ -250,7 +257,31 @@ impl VideoEncoderBuilder {
             });
         }
 
+        if self.faststart && self.sink.is_some() {
+            // `movflags=+faststart` finalises by *reopening the output for reading*
+            // (`mov_write_trailer` -> `shift_data` -> `ff_format_shift_data`, which
+            // does `io_open(s, &read_pb, s->url, AVIO_FLAG_READ, ...)`). With a sink
+            // the bytes never reached `s->url`, so that read hits whatever is at the
+            // path -- nothing, or an unrelated file. Measured: with no such file
+            // `finish()` fails and leaves a moov-less stream in the sink; with a
+            // stale file of that name `finish()` returns `Ok` and that file's
+            // contents are copied into the caller's sink. Any muxer that relocates
+            // data by reopening `s->url` is incompatible with a custom `pb`.
+            return Err(EncodeError::InvalidConfig {
+                reason: "faststart cannot write to a caller-supplied sink".to_string(),
+            });
+        }
+
         if self.two_pass {
+            if self.sink.is_some() {
+                // Pass 2 opens the output after pass 1 has run, so it needs an
+                // output it can open twice. A sink is moved in once and cannot be
+                // reopened, and half-supporting that would mean silently writing
+                // only the second pass.
+                return Err(EncodeError::InvalidConfig {
+                    reason: "Two-pass encoding cannot write to a caller-supplied sink".to_string(),
+                });
+            }
             if !has_video {
                 return Err(EncodeError::InvalidConfig {
                     reason: "Two-pass encoding requires a video stream".to_string(),
@@ -622,7 +653,7 @@ impl VideoEncoder {
         // dimensions, so we must also check for audio configuration.
         let has_audio = config.audio_sample_rate.is_some() && config.audio_channels.is_some();
         let inner = if config.video_width.is_some() || has_audio {
-            Some(VideoEncoderInner::new(&config)?)
+            Some(VideoEncoderInner::new(&config, builder.sink)?)
         } else {
             None
         };

--- a/crates/ff-encode/src/video/encoder_inner/mod.rs
+++ b/crates/ff-encode/src/video/encoder_inner/mod.rs
@@ -155,7 +155,10 @@ pub(super) struct VideoEncoderConfig {
 
 impl VideoEncoderInner {
     /// Create a new encoder with the given configuration.
-    pub(super) fn new(config: &VideoEncoderConfig) -> Result<Self, EncodeError> {
+    pub(super) fn new(
+        config: &VideoEncoderConfig,
+        sink: Option<Box<dyn ff_sys::IoSink>>,
+    ) -> Result<Self, EncodeError> {
         unsafe {
             ff_sys::ensure_initialized();
 
@@ -257,7 +260,29 @@ impl VideoEncoderInner {
             if !config.two_pass {
                 // Muxers that manage their own IO (image2 sequences, AVFMT_NOFILE)
                 // must not have a `pb` opened for them.
-                if !encoder.format_ctx.is_nofile() {
+                if let Some(sink) = sink {
+                    // A caller-supplied sink replaces the file entirely. A muxer
+                    // that manages its own IO has nowhere to put it, so that
+                    // combination is an error rather than a silently ignored sink.
+                    if encoder.format_ctx.is_nofile() {
+                        return Err(EncodeError::InvalidConfig {
+                            reason: format!(
+                                "the {} muxer manages its own IO and cannot write to a sink",
+                                config.path.display()
+                            ),
+                        });
+                    }
+                    encoder
+                        .format_ctx
+                        .set_custom_io(sink)
+                        .map_err(|e| EncodeError::Ffmpeg {
+                            code: e.code(),
+                            message: format!(
+                                "Cannot attach the output sink: {}",
+                                ff_sys::av_error_string(e.code())
+                            ),
+                        })?;
+                } else if !encoder.format_ctx.is_nofile() {
                     encoder.format_ctx.open_io(&config.path).map_err(|_| {
                         EncodeError::CannotCreateFile {
                             path: config.path.clone(),

--- a/crates/ff-encode/tests/custom_io_tests.rs
+++ b/crates/ff-encode/tests/custom_io_tests.rs
@@ -1,0 +1,255 @@
+//! Muxing into a caller-supplied byte sink (#1600).
+//!
+//! The assertions are a round trip rather than "the buffer is non-empty": MP4
+//! rewrites its header once the sizes are known, and `avio_context_free` discards
+//! whatever is still buffered, so a sink that is never seeked or never flushed
+//! still collects plausible-looking bytes that no demuxer will open.
+//!
+//! Probe-gated: the suite skips when the H.264 encoder or the MP4 muxer is
+//! missing, which is the state of CI's `--disable-everything` `FFmpeg` build.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::io::{Cursor, Seek, SeekFrom, Write};
+use std::sync::{Arc, Mutex};
+
+use ff_encode::{BitrateMode, VideoCodec, VideoEncoder};
+use ff_format::VideoFrame;
+
+const W: u32 = 64;
+const H: u32 = 64;
+const FRAMES: usize = 10;
+
+/// An in-memory sink whose bytes stay reachable after the encoder has taken it.
+///
+/// The sink itself is moved into the encoder, so a bare `Cursor` would be
+/// unreadable afterwards. Sharing the cursor is also the shape a caller wanting
+/// the output in memory would actually write.
+#[derive(Clone)]
+struct SharedSink(Arc<Mutex<Cursor<Vec<u8>>>>);
+
+impl SharedSink {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Cursor::new(Vec::new()))))
+    }
+
+    fn bytes(&self) -> Vec<u8> {
+        self.0
+            .lock()
+            .map_or_else(|_| Vec::new(), |c| c.get_ref().clone())
+    }
+}
+
+impl Write for SharedSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut guard = self
+            .0
+            .lock()
+            .map_err(|_| std::io::Error::other("sink poisoned"))?;
+        guard.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for SharedSink {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let mut guard = self
+            .0
+            .lock()
+            .map_err(|_| std::io::Error::other("sink poisoned"))?;
+        guard.seek(pos)
+    }
+}
+
+/// A solid mid-grey frame; the content does not matter, only that it encodes.
+fn frame() -> Option<VideoFrame> {
+    VideoFrame::from_rgba(W, H, vec![128u8; (W * H * 4) as usize]).ok()
+}
+
+/// Encodes `FRAMES` frames into `sink`, or `None` when this environment cannot
+/// encode at all (a skip, not a failure).
+fn encode_into(sink: SharedSink) -> Option<()> {
+    let mut encoder = VideoEncoder::create("out.mp4")
+        .video(W, H, 30.0)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Cbr(400_000))
+        .output_sink(sink)
+        .build()
+        .ok()?;
+    let f = frame()?;
+    for _ in 0..FRAMES {
+        encoder.push_video(&f).ok()?;
+    }
+    encoder.finish().ok()
+}
+
+/// The control: the same encode written to a file the ordinary way.
+///
+/// The comparison is against this rather than against a fixed frame count,
+/// because the encoder's own flush behaviour decides how many frames come back
+/// (measured: 9 of 10 pushed, on both routes). A hard-coded expectation would
+/// either bake that in as if it were the sink's doing, or hide a real loss.
+fn encode_to_file() -> Option<(u64, usize)> {
+    let dir = std::env::temp_dir().join("avio-custom-io-tests");
+    std::fs::create_dir_all(&dir).ok()?;
+    let path = dir.join("control.mp4");
+    let _ = std::fs::remove_file(&path);
+    let mut encoder = VideoEncoder::create(&path)
+        .video(W, H, 30.0)
+        .video_codec(VideoCodec::H264)
+        .bitrate_mode(BitrateMode::Cbr(400_000))
+        .build()
+        .ok()?;
+    let f = frame()?;
+    for _ in 0..FRAMES {
+        encoder.push_video(&f).ok()?;
+    }
+    encoder.finish().ok()?;
+    let len = std::fs::metadata(&path).ok()?.len();
+    let mut decoder = ff_decode::VideoDecoder::open(&path).build().ok()?;
+    let mut frames = 0usize;
+    while let Ok(Some(_)) = decoder.decode_one() {
+        frames += 1;
+    }
+    let _ = std::fs::remove_file(&path);
+    Some((len, frames))
+}
+
+#[test]
+fn encoding_into_an_in_memory_sink_should_produce_a_decodable_stream() {
+    let sink = SharedSink::new();
+    if encode_into(sink.clone()).is_none() {
+        return; // no H.264 encoder / no MP4 muxer here
+    }
+
+    let Some((file_len, file_frames)) = encode_to_file() else {
+        return;
+    };
+
+    let bytes = sink.bytes();
+    // The real assertion: those bytes are a container a demuxer opens and
+    // decodes, and they are the same output the file route produces. That only
+    // holds if the seek callback let the muxer rewrite its header and the tail
+    // was flushed before teardown -- a truncated or never-seeked output fails
+    // here, where a "non-empty" check would not.
+    let mut decoder = ff_decode::VideoDecoder::from_reader(Cursor::new(bytes.clone()))
+        .build()
+        .expect("the sink's bytes must be a decodable stream");
+    let mut decoded = 0usize;
+    while let Ok(Some(_)) = decoder.decode_one() {
+        decoded += 1;
+    }
+    println!(
+        "sink: {} bytes / {decoded} frames | file: {file_len} bytes / {file_frames} frames",
+        bytes.len()
+    );
+    assert!(file_frames > 0, "the control must decode something");
+    assert_eq!(
+        bytes.len() as u64,
+        file_len,
+        "the sink must receive the same output the file route writes"
+    );
+    assert_eq!(
+        decoded, file_frames,
+        "the sink's stream must decode to the same frames as the file's"
+    );
+}
+
+#[test]
+fn a_sink_should_receive_the_whole_stream_not_just_its_head() {
+    // Guards the flush specifically. `avio_context_free` discards what is still
+    // buffered, and the buffer is 4 KiB, so an unflushed teardown loses the tail
+    // of a stream this size -- which the header rewrite alone would not reveal.
+    let sink = SharedSink::new();
+    if encode_into(sink.clone()).is_none() {
+        return;
+    }
+    let bytes = sink.bytes();
+    assert!(
+        bytes.len() > 1024,
+        "a 10-frame stream should be more than a header, got {} bytes",
+        bytes.len()
+    );
+    // `mdat` is the payload box; its presence means more than the header reached
+    // the sink.
+    assert!(
+        bytes.windows(4).any(|w| w == b"mdat"),
+        "the muxed payload must have reached the sink"
+    );
+}
+
+#[test]
+fn a_sink_and_faststart_should_be_rejected_at_build_time() {
+    // `movflags=+faststart` finalises by reopening the output for reading
+    // (`mov_write_trailer` -> `shift_data` -> `ff_format_shift_data`, which does
+    // `io_open(s, &read_pb, s->url, AVIO_FLAG_READ, ...)`). With a sink the bytes
+    // never reached `s->url`. Measured before this was rejected: with no file at
+    // that path `finish()` failed and left a moov-less stream in the sink; with an
+    // unrelated file of that name `finish()` returned **Ok** and that file's bytes
+    // were copied into the caller's sink. A silent-Ok corruption is exactly what a
+    // build-time rejection has to prevent.
+    let built = VideoEncoder::create("out.mp4")
+        .video(W, H, 30.0)
+        .video_codec(VideoCodec::H264)
+        .faststart()
+        .output_sink(SharedSink::new())
+        .build();
+    assert!(
+        built.is_err(),
+        "faststart with a caller-supplied sink must be rejected"
+    );
+}
+
+#[test]
+fn a_sink_and_a_self_managing_muxer_should_be_rejected() {
+    // An `AVFMT_NOFILE` muxer (an image2 sequence, selected by the '%' in the path)
+    // opens its own outputs per frame, so there is nowhere to attach a sink. The
+    // alternative to rejecting is accepting the sink and never writing to it.
+    //
+    // The control matters here: a `%03d.png` sequence fails to build in this
+    // configuration whether or not a sink is attached, so a test using it would pass
+    // without ever reaching this branch (it did, until mutation injection showed the
+    // branch could be deleted with everything still green).
+    let dir = std::env::temp_dir().join("avio-custom-io-tests");
+    let _ = std::fs::create_dir_all(&dir);
+    let pattern = dir.join("frame_%03d.mp4");
+
+    let control = VideoEncoder::create(&pattern)
+        .video(W, H, 30.0)
+        .video_codec(VideoCodec::H264)
+        .build();
+    if control.is_err() {
+        return; // this environment cannot build the sequence encoder at all
+    }
+    drop(control);
+
+    let built = VideoEncoder::create(&pattern)
+        .video(W, H, 30.0)
+        .video_codec(VideoCodec::H264)
+        .output_sink(SharedSink::new())
+        .build();
+    assert!(
+        built.is_err(),
+        "a self-managing muxer with a caller-supplied sink must be rejected"
+    );
+}
+
+#[test]
+fn a_sink_and_two_pass_should_be_rejected_at_build_time() {
+    // Pass 2 reopens the output, which a moved-in sink cannot serve. The failure
+    // has to be at build time; silently writing only the second pass would be a
+    // truncated file with no error.
+    let built = VideoEncoder::create("out.mp4")
+        .video(W, H, 30.0)
+        .video_codec(VideoCodec::H264)
+        .two_pass()
+        .output_sink(SharedSink::new())
+        .build();
+    assert!(
+        built.is_err(),
+        "two-pass with a caller-supplied sink must be rejected"
+    );
+}

--- a/crates/ff-sys/src/constants.rs
+++ b/crates/ff-sys/src/constants.rs
@@ -22,6 +22,14 @@ pub const AVFMT_TS_DISCONT: i32 = 0x0200;
 /// close one on drop.
 pub const AVFMT_NOFILE: i32 = 0x0001;
 
+/// `AVFMT_FLAG_CUSTOM_IO`: the caller supplied the context's `pb`, so libavformat
+/// must not `avio_close()` it.
+///
+/// Hand-defined because bindgen's `AV_.*` variable allowlist does not match
+/// `AVFMT_`, the same reason [`AVFMT_NOFILE`] is defined here. The value is from
+/// `libavformat/avformat.h`.
+pub const AVFMT_FLAG_CUSTOM_IO: i32 = 0x0080;
+
 /// `AV_BUFFERSRC_FLAG_KEEP_REF` normalized to `i32` for cross-platform use.
 ///
 /// bindgen generates `AV_BUFFERSRC_FLAG_KEEP_REF` as `u32` on Linux/macOS

--- a/crates/ff-sys/src/docsrs_stubs.rs
+++ b/crates/ff-sys/src/docsrs_stubs.rs
@@ -1449,6 +1449,14 @@ impl InputFormatContext {
         Err(crate::AvError::new(-1))
     }
 
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn open_custom(
+        _source: impl crate::IoSource + 'static,
+    ) -> Result<Self, crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
     #[must_use]
     pub fn nb_streams(&self) -> u32 {
         0
@@ -1588,6 +1596,15 @@ impl OutputFormatContext {
     /// # Errors
     /// Stub; never executed on docs.rs.
     pub fn open_io(&mut self, _path: &std::path::Path) -> Result<(), crate::AvError> {
+        Err(crate::AvError::new(-1))
+    }
+
+    /// # Errors
+    /// Stub; never executed on docs.rs.
+    pub fn set_custom_io(
+        &mut self,
+        _sink: impl crate::IoSink + 'static,
+    ) -> Result<(), crate::AvError> {
         Err(crate::AvError::new(-1))
     }
 

--- a/crates/ff-sys/src/format_context.rs
+++ b/crates/ff-sys/src/format_context.rs
@@ -22,6 +22,8 @@ use std::path::Path;
 use std::ptr::NonNull;
 use std::time::Duration;
 
+use crate::io_context::IoContext;
+use crate::io_traits::{IoSink, IoSource};
 use crate::{
     AV_DICT_IGNORE_SUFFIX, AV_INPUT_BUFFER_PADDING_SIZE, AV_TIME_BASE, AVChannelLayout, AVChapter,
     AVCodecID, AVCodecID_AV_CODEC_ID_BIN_DATA, AVCodecParameters, AVColorPrimaries, AVColorRange,
@@ -30,8 +32,9 @@ use crate::{
     Packet, av_dict_get as ffi_av_dict_get, av_dict_set as ffi_av_dict_set,
     av_interleaved_write_frame as ffi_av_interleaved_write_frame, av_mallocz as ffi_av_mallocz,
     av_opt_set as ffi_av_opt_set, avcodec_parameters_copy as ffi_avcodec_parameters_copy,
+    avformat_alloc_context as ffi_avformat_alloc_context,
     avformat_close_input as ffi_avformat_close_input,
-    avformat_new_stream as ffi_avformat_new_stream,
+    avformat_new_stream as ffi_avformat_new_stream, avformat_open_input as ffi_avformat_open_input,
 };
 
 /// Collects every entry of an `AVDictionary` into a map.
@@ -87,6 +90,19 @@ unsafe fn read_dict(dict: *const AVDictionary) -> HashMap<String, String> {
 #[derive(Debug)]
 pub struct InputFormatContext {
     ptr: NonNull<AVFormatContext>,
+    /// The custom `AVIOContext` this input reads through, when it was opened from
+    /// a Rust source rather than a path or URL.
+    ///
+    /// Declared after `ptr` on purpose: `Drop::drop` runs before any field is
+    /// dropped, so the format context is closed first and this is released after,
+    /// which is the only order in which the demuxer can never call back into a
+    /// freed source.
+    ///
+    /// Never read: holding it *is* its job. Unlike the output side, nothing has to
+    /// consult it, because `AVFMT_FLAG_CUSTOM_IO` already stops
+    /// `avformat_close_input` from touching the `pb`.
+    #[allow(dead_code)]
+    io: Option<IoContext>,
 }
 
 impl InputFormatContext {
@@ -135,12 +151,71 @@ impl InputFormatContext {
         Self::from_raw(ptr)
     }
 
+    /// Opens `source` as the input, demuxing through a custom `AVIOContext`
+    /// instead of a path or URL.
+    ///
+    /// The format is autodetected from the bytes the source yields, so the caller
+    /// does not name it. `source` is moved into the context and dropped with it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the context cannot be allocated or the source
+    /// does not yield a recognised media format.
+    pub fn open_custom(source: impl IoSource + 'static) -> Result<Self, AvError> {
+        crate::ensure_initialized();
+        let io = IoContext::reader(source)?;
+
+        // SAFETY: allocates a fresh demux context or returns null.
+        let ctx = unsafe { ffi_avformat_alloc_context() };
+        let ctx = NonNull::new(ctx).ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))?;
+
+        // SAFETY: `ctx` is the context just allocated and not yet shared. `pb` and
+        //         `flags` are plain fields. `avformat.h` prescribes exactly this for
+        //         custom IO: "preallocate the format context and set its pb field".
+        //
+        //         `AVFMT_FLAG_CUSTOM_IO` is what stops `avformat_close_input` from
+        //         closing a `pb` it does not own. Setting it here is belt and
+        //         braces: measured on this FFmpeg, `avformat_open_input` sets the
+        //         flag itself when it finds a `pb` already in place (with the line
+        //         below removed the opened context still reports 0x200080). That is
+        //         not something the header promises, and the flag's documented
+        //         meaning is exactly this situation, so it is stated rather than
+        //         assumed.
+        unsafe {
+            (*ctx.as_ptr()).pb = io.as_ptr();
+            (*ctx.as_ptr()).flags |= crate::constants::AVFMT_FLAG_CUSTOM_IO;
+        }
+
+        let mut raw = ctx.as_ptr();
+        // SAFETY: `raw` points at the context just allocated. A null url and format
+        //         let FFmpeg probe the custom `pb`. Per `avformat.h`, a user-supplied
+        //         context "will be freed on failure and its pointer set to NULL", so
+        //         the error path below must not free it again.
+        let ret = unsafe {
+            ffi_avformat_open_input(
+                &mut raw,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ret < 0 {
+            // FFmpeg freed the format context. `io` drops here, releasing the
+            // AVIOContext, its buffer and the source exactly once.
+            return Err(AvError::new(ret));
+        }
+
+        NonNull::new(raw)
+            .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
+            .map(|ptr| Self { ptr, io: Some(io) })
+    }
+
     /// Wraps a freshly opened, non-null context pointer in the owned type.
     fn from_raw(ptr: *mut AVFormatContext) -> Result<Self, AvError> {
         // The `open_*` wrappers return `Ok` only with a non-null context.
         NonNull::new(ptr)
             .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
-            .map(|ptr| Self { ptr })
+            .map(|ptr| Self { ptr, io: None })
     }
 
     /// Returns the number of streams in the container.
@@ -355,7 +430,9 @@ impl Drop for InputFormatContext {
         //         frees the context, writing null into our local copy of the
         //         pointer, which is then discarded. The raw binding is used
         //         directly so this type does not depend on the
-        //         `avformat::close_input` wrapper.
+        //         `avformat::close_input` wrapper. For a custom-IO input the
+        //         context carries `AVFMT_FLAG_CUSTOM_IO`, so this leaves `pb`
+        //         alone; the `io` field is dropped after this body and frees it.
         unsafe {
             let mut raw = self.ptr.as_ptr();
             ffi_avformat_close_input(&mut raw);
@@ -386,6 +463,12 @@ unsafe impl Send for InputFormatContext {}
 #[derive(Debug)]
 pub struct OutputFormatContext {
     ptr: NonNull<AVFormatContext>,
+    /// The custom `AVIOContext` this output writes through, when one was attached
+    /// with [`set_custom_io`](Self::set_custom_io).
+    ///
+    /// Its presence is what tells [`close_io`](Self::close_io) and `Drop` that the
+    /// `pb` is **not** one `avio_open` produced and must not be `avio_closep`-ed.
+    io: Option<IoContext>,
 }
 
 impl OutputFormatContext {
@@ -428,7 +511,7 @@ impl OutputFormatContext {
         }
         NonNull::new(ctx)
             .ok_or_else(|| AvError::new(crate::error_codes::ENOMEM))
-            .map(|ptr| Self { ptr })
+            .map(|ptr| Self { ptr, io: None })
     }
 
     /// Returns the number of streams registered on the context.
@@ -480,6 +563,40 @@ impl OutputFormatContext {
         Ok(())
     }
 
+    /// Attaches `sink` as the context's `pb`, so the muxer writes into a Rust
+    /// sink instead of a file.
+    ///
+    /// Use instead of [`open_io`](Self::open_io). Calling it after `open_io` is
+    /// not a leak -- the file's `pb` is closed first -- but it is not a useful
+    /// thing to do. Callers must still skip both for
+    /// [`is_nofile`](Self::is_nofile) muxers, which manage their own IO.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AvError`] if the `AVIOContext` cannot be allocated.
+    pub fn set_custom_io(&mut self, sink: impl IoSink + 'static) -> Result<(), AvError> {
+        let io = IoContext::writer(sink)?;
+        // SAFETY: `self.ptr` is a valid owned mux context; `pb` and `flags` are
+        //         plain fields. A `pb` already in place is closed first: if it came
+        //         from `open_io` it is an `avio_open` context nothing else would
+        //         ever release (`Drop` takes the custom-IO branch once `io` is set),
+        //         so overwriting it would leak the context and its file handle.
+        //         `close_output` null-checks and nulls `pb`, and `self.io` is `None`
+        //         on that path, so nothing is freed twice.
+        //         `AVFMT_FLAG_CUSTOM_IO` marks the `pb` as one the caller owns,
+        //         which is also what `close_io` and `Drop` read off the `io` field
+        //         below to decide not to `avio_closep` it.
+        unsafe {
+            if self.io.is_none() && !(*self.ptr.as_ptr()).pb.is_null() {
+                crate::avformat::close_output(&mut (*self.ptr.as_ptr()).pb);
+            }
+            (*self.ptr.as_ptr()).pb = io.as_ptr();
+            (*self.ptr.as_ptr()).flags |= crate::constants::AVFMT_FLAG_CUSTOM_IO;
+        }
+        self.io = Some(io);
+        Ok(())
+    }
+
     /// Writes the container header.
     ///
     /// # Errors
@@ -516,7 +633,19 @@ impl OutputFormatContext {
     /// after the header write so the muxer can manage its own segment files. The
     /// close nulls `pb`, so a later drop does not double-close. This is a no-op
     /// when `pb` is already null.
+    /// A custom `pb` ([`set_custom_io`](Self::set_custom_io)) is released rather
+    /// than closed: `avio_closep` would free a context this type does not own that
+    /// way, so the owned context is dropped instead, which frees the AVIO context,
+    /// its buffer and the sink exactly once.
     pub fn close_io(&mut self) {
+        if let Some(io) = self.io.take() {
+            // SAFETY: `self.ptr` is a valid owned mux context; `pb` is a plain
+            //         field. It is nulled before `io` is dropped so the context
+            //         never holds a dangling `pb`.
+            unsafe { (*self.ptr.as_ptr()).pb = std::ptr::null_mut() };
+            drop(io);
+            return;
+        }
         // SAFETY: `self.ptr` is a valid owned mux context; `close_output`
         //         null-checks `pb` and nulls it after closing.
         unsafe { crate::avformat::close_output(&mut (*self.ptr.as_ptr()).pb) };
@@ -850,17 +979,24 @@ pub struct ChapterSpec<'a> {
 impl Drop for OutputFormatContext {
     fn drop(&mut self) {
         // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
-        //         runs exactly once. Close the caller-opened `pb` if one is still
-        //         open (it is null for `AVFMT_NOFILE` muxers, where the caller
-        //         opened none, and after `close_io`), then free the context. A
-        //         non-null `pb` is always one the caller opened and owns, so it
-        //         must be closed regardless of the muxer flags — mirroring the
-        //         manual `if pb != null { avio_closep }` teardown this replaces.
+        //         runs exactly once. A non-null `pb` is one of two things, and they
+        //         are released differently:
+        //
+        //         - one `open_io` opened with `avio_open`, which must be
+        //           `avio_closep`-ed. It is null for `AVFMT_NOFILE` muxers, where
+        //           the caller opened none, and after `close_io`.
+        //         - one `set_custom_io` attached, owned by the `io` field. Closing
+        //           that with `avio_closep` would free a context `IoContext` also
+        //           frees, so it is nulled here and released when `io` drops right
+        //           after this body.
+        //
         //         `close_output` null-checks and nulls `pb`; `avformat_free_context`
-        //         does not touch `pb`.
+        //         does not touch `pb` either way.
         unsafe {
             let ctx = self.ptr.as_ptr();
-            if !(*ctx).pb.is_null() {
+            if self.io.is_some() {
+                (*ctx).pb = std::ptr::null_mut();
+            } else if !(*ctx).pb.is_null() {
                 crate::avformat::close_output(&mut (*ctx).pb);
             }
             crate::avformat_free_context(ctx);
@@ -1136,6 +1272,67 @@ mod tests {
         // context (the error path returns before any owned value is built).
         let result = InputFormatContext::open(Path::new("/nonexistent/path/to/file.mp4"));
         assert!(result.is_err());
+    }
+
+    /// The asset used by the custom-IO tests, or `None` when it is unavailable.
+    fn custom_io_fixture() -> Option<Vec<u8>> {
+        let path = std::path::PathBuf::from(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../assets/audio/konekonoosanpo.mp3"
+        ));
+        std::fs::read(path).ok()
+    }
+
+    #[test]
+    fn open_custom_should_mark_the_context_as_custom_io() {
+        // Pins the end state rather than the line that produces it: measured,
+        // `avformat_open_input` also sets this flag when it finds a `pb` already in
+        // place, so removing the explicit set does not change the result here. What
+        // the assertion is worth is catching a future where neither does it, since
+        // the consequence -- `avformat_close_input` closing a `pb` this type also
+        // frees -- is a double free that does not reliably crash.
+        let Some(bytes) = custom_io_fixture() else {
+            return; // fixture missing
+        };
+        let Ok(ctx) = InputFormatContext::open_custom(std::io::Cursor::new(bytes)) else {
+            return; // demuxer absent (CI's minimal FFmpeg) -- nothing to exercise
+        };
+        // SAFETY: `ctx` owns a valid demux context; `flags` is a plain field.
+        let flags = unsafe { (*ctx.ptr.as_ptr()).flags };
+        assert_ne!(
+            flags & crate::constants::AVFMT_FLAG_CUSTOM_IO,
+            0,
+            "a custom-IO input must carry AVFMT_FLAG_CUSTOM_IO"
+        );
+    }
+
+    #[test]
+    fn open_custom_should_reject_bytes_that_are_not_a_container() {
+        // The error path has to release the AVIO context and the source without a
+        // format context to hang them on; this drives it.
+        let result = InputFormatContext::open_custom(std::io::Cursor::new(vec![0u8; 512]));
+        assert!(result.is_err(), "512 zero bytes are not a media container");
+    }
+
+    #[test]
+    fn set_custom_io_should_mark_the_context_as_custom_io() {
+        // Mirror of the input case: the output `Drop` reads the `io` field rather
+        // than the flag, but the flag is what libavformat itself keys on, so both
+        // have to be set.
+        let Ok(mut ctx) = OutputFormatContext::new(None, Path::new("out.mp4")) else {
+            return; // mp4 muxer absent
+        };
+        if ctx.set_custom_io(std::io::Cursor::new(Vec::new())).is_err() {
+            return;
+        }
+        // SAFETY: `ctx` owns a valid mux context; `flags` is a plain field.
+        let flags = unsafe { (*ctx.ptr.as_ptr()).flags };
+        assert_ne!(
+            flags & crate::constants::AVFMT_FLAG_CUSTOM_IO,
+            0,
+            "a custom-IO output must carry AVFMT_FLAG_CUSTOM_IO"
+        );
+        assert!(ctx.io.is_some(), "the sink must be owned by the context");
     }
 
     #[test]

--- a/crates/ff-sys/src/io_context.rs
+++ b/crates/ff-sys/src/io_context.rs
@@ -1,0 +1,695 @@
+//! RAII owner for a custom `AVIOContext` backed by a Rust [`IoSource`] or
+//! [`IoSink`].
+//!
+//! [`IoContext`] allocates the context and its buffer, keeps the boxed Rust
+//! reader/writer alive for exactly as long as FFmpeg may call back into it, and
+//! frees all three exactly once on drop. It is `pub(crate)`: callers reach it
+//! through [`InputFormatContext::open_custom`](crate::InputFormatContext::open_custom)
+//! and [`OutputFormatContext::set_custom_io`](crate::OutputFormatContext::set_custom_io),
+//! so no public signature mentions an `AVIOContext` at all.
+//!
+//! # Ownership contract
+//!
+//! From `libavformat/avio.h`, which is the authority here rather than any prose
+//! elsewhere:
+//!
+//! - the buffer must come from `av_malloc`;
+//! - libavformat **may free it and install a different one**, so the buffer to
+//!   release on teardown is whatever `AVIOContext.buffer` points at then, not the
+//!   pointer originally passed in;
+//! - the context itself is released by `avio_context_free`, which does not touch
+//!   the buffer.
+//!
+//! Hence the drop order: free `ctx->buffer`, free the context, then drop the
+//! boxed Rust state.
+
+use std::ffi::c_void;
+use std::io::{ErrorKind, SeekFrom};
+use std::os::raw::{c_int, c_uchar};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::ptr::NonNull;
+
+use crate::io_traits::{IoSink, IoSource};
+use crate::{AVIOContext, AvError, av_freep as ffi_av_freep, av_malloc as ffi_av_malloc};
+
+// Declared here rather than taken from bindgen: the generator's allowlist covers
+// `av_*` / `avformat_*` / `avcodec_*` and friends, none of which match `avio_*`,
+// so no `avio_` function reaches the generated bindings. This mirrors the
+// existing `avio_open` / `avio_closep` declarations in `avformat.rs`.
+//
+// The three callback types are pinned to the ones `AVIOContext` itself declares
+// by `assert_callback_abi` below.
+unsafe extern "C" {
+    fn avio_alloc_context(
+        buffer: *mut c_uchar,
+        buffer_size: c_int,
+        write_flag: c_int,
+        opaque: *mut c_void,
+        read_packet: Option<unsafe extern "C" fn(*mut c_void, *mut u8, c_int) -> c_int>,
+        write_packet: Option<unsafe extern "C" fn(*mut c_void, *const u8, c_int) -> c_int>,
+        seek: Option<unsafe extern "C" fn(*mut c_void, i64, c_int) -> i64>,
+    ) -> *mut AVIOContext;
+    fn avio_context_free(s: *mut *mut AVIOContext);
+}
+
+/// Fails to compile if the hand-declared callback types stop matching the ones
+/// bindgen generated for `AVIOContext`.
+///
+/// A hand-written FFI signature that disagrees with the C ABI produces no
+/// diagnostic and no test failure -- it corrupts the stack at the call. Neither a
+/// Windows development machine nor the `DOCS_RS` job (which compiles against
+/// stubs) would show it, so the check has to be a compile-time one, here, against
+/// the generated struct.
+#[allow(dead_code)]
+fn assert_callback_abi(ctx: &AVIOContext) {
+    let _: Option<unsafe extern "C" fn(*mut c_void, *mut u8, c_int) -> c_int> = ctx.read_packet;
+    let _: Option<unsafe extern "C" fn(*mut c_void, *const u8, c_int) -> c_int> = ctx.write_packet;
+    let _: Option<unsafe extern "C" fn(*mut c_void, i64, c_int) -> i64> = ctx.seek;
+}
+
+/// Buffer size handed to `avio_alloc_context`.
+///
+/// `avio.h` recommends a protocol's block size, or a cache page for everything
+/// else. There is no block size to match here, so it is a page.
+const BUFFER_SIZE: usize = 4096;
+
+/// `AVSEEK_SIZE`: the demuxer is asking for the stream's total length rather than
+/// seeking. Present in the bindings; named here for readability alongside
+/// [`AVSEEK_FORCE`].
+const AVSEEK_SIZE: c_int = crate::AVSEEK_SIZE as c_int;
+
+/// `AVSEEK_FORCE`: a hint OR-ed into `whence`, not a position. It has to be
+/// masked off before the remaining bits are read as a `SeekFrom`.
+const AVSEEK_FORCE: c_int = 0x2_0000;
+
+/// The Rust end of the callbacks, owned by an [`IoContext`].
+enum IoState {
+    Read(Box<dyn IoSource>),
+    Write(Box<dyn IoSink>),
+}
+
+/// An owned custom `AVIOContext` and the Rust reader or writer behind it.
+pub(crate) struct IoContext {
+    ptr: NonNull<AVIOContext>,
+    /// The boxed state, held as a raw pointer rather than a live `Box` because
+    /// FFmpeg holds the same address in `opaque` for as long as this type lives.
+    /// Keeping it raw means no Rust reference to it exists between callbacks.
+    state: NonNull<IoState>,
+}
+
+impl IoContext {
+    /// Wraps `source` as a readable `AVIOContext`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ENOMEM` if the buffer or the context cannot be allocated.
+    pub(crate) fn reader(source: impl IoSource + 'static) -> Result<Self, AvError> {
+        Self::alloc(IoState::Read(Box::new(source)), 0)
+    }
+
+    /// Wraps `sink` as a writable `AVIOContext`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ENOMEM` if the buffer or the context cannot be allocated.
+    pub(crate) fn writer(sink: impl IoSink + 'static) -> Result<Self, AvError> {
+        Self::alloc(IoState::Write(Box::new(sink)), 1)
+    }
+
+    /// The raw context, for attaching to a format context's `pb`.
+    pub(crate) fn as_ptr(&self) -> *mut AVIOContext {
+        self.ptr.as_ptr()
+    }
+
+    /// Allocates the buffer and the context around an already-boxed state.
+    fn alloc(state: IoState, write_flag: c_int) -> Result<Self, AvError> {
+        crate::ensure_initialized();
+
+        // SAFETY: a plain allocation; the size is a compile-time constant. FFmpeg
+        //         requires the buffer to come from `av_malloc` specifically, so
+        //         this cannot be a Rust allocation.
+        let buffer = unsafe { alloc_buffer() };
+        let Some(buffer) = NonNull::new(buffer) else {
+            return Err(AvError::new(crate::error_codes::ENOMEM));
+        };
+
+        let state = NonNull::from(Box::leak(Box::new(state)));
+        let (read, write) = match write_flag {
+            0 => (
+                Some(read_packet as unsafe extern "C" fn(*mut c_void, *mut u8, c_int) -> c_int),
+                None,
+            ),
+            _ => (
+                None,
+                Some(write_packet as unsafe extern "C" fn(*mut c_void, *const u8, c_int) -> c_int),
+            ),
+        };
+
+        // SAFETY: `buffer` is a live `av_malloc` allocation of `BUFFER_SIZE`, which
+        //         FFmpeg takes over. `state` is a leaked box, so the address stays
+        //         valid until this type's `Drop` reclaims it, which is strictly
+        //         after the context is freed and therefore after the last callback.
+        //         The callback signatures match `AVIOContext`'s own (checked by
+        //         `assert_callback_abi`).
+        let ptr = unsafe {
+            avio_alloc_context(
+                buffer.as_ptr(),
+                c_int::try_from(BUFFER_SIZE).unwrap_or(c_int::MAX),
+                write_flag,
+                state.as_ptr().cast::<c_void>(),
+                read,
+                write,
+                Some(seek),
+            )
+        };
+
+        match NonNull::new(ptr) {
+            Some(ptr) => Ok(Self { ptr, state }),
+            None => {
+                // The context was not created, so nothing took ownership of either
+                // allocation: release both here rather than leaking on the error
+                // path.
+                // SAFETY: `buffer` is still the `av_malloc` allocation nothing else
+                //         holds, and `state` is the box just leaked above.
+                unsafe {
+                    let mut raw = buffer.as_ptr().cast::<c_void>();
+                    ffi_av_freep(std::ptr::addr_of_mut!(raw).cast::<c_void>());
+                    drop(Box::from_raw(state.as_ptr()));
+                }
+                Err(AvError::new(crate::error_codes::ENOMEM))
+            }
+        }
+    }
+}
+
+/// `av_malloc(BUFFER_SIZE)` as a `*mut c_uchar`.
+///
+/// Deliberately *not* zeroing: `read_packet` zeroes what it is about to hand a
+/// `Read` impl anyway, and that has to cover buffers libavformat swaps in later,
+/// which this never sees.
+///
+/// # Safety
+///
+/// Always safe to call; the result must be released with `av_free` / `av_freep`
+/// unless ownership passes to FFmpeg.
+unsafe fn alloc_buffer() -> *mut c_uchar {
+    // SAFETY: `av_malloc` accepts any size and returns null on failure, which the
+    //         caller checks.
+    unsafe { ffi_av_malloc(BUFFER_SIZE).cast::<c_uchar>() }
+}
+
+impl std::fmt::Debug for IoContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The source/sink is caller-supplied and carries no `Debug` bound, and
+        // reading the direction would mean dereferencing `state` from a formatter.
+        // The owning format contexts derive `Debug`, so this only has to exist.
+        f.debug_struct("IoContext").finish_non_exhaustive()
+    }
+}
+
+impl Drop for IoContext {
+    fn drop(&mut self) {
+        // No `avio_flush` here. It looked necessary -- `avio_context_free` discards
+        // whatever is still buffered, and `avio.h` does not say `av_write_trailer`
+        // flushes the `pb` -- but it is not: with the flush removed, muxing a
+        // 9923-byte stream through the 4 KiB buffer produced byte-identical output
+        // (300 frames, sink and file routes alike), so the trailer path already
+        // drains it. Re-add it only with a case that shows a difference.
+        //
+        // SAFETY: we uniquely own the context (NonNull, not Copy/Clone), so this
+        //         runs exactly once. The buffer freed is `ctx->buffer` rather than
+        //         the pointer originally passed in, because libavformat may have
+        //         replaced it (`avio.h`); `avio_context_free` does not free it. The
+        //         boxed state is reclaimed last, after the context that could still
+        //         have called into it is gone.
+        unsafe {
+            let ctx = self.ptr.as_ptr();
+            ffi_av_freep(std::ptr::addr_of_mut!((*ctx).buffer).cast::<c_void>());
+            let mut raw = ctx;
+            avio_context_free(std::ptr::addr_of_mut!(raw));
+            drop(Box::from_raw(self.state.as_ptr()));
+        }
+    }
+}
+
+// SAFETY: an `AVIOContext` is not safe for concurrent access, but moving
+//         ownership between threads is sound because Rust's ownership model
+//         guarantees exclusive access, and the boxed source/sink is itself
+//         `Send` by the trait bound.
+unsafe impl Send for IoContext {}
+
+/// Runs `f` with the state behind `opaque`, mapping a panic to `EIO`.
+///
+/// # Safety
+///
+/// `opaque` must be null or the `IoState` pointer an [`IoContext`] leaked for
+/// this context, still alive because `Drop` reclaims it only after the context is
+/// freed.
+///
+/// Every callback goes through here. A panic that reached the `extern "C"`
+/// boundary would abort the process, so it is caught and reported as an I/O
+/// error instead -- FFmpeg then fails the read or write the way it would for any
+/// other failing source.
+unsafe fn with_state<T>(opaque: *mut c_void, err: T, f: impl FnOnce(&mut IoState) -> T) -> T {
+    if opaque.is_null() {
+        return err;
+    }
+    // SAFETY: `opaque` is the leaked `IoState` box this context was built with,
+    //         still alive because `Drop` reclaims it only after the context is
+    //         freed. FFmpeg calls back serially on the thread that owns the
+    //         context, so this is the only reference in existence.
+    let state = unsafe { &mut *opaque.cast::<IoState>() };
+    catch_unwind(AssertUnwindSafe(|| f(state))).unwrap_or(err)
+}
+
+/// `read_packet`: fill `buf` from the Rust source.
+///
+/// Returns `AVERROR_EOF` rather than 0 at end of stream, which `avio.h` requires.
+///
+/// # Safety
+///
+/// `opaque` must be the `IoState` pointer this context was built with, and `buf`
+/// must point at `buf_size` writable bytes. FFmpeg upholds both for the callbacks
+/// it was handed.
+unsafe extern "C" fn read_packet(opaque: *mut c_void, buf: *mut u8, buf_size: c_int) -> c_int {
+    let eio = crate::error_codes::EIO;
+    if buf.is_null() || buf_size <= 0 {
+        return crate::error_codes::EINVAL;
+    }
+    let len = buf_size as usize;
+    // SAFETY: `buf` is writable for `len` (FFmpeg's contract). Zeroing first is not
+    //         defensive padding: the buffer came from `av_malloc`, and any replacement
+    //         libavformat installs is `av_malloc`/`av_realloc` too, so it is
+    //         uninitialized. `Read::read` is safe code that is permitted to read from
+    //         the slice it is handed, and a `&mut [u8]` over uninitialized memory is
+    //         not a valid reference. The memset is one page per refill, against an
+    //         actual I/O.
+    unsafe { std::ptr::write_bytes(buf, 0, len) };
+    // SAFETY: `buf` is writable for `len` and now initialized.
+    let out = unsafe { std::slice::from_raw_parts_mut(buf, len) };
+    // SAFETY: `opaque` is this context's state; see `with_state`.
+    unsafe {
+        with_state(opaque, eio, |state| {
+            let IoState::Read(source) = state else {
+                return eio;
+            };
+            loop {
+                match source.read(out) {
+                    Ok(0) => return crate::error_codes::EOF,
+                    // `Read` is a safe trait: an implementation may report more bytes
+                    // than it was given without any `unsafe` of its own. Passing that
+                    // on would move FFmpeg's `buf_end` past the allocation
+                    // (`fill_buffer` does `buf_end = dst + len`), so it is rejected
+                    // here rather than trusted.
+                    Ok(n) if n > len => return eio,
+                    Ok(n) => return c_int::try_from(n).unwrap_or(eio),
+                    // Retry rather than report zero bytes: `avio.h` says this callback
+                    // "must never return 0 but rather a proper AVERROR code", and
+                    // `read_packet_wrapper` asserts it. Retrying is what `Read::read_exact`
+                    // does with the same error.
+                    Err(e) if e.kind() == ErrorKind::Interrupted => {}
+                    Err(_) => return eio,
+                }
+            }
+        })
+    }
+}
+
+/// `write_packet`: drain `buf` into the Rust sink.
+///
+/// # Safety
+///
+/// `opaque` must be the `IoState` pointer this context was built with, and `buf`
+/// must point at `buf_size` readable bytes that stay unchanged for the call.
+unsafe extern "C" fn write_packet(opaque: *mut c_void, buf: *const u8, buf_size: c_int) -> c_int {
+    let eio = crate::error_codes::EIO;
+    if buf.is_null() || buf_size < 0 {
+        return crate::error_codes::EINVAL;
+    }
+    // SAFETY: FFmpeg guarantees `buf` points at `buf_size` readable bytes and does
+    //         not change them for the duration of the call.
+    let data = unsafe { std::slice::from_raw_parts(buf, buf_size as usize) };
+    // SAFETY: `opaque` is this context's state; see `with_state`.
+    unsafe {
+        with_state(opaque, eio, |state| {
+            let IoState::Write(sink) = state else {
+                return eio;
+            };
+            match sink.write_all(data) {
+                Ok(()) => buf_size,
+                Err(_) => eio,
+            }
+        })
+    }
+}
+
+/// `seek`: reposition the Rust source or sink, or answer `AVSEEK_SIZE`.
+///
+/// # Safety
+///
+/// `opaque` must be the `IoState` pointer this context was built with.
+unsafe extern "C" fn seek(opaque: *mut c_void, offset: i64, whence: c_int) -> i64 {
+    let eio = i64::from(crate::error_codes::EIO);
+    // SAFETY: `opaque` is this context's state; see `with_state`.
+    unsafe {
+        with_state(opaque, eio, |state| {
+            // `AVSEEK_FORCE` is a hint OR-ed onto `whence`, not a position.
+            let whence = whence & !AVSEEK_FORCE;
+            if whence == AVSEEK_SIZE {
+                return stream_len(state).map_or(eio, |len| len);
+            }
+            let pos = match whence {
+                // A negative absolute position is not a seek that can be performed.
+                // Answering it with 0 would be a *different*, valid seek.
+                0 => match u64::try_from(offset) {
+                    Ok(pos) => SeekFrom::Start(pos),
+                    Err(_) => return i64::from(crate::error_codes::EINVAL),
+                },
+                1 => SeekFrom::Current(offset),
+                2 => SeekFrom::End(offset),
+                _ => return i64::from(crate::error_codes::EINVAL),
+            };
+            let seeked = match state {
+                IoState::Read(source) => source.seek(pos),
+                IoState::Write(sink) => sink.seek(pos),
+            };
+            seeked.map_or(eio, |p| i64::try_from(p).unwrap_or(eio))
+        })
+    }
+}
+
+/// The total length of the stream, leaving the position where it was.
+///
+/// Answering `AVSEEK_SIZE` rather than failing it lets a demuxer size the
+/// container up front instead of probing towards the end.
+fn stream_len(state: &mut IoState) -> Option<i64> {
+    fn measure(
+        current: std::io::Result<u64>,
+        mut seek: impl FnMut(SeekFrom) -> std::io::Result<u64>,
+    ) -> Option<i64> {
+        let here = current.ok()?;
+        let end = seek(SeekFrom::End(0)).ok()?;
+        seek(SeekFrom::Start(here)).ok()?;
+        i64::try_from(end).ok()
+    }
+    match state {
+        IoState::Read(source) => {
+            let here = source.stream_position();
+            measure(here, |p| source.seek(p))
+        }
+        IoState::Write(sink) => {
+            let here = sink.stream_position();
+            measure(here, |p| sink.seek(p))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! What these tests cannot cover.
+    //!
+    //! `Drop` frees `ctx->buffer` **before** `avio_context_free`, because
+    //! libavformat may have replaced the buffer and the context free does not
+    //! touch it. Swapping those two lines is a use-after-free that no assertion
+    //! here detects: reading freed memory does not reliably fault, and `miri`
+    //! cannot run the FFI. The same is true of the explicit
+    //! `AVFMT_FLAG_CUSTOM_IO` set on the input side, which this FFmpeg happens to
+    //! perform itself. Both were confirmed uncaught by mutation injection. Their
+    //! justification is the contract in `avio.h` / `avformat.h`, not a green test,
+    //! and a passing suite here should not be read as covering them.
+
+    use std::io::Cursor;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::{AVSEEK_FORCE, AVSEEK_SIZE, IoContext, read_packet, seek, write_packet};
+
+    /// A cursor that records its own drop, so "freed exactly once" is a count and
+    /// not a judgement.
+    struct CountingSource {
+        inner: Cursor<Vec<u8>>,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl std::io::Read for CountingSource {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.inner.read(buf)
+        }
+    }
+
+    impl std::io::Seek for CountingSource {
+        fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    impl Drop for CountingSource {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// A source whose every read panics, to prove the panic never reaches FFmpeg.
+    struct PanickingSource;
+
+    impl std::io::Read for PanickingSource {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            panic!("the source panicked");
+        }
+    }
+
+    impl std::io::Seek for PanickingSource {
+        fn seek(&mut self, _pos: std::io::SeekFrom) -> std::io::Result<u64> {
+            Ok(0)
+        }
+    }
+
+    #[test]
+    fn dropping_the_context_should_drop_the_source_exactly_once() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let source = CountingSource {
+            inner: Cursor::new(vec![1u8, 2, 3, 4]),
+            drops: Arc::clone(&drops),
+        };
+        let ctx = IoContext::reader(source).expect("allocation should succeed");
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            0,
+            "still owned by the context"
+        );
+        drop(ctx);
+        assert_eq!(
+            drops.load(Ordering::SeqCst),
+            1,
+            "the source must be dropped exactly once with the context"
+        );
+    }
+
+    #[test]
+    fn dropping_a_writer_context_should_drop_the_sink_exactly_once() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        struct CountingSink(Arc<AtomicUsize>, Cursor<Vec<u8>>);
+        impl std::io::Write for CountingSink {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.1.write(buf)
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl std::io::Seek for CountingSink {
+            fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+                self.1.seek(pos)
+            }
+        }
+        impl Drop for CountingSink {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        let ctx = IoContext::writer(CountingSink(Arc::clone(&drops), Cursor::new(Vec::new())))
+            .expect("allocation should succeed");
+        drop(ctx);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn read_packet_should_report_eof_rather_than_zero() {
+        // `avio.h` requires an AVERROR at end of stream; a 0 return is read as a
+        // retry by stream protocols and loops.
+        let ctx = IoContext::reader(Cursor::new(vec![7u8, 8])).expect("allocation");
+        let mut buf = [0u8; 8];
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `buf` is writable for its length; `opaque` is this context's state.
+        let first = unsafe { read_packet(opaque, buf.as_mut_ptr(), 8) };
+        assert_eq!(first, 2, "the whole source is two bytes");
+        assert_eq!(&buf[..2], &[7, 8]);
+        // SAFETY: as above; the source is now exhausted.
+        let second = unsafe { read_packet(opaque, buf.as_mut_ptr(), 8) };
+        assert_eq!(
+            second,
+            crate::error_codes::EOF,
+            "a drained source must report AVERROR_EOF, not 0"
+        );
+    }
+
+    /// A source that reports more bytes than it was handed, without any `unsafe`
+    /// of its own -- which `Read` permits, since it is a safe trait.
+    struct OverreportingSource;
+
+    impl std::io::Read for OverreportingSource {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            Ok(buf.len() + 4096)
+        }
+    }
+
+    impl std::io::Seek for OverreportingSource {
+        fn seek(&mut self, _pos: std::io::SeekFrom) -> std::io::Result<u64> {
+            Ok(0)
+        }
+    }
+
+    /// A source that reports `Interrupted` once and then reads normally.
+    struct InterruptOnceSource {
+        interrupted: bool,
+        inner: Cursor<Vec<u8>>,
+    }
+
+    impl std::io::Read for InterruptOnceSource {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if !self.interrupted {
+                self.interrupted = true;
+                return Err(std::io::Error::from(std::io::ErrorKind::Interrupted));
+            }
+            self.inner.read(buf)
+        }
+    }
+
+    impl std::io::Seek for InterruptOnceSource {
+        fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    #[test]
+    fn read_packet_should_reject_a_source_that_reports_more_than_it_was_given() {
+        // `Read` is a safe trait, so an implementation can report a length it never
+        // wrote without writing any `unsafe`. Forwarding that would move FFmpeg's
+        // `buf_end` past the allocation (`fill_buffer` does `buf_end = dst + len`),
+        // turning safe caller code into an out-of-bounds read.
+        let ctx = IoContext::reader(OverreportingSource).expect("allocation");
+        let mut buf = [0u8; 8];
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `buf` is writable for its length; `opaque` is this context's state.
+        let ret = unsafe { read_packet(opaque, buf.as_mut_ptr(), 8) };
+        assert_eq!(
+            ret,
+            crate::error_codes::EIO,
+            "an over-reported length must be refused, not passed to FFmpeg"
+        );
+    }
+
+    #[test]
+    fn read_packet_should_retry_an_interrupted_read_rather_than_report_zero() {
+        // `avio.h`: this callback "must never return 0 but rather a proper AVERROR
+        // code", and `read_packet_wrapper` asserts it. Returning 0 for a retryable
+        // interrupt reads as a short read, i.e. a silently truncated demux.
+        let source = InterruptOnceSource {
+            interrupted: false,
+            inner: Cursor::new(vec![5u8, 6, 7]),
+        };
+        let ctx = IoContext::reader(source).expect("allocation");
+        let mut buf = [0u8; 8];
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `buf` is writable for its length; `opaque` is this context's state.
+        let ret = unsafe { read_packet(opaque, buf.as_mut_ptr(), 8) };
+        assert_eq!(ret, 3, "the interrupt must be retried, not reported");
+        assert_eq!(&buf[..3], &[5, 6, 7]);
+    }
+
+    #[test]
+    fn seek_should_reject_a_negative_absolute_position() {
+        // Answering an impossible seek with position 0 would be a different, valid
+        // seek -- a silently wrong answer where an error is available.
+        let ctx = IoContext::reader(Cursor::new(vec![0u8; 16])).expect("allocation");
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `opaque` is this context's state.
+        let ret = unsafe { seek(opaque, -8, 0) };
+        assert_eq!(ret, i64::from(crate::error_codes::EINVAL));
+    }
+
+    #[test]
+    fn a_panicking_source_should_return_an_error_instead_of_unwinding() {
+        let ctx = IoContext::reader(PanickingSource).expect("allocation");
+        let mut buf = [0u8; 4];
+        // SAFETY: the context is alive; `buf` is writable for its length.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: as above. The panic inside must be caught by `with_state`; if it
+        //         were not, this test would abort the process rather than fail.
+        let ret = unsafe { read_packet(opaque, buf.as_mut_ptr(), 4) };
+        assert_eq!(
+            ret,
+            crate::error_codes::EIO,
+            "a panicking source must surface as EIO"
+        );
+    }
+
+    #[test]
+    fn seek_should_answer_avseek_size_without_moving_the_position() {
+        let ctx = IoContext::reader(Cursor::new(vec![0u8; 40])).expect("allocation");
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `opaque` is this context's state.
+        let moved = unsafe { seek(opaque, 10, 0) };
+        assert_eq!(moved, 10);
+        // SAFETY: as above.
+        let size = unsafe { seek(opaque, 0, AVSEEK_SIZE) };
+        assert_eq!(size, 40, "AVSEEK_SIZE must report the stream length");
+        // SAFETY: as above.
+        let still_there = unsafe { seek(opaque, 0, 1) };
+        assert_eq!(
+            still_there, 10,
+            "answering AVSEEK_SIZE must leave the position untouched"
+        );
+    }
+
+    #[test]
+    fn seek_should_mask_avseek_force_off_the_whence() {
+        // `AVSEEK_FORCE` is a hint OR-ed onto the whence. Reading it as part of the
+        // position would make every forced seek an EINVAL.
+        let ctx = IoContext::reader(Cursor::new(vec![0u8; 16])).expect("allocation");
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `opaque` is this context's state.
+        let forced = unsafe { seek(opaque, 4, AVSEEK_FORCE) };
+        assert_eq!(forced, 4, "SEEK_SET | AVSEEK_FORCE must still seek");
+    }
+
+    #[test]
+    fn write_packet_should_forward_bytes_to_the_sink() {
+        let ctx = IoContext::writer(Cursor::new(Vec::new())).expect("allocation");
+        let data = [1u8, 2, 3];
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `data` is readable for its length; `opaque` is this context's state.
+        let written = unsafe { write_packet(opaque, data.as_ptr(), 3) };
+        assert_eq!(written, 3);
+    }
+
+    #[test]
+    fn a_reader_context_should_reject_a_write() {
+        // The two states are distinct, so a mis-wired context reports an error
+        // rather than writing into a source.
+        let ctx = IoContext::reader(Cursor::new(vec![0u8; 4])).expect("allocation");
+        let data = [1u8];
+        // SAFETY: the context is alive and owns the state `opaque` points at.
+        let opaque = unsafe { (*ctx.as_ptr()).opaque };
+        // SAFETY: `data` is readable for its length; `opaque` is this context's state.
+        let ret = unsafe { write_packet(opaque, data.as_ptr(), 1) };
+        assert_eq!(ret, crate::error_codes::EIO);
+    }
+}

--- a/crates/ff-sys/src/io_traits.rs
+++ b/crates/ff-sys/src/io_traits.rs
@@ -1,0 +1,26 @@
+//! The Rust side of a custom `AVIOContext`: what a caller may hand FFmpeg as a
+//! byte source or sink.
+//!
+//! Both traits are blanket-implemented, so a caller passes a plain
+//! `std::io::Cursor`, `File`, or anything else meeting the bounds; they exist
+//! only so the boxed form has a name to be stored under.
+//!
+//! `Seek` is required rather than optional. FFmpeg accepts a null seek callback,
+//! but a demuxer that cannot seek behaves differently enough (probing, and the
+//! containers it can open at all) that supporting it is its own piece of work.
+//!
+//! `Send` is required because [`InputFormatContext`](crate::InputFormatContext)
+//! and [`OutputFormatContext`](crate::OutputFormatContext) are `Send`: the source
+//! travels with the context it is attached to.
+
+use std::io::{Read, Seek, Write};
+
+/// A byte source FFmpeg can demux from.
+pub trait IoSource: Read + Seek + Send {}
+
+impl<T: Read + Seek + Send> IoSource for T {}
+
+/// A byte sink FFmpeg can mux into.
+pub trait IoSink: Write + Seek + Send {}
+
+impl<T: Write + Seek + Send> IoSink for T {}

--- a/crates/ff-sys/src/lib.rs
+++ b/crates/ff-sys/src/lib.rs
@@ -44,6 +44,8 @@ pub mod avcodec;
 #[cfg(not(docsrs))]
 pub mod avformat;
 #[cfg(not(docsrs))]
+mod io_context;
+#[cfg(not(docsrs))]
 pub mod swresample;
 #[cfg(not(docsrs))]
 pub mod swscale;
@@ -60,12 +62,15 @@ mod codec_context;
 mod constants;
 mod error;
 pub mod error_codes;
+// Ungated: pure `Read`/`Write` + `Seek` bounds with no FFmpeg dependency, so the
+// docs.rs stubs can name them too.
 #[cfg(not(docsrs))]
 mod format_context;
 #[cfg(not(docsrs))]
 mod frame;
 #[cfg(not(docsrs))]
 mod hwdevice;
+mod io_traits;
 mod log_bridge;
 #[cfg(not(docsrs))]
 mod packet;
@@ -84,7 +89,9 @@ pub use buffersink::{BufferSinkOutcome, buffersink_get_frame};
 pub use codec::Codec;
 #[cfg(not(docsrs))]
 pub use codec_context::{CodecContext, ReceiveOutcome};
-pub use constants::{AV_NOPTS_VALUE, AVFMT_NOFILE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF};
+pub use constants::{
+    AV_NOPTS_VALUE, AVFMT_FLAG_CUSTOM_IO, AVFMT_NOFILE, AVFMT_TS_DISCONT, BUFFERSRC_FLAG_KEEP_REF,
+};
 pub use error::AvError;
 #[cfg(not(docsrs))]
 pub use format_context::{
@@ -94,6 +101,7 @@ pub use format_context::{
 pub use frame::Frame;
 #[cfg(not(docsrs))]
 pub use hwdevice::HwDeviceContext;
+pub use io_traits::{IoSink, IoSource};
 pub use log_bridge::{install_log_bridge, log_level, set_log_level};
 #[cfg(not(docsrs))]
 pub use packet::Packet;


### PR DESCRIPTION
## Objective

- Input and output were limited to paths and URLs, so decoding a buffer already in memory, or handing an export straight to a caller-provided sink, was not expressible.
- Both need `avio_alloc_context`, which the crate had never used. No `avio_*` function is even in the generated bindings, since bindgen's allowlist does not match that prefix.

## Solution

- Add `IoContext`, a crate-private RAII owner around a custom `AVIOContext`: it allocates the context and its buffer, keeps the boxed reader or writer alive for as long as FFmpeg may call back, and frees all three once on drop. `ctx->buffer` is freed before the context, since libavformat may have replaced it.
- Attach it through `InputFormatContext::open_custom` / `OutputFormatContext::set_custom_io`, with `VideoDecoder::from_reader` and `VideoEncoderBuilder::output_sink` as the entry points. No public signature mentions an `AVIOContext`.
- Pin the callback types at compile time to the ones bindgen generated, because a hand-written FFI signature that disagrees with the C ABI is silent on a Windows host and in the docs.rs job.
- Callbacks catch unwinding, report `AVERROR_EOF` rather than 0, retry an interrupted read, and refuse a length a `Read` impl reports beyond its buffer.
- Reject two-pass and `faststart` alongside a sink: both finalise by reopening the output. Measured, `faststart` copied an unrelated file's contents into the sink while reporting success.

Verified end to end: decoding from memory matches decoding the file (24 frames, 1920x1080), and encoding into an in-memory sink matches the file route byte for byte (1897 bytes, 9 frames).

Closes #1600