### PR TITLE
fix(avio): accept a stalled machine in the preview parity span assertion

### DIFF
--- a/crates/avio/tests/preview_export_parity.rs
+++ b/crates/avio/tests/preview_export_parity.rs
@@ -239,6 +239,9 @@ fn preview_and_export_should_agree_structurally() {
     // Scoped so the runner and its handle (and therefore its decoder threads, which
     // hold the source file open) are dropped before the export reads the same file.
     let state = Arc::new(Mutex::new(PreviewState::default()));
+    // How long the runner was actually live. The span assertion below needs it to tell a
+    // machine that stalled from a runner that stopped; see there for why.
+    let preview_elapsed;
     {
         let (mut runner, handle) = match TimelinePlayer::open(&timeline) {
             Ok(p) => p,
@@ -251,7 +254,9 @@ fn preview_and_export_should_agree_structurally() {
             state: Arc::clone(&state),
             handle: handle.clone(),
         }));
+        let started = std::time::Instant::now();
         let _ = runner.run();
+        preview_elapsed = started.elapsed();
     }
     let preview = state
         .lock()
@@ -306,16 +311,36 @@ fn preview_and_export_should_agree_structurally() {
     );
     // The timeline is exactly the source's length: `EXPECTED_FRAMES` frames at `FPS`.
     let end = Duration::from_secs_f64(EXPECTED_FRAMES as f64 / FPS);
-    // Not the exact end: the runner is real-time and drops frames it cannot deliver on
-    // time, the tail included (`SceneRunner`'s "dropped late frame" path), so requiring
-    // it is flaky — a coverage run came in at 366ms of 500ms. Half the span still
-    // separates a runner that played the timeline from one stuck at its opening frames.
+    // Not the exact end: the runner is real-time and drops any frame more than one
+    // period late (`SceneRunner`'s "dropped late frame" path), the tail included, so
+    // requiring it is flaky: a coverage run came in at 366ms of 500ms.
+    //
+    // Half the span is not enough either. The drop is unbounded: one stall longer than
+    // the timeline drops *every* frame after the first, which is how this failed on
+    // macOS CI with 1 frame at 0ns (#1780). The likely stall is lazy wgpu pipeline
+    // compilation on a paravirtualised GPU, and it is a property of the machine rather
+    // than of the runner. Moving the threshold a third time would not fix that shape.
+    //
+    // So accept either: the preview covered most of the span, or the run genuinely
+    // spent the timeline's duration trying. That still fails a runner that *stops*:
+    // the drop path does not sleep, so a clock that rejects every frame burns through
+    // the timeline in milliseconds and satisfies neither arm.
+    let covered_the_span = preview.last_pts * 2 >= end;
+    let spent_the_duration = preview_elapsed >= end;
     assert!(
-        preview.last_pts * 2 >= end,
-        "preview must play most of the timeline: last pts {:?} over {} frames, end {end:?}",
+        covered_the_span || spent_the_duration,
+        "preview must play most of the timeline or spend its duration trying: \
+         last pts {:?} over {} frames in {preview_elapsed:?}, end {end:?}",
         preview.last_pts,
         preview.frames
     );
+    if !covered_the_span {
+        println!(
+            "preview dropped to {:?} over {} frames in {preview_elapsed:?} (end {end:?}): \
+             the machine could not sustain real time, accepted by the elapsed arm",
+            preview.last_pts, preview.frames
+        );
+    }
     // Non-vacuity: the source is strongly chromatic, so a blank / black / grey frame on
     // either side fails here rather than sailing through the comparison below (two
     // black frames would otherwise "agree" perfectly).


### PR DESCRIPTION
## Objective

- `preview_and_export_should_agree_structurally` fails intermittently on `Test (macos-latest)`. It failed the CI run for a **documentation-only** commit and passed on re-run of the same SHA with no code change, so it can turn any merge red, including the v0.18.0 release PR.

## Solution

- Root cause: the assertion is a wall-clock property asserted on a real-time component. `SceneRunner` drops any frame more than one period late and continues, so a single stall longer than the 500 ms timeline drops **every** frame after the first, giving the observed `last pts 0ns over 1 frames`. The likely stall is lazy wgpu pipeline compilation, since `TimelinePlayer::open` attaches the GPU compositor when an adapter is available and the macOS runner has a paravirtualised GPU.
- Half the span had already replaced the exact end for this same class (#1723), and it is not enough either: the drop is unbounded. Rather than move the threshold a third time, add a second way to pass. The preview covered most of the span, **or** the run genuinely spent the timeline's duration trying.
- A runner that *stops* still fails, because the drop path does not sleep: a clock rejecting every frame burns through the timeline in milliseconds.
- Verified by injecting both shapes rather than by reasoning:

| Injected | frames | last pts | elapsed | old | new |
|---|---|---|---|---|---|
| 700 ms stall in the sink | 1 | 0ns | 782 ms | FAIL | pass |
| stop after the first frame | 1 | 0ns | 85 ms | FAIL | FAIL |

- `PlayerHandle::current_pts` cannot substitute for the delivered PTS: the position is only updated for presented frames, so it stalls with them.
- Test-only. The colour, dimension and frame-count assertions are untouched, and playback stays at rate 1.0 so the pacing path under test is unchanged.

Fixes #1780