### PR TITLE
docs(readme): add library comparison and sharpen the pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # avio
 
-A safe, high-level Rust API over FFmpeg: an editing engine on top of a family of model-free FFmpeg primitive crates.
+**The Rust-native video editing engine, built on safe FFmpeg primitives.**
+
+A high-level API over FFmpeg with two layers: an editing engine (tracks, clips, keyframes, GPU compositing, undo/redo) on top of a family of composable, model-free primitive crates you can also use on their own. Application code never needs `unsafe`.
 
 [![Crates.io](https://img.shields.io/crates/v/avio.svg)](https://crates.io/crates/avio)
 [![Docs.rs](https://docs.rs/avio/badge.svg)](https://docs.rs/avio)
@@ -49,6 +51,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+## Choosing a Rust FFmpeg library
+
+Several good options wrap FFmpeg in Rust. They sit at different levels, so the right one depends on what you are building.
+
+| Library | Layer | Editing model | `unsafe` in your code | Runtime dependency | Best for |
+|---|---|---|:---:|---|---|
+| **avio** + `ff-*` | High-level engine + composable primitives | Yes | None | Linked libav* | Video editing apps and delivery services |
+| `ffmpeg-next` | Thin safe wrapper, near 1:1 with libav* | No | Some | Linked libav* | Full low-level control of the FFmpeg API |
+| `ez-ffmpeg` | High-level, mirrors the FFmpeg CLI | No | None | Linked libav* | Transcoding and filter jobs close to the CLI |
+| `video-rs` | High-level frame toolkit | No | None | Linked libav* | Reading and writing frames (CV / ML pipelines) |
+| `ffmpeg-sidecar` | Wraps the `ffmpeg` binary (subprocess) | No | None | `ffmpeg` executable | Driving the CLI with a clean iterator API |
+
+`ffmpeg-the-third` is an actively maintained fork of `ffmpeg-next`. For raw FFI bindings, see `ffmpeg-sys-next` or `rusty_ffmpeg`. For a non-FFmpeg media framework with its own editing layer, see the `gstreamer` bindings.
+
+avio is the only one of these that ships an editing model: a timeline of tracks and clips, a per-clip effect stack with keyframes, and a preview that matches the exported result. If you do not need that model, the `ff-*` primitives underneath it are usable on their own for safe decode, encode, filter, stream, and GPU compositing, with no editing concepts imposed.
 
 ## Design Philosophy
 

--- a/crates/avio/README.md
+++ b/crates/avio/README.md
@@ -4,6 +4,8 @@
 [![Docs.rs](https://docs.rs/avio/badge.svg)](https://docs.rs/avio)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
+**The Rust-native video editing engine, built on safe FFmpeg primitives.**
+
 An editing engine for video and audio: build a `Timeline` of `Clip`s, edit it with full undo/redo, and render it to a file.
 
 `avio` is the **editing engine** at the top of the `ff-*` crate family. It owns the editing model: an immutable `Timeline` of `Clip`s across video and audio tracks, the derivation that turns that model into rendered frames, and an `Editor` with undo/redo. The `ff-*` primitives it builds on (decode, encode, filter, analysis, remux, stream, preview, GPU render) stay model-free; for standalone primitive work, depend on those crates directly. See the [main repository](https://github.com/itsakeyfut/avio) for the full architecture.
@@ -16,6 +18,22 @@ avio is a **video editing engine**: you describe an edit as data and the engine 
 - **Non-destructive and undoable**: every edit is a pure function over the model, and `Editor` provides full undo/redo where one edit is one step.
 - **Renders the model to a file**: the engine derives frames from the timeline (compositing, transitions, effects, keyframes) and encodes the result.
 - **Built on model-free primitives**: the `ff-*` crates do the decode / encode / filter / render work and impose no editing model; avio is one engine on top of them, and you can build a different one on the same primitives.
+
+## Choosing a Rust FFmpeg library
+
+Several good options wrap FFmpeg in Rust. They sit at different levels, so the right one depends on what you are building.
+
+| Library | Layer | Editing model | `unsafe` in your code | Runtime dependency | Best for |
+|---|---|---|:---:|---|---|
+| **avio** + `ff-*` | High-level engine + composable primitives | Yes | None | Linked libav* | Video editing apps and delivery services |
+| `ffmpeg-next` | Thin safe wrapper, near 1:1 with libav* | No | Some | Linked libav* | Full low-level control of the FFmpeg API |
+| `ez-ffmpeg` | High-level, mirrors the FFmpeg CLI | No | None | Linked libav* | Transcoding and filter jobs close to the CLI |
+| `video-rs` | High-level frame toolkit | No | None | Linked libav* | Reading and writing frames (CV / ML pipelines) |
+| `ffmpeg-sidecar` | Wraps the `ffmpeg` binary (subprocess) | No | None | `ffmpeg` executable | Driving the CLI with a clean iterator API |
+
+`ffmpeg-the-third` is an actively maintained fork of `ffmpeg-next`. For raw FFI bindings, see `ffmpeg-sys-next` or `rusty_ffmpeg`. For a non-FFmpeg media framework with its own editing layer, see the `gstreamer` bindings.
+
+avio is the only one of these that ships an editing model: a timeline of tracks and clips, a per-clip effect stack with keyframes, and a preview that matches the exported result. If you do not need that model, the `ff-*` primitives underneath it are usable on their own for safe decode, encode, filter, stream, and GPU compositing, with no editing concepts imposed.
 
 ## Installation
 

--- a/crates/ff-analysis/README.md
+++ b/crates/ff-analysis/README.md
@@ -4,7 +4,7 @@ Media-analysis primitives for Rust: scene, silence, black-frame and keyframe det
 
 `ff-analysis` reads decoded media and reports analytical data; it does not edit or transform it. It builds on [`ff-decode`](https://crates.io/crates/ff-decode) for frame access and drives its own FFmpeg filter graphs where needed. Errors are typed and carry human-readable context (`AnalysisError`), so a failure reads as an actionable message rather than a raw FFmpeg return code.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-decode/README.md
+++ b/crates/ff-decode/README.md
@@ -4,7 +4,7 @@ Decode video and audio frames without managing codec contexts, packet queues, or
 
 `ff-decode` is a safe, ergonomic wrapper over FFmpeg's decode path: libavcodec decoding and libavformat demuxing, with optional libavutil hardware frames. Errors are typed and contextual (`DecodeError`) and classified via `is_recoverable()` / `is_fatal()`, so callers can react to a corrupt frame or a network hiccup without string-matching FFmpeg return codes.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-encode/README.md
+++ b/crates/ff-encode/README.md
@@ -4,7 +4,7 @@ Encode video and audio with a builder chain. The encoder validates codec, resolu
 
 `ff-encode` is a safe, ergonomic wrapper over FFmpeg's encode path: libavcodec encoding and libavformat muxing, with optional hardware encoders. Settings are validated before any FFmpeg context is allocated, and errors are typed and contextual (`EncodeError`), so a bad codec/container combination or an out-of-range bitrate fails with an actionable message rather than a raw FFmpeg return code.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-filter/README.md
+++ b/crates/ff-filter/README.md
@@ -4,7 +4,7 @@ Apply video and audio transformations without writing FFmpeg filter-graph string
 
 `ff-filter` is a safe, ergonomic wrapper over FFmpeg's libavfilter: build and run video and audio filter graphs without hand-writing filter-graph strings. Errors are typed and contextual (`FilterError`), so a bad input slot or an FFmpeg build error surfaces as a readable message rather than a raw return code.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-pipeline/README.md
+++ b/crates/ff-pipeline/README.md
@@ -4,7 +4,7 @@ Wire decode, filter, and encode into a single configured pipeline. Instead of ma
 
 `ff-pipeline` wires the decode, filter, and encode primitives into a single validated transcode pipeline. It is an orchestration layer rather than a direct FFmpeg wrapper: FFmpeg is touched only through `ff-decode` / `ff-filter` / `ff-encode`. Errors are typed and chain their source (`PipelineError` wraps `DecodeError` / `FilterError` / `EncodeError` via `#[from]`), so a `?` carries the underlying cause up with an actionable message.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-preview/README.md
+++ b/crates/ff-preview/README.md
@@ -4,7 +4,7 @@ Real-time video preview and proxy workflow for Rust. Provides frame-accurate see
 
 `ff-preview` adds a real-time, A/V-synchronised playback and seek loop on top of the decode primitives, converting frames to RGBA via libswscale for display. Decoding is delegated to `ff-decode`; this crate owns the playback clock, frame-accurate seek, and a `FrameSink` trait for custom renderers. Errors are typed and chain their source (`PreviewError`), so a failure reads as an actionable message rather than a raw FFmpeg return code.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-probe/README.md
+++ b/crates/ff-probe/README.md
@@ -4,7 +4,7 @@ Read media file metadata with one function call. `open` returns a structured `Me
 
 `ff-probe` safely wraps FFmpeg's container inspection (libavformat demuxing and stream discovery) as a read-only metadata reader, with no decoding or encoding. Errors are typed and carry path and message context (`ProbeError`), so a failure reads as an actionable message rather than a raw FFmpeg return code.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-remux/README.md
+++ b/crates/ff-remux/README.md
@@ -4,7 +4,7 @@ Stream-copy remuxing for Rust: trim a clip and replace / extract / add an audio 
 
 `ff-remux` is a safe, ergonomic Rust wrapper over FFmpeg's stream-copy remuxing (libavformat demux + mux, no libavcodec encoding). Errors are typed and carry human-readable context (`RemuxError`), so a failure reads as an actionable message rather than a raw FFmpeg return code.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 

--- a/crates/ff-render/README.md
+++ b/crates/ff-render/README.md
@@ -4,7 +4,7 @@ GPU compositing and effects pipeline for video, built on [wgpu]. Applies per-fra
 
 `ff-render` is a GPU compositing and effects pipeline built on [wgpu](https://github.com/gfx-rs/wgpu), not FFmpeg: WGSL shaders run colour grading, blends, chroma-key, masks, transforms, scaling, and a crossfade transition on GPU textures, with a CPU software fallback. It consumes decoded frames and plugs into `ff-preview` through the `FrameSink` trait. Errors are typed and contextual (`RenderError`), so a shader-compile or device failure reads as an actionable message.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Status
 

--- a/crates/ff-stream/README.md
+++ b/crates/ff-stream/README.md
@@ -5,7 +5,7 @@ point it at an input file, and receive a package ready for CDN delivery.
 
 `ff-stream` is a safe, ergonomic wrapper over FFmpeg's adaptive-streaming muxers (the HLS and DASH segmenters in libavformat), driving the encode-and-mux loop from a rendition ladder. Errors are typed and chain their source (`StreamError`), so a failure reads as an actionable message rather than a raw FFmpeg return code.
 
-It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them.
+It is an independent crate: use it on its own, or combine it with the other `ff-*` crates to build any media app or editing model. The `ff-*` crates are model-free primitives that impose no editing model; [`avio`](https://github.com/itsakeyfut/avio) is one editing engine built on top of them. See the [library comparison](https://github.com/itsakeyfut/avio#choosing-a-rust-ffmpeg-library) to choose the right layer.
 
 ## Installation
 


### PR DESCRIPTION
## Objective

- crates.io visitors cannot tell how avio differs from the other Rust FFmpeg options at the point where they decide which crate to use.
- The pitch does not lead with what is distinctive (a Rust-native editing engine, no `unsafe` in application code).

## Solution

- Lead the workspace and avio-crate READMEs with a bold tagline and add a "Choosing a Rust FFmpeg library" section comparing avio against ffmpeg-next, ez-ffmpeg, video-rs, and ffmpeg-sidecar by layer, editing model, `unsafe` exposure, and runtime dependency.
- Append a one-line pointer to that comparison in the ten user-facing ff-* primitive READMEs.
- Leave out ff-sys (internal, not a public dependency) and the FFmpeg-free foundation crates (ff-common, ff-format), where the library-choice comparison does not apply.
- Docs only; no source or code fences changed.