### PR TITLE
test(avio-examples): cover the typed effect model and preview-vs-export

### DIFF
--- a/crates/avio/src/lib.rs
+++ b/crates/avio/src/lib.rs
@@ -165,12 +165,18 @@ pub use ff_pipeline::{EncoderConfig, EncoderConfigBuilder, Progress};
 // `Timeline` and hands it to `ff-preview`'s runner. The `Scene` value types and the
 // `SceneRunner` / `PlayerHandle` handles + `PreviewError` are named by
 // `TimelinePlayer::open`. All are gated on `preview` (`ff-preview` is optional).
+//
+// `FrameSink` and its reference implementation come with them: a runner's only output
+// channel is the sink `SceneRunner::set_sink` takes, so without the trait the preview is
+// write-only for anyone depending on avio alone, and without `RgbaSink` every consumer
+// re-writes the same latest-frame store.
 #[cfg(feature = "preview")]
 mod player;
 #[cfg(feature = "preview")]
 pub use ff_preview::{
-    Pacing, PlayerHandle, PreviewCompositor, PreviewError, Scene, SceneAudioPlacement,
-    SceneAudioTrack, ScenePlacement, SceneRunner, SceneSource, SceneVideoTrack,
+    FrameSink, Pacing, PlayerHandle, PreviewCompositor, PreviewError, RgbaFrame, RgbaSink, Scene,
+    SceneAudioPlacement, SceneAudioTrack, ScenePlacement, SceneRunner, SceneSource,
+    SceneVideoTrack,
 };
 #[cfg(feature = "preview")]
 pub use player::TimelinePlayer;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,8 +15,10 @@ publish = false
 
 [dependencies]
 # Consumer-POV smoke test of the avio editing engine. Enables the opt-in
-# capabilities avio-editor-demo uses (preview + serde).
-avio = { path = "../crates/avio", features = ["preview", "serde"] }
+# capabilities avio-editor-demo uses (preview + serde), plus `gpu`: the scripts
+# should take the route a consumer actually gets, which is GPU compositing where an
+# adapter exists and the CPU fallback where it does not.
+avio = { path = "../crates/avio", features = ["preview", "serde", "gpu"] }
 # The scripts reach for a few ff-* primitives directly (probe a source, synthesize
 # fixture frames) the way a consumer would, since avio no longer re-exports them (ADR-0004).
 ff-decode = { path = "../crates/ff-decode" }

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,8 @@ cargo run -p avio-examples --bin single_clip_export
 cargo run -p avio-examples --bin multitrack_export
 cargo run -p avio-examples --bin transition_export
 cargo run -p avio-examples --bin keyframe_export
+cargo run -p avio-examples --bin effect_color_correct
+cargo run -p avio-examples --bin preview_matches_export
 ```
 
 Point a script at a real media file, and keep the temp files for inspection:
@@ -56,8 +58,8 @@ A script prints one line per check and exits non-zero if any check fails.
 | Multi-track composition / PiP + blend | `multitrack_export` | done |
 | Transitions (`XfadeTransition`) | `transition_export` | done |
 | Keyframe animation (`AnimationTrack`) | `keyframe_export` | done |
-| Per-clip effects (`FilterStep`) | `effect_<name>` | TODO |
-| Preview matches export | `preview_matches_export` | TODO |
+| Per-clip effects (typed `EffectKind`, keyframeable) | `effect_color_correct` | done |
+| Preview matches export | `preview_matches_export` | done |
 | Audio mix + per-clip volume/fades | `audio_mix` | TODO |
 | Ken Burns pan & zoom | `ken_burns` | TODO (after #1295) |
 

--- a/examples/src/bin/effect_color_correct.rs
+++ b/examples/src/bin/effect_color_correct.rs
@@ -1,0 +1,217 @@
+//! Verify the typed effect model: add a `ColorCorrect` effect to a clip through the
+//! editing model, keyframe its brightness 0 -> 0.4 over the first second, render, and
+//! measure that the output brightened over time.
+//!
+//! This exercises the v0.18 effect surface (`Command::AddEffect` -> `ClipEffect` ->
+//! `EffectKind::ColorCorrect` with a keyframed `Param`) against avio alone, through the
+//! public facade a consumer has.
+//!
+//! The measurement is **differential**: the same timeline is rendered twice, once
+//! without the effect and once with it, and the two are compared frame by frame. The
+//! synthetic fixture sweeps its hue over its length, so comparing the first and last
+//! frame of a single render would measure the fixture, not the effect.
+//!
+//! ```bash
+//! cargo run -p avio-examples --bin effect_color_correct
+//! cargo run -p avio-examples --bin effect_color_correct -- --input clip.mp4 --keep
+//! ```
+
+use std::time::Duration;
+
+use avio::{
+    AnimationTrack, Clip, Command, Easing, EditError, Editor, EffectId, EffectKind, Keyframe,
+    Param, Timeline,
+};
+use avio_examples::{
+    BoxResult, Report, decoded_frame_means, mean_channel, parse_args, render_or_skip, resolve_input,
+};
+
+/// Brightness the keyframe track reaches. `eq` takes brightness in `[-1, 1]`, so this
+/// is a large but unsaturating step: big enough to survive a lossy encode, small enough
+/// that a bright fixture does not clip to white and hide the difference.
+const BRIGHTNESS: f64 = 0.4;
+/// How long the brightness ramp takes. Shorter than the fixture, so the last frame sits
+/// on the held end value rather than mid-ramp.
+const RAMP: Duration = Duration::from_secs(1);
+/// Mean-channel difference allowed between the two renders at frame 0, where the keyframe
+/// is still neutral. Not zero: the effected render carries an `eq` step evaluating to
+/// brightness 0 that the baseline does not have at all, and the two files are encoded
+/// independently. Measured 0.00 on the synthetic fixture here (the two encodes come
+/// out identical while the parameter is neutral); the margin is for content and builds
+/// that are less forgiving.
+const TOL_NEUTRAL: f64 = 6.0;
+/// Mean-channel difference the effected render must gain by its last frame. Measured 68.34
+/// on the synthetic fixture; this is a floor any content should clear, set well above
+/// `TOL_NEUTRAL` so "the effect applied" cannot be satisfied by encoder noise.
+const MIN_END_GAIN: f64 = 12.0;
+
+/// The keyframed colour correction this script installs: brightness ramps from neutral
+/// to [`BRIGHTNESS`], every other parameter neutral.
+///
+/// `temperature` and `tint` stay neutral deliberately. They are a GPU-only enrichment
+/// that the CPU `eq` fallback does not reproduce, so a script using them would measure
+/// a different amount on each route.
+fn keyframed_color_correct() -> EffectKind {
+    let brightness = AnimationTrack::new()
+        .push(Keyframe::new(Duration::ZERO, 0.0, Easing::Linear))
+        .push(Keyframe::new(RAMP, BRIGHTNESS, Easing::Linear));
+    EffectKind::ColorCorrect {
+        brightness: Param::Animated(brightness),
+        contrast: Param::Const(1.0),
+        saturation: Param::Const(1.0),
+        temperature: Param::Const(0.0),
+        tint: Param::Const(0.0),
+    }
+}
+
+/// The id of the first clip on the first video track of `timeline`.
+fn first_clip_id(timeline: &Timeline) -> Option<avio::ClipId> {
+    timeline
+        .video_tracks()
+        .first()
+        .and_then(|t| t.clips.first())
+        .map(|c| c.id)
+}
+
+/// The effect list of that clip, after the edit.
+fn first_clip_effects(timeline: &Timeline) -> &[avio::ClipEffect] {
+    timeline
+        .video_tracks()
+        .first()
+        .and_then(|t| t.clips.first())
+        .map_or(&[], |c| c.effects.as_slice())
+}
+
+fn main() -> BoxResult<()> {
+    let args = parse_args();
+    let tmp = tempfile::tempdir()?;
+    let mut report = Report::new("effect_color_correct");
+    // A machine with no encoder cannot even make the fixture; that is the environment,
+    // not a regression, so it skips like the render legs below.
+    let input = match resolve_input(&args, tmp.path()) {
+        Ok(path) => path,
+        Err(e) => {
+            report.skip("generate the input clip", &e.to_string());
+            return report.finish();
+        }
+    };
+
+    let in_info = avio::open(&input)?;
+    let in_video = in_info.video_streams();
+    let Some(v) = in_video.first() else {
+        return Err("input has no video stream".into());
+    };
+    let (canvas_w, canvas_h, fps) = (v.width(), v.height(), v.fps());
+
+    let baseline = Timeline::builder()
+        .canvas(canvas_w, canvas_h)
+        .frame_rate(fps)
+        .video_track(vec![Clip::new(&input)])
+        .build()?;
+    let Some(clip) = first_clip_id(&baseline) else {
+        return Err("the built timeline has no clip to edit".into());
+    };
+
+    // The editing model's own path: the document stamps the effect with an id and the
+    // change lands on the undo stack, which a bare `clip.effects.push` does neither of.
+    let mut editor = Editor::new(baseline.clone());
+    match editor.apply(&Command::AddEffect {
+        clip,
+        kind: keyframed_color_correct(),
+    }) {
+        Ok(_) => {}
+        Err(EditError::ClipNotFound { id }) => {
+            return Err(format!("the timeline lost clip {id:?} between build and edit").into());
+        }
+        Err(e) => return Err(Box::new(e)),
+    }
+    let edited = editor.current().clone();
+
+    let effects = first_clip_effects(&edited);
+    report.check("the clip carries exactly one effect", effects.len() == 1);
+    report.check(
+        "the document stamped the effect with an id",
+        effects.first().is_some_and(|e| e.id != EffectId::UNSET),
+    );
+    report.check(
+        "the effect is a keyframed ColorCorrect",
+        effects.first().is_some_and(|e| {
+            matches!(
+                &e.kind,
+                EffectKind::ColorCorrect { brightness, .. } if !brightness.is_const()
+            )
+        }),
+    );
+    report.check("the edit is undoable", editor.can_undo());
+
+    let base_out = tmp.path().join("baseline.mp4");
+    let effect_out = tmp.path().join("color_corrected.mp4");
+    println!("rendering {canvas_w}x{canvas_h} {fps:.2}fps twice (baseline, colour corrected)");
+    for (label, timeline, out) in [
+        ("baseline render", baseline.clone(), &base_out),
+        ("colour-corrected render", edited.clone(), &effect_out),
+    ] {
+        if let Some(reason) = render_or_skip(timeline, out)? {
+            report.skip(label, &reason);
+            return report.finish();
+        }
+    }
+
+    // Measure the two renders against each other.
+    let (base_means, effect_means) = match (
+        decoded_frame_means(&base_out),
+        decoded_frame_means(&effect_out),
+    ) {
+        (Ok(a), Ok(b)) => (a, b),
+        (Err(e), _) | (_, Err(e)) => {
+            report.skip("decode both renders", &e.to_string());
+            return report.finish();
+        }
+    };
+    let frames = base_means.len().min(effect_means.len());
+    report.check("both renders decoded to frames", frames >= 2);
+    if frames < 2 {
+        return report.finish();
+    }
+
+    let gain = |i: usize| mean_channel(effect_means[i]) - mean_channel(base_means[i]);
+    let (first_gain, last_gain) = (gain(0), gain(frames - 1));
+    println!(
+        "mean-channel gain: frame 0 = {first_gain:+.2}, frame {} = {last_gain:+.2} ({frames} frames)",
+        frames - 1
+    );
+
+    report.check(
+        "the two renders agree where the keyframe is neutral",
+        first_gain.abs() <= TOL_NEUTRAL,
+    );
+    report.check(
+        "the effect brightened the end of the clip",
+        last_gain >= MIN_END_GAIN,
+    );
+    report.check(
+        "the keyframed parameter animated (the gain grew)",
+        last_gain > first_gain + TOL_NEUTRAL,
+    );
+
+    match avio::open(&effect_out) {
+        Ok(out_info) => {
+            let out_video = out_info.video_streams();
+            let (out_w, out_h) = out_video
+                .first()
+                .map_or((0, 0), |v| (v.width(), v.height()));
+            report.check(
+                "output dims match canvas",
+                out_w == canvas_w && out_h == canvas_h,
+            );
+        }
+        Err(e) => {
+            report.skip("re-probe the corrected output", &e.to_string());
+        }
+    }
+
+    if args.keep {
+        println!("kept temp dir: {}", tmp.keep().display());
+    }
+    report.finish()
+}

--- a/examples/src/bin/preview_matches_export.rs
+++ b/examples/src/bin/preview_matches_export.rs
@@ -1,0 +1,250 @@
+//! Verify that the real-time preview and the export agree: drive one timeline through
+//! `TimelinePlayer` and through `Timeline::render`, and compare what each produced.
+//!
+//! `crates/avio/tests/preview_export_parity.rs` makes this claim inside the crate. This
+//! script makes it from outside, through the public facade a consumer has: the preview's
+//! only output channel is the sink `SceneRunner::set_sink` takes, so a consumer has to
+//! be able to name and implement `FrameSink` for the preview to be observable at all.
+//!
+//! The clip carries a non-neutral `ColorCorrect`, so an effect reaches both pipelines
+//! rather than both merely copying frames through.
+//!
+//! What is compared: the frame size, the number of frames, the span the preview covered,
+//! and the colour of each frame against the export's frame at the same index. Frame by
+//! frame rather than over the sequence: the fixture sweeps a full hue circle, so its
+//! sequence average is achromatic and a per-channel divergence would cancel out in it
+//! (the average measures spread 1.3, below this script's own blank-frame threshold).
+//!
+//! Not per-pixel convergence, which is out of scope for v0.18: the preview composites in
+//! rgba while the export normalises to `yuv420p`, and the export is measured after a
+//! lossy encode, so the two land on different numbers for reasons that have nothing to
+//! do with a regression.
+//!
+//! ```bash
+//! cargo run -p avio-examples --bin preview_matches_export
+//! cargo run -p avio-examples --bin preview_matches_export -- --input clip.mp4 --keep
+//! ```
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use avio::{Clip, FrameSink, Pacing, PlayerHandle, Timeline, TimelinePlayer};
+use avio_examples::{
+    BoxResult, Report, channel_distance, decoded_frame_means, mean_rgb, parse_args, render_or_skip,
+    resolve_input,
+};
+
+/// Contrast for the clip's colour correction. Non-neutral, so an effect actually reaches
+/// both pipelines (a neutral `ColorCorrect` compiles to no filter at all).
+const CONTRAST: f32 = 1.3;
+/// Per-channel difference allowed between a preview frame and the export frame at the
+/// same index, taken at its worst over the clip. Coarse by design, for the
+/// rgba-vs-`yuv420p` and lossy-encode reasons above. Measured 6.85 at its worst on the
+/// synthetic fixture; the margin is for content and builds that are less forgiving, not
+/// for slack. Swapping the preview's red and blue channels measures 254.65 here, so the
+/// tolerance is nowhere near wide enough to hide a per-channel divergence.
+const TOL_MEAN_CHANNEL: f64 = 24.0;
+/// Frames the two legs may differ by. The encoder's flush can add one, and the runner
+/// may not deliver the very last frame before EOF.
+const TOL_FRAMES: usize = 2;
+/// Minimum spread between the brightest and darkest channel of the first frame. The
+/// fixture starts on a saturated hue, so a blank, white or grey frame, which is the
+/// shape a broken leg produces, falls below this.
+const MIN_CHROMA_SPREAD: f64 = 30.0;
+/// Multiple of the timeline's own frame count at which the preview leg gives up. A spin
+/// guard for a runner that fails to terminate, so it has to scale with the input: a
+/// fixed cap would cut a long `--input` clip short and report that as a mismatch.
+const PREVIEW_FRAME_CAP_FACTOR: usize = 4;
+
+/// What the preview leg delivered.
+///
+/// Every frame's mean colour is kept rather than summed: the comparison against the
+/// export is per frame, because the sequence average is achromatic on a hue-sweeping
+/// fixture and would hide a per-channel divergence.
+#[derive(Default, Clone)]
+struct PreviewStats {
+    size: Option<(u32, u32)>,
+    frame_means: Vec<[f64; 3]>,
+    last_pts: Duration,
+}
+
+/// Collects [`PreviewStats`] from the runner's presentation thread.
+struct StatsSink {
+    stats: Arc<Mutex<PreviewStats>>,
+    handle: PlayerHandle,
+    cap: usize,
+}
+
+impl FrameSink for StatsSink {
+    fn push_frame(&mut self, rgba: &[u8], width: u32, height: u32, pts: Duration) {
+        let mean = mean_rgb(rgba);
+        let mut stats = match self.stats.lock() {
+            Ok(s) => s,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        stats.size.get_or_insert((width, height));
+        stats.frame_means.push(mean);
+        stats.last_pts = pts;
+        if stats.frame_means.len() >= self.cap {
+            self.handle.stop();
+        }
+    }
+}
+
+/// Plays `timeline` unpaced and returns what the preview delivered, or `Err(reason)`
+/// when the environment cannot open or run the player (skip).
+///
+/// The stats are read back through a retained handle rather than reclaimed from the
+/// sink, so there is no "could not take the stats back" path that would have to be
+/// reported as a skip when it is not an environment problem at all.
+fn preview_stats(timeline: &Timeline, cap: usize) -> Result<PreviewStats, String> {
+    let (mut runner, handle) =
+        TimelinePlayer::open(timeline).map_err(|e| format!("preview unavailable: {e}"))?;
+    let stats = Arc::new(Mutex::new(PreviewStats::default()));
+    // Unpaced: the real-time clock drops late frames, so a paced run would compare the
+    // export against whatever this machine kept up with (ADR-0015).
+    runner.set_pacing(Pacing::Unpaced);
+    runner.set_sink(Box::new(StatsSink {
+        stats: Arc::clone(&stats),
+        handle,
+        cap,
+    }));
+    runner.run().map_err(|e| format!("preview failed: {e}"))?;
+    let collected = stats
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    Ok(collected)
+}
+
+fn main() -> BoxResult<()> {
+    let args = parse_args();
+    let tmp = tempfile::tempdir()?;
+    let mut report = Report::new("preview_matches_export");
+    // A machine with no encoder cannot even make the fixture; that is the environment,
+    // not a regression, so it skips like the two legs below.
+    let input = match resolve_input(&args, tmp.path()) {
+        Ok(path) => path,
+        Err(e) => {
+            report.skip("generate the input clip", &e.to_string());
+            return report.finish();
+        }
+    };
+
+    let in_info = avio::open(&input)?;
+    let in_video = in_info.video_streams();
+    let Some(v) = in_video.first() else {
+        return Err("input has no video stream".into());
+    };
+    let (canvas_w, canvas_h, fps) = (v.width(), v.height(), v.fps());
+    let duration = in_info.duration();
+
+    // The clip builder's colour correction is a `ColorCorrect` effect on the same list
+    // `effect_color_correct` reaches through the editing model.
+    let clip = Clip::new(&input).with_color_correction(0.0, CONTRAST, 1.0);
+    let timeline = Timeline::builder()
+        .canvas(canvas_w, canvas_h)
+        .frame_rate(fps)
+        .video_track(vec![clip])
+        .build()?;
+
+    // The guard scales with the input so a long `--input` clip is not cut short and
+    // then reported as a frame-count mismatch.
+    let expected_frames = (duration.as_secs_f64() * fps).ceil().max(1.0) as usize;
+    let cap = expected_frames
+        .saturating_mul(PREVIEW_FRAME_CAP_FACTOR)
+        .max(60);
+
+    println!("previewing {canvas_w}x{canvas_h} {fps:.2}fps unpaced");
+    let preview = match preview_stats(&timeline, cap) {
+        Ok(s) => s,
+        Err(reason) => {
+            report.skip("preview leg", &reason);
+            return report.finish();
+        }
+    };
+
+    let output = tmp.path().join("export.mp4");
+    println!("exporting the same timeline -> {}", output.display());
+    if let Some(reason) = render_or_skip(timeline.clone(), &output)? {
+        report.skip("export leg", &reason);
+        return report.finish();
+    }
+    let export = match decoded_frame_means(&output) {
+        Ok(means) => means,
+        Err(e) => {
+            report.skip("decode the export", &e.to_string());
+            return report.finish();
+        }
+    };
+
+    let preview_frames = preview.frame_means.len();
+    let frame_gap = preview_frames.abs_diff(export.len());
+    let round1 = |m: [f64; 3]| m.map(|c| (c * 10.0).round() / 10.0);
+    println!(
+        "preview: {preview_frames} frames, span {:.3}s, first {:?}",
+        preview.last_pts.as_secs_f64(),
+        preview.frame_means.first().copied().map(round1)
+    );
+    println!(
+        "export:  {} frames, first {:?} (timeline {:.3}s)",
+        export.len(),
+        export.first().copied().map(round1),
+        duration.as_secs_f64()
+    );
+    if preview_frames >= cap {
+        report.skip(
+            "the preview leg ran to completion",
+            &format!("stopped at the {cap}-frame guard"),
+        );
+        return report.finish();
+    }
+
+    report.check("the preview delivered frames", preview_frames > 0);
+    report.check("the export decoded to frames", !export.is_empty());
+    report.check(
+        "the preview rendered at the canvas size",
+        preview.size == Some((canvas_w, canvas_h)),
+    );
+    report.check(
+        "both legs produced the same number of frames",
+        frame_gap <= TOL_FRAMES,
+    );
+    // Two frame intervals of slack: the runner may stop before presenting the last one.
+    let span_floor = duration.as_secs_f64() - 2.0 / fps.max(1.0);
+    report.check(
+        "the preview covered the timeline's span",
+        preview.last_pts.as_secs_f64() >= span_floor,
+    );
+    let first_spread = |m: [f64; 3]| {
+        m.iter().copied().fold(f64::MIN, f64::max) - m.iter().copied().fold(f64::MAX, f64::min)
+    };
+    report.check(
+        "both legs rendered colour, not a blank frame",
+        preview
+            .frame_means
+            .first()
+            .is_some_and(|m| first_spread(*m) >= MIN_CHROMA_SPREAD)
+            && export
+                .first()
+                .is_some_and(|m| first_spread(*m) >= MIN_CHROMA_SPREAD),
+    );
+    // Frame by frame, not over the sequence: the fixture's hue sweep makes the sequence
+    // average achromatic, so a per-channel divergence would cancel out in it.
+    let worst = preview
+        .frame_means
+        .iter()
+        .zip(export.iter())
+        .map(|(p, e)| channel_distance(*p, *e))
+        .fold(0.0f64, f64::max);
+    println!("preview-vs-export worst per-frame channel distance: {worst:.2}");
+    report.check(
+        "every frame agrees on colour within tolerance",
+        worst <= TOL_MEAN_CHANNEL,
+    );
+
+    if args.keep {
+        println!("kept temp dir: {}", tmp.keep().display());
+    }
+    report.finish()
+}

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -7,8 +7,12 @@
 
 use std::path::{Path, PathBuf};
 
-use avio::{BitrateMode, PixelFormat, Rational, Timestamp, VideoCodec, VideoFrame};
+use avio::{
+    BitrateMode, EncoderConfig, PixelFormat, Rational, Timeline, TimelineError, Timestamp,
+    VideoCodec, VideoFrame,
+};
 use ff_common::PooledBuffer;
+use ff_decode::VideoDecoder;
 use ff_encode::VideoEncoder;
 
 /// Convenience result type for the scripts (`fn main() -> BoxResult<()>`).
@@ -183,6 +187,16 @@ impl Report {
         self.all_ok &= ok;
     }
 
+    /// Records a check the environment could not run, printing `[SKIP]` and leaving
+    /// the verdict untouched.
+    ///
+    /// A machine without the codec, filter or GPU adapter a script needs must neither
+    /// fail (nothing is wrong with avio) nor pass (nothing was verified), so the two
+    /// outcomes `check` offers are both wrong for it.
+    pub fn skip(&mut self, label: &str, reason: &str) {
+        println!("  [SKIP] {label} ({reason})");
+    }
+
     /// Prints the overall verdict and returns `Ok` only if every check passed.
     ///
     /// # Errors
@@ -196,6 +210,86 @@ impl Report {
             Err(format!("{}: FAIL", self.name).into())
         }
     }
+}
+
+/// The mean R/G/B of every frame of a rendered file, in decode order.
+///
+/// Scripts that assert an effect reached the output measure it here: a mean per frame
+/// is coarse enough to survive a lossy encode and specific enough to show a colour
+/// change and its direction. Alpha is ignored (the encode is opaque).
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or decoded, which for a script means
+/// the environment lacks the decoder rather than that avio is wrong.
+pub fn decoded_frame_means(path: &Path) -> BoxResult<Vec<[f64; 3]>> {
+    let mut decoder = VideoDecoder::open(path)
+        .output_format(PixelFormat::Rgba)
+        .build()?;
+    let mut means = Vec::new();
+    while let Some(frame) = decoder.decode_one()? {
+        let Some(rgba) = frame.to_rgba() else {
+            return Err("decoded frame is not convertible to rgba".into());
+        };
+        means.push(mean_rgb(&rgba));
+    }
+    Ok(means)
+}
+
+/// The mean R/G/B of a contiguous rgba buffer (alpha ignored).
+#[must_use]
+pub fn mean_rgb(rgba: &[u8]) -> [f64; 3] {
+    let (mut sum, mut pixels) = ([0f64; 3], 0f64);
+    for px in rgba.as_chunks::<4>().0 {
+        sum[0] += f64::from(px[0]);
+        sum[1] += f64::from(px[1]);
+        sum[2] += f64::from(px[2]);
+        pixels += 1.0;
+    }
+    if pixels == 0.0 {
+        return [0.0; 3];
+    }
+    [sum[0] / pixels, sum[1] / pixels, sum[2] / pixels]
+}
+
+/// The mean of a frame's three channel means: one number per frame, for comparing
+/// overall lightness between two renders of the same content.
+///
+/// Not Rec.601 luma: the channels are weighted equally, which is what a like-for-like
+/// comparison of two renders of the same frame wants.
+#[must_use]
+pub fn mean_channel(mean: [f64; 3]) -> f64 {
+    (mean[0] + mean[1] + mean[2]) / 3.0
+}
+
+/// Whether a render error means "this environment cannot run the pipeline" (skip) as
+/// opposed to a real regression (fail). Mirrors the crates' own test convention.
+#[must_use]
+pub fn is_environment_unavailable(e: &TimelineError) -> bool {
+    matches!(
+        e,
+        TimelineError::Filter(_) | TimelineError::Encode(_) | TimelineError::Decode(_)
+    )
+}
+
+/// Renders `timeline` to `out`. `Ok(None)` rendered; `Ok(Some(reason))` the environment
+/// cannot render here (report it with [`Report::skip`]); `Err` a genuine failure.
+///
+/// # Errors
+///
+/// Returns the render error when it is not one this environment merely lacks.
+pub fn render_or_skip(timeline: Timeline, out: &Path) -> BoxResult<Option<String>> {
+    match timeline.render(out, EncoderConfig::builder().build()) {
+        Ok(()) => Ok(None),
+        Err(e) if is_environment_unavailable(&e) => Ok(Some(e.to_string())),
+        Err(e) => Err(Box::new(e)),
+    }
+}
+
+/// The largest per-channel difference between two frame means.
+#[must_use]
+pub fn channel_distance(a: [f64; 3], b: [f64; 3]) -> f64 {
+    (0..3).fold(0.0f64, |acc, i| acc.max((a[i] - b[i]).abs()))
 }
 
 /// Converts a hue angle (0-360 degrees) to an sRGB triplet (saturation = value = 1).
@@ -232,6 +326,32 @@ mod tests {
         r.check("a", true);
         r.check("b", false);
         assert!(r.finish().is_err());
+    }
+
+    #[test]
+    fn report_should_stay_ok_when_a_check_is_skipped() {
+        let mut r = Report::new("t");
+        r.check("a", true);
+        r.skip("b", "no decoder here");
+        assert!(r.finish().is_ok(), "a skip is not a failure");
+    }
+
+    #[test]
+    fn mean_rgb_should_average_each_channel_independently() {
+        // Two pixels, so a channel-blind implementation (one mean over all bytes)
+        // would collapse these three distinct answers into one.
+        let rgba = [10u8, 20, 30, 255, 30, 60, 90, 255];
+        let mean = mean_rgb(&rgba);
+        assert!((mean[0] - 20.0).abs() < 1e-9);
+        assert!((mean[1] - 40.0).abs() < 1e-9);
+        assert!((mean[2] - 60.0).abs() < 1e-9);
+        assert!((mean_channel(mean) - 40.0).abs() < 1e-9);
+        assert!((channel_distance(mean, [20.0, 40.0, 45.0]) - 15.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mean_rgb_should_be_zero_for_an_empty_buffer() {
+        assert_eq!(mean_rgb(&[]), [0.0; 3]);
     }
 
     #[test]


### PR DESCRIPTION
## Objective

- v0.18.0's headline surface had no coverage in the consumer-perspective harness: grepping `examples/` for `EffectKind`, `ClipEffect` or `TimelinePlayer` returned nothing, and the capability index still named per-clip effects `FilterStep` with both rows TODO.
- That outside view is what catches an API which is correct but unusable, and the typed effect model and the preview/export story shipped without it.

## Solution

- **A facade gap it caught**: `FrameSink` was not re-exported from `avio`. A runner's only output channel is the sink `SceneRunner::set_sink` takes, so a consumer depending on `avio` alone could not observe preview frames at all, and the parity script could not be written. The trait and its reference implementation now sit with the other preview types.
- `effect_color_correct` adds a keyframed `ColorCorrect` through the editing model (`Editor` + `Command::AddEffect`, so the effect is stamped with an id and lands on the undo stack) and measures differentially: the same timeline is rendered with and without the effect and compared at matching frame indices. The fixture sweeps its hue over its length, so comparing one render's first and last frame would measure the fixture, not the effect.
- `preview_matches_export` drives one timeline through `TimelinePlayer` and through `Timeline::render`, comparing frame size, frame count, the span the preview covered, and each frame's colour against the export's frame at the same index. Per frame rather than over the sequence: the hue sweep makes a sequence average achromatic. Swapping the preview's red and blue channels measures 254.65 per frame and 1.21 in the average.
- The harness now asks `avio` for the `gpu` feature, so the scripts take the route a consumer gets: GPU compositing where an adapter exists, the CPU fallback where it does not.
- `Report::skip` reports what the environment could not run without a false pass or a failure; both scripts skip rather than panic when the fixture, a render, the player or a decode is unavailable.

Closes #1785